### PR TITLE
fix: send correct payload to webhook (pr_url + title)

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -20,62 +20,47 @@ jobs:
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
         run: |
-          echo "## Webhook Diagnostic Results" >> $GITHUB_STEP_SUMMARY
+          # Check if secrets are set
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "::error::WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+          if [ -z "$WEBHOOK_TOKEN" ]; then
+            echo "::error::WEBHOOK_TOKEN secret is not set"
+            exit 1
+          fi
+          echo "::notice::Secrets are set, proceeding with webhook call"
 
-          # Test 1: hardcoded minimal payload
-          echo "### Test 1: Hardcoded payload" >> $GITHUB_STEP_SUMMARY
+          # Test: hardcoded minimal payload
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            --data-raw '{"message": "test from github actions"}')
+            --data-raw '{"message": "test from github actions"}' 2>&1)
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
-          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
+          echo "::notice::Test1 hardcoded status=$HTTP_STATUS body=$BODY"
 
-          # Test 2: jq payload piped via stdin
-          echo "### Test 2: jq payload via stdin" >> $GITHUB_STEP_SUMMARY
+          # Test: jq payload
           PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}')
-          echo '- Payload: `'"$PAYLOAD"'`' >> $GITHUB_STEP_SUMMARY
+          echo "::notice::Test2 payload=$PAYLOAD"
           RESPONSE=$(echo "$PAYLOAD" | curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            --data-binary @-)
+            --data-binary @- 2>&1)
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
-          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
+          echo "::notice::Test2 jq status=$HTTP_STATUS body=$BODY"
 
-          # Test 3: text field
-          echo "### Test 3: text field" >> $GITHUB_STEP_SUMMARY
+          # Test: text field
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            --data-raw '{"text": "test from github actions"}')
+            --data-raw '{"text": "test from github actions"}' 2>&1)
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
-          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
+          echo "::notice::Test3 text status=$HTTP_STATUS body=$BODY"
 
-          # Test 4: content field
-          echo "### Test 4: content field" >> $GITHUB_STEP_SUMMARY
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
-            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-raw '{"content": "test from github actions"}')
-          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
-          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
-
-          # Use test 1 result for pass/fail
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
-            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-raw '{"message": "test from github actions"}')
-          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "### Result: FAILED" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Webhook failed"
             exit 1
           fi
-          echo "### Result: SUCCESS" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -20,7 +20,6 @@ jobs:
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
         run: |
-          # Check if secrets are set
           if [ -z "$WEBHOOK_URL" ]; then
             echo "::error::WEBHOOK_URL secret is not set"
             exit 1
@@ -29,38 +28,20 @@ jobs:
             echo "::error::WEBHOOK_TOKEN secret is not set"
             exit 1
           fi
-          echo "::notice::Secrets are set, proceeding with webhook call"
 
-          # Test: hardcoded minimal payload
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
-            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-raw '{"message": "test from github actions"}' 2>&1)
-          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "::notice::Test1 hardcoded status=$HTTP_STATUS body=$BODY"
+          PAYLOAD=$(jq -n --arg pr_url "$PR_URL" --arg title "$TITLE" \
+            '{pr_url: $pr_url, title: $title}')
 
-          # Test: jq payload
-          PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}')
-          echo "::notice::Test2 payload=$PAYLOAD"
           RESPONSE=$(echo "$PAYLOAD" | curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            --data-binary @- 2>&1)
-          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "::notice::Test2 jq status=$HTTP_STATUS body=$BODY"
+            --data-binary @-)
 
-          # Test: text field
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
-            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-raw '{"text": "test from github actions"}' 2>&1)
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "::notice::Test3 text status=$HTTP_STATUS body=$BODY"
+          echo "::notice::status=$HTTP_STATUS body=$BODY"
 
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "::error::Webhook failed"
+            echo "::error::Webhook call failed with status $HTTP_STATUS"
             exit 1
           fi

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -21,6 +21,7 @@ jobs:
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
         run: |
           PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}')
+          echo "Payload: $PAYLOAD"
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -20,58 +20,62 @@ jobs:
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
         run: |
-          # Test 1: hardcoded minimal payload to verify webhook accepts message field
-          echo "--- Test 1: Hardcoded payload ---"
+          echo "## Webhook Diagnostic Results" >> $GITHUB_STEP_SUMMARY
+
+          # Test 1: hardcoded minimal payload
+          echo "### Test 1: Hardcoded payload" >> $GITHUB_STEP_SUMMARY
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
             --data-raw '{"message": "test from github actions"}')
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Status: $HTTP_STATUS"
-          echo "Response: $BODY"
+          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
+          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
 
-          # Test 2: jq-constructed payload piped via stdin
-          echo "--- Test 2: jq payload via stdin ---"
-          RESPONSE=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}' | \
-            curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+          # Test 2: jq payload piped via stdin
+          echo "### Test 2: jq payload via stdin" >> $GITHUB_STEP_SUMMARY
+          PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}')
+          echo '- Payload: `'"$PAYLOAD"'`' >> $GITHUB_STEP_SUMMARY
+          RESPONSE=$(echo "$PAYLOAD" | curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
             --data-binary @-)
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Status: $HTTP_STATUS"
-          echo "Response: $BODY"
+          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
+          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
 
-          # Test 3: text field instead of message
-          echo "--- Test 3: text field ---"
+          # Test 3: text field
+          echo "### Test 3: text field" >> $GITHUB_STEP_SUMMARY
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
             --data-raw '{"text": "test from github actions"}')
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Status: $HTTP_STATUS"
-          echo "Response: $BODY"
+          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
+          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
 
           # Test 4: content field
-          echo "--- Test 4: content field ---"
+          echo "### Test 4: content field" >> $GITHUB_STEP_SUMMARY
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
             --data-raw '{"content": "test from github actions"}')
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Status: $HTTP_STATUS"
-          echo "Response: $BODY"
+          echo "- Status: $HTTP_STATUS" >> $GITHUB_STEP_SUMMARY
+          echo '- Response: `'"$BODY"'`' >> $GITHUB_STEP_SUMMARY
 
-          # Final: use test 1 result for pass/fail
+          # Use test 1 result for pass/fail
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
             --data-raw '{"message": "test from github actions"}')
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "All tests failed - webhook may require different payload format"
+            echo "### Result: FAILED" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+          echo "### Result: SUCCESS" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -20,16 +20,58 @@ jobs:
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
         run: |
-          PAYLOAD=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}')
-          echo "Payload: $PAYLOAD"
+          # Test 1: hardcoded minimal payload to verify webhook accepts message field
+          echo "--- Test 1: Hardcoded payload ---"
           RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "$PAYLOAD")
+            --data-raw '{"message": "test from github actions"}')
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Status: $HTTP_STATUS"
           echo "Response: $BODY"
+
+          # Test 2: jq-constructed payload piped via stdin
+          echo "--- Test 2: jq payload via stdin ---"
+          RESPONSE=$(jq -n --arg title "$TITLE" --arg url "$PR_URL" '{message: ($title + "\n" + $url)}' | \
+            curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @-)
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+          BODY=$(echo "$RESPONSE" | sed '$d')
+          echo "Status: $HTTP_STATUS"
+          echo "Response: $BODY"
+
+          # Test 3: text field instead of message
+          echo "--- Test 3: text field ---"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-raw '{"text": "test from github actions"}')
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+          BODY=$(echo "$RESPONSE" | sed '$d')
+          echo "Status: $HTTP_STATUS"
+          echo "Response: $BODY"
+
+          # Test 4: content field
+          echo "--- Test 4: content field ---"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-raw '{"content": "test from github actions"}')
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+          BODY=$(echo "$RESPONSE" | sed '$d')
+          echo "Status: $HTTP_STATUS"
+          echo "Response: $BODY"
+
+          # Final: use test 1 result for pass/fail
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-raw '{"message": "test from github actions"}')
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "All tests failed - webhook may require different payload format"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The workflow was sending `{"message": "..."}` to the webhook, but the transform at `claude-code-done.js` requires `{"pr_url": "...", "title": "..."}` — so every call was being rejected with a 400 error.

Additionally, the workflow had three test variants (Test1 hardcoded, Test2 jq with wrong shape, Test3 text field) cluttering the run.

## Fix

- Replaced all test variants with a single clean curl call
- Payload is now built with `jq` using the `pr_url` and `title` workflow inputs
- Kept error checking for missing secrets (`WEBHOOK_URL`, `WEBHOOK_TOKEN`)
- Logs HTTP status and response body via `::notice::` for debugging