### PR TITLE
fix: add timeout to MFA listFactors to prevent infinite loading spinner

### DIFF
--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -15,6 +15,32 @@ import type { AuthStatus, AuthState } from "./types";
 
 const AuthContext = createContext<AuthState | undefined>(undefined);
 
+/**
+ * Races `request` against a timeout. The timeout timer is always cleared once
+ * the request settles (via `finally`), so it never lingers in the event loop
+ * after the request resolves quickly.
+ *
+ * Rejects with an `AuthError` on timeout; re-throws any other rejection so
+ * callers can handle it uniformly.
+ */
+async function withTimeout<T>(
+  request: Promise<T>,
+  ms: number
+): Promise<T> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timerId = setTimeout(
+      () => reject(new Error("Request timed out")),
+      ms
+    );
+  });
+  try {
+    return await Promise.race([request, timeoutPromise]);
+  } finally {
+    clearTimeout(timerId);
+  }
+}
+
 /** Returns the first verified TOTP factor from a factor list, or undefined. */
 function getVerifiedTotpFactor(factors?: Factor[]): Factor | undefined {
   return factors?.find((f) => f.status === "verified");
@@ -58,11 +84,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    */
   const challengeAndVerifyTotp = useCallback(
     async (factorId: string, code: string) => {
-      const timeout = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Request timed out")), 10000)
-      );
-      const request = supabase.auth.mfa.challengeAndVerify({ factorId, code });
-      const { error } = await Promise.race([request, timeout]).catch((err) => ({
+      const { error } = await withTimeout(
+        supabase.auth.mfa.challengeAndVerify({ factorId, code }),
+        10000
+      ).catch((err) => ({
         error: createAuthError("unknown", err instanceof Error ? err.message : String(err), 500),
       }));
       if (!error) {
@@ -205,16 +230,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const enrollMfa = useCallback(async () => {
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), 10000)
-    );
-    const { data, error } = await Promise.race([
+    const { data, error } = await withTimeout(
       supabase.auth.mfa.enroll({
         factorType: "totp",
         friendlyName: "Authenticator App",
       }),
-      timeout,
-    ]).catch((err) => ({
+      10000
+    ).catch((err) => ({
       data: null,
       error: createAuthError("unknown", err instanceof Error ? err.message : String(err), 500),
     }));
@@ -248,13 +270,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const unenrollMfa = useCallback(async (factorId: string) => {
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), 10000)
-    );
-    const { error } = await Promise.race([
+    const { error } = await withTimeout(
       supabase.auth.mfa.unenroll({ factorId }),
-      timeout,
-    ]).catch((err) => ({
+      10000
+    ).catch((err) => ({
       error: createAuthError("unknown", err instanceof Error ? err.message : String(err), 500),
     }));
     return { error: error ?? null };

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -63,7 +63,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       );
       const request = supabase.auth.mfa.challengeAndVerify({ factorId, code });
       const { error } = await Promise.race([request, timeout]).catch((err) => ({
-        error: err instanceof Error ? err : new Error(String(err)),
+        error: createAuthError("unknown", err instanceof Error ? err.message : String(err), 500),
       }));
       if (!error) {
         setAuthStatus("authenticated");
@@ -216,7 +216,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       timeout,
     ]).catch((err) => ({
       data: null,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: createAuthError("unknown", err instanceof Error ? err.message : String(err), 500),
     }));
     if (error) return { data: null, error };
 
@@ -255,7 +255,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       supabase.auth.mfa.unenroll({ factorId }),
       timeout,
     ]).catch((err) => ({
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: createAuthError("unknown", err instanceof Error ? err.message : String(err), 500),
     }));
     return { error: error ?? null };
   }, []);

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -182,19 +182,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const verifyMfa = useCallback(
     async (code: string) => {
-      const listTimeout = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Request timed out")), 10000)
+      // Read from user.factors (already in React state) instead of calling
+      // supabase.auth.mfa.listFactors(), which internally calls getUser() and
+      // acquires the Supabase internal lock — causing lock contention with the
+      // onAuthStateChange listener that fires during session init.
+      const totpFactor = (user?.factors ?? []).find(
+        (f) => f.factor_type === "totp" && f.status === "verified"
       );
-      const { data: factorsData, error: listError } = await Promise.race([
-        supabase.auth.mfa.listFactors(),
-        listTimeout,
-      ]).catch((err) => ({
-        data: null,
-        error: err instanceof Error ? err : new Error(String(err)),
-      }));
-      if (listError) return { error: listError };
-
-      const totpFactor = getVerifiedTotpFactor(factorsData?.totp);
       if (!totpFactor) {
         return {
           error: createAuthError(
@@ -207,7 +201,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       return challengeAndVerifyTotp(totpFactor.id, code);
     },
-    [challengeAndVerifyTotp]
+    [challengeAndVerifyTotp, user]
   );
 
   const enrollMfa = useCallback(async () => {
@@ -267,26 +261,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const listMfaFactors = useCallback(async () => {
-    // Wrap with a 10-second timeout so a hanging Supabase MFA endpoint
-    // resolves to an error instead of leaving the UI in an infinite spinner.
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), 10000)
+    // Read from user.factors (already in React state) instead of calling
+    // supabase.auth.mfa.listFactors(), which internally calls getUser() and
+    // acquires the Supabase internal lock — causing lock contention with the
+    // onAuthStateChange listener that fires during session init, hanging the
+    // UI for up to 10 seconds.
+    //
+    // This mirrors exactly what the Supabase SDK's own _listFactors() does
+    // internally: it reads user.factors from the already-fetched user object.
+    // user.factors includes both verified and unverified factors, so
+    // MfaEnrollmentFlow can still clean up stale abandoned enrollments.
+    const allTotp = (user?.factors ?? []).filter(
+      (f) => f.factor_type === "totp"
     );
-    const request = supabase.auth.mfa.listFactors();
-    const { data, error } = await Promise.race([request, timeout]).catch(
-      (err) => ({
-        data: null,
-        error: err instanceof Error ? err : new Error(String(err)),
-      })
-    );
-    // Use data.all filtered by factor_type instead of data.totp because
-    // the Supabase client only puts *verified* factors in data.totp.
-    // We need unverified factors too so MfaEnrollmentFlow can clean up
-    // stale enrollments that the user abandoned before verifying.
-    const allTotp =
-      data?.all?.filter((f) => f.factor_type === "totp") ?? [];
-    return { factors: allTotp, error: error ?? null };
-  }, []);
+    return { factors: allTotp, error: null };
+  }, [user]);
 
   const value = useMemo<AuthState>(
     () => ({

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -58,10 +58,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    */
   const challengeAndVerifyTotp = useCallback(
     async (factorId: string, code: string) => {
-      const { error } = await supabase.auth.mfa.challengeAndVerify({
-        factorId,
-        code,
-      });
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Request timed out")), 10000)
+      );
+      const request = supabase.auth.mfa.challengeAndVerify({ factorId, code });
+      const { error } = await Promise.race([request, timeout]).catch((err) => ({
+        error: err instanceof Error ? err : new Error(String(err)),
+      }));
       if (!error) {
         setAuthStatus("authenticated");
       }
@@ -179,8 +182,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const verifyMfa = useCallback(
     async (code: string) => {
-      const { data: factorsData, error: listError } =
-        await supabase.auth.mfa.listFactors();
+      const listTimeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Request timed out")), 10000)
+      );
+      const { data: factorsData, error: listError } = await Promise.race([
+        supabase.auth.mfa.listFactors(),
+        listTimeout,
+      ]).catch((err) => ({
+        data: null,
+        error: err instanceof Error ? err : new Error(String(err)),
+      }));
       if (listError) return { error: listError };
 
       const totpFactor = getVerifiedTotpFactor(factorsData?.totp);
@@ -200,10 +211,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const enrollMfa = useCallback(async () => {
-    const { data, error } = await supabase.auth.mfa.enroll({
-      factorType: "totp",
-      friendlyName: "Authenticator App",
-    });
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Request timed out")), 10000)
+    );
+    const { data, error } = await Promise.race([
+      supabase.auth.mfa.enroll({
+        factorType: "totp",
+        friendlyName: "Authenticator App",
+      }),
+      timeout,
+    ]).catch((err) => ({
+      data: null,
+      error: err instanceof Error ? err : new Error(String(err)),
+    }));
     if (error) return { data: null, error };
 
     // Guard against partial/unexpected response shapes from GoTrue.
@@ -234,12 +254,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const unenrollMfa = useCallback(async (factorId: string) => {
-    const { error } = await supabase.auth.mfa.unenroll({ factorId });
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Request timed out")), 10000)
+    );
+    const { error } = await Promise.race([
+      supabase.auth.mfa.unenroll({ factorId }),
+      timeout,
+    ]).catch((err) => ({
+      error: err instanceof Error ? err : new Error(String(err)),
+    }));
     return { error: error ?? null };
   }, []);
 
   const listMfaFactors = useCallback(async () => {
-    const { data, error } = await supabase.auth.mfa.listFactors();
+    // Wrap with a 10-second timeout so a hanging Supabase MFA endpoint
+    // resolves to an error instead of leaving the UI in an infinite spinner.
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Request timed out")), 10000)
+    );
+    const request = supabase.auth.mfa.listFactors();
+    const { data, error } = await Promise.race([request, timeout]).catch(
+      (err) => ({
+        data: null,
+        error: err instanceof Error ? err : new Error(String(err)),
+      })
+    );
     // Use data.all filtered by factor_type instead of data.totp because
     // the Supabase client only puts *verified* factors in data.totp.
     // We need unverified factors too so MfaEnrollmentFlow can clean up

--- a/frontend/src/auth/__tests__/AuthContext.test.tsx
+++ b/frontend/src/auth/__tests__/AuthContext.test.tsx
@@ -220,11 +220,8 @@ describe("AuthContext", () => {
 
   describe("verifyMfa", () => {
     it("calls challengeAndVerify with the verified TOTP factor", async () => {
-      setupAuthMocks({ authenticated: true });
-      mockMfa.listFactors.mockResolvedValue({
-        data: { all: [verifiedFactor], totp: [verifiedFactor] },
-        error: null,
-      });
+      // verifyMfa reads from user.factors in React state (no listFactors call).
+      setupAuthMocks({ authenticated: true, factors: [verifiedFactor] });
       // challengeAndVerify response shape only matters for the error field;
       // AuthContext doesn't inspect the data payload.
       mockMfa.challengeAndVerify.mockResolvedValue({
@@ -248,11 +245,8 @@ describe("AuthContext", () => {
     });
 
     it("returns error when no verified TOTP factor exists", async () => {
-      setupAuthMocks({ authenticated: true });
-      mockMfa.listFactors.mockResolvedValue({
-        data: { all: [], totp: [] },
-        error: null,
-      });
+      // No factors on user — verifyMfa should return mfa_factor_not_found.
+      setupAuthMocks({ authenticated: true, factors: [] });
 
       const { result } = renderHook(() => useAuth(), {
         wrapper: AuthProvider,
@@ -368,13 +362,9 @@ describe("AuthContext", () => {
   });
 
   describe("listMfaFactors", () => {
-    it("returns TOTP factors from supabase", async () => {
-      setupAuthMocks({ authenticated: true });
-      const factors = [verifiedFactor];
-      mockMfa.listFactors.mockResolvedValue({
-        data: { all: factors, totp: factors },
-        error: null,
-      });
+    it("returns TOTP factors from user state", async () => {
+      // listMfaFactors reads user.factors from React state — no Supabase call.
+      setupAuthMocks({ authenticated: true, factors: [verifiedFactor] });
 
       const { result } = renderHook(() => useAuth(), {
         wrapper: AuthProvider,
@@ -384,16 +374,12 @@ describe("AuthContext", () => {
 
       const response = await result.current.listMfaFactors();
 
-      expect(response.factors).toEqual(factors);
+      expect(response.factors).toEqual([verifiedFactor]);
       expect(response.error).toBeNull();
     });
 
     it("returns empty array when no factors exist", async () => {
-      setupAuthMocks({ authenticated: true });
-      mockMfa.listFactors.mockResolvedValue({
-        data: { all: [], totp: [] },
-        error: null,
-      });
+      setupAuthMocks({ authenticated: true, factors: [] });
 
       const { result } = renderHook(() => useAuth(), {
         wrapper: AuthProvider,
@@ -408,14 +394,10 @@ describe("AuthContext", () => {
     });
 
     it("includes unverified TOTP factors (for stale enrollment cleanup)", async () => {
-      setupAuthMocks({ authenticated: true });
-      // Supabase only puts verified factors in data.totp; unverified are
-      // only in data.all. Our wrapper must pull from data.all so the
-      // enrollment flow can find and clean up stale unverified factors.
-      mockMfa.listFactors.mockResolvedValue({
-        data: { all: [unverifiedFactor], totp: [] },
-        error: null,
-      });
+      // Supabase's onAuthStateChange provides user.factors which includes both
+      // verified and unverified factors, so MfaEnrollmentFlow can find and
+      // clean up stale abandoned enrollments.
+      setupAuthMocks({ authenticated: true, factors: [unverifiedFactor] });
 
       const { result } = renderHook(() => useAuth(), {
         wrapper: AuthProvider,
@@ -430,7 +412,6 @@ describe("AuthContext", () => {
     });
 
     it("excludes non-TOTP factors from results", async () => {
-      setupAuthMocks({ authenticated: true });
       const phoneFactor = {
         id: "factor-phone",
         status: "verified" as const,
@@ -438,13 +419,11 @@ describe("AuthContext", () => {
         created_at: "2024-01-01",
         updated_at: "2024-01-01",
       };
-      mockMfa.listFactors.mockResolvedValue({
-        data: {
-          all: [verifiedFactor, phoneFactor],
-          totp: [verifiedFactor],
-          phone: [phoneFactor],
-        },
-        error: null,
+      // user.factors contains both TOTP and phone factors; listMfaFactors
+      // must only return TOTP ones.
+      setupAuthMocks({
+        authenticated: true,
+        factors: [verifiedFactor, phoneFactor],
       });
 
       const { result } = renderHook(() => useAuth(), {

--- a/frontend/src/auth/__tests__/MfaChallengePage.test.tsx
+++ b/frontend/src/auth/__tests__/MfaChallengePage.test.tsx
@@ -41,10 +41,12 @@ describe("MfaChallengePage", () => {
   });
 
   it("submits the TOTP code via verifyMfa", async () => {
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [verifiedFactor], totp: [verifiedFactor] },
-      error: null,
-    });
+    // verifyMfa reads from user.factors in React state; set up the factor
+    // on the user via setupAuthMocks instead of mocking listFactors.
+    setupAuthMocks({ authenticated: true, factors: [verifiedFactor] });
+    mockMfa.getAuthenticatorAssuranceLevel.mockResolvedValue(
+      aalResponse("aal1", "aal2")
+    );
     mockMfa.challengeAndVerify.mockResolvedValue({
       data: mockSession,
       error: null,

--- a/frontend/src/auth/__tests__/MfaChallengePage.test.tsx
+++ b/frontend/src/auth/__tests__/MfaChallengePage.test.tsx
@@ -67,10 +67,12 @@ describe("MfaChallengePage", () => {
   });
 
   it("shows error message on verification failure", async () => {
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [verifiedFactor], totp: [verifiedFactor] },
-      error: null,
-    });
+    // verifyMfa reads from user.factors in React state; set up the factor
+    // on the user via setupAuthMocks instead of mocking listFactors.
+    setupAuthMocks({ authenticated: true, factors: [verifiedFactor] });
+    mockMfa.getAuthenticatorAssuranceLevel.mockResolvedValue(
+      aalResponse("aal1", "aal2")
+    );
     mockMfa.challengeAndVerify.mockResolvedValue({
       data: null,
       error: new AuthError("Invalid code", 400, "mfa_verification_failed"),

--- a/frontend/src/auth/__tests__/fixtures.ts
+++ b/frontend/src/auth/__tests__/fixtures.ts
@@ -26,6 +26,7 @@ export const mockUser: User = {
   created_at: "2024-01-01",
   app_metadata: {},
   user_metadata: {},
+  factors: [],
 };
 
 export const mockSession: Session = {
@@ -66,17 +67,49 @@ export function aalResponse(current: string, next: string) {
   };
 }
 
-export function setupAuthMocks({ authenticated = false } = {}) {
+/**
+ * Sets up auth mocks for a test.
+ *
+ * @param authenticated - Whether the user is authenticated
+ * @param factors - MFA factors to attach to the session user (default: []).
+ *   AuthContext reads user.factors directly from React state, so tests that
+ *   exercise listMfaFactors or verifyMfa should pass factors here instead of
+ *   mocking supabase.auth.mfa.listFactors().
+ */
+/**
+ * Sets up auth mocks for a test.
+ *
+ * @param authenticated - Whether the user is authenticated
+ * @param factors - MFA factors to attach to the session user (default: []).
+ *   AuthContext reads user.factors directly from React state, so tests that
+ *   exercise listMfaFactors or verifyMfa should pass factors here instead of
+ *   mocking supabase.auth.mfa.listFactors().
+ *
+ * When no factors are provided, the original mockSession reference is used
+ * so that tests doing strict reference equality (toBe) still pass.
+ */
+export function setupAuthMocks({
+  authenticated = false,
+  factors = undefined as typeof verifiedFactor[] | undefined,
+} = {}) {
   // restoreAllMocks (not clearAllMocks) so mock *implementations* from
   // previous tests are removed, not just call counts.
   vi.restoreAllMocks();
   // onAuthStateChange fires INITIAL_SESSION immediately on subscribe,
   // which drives the initial auth state (no separate getSession needed).
   mockAuth.onAuthStateChange.mockImplementation((callback) => {
-    callback(
-      "INITIAL_SESSION",
-      authenticated ? mockSession : null
-    );
+    let session = null;
+    if (authenticated) {
+      if (factors !== undefined) {
+        // Caller explicitly requested specific factors on the user.
+        const user = { ...mockUser, factors };
+        session = { ...mockSession, user };
+      } else {
+        // No factors override — use original mockSession for reference stability.
+        session = mockSession;
+      }
+    }
+    callback("INITIAL_SESSION", session);
     return {
       data: {
         subscription: { id: "test", callback: vi.fn(), unsubscribe: vi.fn() },

--- a/frontend/src/auth/__tests__/fixtures.ts
+++ b/frontend/src/auth/__tests__/fixtures.ts
@@ -75,15 +75,6 @@ export function aalResponse(current: string, next: string) {
  *   AuthContext reads user.factors directly from React state, so tests that
  *   exercise listMfaFactors or verifyMfa should pass factors here instead of
  *   mocking supabase.auth.mfa.listFactors().
- */
-/**
- * Sets up auth mocks for a test.
- *
- * @param authenticated - Whether the user is authenticated
- * @param factors - MFA factors to attach to the session user (default: []).
- *   AuthContext reads user.factors directly from React state, so tests that
- *   exercise listMfaFactors or verifyMfa should pass factors here instead of
- *   mocking supabase.auth.mfa.listFactors().
  *
  * When no factors are provided, the original mockSession reference is used
  * so that tests doing strict reference equality (toBe) still pass.

--- a/frontend/src/auth/__tests__/fixtures.ts
+++ b/frontend/src/auth/__tests__/fixtures.ts
@@ -6,7 +6,7 @@
  * aalResponse) so individual test files don't duplicate boilerplate.
  */
 import { vi } from "vitest";
-import type { Session, User } from "@supabase/supabase-js";
+import type { Session, User, Factor } from "@supabase/supabase-js";
 import { supabase } from "../../lib/supabaseClient";
 
 export const mockAuth = vi.mocked(supabase.auth);
@@ -90,7 +90,7 @@ export function aalResponse(current: string, next: string) {
  */
 export function setupAuthMocks({
   authenticated = false,
-  factors = undefined as typeof verifiedFactor[] | undefined,
+  factors = undefined as Factor[] | undefined,
 } = {}) {
   // restoreAllMocks (not clearAllMocks) so mock *implementations* from
   // previous tests are removed, not just call counts.

--- a/frontend/src/pages/settings/__tests__/SecuritySection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SecuritySection.test.tsx
@@ -172,4 +172,42 @@ describe("SecuritySection", () => {
     // Should be back to the Remove button.
     expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
   });
+
+  it(
+    "shows error state when listFactors times out after 10 seconds",
+    async () => {
+      mockApiFetch();
+      // Use fake timers that auto-advance so async microtasks still flush
+      // while we control setTimeout behaviour.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        // Return a promise that never resolves (simulates a hanging endpoint).
+        mockMfa.listFactors.mockReturnValue(new Promise(() => {}));
+
+        render(<SecuritySection />, { wrapper });
+
+        // Initially shows loading spinner.
+        expect(
+          screen.getByRole("status", { name: "Loading security settings" }),
+        ).toBeInTheDocument();
+
+        // Advance past the 10-second timeout so Promise.race rejects.
+        await vi.advanceTimersByTimeAsync(10001);
+
+        // Should now show the error state with a Try Again button.
+        await waitFor(
+          () => {
+            expect(
+              screen.getByText("Failed to load security settings."),
+            ).toBeInTheDocument();
+          },
+          { timeout: 3000 },
+        );
+        expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+    15000, // allow enough wall-clock time for the fake-timer dance
+  );
 });

--- a/frontend/src/pages/settings/__tests__/SecuritySection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SecuritySection.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Factor } from "@supabase/supabase-js";
 import {
   setupAuthMocks,
-  mockMfa,
   verifiedFactor,
 } from "../../../auth/__tests__/fixtures";
 import { createAuthWrapper } from "../../../test-helpers";
@@ -13,8 +13,14 @@ import { SecuritySection } from "../SecuritySection";
 vi.mock("../../../lib/supabaseClient");
 vi.mock("../../../api/client");
 
-function mockApiFetch() {
-  setupAuthMocks({ authenticated: true });
+/**
+ * Sets up auth and API mocks for SecuritySection tests.
+ * Pass `factors` to control what MFA factors are on the user (default: []).
+ * AuthContext reads user.factors from React state, so factors must be set
+ * on the session user rather than mocking supabase.auth.mfa.listFactors().
+ */
+function mockApiFetch({ factors = [] as Factor[] } = {}) {
+  setupAuthMocks({ authenticated: true, factors });
   mockGet.mockImplementation((url: string) => {
     if (url === "/v1/profile") {
       return Promise.resolve({
@@ -41,10 +47,6 @@ describe("SecuritySection", () => {
 
   it("renders the security card with title", async () => {
     mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [], totp: [] },
-      error: null,
-    });
 
     render(<SecuritySection />, { wrapper });
 
@@ -58,10 +60,6 @@ describe("SecuritySection", () => {
 
   it("shows Two-Factor Authentication heading", async () => {
     mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [], totp: [] },
-      error: null,
-    });
 
     render(<SecuritySection />, { wrapper });
 
@@ -71,8 +69,11 @@ describe("SecuritySection", () => {
   });
 
   it("shows loading state initially", () => {
+    // SecuritySection starts in "loading" view before the first useEffect
+    // fires and loadFactors() resolves. Even though listMfaFactors() now
+    // resolves instantly from user state, the loading spinner is visible on
+    // the initial render (before any effects run).
     mockApiFetch();
-    mockMfa.listFactors.mockReturnValue(new Promise(() => {}));
 
     render(<SecuritySection />, { wrapper });
 
@@ -82,11 +83,8 @@ describe("SecuritySection", () => {
   });
 
   it("shows enrollment flow when no MFA factors exist", async () => {
-    mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [], totp: [] },
-      error: null,
-    });
+    // No factors on user → SecuritySection should show the enrollment button.
+    mockApiFetch({ factors: [] });
 
     render(<SecuritySection />, { wrapper });
 
@@ -98,11 +96,8 @@ describe("SecuritySection", () => {
   });
 
   it("shows enrolled factors with remove button", async () => {
-    mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [verifiedFactor], totp: [verifiedFactor] },
-      error: null,
-    });
+    // User has a verified TOTP factor → SecuritySection should show it.
+    mockApiFetch({ factors: [verifiedFactor] });
 
     render(<SecuritySection />, { wrapper });
 
@@ -113,29 +108,9 @@ describe("SecuritySection", () => {
     expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
   });
 
-  it("shows error state with retry button", async () => {
-    mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: null,
-      error: { message: "Network error" },
-    });
-
-    render(<SecuritySection />, { wrapper });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Failed to load security settings."),
-      ).toBeInTheDocument();
-    });
-    expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
-  });
-
   it("shows confirmation before removing MFA factor", async () => {
-    mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [verifiedFactor], totp: [verifiedFactor] },
-      error: null,
-    });
+    mockApiFetch({ factors: [verifiedFactor] });
+    const { supabase } = await import("../../../lib/supabaseClient");
     const user = userEvent.setup();
 
     render(<SecuritySection />, { wrapper });
@@ -149,15 +124,11 @@ describe("SecuritySection", () => {
 
     expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
-    expect(mockMfa.unenroll).not.toHaveBeenCalled();
+    expect(vi.mocked(supabase.auth.mfa.unenroll)).not.toHaveBeenCalled();
   });
 
   it("cancels MFA removal when Cancel is clicked", async () => {
-    mockApiFetch();
-    mockMfa.listFactors.mockResolvedValue({
-      data: { all: [verifiedFactor], totp: [verifiedFactor] },
-      error: null,
-    });
+    mockApiFetch({ factors: [verifiedFactor] });
     const user = userEvent.setup();
 
     render(<SecuritySection />, { wrapper });
@@ -172,42 +143,4 @@ describe("SecuritySection", () => {
     // Should be back to the Remove button.
     expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
   });
-
-  it(
-    "shows error state when listFactors times out after 10 seconds",
-    async () => {
-      mockApiFetch();
-      // Use fake timers that auto-advance so async microtasks still flush
-      // while we control setTimeout behaviour.
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      try {
-        // Return a promise that never resolves (simulates a hanging endpoint).
-        mockMfa.listFactors.mockReturnValue(new Promise(() => {}));
-
-        render(<SecuritySection />, { wrapper });
-
-        // Initially shows loading spinner.
-        expect(
-          screen.getByRole("status", { name: "Loading security settings" }),
-        ).toBeInTheDocument();
-
-        // Advance past the 10-second timeout so Promise.race rejects.
-        await vi.advanceTimersByTimeAsync(10001);
-
-        // Should now show the error state with a Try Again button.
-        await waitFor(
-          () => {
-            expect(
-              screen.getByText("Failed to load security settings."),
-            ).toBeInTheDocument();
-          },
-          { timeout: 3000 },
-        );
-        expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
-      } finally {
-        vi.useRealTimers();
-      }
-    },
-    15000, // allow enough wall-clock time for the fake-timer dance
-  );
 });


### PR DESCRIPTION
## Real Root Cause

`supabase.auth.mfa.listFactors()` in the Supabase JS SDK does **not** make a network call — it calls `this.getUser()` internally, which acquires an internal lock (`lockAcquireTimeout: 10000ms`). When `onAuthStateChange` fires at session init and also tries to acquire the same lock (via `getAuthenticatorAssuranceLevel()`), the two **compete** and `listFactors()` hangs for up to 10s before timing out.

The previous commit added a redundant 10s timeout that mirrored the SDK's built-in behavior — it didn't fix anything meaningful.

## Fix

The Supabase SDK's own `_listFactors()` implementation simply reads `user.factors` from the already-fetched user object. We already have the `user` object in `AuthContext` state (kept current by `onAuthStateChange`).

**`listMfaFactors` now reads from `user.factors` directly:**

```typescript
// BEFORE (causes lock contention):
const listMfaFactors = useCallback(async () => {
  const request = supabase.auth.mfa.listFactors(); // acquires internal lock → hangs
  // ...
}, []);

// AFTER (reads from already-available user state, no lock contention):
const listMfaFactors = useCallback(async () => {
  const allTotp = (user?.factors ?? []).filter((f) => f.factor_type === "totp");
  return { factors: allTotp, error: null };
}, [user]);
```

**`verifyMfa` gets the same fix** — it also called `listFactors()` to find the TOTP factor ID; it now reads from `user.factors` instead.

## Additional: 10-Second Timeouts on MFA Mutations

As a companion safety measure, `challengeAndVerify`, `enroll`, and `unenroll` now each race against a 10-second timeout via a `withTimeout()` helper. This prevents those operations from hanging indefinitely if the Supabase connection stalls. Unlike the lock-contention hang (which was caused by competing SDK internals), these timeouts guard against network-level hangs. The `withTimeout()` helper clears the timer in a `finally` block so no lingering timers are left behind when requests resolve quickly.

## Why This Is Safe

1. The Supabase SDK's own `_listFactors()` does exactly this — reads `user.factors` from the already-fetched user object
2. `user` is always up-to-date in `AuthContext` because `onAuthStateChange` keeps it current
3. `user.factors` includes both verified and unverified factors, so `MfaEnrollmentFlow` can still find and clean up stale abandoned enrollments
4. No network call, no lock competition, no hang

## Tests Updated

Tests that previously mocked `supabase.auth.mfa.listFactors()` to control what factors appeared now set factors on the session user via `setupAuthMocks({ factors: [...] })` instead, which is how the real code path works.