### PR TITLE
Show webhook response body on failure

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -15,7 +15,14 @@ jobs:
     steps:
       - name: Call webhook
         run: |
-          curl -sf -X POST "${{ secrets.WEBHOOK_URL }}" \
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${{ secrets.WEBHOOK_URL }}" \
             -H "Authorization: Bearer ${{ secrets.WEBHOOK_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"pr_url\": \"${{ inputs.pr_url }}\", \"title\": \"${{ inputs.title }}\"}"
+            -d "{\"pr_url\": \"${{ inputs.pr_url }}\", \"title\": \"${{ inputs.title }}\"}")
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+          BODY=$(echo "$RESPONSE" | sed '$d')
+          echo "Status: $HTTP_STATUS"
+          echo "Response: $BODY"
+          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Updated the trigger-webhook workflow to capture and display the HTTP status code and response body when the webhook call fails, instead of silently failing with `-sf`

## Test plan
- [ ] Merge and re-trigger the workflow to see the actual error from the webhook endpoint

https://claude.ai/code/session_01UcSSGdsKdpfAkApA7Me4ru