### PR TITLE
Add self-hosted and production deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ For the full protocol design, architecture, and security model, see [SPEC.md](SP
 - **[Custom Connectors](docs/custom-connectors.md)** — add connectors from external Git repos (subprocess-based plugin system)
 - **[Consent Banner](docs/consent-banner.md)** — cross-subdomain cookie consent banner (shared between www and app)
 - **[Manual Testing: Agent Registration](docs/manual-testing-agent-registration.md)** — step-by-step guide to test the invite/registration flow
-- **[Deploying to Fly.io](docs/deployment.md)** — Dockerfile, fly.toml, secrets, and DNS setup
+- **[Self-Hosted Deployment](docs/deployment-self-hosted.md)** — complete guide for deploying on your own infrastructure (Docker, Fly.io, bare metal)
+- **[Production Deployment (internal)](docs/deployment-production.md)** — infrastructure, secrets, and operations for app.permissionslip.dev
+- **[Fly.io Deployment](docs/deployment.md)** — Dockerfile, fly.toml, secrets, and DNS setup
 
 ## Tech Stack
 

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -21,14 +21,19 @@
                     │  └───────────┬────────────┘  │
                     └──────────────┼───────────────┘
                                    │
-                 ┌─────────────────┼──────────────────┐
-                 │                 │                   │
-      ┌──────────▼───┐  ┌────────▼────────┐  ┌──────▼──────┐
-      │  Supabase     │  │  Sentry         │  │  Twilio     │
-      │  - Auth (JWT) │  │  - Errors       │  │  - SendGrid │
-      │  - Postgres   │  │  - Performance  │  │  - SMS      │
-      │  - Vault      │  │  - CSP reports  │  │             │
-      └───────────────┘  └─────────────────┘  └─────────────┘
+        ┌──────────────┬───────────┼───────────┬───────────────┐
+        │              │           │           │               │
+ ┌──────▼───┐  ┌──────▼────┐  ┌──▼────┐  ┌───▼─────┐  ┌──────▼──────┐
+ │ Supabase  │  │  Sentry   │  │Twilio │  │ PostHog │  │ Better Stack│
+ │ - Auth    │  │  - Errors │  │-SGrid │  │-Analytics│  │ - Logs     │
+ │ - Postgres│  │  - Perf   │  │- SMS  │  │-Replays │  │ - Alerts   │
+ │ - Vault   │  │  - CSP    │  │       │  │         │  │            │
+ └───────────┘  └───────────┘  └───────┘  └─────────┘  └────────────┘
+                                                ┌───────────────┐
+                                                │  UptimeRobot  │
+                                                │  - Uptime     │
+                                                │  - Status page│
+                                                └───────────────┘
 ```
 
 ## Services
@@ -103,6 +108,116 @@ Source maps are uploaded during Docker builds for readable stack traces.
 - Browser push notifications via FCM / Mozilla Push Service
 - VAPID key pair must be consistent across all instances
 
+### PostHog (Product Analytics)
+
+> **Status:** Planned — see [#352](https://github.com/supersuit-tech/permission-slip-web/issues/352)
+
+Product analytics for understanding user behavior, feature adoption, and funnel drop-off.
+
+- **Service:** [PostHog Cloud](https://posthog.com) (US or EU hosting)
+- **Free tier:** 1M events/month, 5K session recordings/month
+- **What it tracks:** Agent registration, approval flows, standing approvals, action execution, notification config
+- **Privacy:** Respects Do Not Track / cookie consent; no PII in event properties
+
+**Setup steps:**
+1. Create a PostHog Cloud project
+2. Set `VITE_POSTHOG_KEY` (build arg) — PostHog project API key
+3. Optionally set `VITE_POSTHOG_HOST` (build arg) — defaults to `https://us.i.posthog.com`
+4. Add PostHog host to the CSP `connect-src` directive
+5. If key is not set, PostHog is a no-op (safe for dev/staging)
+
+**Env vars (build-time):**
+
+| Variable | Description |
+|---|---|
+| `VITE_POSTHOG_KEY` | PostHog project API key |
+| `VITE_POSTHOG_HOST` | PostHog API host (default: `https://us.i.posthog.com`) |
+
+### Better Stack / Logtail (Log Aggregation)
+
+> **Status:** Planned — see [#331](https://github.com/supersuit-tech/permission-slip-web/issues/331)
+
+Centralized log search and alerting. The app already outputs structured JSON logs (`slog.JSONHandler`) with trace IDs, request method/path, status codes, and timing — no code changes needed.
+
+- **Service:** [Better Stack](https://betterstack.com) (Logtail)
+- **Free tier:** 1GB/month ingestion, 3-day retention
+- **Integration:** Native Fly.io log shipping (no sidecar needed)
+
+**Setup steps:**
+1. Create a Better Stack account and log source
+2. Configure Fly.io log shipping:
+   ```bash
+   # Recommended: native Fly.io → Logtail integration
+   fly logs ship --org <fly-org> --access-token <logtail-source-token>
+   ```
+3. Verify logs appear with correct JSON field parsing (`msg`, `level`, `trace_id`, `method`, `path`, `status`)
+4. Create alerts:
+   - 5xx error rate spike (>5 errors in 5 minutes)
+   - Health check failure logs
+   - Panic/crash logs
+5. Create saved views: all errors, slow requests, auth failures
+
+**No app env vars needed** — log shipping is configured at the Fly.io platform level, not in the app.
+
+### UptimeRobot (Uptime Monitoring)
+
+> **Status:** Planned — see [#332](https://github.com/supersuit-tech/permission-slip-web/issues/332)
+
+External uptime monitoring — catches issues that Fly's internal health checks miss (DNS, TLS cert expiry, CDN/proxy problems).
+
+- **Service:** [UptimeRobot](https://uptimerobot.com)
+- **Free tier:** 50 monitors, 5-minute check intervals
+
+**Setup steps:**
+1. Create an UptimeRobot account
+2. Add HTTP monitor:
+   - **URL:** `https://app.permissionslip.dev/api/health`
+   - **Interval:** 5 minutes
+   - **Expected status:** 200
+   - **Keyword check:** `"status":"ok"` (validates response body, not just HTTP 200)
+3. Configure alert contacts (email, Slack, or webhook)
+4. Optional: set up a public status page at `status.permissionslip.dev`
+
+**No app env vars needed** — UptimeRobot is external.
+
+### Stripe (Billing & Payments)
+
+> **Status:** Planned — see [#341](https://github.com/supersuit-tech/permission-slip-web/issues/341), [#364](https://github.com/supersuit-tech/permission-slip-web/issues/364)
+
+Payment processing for the paid tier: payment method collection, subscription management, and usage-based billing.
+
+- **Service:** [Stripe](https://stripe.com)
+- **Gated by:** `BILLING_ENABLED` env var (default `false`). When disabled, all users get unlimited plan and Stripe is skipped entirely
+
+**Env vars (runtime secrets):**
+
+| Variable | Description |
+|---|---|
+| `BILLING_ENABLED` | `true` to enable billing. Default `false` — all users get unlimited plan |
+| `STRIPE_SECRET_KEY` | Stripe API secret key (`sk_live_xxxx`) |
+| `STRIPE_PUBLISHABLE_KEY` | Stripe publishable key for frontend Checkout (`pk_live_xxxx`) |
+| `STRIPE_WEBHOOK_SECRET` | Webhook signature verification (`whsec_xxxx`) |
+| `STRIPE_PRICE_ID_REQUEST` | Metered Stripe Price ID for per-request billing |
+
+**Env vars (build-time):**
+
+| Variable | Description |
+|---|---|
+| `VITE_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key for frontend (build-time) |
+
+**Setup steps:**
+1. Create Stripe account and get API keys
+2. Create a metered Price for per-request billing ($0.005/request after 1,000 free)
+3. Set up a webhook endpoint at `https://app.permissionslip.dev/api/v1/webhooks/stripe`
+4. Configure webhook to send: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.paid`, `invoice.payment_failed`
+5. Set all env vars via `fly secrets set`
+
+**When `BILLING_ENABLED=false`:**
+- New users get `pay_as_you_go` plan (unlimited)
+- Stripe integration is skipped
+- Request metering is skipped
+- Billing API endpoints return 404
+
 ## Secrets & Environment Variables
 
 ### Fly.io Runtime Secrets
@@ -146,6 +261,16 @@ fly secrets set \
 fly secrets set \
   SENTRY_DSN="https://[key]@[org].ingest.sentry.io/[project]" \
   SENTRY_CSP_ENDPOINT="https://[org].ingest.sentry.io/api/[project]/security/?sentry_key=[key]"
+
+# ── Billing (Stripe) — when BILLING_ENABLED=true ─────────────────────────
+# Not needed until billing is enabled. See #341, #364.
+
+fly secrets set \
+  BILLING_ENABLED="true" \
+  STRIPE_SECRET_KEY="sk_live_xxxx" \
+  STRIPE_PUBLISHABLE_KEY="pk_live_xxxx" \
+  STRIPE_WEBHOOK_SECRET="whsec_xxxx" \
+  STRIPE_PRICE_ID_REQUEST="price_xxxx"
 ```
 
 **List current secrets** (values are hidden):
@@ -165,7 +290,9 @@ fly deploy \
   --build-arg VITE_SENTRY_DSN="https://[key]@[org].ingest.sentry.io/[project]" \
   --build-arg SENTRY_AUTH_TOKEN="sntrys_xxxx" \
   --build-arg SENTRY_ORG="supersuit" \
-  --build-arg SENTRY_PROJECT="permission-slip"
+  --build-arg SENTRY_PROJECT="permission-slip" \
+  --build-arg VITE_POSTHOG_KEY="phc_xxxx" \
+  --build-arg VITE_STRIPE_PUBLISHABLE_KEY="pk_live_xxxx"
 ```
 
 Or hardcode in `fly.toml` for simpler deploys:
@@ -174,6 +301,7 @@ Or hardcode in `fly.toml` for simpler deploys:
 [build.args]
   VITE_SUPABASE_URL = "https://[project-ref].supabase.co"
   VITE_SUPABASE_ANON_KEY = "<anon key>"
+  VITE_POSTHOG_KEY = "phc_xxxx"
   # VITE_SENTRY_DSN, SENTRY_AUTH_TOKEN, etc. can go here too
 ```
 
@@ -203,6 +331,18 @@ Or hardcode in `fly.toml` for simpler deploys:
 | `SENTRY_AUTH_TOKEN` | Build arg | **Set** | Source map upload token |
 | `SENTRY_ORG` | Build arg | **Set** | `supersuit` |
 | `SENTRY_PROJECT` | Build arg | **Set** | `permission-slip` |
+| `VITE_POSTHOG_KEY` | Build arg | **Planned** ([#352]) | PostHog project API key |
+| `VITE_POSTHOG_HOST` | Build arg | **Planned** ([#352]) | PostHog API host (default: `us.i.posthog.com`) |
+| `BILLING_ENABLED` | Runtime secret | **Planned** ([#364]) | `true` to enable billing (default: `false`) |
+| `STRIPE_SECRET_KEY` | Runtime secret | **Planned** ([#341]) | Stripe API secret key |
+| `STRIPE_PUBLISHABLE_KEY` | Runtime secret | **Planned** ([#341]) | Stripe publishable key |
+| `STRIPE_WEBHOOK_SECRET` | Runtime secret | **Planned** ([#341]) | Stripe webhook signing secret |
+| `STRIPE_PRICE_ID_REQUEST` | Runtime secret | **Planned** ([#341]) | Metered Stripe Price ID |
+| `VITE_STRIPE_PUBLISHABLE_KEY` | Build arg | **Planned** ([#341]) | Stripe publishable key (frontend) |
+
+[#352]: https://github.com/supersuit-tech/permission-slip-web/issues/352
+[#364]: https://github.com/supersuit-tech/permission-slip-web/issues/364
+[#341]: https://github.com/supersuit-tech/permission-slip-web/issues/341
 
 ## Deployment Process
 
@@ -270,6 +410,8 @@ Fly handles TLS certificates automatically via Let's Encrypt.
 
 ## CI/CD Pipeline
 
+### CI (Testing)
+
 GitHub Actions runs on every push to `main` and on pull requests:
 
 | Job | What it does |
@@ -278,13 +420,48 @@ GitHub Actions runs on every push to `main` and on pull requests:
 | **Frontend Tests** | Vitest + React Testing Library |
 | **Build** | Full production build (Go binary + React) to catch compilation errors |
 
-The CI pipeline does **not** auto-deploy. Deploys are manual via `fly deploy`.
-
 ### Audit Workflow
 
 A separate `audit.yml` workflow runs dependency vulnerability scans:
 - `govulncheck` for Go modules
 - `npm audit` for frontend packages
+
+### CD (Deployment)
+
+> **Status:** Planned — see [#328](https://github.com/supersuit-tech/permission-slip-web/issues/328)
+
+Currently, deploys are **manual** via `fly deploy`. The planned CD workflow:
+
+- **Trigger:** Push to `main` (after CI passes)
+- **Action:** Deploy to Fly.io using `superfly/flyctl-actions`
+- **Secret:** `FLY_API_TOKEN` GitHub Actions secret (Fly.io deploy token)
+
+**Planned workflow** (`.github/workflows/deploy.yml`):
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [backend, frontend, build]  # require CI to pass
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+```
+
+**GitHub Actions secrets needed:**
+
+| Secret | Description |
+|---|---|
+| `FLY_API_TOKEN` | Fly.io deploy token (generate via `fly tokens create deploy`) |
+
+**Optional:** A staging workflow deploying to `staging.app.permissionslip.dev` on a separate Fly.io app.
 
 ## Monitoring & Observability
 
@@ -411,6 +588,40 @@ Fly secrets are encrypted and can't be viewed via `fly secrets list` (it only sh
 # SSH into the machine and check the env var
 fly ssh console -C "printenv DATABASE_URL"
 ```
+
+## Service Status Overview
+
+Quick reference for what's live vs. planned.
+
+| Service | Purpose | Status | Issue |
+|---|---|---|---|
+| **Fly.io** | Compute / hosting | Live | — |
+| **Supabase** | Auth + Postgres + Vault | Live | — |
+| **Sentry** | Error tracking (backend + frontend) | Live | [#329](https://github.com/supersuit-tech/permission-slip-web/issues/329), [#330](https://github.com/supersuit-tech/permission-slip-web/issues/330) |
+| **SendGrid** | Email notifications | Live | — |
+| **Twilio** | SMS notifications | Live | — |
+| **VAPID / Web Push** | Browser push notifications | Live | — |
+| **PostHog** | Product analytics + session replay | Planned | [#352](https://github.com/supersuit-tech/permission-slip-web/issues/352) |
+| **Better Stack** | Log aggregation + alerting | Planned | [#331](https://github.com/supersuit-tech/permission-slip-web/issues/331) |
+| **UptimeRobot** | Uptime monitoring + status page | Planned | [#332](https://github.com/supersuit-tech/permission-slip-web/issues/332) |
+| **Stripe** | Billing + payments | Planned | [#341](https://github.com/supersuit-tech/permission-slip-web/issues/341) |
+| **GitHub Actions CD** | Auto-deploy on push to main | Planned | [#328](https://github.com/supersuit-tech/permission-slip-web/issues/328) |
+
+### Future Hardening (Phase 3)
+
+These are tracked under [#321](https://github.com/supersuit-tech/permission-slip-web/issues/321) Phase 3 and should be addressed when the app has real users:
+
+- Prometheus metrics or Grafana Cloud for infrastructure metrics
+- Define SLOs and alerting thresholds
+- Database slow query logging
+- Connection pooling verification under load
+- Horizontal scaling load testing
+- Database migration linting in CI
+- Automated backup restore tests
+- Penetration test / security audit
+- Auth endpoint rate limiting (brute force protection)
+- Secret rotation schedule (documented cadence)
+- Dependency update automation (Dependabot or Renovate)
 
 ## Troubleshooting
 

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -1,0 +1,442 @@
+# Production Deployment Guide — app.permissionslip.dev
+
+> **Internal reference** for deploying and operating the production instance at `app.permissionslip.dev`. For self-hosted deployments, see [Self-Hosted Deployment Guide](deployment-self-hosted.md).
+
+## Infrastructure Overview
+
+```
+                    ┌─────────────────────────────┐
+                    │      Cloudflare / DNS        │
+                    │  app.permissionslip.dev      │
+                    └──────────┬──────────────────┘
+                               │ HTTPS
+                    ┌──────────▼──────────────────┐
+                    │         Fly.io               │
+                    │  Region: iad (US East)       │
+                    │  VM: 256MB, shared CPU       │
+                    │  Auto-stop/start enabled     │
+                    │  ┌────────────────────────┐  │
+                    │  │  Permission Slip       │  │
+                    │  │  (Go + React, :8080)   │  │
+                    │  └───────────┬────────────┘  │
+                    └──────────────┼───────────────┘
+                                   │
+                 ┌─────────────────┼──────────────────┐
+                 │                 │                   │
+      ┌──────────▼───┐  ┌────────▼────────┐  ┌──────▼──────┐
+      │  Supabase     │  │  Sentry         │  │  Twilio     │
+      │  - Auth (JWT) │  │  - Errors       │  │  - SendGrid │
+      │  - Postgres   │  │  - Performance  │  │  - SMS      │
+      │  - Vault      │  │  - CSP reports  │  │             │
+      └───────────────┘  └─────────────────┘  └─────────────┘
+```
+
+## Services
+
+### Fly.io (Compute)
+
+- **App name:** Set via `fly.toml` (or `fly launch`)
+- **Region:** `iad` (US East, primary)
+- **Machine:** 256MB RAM, 1 shared CPU
+- **Auto-scaling:** Min 0 machines, scales on request load (soft 200, hard 250 concurrent)
+- **Auto-stop:** Machines stop during idle periods and restart on incoming requests
+- **Health check:** `GET /api/health` — 15s interval, 3s timeout, 10s grace
+- **Shutdown:** Graceful SIGTERM with 30s drain for in-flight requests
+- **TLS:** Automatic via Let's Encrypt (Fly handles certificate provisioning)
+
+**Key Fly commands:**
+
+```bash
+fly status                          # check app status
+fly logs                            # tail logs
+fly ssh console                     # SSH into running machine
+fly scale show                      # current scale settings
+fly scale memory 512                # increase memory
+fly scale count 2                   # add instances
+fly secrets list                    # list all secrets (values hidden)
+```
+
+### Supabase (Auth + Database + Vault)
+
+Permission Slip uses a single Supabase project for:
+
+1. **Authentication** — JWT-based user login (email OTP, MFA)
+2. **PostgreSQL database** — all application data
+3. **Vault** — AES-256-GCM encryption for stored credentials
+
+**What you need from the Supabase dashboard:**
+
+| Value | Where to find | Used as |
+|---|---|---|
+| Project URL | Settings > API | `SUPABASE_URL` (runtime) + `VITE_SUPABASE_URL` (build) |
+| Anon key (public) | Settings > API | `VITE_SUPABASE_ANON_KEY` (build) |
+| Database connection string | Settings > Database > Connection string | `DATABASE_URL` (runtime) |
+
+**Database connection notes:**
+- Use the **pooler endpoint** (port 6543) with `?sslmode=require` — direct connections (port 5432) may be blocked by Supabase firewall rules
+- Connection string format: `postgres://postgres.[project-ref]:[password]@[host]:6543/postgres?sslmode=require`
+
+**Auth configuration** (in Supabase dashboard):
+- **Authentication > URL Configuration:** Add `https://app.permissionslip.dev` to the redirect allow list
+- **Authentication > Email:** Configure email templates as needed
+- **Authentication > Rate Limits:** Review and adjust for production traffic
+
+### Sentry (Error Tracking)
+
+Two Sentry projects (or one with separate DSNs):
+- **Backend:** Captures Go panics, 5xx errors, and uncaught exceptions
+- **Frontend:** Captures React errors, failed API calls, CSP violations
+
+Source maps are uploaded during Docker builds for readable stack traces.
+
+### Notification Services
+
+**Email — Twilio SendGrid:**
+- Used for approval request notifications
+- Requires a verified sender domain and API key
+
+**SMS — Twilio:**
+- Used for SMS approval notifications
+- Requires a Twilio account with a phone number
+
+**Web Push — VAPID:**
+- Browser push notifications via FCM / Mozilla Push Service
+- VAPID key pair must be consistent across all instances
+
+## Secrets & Environment Variables
+
+### Fly.io Runtime Secrets
+
+Set via `fly secrets set`. These are encrypted at rest by Fly and injected as environment variables at runtime.
+
+```bash
+# ── Required ──────────────────────────────────────────────────────────────
+
+fly secrets set \
+  DATABASE_URL="postgres://postgres.[ref]:[pass]@[host]:6543/postgres?sslmode=require" \
+  SUPABASE_URL="https://[project-ref].supabase.co" \
+  BASE_URL="https://app.permissionslip.dev" \
+  ALLOWED_ORIGINS="https://app.permissionslip.dev" \
+  INVITE_HMAC_KEY="<output of: openssl rand -hex 32>"
+
+# ── Web Push (VAPID) ─────────────────────────────────────────────────────
+
+# Generate keys: go run ./cmd/generate-vapid-keys --format=fly
+fly secrets set \
+  VAPID_PUBLIC_KEY="<base64url public key>" \
+  VAPID_PRIVATE_KEY="<base64url private key>" \
+  VAPID_SUBJECT="mailto:admin@supersuit.tech"
+
+# ── Email (SendGrid) ─────────────────────────────────────────────────────
+
+fly secrets set \
+  NOTIFICATION_EMAIL_PROVIDER="twilio-sendgrid" \
+  SENDGRID_API_KEY="SG.xxxx" \
+  NOTIFICATION_EMAIL_FROM="approvals@permissionslip.dev"
+
+# ── SMS (Twilio) ─────────────────────────────────────────────────────────
+
+fly secrets set \
+  TWILIO_ACCOUNT_SID="ACxxxx" \
+  TWILIO_AUTH_TOKEN="xxxx" \
+  TWILIO_FROM_NUMBER="+15551234567"
+
+# ── Error Tracking (Sentry) ──────────────────────────────────────────────
+
+fly secrets set \
+  SENTRY_DSN="https://[key]@[org].ingest.sentry.io/[project]" \
+  SENTRY_CSP_ENDPOINT="https://[org].ingest.sentry.io/api/[project]/security/?sentry_key=[key]"
+```
+
+**List current secrets** (values are hidden):
+
+```bash
+fly secrets list
+```
+
+### Build-Time Args
+
+These are inlined into the JavaScript bundle by Vite. Pass via `fly deploy --build-arg` or configure in `fly.toml` under `[build.args]`.
+
+```bash
+fly deploy \
+  --build-arg VITE_SUPABASE_URL="https://[project-ref].supabase.co" \
+  --build-arg VITE_SUPABASE_ANON_KEY="<anon key from Supabase dashboard>" \
+  --build-arg VITE_SENTRY_DSN="https://[key]@[org].ingest.sentry.io/[project]" \
+  --build-arg SENTRY_AUTH_TOKEN="sntrys_xxxx" \
+  --build-arg SENTRY_ORG="supersuit" \
+  --build-arg SENTRY_PROJECT="permission-slip"
+```
+
+Or hardcode in `fly.toml` for simpler deploys:
+
+```toml
+[build.args]
+  VITE_SUPABASE_URL = "https://[project-ref].supabase.co"
+  VITE_SUPABASE_ANON_KEY = "<anon key>"
+  # VITE_SENTRY_DSN, SENTRY_AUTH_TOKEN, etc. can go here too
+```
+
+### Complete Variable Checklist
+
+| Variable | Type | Status | Description |
+|---|---|---|---|
+| `DATABASE_URL` | Runtime secret | **Required** | Supabase Postgres pooler connection string |
+| `SUPABASE_URL` | Runtime secret | **Required** | Supabase project URL (JWT verification) |
+| `BASE_URL` | Runtime secret | **Required** | `https://app.permissionslip.dev` |
+| `ALLOWED_ORIGINS` | Runtime secret | **Required** | `https://app.permissionslip.dev` |
+| `INVITE_HMAC_KEY` | Runtime secret | **Required** | HMAC key for invite codes |
+| `VAPID_PUBLIC_KEY` | Runtime secret | **Required** | Web Push public key |
+| `VAPID_PRIVATE_KEY` | Runtime secret | **Required** | Web Push private key |
+| `VAPID_SUBJECT` | Runtime secret | **Required** | `mailto:admin@supersuit.tech` |
+| `NOTIFICATION_EMAIL_PROVIDER` | Runtime secret | **Set** | `twilio-sendgrid` |
+| `SENDGRID_API_KEY` | Runtime secret | **Set** | SendGrid API key |
+| `NOTIFICATION_EMAIL_FROM` | Runtime secret | **Set** | Sender address |
+| `TWILIO_ACCOUNT_SID` | Runtime secret | **Set if SMS** | Twilio SID |
+| `TWILIO_AUTH_TOKEN` | Runtime secret | **Set if SMS** | Twilio auth token |
+| `TWILIO_FROM_NUMBER` | Runtime secret | **Set if SMS** | Twilio phone number |
+| `SENTRY_DSN` | Runtime secret | **Set** | Backend error tracking DSN |
+| `SENTRY_CSP_ENDPOINT` | Runtime secret | **Set** | CSP violation reporting |
+| `VITE_SUPABASE_URL` | Build arg | **Required** | Frontend auth URL |
+| `VITE_SUPABASE_ANON_KEY` | Build arg | **Required** | Frontend auth public key |
+| `VITE_SENTRY_DSN` | Build arg | **Set** | Frontend error tracking DSN |
+| `SENTRY_AUTH_TOKEN` | Build arg | **Set** | Source map upload token |
+| `SENTRY_ORG` | Build arg | **Set** | `supersuit` |
+| `SENTRY_PROJECT` | Build arg | **Set** | `permission-slip` |
+
+## Deployment Process
+
+### Standard Deploy
+
+```bash
+# From the repo root — reads VITE_* from environment or fly.toml [build.args]
+fly deploy \
+  --build-arg VITE_SUPABASE_URL=https://[ref].supabase.co \
+  --build-arg VITE_SUPABASE_ANON_KEY=<key>
+```
+
+Or use the Makefile shortcut:
+
+```bash
+VITE_SUPABASE_URL=https://[ref].supabase.co \
+VITE_SUPABASE_ANON_KEY=<key> \
+make deploy
+```
+
+The deploy process:
+1. Fly's remote builders run the multi-stage Docker build
+2. Frontend is compiled with Vite (build args inlined)
+3. Go binary is compiled with the git SHA as the Sentry release
+4. Minimal Alpine runtime image (~30MB) is created
+5. Image is deployed, health check passes, old machine is stopped
+6. Database migrations run automatically on first request
+
+### Verify After Deploy
+
+```bash
+fly status                                          # machine running?
+fly logs                                            # any errors?
+curl -s https://app.permissionslip.dev/api/health   # health check
+```
+
+### Rollback
+
+```bash
+# List recent deployments
+fly releases
+
+# Rollback to a previous release
+fly deploy --image <previous-image-ref>
+```
+
+## DNS Configuration
+
+Domain: `app.permissionslip.dev`
+
+```bash
+# Add the certificate to Fly
+fly certs add app.permissionslip.dev
+
+# Check certificate status
+fly certs show app.permissionslip.dev
+```
+
+Add a CNAME record in your DNS provider:
+- **Type:** CNAME
+- **Name:** `app`
+- **Value:** `<fly-app-name>.fly.dev` (shown in `fly certs show`)
+
+Fly handles TLS certificates automatically via Let's Encrypt.
+
+## CI/CD Pipeline
+
+GitHub Actions runs on every push to `main` and on pull requests:
+
+| Job | What it does |
+|---|---|
+| **Backend Tests** | Go tests against Postgres 16 service container |
+| **Frontend Tests** | Vitest + React Testing Library |
+| **Build** | Full production build (Go binary + React) to catch compilation errors |
+
+The CI pipeline does **not** auto-deploy. Deploys are manual via `fly deploy`.
+
+### Audit Workflow
+
+A separate `audit.yml` workflow runs dependency vulnerability scans:
+- `govulncheck` for Go modules
+- `npm audit` for frontend packages
+
+## Monitoring & Observability
+
+### Health Check
+
+`GET /api/health` returns:
+- `200 OK` — server and database are healthy
+- `503 Service Unavailable` — database is unreachable
+
+Use this for uptime monitoring (e.g., UptimeRobot, Fly's built-in checks).
+
+### Sentry
+
+**Backend errors:**
+- All 5xx errors and panics are captured
+- Sensitive headers (`Authorization`, `Cookie`, `X-Api-Key`) are scrubbed before sending
+- Environment tag: `production`
+- Release tag: git SHA (set via `-ldflags` at build time)
+
+**Frontend errors:**
+- React error boundaries capture component failures
+- Failed API calls are tracked
+- Source maps are uploaded for readable stack traces
+
+**CSP violations:**
+- Reported via `report-uri` directive in Content-Security-Policy header
+- Shows up in Sentry as security events
+
+### Logs
+
+```bash
+fly logs              # tail all logs
+fly logs --app <name> # specific app
+```
+
+The server outputs structured JSON logs (`slog.JSONHandler`). Key log lines at startup:
+- `server listening` — server is up
+- `Connected to database` — DB pool established
+- `Notifications: N channel(s) configured` — which notification channels are active
+- `Connector registry: N connector(s) registered` — loaded connectors
+- `JWT: using JWKS endpoint ...` — auth verification mode
+
+## Operations Runbook
+
+### Scaling
+
+```bash
+# Check current scale
+fly scale show
+
+# Vertical scaling
+fly scale memory 512      # increase to 512MB
+fly scale vm shared-cpu-2x # bigger CPU
+
+# Horizontal scaling
+fly scale count 2          # run 2 instances
+```
+
+When running multiple instances, VAPID keys and `INVITE_HMAC_KEY` must be set as Fly secrets (not auto-generated) so all instances share the same keys.
+
+### Rotating Secrets
+
+```bash
+# Generate new HMAC key
+fly secrets set INVITE_HMAC_KEY="$(openssl rand -hex 32)"
+
+# Rotate VAPID keys (WARNING: invalidates all push subscriptions)
+# Users will need to re-subscribe to push notifications
+go run ./cmd/generate-vapid-keys --format=fly
+# Copy the output and run the fly secrets set command
+
+# Rotate SendGrid API key
+fly secrets set SENDGRID_API_KEY="SG.new-key"
+```
+
+Setting a secret triggers an automatic redeploy.
+
+### Database Migrations
+
+Migrations run automatically on server startup. If you need to run them manually:
+
+```bash
+# SSH into the machine
+fly ssh console
+
+# Migrations are embedded in the binary — restart triggers them
+# For manual control, use the migrate CLI locally:
+DATABASE_URL="<prod-connection-string>" go run ./cmd/migrate up
+DATABASE_URL="<prod-connection-string>" go run ./cmd/migrate down
+```
+
+> **Caution:** Running `migrate down` in production will drop tables. Always verify what the down migration does before running it.
+
+### Custom Connectors
+
+On Fly.io, the filesystem is ephemeral. Use the `CUSTOM_CONNECTORS_JSON` env var:
+
+```bash
+fly secrets set CUSTOM_CONNECTORS_JSON='{"connectors":[{"repo":"https://github.com/acme/ps-jira-connector","ref":"v1.0.0"}]}'
+```
+
+Alternatively, attach a persistent volume:
+
+```bash
+fly volumes create connectors_data --size 1 --region iad
+```
+
+Add to `fly.toml`:
+
+```toml
+[mounts]
+  source = "connectors_data"
+  destination = "/app/connectors"
+
+[env]
+  CONNECTORS_DIR = "/app/connectors"
+```
+
+### Checking Secret Values
+
+Fly secrets are encrypted and can't be viewed via `fly secrets list` (it only shows names). If you need to verify a value:
+
+```bash
+# SSH into the machine and check the env var
+fly ssh console -C "printenv DATABASE_URL"
+```
+
+## Troubleshooting
+
+**Deploy fails on frontend build stage:**
+- Ensure `spec/openapi/openapi.bundle.yaml` is committed — the `npm ci` postinstall hook needs it
+- Check that build args (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`) are being passed
+
+**Health check fails after deploy:**
+- Check `fly logs` for startup errors
+- Common: bad `DATABASE_URL`, expired database password, Supabase project paused (free tier)
+
+**"VAPID_SUBJECT is required in production":**
+- All three VAPID vars must be set, or none. Check `fly secrets list`
+
+**Users can't log in:**
+- Verify `SUPABASE_URL` is correct and the project is active
+- Check that `https://app.permissionslip.dev` is in Supabase's redirect allow list
+- Check Supabase dashboard for auth errors
+
+**CORS errors in browser:**
+- Ensure `ALLOWED_ORIGINS` includes `https://app.permissionslip.dev` (exact match, no trailing slash)
+
+**Invite links don't work:**
+- Check `BASE_URL` is set to `https://app.permissionslip.dev`
+- Check `INVITE_HMAC_KEY` hasn't been rotated since the invite was generated (rotation invalidates pending invites)
+
+**Database connection timeout:**
+- Use the Supabase pooler endpoint (port 6543), not direct connection (port 5432)
+- Check Supabase project status — free tier projects pause after inactivity

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -168,6 +168,32 @@ All three are required to enable SMS. If partially configured, SMS is disabled w
 | `SENTRY_ORG` | Sentry org slug (**build-time** arg) |
 | `SENTRY_PROJECT` | Sentry project slug (**build-time** arg) |
 
+### Product Analytics (PostHog)
+
+Optional. Tracks user behavior, feature adoption, and funnel analytics.
+
+| Variable | Description |
+|---|---|
+| `VITE_POSTHOG_KEY` | PostHog project API key (**build-time**) |
+| `VITE_POSTHOG_HOST` | PostHog API host (**build-time**, default: `https://us.i.posthog.com`) |
+
+If `VITE_POSTHOG_KEY` is not set, analytics are disabled (no-op). PostHog Cloud has a free tier of 1M events/month, or you can [self-host PostHog](https://posthog.com/docs/self-host).
+
+### Billing (Stripe)
+
+Optional. Only needed if you want to enable paid tiers and usage-based billing.
+
+| Variable | Description |
+|---|---|
+| `BILLING_ENABLED` | Set to `true` to enable billing (default: `false`) |
+| `STRIPE_SECRET_KEY` | Stripe API secret key |
+| `STRIPE_PUBLISHABLE_KEY` | Stripe publishable key |
+| `STRIPE_WEBHOOK_SECRET` | Webhook signature verification secret |
+| `STRIPE_PRICE_ID_REQUEST` | Metered Stripe Price for per-request billing |
+| `VITE_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key for frontend (**build-time**) |
+
+When `BILLING_ENABLED=false` (the default), all users get an unlimited plan, Stripe is skipped, request metering is skipped, and billing API endpoints are disabled. This is the recommended setting for self-hosted deployments unless you want to run your own billing.
+
 ### Other Optional Variables
 
 | Variable | Default | Description |
@@ -393,5 +419,13 @@ Migrations run automatically on startup. If they fail, check database connectivi
 | `SENTRY_AUTH_TOKEN` | No | Build | Sentry source map upload |
 | `SENTRY_ORG` | No | Build | Sentry org slug |
 | `SENTRY_PROJECT` | No | Build | Sentry project slug |
+| `VITE_POSTHOG_KEY` | No | Build | PostHog project API key |
+| `VITE_POSTHOG_HOST` | No | Build | PostHog API host (default: `us.i.posthog.com`) |
+| `BILLING_ENABLED` | No | Runtime | Enable billing (`true`/`false`, default: `false`) |
+| `STRIPE_SECRET_KEY` | For billing | Runtime | Stripe API secret key |
+| `STRIPE_PUBLISHABLE_KEY` | For billing | Runtime | Stripe publishable key |
+| `STRIPE_WEBHOOK_SECRET` | For billing | Runtime | Stripe webhook signing secret |
+| `STRIPE_PRICE_ID_REQUEST` | For billing | Runtime | Metered Stripe Price ID |
+| `VITE_STRIPE_PUBLISHABLE_KEY` | For billing | Build | Stripe publishable key (frontend) |
 | `CONNECTORS_DIR` | No | Runtime | Custom connector directory |
 | `CUSTOM_CONNECTORS_JSON` | No | Runtime | Inline connector JSON config |

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -1,0 +1,397 @@
+# Self-Hosted Deployment Guide
+
+This guide covers deploying Permission Slip on your own infrastructure. Permission Slip ships as a single Go binary with the React frontend embedded — no separate web server or static file hosting needed.
+
+## Prerequisites
+
+Before deploying, you'll need:
+
+| Service | Purpose | Notes |
+|---|---|---|
+| **PostgreSQL 16+** | Application database | Any managed provider works (Supabase, Neon, AWS RDS, self-hosted) |
+| **Supabase project** | User authentication (JWT-based) | Free tier is sufficient. Provides login, MFA, and JWT verification |
+| **Docker** (optional) | Container-based deployment | Only needed if deploying via Docker |
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────┐
+│           Permission Slip Server            │
+│  ┌──────────────┐  ┌────────────────────┐   │
+│  │  Go API      │  │  Embedded React    │   │
+│  │  (port 8080) │  │  Frontend          │   │
+│  └──────┬───────┘  └────────────────────┘   │
+│         │                                    │
+└─────────┼────────────────────────────────────┘
+          │
+    ┌─────▼─────┐     ┌──────────────────┐
+    │ PostgreSQL │     │  Supabase Auth   │
+    │ (database) │     │  (JWT provider)  │
+    └───────────┘     └──────────────────┘
+```
+
+The server handles everything on a single port:
+- API endpoints under `/api/v1/`
+- Health check at `/api/health`
+- React SPA for all other routes
+- Database migrations run automatically on startup
+
+## Step 1: Set Up Supabase Auth
+
+Permission Slip uses [Supabase Auth](https://supabase.com/auth) for user authentication. You need a Supabase project — the free tier works fine.
+
+1. Create a project at [supabase.com](https://supabase.com)
+2. From your project dashboard, note these values:
+   - **Project URL** (e.g., `https://abcdefgh.supabase.co`) — used as `SUPABASE_URL`
+   - **Anon key** (public) — used as `VITE_SUPABASE_ANON_KEY` at build time
+3. Under **Authentication > URL Configuration**, add your deployment URL to the redirect allow list
+
+> **Note:** You can use Supabase's hosted database as your `DATABASE_URL` too, or use a separate PostgreSQL instance. Either works.
+
+## Step 2: Set Up PostgreSQL
+
+You need a PostgreSQL 16+ database. Options:
+
+- **Supabase** (bundled with your auth project) — use the connection pooler URL (port 6543) with `?sslmode=require`
+- **Neon** — serverless Postgres, generous free tier
+- **AWS RDS / Google Cloud SQL / Azure Database** — managed Postgres
+- **Self-hosted** — any PostgreSQL 16+ instance
+
+The server runs migrations automatically on startup — no manual migration step needed.
+
+### Supabase Vault (credential encryption)
+
+Permission Slip uses [Supabase Vault](https://supabase.com/docs/guides/database/vault) for encrypting stored credentials (API keys, OAuth tokens) at rest using AES-256-GCM. This requires:
+
+- The `pgsodium` and `vault` PostgreSQL extensions (included in all Supabase projects)
+- A `VAULT_SECRET_KEY` configured on the **database side** (not as an app env var)
+
+If you're using a Supabase-hosted database, vault is already available. If using a non-Supabase database, you'll need to install the `pgsodium` and `supabase_vault` extensions manually, or implement an alternative vault backend.
+
+## Step 3: Configure Environment Variables
+
+### Required Variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string | `postgres://user:pass@host:5432/dbname?sslmode=require` |
+| `SUPABASE_URL` | Supabase project URL (for JWT verification) | `https://abcdefgh.supabase.co` |
+
+### Recommended Variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `BASE_URL` | Public URL of your deployment (used for invite links) | `https://permissions.mycompany.com` |
+| `ALLOWED_ORIGINS` | Comma-separated CORS origins | `https://permissions.mycompany.com` |
+| `INVITE_HMAC_KEY` | HMAC key for invite code signing | Generate: `openssl rand -hex 32` |
+
+### Build-Time Variables (Frontend)
+
+These are inlined into the JavaScript bundle by Vite at build time. They must be passed as `--build-arg` when building Docker images, not as runtime env vars.
+
+| Variable | Description | Example |
+|---|---|---|
+| `VITE_SUPABASE_URL` | Supabase project URL (frontend auth) | `https://abcdefgh.supabase.co` |
+| `VITE_SUPABASE_ANON_KEY` | Supabase anon (public) key | From Supabase dashboard |
+| `VITE_SENTRY_DSN` | Frontend error tracking (optional) | `https://key@o0.ingest.sentry.io/0` |
+
+> The anon key is safe to include in the build — it's a public key visible in client-side JavaScript by design.
+
+### Web Push Notifications (VAPID)
+
+To enable browser push notifications, set all three:
+
+| Variable | Description | Example |
+|---|---|---|
+| `VAPID_PUBLIC_KEY` | VAPID public key | Generate with `make generate-vapid-keys` |
+| `VAPID_PRIVATE_KEY` | VAPID private key (keep secret) | Generate with `make generate-vapid-keys` |
+| `VAPID_SUBJECT` | Contact URL for push services | `mailto:admin@mycompany.com` |
+
+Generate a key pair:
+
+```bash
+# .env format
+make generate-vapid-keys
+
+# Fly.io format (ready-to-run fly secrets set command)
+go run ./cmd/generate-vapid-keys --format=fly
+
+# Heroku format
+go run ./cmd/generate-vapid-keys --format=heroku
+```
+
+If none are set, Web Push is disabled (the app works fine without it). If partially configured, the server will refuse to start.
+
+> **Warning:** Changing VAPID keys invalidates all existing push subscriptions. Users will need to re-subscribe.
+
+### Email Notifications
+
+Pick one provider:
+
+**SendGrid (recommended):**
+
+| Variable | Value |
+|---|---|
+| `NOTIFICATION_EMAIL_PROVIDER` | `twilio-sendgrid` |
+| `SENDGRID_API_KEY` | Your SendGrid API key (`SG.xxxx`) |
+| `NOTIFICATION_EMAIL_FROM` | Sender address (e.g., `approvals@mycompany.com`) |
+
+**SMTP (Gmail, Mailgun, self-hosted, etc.):**
+
+| Variable | Value |
+|---|---|
+| `NOTIFICATION_EMAIL_PROVIDER` | `smtp` |
+| `SMTP_HOST` | SMTP server hostname (e.g., `smtp.gmail.com`) |
+| `SMTP_PORT` | SMTP port (default: `587`) |
+| `SMTP_USERNAME` | SMTP username |
+| `SMTP_PASSWORD` | SMTP password or app password |
+| `NOTIFICATION_EMAIL_FROM` | Sender address |
+
+### SMS Notifications (Twilio)
+
+| Variable | Description |
+|---|---|
+| `TWILIO_ACCOUNT_SID` | Twilio Account SID (`ACxxxx`) |
+| `TWILIO_AUTH_TOKEN` | Twilio Auth Token |
+| `TWILIO_FROM_NUMBER` | Twilio phone number (`+15551234567`) |
+
+All three are required to enable SMS. If partially configured, SMS is disabled with a warning.
+
+### Error Tracking (Sentry)
+
+| Variable | Description |
+|---|---|
+| `SENTRY_DSN` | Backend Sentry DSN (runtime env var) |
+| `SENTRY_CSP_ENDPOINT` | CSP violation report-uri (runtime env var) |
+| `VITE_SENTRY_DSN` | Frontend Sentry DSN (**build-time** arg) |
+| `SENTRY_AUTH_TOKEN` | Source map upload token (**build-time** arg) |
+| `SENTRY_ORG` | Sentry org slug (**build-time** arg) |
+| `SENTRY_PROJECT` | Sentry project slug (**build-time** arg) |
+
+### Other Optional Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `8080` | HTTP listen port |
+| `MODE` | (production) | Set to `development` to disable rate limiting and relax config validation |
+| `TRUSTED_PROXY_HEADER` | `Fly-Client-IP` | HTTP header for real client IP (behind reverse proxy) |
+| `SHUTDOWN_TIMEOUT` | `30s` | Graceful shutdown timeout for in-flight requests |
+| `CONNECTORS_DIR` | `~/.permission_slip/connectors/` | Directory for external connector plugins |
+| `CUSTOM_CONNECTORS_JSON` | (empty) | Inline JSON connector config (alternative to file on disk) |
+| `SUPABASE_JWT_SECRET` | (empty) | Legacy HS256 JWT secret (only for Supabase CLI v1 — not needed with modern Supabase) |
+| `SUPABASE_JWKS_URL` | (auto-derived) | Override JWKS endpoint URL (auto-derived from `SUPABASE_URL` if not set) |
+
+## Deployment Options
+
+### Option A: Docker (Recommended)
+
+The included multi-stage Dockerfile produces a minimal (~30MB) Alpine image.
+
+**Build the image:**
+
+```bash
+docker build \
+  --build-arg VITE_SUPABASE_URL=https://abcdefgh.supabase.co \
+  --build-arg VITE_SUPABASE_ANON_KEY=your-anon-key \
+  -t permission-slip .
+```
+
+**Run the container:**
+
+```bash
+docker run -p 8080:8080 \
+  -e DATABASE_URL="postgres://user:pass@host:5432/dbname?sslmode=require" \
+  -e SUPABASE_URL="https://abcdefgh.supabase.co" \
+  -e BASE_URL="https://permissions.mycompany.com" \
+  -e ALLOWED_ORIGINS="https://permissions.mycompany.com" \
+  -e INVITE_HMAC_KEY="$(openssl rand -hex 32)" \
+  permission-slip
+```
+
+**Docker Compose example:**
+
+```yaml
+version: "3.8"
+services:
+  permission-slip:
+    build:
+      context: .
+      args:
+        VITE_SUPABASE_URL: https://abcdefgh.supabase.co
+        VITE_SUPABASE_ANON_KEY: your-anon-key
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: postgres://user:pass@host:5432/dbname?sslmode=require
+      SUPABASE_URL: https://abcdefgh.supabase.co
+      BASE_URL: https://permissions.mycompany.com
+      ALLOWED_ORIGINS: https://permissions.mycompany.com
+      INVITE_HMAC_KEY: change-me-generate-with-openssl-rand-hex-32
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/api/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+```
+
+### Option B: Fly.io
+
+See the dedicated [Fly.io deployment guide](deployment.md) for full instructions including `fly.toml`, secrets management, DNS, scaling, and custom connectors.
+
+Quick version:
+
+```bash
+fly launch
+fly secrets set \
+  DATABASE_URL="postgres://..." \
+  SUPABASE_URL="https://abcdefgh.supabase.co" \
+  BASE_URL="https://your-app.fly.dev" \
+  ALLOWED_ORIGINS="https://your-app.fly.dev" \
+  INVITE_HMAC_KEY="$(openssl rand -hex 32)"
+fly deploy \
+  --build-arg VITE_SUPABASE_URL=https://abcdefgh.supabase.co \
+  --build-arg VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+### Option C: Build from Source
+
+If you prefer running the binary directly (e.g., on a VM or bare metal):
+
+**Prerequisites:** Go 1.24+, Node.js 20+
+
+```bash
+# Clone and build
+git clone https://github.com/supersuit-tech/permission-slip-web.git
+cd permission-slip-web
+make install
+
+# Set build-time vars for the frontend
+export VITE_SUPABASE_URL=https://abcdefgh.supabase.co
+export VITE_SUPABASE_ANON_KEY=your-anon-key
+make build
+
+# Run
+export DATABASE_URL="postgres://..."
+export SUPABASE_URL="https://abcdefgh.supabase.co"
+export BASE_URL="https://permissions.mycompany.com"
+export ALLOWED_ORIGINS="https://permissions.mycompany.com"
+export INVITE_HMAC_KEY="$(openssl rand -hex 32)"
+./bin/server
+```
+
+The binary is fully static (`CGO_ENABLED=0`) and embeds the React frontend — just copy it to your server and run.
+
+### Option D: Railway / Render / Other PaaS
+
+Permission Slip works on any platform that supports Docker or Go builds:
+
+1. Connect your repo (or push the Docker image)
+2. Set the required environment variables in the platform's dashboard
+3. For Docker-based platforms, configure build args for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+4. Ensure the health check is configured for `GET /api/health` on port 8080
+
+## TLS / Reverse Proxy
+
+The server listens on plain HTTP. In production, terminate TLS in front of it:
+
+- **Fly.io** — handles TLS automatically
+- **nginx / Caddy** — reverse proxy to `localhost:8080`
+- **AWS ALB / GCP Load Balancer** — route to the container on port 8080
+- **Cloudflare Tunnel** — expose the local service via a tunnel
+
+If using a reverse proxy other than Fly.io, set `TRUSTED_PROXY_HEADER` to the header your proxy uses for the real client IP (e.g., `X-Forwarded-For` or `X-Real-IP`). The default is `Fly-Client-IP`.
+
+## Custom Connectors
+
+Permission Slip ships with built-in GitHub and Slack connectors. To add custom connectors:
+
+**Option A — Inline JSON (recommended for containers):**
+
+```bash
+# Set as env var (no filesystem persistence needed)
+export CUSTOM_CONNECTORS_JSON='{"connectors":[{"repo":"https://github.com/acme/ps-jira-connector","ref":"v1.0.0"}]}'
+```
+
+**Option B — File on disk:**
+
+Create a `custom-connectors.json` in the project root and run `make install-connectors`. Set `CONNECTORS_DIR` to a persistent path if your filesystem is ephemeral.
+
+See [Custom Connectors](custom-connectors.md) for details on building your own.
+
+## Health Check
+
+The server exposes `GET /api/health` which:
+- Returns `200 OK` when the server is reachable
+- Reports database connectivity status when `DATABASE_URL` is configured
+- Returns `503 Service Unavailable` if the database is unreachable
+
+Use this endpoint for load balancer health checks, container orchestration, and uptime monitoring.
+
+## Scaling
+
+Permission Slip is stateless (all state is in PostgreSQL), so horizontal scaling is straightforward:
+
+- **Multiple instances:** Run as many copies as needed behind a load balancer
+- **Database connections:** Each instance creates a connection pool. Monitor your database's max connections
+- **VAPID keys:** When running multiple instances, set `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` explicitly so all instances use the same keys (don't rely on auto-generation)
+- **Action token signing:** Keys are ephemeral (generated per-instance on startup). Tokens are short-lived (max 5 min), so this works without shared key storage
+
+## Troubleshooting
+
+**Server won't start — "required configuration value(s) missing":**
+In production mode, `DATABASE_URL` and one of `SUPABASE_URL`/`SUPABASE_JWT_SECRET`/`SUPABASE_JWKS_URL` are required. Check your env vars.
+
+**Frontend shows "Missing VITE_SUPABASE_URL" error:**
+The Supabase build args were not passed at build time. Rebuild the Docker image with `--build-arg VITE_SUPABASE_URL=...`.
+
+**Health check fails after deploy:**
+Check logs. Common causes: missing `DATABASE_URL`, incorrect Supabase credentials, or the database being unreachable from the deployment network.
+
+**Connection refused to database:**
+If using Supabase, ensure the connection string uses the pooler endpoint (port 6543) with `?sslmode=require`. Direct connections (port 5432) may be blocked.
+
+**VAPID error on startup:**
+If any VAPID variable is set, all three (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) must be set. Either set all three or remove them all.
+
+**Migrations fail:**
+Migrations run automatically on startup. If they fail, check database connectivity and permissions. The database user needs `CREATE TABLE`, `ALTER TABLE`, and schema modification privileges.
+
+## Complete Environment Variable Reference
+
+| Variable | Required | Build/Runtime | Description |
+|---|---|---|---|
+| `DATABASE_URL` | Yes | Runtime | PostgreSQL connection string |
+| `SUPABASE_URL` | Yes | Runtime | Supabase project URL (JWT + auth) |
+| `VITE_SUPABASE_URL` | Yes | Build | Supabase URL for frontend auth |
+| `VITE_SUPABASE_ANON_KEY` | Yes | Build | Supabase public anon key |
+| `BASE_URL` | Recommended | Runtime | Public deployment URL |
+| `ALLOWED_ORIGINS` | Recommended | Runtime | CORS allowed origins (comma-separated) |
+| `INVITE_HMAC_KEY` | Recommended | Runtime | HMAC key for invite codes |
+| `PORT` | No | Runtime | Listen port (default: `8080`) |
+| `MODE` | No | Runtime | `development` to relax validation |
+| `TRUSTED_PROXY_HEADER` | No | Runtime | Client IP header (default: `Fly-Client-IP`) |
+| `SHUTDOWN_TIMEOUT` | No | Runtime | Graceful shutdown timeout (default: `30s`) |
+| `SUPABASE_JWT_SECRET` | No | Runtime | Legacy HS256 JWT secret |
+| `SUPABASE_JWKS_URL` | No | Runtime | JWKS endpoint override |
+| `VAPID_PUBLIC_KEY` | For Web Push | Runtime | VAPID public key |
+| `VAPID_PRIVATE_KEY` | For Web Push | Runtime | VAPID private key |
+| `VAPID_SUBJECT` | For Web Push | Runtime | VAPID contact (`mailto:` or `https://`) |
+| `NOTIFICATION_EMAIL_PROVIDER` | For email | Runtime | `twilio-sendgrid` or `smtp` |
+| `SENDGRID_API_KEY` | For SendGrid | Runtime | SendGrid API key |
+| `NOTIFICATION_EMAIL_FROM` | For email | Runtime | Sender email address |
+| `SMTP_HOST` | For SMTP | Runtime | SMTP server hostname |
+| `SMTP_PORT` | For SMTP | Runtime | SMTP port (default: `587`) |
+| `SMTP_USERNAME` | For SMTP | Runtime | SMTP username |
+| `SMTP_PASSWORD` | For SMTP | Runtime | SMTP password |
+| `TWILIO_ACCOUNT_SID` | For SMS | Runtime | Twilio Account SID |
+| `TWILIO_AUTH_TOKEN` | For SMS | Runtime | Twilio Auth Token |
+| `TWILIO_FROM_NUMBER` | For SMS | Runtime | Twilio sender phone number |
+| `SENTRY_DSN` | No | Runtime | Backend error tracking |
+| `SENTRY_CSP_ENDPOINT` | No | Runtime | CSP violation reporting |
+| `VITE_SENTRY_DSN` | No | Build | Frontend error tracking |
+| `SENTRY_AUTH_TOKEN` | No | Build | Sentry source map upload |
+| `SENTRY_ORG` | No | Build | Sentry org slug |
+| `SENTRY_PROJECT` | No | Build | Sentry project slug |
+| `CONNECTORS_DIR` | No | Runtime | Custom connector directory |
+| `CUSTOM_CONNECTORS_JSON` | No | Runtime | Inline connector JSON config |


### PR DESCRIPTION
Two new deployment guides covering env vars, services, and operations:
- docs/deployment-self-hosted.md: for users deploying on their own infra
- docs/deployment-production.md: internal guide for app.permissionslip.dev

https://claude.ai/code/session_01ESUfqmcvCvxkxoKyeXeHo3