### PR TITLE
Add "Manage Cookies" button to footers and embed API

### DIFF
--- a/frontend/src/auth/AuthLayout.tsx
+++ b/frontend/src/auth/AuthLayout.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
 import {
   Card,
   CardContent,
@@ -7,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Footer } from "@/components/Footer";
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -28,11 +28,7 @@ export default function AuthLayout({ children }: AuthLayoutProps) {
           </CardHeader>
           <CardContent className="space-y-4">{children}</CardContent>
         </Card>
-        <div className="flex justify-center gap-4 text-xs text-muted-foreground">
-          <Link to="/policy/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
-          <Link to="/policy/terms" className="hover:text-foreground transition-colors">Terms</Link>
-          <Link to="/policy/cookies" className="hover:text-foreground transition-colors">Cookies</Link>
-        </div>
+        <Footer className="flex justify-center" />
       </div>
     </div>
   );

--- a/frontend/src/auth/__tests__/EmailStep.test.tsx
+++ b/frontend/src/auth/__tests__/EmailStep.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { AuthError } from "@supabase/supabase-js";
 import { MemoryRouter } from "react-router-dom";
+import { CookieConsentProvider } from "@/components/CookieConsentContext";
 import EmailStep from "../EmailStep";
 
 type OnSubmit = (email: string) => Promise<{ error: AuthError | null }>;
@@ -10,7 +11,9 @@ type OnSubmit = (email: string) => Promise<{ error: AuthError | null }>;
 function renderEmailStep(onSubmit: OnSubmit) {
   return render(
     <MemoryRouter>
-      <EmailStep onSubmit={onSubmit} />
+      <CookieConsentProvider>
+        <EmailStep onSubmit={onSubmit} />
+      </CookieConsentProvider>
     </MemoryRouter>,
   );
 }

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { AuthError } from "@supabase/supabase-js";
 import { MemoryRouter } from "react-router-dom";
+import { CookieConsentProvider } from "@/components/CookieConsentContext";
 import OtpStep from "../OtpStep";
 
 vi.mock("../dev", () => ({
@@ -18,7 +19,9 @@ const defaultProps = {
 function renderOtpStep(props = defaultProps) {
   return render(
     <MemoryRouter>
-      <OtpStep {...props} />
+      <CookieConsentProvider>
+        <OtpStep {...props} />
+      </CookieConsentProvider>
     </MemoryRouter>,
   );
 }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -73,8 +73,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         {children}
       </main>
 
-      <footer className="mx-auto mt-12 hidden max-w-[1200px] border-t pt-4 md:block">
-        <div className="flex gap-4 text-xs text-muted-foreground">
+      <footer className="mx-auto mt-12 max-w-[1200px] border-t pt-4">
+        <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
           <Link to="/policy/privacy" className="hover:text-foreground transition-colors">Privacy Policy</Link>
           <Link to="/policy/terms" className="hover:text-foreground transition-colors">Terms of Service</Link>
           <Link to="/policy/cookies" className="hover:text-foreground transition-colors">Cookie Policy</Link>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "react-router-dom";
 import { LayoutDashboard, Activity } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useApprovals } from "@/hooks/useApprovals";
+import { useCookieConsent } from "./CookieConsentContext";
 import { UserMenu } from "./UserMenu";
 import { PendingAgentBanners } from "./PendingAgentBanners";
 
@@ -11,6 +12,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const isActivity = pathname === "/activity";
   const isSettings = pathname === "/settings";
   const { approvals } = useApprovals();
+  const { reset: resetConsent } = useCookieConsent();
   const pendingCount = approvals.length;
 
   return (
@@ -77,6 +79,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           <Link to="/policy/terms" className="hover:text-foreground transition-colors">Terms of Service</Link>
           <Link to="/policy/cookies" className="hover:text-foreground transition-colors">Cookie Policy</Link>
           <a href="mailto:support@supersuit.tech" className="hover:text-foreground transition-colors">Support</a>
+          <button type="button" onClick={resetConsent} className="hover:text-foreground transition-colors">Manage Cookies</button>
         </div>
       </footer>
 

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -2,7 +2,7 @@ import { Link, useLocation } from "react-router-dom";
 import { LayoutDashboard, Activity } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useApprovals } from "@/hooks/useApprovals";
-import { useCookieConsent } from "./CookieConsentContext";
+import { Footer } from "./Footer";
 import { UserMenu } from "./UserMenu";
 import { PendingAgentBanners } from "./PendingAgentBanners";
 
@@ -12,7 +12,6 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const isActivity = pathname === "/activity";
   const isSettings = pathname === "/settings";
   const { approvals } = useApprovals();
-  const { reset: resetConsent } = useCookieConsent();
   const pendingCount = approvals.length;
 
   return (
@@ -73,15 +72,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         {children}
       </main>
 
-      <footer className="mx-auto mt-12 max-w-[1200px] border-t pt-4">
-        <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
-          <Link to="/policy/privacy" className="hover:text-foreground transition-colors">Privacy Policy</Link>
-          <Link to="/policy/terms" className="hover:text-foreground transition-colors">Terms of Service</Link>
-          <Link to="/policy/cookies" className="hover:text-foreground transition-colors">Cookie Policy</Link>
-          <a href="mailto:support@supersuit.tech" className="hover:text-foreground transition-colors">Support</a>
-          <button type="button" onClick={resetConsent} className="hover:text-foreground transition-colors">Manage Cookies</button>
-        </div>
-      </footer>
+      <Footer className="mx-auto mt-12 max-w-[1200px] border-t pt-4" />
 
       {/* Mobile bottom navigation */}
       <nav className="bg-card/95 fixed inset-x-0 bottom-0 z-40 border-t backdrop-blur-sm md:hidden">

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import { useCookieConsent } from "./CookieConsentContext";
+
+interface FooterProps {
+  className?: string;
+}
+
+const linkClass = "hover:text-foreground transition-colors";
+
+/**
+ * Shared site footer used across all layouts (app, auth, policy pages).
+ * Renders policy links, support mailto, and a "Manage Cookies" button
+ * that re-opens the consent banner.
+ */
+export function Footer({ className }: FooterProps) {
+  const { reset: resetConsent } = useCookieConsent();
+
+  return (
+    <footer className={cn("text-xs text-muted-foreground", className)}>
+      <div className="flex flex-wrap gap-x-4 gap-y-2">
+        <Link to="/policy/privacy" className={linkClass}>Privacy Policy</Link>
+        <Link to="/policy/terms" className={linkClass}>Terms of Service</Link>
+        <Link to="/policy/cookies" className={linkClass}>Cookie Policy</Link>
+        <a href="mailto:support@supersuit.tech" className={linkClass}>Support</a>
+        <button type="button" onClick={resetConsent} className={linkClass}>Manage Cookies</button>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/consent-banner/embed.ts
+++ b/frontend/src/consent-banner/embed.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  clearConsent,
   getStoredConsent,
   persistConsent,
   type ConsentStatus,
@@ -144,5 +145,11 @@ if (document.readyState === "loading") {
   reject: () => {
     persistConsent("rejected");
     document.getElementById("ps-consent-banner")?.remove();
+  },
+  /** Clear stored consent and re-show the banner (e.g. from a "Manage Cookies" link). */
+  reset: () => {
+    clearConsent();
+    document.getElementById("ps-consent-banner")?.remove();
+    mount();
   },
 };

--- a/frontend/src/pages/policy/PolicyLayout.tsx
+++ b/frontend/src/pages/policy/PolicyLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import { useCookieConsent } from "../../components/CookieConsentContext";
+import { Footer } from "../../components/Footer";
 
 interface PolicyLayoutProps {
   title: string;
@@ -14,8 +14,6 @@ interface PolicyLayoutProps {
  * Renders outside the auth gate so anyone can view legal documents.
  */
 export function PolicyLayout({ title, lastUpdated, children }: PolicyLayoutProps) {
-  const { reset: resetConsent } = useCookieConsent();
-
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-4 py-8 md:px-6 md:py-12">
@@ -48,22 +46,7 @@ export function PolicyLayout({ title, lastUpdated, children }: PolicyLayoutProps
           {children}
         </main>
 
-        <footer className="mt-12 border-t pt-6">
-          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
-            <Link to="/policy/privacy" className="hover:text-foreground transition-colors">
-              Privacy Policy
-            </Link>
-            <Link to="/policy/terms" className="hover:text-foreground transition-colors">
-              Terms of Service
-            </Link>
-            <Link to="/policy/cookies" className="hover:text-foreground transition-colors">
-              Cookie Policy
-            </Link>
-            <button type="button" onClick={resetConsent} className="hover:text-foreground transition-colors">
-              Manage Cookies
-            </button>
-          </div>
-        </footer>
+        <Footer className="mt-12 border-t pt-6" />
       </div>
     </div>
   );

--- a/frontend/src/pages/policy/PolicyLayout.tsx
+++ b/frontend/src/pages/policy/PolicyLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
+import { useCookieConsent } from "../../components/CookieConsentContext";
 
 interface PolicyLayoutProps {
   title: string;
@@ -13,6 +14,8 @@ interface PolicyLayoutProps {
  * Renders outside the auth gate so anyone can view legal documents.
  */
 export function PolicyLayout({ title, lastUpdated, children }: PolicyLayoutProps) {
+  const { reset: resetConsent } = useCookieConsent();
+
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-4 py-8 md:px-6 md:py-12">
@@ -56,6 +59,9 @@ export function PolicyLayout({ title, lastUpdated, children }: PolicyLayoutProps
             <Link to="/policy/cookies" className="hover:text-foreground transition-colors">
               Cookie Policy
             </Link>
+            <button type="button" onClick={resetConsent} className="hover:text-foreground transition-colors">
+              Manage Cookies
+            </button>
           </div>
         </footer>
       </div>

--- a/frontend/src/test-helpers.tsx
+++ b/frontend/src/test-helpers.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { AuthProvider } from "@/auth/AuthContext";
+import { CookieConsentProvider } from "@/components/CookieConsentContext";
 import { ThemeProvider } from "@/components/ThemeContext";
 import { Toaster } from "@/components/ui/sonner";
 
@@ -22,7 +23,9 @@ export function createAuthWrapper(initialEntries?: string[]) {
     return (
       <MemoryRouter initialEntries={initialEntries}>
         <QueryClientProvider client={queryClient}>
-          <AuthProvider>{children}</AuthProvider>
+          <CookieConsentProvider>
+            <AuthProvider>{children}</AuthProvider>
+          </CookieConsentProvider>
         </QueryClientProvider>
       </MemoryRouter>
     );
@@ -47,10 +50,12 @@ export function renderWithProviders(
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
           <ThemeProvider>
-            <AuthProvider>
-              {children}
-              <Toaster />
-            </AuthProvider>
+            <CookieConsentProvider>
+              <AuthProvider>
+                {children}
+                <Toaster />
+              </AuthProvider>
+            </CookieConsentProvider>
           </ThemeProvider>
         </QueryClientProvider>
       </MemoryRouter>


### PR DESCRIPTION
Allow users to re-open the cookie consent banner after their initial
choice by adding a "Manage Cookies" button to the AppLayout desktop
footer and the PolicyLayout footer. Also expose a reset() method on
the embeddable consent banner's window.__psConsent API so external
sites (e.g. www.permissionslip.dev) can wire up the same behavior.

https://claude.ai/code/session_01SDJUuACoc27buKoXF1J9NY