### PR TITLE
Hide "PS" abbreviation from mobile header

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -22,7 +22,6 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             P
           </span>
           <span className="hidden sm:inline">Permission Slip</span>
-          <span className="sm:hidden">PS</span>
           <span className="rounded-full bg-secondary/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-secondary">
             Beta
           </span>


### PR DESCRIPTION
Remove the mobile-only <span> that displayed "PS" on small screens.
The full "Permission Slip" text remains visible on sm+ breakpoints,
and on mobile the logo icon alone represents the brand.

https://claude.ai/code/session_0177eJEgTvXwesAKsDN66dNf