### PR TITLE
Fix webhook payload to use message field

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -18,7 +18,7 @@ jobs:
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${{ secrets.WEBHOOK_URL }}" \
             -H "Authorization: Bearer ${{ secrets.WEBHOOK_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"pr_url\": \"${{ inputs.pr_url }}\", \"title\": \"${{ inputs.title }}\"}")
+            -d "{\"message\": \"${{ inputs.title }}\n${{ inputs.pr_url }}\"}")
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Status: $HTTP_STATUS"


### PR DESCRIPTION
## Summary
- The OpenClaw webhook hook transform expects a `message` field in the payload, but we were sending `pr_url` and `title` as separate fields, causing `"hook mapping requires message"` errors.
- Changed the payload to send a single `message` field combining the PR title and URL.

## Test plan
- [ ] Trigger the webhook workflow manually and verify it returns a 2xx status
- [ ] Confirm no more `"hook mapping requires message"` errors

https://claude.ai/code/session_01UcSSGdsKdpfAkApA7Me4ru