### PR TITLE
Add Supabase dashboard auth checklist to deployment guides

### DIFF
--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -82,9 +82,20 @@ Permission Slip uses a single Supabase project for:
 - Connection string format: `postgres://postgres.[project-ref]:[password]@[host]:6543/postgres?sslmode=require`
 
 **Auth configuration** (in Supabase dashboard):
-- **Authentication > URL Configuration:** Add `https://app.permissionslip.dev` to the redirect allow list
-- **Authentication > Email:** Configure email templates as needed
-- **Authentication > Rate Limits:** Review and adjust for production traffic
+
+> Permission Slip uses passwordless email OTP login. The Supabase dashboard settings below must match your production environment — the local `supabase/config.toml` only applies to `supabase start` (local dev).
+
+- [ ] **Authentication > URL Configuration > Site URL:** Set to `https://app.permissionslip.dev`. This is the base URL Supabase uses in email templates (magic links, OTP emails, password reset). If this is wrong, email links will point to localhost or the wrong domain.
+- [ ] **Authentication > URL Configuration > Redirect URLs:** Add `https://app.permissionslip.dev` to the allow list. Without this, post-login OAuth/magic-link redirects will fail.
+- [ ] **Authentication > Email Templates:** Review all templates (Confirm signup, Magic Link, Change Email, Reset Password). Ensure they reference the production domain, not localhost. Customize branding as needed.
+- [ ] **Authentication > Email > Enable email OTP:** Ensure email sign-in is enabled (this is the primary auth method).
+- [ ] **Authentication > Rate Limits:** Review and tighten for production traffic. The local config sets all limits to 1000 for dev convenience — production should use Supabase's defaults or stricter values.
+- [ ] **Authentication > Multi-Factor Authentication:** Verify TOTP (App Authenticator) enroll and verify are both enabled. The app supports MFA enrollment and challenge flows.
+- [ ] **Authentication > Sessions:** Review session timeouts. The local config uses 24h timebox / 8h inactivity — adjust for your production security requirements.
+
+**Vault (credential encryption):**
+
+- `VAULT_SECRET_KEY` is **not** a Fly.io runtime secret. Hosted Supabase manages the pgsodium encryption key automatically at the infrastructure level. The Go app never reads this env var — it only exists in `supabase/config.toml` for local development (`supabase start`). For local dev, generate with `openssl rand -hex 32`.
 
 **Fly.io setup:**
 
@@ -798,9 +809,20 @@ These are tracked under [#321](https://github.com/supersuit-tech/permission-slip
 - All three VAPID vars must be set, or none. Check `fly secrets list`
 
 **Users can't log in:**
-- Verify `SUPABASE_URL` is correct and the project is active
-- Check that `https://app.permissionslip.dev` is in Supabase's redirect allow list
-- Check Supabase dashboard for auth errors
+- Verify `SUPABASE_URL` is correct and the Supabase project is active (free tier projects pause after inactivity)
+- Check that the **Site URL** in Supabase dashboard (Authentication > URL Configuration) is set to `https://app.permissionslip.dev` — if it points to localhost, email links will be broken
+- Check that `https://app.permissionslip.dev` is in Supabase's **Redirect URLs** allow list
+- Verify email OTP is enabled in Supabase dashboard (Authentication > Email)
+- Check the Supabase dashboard Auth logs for specific error messages
+
+**MFA not working:**
+- Verify TOTP enroll and verify are both enabled in Supabase dashboard (Authentication > Multi-Factor Authentication)
+- Check that the user's device clock is synced (TOTP codes are time-based and drift-sensitive)
+
+**OTP emails not arriving:**
+- Check Supabase dashboard Auth logs for send failures
+- Verify email rate limits haven't been hit (Authentication > Rate Limits)
+- Check spam/junk folders — Supabase's built-in email sender may trigger spam filters. Consider configuring a custom SMTP provider in the Supabase dashboard for production email deliverability
 
 **CORS errors in browser:**
 - Ensure `ALLOWED_ORIGINS` includes `https://app.permissionslip.dev` (exact match, no trailing slash)

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -44,7 +44,17 @@ Permission Slip uses [Supabase Auth](https://supabase.com/auth) for user authent
 2. From your project dashboard, note these values:
    - **Project URL** (e.g., `https://abcdefgh.supabase.co`) — used as `SUPABASE_URL`
    - **Publishable key** (public) — used as `VITE_SUPABASE_PUBLISHABLE_KEY` at build time
-3. Under **Authentication > URL Configuration**, add your deployment URL to the redirect allow list
+3. Configure the following in the Supabase dashboard:
+
+| Setting | Where | What to set |
+|---|---|---|
+| **Site URL** | Authentication > URL Configuration | Your deployment URL (e.g., `https://permissions.mycompany.com`). Used as the base URL in all auth emails. |
+| **Redirect URLs** | Authentication > URL Configuration | Add your deployment URL to the allow list |
+| **Email OTP** | Authentication > Email | Ensure email sign-in is enabled (the primary auth method) |
+| **Email templates** | Authentication > Email Templates | Review templates reference your domain, not localhost |
+| **MFA (TOTP)** | Authentication > Multi-Factor Authentication | Enable TOTP enroll and verify (if you want MFA support) |
+| **Rate limits** | Authentication > Rate Limits | Review and adjust for your expected traffic |
+| **Session timeouts** | Authentication > Sessions | Set timebox and inactivity timeout per your security policy |
 
 > **Note:** You can use Supabase's hosted database as your `DATABASE_URL` too, or use a separate PostgreSQL instance. Either works.
 
@@ -64,7 +74,9 @@ The server runs migrations automatically on startup — no manual migration step
 Permission Slip uses [Supabase Vault](https://supabase.com/docs/guides/database/vault) for encrypting stored credentials (API keys, OAuth tokens) at rest using AES-256-GCM. This requires:
 
 - The `pgsodium` and `vault` PostgreSQL extensions (included in all Supabase projects)
-- A `VAULT_SECRET_KEY` configured on the **database side** (not as an app env var)
+- A vault encryption key managed at the **database level** (not as an app env var)
+
+> **Note:** `VAULT_SECRET_KEY` is **not** a runtime secret for the Go server. Hosted Supabase manages the pgsodium encryption key automatically. The `VAULT_SECRET_KEY` env var in `.env.example` and `supabase/config.toml` is only used by the local Supabase CLI (`supabase start`). For local dev, generate with `openssl rand -hex 32`.
 
 If you're using a Supabase-hosted database, vault is already available. If using a non-Supabase database, you'll need to install the `pgsodium` and `supabase_vault` extensions manually, or implement an alternative vault backend.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -247,5 +247,8 @@ The Supabase build args were not passed during `fly deploy`. Re-deploy with `--b
 **CORS errors in browser (403 on API calls):**
 Ensure `ALLOWED_ORIGINS` includes your app's exact origin (e.g., `https://your-app.fly.dev`) — no trailing slash. When unset, the server defaults to same-origin only mode, which works for the standard deployment but will reject requests if a custom domain or CDN changes the browser's origin.
 
+**Users can't log in / auth errors:**
+Verify `SUPABASE_URL` is correct and the project is active. In the Supabase dashboard, check that the **Site URL** (Authentication > URL Configuration) points to your deployment URL (not localhost), and that your deployment URL is in the **Redirect URLs** allow list. Check that email OTP and MFA (TOTP) are enabled if you use them. See the [production guide troubleshooting](deployment-production.md#troubleshooting) for more details.
+
 **Connection refused to database:**
 If using Supabase, ensure the connection string uses the pooler endpoint (port 6543) with `?sslmode=require`. Direct connections (port 5432) may be blocked by firewall rules.


### PR DESCRIPTION
## Summary

- Expanded the Supabase dashboard configuration section in all three deployment guides (`deployment-production.md`, `deployment-self-hosted.md`, `deployment.md`) with comprehensive checklists covering Site URL, Redirect URLs, Email OTP, Email Templates, MFA/TOTP, Rate Limits, and Session Timeouts
- Clarified that `VAULT_SECRET_KEY` is a local-dev-only setting — hosted Supabase manages vault encryption automatically at the infrastructure level
- Added new troubleshooting entries for MFA issues, OTP email delivery, and expanded the "Users can't log in" section

## Test plan

- [x] Docs-only changes — no code modified
- [x] Verified build is unaffected (only markdown files changed)

https://claude.ai/code/session_01781u5MwkXDUroLJiCzZuhL