### PR TITLE
Gate SMS notifications behind paid tier

### DIFF
--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -52,4 +52,5 @@ const (
 	ErrSubscriptionNotFound     ErrorCode = "subscription_not_found"
 	ErrAlreadySubscribed        ErrorCode = "already_subscribed"
 	ErrBillingNotEnabled        ErrorCode = "billing_not_enabled"
+	ErrSMSRequiresPaidPlan      ErrorCode = "sms_requires_paid_plan"
 )

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -52,6 +51,11 @@ var allChannels = func() []string {
 	return channels
 }()
 
+// paidOnlyChannels lists channels that require a paid plan.
+var paidOnlyChannels = map[string]bool{
+	"sms": true,
+}
+
 func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		profile := Profile(r.Context())
@@ -63,10 +67,10 @@ func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		smsAvailable := isUserOnPaidPlan(r.Context(), deps.DB, profile.ID)
+		planID := userPlanID(r.Context(), deps.DB, profile.ID)
 
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs, smsAvailable),
+			Preferences: buildPreferencesResponse(prefs, planID),
 		})
 	}
 }
@@ -100,10 +104,18 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 		}
 
 		// Gate SMS behind paid tier: reject enabling SMS on the free plan.
+		// Look up the plan once — reused for both the gate check and the response.
+		planID := userPlanID(r.Context(), deps.DB, profile.ID)
 		if seen["sms"] {
 			for _, p := range req.Preferences {
 				if p.Channel == "sms" && p.Enabled {
-					if aborted := checkSMSPlanAccess(r.Context(), w, r, deps.DB, profile.ID); aborted {
+					if !isPaidPlan(planID) {
+						resp := Forbidden(ErrSMSRequiresPaidPlan, "SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS.")
+						resp.Error.Details = map[string]any{
+							"current_plan":  planID,
+							"required_plan": db.PlanPayAsYouGo,
+						}
+						RespondError(w, r, http.StatusForbidden, resp)
 						return
 					}
 					break
@@ -127,60 +139,42 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		smsAvailable := isUserOnPaidPlan(r.Context(), deps.DB, profile.ID)
-
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs, smsAvailable),
+			Preferences: buildPreferencesResponse(prefs, planID),
 		})
 	}
 }
 
-// checkSMSPlanAccess verifies that the user's plan allows SMS notifications.
-// Returns true if the request should be aborted (free tier or error).
-func checkSMSPlanAccess(ctx context.Context, w http.ResponseWriter, r *http.Request, d db.DBTX, userID string) bool {
+// userPlanID returns the user's current plan ID, defaulting to "free" if the
+// subscription is missing or the lookup fails. Errors are logged but not
+// surfaced — this is a read-only helper for response enrichment.
+func userPlanID(ctx context.Context, d db.DBTX, userID string) string {
 	sub, err := db.GetSubscriptionByUserID(ctx, d, userID)
 	if err != nil {
-		log.Printf("[%s] checkSMSPlanAccess: get subscription: %v", TraceID(r.Context()), err)
-		CaptureError(r.Context(), fmt.Errorf("check SMS plan access: %w", err))
-		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to check plan"))
-		return true
+		log.Printf("userPlanID: get subscription for %s: %v", userID, err)
+		return db.PlanFree
 	}
-	if sub == nil || sub.PlanID == db.PlanFree {
-		resp := Forbidden(ErrSMSRequiresPaidPlan, "SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS.")
-		resp.Error.Details = map[string]any{
-			"current_plan": db.PlanFree,
-			"required_plan": db.PlanPayAsYouGo,
-		}
-		RespondError(w, r, http.StatusForbidden, resp)
-		return true
+	if sub == nil {
+		return db.PlanFree
 	}
-	return false
+	return sub.PlanID
 }
 
-// isUserOnPaidPlan returns true if the user has an active subscription on a
-// non-free plan. Used to determine channel availability in preference responses.
-func isUserOnPaidPlan(ctx context.Context, d db.DBTX, userID string) bool {
-	sub, err := db.GetSubscriptionByUserID(ctx, d, userID)
-	if err != nil || sub == nil {
-		return false
-	}
-	return sub.PlanID != db.PlanFree
-}
-
-// paidOnlyChannels lists channels that require a paid plan.
-var paidOnlyChannels = map[string]bool{
-	"sms": true,
+// isPaidPlan returns true if the plan ID represents a paid (non-free) plan.
+func isPaidPlan(planID string) bool {
+	return planID != db.PlanFree
 }
 
 // buildPreferencesResponse converts DB preferences into the API response,
-// defaulting missing channels to enabled. The smsAvailable flag controls
-// whether plan-gated channels (SMS) are marked as available.
-func buildPreferencesResponse(prefs []db.NotificationPreference, smsAvailable bool) []notificationPreferenceResponse {
+// defaulting missing channels to enabled. The planID controls whether
+// plan-gated channels (SMS) are marked as available.
+func buildPreferencesResponse(prefs []db.NotificationPreference, planID string) []notificationPreferenceResponse {
 	channelMap := make(map[string]bool)
 	for _, p := range prefs {
 		channelMap[p.Channel] = p.Enabled
 	}
 
+	paid := isPaidPlan(planID)
 	result := make([]notificationPreferenceResponse, 0, len(allChannels))
 	for _, ch := range allChannels {
 		enabled, exists := channelMap[ch]
@@ -189,7 +183,7 @@ func buildPreferencesResponse(prefs []db.NotificationPreference, smsAvailable bo
 		}
 		available := true
 		if paidOnlyChannels[ch] {
-			available = smsAvailable
+			available = paid
 		}
 		result = append(result, notificationPreferenceResponse{
 			Channel:   ch,

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -92,6 +94,18 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			seen[p.Channel] = true
 		}
 
+		// Gate SMS behind paid tier: reject enabling SMS on the free plan.
+		if seen["sms"] {
+			for _, p := range req.Preferences {
+				if p.Channel == "sms" && p.Enabled {
+					if aborted := checkSMSPlanAccess(r.Context(), w, r, deps.DB, profile.ID); aborted {
+						return
+					}
+					break
+				}
+			}
+		}
+
 		for _, p := range req.Preferences {
 			if err := db.UpsertNotificationPreference(r.Context(), deps.DB, profile.ID, p.Channel, p.Enabled); err != nil {
 				log.Printf("[%s] handleUpdateNotificationPreferences: upsert %q: %v", TraceID(r.Context()), p.Channel, err)
@@ -112,6 +126,23 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			Preferences: buildPreferencesResponse(prefs),
 		})
 	}
+}
+
+// checkSMSPlanAccess verifies that the user's plan allows SMS notifications.
+// Returns true if the request should be aborted (free tier or error).
+func checkSMSPlanAccess(ctx context.Context, w http.ResponseWriter, r *http.Request, d db.DBTX, userID string) bool {
+	sub, err := db.GetSubscriptionByUserID(ctx, d, userID)
+	if err != nil {
+		log.Printf("[%s] checkSMSPlanAccess: get subscription: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), fmt.Errorf("check SMS plan access: %w", err))
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to check plan"))
+		return true
+	}
+	if sub == nil || sub.PlanID == db.PlanFree {
+		RespondError(w, r, http.StatusForbidden, Forbidden(ErrSMSRequiresPaidPlan, "SMS notifications require a paid plan"))
+		return true
+	}
+	return false
 }
 
 // buildPreferencesResponse converts DB preferences into the API response,

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -11,9 +11,12 @@ import (
 )
 
 // notificationPreferenceResponse is a single channel preference.
+// The Available field indicates whether the user's plan supports this channel;
+// when false, the frontend should show an upgrade prompt instead of a toggle.
 type notificationPreferenceResponse struct {
-	Channel string `json:"channel"`
-	Enabled bool   `json:"enabled"`
+	Channel   string `json:"channel"`
+	Enabled   bool   `json:"enabled"`
+	Available bool   `json:"available"`
 }
 
 // notificationPreferencesResponse wraps the list.
@@ -60,8 +63,10 @@ func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		smsAvailable := isUserOnPaidPlan(r.Context(), deps.DB, profile.ID)
+
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs),
+			Preferences: buildPreferencesResponse(prefs, smsAvailable),
 		})
 	}
 }
@@ -122,8 +127,10 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		smsAvailable := isUserOnPaidPlan(r.Context(), deps.DB, profile.ID)
+
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs),
+			Preferences: buildPreferencesResponse(prefs, smsAvailable),
 		})
 	}
 }
@@ -139,15 +146,36 @@ func checkSMSPlanAccess(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return true
 	}
 	if sub == nil || sub.PlanID == db.PlanFree {
-		RespondError(w, r, http.StatusForbidden, Forbidden(ErrSMSRequiresPaidPlan, "SMS notifications require a paid plan"))
+		resp := Forbidden(ErrSMSRequiresPaidPlan, "SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS.")
+		resp.Error.Details = map[string]any{
+			"current_plan": db.PlanFree,
+			"required_plan": db.PlanPayAsYouGo,
+		}
+		RespondError(w, r, http.StatusForbidden, resp)
 		return true
 	}
 	return false
 }
 
+// isUserOnPaidPlan returns true if the user has an active subscription on a
+// non-free plan. Used to determine channel availability in preference responses.
+func isUserOnPaidPlan(ctx context.Context, d db.DBTX, userID string) bool {
+	sub, err := db.GetSubscriptionByUserID(ctx, d, userID)
+	if err != nil || sub == nil {
+		return false
+	}
+	return sub.PlanID != db.PlanFree
+}
+
+// paidOnlyChannels lists channels that require a paid plan.
+var paidOnlyChannels = map[string]bool{
+	"sms": true,
+}
+
 // buildPreferencesResponse converts DB preferences into the API response,
-// defaulting missing channels to enabled.
-func buildPreferencesResponse(prefs []db.NotificationPreference) []notificationPreferenceResponse {
+// defaulting missing channels to enabled. The smsAvailable flag controls
+// whether plan-gated channels (SMS) are marked as available.
+func buildPreferencesResponse(prefs []db.NotificationPreference, smsAvailable bool) []notificationPreferenceResponse {
 	channelMap := make(map[string]bool)
 	for _, p := range prefs {
 		channelMap[p.Channel] = p.Enabled
@@ -159,9 +187,14 @@ func buildPreferencesResponse(prefs []db.NotificationPreference) []notificationP
 		if !exists {
 			enabled = true // missing rows default to enabled
 		}
+		available := true
+		if paidOnlyChannels[ch] {
+			available = smsAvailable
+		}
 		result = append(result, notificationPreferenceResponse{
-			Channel: ch,
-			Enabled: enabled,
+			Channel:   ch,
+			Enabled:   enabled,
+			Available: available,
 		})
 	}
 	return result

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -36,6 +36,16 @@ func TestUpdateNotificationPreferences_EnableSMS_FreeTier_Rejected(t *testing.T)
 	if resp.Error.Code != ErrSMSRequiresPaidPlan {
 		t.Errorf("expected error code %q, got %q", ErrSMSRequiresPaidPlan, resp.Error.Code)
 	}
+	// Verify error includes plan details for the frontend.
+	if resp.Error.Details == nil {
+		t.Fatal("expected error details with plan info")
+	}
+	if resp.Error.Details["current_plan"] != db.PlanFree {
+		t.Errorf("expected current_plan=%q, got %v", db.PlanFree, resp.Error.Details["current_plan"])
+	}
+	if resp.Error.Details["required_plan"] != db.PlanPayAsYouGo {
+		t.Errorf("expected required_plan=%q, got %v", db.PlanPayAsYouGo, resp.Error.Details["required_plan"])
+	}
 }
 
 func TestUpdateNotificationPreferences_EnableSMS_PaidTier_Allowed(t *testing.T) {
@@ -138,5 +148,71 @@ func TestUpdateNotificationPreferences_MixedChannels_FreeTier_SMSBlocked(t *test
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetNotificationPreferences_SMSAvailable_PaidTier(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-preferences", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp notificationPreferencesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, p := range resp.Preferences {
+		if !p.Available {
+			t.Errorf("expected all channels available on paid plan, got %q unavailable", p.Channel)
+		}
+	}
+}
+
+func TestGetNotificationPreferences_SMSUnavailable_FreeTier(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-preferences", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp notificationPreferencesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, p := range resp.Preferences {
+		if p.Channel == "sms" {
+			if p.Available {
+				t.Error("expected SMS unavailable on free tier")
+			}
+		} else {
+			if !p.Available {
+				t.Errorf("expected %q available on free tier", p.Channel)
+			}
+		}
 	}
 }

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestUpdateNotificationPreferences_EnableSMS_FreeTier_Rejected(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"sms","enabled":true}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if resp.Error.Code != ErrSMSRequiresPaidPlan {
+		t.Errorf("expected error code %q, got %q", ErrSMSRequiresPaidPlan, resp.Error.Code)
+	}
+}
+
+func TestUpdateNotificationPreferences_EnableSMS_PaidTier_Allowed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"sms","enabled":true}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateNotificationPreferences_DisableSMS_FreeTier_Allowed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	// Disabling SMS should work even on free tier (no plan check needed).
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"sms","enabled":false}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateNotificationPreferences_EnableSMS_NoSubscription_Rejected(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	// No subscription row — should be treated as not allowed.
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"sms","enabled":true}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateNotificationPreferences_EnableEmail_FreeTier_Allowed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	// Non-SMS channels should not be plan-gated.
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"email","enabled":true}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateNotificationPreferences_MixedChannels_FreeTier_SMSBlocked(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	// Enabling email (allowed) + SMS (blocked) in a single request should fail.
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"email","enabled":true},{"channel":"sms","enabled":true}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -307,6 +307,7 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -326,10 +327,17 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	if len(resp.Preferences) != 3 {
 		t.Fatalf("expected 3 preferences, got %d", len(resp.Preferences))
 	}
-	// All channels default to enabled when no preferences are set
+	// All channels default to enabled when no preferences are set.
+	// SMS should not be available on the free plan.
 	for _, p := range resp.Preferences {
 		if !p.Enabled {
 			t.Errorf("expected channel %q to default to enabled", p.Channel)
+		}
+		if p.Channel == "sms" && p.Available {
+			t.Error("expected SMS to be unavailable on free plan")
+		}
+		if p.Channel != "sms" && !p.Available {
+			t.Errorf("expected channel %q to be available", p.Channel)
 		}
 	}
 }
@@ -339,6 +347,7 @@ func TestUpdateNotificationPreferences_Toggle(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)

--- a/frontend/src/hooks/__tests__/useNotificationPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useNotificationPreferences.test.tsx
@@ -10,9 +10,9 @@ vi.mock("../../api/client");
 
 const mockPreferencesResponse = {
   preferences: [
-    { channel: "email", enabled: true },
-    { channel: "web-push", enabled: true },
-    { channel: "sms", enabled: false },
+    { channel: "email", enabled: true, available: true },
+    { channel: "web-push", enabled: true, available: true },
+    { channel: "sms", enabled: false, available: true },
   ],
 };
 

--- a/frontend/src/hooks/__tests__/useUpdateNotificationPreferences.test.tsx
+++ b/frontend/src/hooks/__tests__/useUpdateNotificationPreferences.test.tsx
@@ -10,9 +10,9 @@ vi.mock("../../api/client");
 
 const mockUpdatedResponse = {
   preferences: [
-    { channel: "email", enabled: false },
-    { channel: "web-push", enabled: true },
-    { channel: "sms", enabled: true },
+    { channel: "email", enabled: false, available: true },
+    { channel: "web-push", enabled: true, available: true },
+    { channel: "sms", enabled: true, available: true },
   ],
 };
 

--- a/frontend/src/hooks/useUpdateNotificationPreferences.ts
+++ b/frontend/src/hooks/useUpdateNotificationPreferences.ts
@@ -4,7 +4,7 @@ import client from "@/api/client";
 import type { components } from "@/api/schema";
 import { trackEvent, PostHogEvents } from "@/lib/posthog";
 
-type NotificationPreference = components["schemas"]["NotificationPreference"];
+type NotificationPreferenceUpdate = components["schemas"]["NotificationPreferenceUpdate"];
 
 /**
  * Hook for toggling notification channel preferences. Accepts an array
@@ -16,7 +16,7 @@ export function useUpdateNotificationPreferences() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async (preferences: NotificationPreference[]) => {
+    mutationFn: async (preferences: NotificationPreferenceUpdate[]) => {
       if (!session?.access_token) {
         throw new Error("Not authenticated");
       }

--- a/main.go
+++ b/main.go
@@ -239,6 +239,18 @@ func main() {
 	notifyCfg := notify.LoadConfig()
 	senders := notifyCfg.BuildSenders()
 
+	// #17 — Gate SMS behind paid tier: wrap SMS senders with plan checking
+	// and usage tracking. When the DB is available, free-tier users are blocked
+	// and paid-tier SMS usage is recorded in usage_periods.
+	if deps.DB != nil {
+		smsGate := &notify.DBSMSGate{DB: deps.DB}
+		for i, s := range senders {
+			if s.Name() == "sms" {
+				senders[i] = notify.NewPlanGatedSender(s, smsGate)
+			}
+		}
+	}
+
 	// #276 — Web Push (VAPID): Initialize VAPID keys and register sender.
 	// VAPID keys require the database for auto-generation + persistence,
 	// so this is wired here rather than in BuildSenders().

--- a/notify/db_sms_gate.go
+++ b/notify/db_sms_gate.go
@@ -1,0 +1,36 @@
+package notify
+
+import (
+	"context"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// DBSMSGate implements SMSGate by checking the user's subscription plan
+// in the database. Free-tier users are blocked; paid-tier users are allowed
+// and have their SMS usage tracked.
+type DBSMSGate struct {
+	DB db.DBTX
+}
+
+// CanSendSMS returns true if the user is on a paid plan (not "free").
+// Users without a subscription are treated as not allowed.
+func (g *DBSMSGate) CanSendSMS(ctx context.Context, userID string) (bool, error) {
+	sub, err := db.GetSubscriptionByUserID(ctx, g.DB, userID)
+	if err != nil {
+		return false, err
+	}
+	if sub == nil {
+		return false, nil
+	}
+	return sub.PlanID != db.PlanFree, nil
+}
+
+// RecordSMSSent increments the sms_count for the user's current billing period.
+func (g *DBSMSGate) RecordSMSSent(ctx context.Context, userID string) error {
+	now := time.Now()
+	periodStart, periodEnd := db.BillingPeriodBounds(now)
+	_, err := db.IncrementSMSCount(ctx, g.DB, userID, periodStart, periodEnd)
+	return err
+}

--- a/notify/db_sms_gate_test.go
+++ b/notify/db_sms_gate_test.go
@@ -1,0 +1,91 @@
+package notify_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	"github.com/supersuit-tech/permission-slip-web/notify"
+)
+
+func TestDBSMSGate_FreeTier_Blocked(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "free_user")
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	gate := &notify.DBSMSGate{DB: tx}
+	allowed, err := gate.CanSendSMS(context.Background(), uid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("expected CanSendSMS=false for free tier user")
+	}
+}
+
+func TestDBSMSGate_PaidTier_Allowed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "paid_user")
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	gate := &notify.DBSMSGate{DB: tx}
+	allowed, err := gate.CanSendSMS(context.Background(), uid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Error("expected CanSendSMS=true for paid tier user")
+	}
+}
+
+func TestDBSMSGate_NoSubscription_Blocked(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "no_sub_user")
+	// No subscription inserted.
+
+	gate := &notify.DBSMSGate{DB: tx}
+	allowed, err := gate.CanSendSMS(context.Background(), uid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("expected CanSendSMS=false for user without subscription")
+	}
+}
+
+func TestDBSMSGate_RecordSMSSent_IncrementsCount(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "sms_user")
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	gate := &notify.DBSMSGate{DB: tx}
+
+	// Record two SMS sends.
+	if err := gate.RecordSMSSent(context.Background(), uid); err != nil {
+		t.Fatalf("first RecordSMSSent: %v", err)
+	}
+	if err := gate.RecordSMSSent(context.Background(), uid); err != nil {
+		t.Fatalf("second RecordSMSSent: %v", err)
+	}
+
+	// Verify sms_count = 2.
+	usage, err := db.GetCurrentPeriodUsage(context.Background(), tx, uid)
+	if err != nil {
+		t.Fatalf("GetCurrentPeriodUsage: %v", err)
+	}
+	if usage == nil {
+		t.Fatal("expected usage row, got nil")
+	}
+	if usage.SMSCount != 2 {
+		t.Errorf("expected sms_count=2, got %d", usage.SMSCount)
+	}
+}

--- a/notify/sms_cost.go
+++ b/notify/sms_cost.go
@@ -11,6 +11,31 @@ const (
 	SMSRegionInternational SMSRegion = "international"
 )
 
+// euPrefixes lists E.164 dialing codes for EU/EEA countries that map to the
+// UK/EU billing region. Package-level to avoid per-call allocation. Longer
+// prefixes (3+ digits) are listed first so prefix matching is unambiguous.
+var euPrefixes = []string{
+	"+420", // Czech Republic
+	"+358", // Finland
+	"+353", // Ireland
+	"+351", // Portugal
+	"+33",  // France
+	"+49",  // Germany
+	"+39",  // Italy
+	"+34",  // Spain
+	"+31",  // Netherlands
+	"+32",  // Belgium
+	"+43",  // Austria
+	"+41",  // Switzerland
+	"+46",  // Sweden
+	"+47",  // Norway
+	"+45",  // Denmark
+	"+48",  // Poland
+	"+36",  // Hungary
+	"+40",  // Romania
+	"+30",  // Greece
+}
+
 // SMSRegionForPhone returns the billing region for a phone number based on
 // its international dialing prefix. Numbers should be in E.164 format
 // (e.g. "+15551234567"). This is a best-effort mapping; unrecognised prefixes
@@ -28,29 +53,6 @@ func SMSRegionForPhone(phone string) SMSRegion {
 	// UK: +44
 	if strings.HasPrefix(phone, "+44") {
 		return SMSRegionUKEU
-	}
-
-	// EU country codes (common ones)
-	euPrefixes := []string{
-		"+33", // France
-		"+49", // Germany
-		"+39", // Italy
-		"+34", // Spain
-		"+31", // Netherlands
-		"+32", // Belgium
-		"+43", // Austria
-		"+41", // Switzerland
-		"+46", // Sweden
-		"+47", // Norway
-		"+45", // Denmark
-		"+358", // Finland
-		"+353", // Ireland
-		"+351", // Portugal
-		"+48", // Poland
-		"+420", // Czech Republic
-		"+36", // Hungary
-		"+40", // Romania
-		"+30", // Greece
 	}
 
 	for _, prefix := range euPrefixes {

--- a/notify/sms_cost.go
+++ b/notify/sms_cost.go
@@ -1,0 +1,63 @@
+package notify
+
+import "strings"
+
+// SMSRegion identifies a destination region for SMS pricing.
+type SMSRegion string
+
+const (
+	SMSRegionUSCA          SMSRegion = "us_ca"
+	SMSRegionUKEU          SMSRegion = "uk_eu"
+	SMSRegionInternational SMSRegion = "international"
+)
+
+// SMSRegionForPhone returns the billing region for a phone number based on
+// its international dialing prefix. Numbers should be in E.164 format
+// (e.g. "+15551234567"). This is a best-effort mapping; unrecognised prefixes
+// default to "international".
+func SMSRegionForPhone(phone string) SMSRegion {
+	if !strings.HasPrefix(phone, "+") {
+		return SMSRegionInternational
+	}
+
+	// US/Canada: +1
+	if strings.HasPrefix(phone, "+1") {
+		return SMSRegionUSCA
+	}
+
+	// UK: +44
+	if strings.HasPrefix(phone, "+44") {
+		return SMSRegionUKEU
+	}
+
+	// EU country codes (common ones)
+	euPrefixes := []string{
+		"+33", // France
+		"+49", // Germany
+		"+39", // Italy
+		"+34", // Spain
+		"+31", // Netherlands
+		"+32", // Belgium
+		"+43", // Austria
+		"+41", // Switzerland
+		"+46", // Sweden
+		"+47", // Norway
+		"+45", // Denmark
+		"+358", // Finland
+		"+353", // Ireland
+		"+351", // Portugal
+		"+48", // Poland
+		"+420", // Czech Republic
+		"+36", // Hungary
+		"+40", // Romania
+		"+30", // Greece
+	}
+
+	for _, prefix := range euPrefixes {
+		if strings.HasPrefix(phone, prefix) {
+			return SMSRegionUKEU
+		}
+	}
+
+	return SMSRegionInternational
+}

--- a/notify/sms_cost.go
+++ b/notify/sms_cost.go
@@ -1,8 +1,17 @@
 package notify
 
+// sms_cost.go — Destination-based SMS billing region lookup.
+// Region constants here align with stripe.SMSRates keys.
+//
+// NOTE: This lookup is not yet wired into the billing flow. The billing
+// endpoint (api/billing.go) currently charges all SMS at the "us_ca" rate.
+// A future iteration should pass SMSRegionForPhone(recipient.Phone) to
+// CreateSMSInvoiceItem instead of the hardcoded "us_ca" region.
+
 import "strings"
 
 // SMSRegion identifies a destination region for SMS pricing.
+// Values match the keys in stripe.SMSRates.
 type SMSRegion string
 
 const (

--- a/notify/sms_cost_test.go
+++ b/notify/sms_cost_test.go
@@ -1,0 +1,49 @@
+package notify
+
+import "testing"
+
+func TestSMSRegionForPhone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		phone string
+		want  SMSRegion
+	}{
+		// US/Canada
+		{"+15551234567", SMSRegionUSCA},
+		{"+14155551234", SMSRegionUSCA},
+
+		// UK
+		{"+447911123456", SMSRegionUKEU},
+
+		// EU countries
+		{"+33612345678", SMSRegionUKEU},   // France
+		{"+491761234567", SMSRegionUKEU},   // Germany
+		{"+393331234567", SMSRegionUKEU},   // Italy
+		{"+34612345678", SMSRegionUKEU},    // Spain
+		{"+31612345678", SMSRegionUKEU},    // Netherlands
+		{"+358401234567", SMSRegionUKEU},   // Finland
+		{"+353871234567", SMSRegionUKEU},   // Ireland
+		{"+4201234567890", SMSRegionUKEU},  // Czech Republic
+
+		// International
+		{"+81312345678", SMSRegionInternational},   // Japan
+		{"+61412345678", SMSRegionInternational},   // Australia
+		{"+5511912345678", SMSRegionInternational}, // Brazil
+
+		// Edge cases
+		{"5551234567", SMSRegionInternational},   // no + prefix
+		{"+", SMSRegionInternational},             // just +
+		{"", SMSRegionInternational},              // empty
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phone, func(t *testing.T) {
+			t.Parallel()
+			got := SMSRegionForPhone(tt.phone)
+			if got != tt.want {
+				t.Errorf("SMSRegionForPhone(%q) = %q, want %q", tt.phone, got, tt.want)
+			}
+		})
+	}
+}

--- a/notify/sms_gate.go
+++ b/notify/sms_gate.go
@@ -1,0 +1,63 @@
+package notify
+
+import (
+	"context"
+	"log"
+)
+
+// SMSGate determines whether a user's plan allows SMS notifications and
+// records SMS usage after successful delivery. Implementations must be safe
+// for concurrent use.
+type SMSGate interface {
+	// CanSendSMS returns true if the user's plan allows SMS notifications.
+	CanSendSMS(ctx context.Context, userID string) (bool, error)
+
+	// RecordSMSSent increments the SMS usage counter for the current billing period.
+	RecordSMSSent(ctx context.Context, userID string) error
+}
+
+// PlanGatedSender wraps an SMS Sender with plan-based access control.
+// Free-tier users are silently skipped (logged); paid-tier users have
+// their SMS usage tracked after successful delivery.
+type PlanGatedSender struct {
+	inner Sender
+	gate  SMSGate
+}
+
+// NewPlanGatedSender returns a Sender that checks the user's plan before
+// delegating to the inner sender. Pass nil for gate to disable gating
+// (all sends are allowed, no usage tracking).
+func NewPlanGatedSender(inner Sender, gate SMSGate) Sender {
+	if gate == nil {
+		return inner
+	}
+	return &PlanGatedSender{inner: inner, gate: gate}
+}
+
+// Name returns the inner sender's channel name (e.g. "sms").
+func (s *PlanGatedSender) Name() string { return s.inner.Name() }
+
+// Send checks the user's plan before delivering. If the plan does not allow
+// SMS, the send is skipped with a log message and nil is returned (so other
+// channels are unaffected). On successful delivery, SMS usage is recorded.
+func (s *PlanGatedSender) Send(ctx context.Context, approval Approval, recipient Recipient) error {
+	allowed, err := s.gate.CanSendSMS(ctx, recipient.UserID)
+	if err != nil {
+		log.Printf("notify/sms: plan check failed for user %s: %v — skipping SMS", recipient.UserID, err)
+		return nil
+	}
+	if !allowed {
+		log.Printf("notify/sms: skipped for user %s (free tier)", recipient.UserID)
+		return nil
+	}
+
+	if err := s.inner.Send(ctx, approval, recipient); err != nil {
+		return err
+	}
+
+	if err := s.gate.RecordSMSSent(ctx, recipient.UserID); err != nil {
+		log.Printf("notify/sms: failed to record usage for user %s: %v", recipient.UserID, err)
+		// Don't fail the send — usage tracking is best-effort.
+	}
+	return nil
+}

--- a/notify/sms_gate_test.go
+++ b/notify/sms_gate_test.go
@@ -1,0 +1,140 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// stubGate is a test double for SMSGate.
+type stubGate struct {
+	allowed     bool
+	checkErr    error
+	recordErr   error
+	mu          sync.Mutex
+	recordCalls int
+}
+
+func (g *stubGate) CanSendSMS(_ context.Context, _ string) (bool, error) {
+	if g.checkErr != nil {
+		return false, g.checkErr
+	}
+	return g.allowed, nil
+}
+
+func (g *stubGate) RecordSMSSent(_ context.Context, _ string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.recordCalls++
+	return g.recordErr
+}
+
+func (g *stubGate) recordCallCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.recordCalls
+}
+
+func TestPlanGatedSender_FreeTierBlocked(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms"}
+	gate := &stubGate{allowed: false}
+	s := NewPlanGatedSender(inner, gate)
+
+	err := s.Send(context.Background(), testApproval(), testRecipient())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if inner.callCount() != 0 {
+		t.Errorf("expected inner sender NOT to be called (free tier), got %d calls", inner.callCount())
+	}
+	if gate.recordCallCount() != 0 {
+		t.Errorf("expected no usage recording for free tier, got %d calls", gate.recordCallCount())
+	}
+}
+
+func TestPlanGatedSender_PaidTierAllowed(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms"}
+	gate := &stubGate{allowed: true}
+	s := NewPlanGatedSender(inner, gate)
+
+	err := s.Send(context.Background(), testApproval(), testRecipient())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if inner.callCount() != 1 {
+		t.Errorf("expected inner sender to be called once (paid tier), got %d calls", inner.callCount())
+	}
+	if gate.recordCallCount() != 1 {
+		t.Errorf("expected usage recorded once, got %d calls", gate.recordCallCount())
+	}
+}
+
+func TestPlanGatedSender_PlanCheckError_SkipsSMS(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms"}
+	gate := &stubGate{checkErr: errors.New("db unavailable")}
+	s := NewPlanGatedSender(inner, gate)
+
+	err := s.Send(context.Background(), testApproval(), testRecipient())
+	if err != nil {
+		t.Fatalf("expected nil error on plan check failure, got %v", err)
+	}
+	if inner.callCount() != 0 {
+		t.Errorf("expected inner sender NOT called on plan check error, got %d calls", inner.callCount())
+	}
+}
+
+func TestPlanGatedSender_InnerSendError_DoesNotTrackUsage(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms", err: errors.New("twilio error")}
+	gate := &stubGate{allowed: true}
+	s := NewPlanGatedSender(inner, gate)
+
+	err := s.Send(context.Background(), testApproval(), testRecipient())
+	if err == nil {
+		t.Fatal("expected error from inner sender")
+	}
+	if gate.recordCallCount() != 0 {
+		t.Errorf("expected no usage recording on send failure, got %d calls", gate.recordCallCount())
+	}
+}
+
+func TestPlanGatedSender_RecordError_DoesNotFailSend(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms"}
+	gate := &stubGate{allowed: true, recordErr: errors.New("db write failed")}
+	s := NewPlanGatedSender(inner, gate)
+
+	err := s.Send(context.Background(), testApproval(), testRecipient())
+	if err != nil {
+		t.Fatalf("expected nil error (usage tracking is best-effort), got %v", err)
+	}
+	if inner.callCount() != 1 {
+		t.Errorf("expected inner sender called once, got %d calls", inner.callCount())
+	}
+}
+
+func TestPlanGatedSender_Name(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms"}
+	gate := &stubGate{allowed: true}
+	s := NewPlanGatedSender(inner, gate)
+
+	if s.Name() != "sms" {
+		t.Errorf("expected Name() = %q, got %q", "sms", s.Name())
+	}
+}
+
+func TestNewPlanGatedSender_NilGate_ReturnsInner(t *testing.T) {
+	t.Parallel()
+	inner := &stubSender{name: "sms"}
+	s := NewPlanGatedSender(inner, nil)
+
+	// With nil gate, should return inner directly.
+	if s != inner {
+		t.Error("expected NewPlanGatedSender(inner, nil) to return inner directly")
+	}
+}

--- a/spec/openapi/components/paths/profiles.yaml
+++ b/spec/openapi/components/paths/profiles.yaml
@@ -223,6 +223,10 @@ notificationPreferences:
       Returns the authenticated user's notification preferences for all
       channels. Channels without an explicit preference default to enabled.
 
+      The `available` field on each preference indicates whether the user's
+      plan supports the channel. SMS requires a paid plan — free-tier users
+      see `available: false` for the SMS channel.
+
     tags:
       - Profiles
 
@@ -240,10 +244,13 @@ notificationPreferences:
               preferences:
                 - channel: "email"
                   enabled: true
+                  available: true
                 - channel: "sms"
                   enabled: false
+                  available: false
                 - channel: "web-push"
                   enabled: true
+                  available: true
 
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
@@ -264,6 +271,10 @@ notificationPreferences:
       Updates the authenticated user's notification preferences. Accepts an
       array of channel/enabled pairs. Channels not included in the request
       are left unchanged.
+
+      Enabling the SMS channel requires a paid plan. Free-tier users receive
+      a 403 (sms_requires_paid_plan) with `details.current_plan` and
+      `details.required_plan` indicating which plan is needed.
 
     tags:
       - Profiles
@@ -297,6 +308,24 @@ notificationPreferences:
 
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '403':
+        description: |
+          SMS notifications require a paid plan. Returned when attempting to
+          enable the SMS channel on the free tier. The error details include
+          `current_plan` and `required_plan` fields.
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            example:
+              error:
+                code: "sms_requires_paid_plan"
+                message: "SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS."
+                retryable: false
+                details:
+                  current_plan: "free"
+                  required_plan: "pay_as_you_go"
 
       '429':
         $ref: '../responses/errors.yaml#/TooManyRequests'

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -102,6 +102,26 @@ NotificationPreferencesResponse:
         $ref: '#/NotificationPreference'
       description: List of notification channel preferences
 
+NotificationPreferenceUpdate:
+  type: object
+  description: A channel preference update (request-only, no `available` field).
+  required:
+    - channel
+    - enabled
+  properties:
+    channel:
+      type: string
+      description: Notification channel identifier
+      enum:
+        - email
+        - web-push
+        - sms
+      example: "email"
+    enabled:
+      type: boolean
+      description: Whether notifications should be enabled for this channel
+      example: true
+
 UpdateNotificationPreferencesRequest:
   type: object
   description: Request body for updating notification preferences.
@@ -111,7 +131,7 @@ UpdateNotificationPreferencesRequest:
     preferences:
       type: array
       items:
-        $ref: '#/NotificationPreference'
+        $ref: '#/NotificationPreferenceUpdate'
       description: Channel preferences to update. Channels not included are unchanged.
       minItems: 1
 

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -61,10 +61,14 @@ UpdateProfileRequest:
 
 NotificationPreference:
   type: object
-  description: A single notification channel preference.
+  description: |
+    A single notification channel preference. The `available` field indicates
+    whether the user's plan supports this channel. Channels that require a
+    paid plan (e.g. SMS) return `available: false` for free-tier users.
   required:
     - channel
     - enabled
+    - available
   properties:
     channel:
       type: string
@@ -77,6 +81,13 @@ NotificationPreference:
     enabled:
       type: boolean
       description: Whether notifications are enabled for this channel
+      example: true
+    available:
+      type: boolean
+      description: |
+        Whether this channel is available on the user's current plan.
+        When false, the channel is plan-gated and cannot be enabled.
+        SMS requires a paid plan (pay_as_you_go or higher).
       example: true
 
 NotificationPreferencesResponse:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4528,6 +4528,10 @@ paths:
       description: |
         Returns the authenticated user's notification preferences for all
         channels. Channels without an explicit preference default to enabled.
+
+        The `available` field on each preference indicates whether the user's
+        plan supports the channel. SMS requires a paid plan — free-tier users
+        see `available: false` for the SMS channel.
       tags:
         - Profiles
       security:
@@ -4543,10 +4547,13 @@ paths:
                 preferences:
                   - channel: email
                     enabled: true
+                    available: true
                   - channel: sms
                     enabled: false
+                    available: false
                   - channel: web-push
                     enabled: true
+                    available: true
         '401':
           $ref: '#/components/responses/Unauthorized'
         '429':
@@ -4562,6 +4569,10 @@ paths:
         Updates the authenticated user's notification preferences. Accepts an
         array of channel/enabled pairs. Channels not included in the request
         are left unchanged.
+
+        Enabling the SMS channel requires a paid plan. Free-tier users receive
+        a 403 (sms_requires_paid_plan) with `details.current_plan` and
+        `details.required_plan` indicating which plan is needed.
       tags:
         - Profiles
       security:
@@ -4589,6 +4600,23 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: |
+            SMS notifications require a paid plan. Returned when attempting to
+            enable the SMS channel on the free tier. The error details include
+            `current_plan` and `required_plan` fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: sms_requires_paid_plan
+                  message: SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS.
+                  retryable: false
+                  details:
+                    current_plan: free
+                    required_plan: pay_as_you_go
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -8072,10 +8100,14 @@ components:
           example: true
     NotificationPreference:
       type: object
-      description: A single notification channel preference.
+      description: |
+        A single notification channel preference. The `available` field indicates
+        whether the user's plan supports this channel. Channels that require a
+        paid plan (e.g. SMS) return `available: false` for free-tier users.
       required:
         - channel
         - enabled
+        - available
       properties:
         channel:
           type: string
@@ -8088,6 +8120,13 @@ components:
         enabled:
           type: boolean
           description: Whether notifications are enabled for this channel
+          example: true
+        available:
+          type: boolean
+          description: |
+            Whether this channel is available on the user's current plan.
+            When false, the channel is plan-gated and cannot be enabled.
+            SMS requires a paid plan (pay_as_you_go or higher).
           example: true
     NotificationPreferencesResponse:
       type: object
@@ -8109,7 +8148,7 @@ components:
         preferences:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationPreference'
+            $ref: '#/components/schemas/NotificationPreferenceUpdate'
           description: Channel preferences to update. Channels not included are unchanged.
           minItems: 1
     DeleteAccountRequest:
@@ -8747,6 +8786,25 @@ components:
             recently downgraded from a paid plan. After this time, the shorter
             retention window takes effect.
           example: '2026-03-08T14:30:00Z'
+    NotificationPreferenceUpdate:
+      type: object
+      description: A channel preference update (request-only, no `available` field).
+      required:
+        - channel
+        - enabled
+      properties:
+        channel:
+          type: string
+          description: Notification channel identifier
+          enum:
+            - email
+            - web-push
+            - sms
+          example: email
+        enabled:
+          type: boolean
+          description: Whether notifications should be enabled for this channel
+          example: true
     PlanLimits:
       type: object
       required:


### PR DESCRIPTION
## Summary

Closes #17

- Add `PlanGatedSender` wrapper in the notification dispatcher that checks the user's subscription before sending SMS — free-tier users are silently skipped, paid-tier users get SMS delivered and `usage_periods.sms_count` incremented
- Reject enabling SMS channel via `PUT /profile/notification-preferences` for free-tier users with 403 `sms_requires_paid_plan`
- Add destination-based SMS cost lookup (`SMSRegionForPhone`) mapping E.164 phone numbers to billing regions (US/CA, UK/EU, international)

## Test plan

- [x] `PlanGatedSender` unit tests: free tier blocked, paid tier allowed + usage tracked, plan check error skips SMS, inner send error skips usage, record error doesn't fail send, nil gate passthrough
- [x] `DBSMSGate` integration tests: free tier blocked, paid tier allowed, no subscription blocked, SMS count incremented
- [x] API tests: enable SMS on free tier → 403, enable SMS on paid tier → 200, disable SMS on free tier → 200, no subscription → 403, non-SMS channels unaffected, mixed channels with SMS → 403
- [x] `SMSRegionForPhone` tests: US/CA, UK, EU countries, international, edge cases
- [x] Full backend test suite passes (`make test-backend`)
- [x] Go build compiles cleanly

https://claude.ai/code/session_01CnnsQGpp65okwRVApn1ryQ