### PR TITLE
Add beta badge to header navigation

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -23,6 +23,9 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           </span>
           <span className="hidden sm:inline">Permission Slip</span>
           <span className="sm:hidden">PS</span>
+          <span className="rounded-full bg-secondary/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-secondary">
+            Beta
+          </span>
         </Link>
         <ul className="hidden list-none gap-6 md:flex">
           <li className={cn(


### PR DESCRIPTION
Adds a small "Beta" pill badge next to the Permission Slip logo in the
top navigation bar to clearly communicate the product is in beta.

https://claude.ai/code/session_017KKDPNJAfFbpo1nM6jXc8G