### PR TITLE
feat: clarify liability policies and add ToS agreement to onboarding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -1451,6 +1452,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -2133,6 +2164,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "postinstall": "npm run generate:api"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/frontend/src/auth/OnboardingPage.tsx
+++ b/frontend/src/auth/OnboardingPage.tsx
@@ -1,8 +1,10 @@
 import { useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "./AuthContext";
 import AuthLayout from "./AuthLayout";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { FormError } from "@/components/FormError";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,6 +15,7 @@ export default function OnboardingPage() {
   const { session, signOut } = useAuth();
   const queryClient = useQueryClient();
   const [username, setUsername] = useState("");
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -67,9 +70,42 @@ export default function OnboardingPage() {
             3–32 characters. Letters, digits, underscores, and hyphens only.
           </p>
         </div>
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="agree-tos"
+            checked={agreedToTerms}
+            onCheckedChange={(checked) => setAgreedToTerms(checked === true)}
+            required
+          />
+          <Label
+            htmlFor="agree-tos"
+            className="text-sm font-normal leading-snug"
+          >
+            I agree to the{" "}
+            <Link
+              to="/policy/terms"
+              target="_blank"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              Terms of Service
+            </Link>{" "}
+            and{" "}
+            <Link
+              to="/policy/privacy"
+              target="_blank"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              Privacy Policy
+            </Link>
+          </Label>
+        </div>
         <FormError error={error} prefix />
         <div className="flex gap-2">
-          <Button type="submit" className="flex-1" disabled={isSubmitting}>
+          <Button
+            type="submit"
+            className="flex-1"
+            disabled={isSubmitting || !agreedToTerms}
+          >
             {isSubmitting ? "Creating account…" : "Create account"}
           </Button>
           <Button

--- a/frontend/src/auth/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/auth/__tests__/OnboardingPage.test.tsx
@@ -24,6 +24,27 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
 
+  it("renders the terms of service agreement checkbox", async () => {
+    renderWithProviders(<OnboardingPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/I agree to the/)).toBeInTheDocument();
+  });
+
+  it("disables submit button until terms checkbox is checked", async () => {
+    renderWithProviders(<OnboardingPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText("Username")).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByText("Create account");
+    expect(submitButton).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(submitButton).toBeEnabled();
+  });
+
   it("calls signOut when Cancel is clicked", async () => {
     mockAuth.signOut.mockResolvedValue({ error: null });
     renderWithProviders(<OnboardingPage />);
@@ -44,6 +65,7 @@ describe("OnboardingPage", () => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "alice");
+    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(screen.getByText("Create account"));
 
     await waitFor(() => {
@@ -65,6 +87,7 @@ describe("OnboardingPage", () => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "taken");
+    await userEvent.click(screen.getByRole("checkbox"));
     await userEvent.click(screen.getByText("Create account"));
 
     await waitFor(() => {

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { CheckIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/frontend/src/pages/policy/TermsOfServicePage.tsx
+++ b/frontend/src/pages/policy/TermsOfServicePage.tsx
@@ -44,24 +44,31 @@ export function TermsOfServicePage() {
       </p>
 
       {/* ------------------------------------------------------------------ */}
-      <h2>4. Beta Disclaimer</h2>
+      <h2>4. Service Disclaimer</h2>
       <p>
-        The Service is currently in <strong>beta</strong>. During the beta
-        period:
+        The Service is provided <strong>&quot;as is&quot;</strong> and{" "}
+        <strong>&quot;as available&quot;</strong> without warranties of any kind,
+        whether express, implied, or statutory, including but not limited to
+        implied warranties of merchantability, fitness for a particular purpose,
+        and non-infringement. This disclaimer applies at all times, regardless
+        of whether the Service is labeled as &quot;beta,&quot;
+        &quot;preview,&quot; or generally available.
       </p>
       <ul>
-        <li>
-          The Service is provided <strong>&quot;as is&quot;</strong> and{" "}
-          <strong>&quot;as available&quot;</strong> without warranties of any kind
-        </li>
         <li>Features may change, be modified, or be removed without notice</li>
         <li>
           We make no guarantees regarding uptime, availability, or reliability
         </li>
         <li>
-          The beta period will be clearly communicated when it ends
+          You use the Service entirely at your own risk
         </li>
       </ul>
+      <p>
+        The Service is currently in <strong>beta</strong>. The beta period will
+        be clearly communicated when it ends. The disclaimers in this section
+        are not limited to the beta period and survive in full force after
+        any beta period concludes.
+      </p>
 
       {/* ------------------------------------------------------------------ */}
       <h2>5. Pricing and Payment</h2>
@@ -309,8 +316,9 @@ export function TermsOfServicePage() {
       <ul>
         <li>
           The Service is provided <strong>&quot;AS IS&quot;</strong> and{" "}
-          <strong>&quot;AS AVAILABLE&quot;</strong> during beta, without warranty
-          of any kind, whether express, implied, or statutory
+          <strong>&quot;AS AVAILABLE&quot;</strong> without warranty of any kind,
+          whether express, implied, or statutory, at all times and regardless of
+          any beta, preview, or general availability designation
         </li>
         <li>
           We make no warranty of uptime, availability, or fitness for a
@@ -522,7 +530,19 @@ export function TermsOfServicePage() {
       </p>
 
       {/* ------------------------------------------------------------------ */}
-      <h2>20. Contact Us</h2>
+      <h2>20. No Legal Advice</h2>
+      <p>
+        Nothing in these Terms, the Service, or any documentation or
+        communications from us constitutes legal, financial, or professional
+        advice. The Service is a software tool &mdash; not a legal service. You
+        should consult your own qualified legal counsel before relying on the
+        Service for any use case involving regulatory compliance, data
+        governance, or liability exposure. We make no representation that the
+        Service satisfies any particular legal or regulatory requirement.
+      </p>
+
+      {/* ------------------------------------------------------------------ */}
+      <h2>21. Contact Us</h2>
       <p>
         If you have questions about these Terms, contact us at:
       </p>

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,5 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 
+// jsdom doesn't implement ResizeObserver — stub it for Radix UI primitives
+// (e.g. Checkbox) that rely on it.
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // jsdom doesn't implement matchMedia — stub it for ThemeProvider and any
 // component that checks prefers-color-scheme.
 Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
- Decouple "as-is" and warranty disclaimers from beta status so they
  survive post-beta (Sections 4 and 12)
- Add "No Legal Advice" disclaimer as new Section 20
- Add required Terms of Service / Privacy Policy agreement checkbox
  to the username creation screen during onboarding
- Add Checkbox UI component (Radix-based, shadcn/ui pattern)
- Add ResizeObserver stub to test setup for Radix compatibility
- Update OnboardingPage tests for new checkbox behavior

https://claude.ai/code/session_01RgRHX6rhpLKEfjPdLxNDT4