### PR TITLE
Rename SUPABASE_ANON_KEY to SUPABASE_PUBLISHABLE_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ DATABASE_URL_TEST=postgres://localhost:5432/permission_slip_test?sslmode=disable
 # Supabase — used by the React frontend
 # Run `supabase status` to get your local credentials (see README step 5)
 VITE_SUPABASE_URL=http://127.0.0.1:54321
-VITE_SUPABASE_ANON_KEY=your-anon-key-from-supabase-status
+VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key-from-supabase-status
 
 # Supabase — Go backend JWT authentication
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ cp .env.example .env
 
 # 5. Start Supabase (requires Docker running)
 supabase start
-supabase status   # copy the anon key into .env as VITE_SUPABASE_ANON_KEY
+supabase status   # copy the publishable key into .env as VITE_SUPABASE_PUBLISHABLE_KEY
 
 # 6. Run database migrations
 make migrate-up
@@ -109,7 +109,7 @@ Run `cp .env.example .env` and fill in the values. The essential variables for l
 | `DATABASE_URL_TEST` | _(empty)_ | Postgres connection string for `go test` and CI |
 | `SUPABASE_URL` | _(empty)_ | Supabase project URL (e.g. `http://127.0.0.1:54321` locally) |
 | `VITE_SUPABASE_URL` | _(empty)_ | Supabase URL for the React frontend |
-| `VITE_SUPABASE_ANON_KEY` | _(empty)_ | Supabase anon key for the React frontend |
+| `VITE_SUPABASE_PUBLISHABLE_KEY` | _(empty)_ | Supabase publishable key for the React frontend |
 | `BASE_URL` | _(empty)_ | Public base URL — used for invite URLs |
 | `INVITE_HMAC_KEY` | _(empty)_ | HMAC key for invite codes — generate with `openssl rand -hex 32` |
 | `VAULT_SECRET_KEY` | _(empty)_ | Encryption key for Supabase Vault (AES-256-GCM) — generate with `openssl rand -hex 32` |
@@ -130,7 +130,7 @@ Copy the output into your `.env`:
 
 ```bash
 VITE_SUPABASE_URL=http://127.0.0.1:54321
-VITE_SUPABASE_ANON_KEY=<anon key from supabase status>
+VITE_SUPABASE_PUBLISHABLE_KEY=<publishable key from supabase status>
 ```
 
 **Supabase Studio:** Open **http://127.0.0.1:54323** to manage your local database, tables, RLS policies, and auth.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Permission Slip.
 # Produces a minimal (~30MB) runtime image containing only the static binary.
 #
-# Build: docker build --build-arg VITE_SUPABASE_URL=... --build-arg VITE_SUPABASE_ANON_KEY=... -t permission-slip-web .
+# Build: docker build --build-arg VITE_SUPABASE_URL=... --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=... -t permission-slip-web .
 # Run:   docker run -p 8080:8080 -e DATABASE_URL=... -e SUPABASE_URL=... permission-slip-web
 
 # ── Stage 1: Build frontend ──────────────────────────────────────────────────
@@ -20,7 +20,7 @@ RUN npm ci
 # Vite inlines VITE_* env vars into the JS bundle at build time.
 # Pass these as Docker build args (--build-arg) or via [build.args] in fly.toml.
 ARG VITE_SUPABASE_URL
-ARG VITE_SUPABASE_ANON_KEY
+ARG VITE_SUPABASE_PUBLISHABLE_KEY
 ARG VITE_SENTRY_DSN
 
 # Sentry source-map upload (optional — skip if not set).

--- a/Makefile
+++ b/Makefile
@@ -58,22 +58,22 @@ run:
 # ---------- Deployment ----------
 
 # Build Docker image locally for testing before deploying.
-# Requires VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in the environment
+# Requires VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY in the environment
 # (Vite inlines these into the JS bundle at build time).
-# Usage: VITE_SUPABASE_URL=https://xxx.supabase.co VITE_SUPABASE_ANON_KEY=yyy make docker-build
+# Usage: VITE_SUPABASE_URL=https://xxx.supabase.co VITE_SUPABASE_PUBLISHABLE_KEY=yyy make docker-build
 docker-build:
 	docker build \
 		--build-arg VITE_SUPABASE_URL=$${VITE_SUPABASE_URL} \
-		--build-arg VITE_SUPABASE_ANON_KEY=$${VITE_SUPABASE_ANON_KEY} \
+		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY} \
 		-t permission-slip-web .
 
 # Deploy to Fly.io. Reads Supabase build args from the environment.
 # Alternatively, configure [build.args] in fly.toml and just run: fly deploy
-# Usage: VITE_SUPABASE_URL=https://xxx.supabase.co VITE_SUPABASE_ANON_KEY=yyy make deploy
+# Usage: VITE_SUPABASE_URL=https://xxx.supabase.co VITE_SUPABASE_PUBLISHABLE_KEY=yyy make deploy
 deploy:
 	fly deploy \
 		--build-arg VITE_SUPABASE_URL=$${VITE_SUPABASE_URL} \
-		--build-arg VITE_SUPABASE_ANON_KEY=$${VITE_SUPABASE_ANON_KEY}
+		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY}
 
 # ---------- Testing ----------
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ supabase start                        # start local Supabase stack (requires Doc
 supabase status                       # get local URLs and keys for .env
 ```
 
-Copy the `anon key` from `supabase status` into your `.env` as `VITE_SUPABASE_ANON_KEY`. The default `DATABASE_URL` in `.env.example` already points to Supabase's local Postgres (`127.0.0.1:54322`).
+Copy the `publishable key` from `supabase status` into your `.env` as `VITE_SUPABASE_PUBLISHABLE_KEY`. The default `DATABASE_URL` in `.env.example` already points to Supabase's local Postgres (`127.0.0.1:54322`).
 
 See the [Supabase docs](https://supabase.com/docs/guides/local-development) for more details.
 
@@ -170,7 +170,7 @@ The mobile app lives in `mobile/` and uses React Native (Expo). It shares the sa
 ```bash
 cd mobile
 npm install
-cp .env.example .env   # set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY
+cp .env.example .env   # set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 npm start              # Expo dev server — scan QR with Expo Go app
 ```
 

--- a/api/auth_integration_test.go
+++ b/api/auth_integration_test.go
@@ -563,11 +563,11 @@ func TestIntegration_UserLifecycle_SignupCreatesAuthUser(t *testing.T) {
 
 // --- Helpers for Supabase keys ---
 
-// supabaseAnonKey returns the Supabase anon key for the local instance.
-// The default local dev anon key is well-known and stable.
+// supabaseAnonKey returns the Supabase publishable key (formerly "anon key")
+// for the local instance. The default local dev key is well-known and stable.
 func supabaseAnonKey(t *testing.T) string {
 	t.Helper()
-	// Standard Supabase local dev anon key (public, safe to commit).
+	// Standard Supabase local dev publishable key (public, safe to commit).
 	return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
 }
 

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -74,7 +74,7 @@ Permission Slip uses a single Supabase project for:
 | Value | Where to find | Used as |
 |---|---|---|
 | Project URL | Settings > API | `SUPABASE_URL` (runtime) + `VITE_SUPABASE_URL` (build) |
-| Anon key (public) | Settings > API | `VITE_SUPABASE_ANON_KEY` (build) |
+| Publishable key (public) | Settings > API | `VITE_SUPABASE_PUBLISHABLE_KEY` (build) |
 | Database connection string | Settings > Database > Connection string | `DATABASE_URL` (runtime) |
 
 **Database connection notes:**
@@ -98,7 +98,7 @@ fly secrets set \
 # Build-time args (inlined into frontend JS bundle)
 fly deploy \
   --build-arg VITE_SUPABASE_URL="https://[project-ref].supabase.co" \
-  --build-arg VITE_SUPABASE_ANON_KEY="<anon key from Supabase dashboard>"
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="<publishable key from Supabase dashboard>"
 ```
 
 ### Sentry (Error Tracking)
@@ -385,7 +385,7 @@ These are inlined into the JavaScript bundle by Vite. Pass via `fly deploy --bui
 ```bash
 fly deploy \
   --build-arg VITE_SUPABASE_URL="https://[project-ref].supabase.co" \
-  --build-arg VITE_SUPABASE_ANON_KEY="<anon key from Supabase dashboard>" \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="<publishable key from Supabase dashboard>" \
   --build-arg VITE_SENTRY_DSN="https://[key]@[org].ingest.sentry.io/[project]" \
   --build-arg SENTRY_AUTH_TOKEN="sntrys_xxxx" \
   --build-arg SENTRY_ORG="supersuit" \
@@ -399,7 +399,7 @@ Or hardcode in `fly.toml` for simpler deploys:
 ```toml
 [build.args]
   VITE_SUPABASE_URL = "https://[project-ref].supabase.co"
-  VITE_SUPABASE_ANON_KEY = "<anon key>"
+  VITE_SUPABASE_PUBLISHABLE_KEY = "<publishable key>"
   VITE_POSTHOG_KEY = "phc_xxxx"
   # VITE_SENTRY_DSN, SENTRY_AUTH_TOKEN, etc. can go here too
 ```
@@ -426,7 +426,7 @@ Or hardcode in `fly.toml` for simpler deploys:
 | `SENTRY_CSP_ENDPOINT` | Runtime secret | **Set** | CSP violation reporting |
 | `SUPABASE_SERVICE_ROLE_KEY` | Runtime secret | **Recommended** | Admin API operations (e.g. account deletion) |
 | `VITE_SUPABASE_URL` | Build arg | **Required** | Frontend auth URL |
-| `VITE_SUPABASE_ANON_KEY` | Build arg | **Required** | Frontend auth public key |
+| `VITE_SUPABASE_PUBLISHABLE_KEY` | Build arg | **Required** | Frontend auth publishable key |
 | `VITE_SENTRY_DSN` | Build arg | **Set** | Frontend error tracking DSN |
 | `SENTRY_AUTH_TOKEN` | Build arg | **Set** | Source map upload token |
 | `SENTRY_ORG` | Build arg | **Set** | `supersuit` |
@@ -453,14 +453,14 @@ Or hardcode in `fly.toml` for simpler deploys:
 # From the repo root — reads VITE_* from environment or fly.toml [build.args]
 fly deploy \
   --build-arg VITE_SUPABASE_URL=https://[ref].supabase.co \
-  --build-arg VITE_SUPABASE_ANON_KEY=<key>
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=<key>
 ```
 
 Or use the Makefile shortcut:
 
 ```bash
 VITE_SUPABASE_URL=https://[ref].supabase.co \
-VITE_SUPABASE_ANON_KEY=<key> \
+VITE_SUPABASE_PUBLISHABLE_KEY=<key> \
 make deploy
 ```
 
@@ -788,7 +788,7 @@ These are tracked under [#321](https://github.com/supersuit-tech/permission-slip
 
 **Deploy fails on frontend build stage:**
 - Ensure `spec/openapi/openapi.bundle.yaml` is committed — the `npm ci` postinstall hook needs it
-- Check that build args (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`) are being passed
+- Check that build args (`VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY`) are being passed
 
 **Health check fails after deploy:**
 - Check `fly logs` for startup errors

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -43,7 +43,7 @@ Permission Slip uses [Supabase Auth](https://supabase.com/auth) for user authent
 1. Create a project at [supabase.com](https://supabase.com)
 2. From your project dashboard, note these values:
    - **Project URL** (e.g., `https://abcdefgh.supabase.co`) — used as `SUPABASE_URL`
-   - **Anon key** (public) — used as `VITE_SUPABASE_ANON_KEY` at build time
+   - **Publishable key** (public) — used as `VITE_SUPABASE_PUBLISHABLE_KEY` at build time
 3. Under **Authentication > URL Configuration**, add your deployment URL to the redirect allow list
 
 > **Note:** You can use Supabase's hosted database as your `DATABASE_URL` too, or use a separate PostgreSQL instance. Either works.
@@ -92,10 +92,10 @@ These are inlined into the JavaScript bundle by Vite at build time. They must be
 | Variable | Description | Example |
 |---|---|---|
 | `VITE_SUPABASE_URL` | Supabase project URL (frontend auth) | `https://abcdefgh.supabase.co` |
-| `VITE_SUPABASE_ANON_KEY` | Supabase anon (public) key | From Supabase dashboard |
+| `VITE_SUPABASE_PUBLISHABLE_KEY` | Supabase publishable key | From Supabase dashboard |
 | `VITE_SENTRY_DSN` | Frontend error tracking (optional) | `https://key@o0.ingest.sentry.io/0` |
 
-> The anon key is safe to include in the build — it's a public key visible in client-side JavaScript by design.
+> The publishable key is safe to include in the build — it's a public key visible in client-side JavaScript by design. (Supabase previously called this the "anon key.")
 
 ### Web Push Notifications (VAPID)
 
@@ -218,7 +218,7 @@ The included multi-stage Dockerfile produces a minimal (~30MB) Alpine image.
 ```bash
 docker build \
   --build-arg VITE_SUPABASE_URL=https://abcdefgh.supabase.co \
-  --build-arg VITE_SUPABASE_ANON_KEY=your-anon-key \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key \
   -t permission-slip .
 ```
 
@@ -244,7 +244,7 @@ services:
       context: .
       args:
         VITE_SUPABASE_URL: https://abcdefgh.supabase.co
-        VITE_SUPABASE_ANON_KEY: your-anon-key
+        VITE_SUPABASE_PUBLISHABLE_KEY: your-publishable-key
     ports:
       - "8080:8080"
     environment:
@@ -277,7 +277,7 @@ fly secrets set \
   INVITE_HMAC_KEY="$(openssl rand -hex 32)"
 fly deploy \
   --build-arg VITE_SUPABASE_URL=https://abcdefgh.supabase.co \
-  --build-arg VITE_SUPABASE_ANON_KEY=your-anon-key
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 ```
 
 ### Option C: Build from Source
@@ -294,7 +294,7 @@ make install
 
 # Set build-time vars for the frontend
 export VITE_SUPABASE_URL=https://abcdefgh.supabase.co
-export VITE_SUPABASE_ANON_KEY=your-anon-key
+export VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 make build
 
 # Run
@@ -314,7 +314,7 @@ Permission Slip works on any platform that supports Docker or Go builds:
 
 1. Connect your repo (or push the Docker image)
 2. Set the required environment variables in the platform's dashboard
-3. For Docker-based platforms, configure build args for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+3. For Docker-based platforms, configure build args for `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY`
 4. Ensure the health check is configured for `GET /api/health` on port 8080
 
 ## TLS / Reverse Proxy
@@ -405,7 +405,7 @@ Migrations run automatically on startup. If they fail, check database connectivi
 | `DATABASE_URL` | Yes | Runtime | PostgreSQL connection string |
 | `SUPABASE_URL` | Yes | Runtime | Supabase project URL (JWT + auth) |
 | `VITE_SUPABASE_URL` | Yes | Build | Supabase URL for frontend auth |
-| `VITE_SUPABASE_ANON_KEY` | Yes | Build | Supabase public anon key |
+| `VITE_SUPABASE_PUBLISHABLE_KEY` | Yes | Build | Supabase publishable key |
 | `BASE_URL` | Recommended | Runtime | Public deployment URL |
 | `ALLOWED_ORIGINS` | Recommended | Runtime | CORS allowed origins (comma-separated, exact match, no trailing slash). Same-origin only when unset. |
 | `INVITE_HMAC_KEY` | Recommended | Runtime | HMAC key for invite codes |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,16 +44,16 @@ See [Secrets Reference](#secrets-reference) below for the full list.
 
 ### 3. Configure frontend build args
 
-The React frontend uses Vite, which inlines `VITE_*` environment variables into the JavaScript bundle at build time. You **must** pass your Supabase URL and anon key as build args — they cannot be set as runtime secrets.
+The React frontend uses Vite, which inlines `VITE_*` environment variables into the JavaScript bundle at build time. You **must** pass your Supabase URL and publishable key as build args — they cannot be set as runtime secrets.
 
-The anon key is safe to include in the build: it's a public key that's always visible in client-side JavaScript.
+The publishable key is safe to include in the build: it's a public key that's always visible in client-side JavaScript. (Supabase previously called this the "anon key" — it's the same value, just renamed in the dashboard.)
 
 **Option A** — Pass as `fly deploy` flags:
 
 ```bash
 fly deploy \
   --build-arg VITE_SUPABASE_URL=https://your-project.supabase.co \
-  --build-arg VITE_SUPABASE_ANON_KEY=your-anon-key
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 ```
 
 **Option B** — Hardcode in `fly.toml` (simpler for CI):
@@ -61,7 +61,7 @@ fly deploy \
 ```toml
 [build.args]
   VITE_SUPABASE_URL = "https://your-project.supabase.co"
-  VITE_SUPABASE_ANON_KEY = "your-anon-key"
+  VITE_SUPABASE_PUBLISHABLE_KEY = "your-publishable-key"
 ```
 
 **Option C** — Use the Makefile shortcut (reads from your shell environment):
@@ -69,11 +69,11 @@ fly deploy \
 ```bash
 # Export the variables first, or inline them:
 export VITE_SUPABASE_URL=https://your-project.supabase.co
-export VITE_SUPABASE_ANON_KEY=your-anon-key
+export VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 make deploy
 
 # Or inline on the same command:
-VITE_SUPABASE_URL=https://your-project.supabase.co VITE_SUPABASE_ANON_KEY=your-anon-key make deploy
+VITE_SUPABASE_URL=https://your-project.supabase.co VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key make deploy
 ```
 
 ### 4. Deploy
@@ -223,7 +223,7 @@ make docker-build
 # Or directly:
 docker build \
   --build-arg VITE_SUPABASE_URL=https://your-project.supabase.co \
-  --build-arg VITE_SUPABASE_ANON_KEY=your-anon-key \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key \
   -t permission-slip-web .
 
 # Run
@@ -242,7 +242,7 @@ Ensure `spec/openapi/openapi.bundle.yaml` is committed — the `npm ci` postinst
 Check logs with `fly logs`. Common causes: missing `DATABASE_URL`, incorrect Supabase credentials, or the database being unreachable from Fly's network.
 
 **Frontend shows "Missing VITE_SUPABASE_URL" error:**
-The Supabase build args were not passed during `fly deploy`. Re-deploy with `--build-arg VITE_SUPABASE_URL=... --build-arg VITE_SUPABASE_ANON_KEY=...` or add `[build.args]` to `fly.toml`. See [Configure frontend build args](#3-configure-frontend-build-args).
+The Supabase build args were not passed during `fly deploy`. Re-deploy with `--build-arg VITE_SUPABASE_URL=... --build-arg VITE_SUPABASE_PUBLISHABLE_KEY=...` or add `[build.args]` to `fly.toml`. See [Configure frontend build args](#3-configure-frontend-build-args).
 
 **CORS errors in browser (403 on API calls):**
 Ensure `ALLOWED_ORIGINS` includes your app's exact origin (e.g., `https://your-app.fly.dev`) — no trailing slash. When unset, the server defaults to same-origin only mode, which works for the standard deployment but will reject requests if a custom domain or CDN changes the browser's origin.

--- a/fly.toml
+++ b/fly.toml
@@ -5,11 +5,9 @@ kill_timeout = '30s'
 
 [build]
   # Vite inlines these into the JS bundle at build time.
-  # Set via: fly deploy --build-arg VITE_SUPABASE_URL=https://xxx.supabase.co ...
-  # Or uncomment and hardcode below for convenience:
-  # [build.args]
-  #   VITE_SUPABASE_URL = "https://your-project.supabase.co"
-  #   VITE_SUPABASE_ANON_KEY = "your-anon-key"
+  [build.args]
+    VITE_SUPABASE_URL = "https://rixmzguicuihjvzumyxm.supabase.co"
+    VITE_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_4Db9aiXHjC7JG-K1w3V54g_qLLrDL4o"
 
 [env]
   PORT = '8080'

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,7 +3,7 @@
 # (routed by Vite's proxy or dev-proxy.cjs). No need to set VITE_SUPABASE_URL locally.
 # In production, VITE_SUPABASE_URL must be set to the real Supabase project URL.
 VITE_SUPABASE_URL=http://127.0.0.1:54321
-VITE_SUPABASE_ANON_KEY=your-anon-key-here
+VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key-here
 
 # Sentry error tracking (optional — omit to disable)
 # VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0

--- a/frontend/REMOTE_DEV.md
+++ b/frontend/REMOTE_DEV.md
@@ -25,14 +25,14 @@ supabase start
 
 ### 2. Update your `.env` file
 
-Get the anon key:
+Get the publishable key:
 ```bash
 supabase status -o env | grep ANON_KEY
 ```
 
 Then set in your `.env` file:
 ```bash
-VITE_SUPABASE_ANON_KEY=<your-anon-key>
+VITE_SUPABASE_PUBLISHABLE_KEY=<your-publishable-key>
 ```
 
 > **Note:** `VITE_SUPABASE_URL` is not needed for local dev. The app auto-resolves Supabase via `window.location.origin/supabase` in dev mode.

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -12,12 +12,12 @@ const supabaseUrl =
     ? `${window.location.origin}/supabase`
     : import.meta.env.VITE_SUPABASE_URL;
 
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabasePublishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
+if (!supabaseUrl || !supabasePublishableKey) {
   throw new Error(
-    "Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables"
+    "Missing VITE_SUPABASE_URL or VITE_SUPABASE_PUBLISHABLE_KEY environment variables"
   );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabasePublishableKey);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -6,8 +6,8 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   /** Supabase project URL (required). */
   readonly VITE_SUPABASE_URL: string;
-  /** Supabase anonymous/public key (required). */
-  readonly VITE_SUPABASE_ANON_KEY: string;
+  /** Supabase publishable key (required). */
+  readonly VITE_SUPABASE_PUBLISHABLE_KEY: string;
   /** Set to "true" to load the standalone React DevTools connector (dev only). */
   readonly VITE_REACT_DEVTOOLS?: string;
   /** Sentry DSN for error tracking. Omit to disable Sentry. */

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,3 +1,3 @@
 # Supabase project credentials (same project as web frontend)
 EXPO_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key-here

--- a/mobile/src/lib/supabaseClient.ts
+++ b/mobile/src/lib/supabaseClient.ts
@@ -5,16 +5,16 @@ import { secureStorage } from "./secureStorage";
 // Expo inlines EXPO_PUBLIC_* env vars at build time (SDK 49+).
 // Set these in a .env file or your shell environment.
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+const supabasePublishableKey = process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
+if (!supabaseUrl || !supabasePublishableKey) {
   throw new Error(
     "Missing Supabase configuration. Set EXPO_PUBLIC_SUPABASE_URL and " +
-      "EXPO_PUBLIC_SUPABASE_ANON_KEY in your environment (e.g. in .env)."
+      "EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY in your environment (e.g. in .env)."
   );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
   auth: {
     // Use expo-secure-store (Keychain / EncryptedSharedPreferences) instead
     // of AsyncStorage to protect auth tokens on rooted/jailbroken devices.


### PR DESCRIPTION
## Summary

- Renames `VITE_SUPABASE_ANON_KEY` → `VITE_SUPABASE_PUBLISHABLE_KEY` and `EXPO_PUBLIC_SUPABASE_ANON_KEY` → `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` across the entire codebase (source code, build config, docs) to match Supabase's dashboard terminology change
- Adds production Supabase build args to `fly.toml` under `[build.args]` so deploys no longer require `--build-arg` flags
- Updates all deployment docs, README, CONTRIBUTING, .env.examples, Dockerfile, and Makefile

## Test plan

- [x] Frontend TypeScript compilation (`tsc -b`) passes with the renamed env var
- [x] Vite production build succeeds
- [x] All 519 frontend tests pass
- [x] Grep confirms zero remaining references to old `VITE_SUPABASE_ANON_KEY` or `EXPO_PUBLIC_SUPABASE_ANON_KEY`
- [ ] Verify `fly deploy` picks up `[build.args]` from `fly.toml` correctly on next production deploy
- [ ] Existing contributors update local `.env` after pulling (old var name will cause startup error — this is intentional to force the rename)

https://claude.ai/code/session_01QsWzyiKcindMvLLJnVCCWV