### PR TITLE
Add community connectors directory page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For the full protocol design, architecture, and security model, see [SPEC.md](SP
 - **[Architecture](docs/architecture.md)** — system diagrams and component overview
 - **[Agent Integration Guide](docs/agents.md)** — how to integrate an autonomous agent with Permission Slip
 - **[Custom Connectors](docs/custom-connectors.md)** — add connectors from external Git repos (subprocess-based plugin system)
+- **[Community Connectors](docs/community-connectors.md)** — directory of third-party connectors built by the community
 - **[Consent Banner](docs/consent-banner.md)** — cross-subdomain cookie consent banner (shared between www and app)
 - **[Manual Testing: Agent Registration](docs/manual-testing-agent-registration.md)** — step-by-step guide to test the invite/registration flow
 - **[Self-Hosted Deployment](docs/deployment-self-hosted.md)** — complete guide for deploying on your own infrastructure (Docker, Fly.io, bare metal)

--- a/docs/community-connectors.md
+++ b/docs/community-connectors.md
@@ -1,0 +1,28 @@
+# Community Connectors
+
+Community connectors are custom connectors built and maintained by third parties. They extend Permission Slip with integrations beyond the built-in connectors.
+
+> **Disclaimer:** Listing a connector here does not constitute an endorsement, security review, or guarantee of any kind. These connectors are maintained by their respective authors, not by the Permission Slip team. **Do your own research** — review the source code, check the author's reputation, and assess the risks before installing any third-party connector. You are responsible for any connectors you choose to install.
+
+For background on how custom connectors work, see [Custom Connectors](custom-connectors.md).
+
+## Connectors
+
+_No community connectors listed yet._
+
+If you've built a custom connector and would like it listed here, open a pull request adding it to the table below.
+
+<!-- Add connectors to this table as they become available:
+
+| Connector | Description | Author | Link |
+|-----------|-------------|--------|------|
+| Example   | Does X      | @user  | [repo](https://github.com/...) |
+
+-->
+
+## Building Your Own
+
+Want to create a custom connector? See the guides:
+
+- **[Custom Connectors](custom-connectors.md)** — how to install and use external connectors (subprocess-based plugin system)
+- **[Creating Connectors](creating-connectors.md)** — how to build a built-in connector compiled into the binary

--- a/docs/custom-connectors.md
+++ b/docs/custom-connectors.md
@@ -258,6 +258,10 @@ func main() {
 }
 ```
 
+## Community Connectors
+
+Looking for connectors built by the community? See the [Community Connectors](community-connectors.md) directory.
+
 ## Security Considerations
 
 External connectors run as subprocesses with the same privileges as the server process. Treat custom connectors with the same trust level as any code dependency:


### PR DESCRIPTION
Create docs/community-connectors.md with a disclaimer that listing
connectors is not an endorsement or security review (DYOR), an empty
connectors list with a PR template for submissions, and links to the
connector-building guides. Link to it from the README documentation
section and from docs/custom-connectors.md.

https://claude.ai/code/session_01Qn9Nu3H6HKt8bqSnC4NwQJ