### PR TITLE
fix: document ALLOWED_ORIGINS requirement for ngrok/external dev access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ SUPABASE_URL=http://127.0.0.1:54321
 # "same-origin only" mode: requests whose Origin matches the server's own
 # Host are allowed; all other cross-origin requests are blocked.
 # Example: https://app.permissionslip.dev,https://staging.permissionslip.dev
+#
+# For local dev with ngrok or any external tunnel:
+# ALLOWED_ORIGINS=https://your-subdomain.ngrok-free.app
 ALLOWED_ORIGINS=
 
 # Public base URL — used to construct invite URLs for agent registration

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ make dev-frontend
 
 Open **http://localhost:5173**. API requests to `/api/*` are automatically proxied to the Go server.
 
+> **Accessing via ngrok or an external URL?** Set `ALLOWED_ORIGINS` to your public URL (e.g. `ALLOWED_ORIGINS=https://your-subdomain.ngrok-free.app make dev-backend`) so the Go backend allows cross-origin requests. Without it, API calls from a non-localhost origin will be blocked with 403.
+
 ## Production Build
 
 Build a single Go binary with the React frontend embedded:


### PR DESCRIPTION
## Bug

When running the dev stack via an ngrok tunnel (or any external URL), the Go backend returns **403** on cross-origin requests (e.g. `POST /api/v1/onboarding`). This causes the username/onboarding creation form to fail with "Something went wrong".

## Root Cause

The Vite dev server runs on port 5173 and the Go backend on port 8080. When ngrok tunnels port 3000 (the proxy), requests arrive at the Go server from the ngrok origin — which is different from `localhost`. Because `ALLOWED_ORIGINS` is not set in `.env`, the server operates in same-origin-only mode and blocks all cross-origin requests with 403.

## Fix

This PR improves documentation so developers are aware of the `ALLOWED_ORIGINS` requirement before running into this confusing 403:

- **`.env.example`**: Added a comment explaining that `ALLOWED_ORIGINS` must be set when using ngrok or any external tunnel during local dev.
- **`README.md`**: Added a callout in the "Run in development" section explaining that accessing the app via ngrok or an external URL requires setting `ALLOWED_ORIGINS` to the public URL, otherwise API calls will be blocked with 403.

## How to fix locally

```bash
ALLOWED_ORIGINS=https://your-subdomain.ngrok-free.app make dev-backend
```

Or set it in your `.env` file:
```
ALLOWED_ORIGINS=https://your-subdomain.ngrok-free.app
```