### PR TITLE
Add PostHog product analytics with consent-gated initialization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,4 +141,16 @@ VAULT_SECRET_KEY=your-vault-secret-key-from-openssl-rand
 # Settings → Security Headers → report-uri.
 # SENTRY_CSP_ENDPOINT=https://o0.ingest.sentry.io/api/0/security/?sentry_key=abc
 
+# ── Product Analytics (PostHog) ─────────────────────────────────────────────
+#
+# PostHog is disabled when VITE_POSTHOG_KEY is not set. Events are only
+# sent after the user accepts the cookie consent banner.
+#
+# VITE_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# VITE_POSTHOG_HOST=https://us.i.posthog.com
+#
+# Backend CSP — must match VITE_POSTHOG_HOST so the browser can send
+# events. Only needed in production (Vite dev server has no CSP).
+# POSTHOG_HOST=https://us.i.posthog.com
+
 # VITE_REACT_DEVTOOLS=true  # Uncomment to connect to standalone react-devtools app (npm run devtools)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ Beyond the variables in `.env.example`, these require attention for production:
 | `SENTRY_DSN` | Optional | Sentry DSN for backend error tracking — panics and 5xx errors are captured automatically |
 | `VITE_SENTRY_DSN` | Optional | Sentry DSN for frontend error tracking (build-time) — React errors, failed API calls, and performance data |
 | `SENTRY_CSP_ENDPOINT` | Optional | Sentry CSP report-uri endpoint — captures Content-Security-Policy violations as Sentry events |
+| `VITE_POSTHOG_KEY` | Optional | PostHog project API key for product analytics (build-time) — consent-gated, no data sent until user accepts cookies |
+| `VITE_POSTHOG_HOST` | Optional | PostHog API host (build-time, default: `https://us.i.posthog.com`) — use a custom host if self-hosting PostHog |
+| `POSTHOG_HOST` | Optional | PostHog API host added to CSP `connect-src` — must match `VITE_POSTHOG_HOST` (runtime) |
 | `SHUTDOWN_TIMEOUT` | Optional | Graceful shutdown timeout for draining in-flight requests (default: `30s`) |
 | `VAPID_PUBLIC_KEY` | For Web Push | VAPID public key for Web Push notifications |
 | `VAPID_PRIVATE_KEY` | For Web Push | VAPID private key — keep secret, never commit to git |
@@ -196,6 +199,21 @@ make test-frontend     # frontend tests (no database needed)
 ```
 
 Backend tests run against a real Postgres database. Frontend tests use a mocked Supabase client. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full testing strategy.
+
+## Observability
+
+### Error Tracking (Sentry)
+
+Sentry captures backend panics/5xx errors and frontend React errors. Set `SENTRY_DSN` (backend) and `VITE_SENTRY_DSN` (frontend) to enable.
+
+### Product Analytics (PostHog)
+
+PostHog provides privacy-focused product analytics. It is **fully consent-gated** — no data is collected until the user explicitly accepts cookies via the consent banner.
+
+- Set `VITE_POSTHOG_KEY` and optionally `VITE_POSTHOG_HOST` to enable (build-time).
+- Set `POSTHOG_HOST` to add the PostHog API host to the CSP `connect-src` directive (runtime).
+- If `VITE_POSTHOG_KEY` is not set, PostHog is completely disabled — no SDK code executes.
+- Events are defined in `frontend/src/lib/posthog-events.ts`. To add a new event, add a constant there and use `trackEvent()` from `@/lib/posthog`.
 
 ## Contributing
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,3 +7,8 @@ VITE_SUPABASE_ANON_KEY=your-anon-key-here
 
 # Sentry error tracking (optional — omit to disable)
 # VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+
+# PostHog product analytics (optional — omit to disable)
+# Events are only sent after the user accepts the cookie consent banner.
+# VITE_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "cmdk": "^1.1.1",
         "lucide-react": "^0.574.0",
         "openapi-fetch": "^0.17.0",
+        "posthog-js": "^1.356.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.13.0",
@@ -1094,13 +1095,326 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
+      "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.23.1.tgz",
+      "integrity": "sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.356.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.356.1.tgz",
+      "integrity": "sha512-miIUjs4LiBDMOxKkC87HEJLIih0pNGMAjxx+mW4X7jLpN41n0PLMW7swRE6uuxcMV0z3H6MllRSCYmsokkyfuQ==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3232,6 +3546,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -3832,6 +4153,31 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
@@ -3980,6 +4326,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4281,6 +4636,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -4767,7 +5128,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -5158,6 +5518,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5576,6 +5942,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -5700,6 +6075,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.356.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.356.1.tgz",
+      "integrity": "sha512-4EQliSyTp3j/xOaWpZmu7fk1b4S+J3qy4JOu5Xy3/MYFxv1SlAylgifRdCbXZxCQWb6PViaNvwRf4EmburgfWA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.23.1",
+        "@posthog/types": "1.356.1",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.1",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.28.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
+      "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -5724,6 +6130,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -5772,6 +6202,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -6179,6 +6615,27 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -6826,6 +7283,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -6882,7 +7345,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "cmdk": "^1.1.1",
     "lucide-react": "^0.574.0",
     "openapi-fetch": "^0.17.0",
+    "posthog-js": "^1.356.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.13.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useEffect } from "react";
 import { Loader2 } from "lucide-react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "./auth/AuthContext";
+import { identifyUser, resetPostHogIdentity } from "./lib/posthog";
 import LoginPage from "./auth/LoginPage";
 import MfaChallengePage from "./auth/MfaChallengePage";
 import OnboardingPage from "./auth/OnboardingPage";
@@ -51,13 +52,16 @@ function App() {
   const { authStatus, user } = useAuth();
   const { needsOnboarding, isLoading: profileLoading } = useProfile();
 
-  // Set Sentry user context so errors include the user's identity.
-  // Only the opaque Supabase user ID is sent — no email or PII.
+  // Set Sentry + PostHog user context so errors and analytics include
+  // the user's identity. Only the opaque Supabase user ID is sent — no
+  // email or PII.
   useEffect(() => {
     if (authStatus === "authenticated" && user) {
       Sentry.setUser({ id: user.id });
+      identifyUser(user.id);
     } else {
       Sentry.setUser(null);
+      resetPostHogIdentity();
     }
   }, [authStatus, user]);
 

--- a/frontend/src/components/CookieConsentBanner.tsx
+++ b/frontend/src/components/CookieConsentBanner.tsx
@@ -20,11 +20,11 @@ export function CookieConsentBanner() {
     >
       <div className="mx-auto flex max-w-[1200px] flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <p className="text-sm text-card-foreground">
-          We use cookies and local storage for authentication and to improve
-          your experience. You can accept or reject non-essential cookies. See
-          our{" "}
-          <a href="/policy/privacy" className="underline underline-offset-4 hover:text-primary">
-            Privacy Policy
+          We use essential cookies for authentication. Accepting enables
+          privacy-focused analytics (PostHog) to help us improve the product
+          — no advertising or tracking. See our{" "}
+          <a href="/policy/cookies" className="underline underline-offset-4 hover:text-primary">
+            Cookie Policy
           </a>{" "}
           for details.
         </p>

--- a/frontend/src/components/PostHogProvider.tsx
+++ b/frontend/src/components/PostHogProvider.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useLocation } from "react-router-dom";
+import { useCookieConsent } from "./CookieConsentContext";
+import {
+  initPostHog,
+  isPostHogConfigured,
+  optInPostHog,
+  optOutPostHog,
+  capturePageView,
+} from "../lib/posthog";
+
+/**
+ * Bridges the cookie consent state with PostHog's opt-in/opt-out API.
+ *
+ * - Initializes PostHog once on mount (opted out by default).
+ * - Watches the consent state and enables/disables capturing accordingly.
+ * - Captures page views on React Router navigation when opted in.
+ *
+ * Must be placed inside both <BrowserRouter> and <CookieConsentProvider>.
+ */
+export function PostHogProvider({ children }: { children: ReactNode }) {
+  const { consent } = useCookieConsent();
+  const location = useLocation();
+  const initializedRef = useRef(false);
+
+  // Initialize PostHog once on mount.
+  useEffect(() => {
+    if (!isPostHogConfigured || initializedRef.current) return;
+    initPostHog();
+    initializedRef.current = true;
+  }, []);
+
+  // React to consent changes.
+  useEffect(() => {
+    if (!initializedRef.current) return;
+
+    if (consent === "accepted") {
+      optInPostHog();
+    } else {
+      optOutPostHog();
+    }
+  }, [consent]);
+
+  // Capture page views on route changes.
+  useEffect(() => {
+    if (!initializedRef.current) return;
+    capturePageView();
+  }, [location.pathname]);
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/PostHogProvider.tsx
+++ b/frontend/src/components/PostHogProvider.tsx
@@ -41,11 +41,13 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
     }
   }, [consent]);
 
-  // Capture page views on route changes.
+  // Capture page views on route changes — only when consent is granted.
+  // PostHog's SDK also guards internally, but we add an application-level
+  // check as defense-in-depth against potential SDK opt-out bugs.
   useEffect(() => {
-    if (!initializedRef.current) return;
+    if (!initializedRef.current || consent !== "accepted") return;
     capturePageView();
-  }, [location.pathname]);
+  }, [location.pathname, consent]);
 
   return <>{children}</>;
 }

--- a/frontend/src/components/__tests__/CookieConsentBanner.test.tsx
+++ b/frontend/src/components/__tests__/CookieConsentBanner.test.tsx
@@ -31,7 +31,7 @@ describe("CookieConsentBanner", () => {
   it("renders the banner when no consent has been given", () => {
     renderBanner();
     expect(screen.getByRole("region", { name: /cookie consent/i })).toBeInTheDocument();
-    expect(screen.getByText(/we use cookies/i)).toBeInTheDocument();
+    expect(screen.getByText(/we use essential cookies/i)).toBeInTheDocument();
     expect(screen.getByText("Accept All")).toBeInTheDocument();
     expect(screen.getByText("Reject All")).toBeInTheDocument();
   });
@@ -62,9 +62,9 @@ describe("CookieConsentBanner", () => {
     expect(screen.queryByRole("region")).not.toBeInTheDocument();
   });
 
-  it("contains a link to the privacy policy", () => {
+  it("contains a link to the cookie policy", () => {
     renderBanner();
-    const link = screen.getByRole("link", { name: /privacy policy/i });
-    expect(link).toHaveAttribute("href", "/policy/privacy");
+    const link = screen.getByRole("link", { name: /cookie policy/i });
+    expect(link).toHaveAttribute("href", "/policy/cookies");
   });
 });

--- a/frontend/src/components/__tests__/PostHogProvider.test.tsx
+++ b/frontend/src/components/__tests__/PostHogProvider.test.tsx
@@ -99,8 +99,17 @@ describe("PostHogProvider", () => {
     expect(mockOptOutPostHog).toHaveBeenCalledTimes(1);
   });
 
-  it("captures a page view on initial render", () => {
+  it("does not capture page views without consent", () => {
     renderWithProviders("/dashboard");
+    expect(mockCapturePageView).not.toHaveBeenCalled();
+  });
+
+  it("captures a page view after consent is granted", async () => {
+    renderWithProviders("/dashboard");
+    mockCapturePageView.mockClear();
+
+    await userEvent.click(screen.getByText("Accept"));
+
     expect(mockCapturePageView).toHaveBeenCalled();
   });
 

--- a/frontend/src/components/__tests__/PostHogProvider.test.tsx
+++ b/frontend/src/components/__tests__/PostHogProvider.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import {
+  CookieConsentProvider,
+  useCookieConsent,
+} from "../CookieConsentContext";
+import { PostHogProvider } from "../PostHogProvider";
+import { clearConsentCookie } from "../../test-cookie-helpers";
+
+// Mock the posthog module so we can verify opt-in/opt-out and page view calls.
+const mockInitPostHog = vi.fn();
+const mockOptInPostHog = vi.fn();
+const mockOptOutPostHog = vi.fn();
+const mockCapturePageView = vi.fn();
+
+vi.mock("../../lib/posthog", () => ({
+  isPostHogConfigured: true,
+  initPostHog: (...args: unknown[]) => mockInitPostHog(...args),
+  optInPostHog: (...args: unknown[]) => mockOptInPostHog(...args),
+  optOutPostHog: (...args: unknown[]) => mockOptOutPostHog(...args),
+  capturePageView: (...args: unknown[]) => mockCapturePageView(...args),
+}));
+
+/** Test harness that renders PostHogProvider with consent controls. */
+function TestHarness() {
+  const { consent, accept, reject, reset } = useCookieConsent();
+  return (
+    <div>
+      <span data-testid="consent">{consent ?? "null"}</span>
+      <button onClick={accept}>Accept</button>
+      <button onClick={reject}>Reject</button>
+      <button onClick={reset}>Reset</button>
+    </div>
+  );
+}
+
+function renderWithProviders(initialRoute = "/") {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <CookieConsentProvider>
+        <PostHogProvider>
+          <TestHarness />
+        </PostHogProvider>
+      </CookieConsentProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("PostHogProvider", () => {
+  beforeEach(() => {
+    clearConsentCookie();
+    mockInitPostHog.mockClear();
+    mockOptInPostHog.mockClear();
+    mockOptOutPostHog.mockClear();
+    mockCapturePageView.mockClear();
+  });
+
+  it("initializes PostHog on mount", () => {
+    renderWithProviders();
+    expect(mockInitPostHog).toHaveBeenCalledTimes(1);
+  });
+
+  it("opts out when consent is null (undecided)", () => {
+    renderWithProviders();
+    // Initial consent is null → should opt out
+    expect(mockOptOutPostHog).toHaveBeenCalled();
+    expect(mockOptInPostHog).not.toHaveBeenCalled();
+  });
+
+  it("opts in when user accepts cookies", async () => {
+    renderWithProviders();
+    mockOptInPostHog.mockClear();
+
+    await userEvent.click(screen.getByText("Accept"));
+
+    expect(mockOptInPostHog).toHaveBeenCalledTimes(1);
+  });
+
+  it("opts out when user rejects cookies", async () => {
+    renderWithProviders();
+    mockOptOutPostHog.mockClear();
+
+    await userEvent.click(screen.getByText("Reject"));
+
+    expect(mockOptOutPostHog).toHaveBeenCalledTimes(1);
+  });
+
+  it("opts out when consent is reset", async () => {
+    renderWithProviders();
+
+    // First accept
+    await userEvent.click(screen.getByText("Accept"));
+    mockOptOutPostHog.mockClear();
+
+    // Then reset
+    await userEvent.click(screen.getByText("Reset"));
+    expect(mockOptOutPostHog).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures a page view on initial render", () => {
+    renderWithProviders("/dashboard");
+    expect(mockCapturePageView).toHaveBeenCalled();
+  });
+
+  it("does not initialize PostHog more than once", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <PostHogProvider>
+            <TestHarness />
+          </PostHogProvider>
+        </CookieConsentProvider>
+      </MemoryRouter>,
+    );
+
+    // Force a re-render
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <PostHogProvider>
+            <TestHarness />
+          </PostHogProvider>
+        </CookieConsentProvider>
+      </MemoryRouter>,
+    );
+
+    expect(mockInitPostHog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/consent-banner/embed.ts
+++ b/frontend/src/consent-banner/embed.ts
@@ -69,14 +69,14 @@ function createBanner(): HTMLElement | null {
   // risk of XSS if this template is ever modified to include dynamic values.
   text.appendChild(
     document.createTextNode(
-      "We use cookies to analyze site usage and improve your experience. You can accept or reject non-essential cookies. See our ",
+      "We use essential cookies for authentication. Accepting enables privacy-focused analytics to help us improve the product \u2014 no advertising or tracking. See our ",
     ),
   );
   const policyLink = document.createElement("a");
-  policyLink.href = "https://app.permissionslip.dev/policy/privacy";
+  policyLink.href = "https://app.permissionslip.dev/policy/cookies";
   policyLink.style.cssText =
     "text-decoration:underline;text-underline-offset:4px;color:inherit";
-  policyLink.textContent = "Privacy Policy";
+  policyLink.textContent = "Cookie Policy";
   text.appendChild(policyLink);
   text.appendChild(document.createTextNode(" for details."));
 

--- a/frontend/src/hooks/useApproveApproval.ts
+++ b/frontend/src/hooks/useApproveApproval.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
+import { trackEvent } from "@/lib/posthog";
 
 export function useApproveApproval() {
   const { session } = useAuth();
@@ -21,7 +22,10 @@ export function useApproveApproval() {
       if (error) throw new Error("Failed to approve request");
       return data;
     },
-    // No onSuccess invalidation — the approved row stays visible so the user
+    onSuccess: () => {
+      trackEvent("approval_approved");
+    },
+    // No query invalidation — the approved row stays visible so the user
     // can read/copy the confirmation code. The 5-second polling in useApprovals
     // handles eventual removal from the pending list.
   });

--- a/frontend/src/hooks/useApproveApproval.ts
+++ b/frontend/src/hooks/useApproveApproval.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 export function useApproveApproval() {
   const { session } = useAuth();
@@ -23,7 +24,7 @@ export function useApproveApproval() {
       return data;
     },
     onSuccess: () => {
-      trackEvent("approval_approved");
+      trackEvent(PostHogEvents.APPROVAL_APPROVED);
     },
     // No query invalidation — the approved row stays visible so the user
     // can read/copy the confirmation code. The 5-second polling in useApprovals

--- a/frontend/src/hooks/useApproveApproval.ts
+++ b/frontend/src/hooks/useApproveApproval.ts
@@ -1,8 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 export function useApproveApproval() {
   const { session } = useAuth();

--- a/frontend/src/hooks/useCreateInvite.ts
+++ b/frontend/src/hooks/useCreateInvite.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
+import { trackEvent } from "@/lib/posthog";
 
 export type InviteResponse =
   components["schemas"]["CreateRegistrationInviteResponse"];
@@ -24,6 +25,9 @@ export function useCreateInvite() {
       );
       if (error) throw new Error("Failed to generate invite code");
       return data;
+    },
+    onSuccess: () => {
+      trackEvent("invite_created");
     },
   });
 

--- a/frontend/src/hooks/useCreateInvite.ts
+++ b/frontend/src/hooks/useCreateInvite.ts
@@ -3,6 +3,7 @@ import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 export type InviteResponse =
   components["schemas"]["CreateRegistrationInviteResponse"];
@@ -27,7 +28,7 @@ export function useCreateInvite() {
       return data;
     },
     onSuccess: () => {
-      trackEvent("invite_created");
+      trackEvent(PostHogEvents.INVITE_CREATED);
     },
   });
 

--- a/frontend/src/hooks/useCreateInvite.ts
+++ b/frontend/src/hooks/useCreateInvite.ts
@@ -2,8 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 export type InviteResponse =
   components["schemas"]["CreateRegistrationInviteResponse"];

--- a/frontend/src/hooks/useCreateStandingApproval.ts
+++ b/frontend/src/hooks/useCreateStandingApproval.ts
@@ -3,6 +3,7 @@ import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { getApiErrorMessage } from "@/api/errors";
 import type { components } from "@/api/schema";
+import { trackEvent } from "@/lib/posthog";
 
 type CreateStandingApprovalRequest =
   components["schemas"]["CreateStandingApprovalRequest"];
@@ -32,6 +33,7 @@ export function useCreateStandingApproval() {
       return data;
     },
     onSuccess: () => {
+      trackEvent("standing_approval_created");
       queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
     },
   });

--- a/frontend/src/hooks/useCreateStandingApproval.ts
+++ b/frontend/src/hooks/useCreateStandingApproval.ts
@@ -4,6 +4,7 @@ import client from "@/api/client";
 import { getApiErrorMessage } from "@/api/errors";
 import type { components } from "@/api/schema";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 type CreateStandingApprovalRequest =
   components["schemas"]["CreateStandingApprovalRequest"];
@@ -33,7 +34,7 @@ export function useCreateStandingApproval() {
       return data;
     },
     onSuccess: () => {
-      trackEvent("standing_approval_created");
+      trackEvent(PostHogEvents.STANDING_APPROVAL_CREATED);
       queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
     },
   });

--- a/frontend/src/hooks/useCreateStandingApproval.ts
+++ b/frontend/src/hooks/useCreateStandingApproval.ts
@@ -3,8 +3,7 @@ import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { getApiErrorMessage } from "@/api/errors";
 import type { components } from "@/api/schema";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 type CreateStandingApprovalRequest =
   components["schemas"]["CreateStandingApprovalRequest"];

--- a/frontend/src/hooks/useDeactivateAgent.ts
+++ b/frontend/src/hooks/useDeactivateAgent.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 export function useDeactivateAgent() {
   const { session } = useAuth();
@@ -23,7 +24,7 @@ export function useDeactivateAgent() {
       if (error) throw new Error("Failed to deactivate agent");
     },
     onSuccess: (_data, agentId) => {
-      trackEvent("agent_deactivated", { agent_id: agentId });
+      trackEvent(PostHogEvents.AGENT_DEACTIVATED, { agent_id: agentId });
       queryClient.invalidateQueries({ queryKey: ["agent", agentId] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/frontend/src/hooks/useDeactivateAgent.ts
+++ b/frontend/src/hooks/useDeactivateAgent.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 export function useDeactivateAgent() {
   const { session } = useAuth();

--- a/frontend/src/hooks/useDeactivateAgent.ts
+++ b/frontend/src/hooks/useDeactivateAgent.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
+import { trackEvent } from "@/lib/posthog";
 
 export function useDeactivateAgent() {
   const { session } = useAuth();
@@ -22,6 +23,7 @@ export function useDeactivateAgent() {
       if (error) throw new Error("Failed to deactivate agent");
     },
     onSuccess: (_data, agentId) => {
+      trackEvent("agent_deactivated", { agent_id: agentId });
       queryClient.invalidateQueries({ queryKey: ["agent", agentId] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/frontend/src/hooks/useDenyApproval.ts
+++ b/frontend/src/hooks/useDenyApproval.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 export function useDenyApproval() {
   const { session } = useAuth();

--- a/frontend/src/hooks/useDenyApproval.ts
+++ b/frontend/src/hooks/useDenyApproval.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 export function useDenyApproval() {
   const { session } = useAuth();
@@ -23,7 +24,7 @@ export function useDenyApproval() {
       if (error) throw new Error("Failed to deny request");
     },
     onSuccess: () => {
-      trackEvent("approval_denied");
+      trackEvent(PostHogEvents.APPROVAL_DENIED);
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
     },
   });

--- a/frontend/src/hooks/useDenyApproval.ts
+++ b/frontend/src/hooks/useDenyApproval.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
+import { trackEvent } from "@/lib/posthog";
 
 export function useDenyApproval() {
   const { session } = useAuth();
@@ -22,6 +23,7 @@ export function useDenyApproval() {
       if (error) throw new Error("Failed to deny request");
     },
     onSuccess: () => {
+      trackEvent("approval_denied");
       queryClient.invalidateQueries({ queryKey: ["approvals"] });
     },
   });

--- a/frontend/src/hooks/useRevokeStandingApproval.ts
+++ b/frontend/src/hooks/useRevokeStandingApproval.ts
@@ -3,6 +3,7 @@ import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { getApiErrorMessage } from "@/api/errors";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 export function useRevokeStandingApproval() {
   const { session } = useAuth();
@@ -31,7 +32,7 @@ export function useRevokeStandingApproval() {
       return data;
     },
     onSuccess: () => {
-      trackEvent("standing_approval_revoked");
+      trackEvent(PostHogEvents.STANDING_APPROVAL_REVOKED);
       queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
     },
   });

--- a/frontend/src/hooks/useRevokeStandingApproval.ts
+++ b/frontend/src/hooks/useRevokeStandingApproval.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { getApiErrorMessage } from "@/api/errors";
+import { trackEvent } from "@/lib/posthog";
 
 export function useRevokeStandingApproval() {
   const { session } = useAuth();
@@ -30,6 +31,7 @@ export function useRevokeStandingApproval() {
       return data;
     },
     onSuccess: () => {
+      trackEvent("standing_approval_revoked");
       queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
     },
   });

--- a/frontend/src/hooks/useRevokeStandingApproval.ts
+++ b/frontend/src/hooks/useRevokeStandingApproval.ts
@@ -2,8 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { getApiErrorMessage } from "@/api/errors";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 export function useRevokeStandingApproval() {
   const { session } = useAuth();

--- a/frontend/src/hooks/useUpdateAgent.ts
+++ b/frontend/src/hooks/useUpdateAgent.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 export function useUpdateAgent() {
   const { session } = useAuth();

--- a/frontend/src/hooks/useUpdateAgent.ts
+++ b/frontend/src/hooks/useUpdateAgent.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 export function useUpdateAgent() {
   const { session } = useAuth();
@@ -28,7 +29,7 @@ export function useUpdateAgent() {
       return data;
     },
     onSuccess: (_data, variables) => {
-      trackEvent("agent_updated", { agent_id: variables.agentId });
+      trackEvent(PostHogEvents.AGENT_UPDATED, { agent_id: variables.agentId });
       queryClient.invalidateQueries({ queryKey: ["agent", variables.agentId] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/frontend/src/hooks/useUpdateAgent.ts
+++ b/frontend/src/hooks/useUpdateAgent.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
+import { trackEvent } from "@/lib/posthog";
 
 export function useUpdateAgent() {
   const { session } = useAuth();
@@ -27,6 +28,7 @@ export function useUpdateAgent() {
       return data;
     },
     onSuccess: (_data, variables) => {
+      trackEvent("agent_updated", { agent_id: variables.agentId });
       queryClient.invalidateQueries({ queryKey: ["agent", variables.agentId] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/frontend/src/hooks/useUpdateNotificationPreferences.ts
+++ b/frontend/src/hooks/useUpdateNotificationPreferences.ts
@@ -3,6 +3,7 @@ import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
 import { trackEvent } from "@/lib/posthog";
+import { PostHogEvents } from "@/lib/posthog-events";
 
 type NotificationPreference = components["schemas"]["NotificationPreference"];
 
@@ -32,7 +33,7 @@ export function useUpdateNotificationPreferences() {
       return data;
     },
     onSuccess: () => {
-      trackEvent("notification_preferences_updated");
+      trackEvent(PostHogEvents.NOTIFICATION_PREFERENCES_UPDATED);
       queryClient.invalidateQueries({
         queryKey: ["notification-preferences"],
       });

--- a/frontend/src/hooks/useUpdateNotificationPreferences.ts
+++ b/frontend/src/hooks/useUpdateNotificationPreferences.ts
@@ -2,8 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
-import { trackEvent } from "@/lib/posthog";
-import { PostHogEvents } from "@/lib/posthog-events";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
 type NotificationPreference = components["schemas"]["NotificationPreference"];
 

--- a/frontend/src/hooks/useUpdateNotificationPreferences.ts
+++ b/frontend/src/hooks/useUpdateNotificationPreferences.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
+import { trackEvent } from "@/lib/posthog";
 
 type NotificationPreference = components["schemas"]["NotificationPreference"];
 
@@ -31,6 +32,7 @@ export function useUpdateNotificationPreferences() {
       return data;
     },
     onSuccess: () => {
+      trackEvent("notification_preferences_updated");
       queryClient.invalidateQueries({
         queryKey: ["notification-preferences"],
       });

--- a/frontend/src/lib/__tests__/posthog.test.ts
+++ b/frontend/src/lib/__tests__/posthog.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PostHogEvents } from "../posthog-events";
 
 // Mock posthog-js before importing our module.
 const mockInit = vi.fn();
@@ -44,7 +45,7 @@ describe("posthog utilities", () => {
 
     it("trackEvent does not call posthog.capture", async () => {
       const mod = await import("../posthog");
-      mod.trackEvent("test_event", { key: "value" });
+      mod.trackEvent(PostHogEvents.APPROVAL_APPROVED, { key: "value" });
       expect(mockCapture).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/lib/__tests__/posthog.test.ts
+++ b/frontend/src/lib/__tests__/posthog.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock posthog-js before importing our module.
+const mockInit = vi.fn();
+const mockCapture = vi.fn();
+const mockIdentify = vi.fn();
+const mockReset = vi.fn();
+const mockOptIn = vi.fn();
+const mockOptOut = vi.fn();
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: mockInit,
+    capture: mockCapture,
+    identify: mockIdentify,
+    reset: mockReset,
+    opt_in_capturing: mockOptIn,
+    opt_out_capturing: mockOptOut,
+  },
+}));
+
+describe("posthog utilities", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockInit.mockClear();
+    mockCapture.mockClear();
+    mockIdentify.mockClear();
+    mockReset.mockClear();
+    mockOptIn.mockClear();
+    mockOptOut.mockClear();
+  });
+
+  describe("when VITE_POSTHOG_KEY is not set", () => {
+    it("isPostHogConfigured is false", async () => {
+      const mod = await import("../posthog");
+      expect(mod.isPostHogConfigured).toBe(false);
+    });
+
+    it("initPostHog does not call posthog.init", async () => {
+      const mod = await import("../posthog");
+      mod.initPostHog();
+      expect(mockInit).not.toHaveBeenCalled();
+    });
+
+    it("trackEvent does not call posthog.capture", async () => {
+      const mod = await import("../posthog");
+      mod.trackEvent("test_event", { key: "value" });
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it("identifyUser does not call posthog.identify", async () => {
+      const mod = await import("../posthog");
+      mod.identifyUser("user-123");
+      expect(mockIdentify).not.toHaveBeenCalled();
+    });
+
+    it("resetPostHogIdentity does not call posthog.reset", async () => {
+      const mod = await import("../posthog");
+      mod.resetPostHogIdentity();
+      expect(mockReset).not.toHaveBeenCalled();
+    });
+
+    it("optInPostHog does not call posthog.opt_in_capturing", async () => {
+      const mod = await import("../posthog");
+      mod.optInPostHog();
+      expect(mockOptIn).not.toHaveBeenCalled();
+    });
+
+    it("optOutPostHog does not call posthog.opt_out_capturing", async () => {
+      const mod = await import("../posthog");
+      mod.optOutPostHog();
+      expect(mockOptOut).not.toHaveBeenCalled();
+    });
+
+    it("capturePageView does not call posthog.capture", async () => {
+      const mod = await import("../posthog");
+      mod.capturePageView();
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/lib/posthog-events.ts
+++ b/frontend/src/lib/posthog-events.ts
@@ -1,0 +1,34 @@
+/**
+ * Centralized PostHog event names.
+ *
+ * All product analytics events must be defined here. This ensures:
+ *  - Autocomplete and type safety when calling trackEvent()
+ *  - A single place to audit every event the app tracks
+ *  - Typos are caught at compile time, not silently in PostHog
+ *
+ * Naming convention: <entity>_<past_tense_action>
+ *   e.g., "approval_approved", "standing_approval_created"
+ */
+
+export const PostHogEvents = {
+  // Approval workflow
+  APPROVAL_APPROVED: "approval_approved",
+  APPROVAL_DENIED: "approval_denied",
+
+  // Standing approvals
+  STANDING_APPROVAL_CREATED: "standing_approval_created",
+  STANDING_APPROVAL_REVOKED: "standing_approval_revoked",
+
+  // Agent management
+  AGENT_UPDATED: "agent_updated",
+  AGENT_DEACTIVATED: "agent_deactivated",
+
+  // Agent registration
+  INVITE_CREATED: "invite_created",
+
+  // Notification settings
+  NOTIFICATION_PREFERENCES_UPDATED: "notification_preferences_updated",
+} as const;
+
+export type PostHogEventName =
+  (typeof PostHogEvents)[keyof typeof PostHogEvents];

--- a/frontend/src/lib/posthog.ts
+++ b/frontend/src/lib/posthog.ts
@@ -1,0 +1,90 @@
+/**
+ * PostHog product analytics — consent-gated initialization.
+ *
+ * PostHog is only active when:
+ *  1. VITE_POSTHOG_KEY is set (build-time env var)
+ *  2. The user has accepted cookies via the consent banner
+ *
+ * The SDK starts in opted-out state with memory-only persistence (no
+ * cookies or localStorage). When consent is granted, capturing is
+ * enabled. This ensures zero data is sent before explicit consent.
+ */
+import posthog from "posthog-js";
+
+const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined;
+const POSTHOG_HOST =
+  (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ||
+  "https://us.i.posthog.com";
+
+/** Whether PostHog is configured (API key is present). */
+export const isPostHogConfigured = Boolean(POSTHOG_KEY);
+
+/**
+ * Initialize the PostHog client. Must be called once at app startup.
+ * Starts with capturing disabled — consent must be granted first.
+ */
+export function initPostHog(): void {
+  if (!POSTHOG_KEY) return;
+
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    // Start opted out — no events are sent until the user consents.
+    opt_out_capturing_by_default: true,
+    // Memory-only persistence avoids writing cookies/localStorage
+    // before the user has made a consent choice.
+    persistence: "memory",
+    // Disable automatic pageview on init — we capture manually on
+    // route changes inside PostHogProvider.
+    capture_pageview: false,
+    // Capture page-leave events (duration, scroll depth) when opted in.
+    capture_pageleave: true,
+    // Don't send the real IP to PostHog for privacy.
+    ip: false,
+  });
+}
+
+/** Enable PostHog capturing after consent is granted. */
+export function optInPostHog(): void {
+  if (!isPostHogConfigured) return;
+  posthog.opt_in_capturing();
+}
+
+/** Disable PostHog capturing when consent is rejected or reset. */
+export function optOutPostHog(): void {
+  if (!isPostHogConfigured) return;
+  posthog.opt_out_capturing();
+}
+
+/**
+ * Identify an authenticated user. Uses the opaque Supabase user ID —
+ * no PII (email, name, etc.) is sent.
+ */
+export function identifyUser(userId: string): void {
+  if (!isPostHogConfigured) return;
+  posthog.identify(userId);
+}
+
+/** Reset the PostHog identity on logout. */
+export function resetPostHogIdentity(): void {
+  if (!isPostHogConfigured) return;
+  posthog.reset();
+}
+
+/** Capture a page view for the current URL. */
+export function capturePageView(): void {
+  if (!isPostHogConfigured) return;
+  posthog.capture("$pageview");
+}
+
+/**
+ * Track a product analytics event. No-ops if PostHog is not configured
+ * or if the user has not consented (PostHog's internal opt-out flag
+ * prevents capture calls from sending data).
+ */
+export function trackEvent(
+  eventName: string,
+  properties?: Record<string, string | number | boolean>,
+): void {
+  if (!isPostHogConfigured) return;
+  posthog.capture(eventName, properties);
+}

--- a/frontend/src/lib/posthog.ts
+++ b/frontend/src/lib/posthog.ts
@@ -12,6 +12,11 @@
 import posthog from "posthog-js";
 import type { PostHogEventName } from "./posthog-events";
 
+// Re-export so consumers can import everything from a single module:
+//   import { trackEvent, PostHogEvents } from "@/lib/posthog";
+export { PostHogEvents } from "./posthog-events";
+export type { PostHogEventName } from "./posthog-events";
+
 const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined;
 const POSTHOG_HOST =
   (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ||

--- a/frontend/src/lib/posthog.ts
+++ b/frontend/src/lib/posthog.ts
@@ -10,6 +10,7 @@
  * enabled. This ensures zero data is sent before explicit consent.
  */
 import posthog from "posthog-js";
+import type { PostHogEventName } from "./posthog-events";
 
 const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined;
 const POSTHOG_HOST =
@@ -19,13 +20,26 @@ const POSTHOG_HOST =
 /** Whether PostHog is configured (API key is present). */
 export const isPostHogConfigured = Boolean(POSTHOG_KEY);
 
+const isDev = import.meta.env.DEV;
+
+/** Dev-mode logging prefixed with [PostHog]. Stripped in production builds. */
+function devLog(...args: unknown[]): void {
+  if (isDev) {
+    console.log("[PostHog]", ...args);
+  }
+}
+
 /**
  * Initialize the PostHog client. Must be called once at app startup.
  * Starts with capturing disabled — consent must be granted first.
  */
 export function initPostHog(): void {
-  if (!POSTHOG_KEY) return;
+  if (!POSTHOG_KEY) {
+    devLog("disabled (VITE_POSTHOG_KEY not set)");
+    return;
+  }
 
+  devLog("initializing →", POSTHOG_HOST);
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
     // Start opted out — no events are sent until the user consents.
@@ -46,12 +60,14 @@ export function initPostHog(): void {
 /** Enable PostHog capturing after consent is granted. */
 export function optInPostHog(): void {
   if (!isPostHogConfigured) return;
+  devLog("consent granted → capturing enabled");
   posthog.opt_in_capturing();
 }
 
 /** Disable PostHog capturing when consent is rejected or reset. */
 export function optOutPostHog(): void {
   if (!isPostHogConfigured) return;
+  devLog("consent revoked → capturing disabled");
   posthog.opt_out_capturing();
 }
 
@@ -80,11 +96,15 @@ export function capturePageView(): void {
  * Track a product analytics event. No-ops if PostHog is not configured
  * or if the user has not consented (PostHog's internal opt-out flag
  * prevents capture calls from sending data).
+ *
+ * Event names are typed — use constants from `posthog-events.ts` to
+ * get autocomplete and prevent typos.
  */
 export function trackEvent(
-  eventName: string,
+  eventName: PostHogEventName,
   properties?: Record<string, string | number | boolean>,
 ): void {
   if (!isPostHogConfigured) return;
+  devLog("event:", eventName, properties ?? "");
   posthog.capture(eventName, properties);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -26,6 +26,7 @@ import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "./auth/AuthContext";
 import { CookieConsentBanner } from "./components/CookieConsentBanner";
 import { CookieConsentProvider } from "./components/CookieConsentContext";
+import { PostHogProvider } from "./components/PostHogProvider";
 import { ThemeProvider } from "./components/ThemeContext";
 import { Toaster } from "./components/ui/sonner";
 import App from "./App";
@@ -77,11 +78,13 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <CookieConsentProvider>
-            <AuthProvider>
-              <App />
-              <CookieConsentBanner />
-              <Toaster />
-            </AuthProvider>
+            <PostHogProvider>
+              <AuthProvider>
+                <App />
+                <CookieConsentBanner />
+                <Toaster />
+              </AuthProvider>
+            </PostHogProvider>
           </CookieConsentProvider>
         </ThemeProvider>
       </QueryClientProvider>

--- a/frontend/src/pages/policy/CookiePolicyPage.tsx
+++ b/frontend/src/pages/policy/CookiePolicyPage.tsx
@@ -35,9 +35,10 @@ export function CookiePolicyPage() {
 
       <h2>2. How We Use Cookies and Local Storage</h2>
       <p>
-        Permission Slip currently uses <strong>no third-party tracking cookies</strong>.
-        We do not use Google Analytics, advertising pixels, behavioral tracking,
-        or any similar third-party analytics or marketing tools.
+        Permission Slip does not use advertising pixels, behavioral tracking,
+        or marketing tools. We use a single, privacy-focused analytics service
+        (PostHog) that is <strong>only activated after you accept cookies</strong>{" "}
+        via our consent banner.
       </p>
       <p>
         All storage we use falls into the following categories:
@@ -102,20 +103,41 @@ export function CookiePolicyPage() {
         </tbody>
       </table>
 
-      <h3>2.3 Analytics (Future)</h3>
+      <h3>2.3 Analytics (Consent Required)</h3>
       <p>
-        We do not currently use any analytics cookies. If we introduce analytics
-        or marketing tools in the future, they will:
+        We use <strong>PostHog</strong>, a privacy-focused product analytics
+        platform, to understand how people use Permission Slip (e.g., feature
+        adoption, navigation patterns). PostHog analytics is{" "}
+        <strong>only active when you accept cookies</strong> via our consent
+        banner. If you decline or have not yet responded, no analytics data is
+        collected or sent.
       </p>
-      <ul>
-        <li>Require your consent via our cookie consent banner before activation</li>
-        <li>Be limited to operational metadata only (see our{" "}
-          <Link to="/policy/privacy">Privacy Policy</Link>, Section 4, for the
-          distinction between operational metadata and request content)
-        </li>
-        <li>Provide an opt-out mechanism</li>
-        <li>Be listed in an updated version of this policy with specific cookie names and purposes</li>
-      </ul>
+      <table>
+        <thead>
+          <tr>
+            <th>Storage Mechanism</th>
+            <th>Key / Name</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>In-memory only</td>
+            <td>PostHog anonymous ID</td>
+            <td>
+              Temporary identifier for the current session; not persisted to
+              disk and cleared on page reload
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        PostHog analytics data is limited to operational metadata only (see
+        our <Link to="/policy/privacy">Privacy Policy</Link>, Section 4, for
+        the distinction between operational metadata and request content). No
+        emails, names, or other PII are included in analytics events. Your IP
+        address is not sent to PostHog.
+      </p>
 
       <h2>3. Managing Your Preferences</h2>
 

--- a/main.go
+++ b/main.go
@@ -311,6 +311,16 @@ func main() {
 			extraConnectSrc = append(extraConnectSrc, parsed.Scheme+"://"+parsed.Host)
 		}
 	}
+	// PostHog product analytics — allow the frontend to send events to the
+	// PostHog API host. Only added when POSTHOG_HOST is set.
+	if posthogHost := strings.TrimSpace(os.Getenv("POSTHOG_HOST")); posthogHost != "" {
+		parsed, err := url.Parse(posthogHost)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			log.Printf("Warning: POSTHOG_HOST %q is not a valid URL; skipping CSP connect-src entry", posthogHost)
+		} else {
+			extraConnectSrc = append(extraConnectSrc, parsed.Scheme+"://"+parsed.Host)
+		}
+	}
 	handler = api.SecurityHeadersMiddleware(sentryCSPEndpoint, extraConnectSrc...)(handler)
 
 	srv := &http.Server{


### PR DESCRIPTION
Integrates posthog-js with full respect for the existing cookie consent
banner. PostHog starts opted out with memory-only persistence (no
cookies or localStorage before consent). When the user accepts cookies,
capturing is enabled; rejecting or resetting consent disables it.

- Add lib/posthog.ts with consent-aware init, identify, and trackEvent
- Add PostHogProvider that bridges CookieConsentContext with PostHog
- Identify users with opaque Supabase ID on login (no PII)
- Track key events: approval approved/denied, standing approval
  created/revoked, agent updated/deactivated, invite created,
  notification preferences updated
- Capture page views on React Router navigation
- Add POSTHOG_HOST to CSP connect-src in Go middleware
- Add VITE_POSTHOG_KEY and VITE_POSTHOG_HOST env vars
- Update Cookie Policy page with PostHog analytics disclosure
- Add tests for posthog module and PostHogProvider

Closes #24

https://claude.ai/code/session_012Vm3QPXJazkphhZMqZZgoX