### PR TITLE
add test to catch duplicate migration timestamps and CLAUDE.md instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,18 @@ Database tests require a running Postgres instance. They use `DATABASE_URL_TEST`
 - **Changed migrations or db/ code:** run `go test ./db/... -v` at minimum
 - **Not sure:** run `make test`
 
+## Creating Migrations
+
+**ALWAYS use `make migrate-create` to create new migration files.** Never manually create migration files or invent timestamps — this has caused duplicate timestamp collisions that break goose.
+
+```bash
+make migrate-create NAME=add_users_table
+```
+
+This generates a real timestamp from `date +%Y%m%d%H%M%S` and creates the file with the correct goose boilerplate. If you need multiple migrations, run the command once for each — the second-level precision ensures unique timestamps when run sequentially.
+
+A test (`TestMigrationTimestampsUnique` in `db/migrations_integrity_test.go`) validates that all migration timestamps are unique and in sorted order. This runs as part of `make test-backend` and will catch duplicates before CI.
+
 ## Database Seed Data
 
 Whenever you make changes to database schema, tables, or migrations, review the seed file and update it to reflect the new schema. Add seed data for any new tables or columns so the seed remains comprehensive and stable. The seed should always be runnable against the current schema without errors.

--- a/db/migrations_integrity_test.go
+++ b/db/migrations_integrity_test.go
@@ -1,0 +1,120 @@
+package db_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestMigrationTimestampsUnique ensures no two migration files share the same
+// timestamp prefix. Goose uses the numeric prefix for ordering; duplicates
+// cause non-deterministic application order and potential failures.
+func TestMigrationTimestampsUnique(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read migrations directory: %v", err)
+	}
+
+	seen := make(map[string]string) // timestamp -> filename
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+
+		ts := extractTimestamp(name)
+		if ts == "" {
+			t.Errorf("migration file %q has no numeric timestamp prefix", name)
+			continue
+		}
+
+		if prev, ok := seen[ts]; ok {
+			t.Errorf("duplicate migration timestamp %s:\n  %s\n  %s", ts, prev, name)
+		}
+		seen[ts] = name
+	}
+}
+
+// TestMigrationTimestampsSorted ensures migration files are in strictly
+// ascending order by their timestamp prefix. Out-of-order migrations can
+// cause goose to skip files or apply them in the wrong sequence.
+func TestMigrationTimestampsSorted(t *testing.T) {
+	t.Parallel()
+
+	dir := migrationsDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read migrations directory: %v", err)
+	}
+
+	var timestamps []struct {
+		ts   string
+		name string
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		ts := extractTimestamp(name)
+		if ts == "" {
+			continue
+		}
+		timestamps = append(timestamps, struct {
+			ts   string
+			name string
+		}{ts, name})
+	}
+
+	sorted := sort.SliceIsSorted(timestamps, func(i, j int) bool {
+		return timestamps[i].ts < timestamps[j].ts
+	})
+	if !sorted {
+		for i := 1; i < len(timestamps); i++ {
+			if timestamps[i].ts < timestamps[i-1].ts {
+				t.Errorf("migration out of order: %s (after %s)",
+					timestamps[i].name, timestamps[i-1].name)
+			}
+		}
+	}
+}
+
+// extractTimestamp returns the leading numeric prefix of a migration filename.
+// For "20260216002736_profiles.sql" it returns "20260216002736".
+// Returns "" if the filename doesn't start with digits.
+func extractTimestamp(filename string) string {
+	idx := strings.IndexByte(filename, '_')
+	if idx <= 0 {
+		return ""
+	}
+	prefix := filename[:idx]
+	for _, c := range prefix {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+	return prefix
+}
+
+// migrationsDir returns the absolute path to the db/migrations directory,
+// relative to this test file's location.
+func migrationsDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to determine test file path")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "migrations")
+}


### PR DESCRIPTION
Duplicate migration timestamps have broken goose multiple times (see aa5d252,
64ee179). Two changes to prevent recurrence:

1. New Go test (TestMigrationTimestampsUnique, TestMigrationTimestampsSorted)
   that validates all migration files have unique timestamps in sorted order.
   Runs without Postgres as part of `make test-backend`.

2. CLAUDE.md now instructs to always use `make migrate-create` instead of
   manually creating migration files with invented timestamps.

https://claude.ai/code/session_01CBsLRn77aEysB1tgdgmKau