### PR TITLE
Fix audit log gaps: connector tracking, execution status, usage breakdown

### DIFF
--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -352,6 +352,15 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 
 // connectorIDFromActionType extracts the connector ID from an action type string.
 // Action types follow the convention "connector_id.action_name" (e.g. "github.create_issue").
+// Returns nil if the action type is malformed (no dot, empty prefix, or empty string).
+//
+// Examples:
+//
+//	"github.create_issue" → &"github"
+//	"slack.send_message"  → &"slack"
+//	"malformed_type"      → nil
+//	".missing_prefix"     → nil
+//	""                    → nil
 func connectorIDFromActionType(actionType string) *string {
 	if parts := strings.SplitN(actionType, ".", 2); len(parts) == 2 && parts[0] != "" {
 		return &parts[0]
@@ -360,13 +369,13 @@ func connectorIDFromActionType(actionType string) *string {
 }
 
 // emitActionExecutedAuditEvent writes an action.executed audit event for
-// one-off token-based execution. Errors are logged but do not block the
-// request (best-effort audit trail).
+// one-off token-based execution. Not billable because the approval request
+// was already counted when it was created.
 func emitActionExecutedAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, approvalID, actionType string, agentMeta []byte) {
 	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
 	execStatus := db.ExecStatusSuccess
 
-	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
+	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
 		UserID:          userID,
 		AgentID:         agentID,
 		EventType:       db.AuditEventActionExecuted,
@@ -377,9 +386,7 @@ func emitActionExecutedAuditEvent(ctx context.Context, d db.DBTX, userID string,
 		Action:          actionJSON,
 		ConnectorID:     connectorIDFromActionType(actionType),
 		ExecutionStatus: &execStatus,
-	}); err != nil {
-		log.Printf("audit: failed to insert action executed audit event: %v", err)
-	}
+	}, false)
 }
 
 // ── JWT token parsing ──────────────────────────────────────────────────────

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -171,8 +171,13 @@ func handleTokenPath(w http.ResponseWriter, r *http.Request, deps *Deps, agent *
 
 	// ── Execute the action via connector ──────────────────────────
 
-	var actionResultPtr *json.RawMessage
-	if result, execErr := executeConnectorAction(r.Context(), deps, approval.ApproverID, req.ActionID, req.Parameters); execErr != nil {
+	result, execErr := executeConnectorAction(r.Context(), deps, approval.ApproverID, req.ActionID, req.Parameters)
+
+	// Always emit the audit event with the actual execution result,
+	// regardless of success or failure.
+	emitActionExecutedAuditEvent(r.Context(), deps.DB, approval.ApproverID, agent.AgentID, claims.ApprovalID, req.ActionID, agent.Metadata, execErr)
+
+	if execErr != nil {
 		if handleConnectorError(w, r, execErr) {
 			return
 		}
@@ -180,19 +185,17 @@ func handleTokenPath(w http.ResponseWriter, r *http.Request, deps *Deps, agent *
 		CaptureError(r.Context(), execErr)
 		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to execute action"))
 		return
-	} else if result != nil {
-		actionResultPtr = &result.Data
 	}
 
-	executedAt := time.Now().UTC()
-
-	// Emit audit event (best-effort).
-	emitActionExecutedAuditEvent(r.Context(), deps.DB, approval.ApproverID, agent.AgentID, claims.ApprovalID, req.ActionID, agent.Metadata)
+	var actionResultPtr *json.RawMessage
+	if result != nil {
+		actionResultPtr = &result.Data
+	}
 
 	RespondJSON(w, http.StatusOK, executeActionTokenResponse{
 		Status:     "success",
 		ActionID:   req.ActionID,
-		ExecutedAt: executedAt,
+		ExecutedAt: time.Now().UTC(),
 		Result:     actionResultPtr,
 	})
 }
@@ -311,14 +314,15 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		return
 	}
 
-	// ── Emit audit event (best-effort) ──────────────────────────
-
-	emitStandingApprovalAuditEvent(r.Context(), deps.DB, exec.UserID, exec.AgentID, sa.StandingApprovalID, exec.ActionType, exec.AgentMeta)
-
 	// ── Execute the action via connector ─────────────────────────
 
-	var actionResultPtr *json.RawMessage
-	if result, execErr := executeConnectorAction(r.Context(), deps, exec.UserID, req.Action.Type, params); execErr != nil {
+	result, execErr := executeConnectorAction(r.Context(), deps, exec.UserID, req.Action.Type, params)
+
+	// Always emit the audit event with the actual execution result,
+	// regardless of success or failure (best-effort).
+	emitStandingApprovalAuditEvent(r.Context(), deps.DB, exec.UserID, exec.AgentID, sa.StandingApprovalID, exec.ActionType, exec.AgentMeta, execErr)
+
+	if execErr != nil {
 		if handleConnectorError(w, r, execErr) {
 			return
 		}
@@ -326,7 +330,10 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		CaptureError(r.Context(), execErr)
 		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to execute connector action"))
 		return
-	} else if result != nil {
+	}
+
+	var actionResultPtr *json.RawMessage
+	if result != nil {
 		actionResultPtr = &result.Data
 	}
 
@@ -350,30 +357,15 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 
 // ── Audit event emission ───────────────────────────────────────────────────
 
-// connectorIDFromActionType extracts the connector ID from an action type string.
-// Action types follow the convention "connector_id.action_name" (e.g. "github.create_issue").
-// Returns nil if the action type is malformed (no dot, empty prefix, or empty string).
-//
-// Examples:
-//
-//	"github.create_issue" → &"github"
-//	"slack.send_message"  → &"slack"
-//	"malformed_type"      → nil
-//	".missing_prefix"     → nil
-//	""                    → nil
-func connectorIDFromActionType(actionType string) *string {
-	if parts := strings.SplitN(actionType, ".", 2); len(parts) == 2 && parts[0] != "" {
-		return &parts[0]
-	}
-	return nil
-}
-
 // emitActionExecutedAuditEvent writes an action.executed audit event for
 // one-off token-based execution. Not billable because the approval request
 // was already counted when it was created.
-func emitActionExecutedAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, approvalID, actionType string, agentMeta []byte) {
+//
+// execErr should be the error from connector execution, or nil on success.
+// The execution_status and execution_error fields are derived from execErr.
+func emitActionExecutedAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, approvalID, actionType string, agentMeta []byte, execErr error) {
 	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
-	execStatus := db.ExecStatusSuccess
+	execStatus, execErrMsg := resolveExecResult(execErr)
 
 	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
 		UserID:          userID,
@@ -386,6 +378,7 @@ func emitActionExecutedAuditEvent(ctx context.Context, d db.DBTX, userID string,
 		Action:          actionJSON,
 		ConnectorID:     connectorIDFromActionType(actionType),
 		ExecutionStatus: &execStatus,
+		ExecutionError:  execErrMsg,
 	}, false)
 }
 

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -350,21 +350,33 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 
 // ── Audit event emission ───────────────────────────────────────────────────
 
+// connectorIDFromActionType extracts the connector ID from an action type string.
+// Action types follow the convention "connector_id.action_name" (e.g. "github.create_issue").
+func connectorIDFromActionType(actionType string) *string {
+	if parts := strings.SplitN(actionType, ".", 2); len(parts) == 2 && parts[0] != "" {
+		return &parts[0]
+	}
+	return nil
+}
+
 // emitActionExecutedAuditEvent writes an action.executed audit event for
 // one-off token-based execution. Errors are logged but do not block the
 // request (best-effort audit trail).
 func emitActionExecutedAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, approvalID, actionType string, agentMeta []byte) {
 	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
+	execStatus := db.ExecStatusSuccess
 
 	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
-		UserID:     userID,
-		AgentID:    agentID,
-		EventType:  db.AuditEventActionExecuted,
-		Outcome:    "auto_executed",
-		SourceID:   approvalID,
-		SourceType: "approval",
-		AgentMeta:  agentMeta,
-		Action:     actionJSON,
+		UserID:          userID,
+		AgentID:         agentID,
+		EventType:       db.AuditEventActionExecuted,
+		Outcome:         "auto_executed",
+		SourceID:        approvalID,
+		SourceType:      "approval",
+		AgentMeta:       agentMeta,
+		Action:          actionJSON,
+		ConnectorID:     connectorIDFromActionType(actionType),
+		ExecutionStatus: &execStatus,
 	}); err != nil {
 		log.Printf("audit: failed to insert action executed audit event: %v", err)
 	}

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -443,17 +443,35 @@ func unprocessableEntity(code ErrorCode, message string) ErrorResponse {
 
 // emitApprovalRequestAuditEvent writes an audit event for a new approval request.
 // Only the action type is persisted — parameters are redacted.
+// Also increments the usage meter for billing (approval requests are billable events).
 func emitApprovalRequestAuditEvent(ctx context.Context, d db.DBTX, userID string, appr *db.Approval, agentMeta []byte) {
+	actionType := actionTypeFromJSON(appr.Action)
+
 	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
-		UserID:     userID,
-		AgentID:    appr.AgentID,
-		EventType:  db.AuditEventApprovalRequested,
-		Outcome:    "pending",
-		SourceID:   appr.ApprovalID,
-		SourceType: "approval",
-		AgentMeta:  agentMeta,
-		Action:     redactActionToType(appr.Action),
+		UserID:      userID,
+		AgentID:     appr.AgentID,
+		EventType:   db.AuditEventApprovalRequested,
+		Outcome:     "pending",
+		SourceID:    appr.ApprovalID,
+		SourceType:  "approval",
+		AgentMeta:   agentMeta,
+		Action:      redactActionToType(appr.Action),
+		ConnectorID: connectorIDFromActionType(actionType),
 	}); err != nil {
 		log.Printf("audit: failed to insert approval request audit event: %v", err)
+	}
+
+	// Increment usage meter (best-effort, billing).
+	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
+	connectorID := ""
+	if cid := connectorIDFromActionType(actionType); cid != nil {
+		connectorID = *cid
+	}
+	if _, err := db.IncrementRequestCountWithBreakdown(ctx, d, userID, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     appr.AgentID,
+		ConnectorID: connectorID,
+		ActionType:  actionType,
+	}); err != nil {
+		log.Printf("audit: failed to increment usage count for approval request: %v", err)
 	}
 }

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -443,11 +443,9 @@ func unprocessableEntity(code ErrorCode, message string) ErrorResponse {
 
 // emitApprovalRequestAuditEvent writes an audit event for a new approval request.
 // Only the action type is persisted — parameters are redacted.
-// Also increments the usage meter for billing (approval requests are billable events).
+// Billable: approval requests count toward the user's monthly request quota.
 func emitApprovalRequestAuditEvent(ctx context.Context, d db.DBTX, userID string, appr *db.Approval, agentMeta []byte) {
-	actionType := actionTypeFromJSON(appr.Action)
-
-	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
+	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
 		UserID:      userID,
 		AgentID:     appr.AgentID,
 		EventType:   db.AuditEventApprovalRequested,
@@ -456,22 +454,6 @@ func emitApprovalRequestAuditEvent(ctx context.Context, d db.DBTX, userID string
 		SourceType:  "approval",
 		AgentMeta:   agentMeta,
 		Action:      redactActionToType(appr.Action),
-		ConnectorID: connectorIDFromActionType(actionType),
-	}); err != nil {
-		log.Printf("audit: failed to insert approval request audit event: %v", err)
-	}
-
-	// Increment usage meter (best-effort, billing).
-	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
-	connectorID := ""
-	if cid := connectorIDFromActionType(actionType); cid != nil {
-		connectorID = *cid
-	}
-	if _, err := db.IncrementRequestCountWithBreakdown(ctx, d, userID, periodStart, periodEnd, db.UsageBreakdownKeys{
-		AgentID:     appr.AgentID,
-		ConnectorID: connectorID,
-		ActionType:  actionType,
-	}); err != nil {
-		log.Printf("audit: failed to increment usage count for approval request: %v", err)
-	}
+		ConnectorID: connectorIDFromActionType(actionTypeFromJSON(appr.Action)),
+	}, true)
 }

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -287,7 +287,7 @@ func emitApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, appr 
 		return
 	}
 
-	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
+	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
 		UserID:      userID,
 		AgentID:     appr.AgentID,
 		EventType:   eventType,
@@ -297,9 +297,7 @@ func emitApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, appr 
 		AgentMeta:   agentMeta,
 		Action:      redactActionToType(appr.Action),
 		ConnectorID: connectorIDFromActionType(actionTypeFromJSON(appr.Action)),
-	}); err != nil {
-		log.Printf("audit: failed to insert approval audit event: %v", err)
-	}
+	}, false)
 }
 
 // redactActionToType extracts only the "type" field from an action JSON blob,

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -288,14 +288,15 @@ func emitApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, appr 
 	}
 
 	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
-		UserID:     userID,
-		AgentID:    appr.AgentID,
-		EventType:  eventType,
-		Outcome:    appr.Status,
-		SourceID:   appr.ApprovalID,
-		SourceType: "approval",
-		AgentMeta:  agentMeta,
-		Action:     redactActionToType(appr.Action),
+		UserID:      userID,
+		AgentID:     appr.AgentID,
+		EventType:   eventType,
+		Outcome:     appr.Status,
+		SourceID:    appr.ApprovalID,
+		SourceType:  "approval",
+		AgentMeta:   agentMeta,
+		Action:      redactActionToType(appr.Action),
+		ConnectorID: connectorIDFromActionType(actionTypeFromJSON(appr.Action)),
 	}); err != nil {
 		log.Printf("audit: failed to insert approval audit event: %v", err)
 	}
@@ -316,6 +317,21 @@ func redactActionToType(raw []byte) []byte {
 	}
 	redacted, _ := json.Marshal(map[string]string{"type": obj.Type})
 	return redacted
+}
+
+// actionTypeFromJSON extracts the "type" field from an action JSON blob.
+// Returns "" if the type cannot be extracted.
+func actionTypeFromJSON(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(raw, &obj) != nil {
+		return ""
+	}
+	return obj.Type
 }
 
 // generateConfirmationCode produces a 6-character confirmation code from the

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -300,38 +300,6 @@ func emitApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, appr 
 	}, false)
 }
 
-// redactActionToType extracts only the "type" field from an action JSON blob,
-// discarding parameters and other user-provided data. Returns {"type":"…"} or
-// nil if the type cannot be extracted.
-func redactActionToType(raw []byte) []byte {
-	if len(raw) == 0 {
-		return nil
-	}
-	var obj struct {
-		Type string `json:"type"`
-	}
-	if json.Unmarshal(raw, &obj) != nil || obj.Type == "" {
-		return nil
-	}
-	redacted, _ := json.Marshal(map[string]string{"type": obj.Type})
-	return redacted
-}
-
-// actionTypeFromJSON extracts the "type" field from an action JSON blob.
-// Returns "" if the type cannot be extracted.
-func actionTypeFromJSON(raw []byte) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var obj struct {
-		Type string `json:"type"`
-	}
-	if json.Unmarshal(raw, &obj) != nil {
-		return ""
-	}
-	return obj.Type
-}
-
 // generateConfirmationCode produces a 6-character confirmation code from the
 // safe character set and its HMAC-SHA256 hash (or plain SHA-256 when hmacKey
 // is empty). Returns (formattedCode "XXX-XXX", hexHash, error).

--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -116,8 +116,9 @@ func handleListAuditEvents(deps *Deps) http.HandlerFunc {
 		agentIDStr := r.URL.Query().Get("agent_id")
 		eventTypesStr := r.URL.Query().Get("event_type")
 		outcomeStr := r.URL.Query().Get("outcome")
+		connectorIDStr := r.URL.Query().Get("connector_id")
 
-		if agentIDStr != "" || eventTypesStr != "" || outcomeStr != "" {
+		if agentIDStr != "" || eventTypesStr != "" || outcomeStr != "" || connectorIDStr != "" {
 			filter = &db.AuditEventFilter{}
 
 			if agentIDStr != "" {
@@ -145,6 +146,10 @@ func handleListAuditEvents(deps *Deps) http.HandlerFunc {
 					return
 				}
 				filter.Outcome = outcomeStr
+			}
+
+			if connectorIDStr != "" {
+				filter.ConnectorID = &connectorIDStr
 			}
 		}
 
@@ -241,6 +246,12 @@ func handleExportAuditLogs(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		// Parse optional connector_id filter.
+		var connectorID *string
+		if v := r.URL.Query().Get("connector_id"); v != "" {
+			connectorID = &v
+		}
+
 		// Parse optional cursor (compound: "RFC3339Nano,id").
 		var cursor *db.AuditLogExportCursor
 		if v := r.URL.Query().Get("after"); v != "" {
@@ -252,7 +263,7 @@ func handleExportAuditLogs(deps *Deps) http.HandlerFunc {
 			cursor = &db.AuditLogExportCursor{Timestamp: ts, ID: id}
 		}
 
-		page, err := db.ExportAuditLogs(r.Context(), deps.DB, userID, since, until, eventTypes, limit, cursor)
+		page, err := db.ExportAuditLogs(r.Context(), deps.DB, userID, since, until, eventTypes, connectorID, limit, cursor)
 		if err != nil {
 			log.Printf("[%s] ExportAuditLogs: %v", TraceID(r.Context()), err)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to export audit logs"))

--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -149,6 +149,10 @@ func handleListAuditEvents(deps *Deps) http.HandlerFunc {
 			}
 
 			if connectorIDStr != "" {
+				if len(connectorIDStr) > 128 {
+					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id exceeds maximum length"))
+					return
+				}
 				filter.ConnectorID = &connectorIDStr
 			}
 		}
@@ -249,6 +253,10 @@ func handleExportAuditLogs(deps *Deps) http.HandlerFunc {
 		// Parse optional connector_id filter.
 		var connectorID *string
 		if v := r.URL.Query().Get("connector_id"); v != "" {
+			if len(v) > 128 {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id exceeds maximum length"))
+				return
+			}
 			connectorID = &v
 		}
 

--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -16,26 +16,32 @@ import (
 // for the activity feed (GET /audit-events). Does NOT include id or source_id
 // since the activity feed is for display purposes only.
 type auditEventResponse struct {
-	EventType string    `json:"event_type"`
-	Timestamp time.Time `json:"timestamp"`
-	AgentID   int64     `json:"agent_id"`
-	AgentMeta any       `json:"agent_metadata,omitempty"`
-	Action    any       `json:"action,omitempty"`
-	Outcome   string    `json:"outcome"`
+	EventType       string    `json:"event_type"`
+	Timestamp       time.Time `json:"timestamp"`
+	AgentID         int64     `json:"agent_id"`
+	AgentMeta       any       `json:"agent_metadata,omitempty"`
+	Action          any       `json:"action,omitempty"`
+	Outcome         string    `json:"outcome"`
+	ConnectorID     *string   `json:"connector_id,omitempty"`
+	ExecutionStatus *string   `json:"execution_status,omitempty"`
+	ExecutionError  *string   `json:"execution_error,omitempty"`
 }
 
 // auditLogExportEventResponse is the JSON representation of a single audit
 // event for the export endpoint (GET /audit-logs). Includes id and source_id
 // (always present, never omitted) for SIEM deduplication and event correlation.
 type auditLogExportEventResponse struct {
-	ID        int64     `json:"id"`
-	EventType string    `json:"event_type"`
-	Timestamp time.Time `json:"timestamp"`
-	AgentID   int64     `json:"agent_id"`
-	AgentMeta any       `json:"agent_metadata,omitempty"`
-	Action    any       `json:"action,omitempty"`
-	Outcome   string    `json:"outcome"`
-	SourceID  string    `json:"source_id"`
+	ID              int64     `json:"id"`
+	EventType       string    `json:"event_type"`
+	Timestamp       time.Time `json:"timestamp"`
+	AgentID         int64     `json:"agent_id"`
+	AgentMeta       any       `json:"agent_metadata,omitempty"`
+	Action          any       `json:"action,omitempty"`
+	Outcome         string    `json:"outcome"`
+	SourceID        string    `json:"source_id"`
+	ConnectorID     *string   `json:"connector_id,omitempty"`
+	ExecutionStatus *string   `json:"execution_status,omitempty"`
+	ExecutionError  *string   `json:"execution_error,omitempty"`
 }
 
 // auditEventListResponse is the paginated JSON response for GET /audit-events.
@@ -276,12 +282,15 @@ func handleExportAuditLogs(deps *Deps) http.HandlerFunc {
 // for the activity feed endpoint.
 func toAuditEventResponse(e db.AuditEvent) auditEventResponse {
 	return auditEventResponse{
-		EventType: string(e.EventType),
-		Timestamp: e.Timestamp,
-		AgentID:   e.AgentID,
-		AgentMeta: unmarshalJSONB(e.AgentMeta),
-		Action:    unmarshalJSONB(e.Action),
-		Outcome:   e.Outcome,
+		EventType:       string(e.EventType),
+		Timestamp:       e.Timestamp,
+		AgentID:         e.AgentID,
+		AgentMeta:       unmarshalJSONB(e.AgentMeta),
+		Action:          unmarshalJSONB(e.Action),
+		Outcome:         e.Outcome,
+		ConnectorID:     e.ConnectorID,
+		ExecutionStatus: e.ExecutionStatus,
+		ExecutionError:  e.ExecutionError,
 	}
 }
 
@@ -291,14 +300,17 @@ func toAuditEventResponse(e db.AuditEvent) auditEventResponse {
 // matching the OpenAPI schema's `required` declaration.
 func toExportAuditEventResponse(e db.AuditEvent) auditLogExportEventResponse {
 	return auditLogExportEventResponse{
-		ID:        e.ID,
-		EventType: string(e.EventType),
-		Timestamp: e.Timestamp,
-		AgentID:   e.AgentID,
-		AgentMeta: unmarshalJSONB(e.AgentMeta),
-		Action:    unmarshalJSONB(e.Action),
-		Outcome:   e.Outcome,
-		SourceID:  e.SourceID,
+		ID:              e.ID,
+		EventType:       string(e.EventType),
+		Timestamp:       e.Timestamp,
+		AgentID:         e.AgentID,
+		AgentMeta:       unmarshalJSONB(e.AgentMeta),
+		Action:          unmarshalJSONB(e.Action),
+		Outcome:         e.Outcome,
+		SourceID:        e.SourceID,
+		ConnectorID:     e.ConnectorID,
+		ExecutionStatus: e.ExecutionStatus,
+		ExecutionError:  e.ExecutionError,
 	}
 }
 

--- a/api/audit_helpers.go
+++ b/api/audit_helpers.go
@@ -2,11 +2,19 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
 )
+
+// ── Shared audit utilities ──────────────────────────────────────────────────
+//
+// These helpers are used by multiple audit event emission functions across the
+// api package. They are centralised here to avoid duplication and keep the
+// audit infrastructure in one place.
 
 // emitAuditEventWithUsage inserts an audit event and optionally increments the
 // usage meter for billing. Both operations are best-effort: errors are logged
@@ -41,4 +49,71 @@ func emitAuditEventWithUsage(ctx context.Context, d db.DBTX, p db.InsertAuditEve
 	}); err != nil {
 		log.Printf("audit: failed to increment usage for %s event: %v", p.EventType, err)
 	}
+}
+
+// connectorIDFromActionType extracts the connector ID from an action type string.
+// Action types follow the convention "connector_id.action_name" (e.g. "github.create_issue").
+// Returns nil if the action type is malformed (no dot, empty prefix, or empty string).
+//
+// Examples:
+//
+//	"github.create_issue" → &"github"
+//	"slack.send_message"  → &"slack"
+//	"malformed_type"      → nil
+//	".missing_prefix"     → nil
+//	""                    → nil
+func connectorIDFromActionType(actionType string) *string {
+	if parts := strings.SplitN(actionType, ".", 2); len(parts) == 2 && parts[0] != "" {
+		return &parts[0]
+	}
+	return nil
+}
+
+// actionTypeFromJSON extracts the "type" field from an action JSON blob.
+// Returns "" if the type cannot be extracted.
+func actionTypeFromJSON(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(raw, &obj) != nil {
+		return ""
+	}
+	return obj.Type
+}
+
+// resolveExecResult maps a connector execution error to the appropriate
+// execution_status and execution_error values for the audit event. Returns
+// ("success", nil) on success, or ("failure", &message) on error.
+//
+// The error message is truncated to avoid storing excessively large strings;
+// execution_error is exposed in the API so internal details must not leak.
+func resolveExecResult(execErr error) (status string, errMsg *string) {
+	if execErr == nil {
+		return db.ExecStatusSuccess, nil
+	}
+	msg := execErr.Error()
+	if len(msg) > 512 {
+		msg = msg[:512]
+	}
+	return db.ExecStatusFailure, &msg
+}
+
+// redactActionToType extracts only the "type" field from an action JSON blob,
+// discarding parameters and other user-provided data. Returns {"type":"…"} or
+// nil if the type cannot be extracted.
+func redactActionToType(raw []byte) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	var obj struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(raw, &obj) != nil || obj.Type == "" {
+		return nil
+	}
+	redacted, _ := json.Marshal(map[string]string{"type": obj.Type})
+	return redacted
 }

--- a/api/audit_helpers.go
+++ b/api/audit_helpers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"strings"
 	"time"
@@ -86,7 +87,8 @@ func actionTypeFromJSON(raw []byte) string {
 
 // resolveExecResult maps a connector execution error to the appropriate
 // execution_status and execution_error values for the audit event. Returns
-// ("success", nil) on success, or ("failure", &message) on error.
+// ("success", nil) on success, ("timeout", &message) for deadline exceeded,
+// or ("failure", &message) for all other errors.
 //
 // The error message is truncated to avoid storing excessively large strings;
 // execution_error is exposed in the API so internal details must not leak.
@@ -97,6 +99,9 @@ func resolveExecResult(execErr error) (status string, errMsg *string) {
 	msg := execErr.Error()
 	if len(msg) > 512 {
 		msg = msg[:512]
+	}
+	if errors.Is(execErr, context.DeadlineExceeded) {
+		return db.ExecStatusTimeout, &msg
 	}
 	return db.ExecStatusFailure, &msg
 }

--- a/api/audit_helpers.go
+++ b/api/audit_helpers.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// emitAuditEventWithUsage inserts an audit event and optionally increments the
+// usage meter for billing. Both operations are best-effort: errors are logged
+// but never propagated to the caller (audit and metering should not block the
+// request path).
+//
+// Set billable to true for events that count toward the user's monthly request
+// quota (approval.requested and standing_approval.executed).
+func emitAuditEventWithUsage(ctx context.Context, d db.DBTX, p db.InsertAuditEventParams, billable bool) {
+	if err := db.InsertAuditEvent(ctx, d, p); err != nil {
+		log.Printf("audit: failed to insert %s event: %v", p.EventType, err)
+	}
+
+	if !billable {
+		return
+	}
+
+	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
+	connectorID := ""
+	if p.ConnectorID != nil {
+		connectorID = *p.ConnectorID
+	}
+	actionType := ""
+	if p.Action != nil {
+		actionType = actionTypeFromJSON(p.Action)
+	}
+
+	if _, err := db.IncrementRequestCountWithBreakdown(ctx, d, p.UserID, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     p.AgentID,
+		ConnectorID: connectorID,
+		ActionType:  actionType,
+	}); err != nil {
+		log.Printf("audit: failed to increment usage for %s event: %v", p.EventType, err)
+	}
+}

--- a/api/audit_helpers_test.go
+++ b/api/audit_helpers_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+func TestConnectorIDFromActionType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  *string
+	}{
+		{"github.create_issue", strPtr("github")},
+		{"slack.send_message", strPtr("slack")},
+		{"email.send", strPtr("email")},
+		{"connector.deeply.nested.action", strPtr("connector")},
+		{"malformed_type", nil},
+		{".missing_prefix", nil},
+		{"", nil},
+		{"trailing.", strPtr("trailing")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := connectorIDFromActionType(tt.input)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("connectorIDFromActionType(%q) = %q, want nil", tt.input, *got)
+				}
+			} else {
+				if got == nil {
+					t.Errorf("connectorIDFromActionType(%q) = nil, want %q", tt.input, *tt.want)
+				} else if *got != *tt.want {
+					t.Errorf("connectorIDFromActionType(%q) = %q, want %q", tt.input, *got, *tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestActionTypeFromJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{"valid", []byte(`{"type":"email.send","version":"1"}`), "email.send"},
+		{"type only", []byte(`{"type":"github.create_issue"}`), "github.create_issue"},
+		{"empty type", []byte(`{"type":""}`), ""},
+		{"no type field", []byte(`{"action":"something"}`), ""},
+		{"empty json", []byte(`{}`), ""},
+		{"nil input", nil, ""},
+		{"empty bytes", []byte{}, ""},
+		{"invalid json", []byte(`not json`), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := actionTypeFromJSON(tt.input); got != tt.want {
+				t.Errorf("actionTypeFromJSON(%s) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactActionToType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   []byte
+		want    string
+		wantNil bool
+	}{
+		{"valid", []byte(`{"type":"email.send","parameters":{"to":"alice@example.com"}}`), `{"type":"email.send"}`, false},
+		{"type only", []byte(`{"type":"github.create_issue"}`), `{"type":"github.create_issue"}`, false},
+		{"empty type", []byte(`{"type":""}`), "", true},
+		{"no type", []byte(`{"action":"something"}`), "", true},
+		{"nil", nil, "", true},
+		{"empty", []byte{}, "", true},
+		{"invalid json", []byte(`not json`), "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactActionToType(tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("redactActionToType(%s) = %s, want nil", tt.input, got)
+				}
+			} else {
+				if string(got) != tt.want {
+					t.Errorf("redactActionToType(%s) = %s, want %s", tt.input, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveExecResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		status, errMsg := resolveExecResult(nil)
+		if status != db.ExecStatusSuccess {
+			t.Errorf("status = %q, want %q", status, db.ExecStatusSuccess)
+		}
+		if errMsg != nil {
+			t.Errorf("errMsg = %q, want nil", *errMsg)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		status, errMsg := resolveExecResult(errors.New("connection refused"))
+		if status != db.ExecStatusFailure {
+			t.Errorf("status = %q, want %q", status, db.ExecStatusFailure)
+		}
+		if errMsg == nil {
+			t.Fatal("errMsg = nil, want non-nil")
+		}
+		if *errMsg != "connection refused" {
+			t.Errorf("errMsg = %q, want %q", *errMsg, "connection refused")
+		}
+	})
+
+	t.Run("truncation", func(t *testing.T) {
+		longErr := errors.New(strings.Repeat("x", 1000))
+		status, errMsg := resolveExecResult(longErr)
+		if status != db.ExecStatusFailure {
+			t.Errorf("status = %q, want %q", status, db.ExecStatusFailure)
+		}
+		if errMsg == nil {
+			t.Fatal("errMsg = nil, want non-nil")
+		}
+		if len(*errMsg) != 512 {
+			t.Errorf("len(errMsg) = %d, want 512", len(*errMsg))
+		}
+	})
+}
+
+func strPtr(s string) *string { return &s }

--- a/api/audit_helpers_test.go
+++ b/api/audit_helpers_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -121,6 +123,27 @@ func TestResolveExecResult(t *testing.T) {
 		}
 		if *errMsg != "connection refused" {
 			t.Errorf("errMsg = %q, want %q", *errMsg, "connection refused")
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		status, errMsg := resolveExecResult(context.DeadlineExceeded)
+		if status != db.ExecStatusTimeout {
+			t.Errorf("status = %q, want %q", status, db.ExecStatusTimeout)
+		}
+		if errMsg == nil {
+			t.Fatal("errMsg = nil, want non-nil")
+		}
+	})
+
+	t.Run("wrapped timeout", func(t *testing.T) {
+		wrappedErr := fmt.Errorf("connector execution: %w", context.DeadlineExceeded)
+		status, errMsg := resolveExecResult(wrappedErr)
+		if status != db.ExecStatusTimeout {
+			t.Errorf("status = %q, want %q", status, db.ExecStatusTimeout)
+		}
+		if errMsg == nil {
+			t.Fatal("errMsg = nil, want non-nil")
 		}
 	})
 

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -348,13 +348,12 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 }
 
 // emitStandingApprovalAuditEvent writes a standing_approval.executed audit event.
-// Errors are logged but do not block the request (best-effort audit trail).
-// Also increments the usage meter for billing (standing approval executions are billable events).
+// Billable: standing approval executions count toward the user's monthly request quota.
 func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, saID, actionType string, agentMeta []byte) {
 	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
 	execStatus := db.ExecStatusSuccess
 
-	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
+	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
 		UserID:          userID,
 		AgentID:         agentID,
 		EventType:       db.AuditEventStandingExecution,
@@ -365,23 +364,7 @@ func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID strin
 		Action:          actionJSON,
 		ConnectorID:     connectorIDFromActionType(actionType),
 		ExecutionStatus: &execStatus,
-	}); err != nil {
-		log.Printf("audit: failed to insert standing approval audit event: %v", err)
-	}
-
-	// Increment usage meter (best-effort, billing).
-	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
-	connectorID := ""
-	if cid := connectorIDFromActionType(actionType); cid != nil {
-		connectorID = *cid
-	}
-	if _, err := db.IncrementRequestCountWithBreakdown(ctx, d, userID, periodStart, periodEnd, db.UsageBreakdownKeys{
-		AgentID:     agentID,
-		ConnectorID: connectorID,
-		ActionType:  actionType,
-	}); err != nil {
-		log.Printf("audit: failed to increment usage count for standing approval execution: %v", err)
-	}
+	}, true)
 }
 
 func toStandingApprovalResponse(sa db.StandingApproval) standingApprovalResponse {

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -320,21 +320,25 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Emit audit event (best-effort).
-		emitStandingApprovalAuditEvent(r.Context(), deps.DB, profile.ID, exec.AgentID, saID, exec.ActionType, exec.AgentMeta)
-
 		// Attempt connector execution. If no connector is registered for this
 		// action type, the existing behavior (record execution, emit audit event)
 		// still works — execution just returns no external result (graceful degradation).
-		var actionResultPtr *json.RawMessage
-		if result, execErr := executeConnectorAction(r.Context(), deps, profile.ID, exec.ActionType, req.Parameters); execErr != nil {
+		result, execErr := executeConnectorAction(r.Context(), deps, profile.ID, exec.ActionType, req.Parameters)
+
+		// Always emit the audit event with the actual execution result (best-effort).
+		emitStandingApprovalAuditEvent(r.Context(), deps.DB, profile.ID, exec.AgentID, saID, exec.ActionType, exec.AgentMeta, execErr)
+
+		if execErr != nil {
 			if handleConnectorError(w, r, execErr) {
 				return
 			}
 			log.Printf("[%s] ExecuteStandingApproval: connector execution: %v", TraceID(r.Context()), execErr)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to execute connector action"))
 			return
-		} else if result != nil {
+		}
+
+		var actionResultPtr *json.RawMessage
+		if result != nil {
 			actionResultPtr = &result.Data
 		}
 
@@ -349,9 +353,12 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 
 // emitStandingApprovalAuditEvent writes a standing_approval.executed audit event.
 // Billable: standing approval executions count toward the user's monthly request quota.
-func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, saID, actionType string, agentMeta []byte) {
+//
+// execErr should be the error from connector execution, or nil on success.
+// The execution_status and execution_error fields are derived from execErr.
+func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, saID, actionType string, agentMeta []byte, execErr error) {
 	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
-	execStatus := db.ExecStatusSuccess
+	execStatus, execErrMsg := resolveExecResult(execErr)
 
 	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
 		UserID:          userID,
@@ -364,6 +371,7 @@ func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID strin
 		Action:          actionJSON,
 		ConnectorID:     connectorIDFromActionType(actionType),
 		ExecutionStatus: &execStatus,
+		ExecutionError:  execErrMsg,
 	}, true)
 }
 

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -349,20 +349,38 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 
 // emitStandingApprovalAuditEvent writes a standing_approval.executed audit event.
 // Errors are logged but do not block the request (best-effort audit trail).
+// Also increments the usage meter for billing (standing approval executions are billable events).
 func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, saID, actionType string, agentMeta []byte) {
 	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
+	execStatus := db.ExecStatusSuccess
 
 	if err := db.InsertAuditEvent(ctx, d, db.InsertAuditEventParams{
-		UserID:     userID,
-		AgentID:    agentID,
-		EventType:  db.AuditEventStandingExecution,
-		Outcome:    "auto_executed",
-		SourceID:   saID,
-		SourceType: "standing_approval",
-		AgentMeta:  agentMeta,
-		Action:     actionJSON,
+		UserID:          userID,
+		AgentID:         agentID,
+		EventType:       db.AuditEventStandingExecution,
+		Outcome:         "auto_executed",
+		SourceID:        saID,
+		SourceType:      "standing_approval",
+		AgentMeta:       agentMeta,
+		Action:          actionJSON,
+		ConnectorID:     connectorIDFromActionType(actionType),
+		ExecutionStatus: &execStatus,
 	}); err != nil {
 		log.Printf("audit: failed to insert standing approval audit event: %v", err)
+	}
+
+	// Increment usage meter (best-effort, billing).
+	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
+	connectorID := ""
+	if cid := connectorIDFromActionType(actionType); cid != nil {
+		connectorID = *cid
+	}
+	if _, err := db.IncrementRequestCountWithBreakdown(ctx, d, userID, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     agentID,
+		ConnectorID: connectorID,
+		ActionType:  actionType,
+	}); err != nil {
+		log.Printf("audit: failed to increment usage count for standing approval execution: %v", err)
 	}
 }
 

--- a/db/agents.go
+++ b/db/agents.go
@@ -84,6 +84,10 @@ type AgentPage struct {
 // agentListColumns extends agentColumns with computed stats for the list query.
 // request_count_30d includes both one-off approval requests and standing
 // approval executions to accurately reflect total agent activity.
+//
+// Design note: this queries the source-of-truth tables (approvals,
+// standing_approval_executions) rather than audit_events, because audit event
+// insertion is best-effort and could undercount if inserts fail silently.
 const agentListColumns = agentColumns + `,
 	(SELECT COUNT(*)
 	 FROM approvals

--- a/db/agents.go
+++ b/db/agents.go
@@ -82,11 +82,19 @@ type AgentPage struct {
 }
 
 // agentListColumns extends agentColumns with computed stats for the list query.
+// request_count_30d includes both one-off approval requests and standing
+// approval executions to accurately reflect total agent activity.
 const agentListColumns = agentColumns + `,
 	(SELECT COUNT(*)
 	 FROM approvals
 	 WHERE approvals.agent_id = agents.agent_id
-	   AND approvals.created_at > now() - interval '30 days') AS request_count_30d`
+	   AND approvals.created_at > now() - interval '30 days')
+	+
+	(SELECT COUNT(*)
+	 FROM standing_approval_executions sae
+	 JOIN standing_approvals sa ON sa.standing_approval_id = sae.standing_approval_id
+	 WHERE sa.agent_id = agents.agent_id
+	   AND sae.executed_at > now() - interval '30 days') AS request_count_30d`
 
 // scanAgentListItem scans a row selected with agentListColumns into an AgentListItem.
 func scanAgentListItem(row pgx.Row) (*AgentListItem, error) {

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -103,7 +103,7 @@ type InsertAuditEventParams struct {
 	Action          []byte  // raw JSONB, may be nil
 	ConnectorID     *string // which connector handled the action (nil for lifecycle events)
 	ExecutionStatus *string // "success", "failure", "timeout", "skipped" (nil for non-execution events)
-	ExecutionError  *string // failure details (nil unless ExecutionStatus is "failure")
+	ExecutionError  *string // failure details (nil unless ExecutionStatus is "failure"); exposed in API — never store internal/sensitive details
 }
 
 // InsertAuditEvent writes a new row into the audit_events table.

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -42,14 +42,17 @@ func IsValidAuditEventType(t AuditEventType) bool {
 
 // AuditEvent represents a single activity event in the audit trail.
 type AuditEvent struct {
-	ID        int64
-	EventType AuditEventType
-	Timestamp time.Time
-	AgentID   int64
-	AgentMeta []byte // raw JSONB (agent metadata snapshot at event time)
-	Action    []byte // raw JSONB (approval action details, nullable)
-	Outcome   string // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
-	SourceID  string // unique ID per event source (e.g. approval_id)
+	ID              int64
+	EventType       AuditEventType
+	Timestamp       time.Time
+	AgentID         int64
+	AgentMeta       []byte  // raw JSONB (agent metadata snapshot at event time)
+	Action          []byte  // raw JSONB (approval action details, nullable)
+	Outcome         string  // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
+	SourceID        string  // unique ID per event source (e.g. approval_id)
+	ConnectorID     *string // which connector handled the action (nullable for lifecycle events)
+	ExecutionStatus *string // "success", "failure", "timeout", "skipped" (nullable)
+	ExecutionError  *string // failure details (nullable)
 }
 
 // AuditEventPage holds a page of audit events plus a flag indicating whether more exist.
@@ -79,25 +82,37 @@ const MaxAuditEventListSize = 100
 // DefaultAuditEventLimit is the default page size.
 const DefaultAuditEventLimit = 20
 
+// ExecutionStatus constants for audit event execution tracking.
+const (
+	ExecStatusSuccess = "success"
+	ExecStatusFailure = "failure"
+	ExecStatusTimeout = "timeout"
+	ExecStatusSkipped = "skipped"
+)
+
 // InsertAuditEventParams holds the parameters for inserting an audit event.
 type InsertAuditEventParams struct {
-	UserID     string
-	AgentID    int64
-	EventType  AuditEventType
-	Outcome    string
-	SourceID   string
-	SourceType string
-	AgentMeta  []byte // raw JSONB
-	Action     []byte // raw JSONB, may be nil
+	UserID          string
+	AgentID         int64
+	EventType       AuditEventType
+	Outcome         string
+	SourceID        string
+	SourceType      string
+	AgentMeta       []byte  // raw JSONB
+	Action          []byte  // raw JSONB, may be nil
+	ConnectorID     *string // which connector handled the action (nil for lifecycle events)
+	ExecutionStatus *string // "success", "failure", "timeout", "skipped" (nil for non-execution events)
+	ExecutionError  *string // failure details (nil unless ExecutionStatus is "failure")
 }
 
 // InsertAuditEvent writes a new row into the audit_events table.
 func InsertAuditEvent(ctx context.Context, db DBTX, p InsertAuditEventParams) error {
 	_, err := db.Exec(ctx,
-		`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, action)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, action, connector_id, execution_status, execution_error)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		p.UserID, p.AgentID, string(p.EventType), p.Outcome,
 		p.SourceID, p.SourceType, p.AgentMeta, p.Action,
+		p.ConnectorID, p.ExecutionStatus, p.ExecutionError,
 	)
 	if err != nil {
 		return fmt.Errorf("insert audit event: %w", err)
@@ -163,7 +178,7 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 
 	query := fmt.Sprintf(
 		`SELECT ae.id, ae.event_type, ae.created_at, ae.agent_id, ae.agent_meta, ae.action,
-		        %s AS outcome, ae.source_id
+		        %s AS outcome, ae.source_id, ae.connector_id, ae.execution_status, ae.execution_error
 		 FROM audit_events ae
 		 LEFT JOIN agents a ON ae.agent_id = a.agent_id
 		 WHERE %s
@@ -265,7 +280,7 @@ func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Tim
 
 	query := fmt.Sprintf(
 		`SELECT ae.id, ae.event_type, ae.created_at, ae.agent_id, ae.agent_meta, ae.action,
-		        %s AS outcome, ae.source_id
+		        %s AS outcome, ae.source_id, ae.connector_id, ae.execution_status, ae.execution_error
 		 FROM audit_events ae
 		 LEFT JOIN agents a ON ae.agent_id = a.agent_id
 		 WHERE %s
@@ -299,7 +314,10 @@ func scanAuditEvents(rows pgx.Rows) ([]AuditEvent, error) {
 	for rows.Next() {
 		var e AuditEvent
 		var eventType string
-		if err := rows.Scan(&e.ID, &eventType, &e.Timestamp, &e.AgentID, &e.AgentMeta, &e.Action, &e.Outcome, &e.SourceID); err != nil {
+		if err := rows.Scan(
+			&e.ID, &eventType, &e.Timestamp, &e.AgentID, &e.AgentMeta, &e.Action,
+			&e.Outcome, &e.SourceID, &e.ConnectorID, &e.ExecutionStatus, &e.ExecutionError,
+		); err != nil {
 			return nil, fmt.Errorf("scan audit event: %w", err)
 		}
 		e.EventType = AuditEventType(eventType)

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -71,9 +71,10 @@ type AuditEventCursor struct {
 
 // AuditEventFilter holds optional filters for the audit event query.
 type AuditEventFilter struct {
-	AgentID    *int64
-	EventTypes []AuditEventType // if non-empty, include only these types
-	Outcome    string           // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
+	AgentID     *int64
+	EventTypes  []AuditEventType // if non-empty, include only these types
+	Outcome     string           // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
+	ConnectorID *string          // if non-nil, include only events for this connector
 }
 
 // MaxAuditEventListSize is the hard cap on returned events.
@@ -172,6 +173,9 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 		if filter.Outcome != "" {
 			where = append(where, outcomeFilter(filter.Outcome, b))
 		}
+		if filter.ConnectorID != nil {
+			where = append(where, "ae.connector_id = "+b.addArg(*filter.ConnectorID))
+		}
 	}
 
 	limitPlaceholder := b.addArg(fetchLimit)
@@ -242,7 +246,8 @@ type AuditLogExportCursor struct {
 // Optional parameters:
 //   - until: if non-nil, only returns events created before this timestamp
 //   - eventTypes: if non-empty, only returns events matching these types
-func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Time, until *time.Time, eventTypes []AuditEventType, limit int, cursor *AuditLogExportCursor) (*AuditEventPage, error) {
+//   - connectorID: if non-nil, only returns events for the specified connector
+func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Time, until *time.Time, eventTypes []AuditEventType, connectorID *string, limit int, cursor *AuditLogExportCursor) (*AuditEventPage, error) {
 	if limit <= 0 {
 		limit = DefaultAuditLogExportLimit
 	}
@@ -268,6 +273,10 @@ func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Tim
 			placeholders[i] = b.addArg(string(et))
 		}
 		where = append(where, "ae.event_type IN ("+strings.Join(placeholders, ", ")+")")
+	}
+
+	if connectorID != nil {
+		where = append(where, "ae.connector_id = "+b.addArg(*connectorID))
 	}
 
 	if cursor != nil {

--- a/db/audit_events_test.go
+++ b/db/audit_events_test.go
@@ -707,4 +707,96 @@ func TestInsertAuditEvent(t *testing.T) {
 			t.Errorf("expected nil action, got %s", string(page.Events[0].Action))
 		}
 	})
+
+	t.Run("WithConnectorAndExecutionStatus", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		// Insert a connector so the FK is satisfied.
+		testhelper.InsertConnector(t, tx, "github")
+
+		connectorID := "github"
+		execStatus := db.ExecStatusSuccess
+
+		err := db.InsertAuditEvent(ctx, tx, db.InsertAuditEventParams{
+			UserID:          uid,
+			AgentID:         agentID,
+			EventType:       db.AuditEventActionExecuted,
+			Outcome:         "auto_executed",
+			SourceID:        "test-approval-2",
+			SourceType:      "approval",
+			AgentMeta:       []byte(`{"name":"test"}`),
+			Action:          []byte(`{"type":"github.create_issue"}`),
+			ConnectorID:     &connectorID,
+			ExecutionStatus: &execStatus,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil)
+		if err != nil {
+			t.Fatalf("list error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(page.Events))
+		}
+		e := page.Events[0]
+		if e.ConnectorID == nil || *e.ConnectorID != "github" {
+			t.Errorf("expected connector_id=github, got %v", e.ConnectorID)
+		}
+		if e.ExecutionStatus == nil || *e.ExecutionStatus != db.ExecStatusSuccess {
+			t.Errorf("expected execution_status=success, got %v", e.ExecutionStatus)
+		}
+		if e.ExecutionError != nil {
+			t.Errorf("expected nil execution_error, got %v", e.ExecutionError)
+		}
+	})
+
+	t.Run("WithExecutionFailure", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		testhelper.InsertConnector(t, tx, "slack")
+
+		connectorID := "slack"
+		execStatus := db.ExecStatusFailure
+		execError := "API rate limit exceeded"
+
+		err := db.InsertAuditEvent(ctx, tx, db.InsertAuditEventParams{
+			UserID:          uid,
+			AgentID:         agentID,
+			EventType:       db.AuditEventStandingExecution,
+			Outcome:         "auto_executed",
+			SourceID:        "test-sa-1",
+			SourceType:      "standing_approval",
+			AgentMeta:       []byte(`{"name":"test"}`),
+			Action:          []byte(`{"type":"slack.send_message"}`),
+			ConnectorID:     &connectorID,
+			ExecutionStatus: &execStatus,
+			ExecutionError:  &execError,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil)
+		if err != nil {
+			t.Fatalf("list error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(page.Events))
+		}
+		e := page.Events[0]
+		if e.ExecutionStatus == nil || *e.ExecutionStatus != db.ExecStatusFailure {
+			t.Errorf("expected execution_status=failure, got %v", e.ExecutionStatus)
+		}
+		if e.ExecutionError == nil || *e.ExecutionError != "API rate limit exceeded" {
+			t.Errorf("expected execution_error='API rate limit exceeded', got %v", e.ExecutionError)
+		}
+	})
 }

--- a/db/audit_events_test.go
+++ b/db/audit_events_test.go
@@ -236,6 +236,31 @@ func TestListAuditEvents(t *testing.T) {
 		}
 	})
 
+	t.Run("FilterByConnectorID", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		github := "github"
+		slack := "slack"
+		testhelper.InsertAuditEventWithConnector(t, tx, uid, agentID, "approval.approved", "approved", testhelper.GenerateID(t, "appr_"), &github)
+		testhelper.InsertAuditEventWithConnector(t, tx, uid, agentID, "approval.approved", "approved", testhelper.GenerateID(t, "appr_"), &slack)
+		testhelper.InsertAuditEventWithConnector(t, tx, uid, agentID, "agent.registered", "registered", testhelper.GenerateID(t, "ar_"), nil)
+
+		filter := &db.AuditEventFilter{ConnectorID: &github}
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, filter)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(page.Events))
+		}
+		if page.Events[0].ConnectorID == nil || *page.Events[0].ConnectorID != "github" {
+			t.Errorf("expected connector_id=github, got %v", page.Events[0].ConnectorID)
+		}
+	})
+
 	t.Run("Pagination", func(t *testing.T) {
 		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
@@ -625,6 +650,31 @@ func TestExportAuditLogs(t *testing.T) {
 			if e.EventType != db.AuditEventApprovalApproved && e.EventType != db.AuditEventApprovalDenied {
 				t.Errorf("unexpected event type: %s", e.EventType)
 			}
+		}
+	})
+
+	t.Run("ConnectorIDFilter", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		github := "github"
+		slack := "slack"
+		testhelper.InsertAuditEventWithConnector(t, tx, uid, agentID, "approval.approved", "approved", testhelper.GenerateID(t, "appr_"), &github)
+		testhelper.InsertAuditEventWithConnector(t, tx, uid, agentID, "standing_approval.executed", "auto_executed", testhelper.GenerateID(t, "sae_"), &slack)
+		testhelper.InsertAuditEventWithConnector(t, tx, uid, agentID, "agent.registered", "registered", fmt.Sprintf("ar:%d", agentID), nil)
+
+		since := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, &slack, 100, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(page.Events))
+		}
+		if page.Events[0].ConnectorID == nil || *page.Events[0].ConnectorID != "slack" {
+			t.Errorf("expected connector_id=slack, got %v", page.Events[0].ConnectorID)
 		}
 	})
 }

--- a/db/audit_events_test.go
+++ b/db/audit_events_test.go
@@ -414,7 +414,7 @@ func TestExportAuditLogs(t *testing.T) {
 		testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 100, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 100, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -438,7 +438,7 @@ func TestExportAuditLogs(t *testing.T) {
 		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.denied", "denied", testhelper.GenerateID(t, "appr_"), recent)
 
 		since := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 100, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 100, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -463,7 +463,7 @@ func TestExportAuditLogs(t *testing.T) {
 		}
 
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 100, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 100, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -493,7 +493,7 @@ func TestExportAuditLogs(t *testing.T) {
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 		// Page 1
-		page1, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 2, nil)
+		page1, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 2, nil)
 		if err != nil {
 			t.Fatalf("page 1: %v", err)
 		}
@@ -507,7 +507,7 @@ func TestExportAuditLogs(t *testing.T) {
 		// Page 2
 		last := page1.Events[len(page1.Events)-1]
 		cursor := &db.AuditLogExportCursor{Timestamp: last.Timestamp, ID: last.ID}
-		page2, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 2, cursor)
+		page2, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 2, cursor)
 		if err != nil {
 			t.Fatalf("page 2: %v", err)
 		}
@@ -529,7 +529,7 @@ func TestExportAuditLogs(t *testing.T) {
 		// Page 3
 		last2 := page2.Events[len(page2.Events)-1]
 		cursor2 := &db.AuditLogExportCursor{Timestamp: last2.Timestamp, ID: last2.ID}
-		page3, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 2, cursor2)
+		page3, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 2, cursor2)
 		if err != nil {
 			t.Fatalf("page 3: %v", err)
 		}
@@ -553,7 +553,7 @@ func TestExportAuditLogs(t *testing.T) {
 		testhelper.InsertUser(t, tx, uid2, "u2_"+uid2[:6])
 
 		since := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-		page, err := db.ExportAuditLogs(ctx, tx, uid2, since, nil, nil, 100, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid2, since, nil, nil, nil, 100, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -569,7 +569,7 @@ func TestExportAuditLogs(t *testing.T) {
 		testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, 0, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, nil, nil, 0, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -593,7 +593,7 @@ func TestExportAuditLogs(t *testing.T) {
 
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-		page, err := db.ExportAuditLogs(ctx, tx, uid, since, &until, nil, 100, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, &until, nil, nil, 100, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -614,7 +614,7 @@ func TestExportAuditLogs(t *testing.T) {
 
 		since := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 		eventTypes := []db.AuditEventType{db.AuditEventApprovalApproved, db.AuditEventApprovalDenied}
-		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, eventTypes, 100, nil)
+		page, err := db.ExportAuditLogs(ctx, tx, uid, since, nil, eventTypes, nil, 100, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/db/migrations/20260228300000_audit_events_connector_id.sql
+++ b/db/migrations/20260228300000_audit_events_connector_id.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+
+-- Add connector_id to audit_events for per-connector analytics and billing.
+-- Nullable because agent lifecycle events (registered, deactivated) have no
+-- associated connector.
+-- No FK constraint because the connector_id is derived from the action type
+-- string and used for analytics — the connector may not yet be registered
+-- (or may have been removed).
+ALTER TABLE audit_events
+    ADD COLUMN connector_id text;
+
+CREATE INDEX idx_audit_events_connector_created
+    ON audit_events (connector_id, created_at DESC)
+    WHERE connector_id IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_audit_events_connector_created;
+ALTER TABLE audit_events DROP COLUMN IF EXISTS connector_id;

--- a/db/migrations/20260228300001_audit_events_execution_result.sql
+++ b/db/migrations/20260228300001_audit_events_execution_result.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+-- Track whether executed actions succeeded or failed at the third-party service.
+-- Only populated for action.executed and standing_approval.executed events.
+ALTER TABLE audit_events
+    ADD COLUMN execution_status text CHECK (execution_status IN ('success', 'failure', 'timeout', 'skipped'));
+
+ALTER TABLE audit_events
+    ADD COLUMN execution_error text;
+
+-- +goose Down
+
+ALTER TABLE audit_events DROP COLUMN IF EXISTS execution_error;
+ALTER TABLE audit_events DROP COLUMN IF EXISTS execution_status;

--- a/db/migrations/20260228300002_usage_periods_breakdown.sql
+++ b/db/migrations/20260228300002_usage_periods_breakdown.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+
+-- Add JSONB breakdown column for per-agent, per-connector, and per-action-type
+-- usage analytics within a billing period.
+-- Structure: { "by_agent": { "<agent_id>": N }, "by_connector": { "<connector_id>": N }, "by_action_type": { "<type>": N } }
+ALTER TABLE usage_periods
+    ADD COLUMN breakdown jsonb NOT NULL DEFAULT '{}';
+
+-- +goose Down
+
+ALTER TABLE usage_periods DROP COLUMN IF EXISTS breakdown;

--- a/db/testhelper/fixtures_audit_events.go
+++ b/db/testhelper/fixtures_audit_events.go
@@ -34,6 +34,15 @@ func InsertAuditEventAt(t *testing.T, d db.DBTX, userID string, agentID int64, e
 		userID, agentID, eventType, outcome, sourceID, SourceTypeForEvent(eventType), createdAt)
 }
 
+// InsertAuditEventWithConnector inserts an audit event with an explicit connector_id.
+func InsertAuditEventWithConnector(t *testing.T, d db.DBTX, userID string, agentID int64, eventType, outcome, sourceID string, connectorID *string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, action, connector_id, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, '{"name":"test"}', '{"type":"test.action"}', $7, $8)`,
+		userID, agentID, eventType, outcome, sourceID, SourceTypeForEvent(eventType), connectorID, time.Now())
+}
+
 // InsertAuditEventWithAction inserts an audit event with explicit agent_meta and action JSONB values.
 func InsertAuditEventWithAction(t *testing.T, d db.DBTX, userID string, agentID int64, eventType, outcome, sourceID string, agentMeta, action []byte) {
 	t.Helper()

--- a/db/usage_periods.go
+++ b/db/usage_periods.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -23,10 +25,11 @@ type UsagePeriod struct {
 	PeriodEnd    time.Time // exclusive: first instant of the next month
 	RequestCount int
 	SMSCount     int
+	Breakdown    []byte // raw JSONB: { "by_agent": {...}, "by_connector": {...}, "by_action_type": {...} }
 	CreatedAt    time.Time
 }
 
-const usagePeriodColumns = `id, user_id, period_start, period_end, request_count, sms_count, created_at`
+const usagePeriodColumns = `id, user_id, period_start, period_end, request_count, sms_count, breakdown, created_at`
 
 func scanUsagePeriod(row pgx.Row) (*UsagePeriod, error) {
 	var u UsagePeriod
@@ -37,6 +40,7 @@ func scanUsagePeriod(row pgx.Row) (*UsagePeriod, error) {
 		&u.PeriodEnd,
 		&u.RequestCount,
 		&u.SMSCount,
+		&u.Breakdown,
 		&u.CreatedAt,
 	)
 	if err != nil {
@@ -78,6 +82,76 @@ func IncrementRequestCount(ctx context.Context, db DBTX, userID string, periodSt
 		userID, periodStart, periodEnd))
 }
 
+// UsageBreakdownKeys holds the keys used to update the JSONB breakdown
+// when incrementing the request count.
+type UsageBreakdownKeys struct {
+	AgentID     int64
+	ConnectorID string // may be empty if unknown
+	ActionType  string // may be empty if unknown
+}
+
+// IncrementRequestCountWithBreakdown atomically increments the request count
+// and updates the JSONB breakdown for the given user and billing period.
+// The breakdown tracks counts by agent, connector, and action type using
+// atomic jsonb_set operations.
+func IncrementRequestCountWithBreakdown(ctx context.Context, db DBTX, userID string, periodStart, periodEnd time.Time, keys UsageBreakdownKeys) (*UsagePeriod, error) {
+	agentKey := strconv.FormatInt(keys.AgentID, 10)
+
+	// Build the breakdown update expression. We use nested jsonb_set calls
+	// to atomically increment counters within the JSONB breakdown column.
+	// Each path (by_agent.<id>, by_connector.<id>, by_action_type.<type>)
+	// is incremented by 1, initialising to 1 if the key doesn't exist.
+	breakdownUpdate := `
+		jsonb_set(
+			jsonb_set(
+				jsonb_set(
+					COALESCE(usage_periods.breakdown, '{}'),
+					'{by_agent}',
+					jsonb_set(
+						COALESCE(usage_periods.breakdown->'by_agent', '{}'),
+						ARRAY[$4::text],
+						to_jsonb(COALESCE((usage_periods.breakdown->'by_agent'->>$4::text)::int, 0) + 1)
+					)
+				),
+				'{by_connector}',
+				CASE WHEN $5::text = '' THEN COALESCE(usage_periods.breakdown->'by_connector', '{}')
+				ELSE jsonb_set(
+					COALESCE(usage_periods.breakdown->'by_connector', '{}'),
+					ARRAY[$5::text],
+					to_jsonb(COALESCE((usage_periods.breakdown->'by_connector'->>$5::text)::int, 0) + 1)
+				) END
+			),
+			'{by_action_type}',
+			CASE WHEN $6::text = '' THEN COALESCE(usage_periods.breakdown->'by_action_type', '{}')
+			ELSE jsonb_set(
+				COALESCE(usage_periods.breakdown->'by_action_type', '{}'),
+				ARRAY[$6::text],
+				to_jsonb(COALESCE((usage_periods.breakdown->'by_action_type'->>$6::text)::int, 0) + 1)
+			) END
+		)`
+
+	query := fmt.Sprintf(
+		`INSERT INTO usage_periods (user_id, period_start, period_end, request_count, breakdown)
+		 VALUES ($1, $2, $3, 1, jsonb_build_object(
+			'by_agent', jsonb_build_object($4::text, 1),
+			'by_connector', CASE WHEN $5::text = '' THEN '{}'::jsonb ELSE jsonb_build_object($5::text, 1) END,
+			'by_action_type', CASE WHEN $6::text = '' THEN '{}'::jsonb ELSE jsonb_build_object($6::text, 1) END
+		 ))
+		 ON CONFLICT (user_id, period_start)
+		 DO UPDATE SET request_count = usage_periods.request_count + 1,
+		              period_end = EXCLUDED.period_end,
+		              breakdown = %s
+		 RETURNING %s`,
+		breakdownUpdate,
+		usagePeriodColumns,
+	)
+
+	return scanUsagePeriod(db.QueryRow(ctx, query,
+		userID, periodStart, periodEnd,
+		agentKey, keys.ConnectorID, keys.ActionType,
+	))
+}
+
 // IncrementSMSCount atomically increments the SMS count for the given user
 // and billing period. If no row exists for the period, one is created via upsert.
 func IncrementSMSCount(ctx context.Context, db DBTX, userID string, periodStart, periodEnd time.Time) (*UsagePeriod, error) {
@@ -103,4 +177,13 @@ func GetUsageByPeriod(ctx context.Context, db DBTX, userID string, periodStart t
 		return nil, nil
 	}
 	return u, err
+}
+
+// BillingPeriodBounds returns the start (inclusive) and end (exclusive) of the
+// billing month containing the given time, using UTC.
+func BillingPeriodBounds(t time.Time) (start, end time.Time) {
+	t = t.UTC()
+	start = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end = start.AddDate(0, 1, 0)
+	return start, end
 }

--- a/db/usage_periods.go
+++ b/db/usage_periods.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -179,8 +180,49 @@ func GetUsageByPeriod(ctx context.Context, db DBTX, userID string, periodStart t
 	return u, err
 }
 
+// UsageBreakdown is the typed representation of the usage_periods.breakdown JSONB
+// column. Each map key is an identifier (agent ID, connector ID, or action type)
+// and the value is the number of billable requests attributed to that key.
+type UsageBreakdown struct {
+	ByAgent      map[string]int `json:"by_agent"`
+	ByConnector  map[string]int `json:"by_connector"`
+	ByActionType map[string]int `json:"by_action_type"`
+}
+
+// ParseBreakdown unmarshals the raw JSONB breakdown into a typed struct.
+// Returns a zero-value UsageBreakdown (empty maps) if the raw bytes are empty
+// or cannot be parsed.
+func (u *UsagePeriod) ParseBreakdown() UsageBreakdown {
+	var b UsageBreakdown
+	if len(u.Breakdown) > 0 {
+		_ = json.Unmarshal(u.Breakdown, &b)
+	}
+	if b.ByAgent == nil {
+		b.ByAgent = map[string]int{}
+	}
+	if b.ByConnector == nil {
+		b.ByConnector = map[string]int{}
+	}
+	if b.ByActionType == nil {
+		b.ByActionType = map[string]int{}
+	}
+	return b
+}
+
+// GetCurrentPeriodUsage returns the usage record for the current billing month
+// (based on UTC now), or nil if no usage has been recorded yet this month.
+func GetCurrentPeriodUsage(ctx context.Context, db DBTX, userID string) (*UsagePeriod, error) {
+	periodStart, _ := BillingPeriodBounds(time.Now())
+	return GetUsageByPeriod(ctx, db, userID, periodStart)
+}
+
 // BillingPeriodBounds returns the start (inclusive) and end (exclusive) of the
-// billing month containing the given time, using UTC.
+// billing month containing the given time. All calculations use UTC.
+//
+// Example:
+//
+//	BillingPeriodBounds(2026-02-15T14:30:00Z)
+//	→ (2026-02-01T00:00:00Z, 2026-03-01T00:00:00Z)
 func BillingPeriodBounds(t time.Time) (start, end time.Time) {
 	t = t.UTC()
 	start = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)

--- a/db/usage_periods_test.go
+++ b/db/usage_periods_test.go
@@ -489,3 +489,66 @@ func TestBillingPeriodBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBreakdown(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil breakdown", func(t *testing.T) {
+		t.Parallel()
+		u := &db.UsagePeriod{Breakdown: nil}
+		b := u.ParseBreakdown()
+		if b.ByAgent == nil || b.ByConnector == nil || b.ByActionType == nil {
+			t.Fatal("expected initialized maps, got nil")
+		}
+		if len(b.ByAgent) != 0 || len(b.ByConnector) != 0 || len(b.ByActionType) != 0 {
+			t.Error("expected empty maps for nil breakdown")
+		}
+	})
+
+	t.Run("empty object", func(t *testing.T) {
+		t.Parallel()
+		u := &db.UsagePeriod{Breakdown: []byte(`{}`)}
+		b := u.ParseBreakdown()
+		if len(b.ByAgent) != 0 || len(b.ByConnector) != 0 || len(b.ByActionType) != 0 {
+			t.Error("expected empty maps for empty object")
+		}
+	})
+
+	t.Run("partial keys", func(t *testing.T) {
+		t.Parallel()
+		u := &db.UsagePeriod{Breakdown: []byte(`{"by_agent":{"42":5}}`)}
+		b := u.ParseBreakdown()
+		if b.ByAgent["42"] != 5 {
+			t.Errorf("ByAgent[42] = %d, want 5", b.ByAgent["42"])
+		}
+		if b.ByConnector == nil || b.ByActionType == nil {
+			t.Fatal("expected initialized maps for missing keys")
+		}
+	})
+
+	t.Run("full breakdown", func(t *testing.T) {
+		t.Parallel()
+		raw := `{"by_agent":{"1":10,"2":3},"by_connector":{"github":8,"slack":5},"by_action_type":{"github.create_issue":6,"slack.send_message":7}}`
+		u := &db.UsagePeriod{Breakdown: []byte(raw)}
+		b := u.ParseBreakdown()
+		if b.ByAgent["1"] != 10 || b.ByAgent["2"] != 3 {
+			t.Errorf("ByAgent = %v", b.ByAgent)
+		}
+		if b.ByConnector["github"] != 8 || b.ByConnector["slack"] != 5 {
+			t.Errorf("ByConnector = %v", b.ByConnector)
+		}
+		if b.ByActionType["github.create_issue"] != 6 || b.ByActionType["slack.send_message"] != 7 {
+			t.Errorf("ByActionType = %v", b.ByActionType)
+		}
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		t.Parallel()
+		u := &db.UsagePeriod{Breakdown: []byte(`not json`)}
+		b := u.ParseBreakdown()
+		// Should degrade gracefully with empty initialized maps.
+		if b.ByAgent == nil || b.ByConnector == nil || b.ByActionType == nil {
+			t.Fatal("expected initialized maps, got nil")
+		}
+	})
+}

--- a/db/usage_periods_test.go
+++ b/db/usage_periods_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ func TestUsagePeriodsSchema(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	testhelper.RequireColumns(t, tx, "usage_periods", []string{
 		"id", "user_id", "period_start", "period_end",
-		"request_count", "sms_count", "created_at",
+		"request_count", "sms_count", "breakdown", "created_at",
 	})
 }
 
@@ -348,5 +349,143 @@ func TestIncrementRequestCountConcurrent(t *testing.T) {
 	want := goroutines * incrementsPerGoroutine
 	if usage.RequestCount != want {
 		t.Errorf("expected request_count=%d after concurrent increments, got %d", want, usage.RequestCount)
+	}
+}
+
+func TestIncrementRequestCountWithBreakdown(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	ctx := context.Background()
+
+	periodStart := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// First increment creates the row with breakdown
+	usage, err := db.IncrementRequestCountWithBreakdown(ctx, tx, uid, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     42,
+		ConnectorID: "github",
+		ActionType:  "github.create_issue",
+	})
+	if err != nil {
+		t.Fatalf("IncrementRequestCountWithBreakdown: %v", err)
+	}
+	if usage.RequestCount != 1 {
+		t.Errorf("expected request_count=1, got %d", usage.RequestCount)
+	}
+	if usage.Breakdown == nil {
+		t.Fatal("expected non-nil breakdown")
+	}
+
+	// Second increment for same agent/connector
+	usage, err = db.IncrementRequestCountWithBreakdown(ctx, tx, uid, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     42,
+		ConnectorID: "github",
+		ActionType:  "github.create_issue",
+	})
+	if err != nil {
+		t.Fatalf("IncrementRequestCountWithBreakdown: %v", err)
+	}
+	if usage.RequestCount != 2 {
+		t.Errorf("expected request_count=2, got %d", usage.RequestCount)
+	}
+
+	// Third increment with different agent/connector
+	usage, err = db.IncrementRequestCountWithBreakdown(ctx, tx, uid, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     99,
+		ConnectorID: "slack",
+		ActionType:  "slack.send_message",
+	})
+	if err != nil {
+		t.Fatalf("IncrementRequestCountWithBreakdown: %v", err)
+	}
+	if usage.RequestCount != 3 {
+		t.Errorf("expected request_count=3, got %d", usage.RequestCount)
+	}
+
+	// Verify breakdown JSONB is populated
+	var breakdown map[string]map[string]int
+	if err := json.Unmarshal(usage.Breakdown, &breakdown); err != nil {
+		t.Fatalf("failed to unmarshal breakdown: %v", err)
+	}
+	if breakdown["by_agent"]["42"] != 2 {
+		t.Errorf("expected by_agent[42]=2, got %d", breakdown["by_agent"]["42"])
+	}
+	if breakdown["by_agent"]["99"] != 1 {
+		t.Errorf("expected by_agent[99]=1, got %d", breakdown["by_agent"]["99"])
+	}
+	if breakdown["by_connector"]["github"] != 2 {
+		t.Errorf("expected by_connector[github]=2, got %d", breakdown["by_connector"]["github"])
+	}
+	if breakdown["by_connector"]["slack"] != 1 {
+		t.Errorf("expected by_connector[slack]=1, got %d", breakdown["by_connector"]["slack"])
+	}
+}
+
+func TestIncrementRequestCountWithBreakdownEmptyConnector(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	ctx := context.Background()
+
+	periodStart := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// Increment with empty connector_id and action_type (e.g. agent lifecycle events)
+	usage, err := db.IncrementRequestCountWithBreakdown(ctx, tx, uid, periodStart, periodEnd, db.UsageBreakdownKeys{
+		AgentID:     42,
+		ConnectorID: "",
+		ActionType:  "",
+	})
+	if err != nil {
+		t.Fatalf("IncrementRequestCountWithBreakdown: %v", err)
+	}
+	if usage.RequestCount != 1 {
+		t.Errorf("expected request_count=1, got %d", usage.RequestCount)
+	}
+}
+
+func TestBillingPeriodBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      time.Time
+		wantStart  time.Time
+		wantEnd    time.Time
+	}{
+		{
+			name:      "middle of month",
+			input:     time.Date(2026, 2, 15, 14, 30, 0, 0, time.UTC),
+			wantStart: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "first of month",
+			input:     time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "last day of year",
+			input:     time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC),
+			wantStart: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			start, end := db.BillingPeriodBounds(tt.input)
+			if !start.Equal(tt.wantStart) {
+				t.Errorf("start: got %v, want %v", start, tt.wantStart)
+			}
+			if !end.Equal(tt.wantEnd) {
+				t.Errorf("end: got %v, want %v", end, tt.wantEnd)
+			}
+		})
 	}
 }

--- a/spec/openapi/components/paths/audit_events.yaml
+++ b/spec/openapi/components/paths/audit_events.yaml
@@ -47,6 +47,15 @@ exportAuditLogs:
         schema:
           type: string
         example: "approval.approved,approval.denied"
+      - name: connector_id
+        in: query
+        required: false
+        description: |
+          Filter events to a specific connector (e.g. "github", "slack").
+          Only returns events where the action was handled by this connector.
+        schema:
+          type: string
+        example: "github"
       - name: limit
         in: query
         required: false
@@ -219,6 +228,15 @@ listAuditEvents:
             - pending
             - expired
         example: "approved"
+      - name: connector_id
+        in: query
+        required: false
+        description: |
+          Filter events to a specific connector (e.g. "github", "slack").
+          Only returns events where the action was handled by this connector.
+        schema:
+          type: string
+        example: "github"
 
     responses:
       '200':

--- a/spec/openapi/components/paths/audit_events.yaml
+++ b/spec/openapi/components/paths/audit_events.yaml
@@ -100,6 +100,8 @@ exportAuditLogs:
                       subject: "Hello"
                   outcome: "approved"
                   source_id: "appr_abc123"
+                  connector_id: "email"
+                  execution_status: null
                 - id: 12346
                   event_type: "standing_approval.executed"
                   timestamp: "2026-02-20T14:35:00Z"
@@ -111,6 +113,8 @@ exportAuditLogs:
                     version: "1"
                   outcome: "auto_executed"
                   source_id: "sae_def456"
+                  connector_id: "email"
+                  execution_status: "success"
               has_more: true
               next_cursor: "2026-02-20T14:35:00.123456789Z,12346"
 
@@ -259,6 +263,8 @@ listAuditEvents:
                       to: "alice@example.com"
                       subject: "Hello"
                   outcome: "approved"
+                  connector_id: "email"
+                  execution_status: null
                 - event_type: "standing_approval.executed"
                   timestamp: "2026-02-20T14:25:00Z"
                   agent_id: 42
@@ -270,6 +276,8 @@ listAuditEvents:
                     constraints:
                       sender: "*@mycompany.com"
                   outcome: "auto_executed"
+                  connector_id: "email"
+                  execution_status: "success"
                 - event_type: "agent.registered"
                   timestamp: "2026-02-19T10:00:00Z"
                   agent_id: 43

--- a/spec/openapi/components/schemas/audit_events.yaml
+++ b/spec/openapi/components/schemas/audit_events.yaml
@@ -57,6 +57,32 @@ AuditEvent:
         - expired
       description: The outcome of the event.
       example: "approved"
+    connector_id:
+      type: string
+      nullable: true
+      description: |
+        The connector that handled this action (e.g. "github", "slack").
+        Null for agent lifecycle events (registered, deactivated).
+      example: "github"
+    execution_status:
+      type: string
+      nullable: true
+      enum:
+        - success
+        - failure
+        - timeout
+        - skipped
+      description: |
+        Whether the executed action succeeded or failed at the third-party
+        service. Only present for action.executed and standing_approval.executed
+        events.
+      example: "success"
+    execution_error:
+      type: string
+      nullable: true
+      description: |
+        Details about why the execution failed. Only present when
+        execution_status is "failure".
 
 AuditLogEvent:
   type: object
@@ -130,6 +156,32 @@ AuditLogEvent:
         standing approval execution id, agent id). Useful for correlating
         events back to their originating resource.
       example: "appr_abc123"
+    connector_id:
+      type: string
+      nullable: true
+      description: |
+        The connector that handled this action (e.g. "github", "slack").
+        Null for agent lifecycle events (registered, deactivated).
+      example: "github"
+    execution_status:
+      type: string
+      nullable: true
+      enum:
+        - success
+        - failure
+        - timeout
+        - skipped
+      description: |
+        Whether the executed action succeeded or failed at the third-party
+        service. Only present for action.executed and standing_approval.executed
+        events.
+      example: "success"
+    execution_error:
+      type: string
+      nullable: true
+      description: |
+        Details about why the execution failed. Only present when
+        execution_status is "failure".
 
 AuditLogExportResponse:
   type: object

--- a/spec/openapi/components/schemas/audit_events.yaml
+++ b/spec/openapi/components/schemas/audit_events.yaml
@@ -10,9 +10,11 @@ AuditEvent:
     event_type:
       type: string
       enum:
+        - approval.requested
         - approval.approved
         - approval.denied
         - approval.cancelled
+        - action.executed
         - standing_approval.executed
         - agent.registered
         - agent.deactivated

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -6685,6 +6685,32 @@ components:
             - expired
           description: The outcome of the event.
           example: approved
+        connector_id:
+          type: string
+          nullable: true
+          description: |
+            The connector that handled this action (e.g. "github", "slack").
+            Null for agent lifecycle events (registered, deactivated).
+          example: github
+        execution_status:
+          type: string
+          nullable: true
+          enum:
+            - success
+            - failure
+            - timeout
+            - skipped
+          description: |
+            Whether the executed action succeeded or failed at the third-party
+            service. Only present for action.executed and standing_approval.executed
+            events.
+          example: success
+        execution_error:
+          type: string
+          nullable: true
+          description: |
+            Details about why the execution failed. Only present when
+            execution_status is "failure".
     AuditEventListResponse:
       type: object
       description: Paginated list of audit events.
@@ -6779,6 +6805,32 @@ components:
             standing approval execution id, agent id). Useful for correlating
             events back to their originating resource.
           example: appr_abc123
+        connector_id:
+          type: string
+          nullable: true
+          description: |
+            The connector that handled this action (e.g. "github", "slack").
+            Null for agent lifecycle events (registered, deactivated).
+          example: github
+        execution_status:
+          type: string
+          nullable: true
+          enum:
+            - success
+            - failure
+            - timeout
+            - skipped
+          description: |
+            Whether the executed action succeeded or failed at the third-party
+            service. Only present for action.executed and standing_approval.executed
+            events.
+          example: success
+        execution_error:
+          type: string
+          nullable: true
+          description: |
+            Details about why the execution failed. Only present when
+            execution_status is "failure".
     AuditLogExportResponse:
       type: object
       description: Paginated export of audit log events in chronological order.

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1555,6 +1555,15 @@ paths:
           schema:
             type: string
           example: approval.approved,approval.denied
+        - name: connector_id
+          in: query
+          required: false
+          description: |
+            Filter events to a specific connector (e.g. "github", "slack").
+            Only returns events where the action was handled by this connector.
+          schema:
+            type: string
+          example: github
         - name: limit
           in: query
           required: false
@@ -1716,6 +1725,15 @@ paths:
               - pending
               - expired
           example: approved
+        - name: connector_id
+          in: query
+          required: false
+          description: |
+            Filter events to a specific connector (e.g. "github", "slack").
+            Only returns events where the action was handled by this connector.
+          schema:
+            type: string
+          example: github
       responses:
         '200':
           description: Audit events retrieved successfully
@@ -6638,9 +6656,11 @@ components:
         event_type:
           type: string
           enum:
+            - approval.requested
             - approval.approved
             - approval.denied
             - approval.cancelled
+            - action.executed
             - standing_approval.executed
             - agent.registered
             - agent.deactivated

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1607,6 +1607,8 @@ paths:
                         subject: Hello
                     outcome: approved
                     source_id: appr_abc123
+                    connector_id: email
+                    execution_status: null
                   - id: 12346
                     event_type: standing_approval.executed
                     timestamp: '2026-02-20T14:35:00Z'
@@ -1618,6 +1620,8 @@ paths:
                       version: '1'
                     outcome: auto_executed
                     source_id: sae_def456
+                    connector_id: email
+                    execution_status: success
                 has_more: true
                 next_cursor: 2026-02-20T14:35:00.123456789Z,12346
         '400':
@@ -1755,6 +1759,8 @@ paths:
                         to: alice@example.com
                         subject: Hello
                     outcome: approved
+                    connector_id: email
+                    execution_status: null
                   - event_type: standing_approval.executed
                     timestamp: '2026-02-20T14:25:00Z'
                     agent_id: 42
@@ -1766,6 +1772,8 @@ paths:
                       constraints:
                         sender: '*@mycompany.com'
                     outcome: auto_executed
+                    connector_id: email
+                    execution_status: success
                   - event_type: agent.registered
                     timestamp: '2026-02-19T10:00:00Z'
                     agent_id: 43


### PR DESCRIPTION
Addresses issue #367 by closing several audit log gaps:

1. request_count_30d: Now includes standing approval executions in addition
   to one-off approval requests for accurate agent activity counts.

2. connector_id on audit_events: New nullable column tracks which connector
   handled each action, derived from the action_type convention
   (e.g. "github.create_issue" → "github"). Populated on all action-related
   audit events (approval.requested, approval.approved/denied/cancelled,
   action.executed, standing_approval.executed).

3. execution_status/execution_error on audit_events: New columns track
   whether connector actions succeeded or failed. Supports values:
   success, failure, timeout, skipped.

4. Usage breakdown: New JSONB breakdown column on usage_periods tracks
   per-agent, per-connector, and per-action-type request counts within
   each billing period using atomic jsonb_set operations.

5. Billable event metering: approval.requested and standing_approval.executed
   events now increment usage_periods with full breakdown data.

Includes migrations, OpenAPI spec updates, API response changes, and tests.

https://claude.ai/code/session_01V3KHfAXQWEgxvHv3wc4KN4