### PR TITLE
Add CORS troubleshooting and env var guidance to deployment docs

### DIFF
--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -82,7 +82,7 @@ If you're using a Supabase-hosted database, vault is already available. If using
 | Variable | Description | Example |
 |---|---|---|
 | `BASE_URL` | Public URL of your deployment (used for invite links) | `https://permissions.mycompany.com` |
-| `ALLOWED_ORIGINS` | Comma-separated CORS origins | `https://permissions.mycompany.com` |
+| `ALLOWED_ORIGINS` | Comma-separated CORS origins (exact match, no trailing slash). Defaults to same-origin only when unset — which works out of the box since the SPA is embedded in the binary. Set this if you serve the app behind a reverse proxy or CDN that changes the origin. | `https://permissions.mycompany.com` |
 | `INVITE_HMAC_KEY` | HMAC key for invite code signing | Generate: `openssl rand -hex 32` |
 
 ### Build-Time Variables (Frontend)
@@ -389,6 +389,9 @@ Check logs. Common causes: missing `DATABASE_URL`, incorrect Supabase credential
 **Connection refused to database:**
 If using Supabase, ensure the connection string uses the pooler endpoint (port 6543) with `?sslmode=require`. Direct connections (port 5432) may be blocked.
 
+**CORS errors in browser (403 on API calls):**
+Ensure `ALLOWED_ORIGINS` includes your deployment's exact origin (e.g., `https://permissions.mycompany.com`) — no trailing slash. If you're behind a reverse proxy or CDN, the origin seen by the browser may differ from `BASE_URL`. When `ALLOWED_ORIGINS` is unset, the server runs in same-origin only mode, which works for the standard embedded-SPA deployment but will reject requests from a different origin.
+
 **VAPID error on startup:**
 If any VAPID variable is set, all three (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) must be set. Either set all three or remove them all.
 
@@ -404,7 +407,7 @@ Migrations run automatically on startup. If they fail, check database connectivi
 | `VITE_SUPABASE_URL` | Yes | Build | Supabase URL for frontend auth |
 | `VITE_SUPABASE_ANON_KEY` | Yes | Build | Supabase public anon key |
 | `BASE_URL` | Recommended | Runtime | Public deployment URL |
-| `ALLOWED_ORIGINS` | Recommended | Runtime | CORS allowed origins (comma-separated) |
+| `ALLOWED_ORIGINS` | Recommended | Runtime | CORS allowed origins (comma-separated, exact match, no trailing slash). Same-origin only when unset. |
 | `INVITE_HMAC_KEY` | Recommended | Runtime | HMAC key for invite codes |
 | `PORT` | No | Runtime | Listen port (default: `8080`) |
 | `MODE` | No | Runtime | `development` to relax validation |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,7 +96,7 @@ curl https://your-app.fly.dev/api/health
 | `SUPABASE_URL` | Yes | Supabase project URL (JWT verification via JWKS + auth) |
 | `SUPABASE_SERVICE_ROLE_KEY` | Recommended | Supabase service_role key — required for account deletion (removes auth user). Get from Supabase dashboard |
 | `BASE_URL` | Recommended | Public URL (e.g., `https://app.permissionslip.dev`) — required for invite link generation |
-| `ALLOWED_ORIGINS` | Recommended | CORS origins (e.g., `https://app.permissionslip.dev`). Defaults to same-origin only if unset |
+| `ALLOWED_ORIGINS` | Recommended | CORS origins — comma-separated, exact match, no trailing slash (e.g., `https://app.permissionslip.dev`). Defaults to same-origin only if unset |
 | `INVITE_HMAC_KEY` | Recommended | HMAC key for invite codes — `openssl rand -hex 32` |
 | `SUPABASE_JWT_SECRET` | Legacy only | JWT secret for HS256 verification. Not needed when using ES256/JWKS (derived automatically from `SUPABASE_URL`) |
 | `SENTRY_DSN` | Optional | Sentry DSN for backend error tracking |
@@ -243,6 +243,9 @@ Check logs with `fly logs`. Common causes: missing `DATABASE_URL`, incorrect Sup
 
 **Frontend shows "Missing VITE_SUPABASE_URL" error:**
 The Supabase build args were not passed during `fly deploy`. Re-deploy with `--build-arg VITE_SUPABASE_URL=... --build-arg VITE_SUPABASE_ANON_KEY=...` or add `[build.args]` to `fly.toml`. See [Configure frontend build args](#3-configure-frontend-build-args).
+
+**CORS errors in browser (403 on API calls):**
+Ensure `ALLOWED_ORIGINS` includes your app's exact origin (e.g., `https://your-app.fly.dev`) — no trailing slash. When unset, the server defaults to same-origin only mode, which works for the standard deployment but will reject requests if a custom domain or CDN changes the browser's origin.
 
 **Connection refused to database:**
 If using Supabase, ensure the connection string uses the pooler endpoint (port 6543) with `?sslmode=require`. Direct connections (port 5432) may be blocked by firewall rules.


### PR DESCRIPTION
The self-hosted and Fly.io deployment docs referenced ALLOWED_ORIGINS but
didn't explain the default same-origin behavior, when it needs to be set
(reverse proxy / CDN), or the exact-match / no-trailing-slash requirement.
Adds troubleshooting entries and improves env var table descriptions.

https://claude.ai/code/session_012NTNdUNEoU1ooePKR7TeZp