### PR TITLE
Enable Row-Level Security on all application tables

### DIFF
--- a/db/migrations/20260303220625_enable_rls_all_tables.sql
+++ b/db/migrations/20260303220625_enable_rls_all_tables.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+-- Enable Row-Level Security on all application tables.
+--
+-- Purpose: Lock down the Supabase PostgREST data API. With RLS enabled and no
+-- permissive policies, the anon/authenticated roles cannot read or write any
+-- table via PostgREST. The Go backend connects as the postgres superuser, which
+-- bypasses RLS entirely — no application code changes are needed.
+--
+-- ALTER TABLE ... ENABLE ROW LEVEL SECURITY is idempotent: if RLS was already
+-- enabled (e.g. via the Supabase dashboard), this is a no-op.
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE connectors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE connector_actions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE connector_required_credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE registration_invites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE approvals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE request_ids ENABLE ROW LEVEL SECURITY;
+ALTER TABLE consumed_tokens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_connectors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE action_configurations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE action_config_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE standing_approvals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE standing_approval_executions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE usage_periods ENABLE ROW LEVEL SECURITY;
+ALTER TABLE stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE server_config ENABLE ROW LEVEL SECURITY;
+
+-- +goose Down
+ALTER TABLE profiles DISABLE ROW LEVEL SECURITY;
+ALTER TABLE connectors DISABLE ROW LEVEL SECURITY;
+ALTER TABLE connector_actions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE connector_required_credentials DISABLE ROW LEVEL SECURITY;
+ALTER TABLE registration_invites DISABLE ROW LEVEL SECURITY;
+ALTER TABLE agents DISABLE ROW LEVEL SECURITY;
+ALTER TABLE approvals DISABLE ROW LEVEL SECURITY;
+ALTER TABLE request_ids DISABLE ROW LEVEL SECURITY;
+ALTER TABLE consumed_tokens DISABLE ROW LEVEL SECURITY;
+ALTER TABLE credentials DISABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_connectors DISABLE ROW LEVEL SECURITY;
+ALTER TABLE action_configurations DISABLE ROW LEVEL SECURITY;
+ALTER TABLE action_config_templates DISABLE ROW LEVEL SECURITY;
+ALTER TABLE standing_approvals DISABLE ROW LEVEL SECURITY;
+ALTER TABLE standing_approval_executions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_events DISABLE ROW LEVEL SECURITY;
+ALTER TABLE plans DISABLE ROW LEVEL SECURITY;
+ALTER TABLE subscriptions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE usage_periods DISABLE ROW LEVEL SECURITY;
+ALTER TABLE stripe_webhook_events DISABLE ROW LEVEL SECURITY;
+ALTER TABLE push_subscriptions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_preferences DISABLE ROW LEVEL SECURITY;
+ALTER TABLE server_config DISABLE ROW LEVEL SECURITY;

--- a/db/rls_test.go
+++ b/db/rls_test.go
@@ -1,0 +1,48 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+// TestRLSEnabledOnAllTables verifies that every application table in the public
+// schema has Row-Level Security enabled. This prevents future migrations from
+// accidentally creating tables without RLS, which would expose them via the
+// Supabase PostgREST data API.
+func TestRLSEnabledOnAllTables(t *testing.T) {
+	t.Parallel()
+	pool := testhelper.SetupTestDB(t)
+
+	rows, err := pool.Query(context.Background(), `
+		SELECT tablename, rowsecurity
+		FROM pg_tables
+		WHERE schemaname = 'public'
+		  AND tablename != 'goose_db_version'
+		ORDER BY tablename
+	`)
+	if err != nil {
+		t.Fatalf("failed to query pg_tables: %v", err)
+	}
+	defer rows.Close()
+
+	var count int
+	for rows.Next() {
+		var tablename string
+		var rowsecurity bool
+		if err := rows.Scan(&tablename, &rowsecurity); err != nil {
+			t.Fatalf("failed to scan row: %v", err)
+		}
+		count++
+		if !rowsecurity {
+			t.Errorf("table %q does not have RLS enabled", tablename)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration error: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("no tables found in public schema — migrations may not have run")
+	}
+}

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -415,6 +415,12 @@ The `CHECK (verification_attempts >= 0)` constraint prevents a backend bug from 
 
 **Approvals:** SHA-256 hash stored in `confirmation_code_hash`, compared using constant-time comparison in the Go backend.
 
+### Row-Level Security (RLS)
+
+All application tables have RLS enabled via migration. The sole purpose is locking down the Supabase PostgREST data API — with RLS on and no permissive policies, the `anon` and `authenticated` roles are denied access. The Go backend connects as a superuser and is unaffected.
+
+`TestRLSEnabledOnAllTables` in `db/rls_test.go` enforces this: any new table added to the `public` schema without RLS will fail CI.
+
 ### Extensions
 
 - `uuid-ossp` and `pgcrypto` — enabled in `00001_init.sql`

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -97,6 +97,23 @@ Permission Slip uses a single Supabase project for:
 
 - `VAULT_SECRET_KEY` is **not** a Fly.io runtime secret. Hosted Supabase manages the pgsodium encryption key automatically at the infrastructure level. The Go app never reads this env var — it only exists in `supabase/config.toml` for local development (`supabase start`). For local dev, generate with `openssl rand -hex 32`.
 
+**Row-Level Security (RLS):**
+
+RLS is enabled on all application tables via a database migration that runs automatically on startup. This locks down the Supabase PostgREST data API — with RLS enabled and no permissive policies, the `anon` and `authenticated` roles cannot read or write any table through PostgREST, even with a valid JWT.
+
+The Go backend connects as the `postgres` superuser, which bypasses RLS entirely. No application code changes are needed.
+
+To verify RLS is enabled after deployment:
+
+```sql
+SELECT tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename != 'goose_db_version'
+ORDER BY tablename;
+```
+
+All rows should show `rowsecurity = true`. A database test (`TestRLSEnabledOnAllTables`) enforces this in CI so new tables can't be added without RLS.
+
 **Fly.io setup:**
 
 ```bash
@@ -818,6 +835,7 @@ These are tracked under [#321](https://github.com/supersuit-tech/permission-slip
 - Database migration linting in CI
 - Automated backup restore tests
 - Penetration test / security audit
+- Row-Level Security policies — add per-user RLS policies and connect `SET LOCAL` in the Go database layer for defense-in-depth on backend queries (RLS is already enabled on all tables; this adds actual policies)
 - Auth endpoint rate limiting (brute force protection)
 - Dependency update automation (Dependabot or Renovate)
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -80,6 +80,12 @@ Permission Slip uses [Supabase Vault](https://supabase.com/docs/guides/database/
 
 If you're using a Supabase-hosted database, vault is already available. If using a non-Supabase database, you'll need to install the `pgsodium` and `supabase_vault` extensions manually, or implement an alternative vault backend.
 
+### Row-Level Security (RLS)
+
+RLS is enabled on all application tables via a migration that runs automatically on startup. If you're using a Supabase-hosted database, this locks down the PostgREST data API so the `anon` and `authenticated` roles cannot access tables directly — all access goes through the Go backend. If you're using a non-Supabase PostgreSQL instance, RLS is still enabled but has no practical effect since there's no PostgREST layer exposing the database.
+
+The Go backend connects as a superuser and bypasses RLS entirely — no configuration is needed.
+
 ## Step 3: Configure Environment Variables
 
 ### Required Variables


### PR DESCRIPTION
## Summary

- Adds a migration (`20260303220625_enable_rls_all_tables.sql`) that enables RLS on all 23 application tables in the `public` schema. The statement is idempotent — safe even if RLS was already toggled via the Supabase dashboard.
- Locks down the Supabase PostgREST data API: with RLS enabled and no permissive policies, `anon`/`authenticated` roles can't read or write tables through PostgREST. The Go backend connects as superuser and bypasses RLS entirely — no app code changes needed.
- Adds `TestRLSEnabledOnAllTables` in `db/rls_test.go` to catch any future table created without RLS.
- Documents RLS in the production deployment guide, self-hosted guide, and database schema docs.
- Adds Phase 2 RLS (per-user policies + `SET LOCAL`) to the Future Hardening roadmap.

## Test plan

- [x] `TestRLSEnabledOnAllTables` passes — confirms all tables have `rowsecurity = true`
- [x] Full `make test-backend` passes — no regressions
- [x] `make build` succeeds
- [ ] Verify migration applies cleanly on production Supabase (idempotent with existing GUI-enabled RLS)

https://claude.ai/code/session_016bQf2WwTAymBkjVR58R7BV