### PR TITLE
Fix Docker build: copy shared/ dir into frontend stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
 
+# Copy shared validation config (imported by frontend/src/lib/validation.ts)
+COPY shared/ /app/shared/
+
 # Copy frontend source and build
 COPY frontend/ ./
 RUN npm run build


### PR DESCRIPTION
The frontend imports validation constants from `shared/validation.json`
via a relative path. The Dockerfile's frontend stage only copied
`frontend/` and `spec/`, so this import failed during `tsc -b` in the
Docker build. Adding a COPY for `shared/` resolves the build error.

https://claude.ai/code/session_01J1aZZGiJkbRFQEE2quAYPb