### PR TITLE
feat: add marketing opt-in to onboarding and notification settings

### DIFF
--- a/api/onboarding.go
+++ b/api/onboarding.go
@@ -14,7 +14,7 @@ import (
 
 type onboardingRequest struct {
 	Username       string `json:"username" validate:"required"`
-	MarketingOptIn bool   `json:"marketing_opt_in"`
+	MarketingOptIn bool   `json:"marketing_opt_in"` // defaults to false when omitted
 }
 
 type onboardingResponse struct {

--- a/api/onboarding.go
+++ b/api/onboarding.go
@@ -13,7 +13,8 @@ import (
 )
 
 type onboardingRequest struct {
-	Username string `json:"username" validate:"required"`
+	Username       string `json:"username" validate:"required"`
+	MarketingOptIn bool   `json:"marketing_opt_in"`
 }
 
 type onboardingResponse struct {
@@ -68,7 +69,7 @@ func handleOnboarding(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		profile, err := db.CreateProfile(r.Context(), deps.DB, userID, username)
+		profile, err := db.CreateProfile(r.Context(), deps.DB, userID, username, req.MarketingOptIn)
 		if err != nil {
 			var onboardErr *db.OnboardingError
 			if errors.As(err, &onboardErr) {

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -14,19 +14,21 @@ import (
 
 // profileResponse is the JSON shape returned by GET /profile.
 type profileResponse struct {
-	ID        string    `json:"id"`
-	Username  string    `json:"username"`
-	Email     *string   `json:"email,omitempty"`
-	Phone     *string   `json:"phone,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	ID             string    `json:"id"`
+	Username       string    `json:"username"`
+	Email          *string   `json:"email,omitempty"`
+	Phone          *string   `json:"phone,omitempty"`
+	MarketingOptIn bool      `json:"marketing_opt_in"`
+	CreatedAt      time.Time `json:"created_at"`
 }
 
 // updateProfileRaw uses json.RawMessage to detect which fields were actually
 // provided in the request body, enabling true PATCH semantics (absent fields
 // are left unchanged, explicit null clears the field).
 type updateProfileRaw struct {
-	Email json.RawMessage `json:"email"`
-	Phone json.RawMessage `json:"phone"`
+	Email          json.RawMessage `json:"email"`
+	Phone          json.RawMessage `json:"phone"`
+	MarketingOptIn json.RawMessage `json:"marketing_opt_in"`
 }
 
 // RegisterProfileRoutes adds profile-related endpoints to the mux.
@@ -51,11 +53,12 @@ func handleGetProfile() http.HandlerFunc {
 		profile := Profile(r.Context())
 
 		RespondJSON(w, http.StatusOK, profileResponse{
-			ID:        profile.ID,
-			Username:  profile.Username,
-			Email:     profile.Email,
-			Phone:     profile.Phone,
-			CreatedAt: profile.CreatedAt,
+			ID:             profile.ID,
+			Username:       profile.Username,
+			Email:          profile.Email,
+			Phone:          profile.Phone,
+			MarketingOptIn: profile.MarketingOptIn,
+			CreatedAt:      profile.CreatedAt,
 		})
 	}
 }
@@ -89,6 +92,26 @@ func parseOptionalString(raw json.RawMessage) (*string, bool, error) {
 	return &s, true, nil
 }
 
+// parseOptionalBool parses a json.RawMessage that may be a bool or absent.
+// Returns (value, wasProvided, error):
+//   - absent field   → (nil, false, nil)
+//   - true/false     → (&b, true, nil)
+//   - null           → (nil, false, error) — boolean fields are non-nullable
+//   - wrong type     → (nil, false, error)
+func parseOptionalBool(raw json.RawMessage) (*bool, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil // field not present in JSON
+	}
+	if isRawJSONNull(raw) {
+		return nil, false, fmt.Errorf("expected a boolean, got null")
+	}
+	var b bool
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return nil, false, fmt.Errorf("expected a boolean, got %s", raw)
+	}
+	return &b, true, nil
+}
+
 func handleUpdateProfile(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		profile := Profile(r.Context())
@@ -101,6 +124,7 @@ func handleUpdateProfile(deps *Deps) http.HandlerFunc {
 		// Start from current values and only override provided fields.
 		email := profile.Email
 		phone := profile.Phone
+		var marketingOptIn *bool // nil means "not provided" → leave unchanged
 
 		if parsed, provided, err := parseOptionalString(req.Email); err != nil {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "email: "+err.Error()))
@@ -124,7 +148,14 @@ func handleUpdateProfile(deps *Deps) http.HandlerFunc {
 			phone = parsed
 		}
 
-		if err := db.UpdateProfileContactFields(r.Context(), deps.DB, profile.ID, email, phone); err != nil {
+		if parsed, provided, err := parseOptionalBool(req.MarketingOptIn); err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "marketing_opt_in: "+err.Error()))
+			return
+		} else if provided {
+			marketingOptIn = parsed
+		}
+
+		if err := db.UpdateProfileFields(r.Context(), deps.DB, profile.ID, email, phone, marketingOptIn); err != nil {
 			log.Printf("[%s] handleUpdateProfile: %v", TraceID(r.Context()), err)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update profile"))
 			return
@@ -139,11 +170,12 @@ func handleUpdateProfile(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusOK, profileResponse{
-			ID:        updated.ID,
-			Username:  updated.Username,
-			Email:     updated.Email,
-			Phone:     updated.Phone,
-			CreatedAt: updated.CreatedAt,
+			ID:             updated.ID,
+			Username:       updated.Username,
+			Email:          updated.Email,
+			Phone:          updated.Phone,
+			MarketingOptIn: updated.MarketingOptIn,
+			CreatedAt:      updated.CreatedAt,
 		})
 	}
 }

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -22,6 +22,17 @@ type profileResponse struct {
 	CreatedAt      time.Time `json:"created_at"`
 }
 
+func toProfileResponse(p *db.Profile) profileResponse {
+	return profileResponse{
+		ID:             p.ID,
+		Username:       p.Username,
+		Email:          p.Email,
+		Phone:          p.Phone,
+		MarketingOptIn: p.MarketingOptIn,
+		CreatedAt:      p.CreatedAt,
+	}
+}
+
 // updateProfileRaw uses json.RawMessage to detect which fields were actually
 // provided in the request body, enabling true PATCH semantics (absent fields
 // are left unchanged, explicit null clears the field).
@@ -52,14 +63,7 @@ func handleGetProfile() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		profile := Profile(r.Context())
 
-		RespondJSON(w, http.StatusOK, profileResponse{
-			ID:             profile.ID,
-			Username:       profile.Username,
-			Email:          profile.Email,
-			Phone:          profile.Phone,
-			MarketingOptIn: profile.MarketingOptIn,
-			CreatedAt:      profile.CreatedAt,
-		})
+		RespondJSON(w, http.StatusOK, toProfileResponse(profile))
 	}
 }
 
@@ -169,14 +173,7 @@ func handleUpdateProfile(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		RespondJSON(w, http.StatusOK, profileResponse{
-			ID:             updated.ID,
-			Username:       updated.Username,
-			Email:          updated.Email,
-			Phone:          updated.Phone,
-			MarketingOptIn: updated.MarketingOptIn,
-			CreatedAt:      updated.CreatedAt,
-		})
+		RespondJSON(w, http.StatusOK, toProfileResponse(updated))
 	}
 }
 

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -179,7 +179,7 @@ func TestUpdateProfile_PartialUpdate_OnlyEmail(t *testing.T) {
 
 	// Set initial phone
 	phone := "+15559999999"
-	if err := db.UpdateProfileContactFields(context.Background(), tx, uid, nil, &phone); err != nil {
+	if err := db.UpdateProfileFields(context.Background(), tx, uid, nil, &phone, nil); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 
@@ -216,7 +216,7 @@ func TestUpdateProfile_ClearField_WithNull(t *testing.T) {
 
 	// Set initial email
 	email := "old@example.com"
-	if err := db.UpdateProfileContactFields(context.Background(), tx, uid, &email, nil); err != nil {
+	if err := db.UpdateProfileFields(context.Background(), tx, uid, &email, nil, nil); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 
@@ -426,5 +426,80 @@ func TestUpdateNotificationPreferences_DuplicateChannel(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- Marketing opt-in tests ---
+
+func TestUpdateProfile_SetMarketingOptIn(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPatch, "/profile", uid,
+		`{"marketing_opt_in":true}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp profileResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if !resp.MarketingOptIn {
+		t.Error("expected marketing_opt_in to be true")
+	}
+}
+
+func TestUpdateProfile_MarketingOptIn_NullRejected(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPatch, "/profile", uid,
+		`{"marketing_opt_in":null}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for null marketing_opt_in, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetProfile_IncludesMarketingOptIn(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/profile", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp profileResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	// Default should be false.
+	if resp.MarketingOptIn {
+		t.Error("expected marketing_opt_in to default to false")
 	}
 }

--- a/db/migrations/20260301000000_marketing_opt_in.sql
+++ b/db/migrations/20260301000000_marketing_opt_in.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Add marketing opt-in preference to profiles.
+-- Defaults to false (opt-in, not opt-out).
+
+ALTER TABLE profiles
+  ADD COLUMN marketing_opt_in BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE profiles DROP COLUMN IF EXISTS marketing_opt_in;

--- a/db/onboarding.go
+++ b/db/onboarding.go
@@ -29,7 +29,7 @@ const (
 // Returns the created Profile, or an *OnboardingError if the username is
 // already taken (OnboardingErrUsernameTaken) or if a profile already exists
 // for this user due to a concurrent request (OnboardingErrProfileExists).
-func CreateProfile(ctx context.Context, db DBTX, userID, username string) (*Profile, error) {
+func CreateProfile(ctx context.Context, db DBTX, userID, username string, marketingOptIn bool) (*Profile, error) {
 	// Upsert auth.users so the FK from profiles is satisfied.
 	// In production (Supabase), auth.users is managed by Supabase and this
 	// row already exists by the time the user reaches onboarding.
@@ -44,10 +44,10 @@ func CreateProfile(ctx context.Context, db DBTX, userID, username string) (*Prof
 
 	var p Profile
 	err = db.QueryRow(ctx,
-		`INSERT INTO profiles (id, username) VALUES ($1, $2)
-		 RETURNING id, username, created_at`,
-		userID, username,
-	).Scan(&p.ID, &p.Username, &p.CreatedAt)
+		`INSERT INTO profiles (id, username, marketing_opt_in) VALUES ($1, $2, $3)
+		 RETURNING id, username, marketing_opt_in, created_at`,
+		userID, username, marketingOptIn,
+	).Scan(&p.ID, &p.Username, &p.MarketingOptIn, &p.CreatedAt)
 
 	if err != nil {
 		var pgErr *pgconn.PgError

--- a/db/onboarding_test.go
+++ b/db/onboarding_test.go
@@ -13,7 +13,7 @@ func TestCreateProfile_Success(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 
-	profile, err := db.CreateProfile(context.Background(), tx, uid, "newuser")
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "newuser", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestCreateProfile_UsernameTaken(t *testing.T) {
 	uid2 := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid1, "taken")
 
-	_, err := db.CreateProfile(context.Background(), tx, uid2, "taken")
+	_, err := db.CreateProfile(context.Background(), tx, uid2, "taken", false)
 	if err == nil {
 		t.Fatal("expected error for duplicate username, got nil")
 	}
@@ -60,12 +60,35 @@ func TestCreateProfile_Idempotent_AuthUsers(t *testing.T) {
 	// Pre-insert the auth.users row (as Supabase would have done)
 	testhelper.MustExec(t, tx, `INSERT INTO auth.users (id) VALUES ($1)`, uid)
 
-	profile, err := db.CreateProfile(context.Background(), tx, uid, "preseeded")
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "preseeded", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if profile == nil || profile.Username != "preseeded" {
 		t.Errorf("expected profile with username 'preseeded', got %+v", profile)
+	}
+}
+
+func TestCreateProfile_MarketingOptIn(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "marketer", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !profile.MarketingOptIn {
+		t.Error("expected marketing_opt_in to be true")
+	}
+
+	// Re-fetch to confirm persistence.
+	fetched, err := db.GetProfileByUserID(context.Background(), tx, uid)
+	if err != nil {
+		t.Fatalf("re-fetch: %v", err)
+	}
+	if !fetched.MarketingOptIn {
+		t.Error("expected marketing_opt_in to be true after re-fetch")
 	}
 }
 

--- a/db/profiles.go
+++ b/db/profiles.go
@@ -10,11 +10,12 @@ import (
 
 // Profile represents a row from the profiles table.
 type Profile struct {
-	ID        string
-	Username  string
-	Email     *string // nullable — user opts in by setting an address
-	Phone     *string // nullable — E.164 format (e.g. "+15551234567")
-	CreatedAt time.Time
+	ID             string
+	Username       string
+	Email          *string // nullable — user opts in by setting an address
+	Phone          *string // nullable — E.164 format (e.g. "+15551234567")
+	MarketingOptIn bool    // opt-in for product update emails
+	CreatedAt      time.Time
 }
 
 // GetProfileByUserID returns the profile for the given user ID,
@@ -22,9 +23,9 @@ type Profile struct {
 func GetProfileByUserID(ctx context.Context, db DBTX, userID string) (*Profile, error) {
 	var p Profile
 	err := db.QueryRow(ctx,
-		"SELECT id, username, email, phone, created_at FROM profiles WHERE id = $1",
+		"SELECT id, username, email, phone, marketing_opt_in, created_at FROM profiles WHERE id = $1",
 		userID,
-	).Scan(&p.ID, &p.Username, &p.Email, &p.Phone, &p.CreatedAt)
+	).Scan(&p.ID, &p.Username, &p.Email, &p.Phone, &p.MarketingOptIn, &p.CreatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -34,12 +35,13 @@ func GetProfileByUserID(ctx context.Context, db DBTX, userID string) (*Profile, 
 	return &p, nil
 }
 
-// UpdateProfileContactFields updates the email and phone columns for the
-// given user. Pass nil to clear a field.
-func UpdateProfileContactFields(ctx context.Context, db DBTX, userID string, email, phone *string) error {
+// UpdateProfileFields updates the mutable profile columns for the given user.
+// Pass nil for string fields to clear them; pass nil for marketingOptIn to
+// leave it unchanged.
+func UpdateProfileFields(ctx context.Context, db DBTX, userID string, email, phone *string, marketingOptIn *bool) error {
 	_, err := db.Exec(ctx,
-		"UPDATE profiles SET email = $2, phone = $3 WHERE id = $1",
-		userID, email, phone,
+		"UPDATE profiles SET email = $2, phone = $3, marketing_opt_in = COALESCE($4, marketing_opt_in) WHERE id = $1",
+		userID, email, phone, marketingOptIn,
 	)
 	return err
 }

--- a/db/profiles_test.go
+++ b/db/profiles_test.go
@@ -90,7 +90,7 @@ func TestGetProfileByUserID_NullContactFields(t *testing.T) {
 	}
 }
 
-func TestUpdateProfileContactFields(t *testing.T) {
+func TestUpdateProfileFields(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -103,7 +103,7 @@ func TestUpdateProfileContactFields(t *testing.T) {
 	// Set both fields.
 	err := db.UpdateProfileFields(ctx, tx, uid, &email, &phone, nil)
 	if err != nil {
-		t.Fatalf("update contact fields: %v", err)
+		t.Fatalf("update profile fields: %v", err)
 	}
 
 	profile, err := db.GetProfileByUserID(ctx, tx, uid)
@@ -120,7 +120,7 @@ func TestUpdateProfileContactFields(t *testing.T) {
 	// Clear both fields.
 	err = db.UpdateProfileFields(ctx, tx, uid, nil, nil, nil)
 	if err != nil {
-		t.Fatalf("clear contact fields: %v", err)
+		t.Fatalf("clear profile fields: %v", err)
 	}
 	profile, err = db.GetProfileByUserID(ctx, tx, uid)
 	if err != nil {

--- a/db/profiles_test.go
+++ b/db/profiles_test.go
@@ -11,7 +11,7 @@ import (
 func TestProfilesSchema(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
-	testhelper.RequireColumns(t, tx, "profiles", []string{"id", "username", "email", "phone", "created_at"})
+	testhelper.RequireColumns(t, tx, "profiles", []string{"id", "username", "email", "phone", "marketing_opt_in", "created_at"})
 }
 
 func TestProfilesUsernameUnique(t *testing.T) {
@@ -101,7 +101,7 @@ func TestUpdateProfileContactFields(t *testing.T) {
 	phone := "+15551234567"
 
 	// Set both fields.
-	err := db.UpdateProfileContactFields(ctx, tx, uid, &email, &phone)
+	err := db.UpdateProfileFields(ctx, tx, uid, &email, &phone, nil)
 	if err != nil {
 		t.Fatalf("update contact fields: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestUpdateProfileContactFields(t *testing.T) {
 	}
 
 	// Clear both fields.
-	err = db.UpdateProfileContactFields(ctx, tx, uid, nil, nil)
+	err = db.UpdateProfileFields(ctx, tx, uid, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("clear contact fields: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestProfileEmailFormatConstraint(t *testing.T) {
 
 	ctx := context.Background()
 	badEmail := "not-an-email"
-	err := db.UpdateProfileContactFields(ctx, tx, uid, &badEmail, nil)
+	err := db.UpdateProfileFields(ctx, tx, uid, &badEmail, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid email format, got nil")
 	}
@@ -156,8 +156,53 @@ func TestProfilePhoneE164Constraint(t *testing.T) {
 
 	ctx := context.Background()
 	badPhone := "555-1234"
-	err := db.UpdateProfileContactFields(ctx, tx, uid, nil, &badPhone)
+	err := db.UpdateProfileFields(ctx, tx, uid, nil, &badPhone, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid phone format, got nil")
+	}
+}
+
+func TestUpdateProfileFields_MarketingOptIn(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+
+	// Default should be false.
+	profile, err := db.GetProfileByUserID(ctx, tx, uid)
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile.MarketingOptIn {
+		t.Error("expected marketing_opt_in to default to false")
+	}
+
+	// Set to true.
+	optIn := true
+	err = db.UpdateProfileFields(ctx, tx, uid, nil, nil, &optIn)
+	if err != nil {
+		t.Fatalf("update marketing opt-in: %v", err)
+	}
+	profile, err = db.GetProfileByUserID(ctx, tx, uid)
+	if err != nil {
+		t.Fatalf("re-fetch: %v", err)
+	}
+	if !profile.MarketingOptIn {
+		t.Error("expected marketing_opt_in to be true")
+	}
+
+	// Nil should leave it unchanged.
+	err = db.UpdateProfileFields(ctx, tx, uid, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("update with nil: %v", err)
+	}
+	profile, err = db.GetProfileByUserID(ctx, tx, uid)
+	if err != nil {
+		t.Fatalf("re-fetch after nil: %v", err)
+	}
+	if !profile.MarketingOptIn {
+		t.Error("expected marketing_opt_in to remain true when nil passed")
 	}
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -19,7 +19,7 @@ vi.mock("sonner");
 // When authenticated, simulate a profile existing (no onboarding needed).
 vi.mock("../hooks/useProfile", () => ({
   useProfile: () => ({
-    profile: { id: "user-123", username: "testuser", created_at: "2024-01-01" },
+    profile: { id: "user-123", username: "testuser", marketing_opt_in: false, created_at: "2024-01-01" },
     needsOnboarding: false,
     isLoading: false,
   }),

--- a/frontend/src/auth/OnboardingPage.tsx
+++ b/frontend/src/auth/OnboardingPage.tsx
@@ -16,6 +16,7 @@ export default function OnboardingPage() {
   const queryClient = useQueryClient();
   const [username, setUsername] = useState("");
   const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -27,7 +28,7 @@ export default function OnboardingPage() {
     try {
       const { error: apiError } = await client.POST("/v1/onboarding", {
         headers: { Authorization: `Bearer ${session?.access_token}` },
-        body: { username: username.trim() },
+        body: { username: username.trim(), marketing_opt_in: marketingOptIn },
       });
 
       if (apiError) {
@@ -101,6 +102,20 @@ export default function OnboardingPage() {
               </Link>
             </div>
           </div>
+        </div>
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="marketing-opt-in"
+            checked={marketingOptIn}
+            onCheckedChange={(checked) => setMarketingOptIn(checked === true)}
+          />
+          <Label
+            htmlFor="marketing-opt-in"
+            className="text-sm font-normal leading-snug text-muted-foreground"
+          >
+            Keep me in the loop — Get occasional emails about new features,
+            platform updates, and tips to get more out of Permission Slip.
+          </Label>
         </div>
         <FormError error={error} prefix />
         <div className="flex gap-2">

--- a/frontend/src/auth/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/auth/__tests__/OnboardingPage.test.tsx
@@ -27,9 +27,16 @@ describe("OnboardingPage", () => {
   it("renders the terms of service agreement checkbox", async () => {
     renderWithProviders(<OnboardingPage />);
     await waitFor(() => {
-      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      expect(screen.getAllByRole("checkbox")).toHaveLength(2);
     });
     expect(screen.getByText(/I agree to the/)).toBeInTheDocument();
+  });
+
+  it("renders the marketing opt-in checkbox", async () => {
+    renderWithProviders(<OnboardingPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Keep me in the loop/)).toBeInTheDocument();
+    });
   });
 
   it("disables submit button until terms checkbox is checked", async () => {
@@ -41,7 +48,8 @@ describe("OnboardingPage", () => {
     const submitButton = screen.getByText("Create account");
     expect(submitButton).toBeDisabled();
 
-    await userEvent.click(screen.getByRole("checkbox"));
+    const tosCheckbox = screen.getByLabelText(/I agree to the/);
+    await userEvent.click(tosCheckbox);
     expect(submitButton).toBeEnabled();
   });
 
@@ -65,13 +73,13 @@ describe("OnboardingPage", () => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "alice");
-    await userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByLabelText(/I agree to the/));
     await userEvent.click(screen.getByText("Create account"));
 
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith(
         "/v1/onboarding",
-        expect.objectContaining({ body: { username: "alice" } })
+        expect.objectContaining({ body: { username: "alice", marketing_opt_in: false } })
       );
     });
   });
@@ -87,7 +95,7 @@ describe("OnboardingPage", () => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "taken");
-    await userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByLabelText(/I agree to the/));
     await userEvent.click(screen.getByText("Create account"));
 
     await waitFor(() => {

--- a/frontend/src/auth/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/auth/__tests__/OnboardingPage.test.tsx
@@ -84,6 +84,26 @@ describe("OnboardingPage", () => {
     });
   });
 
+  it("sends marketing_opt_in=true when checkbox is checked", async () => {
+    mockPost.mockResolvedValue({ data: { id: "1", username: "bob", created_at: "2024-01-01" }, error: undefined });
+    renderWithProviders(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Username")).toBeInTheDocument();
+    });
+    await userEvent.type(screen.getByLabelText("Username"), "bob");
+    await userEvent.click(screen.getByLabelText(/I agree to the/));
+    await userEvent.click(screen.getByLabelText(/Keep me in the loop/));
+    await userEvent.click(screen.getByText("Create account"));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/v1/onboarding",
+        expect.objectContaining({ body: { username: "bob", marketing_opt_in: true } })
+      );
+    });
+  });
+
   it("shows error when API returns an error", async () => {
     mockPost.mockResolvedValue({
       data: undefined,

--- a/frontend/src/components/__tests__/UserMenu.test.tsx
+++ b/frontend/src/components/__tests__/UserMenu.test.tsx
@@ -42,7 +42,7 @@ describe("UserMenu", () => {
 
   it("shows username in the nav trigger when profile is loaded", async () => {
     mockUseProfile.mockReturnValue({
-      profile: { id: "user-123", username: "janedoe", created_at: "2024-01-01T00:00:00Z" },
+      profile: { id: "user-123", username: "janedoe", marketing_opt_in: false, created_at: "2024-01-01T00:00:00Z" },
       needsOnboarding: false,
       isLoading: false,
     });
@@ -55,7 +55,7 @@ describe("UserMenu", () => {
 
   it("shows username and email when profile is loaded", async () => {
     mockUseProfile.mockReturnValue({
-      profile: { id: "user-123", username: "janedoe", created_at: "2024-01-01T00:00:00Z" },
+      profile: { id: "user-123", username: "janedoe", marketing_opt_in: false, created_at: "2024-01-01T00:00:00Z" },
       needsOnboarding: false,
       isLoading: false,
     });

--- a/frontend/src/hooks/__tests__/useProfile.test.tsx
+++ b/frontend/src/hooks/__tests__/useProfile.test.tsx
@@ -34,6 +34,7 @@ describe("useProfile", () => {
     const mockProfile = {
       id: "user-123",
       username: "janedoe",
+      marketing_opt_in: false,
       created_at: "2024-01-01T00:00:00Z",
     };
     mockGet.mockResolvedValue({

--- a/frontend/src/hooks/__tests__/useUpdateProfile.test.tsx
+++ b/frontend/src/hooks/__tests__/useUpdateProfile.test.tsx
@@ -13,6 +13,7 @@ const mockUpdatedProfile = {
   username: "alice",
   email: "new@example.com",
   phone: "+15551234567",
+  marketing_opt_in: false,
   created_at: "2026-01-01T00:00:00Z",
 };
 

--- a/frontend/src/lib/posthog-events.ts
+++ b/frontend/src/lib/posthog-events.ts
@@ -28,6 +28,9 @@ export const PostHogEvents = {
 
   // Notification settings
   NOTIFICATION_PREFERENCES_UPDATED: "notification_preferences_updated",
+
+  // Marketing preferences
+  MARKETING_OPT_IN_UPDATED: "marketing_opt_in_updated",
 } as const;
 
 export type PostHogEventName =

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -47,7 +47,8 @@ export function NotificationSection() {
   }
 
   async function handleToggleProductUpdates() {
-    const newValue = !profile?.marketing_opt_in;
+    if (!profile) return;
+    const newValue = !profile.marketing_opt_in;
     try {
       await updateProfile({ marketing_opt_in: newValue });
       trackEvent(PostHogEvents.MARKETING_OPT_IN_UPDATED, { enabled: newValue });
@@ -147,7 +148,7 @@ export function NotificationSection() {
                 <Button
                   variant={profile?.marketing_opt_in ? "default" : "outline"}
                   size="sm"
-                  disabled={isUpdatingProfile}
+                  disabled={isUpdatingProfile || !profile}
                   onClick={handleToggleProductUpdates}
                 >
                   {profile?.marketing_opt_in ? "Enabled" : "Disabled"}

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -2,6 +2,7 @@ import { Bell, Loader2, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import { useProfile } from "@/hooks/useProfile";
 import { useUpdateProfile } from "@/hooks/useUpdateProfile";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
 import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "@/hooks/useUpdateNotificationPreferences";
 import { Button } from "@/components/ui/button";
@@ -46,10 +47,12 @@ export function NotificationSection() {
   }
 
   async function handleToggleProductUpdates() {
+    const newValue = !profile?.marketing_opt_in;
     try {
-      await updateProfile({ marketing_opt_in: !profile?.marketing_opt_in });
+      await updateProfile({ marketing_opt_in: newValue });
+      trackEvent(PostHogEvents.MARKETING_OPT_IN_UPDATED, { enabled: newValue });
       toast.success(
-        `Product updates ${!profile?.marketing_opt_in ? "enabled" : "disabled"}.`,
+        `Product updates ${newValue ? "enabled" : "disabled"}.`,
       );
     } catch {
       toast.error("Failed to update product updates preference.");
@@ -150,6 +153,12 @@ export function NotificationSection() {
                   {profile?.marketing_opt_in ? "Enabled" : "Disabled"}
                 </Button>
               </div>
+              {!profile?.email && profile?.marketing_opt_in && (
+                <div className="mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+                  <AlertTriangle className="size-3.5 shrink-0" />
+                  <span>Add a contact email above to receive product update emails.</span>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -1,6 +1,7 @@
 import { Bell, Loader2, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import { useProfile } from "@/hooks/useProfile";
+import { useUpdateProfile } from "@/hooks/useUpdateProfile";
 import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "@/hooks/useUpdateNotificationPreferences";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,7 @@ const CHANNEL_LABELS: Record<string, { name: string; description: string }> = {
 
 export function NotificationSection() {
   const { profile } = useProfile();
+  const { updateProfile, isLoading: isUpdatingProfile } = useUpdateProfile();
   const { preferences, isLoading, error } = useNotificationPreferences();
   const { updatePreferences, isLoading: isUpdating } =
     useUpdateNotificationPreferences();
@@ -41,6 +43,17 @@ export function NotificationSection() {
   }
   if (!profile?.phone) {
     missingContact["sms"] = "Add a phone number above to receive SMS notifications.";
+  }
+
+  async function handleToggleProductUpdates() {
+    try {
+      await updateProfile({ marketing_opt_in: !profile?.marketing_opt_in });
+      toast.success(
+        `Product updates ${!profile?.marketing_opt_in ? "enabled" : "disabled"}.`,
+      );
+    } catch {
+      toast.error("Failed to update product updates preference.");
+    }
   }
 
   async function handleToggle(channel: string, currentEnabled: boolean) {
@@ -116,6 +129,28 @@ export function NotificationSection() {
                 </div>
               );
             })}
+
+            <hr className="border-border" />
+
+            <div className="rounded-lg border p-4">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">Product updates</p>
+                  <p className="text-xs text-muted-foreground">
+                    Occasional emails about new features, platform improvements,
+                    and tips.
+                  </p>
+                </div>
+                <Button
+                  variant={profile?.marketing_opt_in ? "default" : "outline"}
+                  size="sm"
+                  disabled={isUpdatingProfile}
+                  onClick={handleToggleProductUpdates}
+                >
+                  {profile?.marketing_opt_in ? "Enabled" : "Disabled"}
+                </Button>
+              </div>
+            </div>
           </div>
         )}
       </CardContent>

--- a/frontend/src/pages/settings/__tests__/AccountSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/AccountSection.test.tsx
@@ -18,6 +18,7 @@ const mockProfile = {
   username: "alice",
   email: "alice@example.com",
   phone: "+15551234567",
+  marketing_opt_in: false,
   created_at: "2026-01-01T00:00:00Z",
 };
 

--- a/frontend/src/pages/settings/__tests__/AddCredentialDialog.test.tsx
+++ b/frontend/src/pages/settings/__tests__/AddCredentialDialog.test.tsx
@@ -21,6 +21,7 @@ function mockApiFetch() {
         data: {
           id: "user-123",
           username: "alice",
+          marketing_opt_in: false,
           created_at: "2026-01-01T00:00:00Z",
         },
         response: { status: 200 },

--- a/frontend/src/pages/settings/__tests__/CredentialSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/CredentialSection.test.tsx
@@ -21,6 +21,7 @@ function mockApiFetch(credentials: unknown[] = []) {
         data: {
           id: "user-123",
           username: "alice",
+          marketing_opt_in: false,
           created_at: "2026-01-01T00:00:00Z",
         },
         response: { status: 200 },

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -5,6 +5,7 @@ import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
 import { createAuthWrapper } from "../../../test-helpers";
 import {
   mockGet,
+  mockPatch,
   mockPut,
   resetClientMocks,
 } from "../../../api/__mocks__/client";
@@ -227,6 +228,64 @@ describe("NotificationSection", () => {
           },
         }),
       );
+    });
+  });
+
+  it("renders the product updates section", async () => {
+    mockApiFetch();
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Product updates")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Occasional emails about new features/),
+    ).toBeInTheDocument();
+  });
+
+  it("calls updateProfile when product updates toggle is clicked", async () => {
+    mockApiFetch();
+    mockPatch.mockResolvedValue({
+      data: { ...profileWithContact, marketing_opt_in: true },
+    });
+    const user = userEvent.setup();
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Product updates")).toBeInTheDocument();
+    });
+
+    // The product updates button is the last "Disabled" button
+    const disabledButtons = screen.getAllByRole("button").filter(
+      (b) => b.textContent === "Disabled",
+    );
+    const productUpdatesBtn = disabledButtons[disabledButtons.length - 1]!;
+    await user.click(productUpdatesBtn);
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith(
+        "/v1/profile",
+        expect.objectContaining({
+          body: { marketing_opt_in: true },
+        }),
+      );
+    });
+  });
+
+  it("shows warning when product updates enabled but email is missing", async () => {
+    const profileOptedIn = { ...profileNoContact, marketing_opt_in: true };
+    mockApiFetch(profileOptedIn, allEnabled);
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Add a contact email above to receive product update emails.",
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -24,6 +24,7 @@ interface MockProfile {
   username: string;
   email?: string | null;
   phone?: string | null;
+  marketing_opt_in: boolean;
   created_at: string;
 }
 
@@ -32,12 +33,14 @@ const profileWithContact: MockProfile = {
   username: "alice",
   email: "alice@example.com",
   phone: "+15551234567",
+  marketing_opt_in: false,
   created_at: "2026-01-01T00:00:00Z",
 };
 
 const profileNoContact: MockProfile = {
   id: "user-123",
   username: "alice",
+  marketing_opt_in: false,
   created_at: "2026-01-01T00:00:00Z",
 };
 
@@ -119,8 +122,9 @@ describe("NotificationSection", () => {
       const disabledButtons = buttons.filter(
         (b) => b.textContent === "Disabled",
       );
+      // 2 channel enabled (email, sms) + 2 disabled (web-push, product updates)
       expect(enabledButtons).toHaveLength(2);
-      expect(disabledButtons).toHaveLength(1);
+      expect(disabledButtons).toHaveLength(2);
     });
   });
 

--- a/frontend/src/pages/settings/__tests__/SecuritySection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SecuritySection.test.tsx
@@ -21,6 +21,7 @@ function mockApiFetch() {
         data: {
           id: "user-123",
           username: "alice",
+          marketing_opt_in: false,
           created_at: "2026-01-01T00:00:00Z",
         },
         response: { status: 200 },

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -13,6 +13,7 @@ const mockProfile = {
   username: "alice",
   email: "alice@example.com",
   phone: "+15551234567",
+  marketing_opt_in: false,
   created_at: "2026-01-01T00:00:00Z",
 };
 

--- a/spec/openapi/components/schemas/onboarding.yaml
+++ b/spec/openapi/components/schemas/onboarding.yaml
@@ -14,6 +14,11 @@ OnboardingRequest:
       maxLength: 32
       pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,31}$"
       example: "alice"
+    marketing_opt_in:
+      type: boolean
+      description: Whether the user opts in to product update emails. Defaults to false.
+      default: false
+      example: false
 
 OnboardingResponse:
   type: object

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -4,6 +4,7 @@ ProfileResponse:
   required:
     - id
     - username
+    - marketing_opt_in
     - created_at
   properties:
     id:
@@ -26,6 +27,10 @@ ProfileResponse:
       nullable: true
       description: Contact phone number in E.164 format (user-provided, opt-in for SMS notifications)
       example: "+15551234567"
+    marketing_opt_in:
+      type: boolean
+      description: Whether the user has opted in to product update emails.
+      example: false
     created_at:
       type: string
       format: date-time
@@ -34,7 +39,7 @@ ProfileResponse:
 
 UpdateProfileRequest:
   type: object
-  description: Request body for updating profile contact fields.
+  description: Request body for updating profile fields.
   properties:
     email:
       type: string
@@ -46,6 +51,10 @@ UpdateProfileRequest:
       nullable: true
       description: Contact phone number in E.164 format. Pass null or empty string to clear.
       example: "+15551234567"
+    marketing_opt_in:
+      type: boolean
+      description: Whether the user opts in to product update emails.
+      example: true
 
 NotificationPreference:
   type: object

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -53,7 +53,10 @@ UpdateProfileRequest:
       example: "+15551234567"
     marketing_opt_in:
       type: boolean
-      description: Whether the user opts in to product update emails.
+      description: >
+        Whether the user opts in to product update emails.
+        Omit the field to leave the current value unchanged;
+        unlike email/phone this field cannot be null.
       example: true
 
 NotificationPreference:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7864,7 +7864,8 @@ components:
           example: '+15551234567'
         marketing_opt_in:
           type: boolean
-          description: Whether the user opts in to product update emails.
+          description: |
+            Whether the user opts in to product update emails. Omit the field to leave the current value unchanged; unlike email/phone this field cannot be null.
           example: true
     NotificationPreference:
       type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7783,6 +7783,11 @@ components:
           maxLength: 32
           pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,31}$
           example: alice
+        marketing_opt_in:
+          type: boolean
+          description: Whether the user opts in to product update emails. Defaults to false.
+          default: false
+          example: false
     OnboardingResponse:
       type: object
       description: The newly created (or existing) user profile.
@@ -7811,6 +7816,7 @@ components:
       required:
         - id
         - username
+        - marketing_opt_in
         - created_at
       properties:
         id:
@@ -7833,6 +7839,10 @@ components:
           nullable: true
           description: Contact phone number in E.164 format (user-provided, opt-in for SMS notifications)
           example: '+15551234567'
+        marketing_opt_in:
+          type: boolean
+          description: Whether the user has opted in to product update emails.
+          example: false
         created_at:
           type: string
           format: date-time
@@ -7840,7 +7850,7 @@ components:
           example: '2026-02-16T00:27:36Z'
     UpdateProfileRequest:
       type: object
-      description: Request body for updating profile contact fields.
+      description: Request body for updating profile fields.
       properties:
         email:
           type: string
@@ -7852,6 +7862,10 @@ components:
           nullable: true
           description: Contact phone number in E.164 format. Pass null or empty string to clear.
           example: '+15551234567'
+        marketing_opt_in:
+          type: boolean
+          description: Whether the user opts in to product update emails.
+          example: true
     NotificationPreference:
       type: object
       description: A single notification channel preference.


### PR DESCRIPTION
Add an optional, unchecked-by-default "Keep me in the loop" checkbox
during username creation (below Terms of Service), and a "Product
updates" toggle in the notification preferences section of settings.

Full-stack implementation:
- DB migration adds marketing_opt_in boolean column (default false)
- Backend accepts marketing_opt_in in POST /v1/onboarding
- Backend returns/accepts it in GET/PATCH /v1/profile
- OpenAPI spec updated with new field on all relevant schemas
- Frontend OnboardingPage renders opt-in checkbox
- Frontend NotificationSection renders product updates toggle
- All tests updated, new tests added for the new field

https://claude.ai/code/session_01VkhhaTRnmcddcfMSw5tNAg