### PR TITLE
Increase default React Query staleTime from 30s to 5min

### DIFF
--- a/frontend/src/hooks/useDataRetention.ts
+++ b/frontend/src/hooks/useDataRetention.ts
@@ -21,7 +21,7 @@ export function useDataRetention() {
       return data as DataRetention;
     },
     enabled: !!accessToken,
-    staleTime: 60_000,
+    // Retention config rarely changes — inherit the global 5min staleTime.
   });
 
   return { dataRetention: data ?? null, isLoading, error, refetch };

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -41,10 +41,7 @@ export function useProfile() {
       return { profile: data as Profile | null, needsOnboarding: false };
     },
     enabled: !!accessToken,
-    // Profile data rarely changes. A 30s staleTime prevents unnecessary
-    // refetches during rapid auth-state transitions (e.g. MFA enrollment)
-    // while still picking up changes reasonably quickly.
-    staleTime: 30_000,
+    // Profile data rarely changes — inherit the global 5min staleTime.
   });
 
   return {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -44,11 +44,12 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       // Default staleTime of 0 causes refetches on every window focus,
-      // mount, and reconnect — even when the data hasn't changed. 30s is
-      // a reasonable baseline that avoids unnecessary network requests
-      // during rapid state transitions (e.g. MFA enrollment) while still
-      // keeping data reasonably fresh. Individual queries can override.
-      staleTime: 30_000,
+      // mount, and reconnect — even when the data hasn't changed. 5min
+      // prevents jarring full-page refreshes when switching back to the
+      // tab. Queries that need near-real-time data (approvals, agents,
+      // audit events) already use refetchInterval, which is unaffected
+      // by staleTime. Individual queries can still override.
+      staleTime: 300_000,
     },
   },
   queryCache: new QueryCache({


### PR DESCRIPTION
Prevents jarring full-page refreshes when switching back to the tab.
Queries that need near-real-time data (approvals, agents, audit events)
already use refetchInterval, which is unaffected by staleTime.

Also removes per-query staleTime overrides from useProfile and
useDataRetention since they were shorter than the new default and
both benefit from the longer cache window.

https://claude.ai/code/session_011xWXpAbEniTH3nLt3UdJzc