### PR TITLE
Add billing API endpoints

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
+	pstripe "github.com/supersuit-tech/permission-slip-web/stripe"
 )
 
 // ── Response types ──────────────────────────────────────────────────────────
@@ -42,6 +43,34 @@ type checkoutResponse struct {
 	URL string `json:"url"`
 }
 
+type usageResponse struct {
+	PeriodStart time.Time       `json:"period_start"`
+	PeriodEnd   time.Time       `json:"period_end"`
+	Requests    requestsUsage   `json:"requests"`
+	SMS         smsUsage        `json:"sms"`
+}
+
+type requestsUsage struct {
+	Total           int  `json:"total"`
+	Included        int  `json:"included"`
+	Overage         int  `json:"overage"`
+	OverageCostCents int `json:"overage_cost_cents"`
+}
+
+type smsUsage struct {
+	Total     int `json:"total"`
+	CostCents int `json:"cost_cents"`
+}
+
+type invoiceListResponse struct {
+	Invoices []pstripe.InvoiceSummary `json:"invoices"`
+}
+
+type downgradeResponse struct {
+	Status string `json:"status"`
+	PlanID string `json:"plan_id"`
+}
+
 // ── Route registration ──────────────────────────────────────────────────────
 
 // RegisterBillingRoutes adds billing endpoints to the mux.
@@ -49,7 +78,11 @@ type checkoutResponse struct {
 func RegisterBillingRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /billing/subscription", requireProfile(handleGetSubscription(deps)))
+	mux.Handle("GET /billing/usage", requireProfile(handleGetUsage(deps)))
 	mux.Handle("POST /billing/checkout", requireProfile(handleCreateCheckout(deps)))
+	mux.Handle("POST /billing/upgrade", requireProfile(handleCreateCheckout(deps)))
+	mux.Handle("POST /billing/downgrade", requireProfile(handleDowngrade(deps)))
+	mux.Handle("GET /billing/invoices", requireProfile(handleListInvoices(deps)))
 }
 
 // ── GET /billing/subscription ───────────────────────────────────────────────
@@ -174,6 +207,224 @@ func handleCreateCheckout(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusOK, checkoutResponse{URL: sess.URL})
+	}
+}
+
+// ── GET /billing/usage ─────────────────────────────────────────────────────
+
+func handleGetUsage(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		sub, err := db.GetSubscriptionWithPlan(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] GetUsage: subscription lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to fetch subscription"))
+			return
+		}
+		if sub == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrSubscriptionNotFound, "No subscription found"))
+			return
+		}
+
+		resp := usageResponse{
+			PeriodStart: sub.CurrentPeriodStart,
+			PeriodEnd:   sub.CurrentPeriodEnd,
+		}
+
+		// Determine included request allowance from the plan.
+		included := 0
+		if sub.Plan.MaxRequestsPerMonth != nil {
+			included = *sub.Plan.MaxRequestsPerMonth
+		}
+		resp.Requests.Included = included
+
+		usage, err := db.GetCurrentPeriodUsage(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] GetUsage: usage lookup: %v", TraceID(r.Context()), err)
+		}
+		if usage != nil {
+			resp.Requests.Total = usage.RequestCount
+			resp.SMS.Total = usage.SMSCount
+
+			// Calculate overage.
+			if included > 0 && usage.RequestCount > included {
+				overage := usage.RequestCount - included
+				resp.Requests.Overage = overage
+				// $0.005/request = 0.5 cents. Round up using same formula as stripe client.
+				resp.Requests.OverageCostCents = int((int64(overage)*5 + 9) / 10)
+			}
+
+			// SMS cost: $0.01/message (us_ca rate).
+			resp.SMS.CostCents = usage.SMSCount
+		}
+
+		RespondJSON(w, http.StatusOK, resp)
+	}
+}
+
+// ── POST /billing/downgrade ───────────────────────────────────────────────
+
+func handleDowngrade(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		sub, err := db.GetSubscriptionByUserID(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] Downgrade: subscription lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to fetch subscription"))
+			return
+		}
+		if sub == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrSubscriptionNotFound, "No subscription found"))
+			return
+		}
+
+		// Can only downgrade from a paid plan.
+		if sub.PlanID == db.PlanFree {
+			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadyDowngraded, "Already on the free plan"))
+			return
+		}
+
+		// Check plan limits: count agents, standing approvals, credentials.
+		freePlan, err := db.GetPlanByID(r.Context(), deps.DB, db.PlanFree)
+		if err != nil {
+			log.Printf("[%s] Downgrade: free plan lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to fetch free plan limits"))
+			return
+		}
+		if freePlan == nil {
+			log.Printf("[%s] Downgrade: free plan not found", TraceID(r.Context()))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Free plan not configured"))
+			return
+		}
+
+		if err := validateDowngradeLimits(r.Context(), deps, profile.ID, freePlan); err != nil {
+			RespondError(w, r, http.StatusConflict, *err)
+			return
+		}
+
+		// Cancel Stripe subscription if one exists.
+		if deps.Stripe != nil && sub.StripeSubscriptionID != nil {
+			if _, err := deps.Stripe.CancelSubscription(r.Context(), *sub.StripeSubscriptionID); err != nil {
+				log.Printf("[%s] Downgrade: cancel Stripe subscription: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusBadGateway, upstreamError("Failed to cancel subscription with payment provider"))
+				return
+			}
+		}
+
+		// Downgrade plan locally.
+		updated, err := db.UpdateSubscriptionPlan(r.Context(), deps.DB, profile.ID, db.PlanFree)
+		if err != nil {
+			log.Printf("[%s] Downgrade: update plan: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to downgrade plan"))
+			return
+		}
+		if updated == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrSubscriptionNotFound, "No subscription found"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, downgradeResponse{
+			Status: string(updated.Status),
+			PlanID: updated.PlanID,
+		})
+	}
+}
+
+// validateDowngradeLimits checks that the user's current resource counts are
+// within the free plan's limits. Returns an ErrorResponse if any limit is
+// exceeded, nil otherwise.
+func validateDowngradeLimits(ctx context.Context, deps *Deps, userID string, freePlan *db.Plan) *ErrorResponse {
+	if freePlan.MaxAgents != nil {
+		count, err := db.CountRegisteredAgentsByUser(ctx, deps.DB, userID)
+		if err != nil {
+			log.Printf("[%s] Downgrade: count agents: %v", TraceID(ctx), err)
+		} else if count > *freePlan.MaxAgents {
+			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active agents for the free plan")
+			resp.Error.Details = map[string]any{
+				"resource":  "agents",
+				"current":   count,
+				"max_allowed": *freePlan.MaxAgents,
+			}
+			return &resp
+		}
+	}
+
+	if freePlan.MaxStandingApprovals != nil {
+		count, err := db.CountActiveStandingApprovalsByUser(ctx, deps.DB, userID)
+		if err != nil {
+			log.Printf("[%s] Downgrade: count standing approvals: %v", TraceID(ctx), err)
+		} else if count > *freePlan.MaxStandingApprovals {
+			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active standing approvals for the free plan")
+			resp.Error.Details = map[string]any{
+				"resource":  "standing_approvals",
+				"current":   count,
+				"max_allowed": *freePlan.MaxStandingApprovals,
+			}
+			return &resp
+		}
+	}
+
+	if freePlan.MaxCredentials != nil {
+		count, err := db.CountCredentialsByUser(ctx, deps.DB, userID)
+		if err != nil {
+			log.Printf("[%s] Downgrade: count credentials: %v", TraceID(ctx), err)
+		} else if count > *freePlan.MaxCredentials {
+			resp := Conflict(ErrDowngradeLimitExceeded, "Too many stored credentials for the free plan")
+			resp.Error.Details = map[string]any{
+				"resource":  "credentials",
+				"current":   count,
+				"max_allowed": *freePlan.MaxCredentials,
+			}
+			return &resp
+		}
+	}
+
+	return nil
+}
+
+// ── GET /billing/invoices ─────────────────────────────────────────────────
+
+func handleListInvoices(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		if deps.Stripe == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Billing not configured"))
+			return
+		}
+
+		sub, err := db.GetSubscriptionByUserID(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] ListInvoices: subscription lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to fetch subscription"))
+			return
+		}
+		if sub == nil || sub.StripeCustomerID == nil {
+			// No Stripe customer → no invoices.
+			RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: []pstripe.InvoiceSummary{}})
+			return
+		}
+
+		invoices, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, 24)
+		if err != nil {
+			log.Printf("[%s] ListInvoices: Stripe list: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusBadGateway, upstreamError("Failed to fetch invoices"))
+			return
+		}
+		if invoices == nil {
+			invoices = []pstripe.InvoiceSummary{}
+		}
+
+		RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: invoices})
 	}
 }
 

--- a/api/billing.go
+++ b/api/billing.go
@@ -123,10 +123,12 @@ func handleGetSubscription(deps *Deps) http.HandlerFunc {
 			},
 		}
 
-		// Attach current period usage if available.
+		// Attach current period usage if available (non-fatal — subscription
+		// data is still returned without usage on error).
 		usage, err := db.GetCurrentPeriodUsage(r.Context(), deps.DB, profile.ID)
 		if err != nil {
 			log.Printf("[%s] GetSubscription: usage lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
 		}
 		if usage != nil {
 			ui := &usageInfo{
@@ -193,9 +195,11 @@ func handleCreateCheckout(deps *Deps) http.HandlerFunc {
 			}
 			stripeCustomerID = cust.ID
 
-			// Persist Stripe customer ID.
+			// Persist Stripe customer ID so subsequent checkout attempts reuse
+			// the same customer instead of creating duplicates.
 			if _, err := db.UpdateSubscriptionStripe(r.Context(), deps.DB, profile.ID, &stripeCustomerID, nil); err != nil {
 				log.Printf("[%s] CreateCheckout: save customer ID: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
 			}
 		}
 
@@ -464,7 +468,11 @@ func ReportPeriodUsage(ctx context.Context, deps *Deps, userID string, usage *db
 	}
 
 	sub, err := db.GetSubscriptionByUserID(ctx, deps.DB, userID)
-	if err != nil || sub == nil || sub.StripeCustomerID == nil {
+	if err != nil {
+		log.Printf("billing: ReportPeriodUsage: subscription lookup for %s: %v", userID, err)
+		return
+	}
+	if sub == nil || sub.StripeCustomerID == nil {
 		return
 	}
 

--- a/api/billing.go
+++ b/api/billing.go
@@ -256,12 +256,10 @@ func handleGetUsage(deps *Deps) http.HandlerFunc {
 			resp.Requests.Total = usage.RequestCount
 			resp.SMS.Total = usage.SMSCount
 
-			// Calculate overage.
+			// Calculate overage using the shared pricing function.
 			if included > 0 && usage.RequestCount > included {
-				overage := usage.RequestCount - included
-				resp.Requests.Overage = overage
-				// $0.005/request = 0.5 cents. Round up using same formula as stripe client.
-				resp.Requests.OverageCostCents = int((int64(overage)*5 + 9) / 10)
+				resp.Requests.Overage = usage.RequestCount - included
+				resp.Requests.OverageCostCents = pstripe.OverageCostCents(resp.Requests.Overage)
 			}
 
 			// SMS cost: $0.01/message (us_ca rate).
@@ -310,8 +308,12 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		if err := validateDowngradeLimits(r.Context(), deps, profile.ID, freePlan); err != nil {
-			RespondError(w, r, http.StatusConflict, *err)
+		if limitErr := validateDowngradeLimits(r.Context(), deps, profile.ID, freePlan); limitErr != nil {
+			status := http.StatusConflict
+			if limitErr.Error.Code == ErrInternalError {
+				status = http.StatusInternalServerError
+			}
+			RespondError(w, r, status, *limitErr)
 			return
 		}
 

--- a/api/billing.go
+++ b/api/billing.go
@@ -71,6 +71,9 @@ type downgradeResponse struct {
 	PlanID string `json:"plan_id"`
 }
 
+// maxInvoiceResults is the maximum number of invoices returned by the list endpoint.
+const maxInvoiceResults = 24
+
 // ── Route registration ──────────────────────────────────────────────────────
 
 // RegisterBillingRoutes adds billing endpoints to the mux.
@@ -147,12 +150,9 @@ func handleCreateCheckout(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		profile := Profile(r.Context())
 
-		if deps.Stripe == nil {
-			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Billing not configured"))
-			return
-		}
-
-		// Look up existing subscription to check for existing Stripe customer.
+		// Check business logic before infrastructure dependencies so users
+		// get accurate error messages (e.g. "already subscribed" not "billing
+		// not configured").
 		sub, err := db.GetSubscriptionByUserID(r.Context(), deps.DB, profile.ID)
 		if err != nil {
 			log.Printf("[%s] CreateCheckout: subscription lookup: %v", TraceID(r.Context()), err)
@@ -164,6 +164,11 @@ func handleCreateCheckout(deps *Deps) http.HandlerFunc {
 		// If already on paid plan, reject.
 		if sub != nil && sub.PlanID == db.PlanPayAsYouGo {
 			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadySubscribed, "Already subscribed to a paid plan"))
+			return
+		}
+
+		if deps.Stripe == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Billing not configured"))
 			return
 		}
 
@@ -243,6 +248,9 @@ func handleGetUsage(deps *Deps) http.HandlerFunc {
 		usage, err := db.GetCurrentPeriodUsage(r.Context(), deps.DB, profile.ID)
 		if err != nil {
 			log.Printf("[%s] GetUsage: usage lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to fetch usage data"))
+			return
 		}
 		if usage != nil {
 			resp.Requests.Total = usage.RequestCount
@@ -339,17 +347,21 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 
 // validateDowngradeLimits checks that the user's current resource counts are
 // within the free plan's limits. Returns an ErrorResponse if any limit is
-// exceeded, nil otherwise.
+// exceeded or if a count cannot be verified (fail-closed), nil otherwise.
 func validateDowngradeLimits(ctx context.Context, deps *Deps, userID string, freePlan *db.Plan) *ErrorResponse {
 	if freePlan.MaxAgents != nil {
 		count, err := db.CountRegisteredAgentsByUser(ctx, deps.DB, userID)
 		if err != nil {
 			log.Printf("[%s] Downgrade: count agents: %v", TraceID(ctx), err)
-		} else if count > *freePlan.MaxAgents {
+			CaptureError(ctx, err)
+			resp := InternalError("Unable to verify agent count")
+			return &resp
+		}
+		if count > *freePlan.MaxAgents {
 			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active agents for the free plan")
 			resp.Error.Details = map[string]any{
-				"resource":  "agents",
-				"current":   count,
+				"resource":    "agents",
+				"current":     count,
 				"max_allowed": *freePlan.MaxAgents,
 			}
 			return &resp
@@ -360,11 +372,15 @@ func validateDowngradeLimits(ctx context.Context, deps *Deps, userID string, fre
 		count, err := db.CountActiveStandingApprovalsByUser(ctx, deps.DB, userID)
 		if err != nil {
 			log.Printf("[%s] Downgrade: count standing approvals: %v", TraceID(ctx), err)
-		} else if count > *freePlan.MaxStandingApprovals {
+			CaptureError(ctx, err)
+			resp := InternalError("Unable to verify standing approval count")
+			return &resp
+		}
+		if count > *freePlan.MaxStandingApprovals {
 			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active standing approvals for the free plan")
 			resp.Error.Details = map[string]any{
-				"resource":  "standing_approvals",
-				"current":   count,
+				"resource":    "standing_approvals",
+				"current":     count,
 				"max_allowed": *freePlan.MaxStandingApprovals,
 			}
 			return &resp
@@ -375,11 +391,15 @@ func validateDowngradeLimits(ctx context.Context, deps *Deps, userID string, fre
 		count, err := db.CountCredentialsByUser(ctx, deps.DB, userID)
 		if err != nil {
 			log.Printf("[%s] Downgrade: count credentials: %v", TraceID(ctx), err)
-		} else if count > *freePlan.MaxCredentials {
+			CaptureError(ctx, err)
+			resp := InternalError("Unable to verify credential count")
+			return &resp
+		}
+		if count > *freePlan.MaxCredentials {
 			resp := Conflict(ErrDowngradeLimitExceeded, "Too many stored credentials for the free plan")
 			resp.Error.Details = map[string]any{
-				"resource":  "credentials",
-				"current":   count,
+				"resource":    "credentials",
+				"current":     count,
 				"max_allowed": *freePlan.MaxCredentials,
 			}
 			return &resp
@@ -413,7 +433,7 @@ func handleListInvoices(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		invoices, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, 24)
+		invoices, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, maxInvoiceResults)
 		if err != nil {
 			log.Printf("[%s] ListInvoices: Stripe list: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	pstripe "github.com/supersuit-tech/permission-slip-web/stripe"
 )
 
 func TestGetSubscription_ReturnsSubscription(t *testing.T) {
@@ -198,5 +199,461 @@ func TestGetSubscription_HasPaymentMethodWhenStripeCustomerSet(t *testing.T) {
 	}
 	if resp.CanUpgrade {
 		t.Error("expected can_upgrade=false for pay_as_you_go plan")
+	}
+}
+
+// ── GET /billing/usage ────────────────────────────────────────────────────
+
+func TestGetUsage_ReturnsUsage(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	// Record some usage.
+	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
+	for i := 0; i < 5; i++ {
+		if _, err := db.IncrementRequestCount(ctx, tx, uid, periodStart, periodEnd); err != nil {
+			t.Fatalf("IncrementRequestCount: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := db.IncrementSMSCount(ctx, tx, uid, periodStart, periodEnd); err != nil {
+			t.Fatalf("IncrementSMSCount: %v", err)
+		}
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/usage", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp usageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Requests.Total != 5 {
+		t.Errorf("expected requests.total=5, got %d", resp.Requests.Total)
+	}
+	if resp.Requests.Included != 1000 {
+		t.Errorf("expected requests.included=1000, got %d", resp.Requests.Included)
+	}
+	if resp.Requests.Overage != 0 {
+		t.Errorf("expected requests.overage=0, got %d", resp.Requests.Overage)
+	}
+	if resp.Requests.OverageCostCents != 0 {
+		t.Errorf("expected requests.overage_cost_cents=0, got %d", resp.Requests.OverageCostCents)
+	}
+	if resp.SMS.Total != 3 {
+		t.Errorf("expected sms.total=3, got %d", resp.SMS.Total)
+	}
+	if resp.SMS.CostCents != 3 {
+		t.Errorf("expected sms.cost_cents=3, got %d", resp.SMS.CostCents)
+	}
+}
+
+func TestGetUsage_NoSubscription(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/usage", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetUsage_ZeroUsage(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/usage", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp usageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Requests.Total != 0 {
+		t.Errorf("expected requests.total=0, got %d", resp.Requests.Total)
+	}
+	if resp.Requests.Included != 1000 {
+		t.Errorf("expected requests.included=1000 (free plan), got %d", resp.Requests.Included)
+	}
+}
+
+func TestGetUsage_WithOverage(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	// Insert usage that exceeds the free limit directly.
+	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
+	testhelper.MustExec(t, tx,
+		`INSERT INTO usage_periods (user_id, period_start, period_end, request_count)
+		 VALUES ($1, $2, $3, 1050)`,
+		uid, periodStart, periodEnd)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/usage", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp usageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Requests.Total != 1050 {
+		t.Errorf("expected requests.total=1050, got %d", resp.Requests.Total)
+	}
+	if resp.Requests.Overage != 50 {
+		t.Errorf("expected requests.overage=50, got %d", resp.Requests.Overage)
+	}
+	// 50 requests at $0.005 = 25 cents. Formula: ceil(50 * 0.5) = 25
+	if resp.Requests.OverageCostCents != 25 {
+		t.Errorf("expected requests.overage_cost_cents=25, got %d", resp.Requests.OverageCostCents)
+	}
+}
+
+// ── POST /billing/upgrade ─────────────────────────────────────────────────
+
+func TestUpgrade_RequiresStripeClient(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	// No Stripe client → 503.
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true, Stripe: nil}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/upgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ── POST /billing/downgrade ───────────────────────────────────────────────
+
+func TestDowngrade_AlreadyFree(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if errResp.Error.Code != ErrAlreadyDowngraded {
+		t.Errorf("expected error code %s, got %s", ErrAlreadyDowngraded, errResp.Error.Code)
+	}
+}
+
+func TestDowngrade_NoSubscription(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDowngrade_Success_NoStripe(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	// No Stripe client — downgrade should still succeed locally.
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true, Stripe: nil}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.PlanID != db.PlanFree {
+		t.Errorf("expected plan_id=%s, got %s", db.PlanFree, resp.PlanID)
+	}
+
+	// Verify subscription was actually downgraded in DB.
+	sub, err := db.GetSubscriptionByUserID(context.Background(), tx, uid)
+	if err != nil {
+		t.Fatalf("GetSubscriptionByUserID: %v", err)
+	}
+	if sub.PlanID != db.PlanFree {
+		t.Errorf("DB subscription plan_id: expected %s, got %s", db.PlanFree, sub.PlanID)
+	}
+	if sub.DowngradedAt == nil {
+		t.Error("expected downgraded_at to be set after downgrade")
+	}
+}
+
+func TestDowngrade_TooManyAgents(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	// Create more registered agents than the free plan allows.
+	// Free plan limit is 5 agents (from seed data).
+	for i := 0; i < 6; i++ {
+		testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if errResp.Error.Code != ErrDowngradeLimitExceeded {
+		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	}
+	if errResp.Error.Details["resource"] != "agents" {
+		t.Errorf("expected resource=agents, got %v", errResp.Error.Details["resource"])
+	}
+}
+
+func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+
+	// Free plan limit is 10 active standing approvals (from seed data).
+	for i := 0; i < 11; i++ {
+		saID := testhelper.GenerateID(t, "sa_")
+		testhelper.InsertStandingApproval(t, tx, saID, agentID, uid)
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if errResp.Error.Code != ErrDowngradeLimitExceeded {
+		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	}
+	if errResp.Error.Details["resource"] != "standing_approvals" {
+		t.Errorf("expected resource=standing_approvals, got %v", errResp.Error.Details["resource"])
+	}
+}
+
+func TestDowngrade_TooManyCredentials(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	// Free plan limit is 5 credentials (from seed data).
+	for i := 0; i < 6; i++ {
+		credID := testhelper.GenerateID(t, "cred_")
+		service := testhelper.GenerateID(t, "svc_")
+		testhelper.InsertCredential(t, tx, credID, uid, service)
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if errResp.Error.Code != ErrDowngradeLimitExceeded {
+		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	}
+	if errResp.Error.Details["resource"] != "credentials" {
+		t.Errorf("expected resource=credentials, got %v", errResp.Error.Details["resource"])
+	}
+}
+
+// ── GET /billing/invoices ─────────────────────────────────────────────────
+
+func TestListInvoices_RequiresStripeClient(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true, Stripe: nil}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/invoices", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListInvoices_NoStripeCustomer(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	// Stripe is configured but user has no Stripe customer ID → empty list.
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true, Stripe: pstripe.New(pstripe.Config{})}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/invoices", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp invoiceListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp.Invoices) != 0 {
+		t.Errorf("expected empty invoices list, got %d", len(resp.Invoices))
+	}
+}
+
+func TestListInvoices_NoSubscription(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	// No subscription → empty list (not an error).
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true, Stripe: pstripe.New(pstripe.Config{})}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/invoices", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp invoiceListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp.Invoices) != 0 {
+		t.Errorf("expected empty invoices list, got %d", len(resp.Invoices))
 	}
 }

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -146,8 +146,8 @@ func TestCreateCheckout_AlreadyPaid(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	// Even with a Stripe client, already-paid users should get 409.
-	// We use nil Stripe since the check happens before any Stripe call.
+	// Business logic (already-paid) is checked before Stripe dependency,
+	// so even with nil Stripe the user gets the correct 409 error.
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true, Stripe: nil}
 	router := NewRouter(deps)
 
@@ -155,12 +155,16 @@ func TestCreateCheckout_AlreadyPaid(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	// The nil Stripe check happens first, but the already-paid check is
-	// after the Stripe nil check, so we'll get 503 here. That's fine —
-	// the important logic (already-paid rejection) is tested when Stripe
-	// is available, which requires a real/mock Stripe client.
-	if w.Code != http.StatusServiceUnavailable {
-		t.Logf("got %d (expected 503 since Stripe is nil)", w.Code)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if errResp.Error.Code != ErrAlreadySubscribed {
+		t.Errorf("expected error code %s, got %s", ErrAlreadySubscribed, errResp.Error.Code)
 	}
 }
 

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -51,5 +51,7 @@ const (
 	ErrCredentialLimitReached   ErrorCode = "credential_limit_reached"
 	ErrSubscriptionNotFound     ErrorCode = "subscription_not_found"
 	ErrAlreadySubscribed        ErrorCode = "already_subscribed"
+	ErrAlreadyDowngraded        ErrorCode = "already_downgraded"
+	ErrDowngradeLimitExceeded   ErrorCode = "downgrade_limit_exceeded"
 	ErrBillingNotEnabled        ErrorCode = "billing_not_enabled"
 )

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -171,7 +171,8 @@ downgrade:
 
       If the user has a Stripe subscription, it is cancelled immediately.
       Returns 409 if the user is already on the free plan or if resource
-      counts exceed free plan limits.
+      counts exceed free plan limits (with details about which resource and
+      the current/allowed counts in the error response).
 
       Only available when `billing_enabled` is `true` in the server config.
     operationId: downgradePlan
@@ -192,6 +193,12 @@ downgrade:
         $ref: '../responses/errors.yaml#/NotFound'
       '409':
         description: Already on free plan or resource limits exceeded
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '500':
+        description: Unable to verify resource counts for limit validation
         content:
           application/json:
             schema:

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -83,6 +83,159 @@ checkout:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+usage:
+  get:
+    summary: Get current usage
+    description: |
+      Returns a detailed usage breakdown for the current billing period,
+      including request counts, overage calculations, and SMS costs.
+
+      Only available when `billing_enabled` is `true` in the server config.
+    operationId: getUsage
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Usage details returned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/UsageResponse'
+            example:
+              period_start: '2026-03-01T00:00:00Z'
+              period_end: '2026-04-01T00:00:00Z'
+              requests:
+                total: 450
+                included: 1000
+                overage: 0
+                overage_cost_cents: 0
+              sms:
+                total: 12
+                cost_cents: 12
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+
+upgrade:
+  post:
+    summary: Upgrade to paid plan
+    description: |
+      Initiates an upgrade to the paid plan by creating a Stripe Checkout Session.
+      Returns a URL to redirect the user to Stripe's hosted checkout page.
+
+      This is an alias for `POST /v1/billing/checkout`.
+
+      If the user doesn't have a Stripe Customer yet, one is created automatically.
+      If the user is already on a paid plan, returns 409 Conflict.
+
+      Only available when `billing_enabled` is `true` and Stripe is configured.
+    operationId: upgradePlan
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Checkout session created
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/CheckoutResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '409':
+        description: Already subscribed to a paid plan
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '502':
+        description: Stripe API error
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+downgrade:
+  post:
+    summary: Downgrade to free plan
+    description: |
+      Downgrades the user from a paid plan to the free tier. Validates that
+      current resource counts (agents, standing approvals, credentials) are
+      within free plan limits before proceeding.
+
+      If the user has a Stripe subscription, it is cancelled immediately.
+      Returns 409 if the user is already on the free plan or if resource
+      counts exceed free plan limits.
+
+      Only available when `billing_enabled` is `true` in the server config.
+    operationId: downgradePlan
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Successfully downgraded
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/DowngradeResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '409':
+        description: Already on free plan or resource limits exceeded
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '502':
+        description: Stripe API error
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+invoices:
+  get:
+    summary: List invoices
+    description: |
+      Returns the user's past invoices from Stripe. Up to 24 paid invoices
+      are returned, sorted by creation date (most recent first).
+
+      Returns an empty list if the user has no Stripe customer or no invoices.
+
+      Only available when `billing_enabled` is `true` and Stripe is configured.
+    operationId: listInvoices
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    responses:
+      '200':
+        description: Invoice list returned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/InvoiceListResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '502':
+        description: Stripe API error
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
 webhook:
   post:
     summary: Stripe webhook

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -134,7 +134,7 @@ RequestsUsage:
       example: 450
     included:
       type: integer
-      description: Number of requests included in the plan (0 = unlimited)
+      description: Number of requests included in the plan for free (0 = unlimited on paid plans)
       example: 1000
     overage:
       type: integer
@@ -142,7 +142,9 @@ RequestsUsage:
       example: 0
     overage_cost_cents:
       type: integer
-      description: Estimated overage cost in cents
+      description: |
+        Estimated overage cost in cents, calculated at $0.005 per request
+        (0.5 cents), rounded up to the nearest cent
       example: 0
 
 SMSUsage:
@@ -157,7 +159,9 @@ SMSUsage:
       example: 12
     cost_cents:
       type: integer
-      description: Estimated SMS cost in cents
+      description: |
+        Estimated SMS cost in cents at the US/CA rate ($0.01 per message).
+        International rates may apply for non-US/CA destinations.
       example: 12
 
 DowngradeResponse:

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -99,6 +99,148 @@ UsageInfo:
       description: Whether current usage exceeds the plan's request limit
       example: false
 
+UsageResponse:
+  type: object
+  required:
+    - period_start
+    - period_end
+    - requests
+    - sms
+  properties:
+    period_start:
+      type: string
+      format: date-time
+      description: Start of the current billing period (inclusive)
+    period_end:
+      type: string
+      format: date-time
+      description: End of the current billing period (exclusive)
+    requests:
+      $ref: '#/RequestsUsage'
+    sms:
+      $ref: '#/SMSUsage'
+
+RequestsUsage:
+  type: object
+  required:
+    - total
+    - included
+    - overage
+    - overage_cost_cents
+  properties:
+    total:
+      type: integer
+      description: Total API requests in the current billing period
+      example: 450
+    included:
+      type: integer
+      description: Number of requests included in the plan (0 = unlimited)
+      example: 1000
+    overage:
+      type: integer
+      description: Number of requests exceeding the included allowance
+      example: 0
+    overage_cost_cents:
+      type: integer
+      description: Estimated overage cost in cents
+      example: 0
+
+SMSUsage:
+  type: object
+  required:
+    - total
+    - cost_cents
+  properties:
+    total:
+      type: integer
+      description: Total SMS messages sent in the current billing period
+      example: 12
+    cost_cents:
+      type: integer
+      description: Estimated SMS cost in cents
+      example: 12
+
+DowngradeResponse:
+  type: object
+  required:
+    - status
+    - plan_id
+  properties:
+    status:
+      type: string
+      enum: [active, past_due, cancelled]
+      description: Subscription status after downgrade
+      example: active
+    plan_id:
+      type: string
+      description: Plan ID after downgrade (always "free")
+      example: free
+
+InvoiceListResponse:
+  type: object
+  required:
+    - invoices
+  properties:
+    invoices:
+      type: array
+      items:
+        $ref: '#/InvoiceSummary'
+
+InvoiceSummary:
+  type: object
+  required:
+    - id
+    - status
+    - currency
+    - amount_due
+    - amount_paid
+    - created
+  properties:
+    id:
+      type: string
+      description: Stripe Invoice ID
+      example: in_1234567890
+    number:
+      type: string
+      description: Invoice number
+      example: INV-0001
+    status:
+      type: string
+      description: Invoice status
+      example: paid
+    currency:
+      type: string
+      description: Three-letter ISO currency code
+      example: usd
+    amount_due:
+      type: integer
+      description: Amount due in cents
+      example: 500
+    amount_paid:
+      type: integer
+      description: Amount paid in cents
+      example: 500
+    period_start:
+      type: integer
+      description: Billing period start (Unix timestamp)
+      example: 1709251200
+    period_end:
+      type: integer
+      description: Billing period end (Unix timestamp)
+      example: 1711929600
+    created:
+      type: integer
+      description: Invoice creation time (Unix timestamp)
+      example: 1711929600
+    hosted_invoice_url:
+      type: string
+      format: uri
+      description: URL to view the invoice on Stripe's hosted page
+    invoice_pdf:
+      type: string
+      format: uri
+      description: URL to download the invoice PDF
+
 CheckoutResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4846,7 +4846,8 @@ paths:
 
         If the user has a Stripe subscription, it is cancelled immediately.
         Returns 409 if the user is already on the free plan or if resource
-        counts exceed free plan limits.
+        counts exceed free plan limits (with details about which resource and
+        the current/allowed counts in the error response).
 
         Only available when `billing_enabled` is `true` in the server config.
       operationId: downgradePlan
@@ -4867,6 +4868,12 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           description: Already on free plan or resource limits exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to verify resource counts for limit validation
           content:
             application/json:
               schema:
@@ -8514,7 +8521,7 @@ components:
           example: 450
         included:
           type: integer
-          description: Number of requests included in the plan (0 = unlimited)
+          description: Number of requests included in the plan for free (0 = unlimited on paid plans)
           example: 1000
         overage:
           type: integer
@@ -8522,7 +8529,9 @@ components:
           example: 0
         overage_cost_cents:
           type: integer
-          description: Estimated overage cost in cents
+          description: |
+            Estimated overage cost in cents, calculated at $0.005 per request
+            (0.5 cents), rounded up to the nearest cent
           example: 0
     SMSUsage:
       type: object
@@ -8536,7 +8545,9 @@ components:
           example: 12
         cost_cents:
           type: integer
-          description: Estimated SMS cost in cents
+          description: |
+            Estimated SMS cost in cents at the US/CA rate ($0.01 per message).
+            International rates may apply for non-US/CA destinations.
           example: 12
     DowngradeResponse:
       type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4720,6 +4720,41 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+  /v1/billing/usage:
+    get:
+      summary: Get current usage
+      description: |
+        Returns a detailed usage breakdown for the current billing period,
+        including request counts, overage calculations, and SMS costs.
+
+        Only available when `billing_enabled` is `true` in the server config.
+      operationId: getUsage
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Usage details returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageResponse'
+              example:
+                period_start: '2026-03-01T00:00:00Z'
+                period_end: '2026-04-01T00:00:00Z'
+                requests:
+                  total: 450
+                  included: 1000
+                  overage: 0
+                  overage_cost_cents: 0
+                sms:
+                  total: 12
+                  cost_cents: 12
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /v1/billing/checkout:
     post:
       summary: Create checkout session
@@ -4752,6 +4787,120 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/upgrade:
+    post:
+      summary: Upgrade to paid plan
+      description: |
+        Initiates an upgrade to the paid plan by creating a Stripe Checkout Session.
+        Returns a URL to redirect the user to Stripe's hosted checkout page.
+
+        This is an alias for `POST /v1/billing/checkout`.
+
+        If the user doesn't have a Stripe Customer yet, one is created automatically.
+        If the user is already on a paid plan, returns 409 Conflict.
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: upgradePlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Checkout session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckoutResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Already subscribed to a paid plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/downgrade:
+    post:
+      summary: Downgrade to free plan
+      description: |
+        Downgrades the user from a paid plan to the free tier. Validates that
+        current resource counts (agents, standing approvals, credentials) are
+        within free plan limits before proceeding.
+
+        If the user has a Stripe subscription, it is cancelled immediately.
+        Returns 409 if the user is already on the free plan or if resource
+        counts exceed free plan limits.
+
+        Only available when `billing_enabled` is `true` in the server config.
+      operationId: downgradePlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Successfully downgraded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DowngradeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Already on free plan or resource limits exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/billing/invoices:
+    get:
+      summary: List invoices
+      description: |
+        Returns the user's past invoices from Stripe. Up to 24 paid invoices
+        are returned, sorted by creation date (most recent first).
+
+        Returns an empty list if the user has no Stripe customer or no invoices.
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: listInvoices
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Invoice list returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '502':
           description: Stripe API error
           content:
@@ -8331,6 +8480,145 @@ components:
           type: boolean
           description: Whether current usage exceeds the plan's request limit
           example: false
+    UsageResponse:
+      type: object
+      required:
+        - period_start
+        - period_end
+        - requests
+        - sms
+      properties:
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (inclusive)
+        period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (exclusive)
+        requests:
+          $ref: '#/components/schemas/RequestsUsage'
+        sms:
+          $ref: '#/components/schemas/SMSUsage'
+    RequestsUsage:
+      type: object
+      required:
+        - total
+        - included
+        - overage
+        - overage_cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total API requests in the current billing period
+          example: 450
+        included:
+          type: integer
+          description: Number of requests included in the plan (0 = unlimited)
+          example: 1000
+        overage:
+          type: integer
+          description: Number of requests exceeding the included allowance
+          example: 0
+        overage_cost_cents:
+          type: integer
+          description: Estimated overage cost in cents
+          example: 0
+    SMSUsage:
+      type: object
+      required:
+        - total
+        - cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total SMS messages sent in the current billing period
+          example: 12
+        cost_cents:
+          type: integer
+          description: Estimated SMS cost in cents
+          example: 12
+    DowngradeResponse:
+      type: object
+      required:
+        - status
+        - plan_id
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+            - past_due
+            - cancelled
+          description: Subscription status after downgrade
+          example: active
+        plan_id:
+          type: string
+          description: Plan ID after downgrade (always "free")
+          example: free
+    InvoiceListResponse:
+      type: object
+      required:
+        - invoices
+      properties:
+        invoices:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceSummary'
+    InvoiceSummary:
+      type: object
+      required:
+        - id
+        - status
+        - currency
+        - amount_due
+        - amount_paid
+        - created
+      properties:
+        id:
+          type: string
+          description: Stripe Invoice ID
+          example: in_1234567890
+        number:
+          type: string
+          description: Invoice number
+          example: INV-0001
+        status:
+          type: string
+          description: Invoice status
+          example: paid
+        currency:
+          type: string
+          description: Three-letter ISO currency code
+          example: usd
+        amount_due:
+          type: integer
+          description: Amount due in cents
+          example: 500
+        amount_paid:
+          type: integer
+          description: Amount paid in cents
+          example: 500
+        period_start:
+          type: integer
+          description: Billing period start (Unix timestamp)
+          example: 1709251200
+        period_end:
+          type: integer
+          description: Billing period end (Unix timestamp)
+          example: 1711929600
+        created:
+          type: integer
+          description: Invoice creation time (Unix timestamp)
+          example: 1711929600
+        hosted_invoice_url:
+          type: string
+          format: uri
+          description: URL to view the invoice on Stripe's hosted page
+        invoice_pdf:
+          type: string
+          format: uri
+          description: URL to download the invoice PDF
     CheckoutResponse:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -229,8 +229,20 @@ paths:
   /v1/billing/subscription:
     $ref: './components/paths/billing.yaml#/subscription'
 
+  /v1/billing/usage:
+    $ref: './components/paths/billing.yaml#/usage'
+
   /v1/billing/checkout:
     $ref: './components/paths/billing.yaml#/checkout'
+
+  /v1/billing/upgrade:
+    $ref: './components/paths/billing.yaml#/upgrade'
+
+  /v1/billing/downgrade:
+    $ref: './components/paths/billing.yaml#/downgrade'
+
+  /v1/billing/invoices:
+    $ref: './components/paths/billing.yaml#/invoices'
 
   /v1/billing/webhook:
     $ref: './components/paths/billing.yaml#/webhook'
@@ -437,6 +449,18 @@ components:
       $ref: './components/schemas/billing.yaml#/SubscriptionResponse'
     UsageInfo:
       $ref: './components/schemas/billing.yaml#/UsageInfo'
+    UsageResponse:
+      $ref: './components/schemas/billing.yaml#/UsageResponse'
+    RequestsUsage:
+      $ref: './components/schemas/billing.yaml#/RequestsUsage'
+    SMSUsage:
+      $ref: './components/schemas/billing.yaml#/SMSUsage'
+    DowngradeResponse:
+      $ref: './components/schemas/billing.yaml#/DowngradeResponse'
+    InvoiceListResponse:
+      $ref: './components/schemas/billing.yaml#/InvoiceListResponse'
+    InvoiceSummary:
+      $ref: './components/schemas/billing.yaml#/InvoiceSummary'
     CheckoutResponse:
       $ref: './components/schemas/billing.yaml#/CheckoutResponse'
 

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -84,6 +84,17 @@ func (c *Client) CreateCheckoutSession(ctx context.Context, stripeCustomerID, su
 // billing period before per-request charges apply.
 const FreeRequestAllowance = 1000
 
+// OverageCostCents calculates the cost in cents for overage requests at
+// $0.005/request (0.5 cents). Uses ceiling division to avoid under-billing
+// for odd counts: ceil(overage * 0.5) = (overage*5 + 9) / 10.
+// Returns 0 if overage is zero or negative.
+func OverageCostCents(overage int) int {
+	if overage <= 0 {
+		return 0
+	}
+	return int((int64(overage)*5 + 9) / 10)
+}
+
 // CreateUsageInvoiceItem creates a Stripe Invoice Item for billable request
 // usage. It calculates the overage beyond the free allowance and charges
 // $0.005 per request. Returns nil (no error) if usage is within the free tier.
@@ -93,9 +104,7 @@ func (c *Client) CreateUsageInvoiceItem(ctx context.Context, stripeCustomerID st
 		return nil, nil // within free tier
 	}
 
-	// $0.005/request = 0.5 cents/request. Stripe amounts are in cents (int64),
-	// so we round up to avoid under-billing for odd counts.
-	amountCents := (billable*5 + 9) / 10 // equivalent to ceil(billable * 0.5)
+	amountCents := int64(OverageCostCents(int(billable)))
 
 	params := &gostripe.InvoiceItemParams{
 		Customer:    gostripe.String(stripeCustomerID),
@@ -179,13 +188,15 @@ func (c *Client) ListInvoices(ctx context.Context, stripeCustomerID string, limi
 	for iter.Next() {
 		inv := iter.Invoice()
 		summary := InvoiceSummary{
-			ID:        inv.ID,
-			Number:    inv.Number,
-			Status:    string(inv.Status),
-			Currency:  string(inv.Currency),
-			AmountDue: inv.AmountDue,
-			AmountPaid: inv.AmountPaid,
-			Created:   inv.Created,
+			ID:          inv.ID,
+			Number:      inv.Number,
+			Status:      string(inv.Status),
+			Currency:    string(inv.Currency),
+			AmountDue:   inv.AmountDue,
+			AmountPaid:  inv.AmountPaid,
+			PeriodStart: inv.PeriodStart,
+			PeriodEnd:   inv.PeriodEnd,
+			Created:     inv.Created,
 		}
 		if inv.HostedInvoiceURL != "" {
 			summary.HostedURL = inv.HostedInvoiceURL

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -7,7 +7,9 @@ import (
 	gostripe "github.com/stripe/stripe-go/v82"
 	"github.com/stripe/stripe-go/v82/checkout/session"
 	"github.com/stripe/stripe-go/v82/customer"
+	"github.com/stripe/stripe-go/v82/invoice"
 	"github.com/stripe/stripe-go/v82/invoiceitem"
+	"github.com/stripe/stripe-go/v82/subscription"
 )
 
 // Config holds Stripe configuration from environment variables.
@@ -144,4 +146,69 @@ func (c *Client) CreateSMSInvoiceItem(ctx context.Context, stripeCustomerID, reg
 		return nil, fmt.Errorf("stripe: create SMS invoice item: %w", err)
 	}
 	return item, nil
+}
+
+// InvoiceSummary is a simplified invoice representation for the API response.
+type InvoiceSummary struct {
+	ID          string `json:"id"`
+	Number      string `json:"number,omitempty"`
+	Status      string `json:"status"`
+	Currency    string `json:"currency"`
+	AmountDue   int64  `json:"amount_due"`
+	AmountPaid  int64  `json:"amount_paid"`
+	PeriodStart int64  `json:"period_start"`
+	PeriodEnd   int64  `json:"period_end"`
+	Created     int64  `json:"created"`
+	HostedURL   string `json:"hosted_invoice_url,omitempty"`
+	PDFURL      string `json:"invoice_pdf,omitempty"`
+}
+
+// ListInvoices returns up to `limit` invoices for the given Stripe customer,
+// filtered to only paid invoices. Returns an empty slice if the customer has
+// no invoices.
+func (c *Client) ListInvoices(ctx context.Context, stripeCustomerID string, limit int) ([]InvoiceSummary, error) {
+	params := &gostripe.InvoiceListParams{
+		Customer: gostripe.String(stripeCustomerID),
+		Status:   gostripe.String("paid"),
+	}
+	params.Limit = gostripe.Int64(int64(limit))
+	params.Context = ctx
+
+	var invoices []InvoiceSummary
+	iter := invoice.List(params)
+	for iter.Next() {
+		inv := iter.Invoice()
+		summary := InvoiceSummary{
+			ID:        inv.ID,
+			Number:    inv.Number,
+			Status:    string(inv.Status),
+			Currency:  string(inv.Currency),
+			AmountDue: inv.AmountDue,
+			AmountPaid: inv.AmountPaid,
+			Created:   inv.Created,
+		}
+		if inv.HostedInvoiceURL != "" {
+			summary.HostedURL = inv.HostedInvoiceURL
+		}
+		if inv.InvoicePDF != "" {
+			summary.PDFURL = inv.InvoicePDF
+		}
+		invoices = append(invoices, summary)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("stripe: list invoices: %w", err)
+	}
+	return invoices, nil
+}
+
+// CancelSubscription cancels a Stripe subscription immediately.
+func (c *Client) CancelSubscription(ctx context.Context, stripeSubscriptionID string) (*gostripe.Subscription, error) {
+	params := &gostripe.SubscriptionCancelParams{}
+	params.Context = ctx
+
+	sub, err := subscription.Cancel(stripeSubscriptionID, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe: cancel subscription: %w", err)
+	}
+	return sub, nil
 }

--- a/stripe/client_test.go
+++ b/stripe/client_test.go
@@ -44,6 +44,29 @@ func TestSMSRates_PricingCorrect(t *testing.T) {
 	}
 }
 
+func TestOverageCostCents(t *testing.T) {
+	tests := []struct {
+		overage  int
+		expected int
+	}{
+		{0, 0},
+		{-1, 0},
+		{1, 1},   // ceil(0.5) = 1 cent
+		{2, 1},   // ceil(1.0) = 1 cent
+		{10, 5},  // ceil(5.0) = 5 cents
+		{50, 25}, // ceil(25.0) = 25 cents
+		{99, 50}, // ceil(49.5) = 50 cents
+		{100, 50},
+		{1000, 500},
+	}
+	for _, tt := range tests {
+		got := OverageCostCents(tt.overage)
+		if got != tt.expected {
+			t.Errorf("OverageCostCents(%d) = %d, want %d", tt.overage, got, tt.expected)
+		}
+	}
+}
+
 func TestNew_SetsAPIKey(t *testing.T) {
 	// Ensure New doesn't panic with empty config.
 	client := New(Config{})


### PR DESCRIPTION
## Summary
- Adds four new billing endpoints: `GET /billing/usage` (detailed usage breakdown with overage calculations), `POST /billing/upgrade` (alias for checkout), `POST /billing/downgrade` (validates free plan limits before downgrading, cancels Stripe subscription), and `GET /billing/invoices` (lists paid invoices from Stripe)
- Adds `ListInvoices` and `CancelSubscription` methods to the Stripe client wrapper
- Includes OpenAPI spec definitions, generated TypeScript types, and 14 new tests covering happy paths and edge cases (limit enforcement for agents/standing approvals/credentials, overage math, empty states)

## Test plan
- [x] All 14 new billing tests pass (`TestGetUsage_*`, `TestUpgrade_*`, `TestDowngrade_*`, `TestListInvoices_*`)
- [x] Full backend test suite passes (`go test ./...`)
- [x] Frontend TypeScript compilation succeeds (`tsc -b` via `npm run build`)
- [x] OpenAPI bundle regenerated and TypeScript types generated
- [ ] Manual test: verify `GET /billing/usage` returns correct overage for a user over the free limit
- [ ] Manual test: verify `POST /billing/downgrade` rejects when agents exceed free plan limit
- [ ] Manual test: verify `GET /billing/invoices` returns invoices for a user with Stripe history

Closes #15

https://claude.ai/code/session_01DA8AU2CRS3ExMGYKQCVVts