### PR TITLE
Add billing endpoints to OpenAPI spec and generate types

### DIFF
--- a/spec/openapi/README.md
+++ b/spec/openapi/README.md
@@ -21,38 +21,66 @@ spec/openapi/
     │   ├── registration.yaml    # Agent registration schemas
     │   ├── approvals.yaml       # Approval request/response schemas
     │   ├── actions.yaml         # Action execution schemas
-    │   ├── credentials.yaml     # Credential vault schemas
-    │   ├── connectors.yaml      # Connector/integration schemas
+    │   ├── action_config_templates.yaml # Action config template schemas
+    │   ├── action_configurations.yaml   # Action configuration schemas
+    │   ├── agents.yaml          # Agent management schemas
+    │   ├── agent_connectors.yaml # Agent-connector relationship schemas
+    │   ├── audit_events.yaml    # Audit event and log schemas
+    │   ├── billing.yaml         # Billing, plan, subscription, usage, invoice schemas
     │   ├── capabilities.yaml    # Agent capability discovery schemas
+    │   ├── config.yaml          # Server configuration schemas
+    │   ├── connectors.yaml      # Connector/integration schemas
+    │   ├── credentials.yaml     # Credential vault schemas
+    │   ├── onboarding.yaml      # Onboarding workflow schemas
+    │   ├── profiles.yaml        # User profile schemas
+    │   ├── push_subscriptions.yaml # Web Push subscription schemas
+    │   ├── registration_invites.yaml # Registration invite schemas
+    │   ├── standing_approvals.yaml   # Standing approval schemas
     │   ├── shared.yaml          # Shared schemas (Action, Token, etc.)
     │   └── errors.yaml          # Error response schemas
     ├── paths/                   # API endpoints
-    │   ├── connectors.yaml      # GET /v1/connectors, GET /v1/connectors/{id}
-    │   ├── registration.yaml    # Agent registration endpoints
-    │   ├── approvals.yaml       # Approval lifecycle endpoints
     │   ├── actions.yaml         # POST /v1/actions/execute
-    │   ├── credentials.yaml     # Credential vault endpoints
+    │   ├── action_config_templates.yaml # Action config template discovery
+    │   ├── action_configurations.yaml   # Action configuration CRUD
+    │   ├── agents.yaml          # Agent management endpoints
+    │   ├── agent_connectors.yaml # Agent-connector management
+    │   ├── approvals.yaml       # Approval lifecycle endpoints
+    │   ├── audit_events.yaml    # Audit event listing and export
+    │   ├── billing.yaml         # Billing plan, usage, upgrade, downgrade, invoices
     │   ├── capabilities.yaml    # GET /v1/agents/{id}/capabilities
-    │   └── standing_approvals.yaml # Standing approval discovery
+    │   ├── config.yaml          # Server configuration
+    │   ├── connectors.yaml      # GET /v1/connectors, GET /v1/connectors/{id}
+    │   ├── credentials.yaml     # Credential vault endpoints
+    │   ├── onboarding.yaml      # Onboarding workflow
+    │   ├── profiles.yaml        # User profile management
+    │   ├── push_subscriptions.yaml # Web Push subscription management
+    │   ├── registration.yaml    # Agent registration endpoints
+    │   ├── registration_invites.yaml # Registration invite creation
+    │   └── standing_approvals.yaml   # Standing approval management
     ├── parameters/              # Reusable parameters
     │   └── common.yaml          # Path parameters (agent_id, approval_id, etc.)
     ├── responses/               # Reusable responses
     │   └── errors.yaml          # Standard error responses
     └── securitySchemes/         # Authentication schemes
-        └── security.yaml        # Signature-based and JWT auth
+        └── security.yaml        # Supabase session JWT and agent signature auth
 ```
 
 ## API Endpoint Groups
 
-| Group | Endpoints | Description |
-|---|---|---|
-| **Connectors** | `GET /v1/connectors`, `GET /v1/connectors/{id}` | Discover available integrations and actions |
-| **Registration** | `POST /invite/{invite_code}`, `POST /v1/agents/{id}/verify` | Agent identity setup via invite URL |
-| **Approvals** | `POST /v1/approvals/request`, `POST .../verify`, `POST .../cancel` | Approval lifecycle |
-| **Actions** | `POST /v1/actions/execute` | Execute approved actions |
-| **Credentials** | `POST /v1/credentials`, `GET /v1/credentials`, `DELETE /v1/credentials/{id}` | Manage stored API credentials |
-| **Capabilities** | `GET /v1/agents/{id}/capabilities` | Agent capability discovery (connectors, actions, schemas, authorization) |
-| **Standing Approvals** | `GET /v1/agents/{id}/standing-approvals` | Discover active standing approvals |
+| Group | Endpoints | Auth | Description |
+|---|---|---|---|
+| **Connectors** | `GET /v1/connectors`, `GET /v1/connectors/{id}` | Public | Discover available integrations and actions |
+| **Registration** | `POST /invite/{code}`, `POST /v1/agents/{id}/verify` | Signature | Agent identity setup via invite URL |
+| **Agents** | `GET/PUT/DELETE /v1/agents/{id}`, `POST .../deactivate` | Session | Agent management |
+| **Approvals** | `POST /v1/approvals/request`, `POST .../verify`, `POST .../cancel` | Signature/Session | Approval lifecycle |
+| **Actions** | `POST /v1/actions/execute` | Signature/Token | Execute approved actions |
+| **Credentials** | `POST/GET /v1/credentials`, `DELETE .../credentials/{id}` | Session | Manage stored API credentials |
+| **Capabilities** | `GET /v1/agents/{id}/capabilities` | Signature | Agent capability discovery |
+| **Standing Approvals** | `GET/POST /v1/standing-approvals`, `POST .../revoke`, `POST .../execute` | Session/Signature | Pre-authorized agent actions |
+| **Audit Events** | `GET /v1/audit-events`, `GET /v1/audit-logs` | Session | Activity feed and audit trail |
+| **Billing** | `GET /v1/billing/plan`, `GET .../usage`, `POST .../upgrade`, `POST .../downgrade`, `GET .../invoices` | Session | Subscription, usage, and invoices |
+| **Profiles** | `GET/PUT /v1/profile`, `GET/PUT .../notification-preferences` | Session | User profile management |
+| **Config** | `GET /v1/config` | Session | Server configuration and feature flags |
 
 ## Usage
 

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -119,11 +119,45 @@ webhook:
     operationId: stripeWebhook
     tags:
       - Billing
+    parameters:
+      - name: Stripe-Signature
+        in: header
+        required: true
+        description: |
+          Stripe webhook signature header. Contains the timestamp and signature(s)
+          used to verify that the request originated from Stripe. The server verifies
+          this against `STRIPE_WEBHOOK_SECRET` before processing any event.
+        schema:
+          type: string
+        example: 't=1614556236,v1=abc123...'
+    requestBody:
+      required: true
+      description: |
+        Raw Stripe webhook event payload. **Must be passed as raw bytes** (not parsed JSON)
+        to the signature verification step — parsing before verification would invalidate
+        the signature check.
+      content:
+        application/json:
+          schema:
+            type: object
+            description: Stripe Event object (structure varies by event type)
+            properties:
+              id:
+                type: string
+                description: Unique event identifier (used for idempotency)
+              type:
+                type: string
+                description: Event type (e.g., checkout.session.completed)
+            required:
+              - id
+              - type
     responses:
       '200':
-        description: Webhook processed successfully
+        description: Webhook processed successfully (always returned to prevent Stripe retries)
       '400':
         description: Invalid signature or malformed event
+      '500':
+        description: Processing failed — Stripe will retry the event
 
 # ── New endpoints for issue #22 ──────────────────────────────────────────────
 

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -116,3 +116,235 @@ webhook:
         description: Webhook processed successfully
       '400':
         description: Invalid signature or malformed event
+
+# ── New endpoints for issue #22 ──────────────────────────────────────────────
+
+plan:
+  get:
+    summary: Get billing plan details
+    description: |
+      Returns the authenticated user's current plan details, subscription status,
+      and a summary of current resource usage (request counts, agent count, etc.).
+
+      This is the primary billing endpoint for the frontend — it provides everything
+      needed to render the billing section of the settings page in a single request.
+
+      Only available when `billing_enabled` is `true` in the server config.
+    operationId: getBillingPlan
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Billing plan details returned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/BillingPlanResponse'
+            example:
+              plan:
+                id: free
+                name: Free
+                max_requests_per_month: 1000
+                max_agents: 3
+                max_standing_approvals: 5
+                max_credentials: 5
+                audit_retention_days: 7
+              subscription:
+                status: active
+                current_period_start: '2026-03-01T00:00:00Z'
+                current_period_end: '2026-04-01T00:00:00Z'
+              usage:
+                requests: 42
+                agents: 2
+                standing_approvals: 3
+                credentials: 1
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        description: No subscription found for this user
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+usage:
+  get:
+    summary: Get detailed usage breakdown
+    description: |
+      Returns detailed usage metrics for the current billing period, including
+      request totals, overage calculations, SMS counts, costs, and an optional
+      breakdown by agent, connector, and action type.
+
+      Only available when `billing_enabled` is `true` in the server config.
+    operationId: getBillingUsage
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Usage details returned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/UsageDetail'
+            example:
+              period_start: '2026-03-01T00:00:00Z'
+              period_end: '2026-04-01T00:00:00Z'
+              requests:
+                total: 1542
+                included: 1000
+                overage: 542
+                cost_cents: 271
+              sms:
+                total: 5
+                cost_cents: 5
+              breakdown:
+                by_agent:
+                  '1': 500
+                  '2': 1042
+                by_connector:
+                  gmail: 300
+                  stripe: 1242
+                by_action_type:
+                  email.send: 300
+                  payment.create: 1242
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        description: No usage data found for this period
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+upgrade:
+  post:
+    summary: Initiate plan upgrade
+    description: |
+      Initiates an upgrade from the free plan to pay-as-you-go by creating a
+      Stripe Checkout Session. Returns a URL to redirect the user to Stripe's
+      hosted checkout page to complete the upgrade.
+
+      If the user doesn't have a Stripe Customer yet, one is created automatically.
+      If the user is already on a paid plan, returns 409 Conflict.
+
+      Only available when `billing_enabled` is `true` and Stripe is configured.
+    operationId: upgradePlan
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Checkout session created for upgrade
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/UpgradeResponse'
+            example:
+              checkout_url: https://checkout.stripe.com/c/pay/cs_test_...
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '409':
+        description: Already subscribed to a paid plan
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '502':
+        description: Stripe API error
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+downgrade:
+  post:
+    summary: Downgrade to free plan
+    description: |
+      Downgrades the user from the pay-as-you-go plan to the free plan.
+      Cancels the Stripe subscription and sets a 7-day grace period during
+      which the user retains the longer audit retention window to export data.
+
+      If the user is already on the free plan, returns 409 Conflict.
+
+      Only available when `billing_enabled` is `true`.
+    operationId: downgradePlan
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Successfully downgraded to free plan
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/DowngradeResponse'
+            example:
+              status: cancelled
+              plan_id: free
+              downgraded_at: '2026-03-02T12:00:00Z'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '409':
+        description: Already on the free plan
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '502':
+        description: Stripe API error (failed to cancel subscription)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+invoices:
+  get:
+    summary: List invoices
+    description: |
+      Returns a list of the authenticated user's past invoices from Stripe,
+      including the amount, status, and a link to view the invoice.
+
+      Only available when `billing_enabled` is `true` and the user has a
+      Stripe customer ID (i.e., has previously been on a paid plan).
+    operationId: listInvoices
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Invoices returned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/InvoiceListResponse'
+            example:
+              invoices:
+                - id: inv_1234567890
+                  date: '2026-02-01T00:00:00Z'
+                  amount_cents: 271
+                  status: paid
+                  stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_1234567890
+                - id: inv_0987654321
+                  date: '2026-01-01T00:00:00Z'
+                  amount_cents: 0
+                  status: paid
+                  stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_0987654321
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -1,9 +1,13 @@
 subscription:
   get:
     summary: Get current subscription
+    deprecated: true
     description: |
       Returns the authenticated user's subscription details including plan info,
       billing period, and current usage metrics.
+
+      **Deprecated:** Use `GET /v1/billing/plan` instead, which returns structured
+      plan, subscription, and usage data in a single response.
 
       Only available when `billing_enabled` is `true` in the server config.
     operationId: getSubscription
@@ -45,10 +49,14 @@ subscription:
 checkout:
   post:
     summary: Create checkout session
+    deprecated: true
     description: |
       Creates a Stripe Checkout Session for upgrading from the free plan to
       pay-as-you-go. Returns a URL to redirect the user to Stripe's hosted
       checkout page.
+
+      **Deprecated:** Use `POST /v1/billing/upgrade` instead, which has the
+      same behavior but a clearer name and response schema.
 
       If the user doesn't have a Stripe Customer yet, one is created automatically.
       If the user is already on a paid plan, returns 409 Conflict.
@@ -155,6 +163,10 @@ plan:
                 status: active
                 current_period_start: '2026-03-01T00:00:00Z'
                 current_period_end: '2026-04-01T00:00:00Z'
+                has_payment_method: false
+                can_upgrade: true
+                can_downgrade: false
+                grace_period_ends_at: null
               usage:
                 requests: 42
                 agents: 2
@@ -175,9 +187,12 @@ usage:
   get:
     summary: Get detailed usage breakdown
     description: |
-      Returns detailed usage metrics for the current billing period, including
-      request totals, overage calculations, SMS counts, costs, and an optional
-      breakdown by agent, connector, and action type.
+      Returns detailed usage metrics for a billing period, including request
+      totals, overage calculations, SMS counts, costs, and an optional breakdown
+      by agent, connector, and action type.
+
+      Defaults to the current billing period. Pass `period_start` to view a
+      historical period (e.g., last month's usage).
 
       Only available when `billing_enabled` is `true` in the server config.
     operationId: getBillingUsage
@@ -185,6 +200,18 @@ usage:
       - Billing
     security:
       - SupabaseSession: []
+    parameters:
+      - name: period_start
+        in: query
+        required: false
+        description: |
+          Start of the billing period to query, as an ISO 8601 date-time.
+          Must be the first day of a month in UTC (e.g., `2026-02-01T00:00:00Z`).
+          Defaults to the current billing period if omitted.
+        schema:
+          type: string
+          format: date-time
+        example: '2026-02-01T00:00:00Z'
     responses:
       '200':
         description: Usage details returned
@@ -294,6 +321,7 @@ downgrade:
               status: cancelled
               plan_id: free
               downgraded_at: '2026-03-02T12:00:00Z'
+              grace_period_ends_at: '2026-03-09T12:00:00Z'
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
       '409':
@@ -315,8 +343,11 @@ invoices:
   get:
     summary: List invoices
     description: |
-      Returns a list of the authenticated user's past invoices from Stripe,
-      including the amount, status, and a link to view the invoice.
+      Returns a paginated list of the authenticated user's past invoices from
+      Stripe, including the amount, status, and a link to view the invoice.
+
+      Results are ordered by date descending (most recent first). Use
+      `starting_after` for cursor-based pagination.
 
       Only available when `billing_enabled` is `true` and the user has a
       Stripe customer ID (i.e., has previously been on a paid plan).
@@ -325,6 +356,25 @@ invoices:
       - Billing
     security:
       - SupabaseSession: []
+    parameters:
+      - name: limit
+        in: query
+        required: false
+        description: Maximum number of invoices to return (1–100). Defaults to 10.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+      - name: starting_after
+        in: query
+        required: false
+        description: |
+          Cursor for pagination. Pass the `id` of the last invoice from the
+          previous page to fetch the next page of results.
+        schema:
+          type: string
+        example: inv_1234567890
     responses:
       '200':
         description: Invoices returned
@@ -336,14 +386,19 @@ invoices:
               invoices:
                 - id: inv_1234567890
                   date: '2026-02-01T00:00:00Z'
+                  period_start: '2026-02-01T00:00:00Z'
+                  period_end: '2026-03-01T00:00:00Z'
                   amount_cents: 271
                   status: paid
                   stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_1234567890
                 - id: inv_0987654321
                   date: '2026-01-01T00:00:00Z'
+                  period_start: '2026-01-01T00:00:00Z'
+                  period_end: '2026-02-01T00:00:00Z'
                   amount_cents: 0
                   status: paid
                   stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_0987654321
+              has_more: false
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
       '503':

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -119,6 +119,7 @@ webhook:
     operationId: stripeWebhook
     tags:
       - Billing
+    security: []  # No auth — Stripe signature verification via Stripe-Signature header
     parameters:
       - name: Stripe-Signature
         in: header
@@ -158,8 +159,6 @@ webhook:
         description: Invalid signature or malformed event
       '500':
         description: Processing failed — Stripe will retry the event
-
-# ── New endpoints for issue #22 ──────────────────────────────────────────────
 
 plan:
   get:

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -162,11 +162,18 @@ Subscription:
     - status
     - current_period_start
     - current_period_end
+    - has_payment_method
+    - can_upgrade
+    - can_downgrade
   properties:
     status:
       type: string
       enum: [active, past_due, cancelled]
-      description: Current subscription status
+      description: |
+        Current subscription status.
+        - `active`: Subscription is in good standing.
+        - `past_due`: Payment failed — prompt the user to update their payment method.
+        - `cancelled`: Subscription was cancelled (user was downgraded to free).
       example: active
     current_period_start:
       type: string
@@ -178,6 +185,27 @@ Subscription:
       format: date-time
       description: End of the current billing period (exclusive)
       example: '2026-04-01T00:00:00Z'
+    has_payment_method:
+      type: boolean
+      description: Whether the user has a Stripe payment method on file. Use this to decide whether to show "Add payment method" prompts.
+      example: false
+    can_upgrade:
+      type: boolean
+      description: Whether the user can upgrade (true when on the free plan). Use this to show/hide the upgrade button.
+      example: true
+    can_downgrade:
+      type: boolean
+      description: Whether the user can downgrade (true when on a paid plan). Use this to show/hide the downgrade button.
+      example: false
+    grace_period_ends_at:
+      type: string
+      format: date-time
+      nullable: true
+      description: |
+        When the downgrade grace period expires, or null if no grace period is active.
+        During the grace period (7 days after downgrade), the user retains the longer
+        audit retention window (90 days) to export their data. After this timestamp,
+        retention drops to the free plan's window (7 days).
 
 UsageSummary:
   type: object
@@ -328,11 +356,12 @@ DowngradeResponse:
     - status
     - plan_id
     - downgraded_at
+    - grace_period_ends_at
   properties:
     status:
       type: string
       enum: [active, past_due, cancelled]
-      description: Updated subscription status
+      description: Updated subscription status (will be `cancelled` after downgrade)
       example: cancelled
     plan_id:
       type: string
@@ -342,6 +371,13 @@ DowngradeResponse:
       type: string
       format: date-time
       description: Timestamp when the downgrade was processed
+    grace_period_ends_at:
+      type: string
+      format: date-time
+      description: |
+        When the 7-day grace period expires. Until this time, the user retains
+        the 90-day audit retention window from their paid plan. Show this to the
+        user so they know how long they have to export their data.
 
 Invoice:
   type: object
@@ -358,32 +394,53 @@ Invoice:
     date:
       type: string
       format: date-time
-      description: Invoice date
+      description: Invoice creation date
       example: '2026-02-01T00:00:00Z'
+    period_start:
+      type: string
+      format: date-time
+      description: Start of the billing period this invoice covers
+      example: '2026-02-01T00:00:00Z'
+    period_end:
+      type: string
+      format: date-time
+      description: End of the billing period this invoice covers
+      example: '2026-03-01T00:00:00Z'
     amount_cents:
       type: integer
-      description: Total invoice amount in cents
+      description: Total invoice amount in cents (0 for periods within the free allowance)
       example: 271
     status:
       type: string
       enum: [draft, open, paid, void, uncollectible]
-      description: Invoice payment status
+      description: |
+        Invoice payment status.
+        - `draft`: Invoice is being prepared (not yet finalized).
+        - `open`: Invoice is finalized and awaiting payment.
+        - `paid`: Payment was collected successfully.
+        - `void`: Invoice was voided (no payment required).
+        - `uncollectible`: Payment could not be collected after all retries.
       example: paid
     stripe_invoice_url:
       type: string
       format: uri
-      description: URL to view the invoice on Stripe's hosted page
+      description: URL to view the full invoice details on Stripe's hosted page
       example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
 
 InvoiceListResponse:
   type: object
   required:
     - invoices
+    - has_more
   properties:
     invoices:
       type: array
       items:
         $ref: '#/Invoice'
+    has_more:
+      type: boolean
+      description: Whether there are more invoices beyond this page. If true, pass the last invoice's `id` as `starting_after` to fetch the next page.
+      example: false
 
 QuotaExceededError:
   type: object

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -47,6 +47,10 @@ SubscriptionResponse:
 PlanLimits:
   type: object
   required:
+    - max_requests_per_month
+    - max_agents
+    - max_standing_approvals
+    - max_credentials
     - audit_retention_days
   properties:
     max_requests_per_month:
@@ -107,54 +111,31 @@ CheckoutResponse:
     url:
       type: string
       format: uri
-      description: Stripe Checkout Session URL — redirect the user here to complete payment
+      pattern: '^https://'
+      description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
       example: https://checkout.stripe.com/c/pay/cs_test_...
 
 # ── New schemas for issue #22 ────────────────────────────────────────────────
 
 Plan:
-  type: object
-  required:
-    - id
-    - name
-    - max_requests_per_month
-    - max_agents
-    - max_standing_approvals
-    - max_credentials
-    - audit_retention_days
-  properties:
-    id:
-      type: string
-      description: Unique plan identifier
-      example: free
-    name:
-      type: string
-      description: Human-readable plan name
-      example: Free
-    max_requests_per_month:
-      type: integer
-      nullable: true
-      description: Monthly request limit (null = unlimited)
-      example: 1000
-    max_agents:
-      type: integer
-      nullable: true
-      description: Maximum number of agents (null = unlimited)
-      example: 3
-    max_standing_approvals:
-      type: integer
-      nullable: true
-      description: Maximum active standing approvals (null = unlimited)
-      example: 5
-    max_credentials:
-      type: integer
-      nullable: true
-      description: Maximum stored credentials (null = unlimited)
-      example: 5
-    audit_retention_days:
-      type: integer
-      description: Number of days audit logs are retained
-      example: 7
+  description: |
+    A billing plan with its resource limits. Composes `PlanLimits` with
+    plan identity fields to avoid duplicating the limit definitions.
+  allOf:
+    - type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: Unique plan identifier
+          example: free
+        name:
+          type: string
+          description: Human-readable plan name
+          example: Free
+    - $ref: '#/PlanLimits'
 
 Subscription:
   type: object
@@ -347,7 +328,8 @@ UpgradeResponse:
     checkout_url:
       type: string
       format: uri
-      description: Stripe Checkout Session URL — redirect the user here to complete payment
+      pattern: '^https://'
+      description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
       example: https://checkout.stripe.com/c/pay/cs_test_...
 
 DowngradeResponse:
@@ -424,7 +406,8 @@ Invoice:
     stripe_invoice_url:
       type: string
       format: uri
-      description: URL to view the full invoice details on Stripe's hosted page
+      pattern: '^https://'
+      description: URL to view the full invoice details on Stripe's hosted page. Always HTTPS.
       example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
 
 InvoiceListResponse:
@@ -443,90 +426,77 @@ InvoiceListResponse:
       example: false
 
 QuotaExceededError:
-  type: object
-  required:
-    - error
-  properties:
+  description: |
+    Returned when the user exceeds their plan's monthly request quota (HTTP 429).
+    Uses the standard ErrorResponse structure. The `details` object contains
+    quota-specific fields to help the frontend render an upgrade prompt.
+  allOf:
+    - $ref: '../schemas/errors.yaml#/ErrorResponse'
+  example:
     error:
-      type: object
-      required:
-        - code
-        - message
-        - retryable
-      properties:
-        code:
-          type: string
-          enum: [quota_exceeded]
-          description: Machine-readable error code
-          example: quota_exceeded
-        message:
-          type: string
-          description: Human-readable error message
-          example: Monthly request quota exceeded. Upgrade your plan for continued access.
-        retryable:
-          type: boolean
-          description: Whether the client should retry
-          example: false
-        details:
-          type: object
-          properties:
-            limit:
-              type: integer
-              description: The plan's request limit
-              example: 1000
-            current_count:
-              type: integer
-              description: Current usage count
-              example: 1001
-            plan_id:
-              type: string
-              description: The user's current plan
-              example: free
-            reset_at:
-              type: string
-              format: date-time
-              description: When the usage counter resets (next billing period start)
+      code: quota_exceeded
+      message: Monthly request quota exceeded. Upgrade your plan for continued access.
+      retryable: false
+      details:
+        limit: 1000
+        current_count: 1001
+        plan_id: free
+        reset_at: '2026-04-01T00:00:00Z'
+
+QuotaExceededDetails:
+  type: object
+  description: Shape of `error.details` for quota_exceeded errors.
+  properties:
+    limit:
+      type: integer
+      description: The plan's request limit
+      example: 1000
+    current_count:
+      type: integer
+      description: Current usage count
+      example: 1001
+    plan_id:
+      type: string
+      description: The user's current plan
+      example: free
+    reset_at:
+      type: string
+      format: date-time
+      description: When the usage counter resets (next billing period start)
 
 ResourceLimitError:
-  type: object
-  required:
-    - error
-  properties:
+  description: |
+    Returned when the user hits a plan-based resource limit (HTTP 403).
+    Uses the standard ErrorResponse structure. The `details` object contains
+    limit-specific fields to help the frontend render an upgrade prompt.
+
+    Possible error codes: `agent_limit_reached`, `standing_approval_limit_reached`,
+    `credential_limit_reached`.
+  allOf:
+    - $ref: '../schemas/errors.yaml#/ErrorResponse'
+  example:
     error:
-      type: object
-      required:
-        - code
-        - message
-        - retryable
-      properties:
-        code:
-          type: string
-          enum:
-            - agent_limit_reached
-            - standing_approval_limit_reached
-            - credential_limit_reached
-          description: Machine-readable error code indicating which resource limit was hit
-          example: agent_limit_reached
-        message:
-          type: string
-          description: Human-readable error message with plan details
-          example: Free plan allows up to 3 agents. Upgrade your plan to add more.
-        retryable:
-          type: boolean
-          description: Whether the client should retry (always false for limit errors)
-          example: false
-        details:
-          type: object
-          properties:
-            current_count:
-              type: integer
-              description: Current number of the resource
-              example: 3
-            limit:
-              type: integer
-              description: Maximum allowed by the plan
-              example: 3
-            plan_id:
-              type: string
-              description: The user's current plan
-              example: free
+      code: agent_limit_reached
+      message: Free plan allows up to 3 agents. Upgrade your plan to add more.
+      retryable: false
+      details:
+        current_count: 3
+        limit: 3
+        plan_id: free
+
+ResourceLimitDetails:
+  type: object
+  description: Shape of `error.details` for resource limit errors.
+  properties:
+    current_count:
+      type: integer
+      description: Current number of the resource
+      example: 3
+    limit:
+      type: integer
+      description: Maximum allowed by the plan
+      example: 3
+    plan_id:
+      type: string
+      description: The user's current plan
+      example: free

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -109,3 +109,367 @@ CheckoutResponse:
       format: uri
       description: Stripe Checkout Session URL — redirect the user here to complete payment
       example: https://checkout.stripe.com/c/pay/cs_test_...
+
+# ── New schemas for issue #22 ────────────────────────────────────────────────
+
+Plan:
+  type: object
+  required:
+    - id
+    - name
+    - max_requests_per_month
+    - max_agents
+    - max_standing_approvals
+    - max_credentials
+    - audit_retention_days
+  properties:
+    id:
+      type: string
+      description: Unique plan identifier
+      example: free
+    name:
+      type: string
+      description: Human-readable plan name
+      example: Free
+    max_requests_per_month:
+      type: integer
+      nullable: true
+      description: Monthly request limit (null = unlimited)
+      example: 1000
+    max_agents:
+      type: integer
+      nullable: true
+      description: Maximum number of agents (null = unlimited)
+      example: 3
+    max_standing_approvals:
+      type: integer
+      nullable: true
+      description: Maximum active standing approvals (null = unlimited)
+      example: 5
+    max_credentials:
+      type: integer
+      nullable: true
+      description: Maximum stored credentials (null = unlimited)
+      example: 5
+    audit_retention_days:
+      type: integer
+      description: Number of days audit logs are retained
+      example: 7
+
+Subscription:
+  type: object
+  required:
+    - status
+    - current_period_start
+    - current_period_end
+  properties:
+    status:
+      type: string
+      enum: [active, past_due, cancelled]
+      description: Current subscription status
+      example: active
+    current_period_start:
+      type: string
+      format: date-time
+      description: Start of the current billing period (inclusive)
+      example: '2026-03-01T00:00:00Z'
+    current_period_end:
+      type: string
+      format: date-time
+      description: End of the current billing period (exclusive)
+      example: '2026-04-01T00:00:00Z'
+
+UsageSummary:
+  type: object
+  required:
+    - requests
+    - agents
+    - standing_approvals
+    - credentials
+  properties:
+    requests:
+      type: integer
+      description: Number of API requests in the current billing period
+      example: 42
+    agents:
+      type: integer
+      description: Current number of registered agents
+      example: 2
+    standing_approvals:
+      type: integer
+      description: Current number of active standing approvals
+      example: 3
+    credentials:
+      type: integer
+      description: Current number of stored credentials
+      example: 1
+
+BillingPlanResponse:
+  type: object
+  required:
+    - plan
+    - subscription
+    - usage
+  properties:
+    plan:
+      $ref: '#/Plan'
+    subscription:
+      $ref: '#/Subscription'
+    usage:
+      $ref: '#/UsageSummary'
+
+UsageDetail:
+  type: object
+  required:
+    - period_start
+    - period_end
+    - requests
+    - sms
+  properties:
+    period_start:
+      type: string
+      format: date-time
+      description: Start of the usage period (inclusive)
+      example: '2026-03-01T00:00:00Z'
+    period_end:
+      type: string
+      format: date-time
+      description: End of the usage period (exclusive)
+      example: '2026-04-01T00:00:00Z'
+    requests:
+      $ref: '#/RequestUsageDetail'
+    sms:
+      $ref: '#/SMSUsageDetail'
+    breakdown:
+      $ref: '#/UsageBreakdown'
+
+RequestUsageDetail:
+  type: object
+  required:
+    - total
+    - included
+    - overage
+    - cost_cents
+  properties:
+    total:
+      type: integer
+      description: Total requests this period
+      example: 1542
+    included:
+      type: integer
+      description: Requests included in the plan at no extra cost
+      example: 1000
+    overage:
+      type: integer
+      description: Billable requests beyond the included allowance
+      example: 542
+    cost_cents:
+      type: integer
+      description: Cost of overage requests in cents
+      example: 271
+
+SMSUsageDetail:
+  type: object
+  required:
+    - total
+    - cost_cents
+  properties:
+    total:
+      type: integer
+      description: Total SMS messages sent this period
+      example: 5
+    cost_cents:
+      type: integer
+      description: Total SMS cost in cents
+      example: 5
+
+UsageBreakdown:
+  type: object
+  properties:
+    by_agent:
+      type: object
+      additionalProperties:
+        type: integer
+      description: Request counts keyed by agent ID
+      example:
+        '1': 500
+        '2': 1042
+    by_connector:
+      type: object
+      additionalProperties:
+        type: integer
+      description: Request counts keyed by connector ID
+      example:
+        gmail: 300
+        stripe: 1242
+    by_action_type:
+      type: object
+      additionalProperties:
+        type: integer
+      description: Request counts keyed by action type
+      example:
+        email.send: 300
+        payment.create: 1242
+
+UpgradeResponse:
+  type: object
+  required:
+    - checkout_url
+  properties:
+    checkout_url:
+      type: string
+      format: uri
+      description: Stripe Checkout Session URL — redirect the user here to complete payment
+      example: https://checkout.stripe.com/c/pay/cs_test_...
+
+DowngradeResponse:
+  type: object
+  required:
+    - status
+    - plan_id
+    - downgraded_at
+  properties:
+    status:
+      type: string
+      enum: [active, past_due, cancelled]
+      description: Updated subscription status
+      example: cancelled
+    plan_id:
+      type: string
+      description: The plan the user was downgraded to
+      example: free
+    downgraded_at:
+      type: string
+      format: date-time
+      description: Timestamp when the downgrade was processed
+
+Invoice:
+  type: object
+  required:
+    - id
+    - date
+    - amount_cents
+    - status
+  properties:
+    id:
+      type: string
+      description: Invoice identifier
+      example: inv_1234567890
+    date:
+      type: string
+      format: date-time
+      description: Invoice date
+      example: '2026-02-01T00:00:00Z'
+    amount_cents:
+      type: integer
+      description: Total invoice amount in cents
+      example: 271
+    status:
+      type: string
+      enum: [draft, open, paid, void, uncollectible]
+      description: Invoice payment status
+      example: paid
+    stripe_invoice_url:
+      type: string
+      format: uri
+      description: URL to view the invoice on Stripe's hosted page
+      example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
+
+InvoiceListResponse:
+  type: object
+  required:
+    - invoices
+  properties:
+    invoices:
+      type: array
+      items:
+        $ref: '#/Invoice'
+
+QuotaExceededError:
+  type: object
+  required:
+    - error
+  properties:
+    error:
+      type: object
+      required:
+        - code
+        - message
+        - retryable
+      properties:
+        code:
+          type: string
+          enum: [quota_exceeded]
+          description: Machine-readable error code
+          example: quota_exceeded
+        message:
+          type: string
+          description: Human-readable error message
+          example: Monthly request quota exceeded. Upgrade your plan for continued access.
+        retryable:
+          type: boolean
+          description: Whether the client should retry
+          example: false
+        details:
+          type: object
+          properties:
+            limit:
+              type: integer
+              description: The plan's request limit
+              example: 1000
+            current_count:
+              type: integer
+              description: Current usage count
+              example: 1001
+            plan_id:
+              type: string
+              description: The user's current plan
+              example: free
+            reset_at:
+              type: string
+              format: date-time
+              description: When the usage counter resets (next billing period start)
+
+ResourceLimitError:
+  type: object
+  required:
+    - error
+  properties:
+    error:
+      type: object
+      required:
+        - code
+        - message
+        - retryable
+      properties:
+        code:
+          type: string
+          enum:
+            - agent_limit_reached
+            - standing_approval_limit_reached
+            - credential_limit_reached
+          description: Machine-readable error code indicating which resource limit was hit
+          example: agent_limit_reached
+        message:
+          type: string
+          description: Human-readable error message with plan details
+          example: Free plan allows up to 3 agents. Upgrade your plan to add more.
+        retryable:
+          type: boolean
+          description: Whether the client should retry (always false for limit errors)
+          example: false
+        details:
+          type: object
+          properties:
+            current_count:
+              type: integer
+              description: Current number of the resource
+              example: 3
+            limit:
+              type: integer
+              description: Maximum allowed by the plan
+              example: 3
+            plan_id:
+              type: string
+              description: The user's current plan
+              example: free

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -115,8 +115,6 @@ CheckoutResponse:
       description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
       example: https://checkout.stripe.com/c/pay/cs_test_...
 
-# ── New schemas for issue #22 ────────────────────────────────────────────────
-
 Plan:
   description: |
     A billing plan with its resource limits. Composes `PlanLimits` with

--- a/spec/openapi/components/schemas/errors.yaml
+++ b/spec/openapi/components/schemas/errors.yaml
@@ -50,23 +50,28 @@ Error:
         - constraint_violation
         # 410 Gone (standing approval)
         - standing_approval_expired
+        # 404 Not Found (billing)
+        - subscription_not_found
         # 409 Conflict
         - agent_already_registered
         - duplicate_request_id
         - approval_already_resolved
         - duplicate_credential
+        - already_subscribed
         # 410 Gone
         - registration_expired
         - verification_locked
         - approval_expired
         # 429 Too Many Requests
         - rate_limited
+        - quota_exceeded
         # 500 Internal Server Error
         - internal_error
         # 502 Bad Gateway
         - upstream_error
         # 503 Service Unavailable
         - service_unavailable
+        - billing_not_enabled
       example: "invalid_signature"
     
     message:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4796,11 +4796,45 @@ paths:
       operationId: stripeWebhook
       tags:
         - Billing
+      parameters:
+        - name: Stripe-Signature
+          in: header
+          required: true
+          description: |
+            Stripe webhook signature header. Contains the timestamp and signature(s)
+            used to verify that the request originated from Stripe. The server verifies
+            this against `STRIPE_WEBHOOK_SECRET` before processing any event.
+          schema:
+            type: string
+          example: t=1614556236,v1=abc123...
+      requestBody:
+        required: true
+        description: |
+          Raw Stripe webhook event payload. **Must be passed as raw bytes** (not parsed JSON)
+          to the signature verification step — parsing before verification would invalidate
+          the signature check.
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Stripe Event object (structure varies by event type)
+              properties:
+                id:
+                  type: string
+                  description: Unique event identifier (used for idempotency)
+                type:
+                  type: string
+                  description: Event type (e.g., checkout.session.completed)
+              required:
+                - id
+                - type
       responses:
         '200':
-          description: Webhook processed successfully
+          description: Webhook processed successfully (always returned to prevent Stripe retries)
         '400':
           description: Invalid signature or malformed event
+        '500':
+          description: Processing failed — Stripe will retry the event
   /v1/billing/plan:
     get:
       summary: Get billing plan details
@@ -8619,51 +8653,28 @@ components:
         url:
           type: string
           format: uri
-          description: Stripe Checkout Session URL — redirect the user here to complete payment
+          pattern: ^https://
+          description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
           example: https://checkout.stripe.com/c/pay/cs_test_...
     Plan:
-      type: object
-      required:
-        - id
-        - name
-        - max_requests_per_month
-        - max_agents
-        - max_standing_approvals
-        - max_credentials
-        - audit_retention_days
-      properties:
-        id:
-          type: string
-          description: Unique plan identifier
-          example: free
-        name:
-          type: string
-          description: Human-readable plan name
-          example: Free
-        max_requests_per_month:
-          type: integer
-          nullable: true
-          description: Monthly request limit (null = unlimited)
-          example: 1000
-        max_agents:
-          type: integer
-          nullable: true
-          description: Maximum number of agents (null = unlimited)
-          example: 3
-        max_standing_approvals:
-          type: integer
-          nullable: true
-          description: Maximum active standing approvals (null = unlimited)
-          example: 5
-        max_credentials:
-          type: integer
-          nullable: true
-          description: Maximum stored credentials (null = unlimited)
-          example: 5
-        audit_retention_days:
-          type: integer
-          description: Number of days audit logs are retained
-          example: 7
+      description: |
+        A billing plan with its resource limits. Composes `PlanLimits` with
+        plan identity fields to avoid duplicating the limit definitions.
+      allOf:
+        - type: object
+          required:
+            - id
+            - name
+          properties:
+            id:
+              type: string
+              description: Unique plan identifier
+              example: free
+            name:
+              type: string
+              description: Human-readable plan name
+              example: Free
+        - $ref: '#/components/schemas/PlanLimits'
     Subscription:
       type: object
       required:
@@ -8851,7 +8862,8 @@ components:
         checkout_url:
           type: string
           format: uri
-          description: Stripe Checkout Session URL — redirect the user here to complete payment
+          pattern: ^https://
+          description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
           example: https://checkout.stripe.com/c/pay/cs_test_...
     DowngradeResponse:
       type: object
@@ -8934,7 +8946,8 @@ components:
         stripe_invoice_url:
           type: string
           format: uri
-          description: URL to view the full invoice details on Stripe's hosted page
+          pattern: ^https://
+          description: URL to view the full invoice details on Stripe's hosted page. Always HTTPS.
           example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
     InvoiceListResponse:
       type: object
@@ -8951,93 +8964,77 @@ components:
           description: Whether there are more invoices beyond this page. If true, pass the last invoice's `id` as `starting_after` to fetch the next page.
           example: false
     QuotaExceededError:
-      type: object
-      required:
-        - error
-      properties:
+      description: |
+        Returned when the user exceeds their plan's monthly request quota (HTTP 429).
+        Uses the standard ErrorResponse structure. The `details` object contains
+        quota-specific fields to help the frontend render an upgrade prompt.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
         error:
-          type: object
-          required:
-            - code
-            - message
-            - retryable
-          properties:
-            code:
-              type: string
-              enum:
-                - quota_exceeded
-              description: Machine-readable error code
-              example: quota_exceeded
-            message:
-              type: string
-              description: Human-readable error message
-              example: Monthly request quota exceeded. Upgrade your plan for continued access.
-            retryable:
-              type: boolean
-              description: Whether the client should retry
-              example: false
-            details:
-              type: object
-              properties:
-                limit:
-                  type: integer
-                  description: The plan's request limit
-                  example: 1000
-                current_count:
-                  type: integer
-                  description: Current usage count
-                  example: 1001
-                plan_id:
-                  type: string
-                  description: The user's current plan
-                  example: free
-                reset_at:
-                  type: string
-                  format: date-time
-                  description: When the usage counter resets (next billing period start)
+          code: quota_exceeded
+          message: Monthly request quota exceeded. Upgrade your plan for continued access.
+          retryable: false
+          details:
+            limit: 1000
+            current_count: 1001
+            plan_id: free
+            reset_at: '2026-04-01T00:00:00Z'
+    QuotaExceededDetails:
+      type: object
+      description: Shape of `error.details` for quota_exceeded errors.
+      properties:
+        limit:
+          type: integer
+          description: The plan's request limit
+          example: 1000
+        current_count:
+          type: integer
+          description: Current usage count
+          example: 1001
+        plan_id:
+          type: string
+          description: The user's current plan
+          example: free
+        reset_at:
+          type: string
+          format: date-time
+          description: When the usage counter resets (next billing period start)
     ResourceLimitError:
-      type: object
-      required:
-        - error
-      properties:
+      description: |
+        Returned when the user hits a plan-based resource limit (HTTP 403).
+        Uses the standard ErrorResponse structure. The `details` object contains
+        limit-specific fields to help the frontend render an upgrade prompt.
+
+        Possible error codes: `agent_limit_reached`, `standing_approval_limit_reached`,
+        `credential_limit_reached`.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
         error:
-          type: object
-          required:
-            - code
-            - message
-            - retryable
-          properties:
-            code:
-              type: string
-              enum:
-                - agent_limit_reached
-                - standing_approval_limit_reached
-                - credential_limit_reached
-              description: Machine-readable error code indicating which resource limit was hit
-              example: agent_limit_reached
-            message:
-              type: string
-              description: Human-readable error message with plan details
-              example: Free plan allows up to 3 agents. Upgrade your plan to add more.
-            retryable:
-              type: boolean
-              description: Whether the client should retry (always false for limit errors)
-              example: false
-            details:
-              type: object
-              properties:
-                current_count:
-                  type: integer
-                  description: Current number of the resource
-                  example: 3
-                limit:
-                  type: integer
-                  description: Maximum allowed by the plan
-                  example: 3
-                plan_id:
-                  type: string
-                  description: The user's current plan
-                  example: free
+          code: agent_limit_reached
+          message: Free plan allows up to 3 agents. Upgrade your plan to add more.
+          retryable: false
+          details:
+            current_count: 3
+            limit: 3
+            plan_id: free
+    ResourceLimitDetails:
+      type: object
+      description: Shape of `error.details` for resource limit errors.
+      properties:
+        current_count:
+          type: integer
+          description: Current number of the resource
+          example: 3
+        limit:
+          type: integer
+          description: Maximum allowed by the plan
+          example: 3
+        plan_id:
+          type: string
+          description: The user's current plan
+          example: free
     ConfigResponse:
       type: object
       description: |
@@ -9451,6 +9448,10 @@ components:
     PlanLimits:
       type: object
       required:
+        - max_requests_per_month
+        - max_agents
+        - max_standing_approvals
+        - max_credentials
         - audit_retention_days
       properties:
         max_requests_per_month:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4796,6 +4796,7 @@ paths:
       operationId: stripeWebhook
       tags:
         - Billing
+      security: []
       parameters:
         - name: Stripe-Signature
           in: header

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4793,6 +4793,231 @@ paths:
           description: Webhook processed successfully
         '400':
           description: Invalid signature or malformed event
+  /v1/billing/plan:
+    get:
+      summary: Get billing plan details
+      description: |
+        Returns the authenticated user's current plan details, subscription status,
+        and a summary of current resource usage (request counts, agent count, etc.).
+
+        This is the primary billing endpoint for the frontend — it provides everything
+        needed to render the billing section of the settings page in a single request.
+
+        Only available when `billing_enabled` is `true` in the server config.
+      operationId: getBillingPlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Billing plan details returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingPlanResponse'
+              example:
+                plan:
+                  id: free
+                  name: Free
+                  max_requests_per_month: 1000
+                  max_agents: 3
+                  max_standing_approvals: 5
+                  max_credentials: 5
+                  audit_retention_days: 7
+                subscription:
+                  status: active
+                  current_period_start: '2026-03-01T00:00:00Z'
+                  current_period_end: '2026-04-01T00:00:00Z'
+                usage:
+                  requests: 42
+                  agents: 2
+                  standing_approvals: 3
+                  credentials: 1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No subscription found for this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/usage:
+    get:
+      summary: Get detailed usage breakdown
+      description: |
+        Returns detailed usage metrics for the current billing period, including
+        request totals, overage calculations, SMS counts, costs, and an optional
+        breakdown by agent, connector, and action type.
+
+        Only available when `billing_enabled` is `true` in the server config.
+      operationId: getBillingUsage
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Usage details returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageDetail'
+              example:
+                period_start: '2026-03-01T00:00:00Z'
+                period_end: '2026-04-01T00:00:00Z'
+                requests:
+                  total: 1542
+                  included: 1000
+                  overage: 542
+                  cost_cents: 271
+                sms:
+                  total: 5
+                  cost_cents: 5
+                breakdown:
+                  by_agent:
+                    '1': 500
+                    '2': 1042
+                  by_connector:
+                    gmail: 300
+                    stripe: 1242
+                  by_action_type:
+                    email.send: 300
+                    payment.create: 1242
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No usage data found for this period
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/upgrade:
+    post:
+      summary: Initiate plan upgrade
+      description: |
+        Initiates an upgrade from the free plan to pay-as-you-go by creating a
+        Stripe Checkout Session. Returns a URL to redirect the user to Stripe's
+        hosted checkout page to complete the upgrade.
+
+        If the user doesn't have a Stripe Customer yet, one is created automatically.
+        If the user is already on a paid plan, returns 409 Conflict.
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: upgradePlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Checkout session created for upgrade
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpgradeResponse'
+              example:
+                checkout_url: https://checkout.stripe.com/c/pay/cs_test_...
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Already subscribed to a paid plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/downgrade:
+    post:
+      summary: Downgrade to free plan
+      description: |
+        Downgrades the user from the pay-as-you-go plan to the free plan.
+        Cancels the Stripe subscription and sets a 7-day grace period during
+        which the user retains the longer audit retention window to export data.
+
+        If the user is already on the free plan, returns 409 Conflict.
+
+        Only available when `billing_enabled` is `true`.
+      operationId: downgradePlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Successfully downgraded to free plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DowngradeResponse'
+              example:
+                status: cancelled
+                plan_id: free
+                downgraded_at: '2026-03-02T12:00:00Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Already on the free plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error (failed to cancel subscription)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/invoices:
+    get:
+      summary: List invoices
+      description: |
+        Returns a list of the authenticated user's past invoices from Stripe,
+        including the amount, status, and a link to view the invoice.
+
+        Only available when `billing_enabled` is `true` and the user has a
+        Stripe customer ID (i.e., has previously been on a paid plan).
+      operationId: listInvoices
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Invoices returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceListResponse'
+              example:
+                invoices:
+                  - id: inv_1234567890
+                    date: '2026-02-01T00:00:00Z'
+                    amount_cents: 271
+                    status: paid
+                    stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_1234567890
+                  - id: inv_0987654321
+                    date: '2026-01-01T00:00:00Z'
+                    amount_cents: 0
+                    status: paid
+                    stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_0987654321
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/config:
     get:
       summary: Get server configuration
@@ -8341,6 +8566,366 @@ components:
           format: uri
           description: Stripe Checkout Session URL — redirect the user here to complete payment
           example: https://checkout.stripe.com/c/pay/cs_test_...
+    Plan:
+      type: object
+      required:
+        - id
+        - name
+        - max_requests_per_month
+        - max_agents
+        - max_standing_approvals
+        - max_credentials
+        - audit_retention_days
+      properties:
+        id:
+          type: string
+          description: Unique plan identifier
+          example: free
+        name:
+          type: string
+          description: Human-readable plan name
+          example: Free
+        max_requests_per_month:
+          type: integer
+          nullable: true
+          description: Monthly request limit (null = unlimited)
+          example: 1000
+        max_agents:
+          type: integer
+          nullable: true
+          description: Maximum number of agents (null = unlimited)
+          example: 3
+        max_standing_approvals:
+          type: integer
+          nullable: true
+          description: Maximum active standing approvals (null = unlimited)
+          example: 5
+        max_credentials:
+          type: integer
+          nullable: true
+          description: Maximum stored credentials (null = unlimited)
+          example: 5
+        audit_retention_days:
+          type: integer
+          description: Number of days audit logs are retained
+          example: 7
+    Subscription:
+      type: object
+      required:
+        - status
+        - current_period_start
+        - current_period_end
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+            - past_due
+            - cancelled
+          description: Current subscription status
+          example: active
+        current_period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (inclusive)
+          example: '2026-03-01T00:00:00Z'
+        current_period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (exclusive)
+          example: '2026-04-01T00:00:00Z'
+    UsageSummary:
+      type: object
+      required:
+        - requests
+        - agents
+        - standing_approvals
+        - credentials
+      properties:
+        requests:
+          type: integer
+          description: Number of API requests in the current billing period
+          example: 42
+        agents:
+          type: integer
+          description: Current number of registered agents
+          example: 2
+        standing_approvals:
+          type: integer
+          description: Current number of active standing approvals
+          example: 3
+        credentials:
+          type: integer
+          description: Current number of stored credentials
+          example: 1
+    BillingPlanResponse:
+      type: object
+      required:
+        - plan
+        - subscription
+        - usage
+      properties:
+        plan:
+          $ref: '#/components/schemas/Plan'
+        subscription:
+          $ref: '#/components/schemas/Subscription'
+        usage:
+          $ref: '#/components/schemas/UsageSummary'
+    UsageDetail:
+      type: object
+      required:
+        - period_start
+        - period_end
+        - requests
+        - sms
+      properties:
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the usage period (inclusive)
+          example: '2026-03-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          description: End of the usage period (exclusive)
+          example: '2026-04-01T00:00:00Z'
+        requests:
+          $ref: '#/components/schemas/RequestUsageDetail'
+        sms:
+          $ref: '#/components/schemas/SMSUsageDetail'
+        breakdown:
+          $ref: '#/components/schemas/UsageBreakdown'
+    RequestUsageDetail:
+      type: object
+      required:
+        - total
+        - included
+        - overage
+        - cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total requests this period
+          example: 1542
+        included:
+          type: integer
+          description: Requests included in the plan at no extra cost
+          example: 1000
+        overage:
+          type: integer
+          description: Billable requests beyond the included allowance
+          example: 542
+        cost_cents:
+          type: integer
+          description: Cost of overage requests in cents
+          example: 271
+    SMSUsageDetail:
+      type: object
+      required:
+        - total
+        - cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total SMS messages sent this period
+          example: 5
+        cost_cents:
+          type: integer
+          description: Total SMS cost in cents
+          example: 5
+    UsageBreakdown:
+      type: object
+      properties:
+        by_agent:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Request counts keyed by agent ID
+          example:
+            '1': 500
+            '2': 1042
+        by_connector:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Request counts keyed by connector ID
+          example:
+            gmail: 300
+            stripe: 1242
+        by_action_type:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Request counts keyed by action type
+          example:
+            email.send: 300
+            payment.create: 1242
+    UpgradeResponse:
+      type: object
+      required:
+        - checkout_url
+      properties:
+        checkout_url:
+          type: string
+          format: uri
+          description: Stripe Checkout Session URL — redirect the user here to complete payment
+          example: https://checkout.stripe.com/c/pay/cs_test_...
+    DowngradeResponse:
+      type: object
+      required:
+        - status
+        - plan_id
+        - downgraded_at
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+            - past_due
+            - cancelled
+          description: Updated subscription status
+          example: cancelled
+        plan_id:
+          type: string
+          description: The plan the user was downgraded to
+          example: free
+        downgraded_at:
+          type: string
+          format: date-time
+          description: Timestamp when the downgrade was processed
+    Invoice:
+      type: object
+      required:
+        - id
+        - date
+        - amount_cents
+        - status
+      properties:
+        id:
+          type: string
+          description: Invoice identifier
+          example: inv_1234567890
+        date:
+          type: string
+          format: date-time
+          description: Invoice date
+          example: '2026-02-01T00:00:00Z'
+        amount_cents:
+          type: integer
+          description: Total invoice amount in cents
+          example: 271
+        status:
+          type: string
+          enum:
+            - draft
+            - open
+            - paid
+            - void
+            - uncollectible
+          description: Invoice payment status
+          example: paid
+        stripe_invoice_url:
+          type: string
+          format: uri
+          description: URL to view the invoice on Stripe's hosted page
+          example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
+    InvoiceListResponse:
+      type: object
+      required:
+        - invoices
+      properties:
+        invoices:
+          type: array
+          items:
+            $ref: '#/components/schemas/Invoice'
+    QuotaExceededError:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+            - retryable
+          properties:
+            code:
+              type: string
+              enum:
+                - quota_exceeded
+              description: Machine-readable error code
+              example: quota_exceeded
+            message:
+              type: string
+              description: Human-readable error message
+              example: Monthly request quota exceeded. Upgrade your plan for continued access.
+            retryable:
+              type: boolean
+              description: Whether the client should retry
+              example: false
+            details:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  description: The plan's request limit
+                  example: 1000
+                current_count:
+                  type: integer
+                  description: Current usage count
+                  example: 1001
+                plan_id:
+                  type: string
+                  description: The user's current plan
+                  example: free
+                reset_at:
+                  type: string
+                  format: date-time
+                  description: When the usage counter resets (next billing period start)
+    ResourceLimitError:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+            - retryable
+          properties:
+            code:
+              type: string
+              enum:
+                - agent_limit_reached
+                - standing_approval_limit_reached
+                - credential_limit_reached
+              description: Machine-readable error code indicating which resource limit was hit
+              example: agent_limit_reached
+            message:
+              type: string
+              description: Human-readable error message with plan details
+              example: Free plan allows up to 3 agents. Upgrade your plan to add more.
+            retryable:
+              type: boolean
+              description: Whether the client should retry (always false for limit errors)
+              example: false
+            details:
+              type: object
+              properties:
+                current_count:
+                  type: integer
+                  description: Current number of the resource
+                  example: 3
+                limit:
+                  type: integer
+                  description: Maximum allowed by the plan
+                  example: 3
+                plan_id:
+                  type: string
+                  description: The user's current plan
+                  example: free
     ConfigResponse:
       type: object
       description: |
@@ -8633,17 +9218,21 @@ components:
             - standing_approval_exhausted
             - constraint_violation
             - standing_approval_expired
+            - subscription_not_found
             - agent_already_registered
             - duplicate_request_id
             - approval_already_resolved
             - duplicate_credential
+            - already_subscribed
             - registration_expired
             - verification_locked
             - approval_expired
             - rate_limited
+            - quota_exceeded
             - internal_error
             - upstream_error
             - service_unavailable
+            - billing_not_enabled
           example: invalid_signature
         message:
           type: string

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4680,9 +4680,13 @@ paths:
   /v1/billing/subscription:
     get:
       summary: Get current subscription
+      deprecated: true
       description: |
         Returns the authenticated user's subscription details including plan info,
         billing period, and current usage metrics.
+
+        **Deprecated:** Use `GET /v1/billing/plan` instead, which returns structured
+        plan, subscription, and usage data in a single response.
 
         Only available when `billing_enabled` is `true` in the server config.
       operationId: getSubscription
@@ -4723,10 +4727,14 @@ paths:
   /v1/billing/checkout:
     post:
       summary: Create checkout session
+      deprecated: true
       description: |
         Creates a Stripe Checkout Session for upgrading from the free plan to
         pay-as-you-go. Returns a URL to redirect the user to Stripe's hosted
         checkout page.
+
+        **Deprecated:** Use `POST /v1/billing/upgrade` instead, which has the
+        same behavior but a clearer name and response schema.
 
         If the user doesn't have a Stripe Customer yet, one is created automatically.
         If the user is already on a paid plan, returns 409 Conflict.
@@ -4829,6 +4837,10 @@ paths:
                   status: active
                   current_period_start: '2026-03-01T00:00:00Z'
                   current_period_end: '2026-04-01T00:00:00Z'
+                  has_payment_method: false
+                  can_upgrade: true
+                  can_downgrade: false
+                  grace_period_ends_at: null
                 usage:
                   requests: 42
                   agents: 2
@@ -4848,9 +4860,12 @@ paths:
     get:
       summary: Get detailed usage breakdown
       description: |
-        Returns detailed usage metrics for the current billing period, including
-        request totals, overage calculations, SMS counts, costs, and an optional
-        breakdown by agent, connector, and action type.
+        Returns detailed usage metrics for a billing period, including request
+        totals, overage calculations, SMS counts, costs, and an optional breakdown
+        by agent, connector, and action type.
+
+        Defaults to the current billing period. Pass `period_start` to view a
+        historical period (e.g., last month's usage).
 
         Only available when `billing_enabled` is `true` in the server config.
       operationId: getBillingUsage
@@ -4858,6 +4873,18 @@ paths:
         - Billing
       security:
         - SupabaseSession: []
+      parameters:
+        - name: period_start
+          in: query
+          required: false
+          description: |
+            Start of the billing period to query, as an ISO 8601 date-time.
+            Must be the first day of a month in UTC (e.g., `2026-02-01T00:00:00Z`).
+            Defaults to the current billing period if omitted.
+          schema:
+            type: string
+            format: date-time
+          example: '2026-02-01T00:00:00Z'
       responses:
         '200':
           description: Usage details returned
@@ -4965,6 +4992,7 @@ paths:
                 status: cancelled
                 plan_id: free
                 downgraded_at: '2026-03-02T12:00:00Z'
+                grace_period_ends_at: '2026-03-09T12:00:00Z'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '409':
@@ -4985,8 +5013,11 @@ paths:
     get:
       summary: List invoices
       description: |
-        Returns a list of the authenticated user's past invoices from Stripe,
-        including the amount, status, and a link to view the invoice.
+        Returns a paginated list of the authenticated user's past invoices from
+        Stripe, including the amount, status, and a link to view the invoice.
+
+        Results are ordered by date descending (most recent first). Use
+        `starting_after` for cursor-based pagination.
 
         Only available when `billing_enabled` is `true` and the user has a
         Stripe customer ID (i.e., has previously been on a paid plan).
@@ -4995,6 +5026,25 @@ paths:
         - Billing
       security:
         - SupabaseSession: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of invoices to return (1–100). Defaults to 10.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+        - name: starting_after
+          in: query
+          required: false
+          description: |
+            Cursor for pagination. Pass the `id` of the last invoice from the
+            previous page to fetch the next page of results.
+          schema:
+            type: string
+          example: inv_1234567890
       responses:
         '200':
           description: Invoices returned
@@ -5006,14 +5056,19 @@ paths:
                 invoices:
                   - id: inv_1234567890
                     date: '2026-02-01T00:00:00Z'
+                    period_start: '2026-02-01T00:00:00Z'
+                    period_end: '2026-03-01T00:00:00Z'
                     amount_cents: 271
                     status: paid
                     stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_1234567890
                   - id: inv_0987654321
                     date: '2026-01-01T00:00:00Z'
+                    period_start: '2026-01-01T00:00:00Z'
+                    period_end: '2026-02-01T00:00:00Z'
                     amount_cents: 0
                     status: paid
                     stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_0987654321
+                has_more: false
         '401':
           $ref: '#/components/responses/Unauthorized'
         '503':
@@ -8615,6 +8670,9 @@ components:
         - status
         - current_period_start
         - current_period_end
+        - has_payment_method
+        - can_upgrade
+        - can_downgrade
       properties:
         status:
           type: string
@@ -8622,7 +8680,11 @@ components:
             - active
             - past_due
             - cancelled
-          description: Current subscription status
+          description: |
+            Current subscription status.
+            - `active`: Subscription is in good standing.
+            - `past_due`: Payment failed — prompt the user to update their payment method.
+            - `cancelled`: Subscription was cancelled (user was downgraded to free).
           example: active
         current_period_start:
           type: string
@@ -8634,6 +8696,27 @@ components:
           format: date-time
           description: End of the current billing period (exclusive)
           example: '2026-04-01T00:00:00Z'
+        has_payment_method:
+          type: boolean
+          description: Whether the user has a Stripe payment method on file. Use this to decide whether to show "Add payment method" prompts.
+          example: false
+        can_upgrade:
+          type: boolean
+          description: Whether the user can upgrade (true when on the free plan). Use this to show/hide the upgrade button.
+          example: true
+        can_downgrade:
+          type: boolean
+          description: Whether the user can downgrade (true when on a paid plan). Use this to show/hide the downgrade button.
+          example: false
+        grace_period_ends_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When the downgrade grace period expires, or null if no grace period is active.
+            During the grace period (7 days after downgrade), the user retains the longer
+            audit retention window (90 days) to export their data. After this timestamp,
+            retention drops to the free plan's window (7 days).
     UsageSummary:
       type: object
       required:
@@ -8776,6 +8859,7 @@ components:
         - status
         - plan_id
         - downgraded_at
+        - grace_period_ends_at
       properties:
         status:
           type: string
@@ -8783,7 +8867,7 @@ components:
             - active
             - past_due
             - cancelled
-          description: Updated subscription status
+          description: Updated subscription status (will be `cancelled` after downgrade)
           example: cancelled
         plan_id:
           type: string
@@ -8793,6 +8877,13 @@ components:
           type: string
           format: date-time
           description: Timestamp when the downgrade was processed
+        grace_period_ends_at:
+          type: string
+          format: date-time
+          description: |
+            When the 7-day grace period expires. Until this time, the user retains
+            the 90-day audit retention window from their paid plan. Show this to the
+            user so they know how long they have to export their data.
     Invoice:
       type: object
       required:
@@ -8808,11 +8899,21 @@ components:
         date:
           type: string
           format: date-time
-          description: Invoice date
+          description: Invoice creation date
           example: '2026-02-01T00:00:00Z'
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the billing period this invoice covers
+          example: '2026-02-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          description: End of the billing period this invoice covers
+          example: '2026-03-01T00:00:00Z'
         amount_cents:
           type: integer
-          description: Total invoice amount in cents
+          description: Total invoice amount in cents (0 for periods within the free allowance)
           example: 271
         status:
           type: string
@@ -8822,22 +8923,33 @@ components:
             - paid
             - void
             - uncollectible
-          description: Invoice payment status
+          description: |
+            Invoice payment status.
+            - `draft`: Invoice is being prepared (not yet finalized).
+            - `open`: Invoice is finalized and awaiting payment.
+            - `paid`: Payment was collected successfully.
+            - `void`: Invoice was voided (no payment required).
+            - `uncollectible`: Payment could not be collected after all retries.
           example: paid
         stripe_invoice_url:
           type: string
           format: uri
-          description: URL to view the invoice on Stripe's hosted page
+          description: URL to view the full invoice details on Stripe's hosted page
           example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
     InvoiceListResponse:
       type: object
       required:
         - invoices
+        - has_more
       properties:
         invoices:
           type: array
           items:
             $ref: '#/components/schemas/Invoice'
+        has_more:
+          type: boolean
+          description: Whether there are more invoices beyond this page. If true, pass the last invoice's `id` as `starting_after` to fetch the next page.
+          example: false
     QuotaExceededError:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -235,6 +235,21 @@ paths:
   /v1/billing/webhook:
     $ref: './components/paths/billing.yaml#/webhook'
 
+  /v1/billing/plan:
+    $ref: './components/paths/billing.yaml#/plan'
+
+  /v1/billing/usage:
+    $ref: './components/paths/billing.yaml#/usage'
+
+  /v1/billing/upgrade:
+    $ref: './components/paths/billing.yaml#/upgrade'
+
+  /v1/billing/downgrade:
+    $ref: './components/paths/billing.yaml#/downgrade'
+
+  /v1/billing/invoices:
+    $ref: './components/paths/billing.yaml#/invoices'
+
   /v1/config:
     $ref: './components/paths/config.yaml#/config'
 
@@ -439,6 +454,34 @@ components:
       $ref: './components/schemas/billing.yaml#/UsageInfo'
     CheckoutResponse:
       $ref: './components/schemas/billing.yaml#/CheckoutResponse'
+    Plan:
+      $ref: './components/schemas/billing.yaml#/Plan'
+    Subscription:
+      $ref: './components/schemas/billing.yaml#/Subscription'
+    UsageSummary:
+      $ref: './components/schemas/billing.yaml#/UsageSummary'
+    BillingPlanResponse:
+      $ref: './components/schemas/billing.yaml#/BillingPlanResponse'
+    UsageDetail:
+      $ref: './components/schemas/billing.yaml#/UsageDetail'
+    RequestUsageDetail:
+      $ref: './components/schemas/billing.yaml#/RequestUsageDetail'
+    SMSUsageDetail:
+      $ref: './components/schemas/billing.yaml#/SMSUsageDetail'
+    UsageBreakdown:
+      $ref: './components/schemas/billing.yaml#/UsageBreakdown'
+    UpgradeResponse:
+      $ref: './components/schemas/billing.yaml#/UpgradeResponse'
+    DowngradeResponse:
+      $ref: './components/schemas/billing.yaml#/DowngradeResponse'
+    Invoice:
+      $ref: './components/schemas/billing.yaml#/Invoice'
+    InvoiceListResponse:
+      $ref: './components/schemas/billing.yaml#/InvoiceListResponse'
+    QuotaExceededError:
+      $ref: './components/schemas/billing.yaml#/QuotaExceededError'
+    ResourceLimitError:
+      $ref: './components/schemas/billing.yaml#/ResourceLimitError'
 
     # Config
     ConfigResponse:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -480,8 +480,12 @@ components:
       $ref: './components/schemas/billing.yaml#/InvoiceListResponse'
     QuotaExceededError:
       $ref: './components/schemas/billing.yaml#/QuotaExceededError'
+    QuotaExceededDetails:
+      $ref: './components/schemas/billing.yaml#/QuotaExceededDetails'
     ResourceLimitError:
       $ref: './components/schemas/billing.yaml#/ResourceLimitError'
+    ResourceLimitDetails:
+      $ref: './components/schemas/billing.yaml#/ResourceLimitDetails'
 
     # Config
     ConfigResponse:


### PR DESCRIPTION
## Summary

- Add 5 new billing endpoints to the OpenAPI spec: `GET /v1/billing/plan`, `GET /v1/billing/usage`, `POST /v1/billing/upgrade`, `POST /v1/billing/downgrade`, `GET /v1/billing/invoices`
- Define 14 new schemas: `Plan`, `Subscription`, `UsageSummary`, `BillingPlanResponse`, `UsageDetail`, `RequestUsageDetail`, `SMSUsageDetail`, `UsageBreakdown`, `UpgradeResponse`, `DowngradeResponse`, `Invoice`, `InvoiceListResponse`, `QuotaExceededError`, `ResourceLimitError`
- Add 4 new error codes to the error enum: `quota_exceeded`, `subscription_not_found`, `already_subscribed`, `billing_not_enabled`
- Regenerate bundled spec and verify TypeScript type generation

Closes #22

## Test plan

- [x] `redocly bundle` succeeds without errors
- [x] `npm run generate:api` produces correct TypeScript types in `schema.d.ts`
- [x] All 519 frontend tests pass (`make test-frontend`)
- [x] All backend tests pass (`make test-backend`)
- [x] Go + frontend builds succeed
- [ ] Verify generated types are usable in new billing UI hooks

https://claude.ai/code/session_01YHu118Ym2Ybs9GAW6fBKQJ