### PR TITLE
Expand deployment docs for PostHog, Better Stack, and VAPID setup

### DIFF
--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -148,6 +148,7 @@ fly deploy \
 
 **Web Push — VAPID:**
 - Browser push notifications via FCM / Mozilla Push Service
+- No external account or signup needed — VAPID keys are a self-generated key pair
 - VAPID key pair must be consistent across all instances
 
 **Fly.io setup:**
@@ -184,11 +185,13 @@ Product analytics for understanding user behavior, feature adoption, and funnel 
 - **Privacy:** Respects Do Not Track / cookie consent; no PII in event properties
 
 **Setup steps:**
-1. Create a PostHog Cloud project
-2. Set `VITE_POSTHOG_KEY` (build arg) — PostHog project API key
-3. Optionally set `VITE_POSTHOG_HOST` (build arg) — defaults to `https://us.i.posthog.com`
-4. Add PostHog host to the CSP `connect-src` directive
-5. If key is not set, PostHog is a no-op (safe for dev/staging)
+1. Sign up at [posthog.com](https://posthog.com) and create a new project
+2. During project creation, choose **US Cloud** (`us.i.posthog.com`) or **EU Cloud** (`eu.i.posthog.com`) based on your data residency requirements
+3. Copy the **Project API Key** from **Project Settings > Project Variables** — this becomes `VITE_POSTHOG_KEY`
+4. Set `VITE_POSTHOG_KEY` as a build arg (see Fly.io setup below)
+5. If you chose EU Cloud, also set `VITE_POSTHOG_HOST` to `https://eu.i.posthog.com` (US Cloud is the default)
+6. The backend automatically adds the PostHog host to the CSP `connect-src` directive when `POSTHOG_HOST` is set
+7. If the key is not set, PostHog is a no-op (safe for dev/staging)
 
 **Env vars (build-time):**
 
@@ -250,18 +253,21 @@ Centralized log search and alerting. The app already outputs structured JSON log
 - **Integration:** Native Fly.io log shipping (no sidecar needed)
 
 **Setup steps:**
-1. Create a Better Stack account and log source
-2. Configure Fly.io log shipping:
+1. Sign up at [betterstack.com](https://betterstack.com) and create a workspace
+2. In the dashboard, go to **Telemetry > Sources > Connect source**
+3. Select **Fly.io** as the source type
+4. Copy the **Source Token** — this is the `<logtail-source-token>` used below
+5. Configure Fly.io log shipping:
    ```bash
    # Recommended: native Fly.io → Logtail integration
    fly logs ship --org <fly-org> --access-token <logtail-source-token>
    ```
-3. Verify logs appear with correct JSON field parsing (`msg`, `level`, `trace_id`, `method`, `path`, `status`)
-4. Create alerts:
+6. Verify logs appear with correct JSON field parsing (`msg`, `level`, `trace_id`, `method`, `path`, `status`)
+7. Create alerts:
    - 5xx error rate spike (>5 errors in 5 minutes)
    - Health check failure logs
    - Panic/crash logs
-5. Create saved views: all errors, slow requests, auth failures
+8. Create saved views: all errors, slow requests, auth failures
 
 **No app env vars needed** — log shipping is configured at the Fly.io platform level, not in the app.
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -111,6 +111,8 @@ These are inlined into the JavaScript bundle by Vite at build time. They must be
 
 ### Web Push Notifications (VAPID)
 
+No external account or signup required — VAPID keys are a self-generated cryptographic key pair.
+
 To enable browser push notifications, set all three:
 
 | Variable | Description | Example |
@@ -184,6 +186,8 @@ All three are required to enable SMS. If partially configured, SMS is disabled w
 
 Optional. Tracks user behavior, feature adoption, and funnel analytics.
 
+To get started: sign up at [posthog.com](https://posthog.com), create a project (choose US or EU cloud for data residency), and copy the **Project API Key** from **Project Settings > Project Variables**.
+
 | Variable | Description |
 |---|---|
 | `VITE_POSTHOG_KEY` | PostHog project API key (**build-time**) |
@@ -205,6 +209,32 @@ Optional. Only needed if you want to enable paid tiers and usage-based billing.
 | `VITE_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key for frontend (**build-time**) |
 
 When `BILLING_ENABLED=false` (the default), all users get an unlimited plan, Stripe is skipped, request metering is skipped, and billing API endpoints are disabled. This is the recommended setting for self-hosted deployments unless you want to run your own billing.
+
+### Log Aggregation (Better Stack)
+
+Optional. Centralizes log search and alerting. The server already outputs structured JSON logs (`slog.JSONHandler`) with trace IDs, request metadata, and timing — no code changes needed.
+
+Sign up at [betterstack.com](https://betterstack.com), create a workspace, then go to **Telemetry > Sources > Connect source** to create a log source and get your **Source Token**.
+
+**Docker deployments** — pipe container logs to Better Stack via their HTTP log drain:
+
+```bash
+# Option A: Docker log driver (recommended)
+docker run \
+  --log-driver=syslog \
+  --log-opt syslog-address=tcp+tls://in.logs.betterstack.com:6514 \
+  --log-opt tag="permission-slip" \
+  permission-slip
+
+# Option B: Use Vector, Fluentd, or Fluent Bit as a log shipper
+# See: https://betterstack.com/docs/logs/logging-start/
+```
+
+**Fly.io deployments** — use the native Fly.io integration (see [Fly.io deployment guide](deployment.md)).
+
+**VMs / bare metal** — use a log shipper like [Vector](https://vector.dev) or [Fluent Bit](https://fluentbit.io) to forward `stdout` JSON logs to Better Stack's HTTP endpoint.
+
+No app env vars needed — log shipping is configured at the infrastructure level, not in the app.
 
 ### Other Optional Variables
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -143,9 +143,29 @@ Or add it to `fly.toml`:
 
 This adds `https://static.cloudflareinsights.com` to `script-src` and `https://cloudflareinsights.com` to `connect-src` in the CSP header.
 
+### Product analytics (PostHog)
+
+Optional. If you want product analytics (feature adoption, funnel analysis, session replays), pass the PostHog project API key as a build arg:
+
+```bash
+fly deploy \
+  --build-arg VITE_POSTHOG_KEY="phc_xxxx"
+```
+
+If using EU Cloud, also set `--build-arg VITE_POSTHOG_HOST="https://eu.i.posthog.com"` and the runtime secret `POSTHOG_HOST="https://eu.i.posthog.com"` (for CSP). US Cloud is the default.
+
+If the key is not set, PostHog is a no-op. See the [production guide PostHog section](deployment-production.md#posthog-product-analytics) for full setup details.
+
 ### Optional notification secrets
 
 ```bash
+# Web Push (VAPID) — no external account needed, just a self-generated key pair
+# Generate keys: go run ./cmd/generate-vapid-keys --format=fly
+fly secrets set \
+  VAPID_PUBLIC_KEY="<base64url public key>" \
+  VAPID_PRIVATE_KEY="<base64url private key>" \
+  VAPID_SUBJECT="mailto:admin@mycompany.com"
+
 # Email via SendGrid
 fly secrets set \
   NOTIFICATION_EMAIL_PROVIDER="twilio-sendgrid" \


### PR DESCRIPTION
## Summary
- **PostHog**: Expanded terse "Create a PostHog Cloud project" step into a full walkthrough (sign up, create project, choose US/EU cloud, copy API key from Project Settings) across all three deployment docs
- **Better Stack**: Added dashboard navigation steps (Telemetry → Sources → Connect source → select Fly.io → copy source token) in production doc; added new log aggregation section for Docker/VM deployments in self-hosted doc
- **VAPID**: Added note in all three docs that no external account or signup is needed — it's a self-generated key pair
- **deployment.md**: Added missing VAPID keys to the notification secrets code block; added PostHog section after Cloudflare Web Analytics with cross-reference to production guide

## Test plan
- [ ] Verify all markdown renders correctly (links, bold, code blocks, numbered lists)
- [ ] Confirm cross-doc links work (e.g., `deployment-production.md#posthog-product-analytics`)
- [ ] Review Better Stack syslog address and Docker log driver flags are accurate

https://claude.ai/code/session_01GLMtXEyJnVeU2jTCCaUMe4