### PR TITLE
Fix fly.toml missing app name

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,21 +13,13 @@ Permission Slip ships as a single Go binary with the React frontend embedded. Th
 
 ### 1. Launch the app
 
-First, set the `app` name in `fly.toml`. Open it and replace `your-app-name` with your actual Fly app name:
-
-```toml
-app = 'my-permission-slip-app'
-```
-
-Then launch:
+From the project root:
 
 ```bash
 fly launch
 ```
 
-This detects the `Dockerfile` and `fly.toml` automatically. Review the settings and confirm. `fly launch` will update the `app` field for you if it isn't already set.
-
-If you already have the app created on Fly.io, you can skip `fly launch` — just make sure the `app` field in `fly.toml` matches your existing app name, then go straight to setting secrets.
+This detects the `Dockerfile` and `fly.toml` automatically (the app name `permission-slip` is already configured). Review the settings and confirm. If the app is already created on Fly.io, skip this step and go straight to setting secrets.
 
 ### 2. Set secrets
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,13 +13,21 @@ Permission Slip ships as a single Go binary with the React frontend embedded. Th
 
 ### 1. Launch the app
 
-From the project root:
+First, set the `app` name in `fly.toml`. Open it and replace `your-app-name` with your actual Fly app name:
+
+```toml
+app = 'my-permission-slip-app'
+```
+
+Then launch:
 
 ```bash
 fly launch
 ```
 
-This detects the `Dockerfile` and `fly.toml` automatically. Review the settings and confirm. If you already have the app created, skip this step and go straight to deploying.
+This detects the `Dockerfile` and `fly.toml` automatically. Review the settings and confirm. `fly launch` will update the `app` field for you if it isn't already set.
+
+If you already have the app created on Fly.io, you can skip `fly launch` — just make sure the `app` field in `fly.toml` matches your existing app name, then go straight to setting secrets.
 
 ### 2. Set secrets
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,4 @@
-# Replace with your Fly app name before deploying.
-# Run `fly launch` to set this automatically, or set it manually.
-app = 'your-app-name'
+app = 'permission-slip'
 primary_region = 'iad'
 kill_signal = 'SIGTERM'
 kill_timeout = '30s'

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,6 @@
-# Replace with your Fly app name (fly launch will set this automatically)
-# app = 'your-app-name'
+# Replace with your Fly app name before deploying.
+# Run `fly launch` to set this automatically, or set it manually.
+app = 'your-app-name'
 primary_region = 'iad'
 kill_signal = 'SIGTERM'
 kill_timeout = '30s'


### PR DESCRIPTION
## Summary
- Hardcode `app = 'permission-slip'` in `fly.toml` — it was previously commented out, causing `fly secrets set` and other fly commands to fail with "config for your app is missing an app"
- Update deployment docs to reflect that the app name is pre-configured

## Test plan
- [ ] Run `fly secrets set` against the updated `fly.toml` and confirm it no longer errors about a missing app
- [ ] Run `fly launch` and verify it picks up the existing app name

https://claude.ai/code/session_017PRxuFhjq7gAaWqeYjA8Cb