### PR TITLE
Add data retention compliance: audit log purge + account deletion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ SUPABASE_URL=http://127.0.0.1:54321
 # SUPABASE_JWKS_URL=http://127.0.0.1:54321/auth/v1/.well-known/jwks.json  # optional override
 # SUPABASE_JWT_SECRET=your-jwt-secret  # legacy HS256 only — not needed for CLI v2+
 
+# Supabase service_role key — required for Admin API operations (e.g. deleting
+# auth users on account deletion). Get from `supabase status` (local dev) or
+# your Supabase project dashboard (production).
+# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
 # Allowed CORS origins — comma-separated list of origins permitted to make
 # cross-origin requests to the API. When empty, the server operates in
 # "same-origin only" mode: requests whose Origin matches the server's own

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -35,10 +36,14 @@ func RegisterProfileRoutes(mux *http.ServeMux, deps *Deps) {
 	// Profile CRUD
 	mux.Handle("GET /profile", requireProfile(handleGetProfile()))
 	mux.Handle("PATCH /profile", requireProfile(handleUpdateProfile(deps)))
+	mux.Handle("DELETE /profile", requireProfile(handleDeleteAccount(deps)))
 
 	// Notification preferences (sub-resource of profile)
 	mux.Handle("GET /profile/notification-preferences", requireProfile(handleGetNotificationPreferences(deps)))
 	mux.Handle("PUT /profile/notification-preferences", requireProfile(handleUpdateNotificationPreferences(deps)))
+
+	// Data retention policy
+	mux.Handle("GET /profile/data-retention", requireProfile(handleGetDataRetention(deps)))
 }
 
 func handleGetProfile() http.HandlerFunc {
@@ -139,6 +144,108 @@ func handleUpdateProfile(deps *Deps) http.HandlerFunc {
 			Email:     updated.Email,
 			Phone:     updated.Phone,
 			CreatedAt: updated.CreatedAt,
+		})
+	}
+}
+
+// deleteAccountRequest is the JSON body for DELETE /profile.
+// The confirmation field acts as a safety check to prevent accidental deletion.
+type deleteAccountRequest struct {
+	Confirmation string `json:"confirmation"`
+}
+
+// deleteAccountResponse is the JSON shape returned by DELETE /profile.
+type deleteAccountResponse struct {
+	Deleted bool   `json:"deleted"`
+	Message string `json:"message"`
+}
+
+func handleDeleteAccount(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		var req deleteAccountRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		if req.Confirmation != "DELETE" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				`To confirm account deletion, set "confirmation" to "DELETE"`))
+			return
+		}
+
+		// Run deletion inside a transaction so vault cleanup and profile
+		// deletion are atomic.
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] handleDeleteAccount: begin tx: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete account"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx)
+		}
+
+		// Build vault delete function if vault is available.
+		var vaultDeleteFn func(ctx context.Context, d db.DBTX, secretID string) error
+		if deps.Vault != nil {
+			vaultDeleteFn = deps.Vault.DeleteSecret
+		}
+
+		if err := db.DeleteAccount(r.Context(), tx, profile.ID, vaultDeleteFn); err != nil {
+			log.Printf("[%s] handleDeleteAccount: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete account"))
+			return
+		}
+
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] handleDeleteAccount: commit: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete account"))
+				return
+			}
+		}
+
+		RespondJSON(w, http.StatusOK, deleteAccountResponse{
+			Deleted: true,
+			Message: "Account and all associated data have been permanently deleted.",
+		})
+	}
+}
+
+// dataRetentionResponse is the JSON shape returned by GET /profile/data-retention.
+type dataRetentionResponse struct {
+	PlanID             string `json:"plan_id"`
+	PlanName           string `json:"plan_name"`
+	AuditRetentionDays int    `json:"audit_retention_days"`
+}
+
+func handleGetDataRetention(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		sp, err := db.GetSubscriptionWithPlan(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] handleGetDataRetention: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to load data retention policy"))
+			return
+		}
+
+		// Fallback for users without a subscription (shouldn't happen, but be safe).
+		if sp == nil {
+			RespondJSON(w, http.StatusOK, dataRetentionResponse{
+				PlanID:             db.PlanFree,
+				PlanName:           "Free",
+				AuditRetentionDays: 7,
+			})
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, dataRetentionResponse{
+			PlanID:             sp.Plan.ID,
+			PlanName:           sp.Plan.Name,
+			AuditRetentionDays: sp.Plan.AuditRetentionDays,
 		})
 	}
 }

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -240,6 +240,7 @@ func handleGetDataRetention(deps *Deps) http.HandlerFunc {
 		}
 
 		// Fallback for users without a subscription (shouldn't happen, but be safe).
+	// Keep these defaults in sync with the free plan in plans seed data.
 		if sp == nil {
 			RespondJSON(w, http.StatusOK, dataRetentionResponse{
 				PlanID:             db.PlanFree,
@@ -257,13 +258,21 @@ func handleGetDataRetention(deps *Deps) http.HandlerFunc {
 	}
 }
 
+// uuidRegex validates that a string is a well-formed UUID v4 (lowercase hex).
+// Used to prevent path traversal when constructing Supabase Admin API URLs.
+var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
 // deleteSupabaseAuthUser calls the Supabase Admin API to delete the auth user.
 // Requires SupabaseURL and SupabaseServiceRoleKey to be configured. If either
 // is missing, it logs a warning and returns nil (no-op).
 func deleteSupabaseAuthUser(ctx context.Context, deps *Deps, userID string) error {
 	if deps.SupabaseURL == "" || deps.SupabaseServiceRoleKey == "" {
-		log.Printf("Warning: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set; skipping auth user deletion for %s", userID)
+		log.Printf("[%s] Warning: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set; skipping auth user deletion", TraceID(ctx))
 		return nil
+	}
+
+	if !uuidRegex.MatchString(userID) {
+		return fmt.Errorf("invalid user ID format: %q", userID)
 	}
 
 	url := fmt.Sprintf("%s/auth/v1/admin/users/%s", deps.SupabaseURL, userID)

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -207,6 +207,13 @@ func handleDeleteAccount(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		// Delete the Supabase Auth user. This is best-effort after the
+		// profile has been deleted — even if this fails, the user can no
+		// longer access any application data.
+		if err := deleteSupabaseAuthUser(r.Context(), deps, profile.ID); err != nil {
+			log.Printf("[%s] handleDeleteAccount: supabase auth cleanup (non-fatal): %v", TraceID(r.Context()), err)
+		}
+
 		RespondJSON(w, http.StatusOK, deleteAccountResponse{
 			Deleted: true,
 			Message: "Account and all associated data have been permanently deleted.",
@@ -248,4 +255,33 @@ func handleGetDataRetention(deps *Deps) http.HandlerFunc {
 			AuditRetentionDays: sp.Plan.AuditRetentionDays,
 		})
 	}
+}
+
+// deleteSupabaseAuthUser calls the Supabase Admin API to delete the auth user.
+// Requires SupabaseURL and SupabaseServiceRoleKey to be configured. If either
+// is missing, it logs a warning and returns nil (no-op).
+func deleteSupabaseAuthUser(ctx context.Context, deps *Deps, userID string) error {
+	if deps.SupabaseURL == "" || deps.SupabaseServiceRoleKey == "" {
+		log.Printf("Warning: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set; skipping auth user deletion for %s", userID)
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/auth/v1/admin/users/%s", deps.SupabaseURL, userID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+deps.SupabaseServiceRoleKey)
+	req.Header.Set("apikey", deps.SupabaseServiceRoleKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("supabase admin API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("supabase admin API returned %d for user %s", resp.StatusCode, userID)
+	}
+	return nil
 }

--- a/api/router.go
+++ b/api/router.go
@@ -19,6 +19,8 @@ type Deps struct {
 	SupabaseJWTSecret string           // HMAC-SHA256 secret for HS256 JWTs (Supabase CLI v1 / test env)
 	SupabaseJWKSURL   string           // JWKS endpoint for ES256 JWTs (Supabase CLI v2+), e.g. "http://127.0.0.1:54321/auth/v1/.well-known/jwks.json"
 	JWKSCache         *JWKSCache       // JWKS key cache; initialized once at startup when SupabaseJWKSURL is set
+	SupabaseURL            string           // Supabase project URL (e.g. "http://127.0.0.1:54321"); used for Admin API calls
+	SupabaseServiceRoleKey string           // Supabase service_role key; required for Admin API calls (e.g. deleting auth users)
 	BaseURL           string           // Public base URL (e.g. "https://app.permissionslip.dev"); used to construct invite URLs
 	InviteHMACKey     string           // HMAC key for hashing short codes (invite codes, confirmation codes); if empty, falls back to plain SHA-256
 	Notifier              *notify.Dispatcher   // notification fan-out; nil means notifications are disabled

--- a/config.go
+++ b/config.go
@@ -75,6 +75,12 @@ func validateConfig() (errs []configError, warnings []configError) {
 	}
 
 	// Optional but recommended — warn in all modes.
+	if os.Getenv("SUPABASE_SERVICE_ROLE_KEY") == "" {
+		warnings = append(warnings, configError{
+			envVar:  "SUPABASE_SERVICE_ROLE_KEY",
+			message: "not set; account deletion will not remove the Supabase auth user (recommended: set for production)",
+		})
+	}
 	if os.Getenv("INVITE_HMAC_KEY") == "" {
 		warnings = append(warnings, configError{
 			envVar:  "INVITE_HMAC_KEY",

--- a/config_test.go
+++ b/config_test.go
@@ -55,13 +55,14 @@ func TestValidateConfig_DevelopmentModeSkipsErrors(t *testing.T) {
 
 func TestValidateConfig_DevelopmentModeNoWarningsWhenConfigured(t *testing.T) {
 	setEnvForTest(t, map[string]string{
-		"MODE":                "development",
-		"DATABASE_URL":        "",
-		"SUPABASE_URL":        "",
-		"SUPABASE_JWT_SECRET": "",
-		"SUPABASE_JWKS_URL":   "",
-		"INVITE_HMAC_KEY":     "test-key",
-		"BASE_URL":            "https://example.com",
+		"MODE":                       "development",
+		"DATABASE_URL":               "",
+		"SUPABASE_URL":               "",
+		"SUPABASE_JWT_SECRET":        "",
+		"SUPABASE_JWKS_URL":          "",
+		"SUPABASE_SERVICE_ROLE_KEY":  "test-key",
+		"INVITE_HMAC_KEY":            "test-key",
+		"BASE_URL":                   "https://example.com",
 	})
 
 	errs, warnings := validateConfig()
@@ -196,14 +197,15 @@ func TestValidateConfig_OptionalWarnings(t *testing.T) {
 
 func TestValidateConfig_AllValid(t *testing.T) {
 	setEnvForTest(t, map[string]string{
-		"MODE":                "",
-		"DATABASE_URL":        "postgres://localhost/test",
-		"SUPABASE_URL":        "http://localhost:54321",
-		"INVITE_HMAC_KEY":     "test-key",
-		"BASE_URL":            "https://example.com",
-		"VAPID_PUBLIC_KEY":    "BExamplePublicKey",
-		"VAPID_PRIVATE_KEY":   "examplePrivateKey",
-		"VAPID_SUBJECT":       "mailto:test@example.com",
+		"MODE":                      "",
+		"DATABASE_URL":              "postgres://localhost/test",
+		"SUPABASE_URL":              "http://localhost:54321",
+		"SUPABASE_SERVICE_ROLE_KEY": "test-service-role-key",
+		"INVITE_HMAC_KEY":           "test-key",
+		"BASE_URL":                  "https://example.com",
+		"VAPID_PUBLIC_KEY":          "BExamplePublicKey",
+		"VAPID_PRIVATE_KEY":         "examplePrivateKey",
+		"VAPID_SUBJECT":             "mailto:test@example.com",
 	})
 
 	errs, warnings := validateConfig()

--- a/db/data_retention.go
+++ b/db/data_retention.go
@@ -14,7 +14,7 @@ func PurgeExpiredAuditEvents(ctx context.Context, db DBTX) (int64, error) {
 		USING subscriptions s
 		JOIN plans p ON p.id = s.plan_id
 		WHERE ae.user_id = s.user_id
-		  AND ae.created_at < now() - (p.audit_retention_days || ' days')::interval`)
+		  AND ae.created_at < now() - make_interval(days => p.audit_retention_days)`)
 	if err != nil {
 		return 0, fmt.Errorf("purge expired audit events: %w", err)
 	}

--- a/db/data_retention.go
+++ b/db/data_retention.go
@@ -7,18 +7,36 @@ import (
 
 // PurgeExpiredAuditEvents deletes audit events older than the retention period
 // for each user's plan. Free-tier users retain 7 days; paid users retain 90 days.
+//
+// Users without a subscription row (shouldn't happen, but defensive) are treated
+// as free-tier and get the 7-day default retention.
+//
 // Returns the total number of rows deleted.
 func PurgeExpiredAuditEvents(ctx context.Context, db DBTX) (int64, error) {
-	tag, err := db.Exec(ctx, `
+	// Pass 1: Purge events for users with a subscription, using their plan's
+	// retention period.
+	tag1, err := db.Exec(ctx, `
 		DELETE FROM audit_events ae
 		USING subscriptions s
 		JOIN plans p ON p.id = s.plan_id
 		WHERE ae.user_id = s.user_id
 		  AND ae.created_at < now() - make_interval(days => p.audit_retention_days)`)
 	if err != nil {
-		return 0, fmt.Errorf("purge expired audit events: %w", err)
+		return 0, fmt.Errorf("purge expired audit events (subscribed users): %w", err)
 	}
-	return tag.RowsAffected(), nil
+
+	// Pass 2: Purge events for users without a subscription row, using the
+	// free-tier default (7 days). This is defensive — every user should have
+	// a subscription, but we don't want orphaned events to accumulate.
+	tag2, err := db.Exec(ctx, `
+		DELETE FROM audit_events ae
+		WHERE NOT EXISTS (SELECT 1 FROM subscriptions s WHERE s.user_id = ae.user_id)
+		  AND ae.created_at < now() - interval '7 days'`)
+	if err != nil {
+		return tag1.RowsAffected(), fmt.Errorf("purge expired audit events (unsubscribed users): %w", err)
+	}
+
+	return tag1.RowsAffected() + tag2.RowsAffected(), nil
 }
 
 // DeleteAccount deletes a user's profile and all associated data. Because most

--- a/db/data_retention.go
+++ b/db/data_retention.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// PurgeExpiredAuditEvents deletes audit events older than the retention period
+// for each user's plan. Free-tier users retain 7 days; paid users retain 90 days.
+// Returns the total number of rows deleted.
+func PurgeExpiredAuditEvents(ctx context.Context, db DBTX) (int64, error) {
+	tag, err := db.Exec(ctx, `
+		DELETE FROM audit_events ae
+		USING subscriptions s
+		JOIN plans p ON p.id = s.plan_id
+		WHERE ae.user_id = s.user_id
+		  AND ae.created_at < now() - (p.audit_retention_days || ' days')::interval`)
+	if err != nil {
+		return 0, fmt.Errorf("purge expired audit events: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// DeleteAccount deletes a user's profile and all associated data. Because most
+// child tables use ON DELETE CASCADE, deleting the profile row removes agents,
+// approvals, credentials, standing approvals, subscriptions, audit events, etc.
+//
+// Vault secrets (encrypted credentials) are stored outside the FK graph in
+// Supabase Vault's vault.secrets table, so they must be deleted separately
+// before the profile row is removed. Pass a nil vaultDeleteFn if no vault
+// cleanup is needed (e.g. in tests).
+//
+// The caller is responsible for deleting the Supabase auth.users row (via
+// Supabase Admin API) after this function succeeds.
+func DeleteAccount(ctx context.Context, d DBTX, userID string, vaultDeleteFn func(ctx context.Context, tx DBTX, secretID string) error) error {
+	// Step 1: Delete vault secrets for all user credentials.
+	if vaultDeleteFn != nil {
+		rows, err := d.Query(ctx,
+			`SELECT vault_secret_id FROM credentials WHERE user_id = $1`, userID)
+		if err != nil {
+			return fmt.Errorf("list credential vault secrets: %w", err)
+		}
+		defer rows.Close()
+
+		var secretIDs []string
+		for rows.Next() {
+			var sid string
+			if err := rows.Scan(&sid); err != nil {
+				return fmt.Errorf("scan vault secret id: %w", err)
+			}
+			secretIDs = append(secretIDs, sid)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate vault secret ids: %w", err)
+		}
+
+		for _, sid := range secretIDs {
+			if err := vaultDeleteFn(ctx, d, sid); err != nil {
+				return fmt.Errorf("delete vault secret %s: %w", sid, err)
+			}
+		}
+	}
+
+	// Step 2: Delete the profile row. ON DELETE CASCADE removes all child rows
+	// (agents, approvals, credentials, subscriptions, audit_events, etc.).
+	tag, err := d.Exec(ctx, `DELETE FROM profiles WHERE id = $1`, userID)
+	if err != nil {
+		return fmt.Errorf("delete profile: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("profile not found")
+	}
+	return nil
+}

--- a/db/data_retention_test.go
+++ b/db/data_retention_test.go
@@ -70,6 +70,41 @@ func TestPurgeExpiredAuditEvents(t *testing.T) {
 		}
 	})
 
+	t.Run("PurgesOldEventsForUserWithoutSubscription", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		// Deliberately do NOT insert a subscription — tests the fallback purge.
+
+		// Insert an event dated 10 days ago — should be purged (>7-day default).
+		testhelper.MustExec(t, tx,
+			`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, created_at)
+			 VALUES ($1, $2, 'approval.approved', 'approved', 'test_nosub', 'approval', '{}', now() - interval '10 days')`,
+			uid, agentID)
+
+		// Insert a recent event — should NOT be purged.
+		testhelper.InsertAuditEvent(t, tx, uid, agentID, "approval.denied", "denied", testhelper.GenerateID(t, "appr_"))
+
+		deleted, err := db.PurgeExpiredAuditEvents(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deleted != 1 {
+			t.Errorf("expected 1 deleted row, got %d", deleted)
+		}
+
+		// Verify the recent event still exists.
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil)
+		if err != nil {
+			t.Fatalf("list error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Errorf("expected 1 remaining event, got %d", len(page.Events))
+		}
+	})
+
 	t.Run("PurgesOldPaidPlanEvents", func(t *testing.T) {
 		t.Parallel()
 		tx := testhelper.SetupTestDB(t)

--- a/db/data_retention_test.go
+++ b/db/data_retention_test.go
@@ -1,0 +1,185 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestPurgeExpiredAuditEvents(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("PurgesOldEventsForFreePlan", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		testhelper.InsertSubscription(t, tx, uid, db.PlanFree) // 7-day retention
+
+		// Insert an event dated 10 days ago — should be purged.
+		testhelper.MustExec(t, tx,
+			`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, created_at)
+			 VALUES ($1, $2, 'approval.approved', 'approved', 'test_old', 'approval', '{}', now() - interval '10 days')`,
+			uid, agentID)
+
+		// Insert a recent event — should NOT be purged.
+		testhelper.InsertAuditEvent(t, tx, uid, agentID, "approval.denied", "denied", testhelper.GenerateID(t, "appr_"))
+
+		deleted, err := db.PurgeExpiredAuditEvents(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deleted != 1 {
+			t.Errorf("expected 1 deleted row, got %d", deleted)
+		}
+
+		// Verify the recent event still exists.
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil)
+		if err != nil {
+			t.Fatalf("list error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Errorf("expected 1 remaining event, got %d", len(page.Events))
+		}
+	})
+
+	t.Run("PreservesPaidPlanEvents", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo) // 90-day retention
+
+		// Insert an event dated 30 days ago — should NOT be purged (within 90 days).
+		testhelper.MustExec(t, tx,
+			`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, created_at)
+			 VALUES ($1, $2, 'approval.approved', 'approved', 'test_30d', 'approval', '{}', now() - interval '30 days')`,
+			uid, agentID)
+
+		deleted, err := db.PurgeExpiredAuditEvents(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deleted != 0 {
+			t.Errorf("expected 0 deleted rows, got %d", deleted)
+		}
+	})
+
+	t.Run("PurgesOldPaidPlanEvents", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+		// Insert event dated 100 days ago — should be purged (>90 days).
+		testhelper.MustExec(t, tx,
+			`INSERT INTO audit_events (user_id, agent_id, event_type, outcome, source_id, source_type, agent_meta, created_at)
+			 VALUES ($1, $2, 'approval.approved', 'approved', 'test_100d', 'approval', '{}', now() - interval '100 days')`,
+			uid, agentID)
+
+		deleted, err := db.PurgeExpiredAuditEvents(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deleted != 1 {
+			t.Errorf("expected 1 deleted row, got %d", deleted)
+		}
+	})
+}
+
+func TestDeleteAccount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("DeletesCascadingData", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+		testhelper.InsertAuditEvent(t, tx, uid, agentID, "approval.approved", "approved", testhelper.GenerateID(t, "appr_"))
+
+		err := db.DeleteAccount(ctx, tx, uid, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify profile is gone.
+		profile, err := db.GetProfileByUserID(ctx, tx, uid)
+		if err != nil {
+			t.Fatalf("profile lookup error: %v", err)
+		}
+		if profile != nil {
+			t.Error("expected profile to be deleted")
+		}
+
+		// Verify audit events are gone.
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil)
+		if err != nil {
+			t.Fatalf("audit events error: %v", err)
+		}
+		if len(page.Events) != 0 {
+			t.Errorf("expected 0 events after deletion, got %d", len(page.Events))
+		}
+
+		// Verify subscription is gone.
+		sub, err := db.GetSubscriptionByUserID(ctx, tx, uid)
+		if err != nil {
+			t.Fatalf("subscription lookup error: %v", err)
+		}
+		if sub != nil {
+			t.Error("expected subscription to be deleted")
+		}
+	})
+
+	t.Run("NotFoundReturnsError", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		fakeUID := testhelper.GenerateUID(t)
+		err := db.DeleteAccount(ctx, tx, fakeUID, nil)
+		if err == nil {
+			t.Error("expected error for non-existent user")
+		}
+	})
+
+	t.Run("CallsVaultDeleteForCredentials", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+		testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+		// Insert a credential row with a fake vault_secret_id.
+		fakeVaultID := testhelper.GenerateUID(t)
+		credID := testhelper.GenerateID(t, "cred_")
+		testhelper.MustExec(t, tx,
+			`INSERT INTO credentials (id, user_id, service, vault_secret_id)
+			 VALUES ($1, $2, 'test_service', $3)`,
+			credID, uid, fakeVaultID)
+
+		var deletedSecrets []string
+		vaultDeleteFn := func(_ context.Context, _ db.DBTX, secretID string) error {
+			deletedSecrets = append(deletedSecrets, secretID)
+			return nil
+		}
+
+		err := db.DeleteAccount(ctx, tx, uid, vaultDeleteFn)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(deletedSecrets) != 1 || deletedSecrets[0] != fakeVaultID {
+			t.Errorf("expected vault delete for %s, got %v", fakeVaultID, deletedSecrets)
+		}
+	})
+}

--- a/db/migrations/20260228300000_data_retention_compliance.sql
+++ b/db/migrations/20260228300000_data_retention_compliance.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+
+-- Change audit_events FK on user_id from RESTRICT to CASCADE so that
+-- deleting a profile cascades to audit events. This is required for
+-- account deletion (GDPR / data retention compliance).
+ALTER TABLE audit_events
+    DROP CONSTRAINT audit_events_user_id_fkey,
+    ADD CONSTRAINT audit_events_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES profiles(id) ON DELETE CASCADE;
+
+-- Similarly, change the agent_id FK from RESTRICT to CASCADE so that
+-- audit events are cleaned up when an agent's owner deletes their account
+-- (agents cascade from profiles, and audit events should follow).
+ALTER TABLE audit_events
+    DROP CONSTRAINT audit_events_agent_id_fkey,
+    ADD CONSTRAINT audit_events_agent_id_fkey
+        FOREIGN KEY (agent_id) REFERENCES agents(agent_id) ON DELETE CASCADE;
+
+-- +goose Down
+
+ALTER TABLE audit_events
+    DROP CONSTRAINT audit_events_agent_id_fkey,
+    ADD CONSTRAINT audit_events_agent_id_fkey
+        FOREIGN KEY (agent_id) REFERENCES agents(agent_id) ON DELETE RESTRICT;
+
+ALTER TABLE audit_events
+    DROP CONSTRAINT audit_events_user_id_fkey,
+    ADD CONSTRAINT audit_events_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES profiles(id) ON DELETE RESTRICT;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,6 +94,7 @@ curl https://your-app.fly.dev/api/health
 |---|---|---|
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `SUPABASE_URL` | Yes | Supabase project URL (JWT verification via JWKS + auth) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Recommended | Supabase service_role key — required for account deletion (removes auth user). Get from Supabase dashboard |
 | `BASE_URL` | Recommended | Public URL (e.g., `https://app.permissionslip.dev`) — required for invite link generation |
 | `ALLOWED_ORIGINS` | Recommended | CORS origins (e.g., `https://app.permissionslip.dev`). Defaults to same-origin only if unset |
 | `INVITE_HMAC_KEY` | Recommended | HMAC key for invite codes — `openssl rand -hex 32` |

--- a/frontend/src/hooks/useDataRetention.ts
+++ b/frontend/src/hooks/useDataRetention.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type DataRetention = components["schemas"]["DataRetentionResponse"];
+
+export function useDataRetention() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["data-retention"],
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/profile/data-retention", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (error) throw new Error("Failed to load data retention policy");
+      return data as DataRetention;
+    },
+    enabled: !!accessToken,
+    staleTime: 60_000,
+  });
+
+  return { dataRetention: data ?? null, isLoading, error };
+}

--- a/frontend/src/hooks/useDataRetention.ts
+++ b/frontend/src/hooks/useDataRetention.ts
@@ -9,7 +9,7 @@ export function useDataRetention() {
   const { session } = useAuth();
   const accessToken = session?.access_token;
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["data-retention"],
     queryFn: async () => {
       if (!accessToken) throw new Error("Missing access token");
@@ -23,5 +23,5 @@ export function useDataRetention() {
     staleTime: 60_000,
   });
 
-  return { dataRetention: data ?? null, isLoading, error };
+  return { dataRetention: data ?? null, isLoading, error, refetch };
 }

--- a/frontend/src/hooks/useDataRetention.ts
+++ b/frontend/src/hooks/useDataRetention.ts
@@ -17,6 +17,7 @@ export function useDataRetention() {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (error) throw new Error("Failed to load data retention policy");
+      // Cast is safe: openapi-fetch returns typed response matching the schema
       return data as DataRetention;
     },
     enabled: !!accessToken,

--- a/frontend/src/hooks/useDeleteAccount.ts
+++ b/frontend/src/hooks/useDeleteAccount.ts
@@ -1,26 +1,36 @@
-import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
 
 export function useDeleteAccount() {
   const { session } = useAuth();
-  const [isDeleting, setIsDeleting] = useState(false);
+  const queryClient = useQueryClient();
 
-  async function deleteAccount() {
-    const accessToken = session?.access_token;
-    if (!accessToken) throw new Error("Missing access token");
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
 
-    setIsDeleting(true);
-    try {
       const { error } = await client.DELETE("/v1/profile", {
-        headers: { Authorization: `Bearer ${accessToken}` },
+        headers: { Authorization: `Bearer ${session.access_token}` },
         body: { confirmation: "DELETE" },
       });
-      if (error) throw new Error("Failed to delete account");
-    } finally {
-      setIsDeleting(false);
-    }
-  }
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to delete account"),
+        );
+      }
+    },
+    onSuccess: () => {
+      // Clear all cached queries since the account no longer exists.
+      queryClient.clear();
+    },
+  });
 
-  return { deleteAccount, isDeleting };
+  return {
+    deleteAccount: () => mutation.mutateAsync(),
+    isDeleting: mutation.isPending,
+  };
 }

--- a/frontend/src/hooks/useDeleteAccount.ts
+++ b/frontend/src/hooks/useDeleteAccount.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+
+export function useDeleteAccount() {
+  const { session } = useAuth();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function deleteAccount() {
+    const accessToken = session?.access_token;
+    if (!accessToken) throw new Error("Missing access token");
+
+    setIsDeleting(true);
+    try {
+      const { error } = await client.DELETE("/v1/profile", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        body: { confirmation: "DELETE" },
+      });
+      if (error) throw new Error("Failed to delete account");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return { deleteAccount, isDeleting };
+}

--- a/frontend/src/pages/settings/DangerZoneSection.tsx
+++ b/frontend/src/pages/settings/DangerZoneSection.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/auth/AuthContext";
@@ -74,8 +74,18 @@ function DeleteAccountDialog({
   const { signOut } = useAuth();
   const { deleteAccount, isDeleting } = useDeleteAccount();
   const [confirmText, setConfirmText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const isConfirmed = confirmText === "DELETE";
+
+  // Auto-focus the confirmation input when the dialog opens.
+  useEffect(() => {
+    if (open) {
+      // Small delay to let the dialog animation complete.
+      const timer = setTimeout(() => inputRef.current?.focus(), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -84,10 +94,11 @@ function DeleteAccountDialog({
     try {
       await deleteAccount();
       toast.success("Account deleted successfully.");
-      // Sign out after deletion — clears the session.
       await signOut();
-    } catch {
-      toast.error("Failed to delete account. Please try again.");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to delete account";
+      toast.error(message);
     }
   }
 
@@ -124,6 +135,7 @@ function DeleteAccountDialog({
               Type <span className="font-mono font-bold">DELETE</span> to confirm
             </Label>
             <Input
+              ref={inputRef}
               id="delete-confirm"
               value={confirmText}
               onChange={(e) => setConfirmText(e.target.value)}

--- a/frontend/src/pages/settings/DangerZoneSection.tsx
+++ b/frontend/src/pages/settings/DangerZoneSection.tsx
@@ -1,0 +1,158 @@
+import { useState, type FormEvent } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/auth/AuthContext";
+import { useDeleteAccount } from "@/hooks/useDeleteAccount";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function DangerZoneSection() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="text-destructive size-5" />
+            <CardTitle className="text-destructive">Danger Zone</CardTitle>
+          </div>
+          <CardDescription>
+            Irreversible actions that permanently affect your account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between rounded-lg border border-destructive/30 p-4">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">Delete Account</p>
+              <p className="text-xs text-muted-foreground">
+                Permanently delete your account and all associated data.
+              </p>
+            </div>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDialogOpen(true)}
+            >
+              Delete Account
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <DeleteAccountDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
+    </>
+  );
+}
+
+function DeleteAccountDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { signOut } = useAuth();
+  const { deleteAccount, isDeleting } = useDeleteAccount();
+  const [confirmText, setConfirmText] = useState("");
+
+  const isConfirmed = confirmText === "DELETE";
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!isConfirmed) return;
+
+    try {
+      await deleteAccount();
+      toast.success("Account deleted successfully.");
+      // Sign out after deletion — clears the session.
+      await signOut();
+    } catch {
+      toast.error("Failed to delete account. Please try again.");
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!isDeleting) {
+      setConfirmText("");
+      onOpenChange(nextOpen);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Are you sure?</DialogTitle>
+          <DialogDescription>
+            This action is <strong className="text-foreground">permanent and irreversible</strong>.
+            Deleting your account will immediately remove:
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="text-sm text-muted-foreground list-disc pl-5 space-y-1">
+          <li>Your profile and contact information</li>
+          <li>All registered agents</li>
+          <li>All stored credentials</li>
+          <li>All approval history and audit logs</li>
+          <li>All standing approvals</li>
+          <li>Your subscription</li>
+        </ul>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="delete-confirm">
+              Type <span className="font-mono font-bold">DELETE</span> to confirm
+            </Label>
+            <Input
+              id="delete-confirm"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE"
+              autoComplete="off"
+              disabled={isDeleting}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="destructive"
+              disabled={!isConfirmed || isDeleting}
+            >
+              {isDeleting && <Loader2 className="animate-spin" />}
+              Delete My Account
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/settings/DataRetentionSection.tsx
+++ b/frontend/src/pages/settings/DataRetentionSection.tsx
@@ -1,0 +1,63 @@
+import { Clock, Loader2 } from "lucide-react";
+import { useDataRetention } from "@/hooks/useDataRetention";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function DataRetentionSection() {
+  const { dataRetention, isLoading } = useDataRetention();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Clock className="text-muted-foreground size-5" />
+          <CardTitle>Data Retention</CardTitle>
+        </div>
+        <CardDescription>
+          How long your data is kept based on your current plan.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div
+            className="flex items-center justify-center py-8"
+            role="status"
+            aria-label="Loading data retention policy"
+          >
+            <Loader2 className="text-muted-foreground size-5 animate-spin" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="rounded-lg border p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">Current Plan</span>
+                <span className="text-sm text-muted-foreground">
+                  {dataRetention?.plan_name ?? "Free"}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">Audit Log Retention</span>
+                <span className="text-sm text-muted-foreground">
+                  {dataRetention?.audit_retention_days ?? 7} days
+                </span>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Audit log events older than your retention period are automatically
+              deleted. Upgrade to a paid plan for 90-day retention.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Account data (profile, credentials) is retained until you
+              explicitly delete your account.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/settings/DataRetentionSection.tsx
+++ b/frontend/src/pages/settings/DataRetentionSection.tsx
@@ -1,5 +1,7 @@
 import { Clock, Loader2 } from "lucide-react";
 import { useDataRetention } from "@/hooks/useDataRetention";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/FormError";
 import {
   Card,
   CardContent,
@@ -9,7 +11,7 @@ import {
 } from "@/components/ui/card";
 
 export function DataRetentionSection() {
-  const { dataRetention, isLoading } = useDataRetention();
+  const { dataRetention, isLoading, error, refetch } = useDataRetention();
 
   return (
     <Card>
@@ -31,6 +33,13 @@ export function DataRetentionSection() {
           >
             <Loader2 className="text-muted-foreground size-5 animate-spin" />
           </div>
+        ) : error ? (
+          <div className="space-y-3">
+            <FormError error="Failed to load data retention policy." />
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Try Again
+            </Button>
+          </div>
         ) : (
           <div className="space-y-4">
             <div className="rounded-lg border p-4 space-y-3">
@@ -46,14 +55,16 @@ export function DataRetentionSection() {
                   {dataRetention?.audit_retention_days ?? 7} days
                 </span>
               </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">Account Data</span>
+                <span className="text-sm text-muted-foreground">
+                  Until account deletion
+                </span>
+              </div>
             </div>
             <p className="text-xs text-muted-foreground">
               Audit log events older than your retention period are automatically
               deleted. Upgrade to a paid plan for 90-day retention.
-            </p>
-            <p className="text-xs text-muted-foreground">
-              Account data (profile, credentials) is retained until you
-              explicitly delete your account.
             </p>
           </div>
         )}

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -4,6 +4,8 @@ import { AccountSection } from "./AccountSection";
 import { NotificationSection } from "./NotificationSection";
 import { SecuritySection } from "./SecuritySection";
 import { CredentialSection } from "./CredentialSection";
+import { DataRetentionSection } from "./DataRetentionSection";
+import { DangerZoneSection } from "./DangerZoneSection";
 
 export function SettingsPage() {
   return (
@@ -23,6 +25,8 @@ export function SettingsPage() {
       <SecuritySection />
       <NotificationSection />
       <CredentialSection />
+      <DataRetentionSection />
+      <DangerZoneSection />
     </div>
   );
 }

--- a/frontend/src/pages/settings/__tests__/DangerZoneSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/DangerZoneSection.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import { mockDelete, resetClientMocks } from "../../../api/__mocks__/client";
+import { DangerZoneSection } from "../DangerZoneSection";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+describe("DangerZoneSection", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper(["/settings"]);
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("renders delete account button", () => {
+    render(<DangerZoneSection />, { wrapper });
+
+    expect(screen.getByText("Danger Zone")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete Account" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens confirmation dialog when clicking delete", async () => {
+    const user = userEvent.setup();
+
+    render(<DangerZoneSection />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Delete Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Are you sure?")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/Type/)).toBeInTheDocument();
+  });
+
+  it("disables submit until DELETE is typed", async () => {
+    const user = userEvent.setup();
+
+    render(<DangerZoneSection />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Delete Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Are you sure?")).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: "Delete My Account" });
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Type/), "DELETE");
+
+    expect(submitButton).toBeEnabled();
+  });
+
+  it("calls delete API and signs out on confirmation", async () => {
+    const user = userEvent.setup();
+    mockDelete.mockResolvedValue({ data: { deleted: true }, error: null });
+
+    render(<DangerZoneSection />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Delete Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Are you sure?")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/Type/), "DELETE");
+    await user.click(screen.getByRole("button", { name: "Delete My Account" }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(
+        "/v1/profile",
+        expect.objectContaining({
+          body: { confirmation: "DELETE" },
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/pages/settings/__tests__/DataRetentionSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/DataRetentionSection.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import { mockGet, resetClientMocks } from "../../../api/__mocks__/client";
+import { DataRetentionSection } from "../DataRetentionSection";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+describe("DataRetentionSection", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper(["/settings"]);
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("shows free plan retention", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/profile/data-retention") {
+        return Promise.resolve({
+          data: {
+            plan_id: "free",
+            plan_name: "Free",
+            audit_retention_days: 7,
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    render(<DataRetentionSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Free")).toBeInTheDocument();
+    });
+    expect(screen.getByText("7 days")).toBeInTheDocument();
+  });
+
+  it("shows paid plan retention", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/profile/data-retention") {
+        return Promise.resolve({
+          data: {
+            plan_id: "pay_as_you_go",
+            plan_name: "Pay As You Go",
+            audit_retention_days: 90,
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    render(<DataRetentionSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Pay As You Go")).toBeInTheDocument();
+    });
+    expect(screen.getByText("90 days")).toBeInTheDocument();
+  });
+
+  it("shows loading state initially", () => {
+    mockGet.mockReturnValue(new Promise(() => {})); // never resolves
+
+    render(<DataRetentionSection />, { wrapper });
+
+    expect(
+      screen.getByRole("status", { name: "Loading data retention policy" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -40,6 +40,15 @@ function mockApiFetch() {
     if (url === "/v1/credentials") {
       return Promise.resolve({ data: { credentials: [] } });
     }
+    if (url === "/v1/profile/data-retention") {
+      return Promise.resolve({
+        data: {
+          plan_id: "free",
+          plan_name: "Free",
+          audit_retention_days: 7,
+        },
+      });
+    }
     return Promise.resolve({ data: null });
   });
 }
@@ -66,7 +75,7 @@ describe("SettingsPage", () => {
     ).toHaveAttribute("href", "/");
   });
 
-  it("renders all four sections", async () => {
+  it("renders all sections", async () => {
     mockApiFetch();
 
     render(<SettingsPage />, { wrapper });
@@ -77,5 +86,7 @@ describe("SettingsPage", () => {
     expect(screen.getByText("Security")).toBeInTheDocument();
     expect(screen.getByText("Notifications")).toBeInTheDocument();
     expect(screen.getByText("Credential Vault")).toBeInTheDocument();
+    expect(screen.getByText("Data Retention")).toBeInTheDocument();
+    expect(screen.getByText("Danger Zone")).toBeInTheDocument();
   });
 });

--- a/main.go
+++ b/main.go
@@ -106,12 +106,14 @@ func main() {
 	deps.Logger = logger
 	deps.SupabaseJWTSecret = os.Getenv("SUPABASE_JWT_SECRET")
 	deps.SupabaseJWKSURL = os.Getenv("SUPABASE_JWKS_URL")
+	deps.SupabaseURL = strings.TrimRight(os.Getenv("SUPABASE_URL"), "/")
+	deps.SupabaseServiceRoleKey = os.Getenv("SUPABASE_SERVICE_ROLE_KEY")
 	// Derive JWKS URL from SUPABASE_URL if not explicitly set.
 	// Supabase CLI v2+ uses ES256 (asymmetric signing); the JWKS endpoint
 	// provides the public key. Legacy CLI v1 and tests use HS256 + JWT secret.
 	if deps.SupabaseJWKSURL == "" {
-		if supabaseURL := os.Getenv("SUPABASE_URL"); supabaseURL != "" {
-			deps.SupabaseJWKSURL = strings.TrimRight(supabaseURL, "/") + "/auth/v1/.well-known/jwks.json"
+		if deps.SupabaseURL != "" {
+			deps.SupabaseJWKSURL = deps.SupabaseURL + "/auth/v1/.well-known/jwks.json"
 		}
 	}
 	if deps.SupabaseJWKSURL != "" {

--- a/spec/openapi/components/paths/profiles.yaml
+++ b/spec/openapi/components/paths/profiles.yaml
@@ -112,11 +112,22 @@ profile:
     summary: Delete Account
     description: |
       Permanently deletes the authenticated user's account and all associated
-      data including agents, approvals, credentials, standing approvals,
-      audit events, and subscription. This action is irreversible.
+      data including agents, approvals, credentials (and their vault secrets),
+      standing approvals, audit events, and subscription. The Supabase auth
+      user is also removed. This action is irreversible.
 
       The request body must include `"confirmation": "DELETE"` as a safety
       check to prevent accidental deletion.
+
+      **What gets deleted:**
+      - Profile and contact information
+      - All registered agents and their configurations
+      - All stored credentials (including encrypted vault secrets)
+      - All approval history and audit log events
+      - All standing approvals and their execution history
+      - Subscription and usage data
+      - Notification preferences and push subscriptions
+      - The Supabase authentication user (best-effort)
 
     tags:
       - Profiles
@@ -165,8 +176,14 @@ dataRetention:
     summary: Get Data Retention Policy
     description: |
       Returns the data retention policy for the authenticated user based on
-      their current plan. Free-tier users retain audit logs for 7 days;
-      paid users retain audit logs for 90 days.
+      their current plan.
+
+      **Retention periods by plan:**
+      - **Free:** 7-day audit log retention
+      - **Pay As You Go:** 90-day audit log retention
+
+      Account data (profile, credentials) is retained indefinitely until
+      the user explicitly deletes their account via `DELETE /v1/profile`.
 
     tags:
       - Profiles

--- a/spec/openapi/components/paths/profiles.yaml
+++ b/spec/openapi/components/paths/profiles.yaml
@@ -107,6 +107,97 @@ profile:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+  delete:
+    operationId: deleteAccount
+    summary: Delete Account
+    description: |
+      Permanently deletes the authenticated user's account and all associated
+      data including agents, approvals, credentials, standing approvals,
+      audit events, and subscription. This action is irreversible.
+
+      The request body must include `"confirmation": "DELETE"` as a safety
+      check to prevent accidental deletion.
+
+    tags:
+      - Profiles
+
+    security:
+      - SupabaseSession: []
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/profiles.yaml#/DeleteAccountRequest'
+          example:
+            confirmation: "DELETE"
+
+    responses:
+      '200':
+        description: Account deleted successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/profiles.yaml#/DeleteAccountResponse'
+            example:
+              deleted: true
+              message: "Account and all associated data have been permanently deleted."
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+dataRetention:
+  get:
+    operationId: getDataRetention
+    summary: Get Data Retention Policy
+    description: |
+      Returns the data retention policy for the authenticated user based on
+      their current plan. Free-tier users retain audit logs for 7 days;
+      paid users retain audit logs for 90 days.
+
+    tags:
+      - Profiles
+
+    security:
+      - SupabaseSession: []
+
+    responses:
+      '200':
+        description: Data retention policy retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/profiles.yaml#/DataRetentionResponse'
+            example:
+              plan_id: "free"
+              plan_name: "Free"
+              audit_retention_days: 7
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
 notificationPreferences:
   get:
     operationId: getNotificationPreferences

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -91,3 +91,53 @@ UpdateNotificationPreferencesRequest:
         $ref: '#/NotificationPreference'
       description: Channel preferences to update. Channels not included are unchanged.
       minItems: 1
+
+DeleteAccountRequest:
+  type: object
+  description: Request body for deleting the authenticated user's account.
+  required:
+    - confirmation
+  properties:
+    confirmation:
+      type: string
+      description: Must be the literal string "DELETE" to confirm the irreversible deletion.
+      enum:
+        - DELETE
+      example: "DELETE"
+
+DeleteAccountResponse:
+  type: object
+  description: Response confirming the account was deleted.
+  required:
+    - deleted
+    - message
+  properties:
+    deleted:
+      type: boolean
+      description: Always true on success.
+      example: true
+    message:
+      type: string
+      description: Human-readable confirmation message.
+      example: "Account and all associated data have been permanently deleted."
+
+DataRetentionResponse:
+  type: object
+  description: The data retention policy for the authenticated user's current plan.
+  required:
+    - plan_id
+    - plan_name
+    - audit_retention_days
+  properties:
+    plan_id:
+      type: string
+      description: The user's current plan ID.
+      example: "free"
+    plan_name:
+      type: string
+      description: Human-readable plan name.
+      example: "Free"
+    audit_retention_days:
+      type: integer
+      description: Number of days audit log events are retained before automatic deletion.
+      example: 7

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4334,11 +4334,22 @@ paths:
       summary: Delete Account
       description: |
         Permanently deletes the authenticated user's account and all associated
-        data including agents, approvals, credentials, standing approvals,
-        audit events, and subscription. This action is irreversible.
+        data including agents, approvals, credentials (and their vault secrets),
+        standing approvals, audit events, and subscription. The Supabase auth
+        user is also removed. This action is irreversible.
 
         The request body must include `"confirmation": "DELETE"` as a safety
         check to prevent accidental deletion.
+
+        **What gets deleted:**
+        - Profile and contact information
+        - All registered agents and their configurations
+        - All stored credentials (including encrypted vault secrets)
+        - All approval history and audit log events
+        - All standing approvals and their execution history
+        - Subscription and usage data
+        - Notification preferences and push subscriptions
+        - The Supabase authentication user (best-effort)
       tags:
         - Profiles
       security:
@@ -4377,8 +4388,14 @@ paths:
       summary: Get Data Retention Policy
       description: |
         Returns the data retention policy for the authenticated user based on
-        their current plan. Free-tier users retain audit logs for 7 days;
-        paid users retain audit logs for 90 days.
+        their current plan.
+
+        **Retention periods by plan:**
+        - **Free:** 7-day audit log retention
+        - **Pay As You Go:** 90-day audit log retention
+
+        Account data (profile, credentials) is retained indefinitely until
+        the user explicitly deletes their account via `DELETE /v1/profile`.
       tags:
         - Profiles
       security:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4329,6 +4329,79 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+    delete:
+      operationId: deleteAccount
+      summary: Delete Account
+      description: |
+        Permanently deletes the authenticated user's account and all associated
+        data including agents, approvals, credentials, standing approvals,
+        audit events, and subscription. This action is irreversible.
+
+        The request body must include `"confirmation": "DELETE"` as a safety
+        check to prevent accidental deletion.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteAccountRequest'
+            example:
+              confirmation: DELETE
+      responses:
+        '200':
+          description: Account deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteAccountResponse'
+              example:
+                deleted: true
+                message: Account and all associated data have been permanently deleted.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/profile/data-retention:
+    get:
+      operationId: getDataRetention
+      summary: Get Data Retention Policy
+      description: |
+        Returns the data retention policy for the authenticated user based on
+        their current plan. Free-tier users retain audit logs for 7 days;
+        paid users retain audit logs for 90 days.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Data retention policy retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataRetentionResponse'
+              example:
+                plan_id: free
+                plan_name: Free
+                audit_retention_days: 7
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/profile/notification-preferences:
     get:
       operationId: getNotificationPreferences
@@ -7693,6 +7766,53 @@ components:
             $ref: '#/components/schemas/NotificationPreference'
           description: Channel preferences to update. Channels not included are unchanged.
           minItems: 1
+    DeleteAccountRequest:
+      type: object
+      description: Request body for deleting the authenticated user's account.
+      required:
+        - confirmation
+      properties:
+        confirmation:
+          type: string
+          description: Must be the literal string "DELETE" to confirm the irreversible deletion.
+          enum:
+            - DELETE
+          example: DELETE
+    DeleteAccountResponse:
+      type: object
+      description: Response confirming the account was deleted.
+      required:
+        - deleted
+        - message
+      properties:
+        deleted:
+          type: boolean
+          description: Always true on success.
+          example: true
+        message:
+          type: string
+          description: Human-readable confirmation message.
+          example: Account and all associated data have been permanently deleted.
+    DataRetentionResponse:
+      type: object
+      description: The data retention policy for the authenticated user's current plan.
+      required:
+        - plan_id
+        - plan_name
+        - audit_retention_days
+      properties:
+        plan_id:
+          type: string
+          description: The user's current plan ID.
+          example: free
+        plan_name:
+          type: string
+          description: Human-readable plan name.
+          example: Free
+        audit_retention_days:
+          type: integer
+          description: Number of days audit log events are retained before automatic deletion.
+          example: 7
     CreatePushSubscriptionRequest:
       type: object
       description: Register a Web Push subscription from the browser.

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -210,6 +210,9 @@ paths:
   /v1/profile:
     $ref: './components/paths/profiles.yaml#/profile'
 
+  /v1/profile/data-retention:
+    $ref: './components/paths/profiles.yaml#/dataRetention'
+
   /v1/profile/notification-preferences:
     $ref: './components/paths/profiles.yaml#/notificationPreferences'
 
@@ -394,6 +397,12 @@ components:
       $ref: './components/schemas/profiles.yaml#/NotificationPreferencesResponse'
     UpdateNotificationPreferencesRequest:
       $ref: './components/schemas/profiles.yaml#/UpdateNotificationPreferencesRequest'
+    DeleteAccountRequest:
+      $ref: './components/schemas/profiles.yaml#/DeleteAccountRequest'
+    DeleteAccountResponse:
+      $ref: './components/schemas/profiles.yaml#/DeleteAccountResponse'
+    DataRetentionResponse:
+      $ref: './components/schemas/profiles.yaml#/DataRetentionResponse'
 
     # Push Subscriptions
     CreatePushSubscriptionRequest:


### PR DESCRIPTION
Implements data retention policy enforcement per plan tier:
- Free tier: 7-day audit log retention
- Paid tier: 90-day audit log retention

Backend:
- Migration to change audit_events FK from RESTRICT to CASCADE
- PurgeExpiredAuditEvents() deletes logs past retention window
- DeleteAccount() cascades profile deletion with vault cleanup
- DELETE /v1/profile endpoint with "DELETE" confirmation safety check
- GET /v1/profile/data-retention endpoint returns plan retention info

Frontend:
- Data Retention section in Settings showing plan and retention period
- Danger Zone section with Delete Account button
- Confirmation dialog requiring user to type "DELETE"
- Signs out user after successful account deletion

OpenAPI spec updated with new endpoints and schemas.

https://claude.ai/code/session_01Db8C4W3BPCfN8pLqz9Ep6J