### PR TITLE
Add webhook notification for idle sessions, make pr_url optional

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -3,8 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       pr_url:
-        description: "PR URL"
-        required: true
+        description: "PR URL (optional — omitted for non-PR notifications)"
+        required: false
+        default: ""
 
 jobs:
   notify:
@@ -25,8 +26,11 @@ jobs:
             exit 1
           fi
 
-          PAYLOAD=$(jq -n --arg pr_url "$PR_URL" \
-            '{pr_url: $pr_url}')
+          if [ -n "$PR_URL" ]; then
+            PAYLOAD=$(jq -n --arg pr_url "$PR_URL" '{pr_url: $pr_url}')
+          else
+            PAYLOAD='{}'
+          fi
 
           RESPONSE=$(echo "$PAYLOAD" | curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Authorization: Bearer $WEBHOOK_TOKEN" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,16 @@
 - If a file is getting large enough that splitting it would improve maintainability, just go ahead and split it — don't ask first.
 - When you need to ask questions, just ask them in regular chat text. Do NOT use the AskUserQuestion tool — it doesn't work reliably.
 
+## Webhook Notification
+
+Whenever you finish a task or need user input and the user hasn't responded within 5 minutes, trigger the webhook to notify them. This uses the same workflow as the `/watch` command but without a PR URL:
+
+```bash
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run trigger-webhook.yml
+```
+
+Do not include `-f pr_url=...` — this is a general "attention needed" ping, not a PR-specific notification.
+
 ## Post-Task Review (before marking complete)
 
 Before presenting work as done, always perform these review passes:


### PR DESCRIPTION
- Add "Webhook Notification" section to CLAUDE.md instructing Claude to
  trigger the webhook when done with a task or waiting for user input
  after 5 minutes of no response (without a PR URL).
- Update trigger-webhook.yml to make pr_url optional (required: false,
  default: "") and conditionally include it in the payload so the
  workflow works for both PR-specific and general notifications.

https://claude.ai/code/session_01KPj7GJGyW76eY1yPMye4Yh