### PR TITLE
Simplify user menu: remove redundant settings shortcuts

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,11 +1,7 @@
-import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   LogOut,
   User,
-  Mail,
-  Bell,
-  Shield,
   KeyRound,
   Moon,
   LifeBuoy,
@@ -15,7 +11,6 @@ import { useProfile } from "@/hooks/useProfile";
 import { useSignOut } from "@/hooks/useSignOut";
 import { useTheme } from "@/components/ThemeContext";
 import { Avatar } from "@/components/ui/avatar";
-import { EmailChangeDialog } from "@/components/EmailChangeDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,8 +21,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MfaSettingsDialog } from "@/pages/security/MfaSettingsDialog";
-import { hasPendingEnrollment } from "@/auth/mfaPendingEnrollment";
 
 export function UserMenu() {
   const { user } = useAuth();
@@ -35,24 +28,11 @@ export function UserMenu() {
   const { theme, toggleTheme } = useTheme();
   const handleSignOut = useSignOut();
   const navigate = useNavigate();
-  const [securityOpen, setSecurityOpen] = useState(false);
-  const [emailDialogOpen, setEmailDialogOpen] = useState(false);
-
-  // Auto-open the security dialog if there's a pending MFA enrollment
-  // for this user (e.g. user switched to authenticator app and the mobile
-  // tab refreshed). Scoped to user.id so a stale entry from a previous
-  // user is ignored.
-  useEffect(() => {
-    if (user?.id && hasPendingEnrollment(user.id)) {
-      setSecurityOpen(true);
-    }
-  }, [user?.id]);
 
   const email = user?.email ?? "unknown";
   const username = profile?.username;
 
   return (
-    <>
       <DropdownMenu>
         <DropdownMenuTrigger
           className="flex cursor-pointer select-none items-center gap-2 rounded-full border-none bg-transparent p-0 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
@@ -81,20 +61,8 @@ export function UserMenu() {
               <span>Profile & Account</span>
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => navigate("/settings")}>
-              <Bell />
-              <span>Notification Preferences</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => navigate("/settings")}>
               <KeyRound />
               <span>Credential Vault</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => setSecurityOpen(true)}>
-              <Shield />
-              <span>Security</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => setEmailDialogOpen(true)}>
-              <Mail />
-              <span>Change Email</span>
             </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
@@ -119,12 +87,5 @@ export function UserMenu() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <MfaSettingsDialog open={securityOpen} onOpenChange={setSecurityOpen} />
-      <EmailChangeDialog
-        open={emailDialogOpen}
-        onOpenChange={setEmailDialogOpen}
-      />
-    </>
   );
 }

--- a/frontend/src/components/__tests__/UserMenu.test.tsx
+++ b/frontend/src/components/__tests__/UserMenu.test.tsx
@@ -10,19 +10,15 @@ import { UserMenu } from "../UserMenu";
 vi.mock("../../lib/supabaseClient");
 vi.mock("sonner");
 vi.mock("../../hooks/useProfile");
-vi.mock("../../auth/mfaPendingEnrollment");
 
 import { useProfile } from "../../hooks/useProfile";
-import { hasPendingEnrollment } from "../../auth/mfaPendingEnrollment";
 const mockUseProfile = vi.mocked(useProfile);
-const mockHasPendingEnrollment = vi.mocked(hasPendingEnrollment);
 
 describe("UserMenu", () => {
   beforeEach(() => {
     setupAuthMocks({ authenticated: true });
     vi.mocked(toast.error).mockClear();
     mockUseProfile.mockReturnValue({ profile: null, needsOnboarding: false, isLoading: false });
-    mockHasPendingEnrollment.mockReturnValue(false);
     localStorage.removeItem("permission-slip-theme");
     document.documentElement.classList.remove("dark");
   });
@@ -74,25 +70,13 @@ describe("UserMenu", () => {
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
   });
 
-  it("shows all menu items including Change Email", async () => {
+  it("shows all menu items", async () => {
     renderWithProviders(<UserMenu />);
     await userEvent.click(screen.getByLabelText("User menu"));
     expect(screen.getByText("Profile & Account")).toBeInTheDocument();
-    expect(screen.getByText("Notification Preferences")).toBeInTheDocument();
     expect(screen.getByText("Credential Vault")).toBeInTheDocument();
-    expect(screen.getByText("Security")).toBeInTheDocument();
-    expect(screen.getByText("Change Email")).toBeInTheDocument();
     expect(screen.getByText("Dark Mode")).toBeInTheDocument();
     expect(screen.getByText("Sign Out")).toBeInTheDocument();
-  });
-
-  it("opens email change dialog when Change Email is clicked", async () => {
-    renderWithProviders(<UserMenu />);
-    await userEvent.click(screen.getByLabelText("User menu"));
-    await userEvent.click(screen.getByText("Change Email"));
-    await waitFor(() => {
-      expect(screen.getByText("Change Email Address")).toBeInTheDocument();
-    });
   });
 
   it("toggles dark mode when clicked", async () => {
@@ -134,23 +118,4 @@ describe("UserMenu", () => {
     consoleSpy.mockRestore();
   });
 
-  it("auto-opens Security dialog when pending enrollment exists for current user", async () => {
-    mockHasPendingEnrollment.mockReturnValue(true);
-    renderWithProviders(<UserMenu />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Security Settings")).toBeInTheDocument();
-    });
-    expect(mockHasPendingEnrollment).toHaveBeenCalledWith("user-123");
-  });
-
-  it("does not auto-open Security dialog when no pending enrollment", async () => {
-    mockHasPendingEnrollment.mockReturnValue(false);
-    renderWithProviders(<UserMenu />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("User menu")).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Security Settings")).not.toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
Remove Notification Preferences, Security, and Change Email from the
dropdown menu. These are all accessible from the Settings page via
Profile & Account. The Security section works inline on the settings
page with full MFA management, and the Account section already has
a Change button for login email.

https://claude.ai/code/session_01J9u72Vb38qEzdvedsqbGvM