### PR TITLE
Fix webhook JSON payload construction

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -14,11 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Call webhook
+        env:
+          TITLE: ${{ inputs.title }}
+          PR_URL: ${{ inputs.pr_url }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
         run: |
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${{ secrets.WEBHOOK_URL }}" \
-            -H "Authorization: Bearer ${{ secrets.WEBHOOK_TOKEN }}" \
+          PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}')
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"message\": \"${{ inputs.title }}\n${{ inputs.pr_url }}\"}")
+            -d "$PAYLOAD")
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Status: $HTTP_STATUS"


### PR DESCRIPTION
## Summary
- The hand-built JSON string had a bare `\n` that produced malformed JSON, causing the webhook server to return 400 `"hook mapping requires message"`
- Use `jq` to properly construct and escape the JSON payload
- Pass inputs/secrets through `env` vars instead of inline `${{ }}` to avoid shell injection

## Test plan
- [ ] Trigger the webhook workflow manually and verify it returns 2xx
- [ ] Verify the webhook message contains the title and PR URL separated by a newline

https://claude.ai/code/session_01UcSSGdsKdpfAkApA7Me4ru