### PR TITLE
Fix Fly.io deployment: reset search_path after vault extension

### DIFF
--- a/db/migrations/20260223200000_vault_extension.sql
+++ b/db/migrations/20260223200000_vault_extension.sql
@@ -19,6 +19,11 @@ END
 $$;
 -- +goose StatementEnd
 
+-- Restore the default search_path. Creating supabase_vault (and its pgsodium
+-- dependency) can alter the session search_path, hiding the public schema
+-- where goose_db_version lives and breaking migration version tracking.
+RESET search_path;
+
 -- +goose Down
 -- Don't drop the extension on down-migration — it may contain secrets
 -- from other applications sharing the same Supabase instance.


### PR DESCRIPTION
## Summary

- Creating `supabase_vault` (and its `pgsodium` dependency) on Supabase-hosted Postgres alters the session `search_path`, hiding the `public` schema where `goose_db_version` lives
- This caused goose to fail with `relation "goose_db_version" does not exist` after running the vault migration, crashing the app before it could listen on port 8080
- Added `RESET search_path;` after the extension creation DO block to restore the database default, so goose can record the migration version
- No-op on plain Postgres (CI/tests) where the extension isn't available

## Test plan

- [x] All DB tests pass (including migration integrity tests)
- [x] Go build compiles cleanly
- [ ] Deploy to Fly.io and verify migrations complete successfully
- [ ] Verify app starts and responds on port 8080

https://claude.ai/code/session_01LdrRNV3nKR2XasUF5SrdVk