### PR TITLE
Add pull-to-refresh and auto-refresh for pending list

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  AppState,
+  type AppStateStatus,
+  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -8,11 +11,20 @@ import {
 } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
+import { focusManager, QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "./src/auth/AuthContext";
 import RootNavigator from "./src/navigation/RootNavigator";
 import { ErrorBoundary } from "./src/components/ErrorBoundary";
 import { colors } from "./src/theme/colors";
+
+// Tell React Query when the app returns to the foreground so queries with
+// refetchOnWindowFocus automatically re-fetch (AppState is the RN equivalent
+// of the browser's visibilitychange event).
+function onAppStateChange(status: AppStateStatus) {
+  if (Platform.OS !== "web") {
+    focusManager.setFocused(status === "active");
+  }
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -87,6 +99,12 @@ function AppContent({ onRetry }: { onRetry: () => void }) {
 }
 
 export default function App() {
+  // Subscribe to AppState changes so React Query knows when the app is focused.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", onAppStateChange);
+    return () => sub.remove();
+  }, []);
+
   // Incrementing the key re-mounts AuthProvider, which re-triggers
   // Supabase's onAuthStateChange and retries the initial session check.
   const [authKey, setAuthKey] = useState(0);

--- a/mobile/src/hooks/useApprovals.ts
+++ b/mobile/src/hooks/useApprovals.ts
@@ -2,9 +2,10 @@
  * React Query hook for fetching the authenticated user's approval requests.
  *
  * Pending approvals poll every 10 seconds (time-sensitive — users need to act
- * quickly). Historical tabs (approved / denied) don't poll since they rarely
- * change. When the app returns to the foreground the focus manager (configured
- * in App.tsx) triggers an immediate refetch so data is always fresh.
+ * quickly). All other statuses (approved, denied, cancelled, all) don't poll
+ * since they represent historical data that rarely changes. When the app
+ * returns to the foreground the focus manager (configured in App.tsx) triggers
+ * an immediate refetch so data is always fresh.
  */
 import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";

--- a/mobile/src/hooks/useApprovals.ts
+++ b/mobile/src/hooks/useApprovals.ts
@@ -1,6 +1,10 @@
 /**
  * React Query hook for fetching the authenticated user's approval requests.
- * Polls every 30 seconds and supports filtering by status.
+ *
+ * Pending approvals poll every 10 seconds (time-sensitive — users need to act
+ * quickly). Historical tabs (approved / denied) don't poll since they rarely
+ * change. When the app returns to the foreground the focus manager (configured
+ * in App.tsx) triggers an immediate refetch so data is always fresh.
  */
 import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -12,11 +16,13 @@ import type { components } from "../api/schema";
 export type ApprovalSummary = components["schemas"]["ApprovalSummary"];
 export type ApprovalStatus = ApprovalSummary["status"];
 
+/** Polling interval in ms — only pending approvals auto-refresh. */
+const PENDING_POLL_INTERVAL_MS = 10_000;
+
 /**
  * Fetches approval requests for the current user, filtered by status.
- * Uses a stable query key (keyed by userId + status) and auto-refetches
- * every 30 seconds. The access token is stored in a ref to avoid
- * unnecessary query invalidation on token refresh.
+ * Uses a stable query key (keyed by userId + status). The access token is
+ * stored in a ref to avoid unnecessary query invalidation on token refresh.
  */
 export function useApprovals(status: "pending" | "approved" | "denied" | "cancelled" | "all" = "pending") {
   const { session } = useAuth();
@@ -46,10 +52,13 @@ export function useApprovals(status: "pending" | "approved" | "denied" | "cancel
       return data;
     },
     enabled: !!accessToken,
-    refetchInterval: 30_000,
-    // Cache stays fresh for 10 s — avoids redundant refetches when the user
+    // Only pending approvals auto-poll — approved / denied are historical.
+    refetchInterval: status === "pending" ? PENDING_POLL_INTERVAL_MS : false,
+    // Immediately refetch when the app returns to the foreground.
+    refetchOnWindowFocus: true,
+    // Cache stays fresh for 5 s — avoids redundant refetches when the user
     // switches tabs back and forth quickly.
-    staleTime: 10_000,
+    staleTime: 5_000,
   });
 
   return {
@@ -61,5 +70,7 @@ export function useApprovals(status: "pending" | "approved" | "denied" | "cancel
       ? (query.error?.message ?? "Unable to load approvals. Please try again later.")
       : null,
     refetch: query.refetch,
+    /** Epoch ms when the query data was last successfully fetched (0 if never). */
+    dataUpdatedAt: query.dataUpdatedAt,
   };
 }

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { useIsFocused } from "@react-navigation/native";
 import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useApprovals, type ApprovalSummary } from "../../hooks/useApprovals";
 import { useAgents, getAgentDisplayName } from "../../hooks/useAgents";
@@ -45,11 +46,15 @@ export default function ApprovalListScreen({ navigation }: Props) {
   const insets = useSafeAreaInsets();
 
   // Re-render the "Updated X ago" label every 15 seconds so it stays current.
+  // Only tick when the screen is focused to avoid background re-renders when
+  // the user is on the detail screen.
+  const isFocused = useIsFocused();
   const [, setTick] = useState(0);
   useEffect(() => {
+    if (!isFocused || dataUpdatedAt === 0) return;
     const id = setInterval(() => setTick((t) => t + 1), 15_000);
     return () => clearInterval(id);
-  }, []);
+  }, [isFocused, dataUpdatedAt]);
   const lastUpdatedText = formatLastUpdated(dataUpdatedAt);
 
   const agentMap = useMemo(() => {

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -4,7 +4,7 @@
  * pull-to-refresh, loading/error/empty states, and navigation to the
  * detail screen.
  */
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -21,7 +21,7 @@ import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useApprovals, type ApprovalSummary } from "../../hooks/useApprovals";
 import { useAgents, getAgentDisplayName } from "../../hooks/useAgents";
 import { colors } from "../../theme/colors";
-import { buildActionSummary, humanizeActionType, safeParams, isExpired as checkExpired, formatRelativeTime } from "./approvalUtils";
+import { buildActionSummary, humanizeActionType, safeParams, isExpired as checkExpired, formatRelativeTime, formatLastUpdated } from "./approvalUtils";
 import { RiskBadge } from "./RiskBadge";
 import { CountdownBadge } from "./CountdownBadge";
 import { useAuth } from "../../auth/AuthContext";
@@ -38,11 +38,19 @@ type Props = NativeStackScreenProps<RootStackParamList, "ApprovalList">;
 
 export default function ApprovalListScreen({ navigation }: Props) {
   const [activeTab, setActiveTab] = useState<StatusTab>("pending");
-  const { approvals, isLoading, isRefetching, error, refetch } =
+  const { approvals, isLoading, isRefetching, error, refetch, dataUpdatedAt } =
     useApprovals(activeTab);
   const { agents } = useAgents();
   const { signOut } = useAuth();
   const insets = useSafeAreaInsets();
+
+  // Re-render the "Updated X ago" label every 15 seconds so it stays current.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 15_000);
+    return () => clearInterval(id);
+  }, []);
+  const lastUpdatedText = formatLastUpdated(dataUpdatedAt);
 
   const agentMap = useMemo(() => {
     const map = new Map<number, { agent_id: number; metadata?: unknown }>();
@@ -144,6 +152,14 @@ export default function ApprovalListScreen({ navigation }: Props) {
           );
         })}
       </View>
+
+      {lastUpdatedText != null && !isLoading && (
+        <View style={styles.lastUpdatedBar}>
+          <Text style={styles.lastUpdatedText} testID="last-updated">
+            {lastUpdatedText}
+          </Text>
+        </View>
+      )}
 
       {isLoading && !isRefetching ? (
         <View style={styles.center}>
@@ -345,6 +361,18 @@ const styles = StyleSheet.create({
     color: colors.white,
     fontSize: 11,
     fontWeight: "700",
+  },
+  lastUpdatedBar: {
+    paddingHorizontal: 20,
+    paddingVertical: 6,
+    backgroundColor: colors.gray50,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray100,
+  },
+  lastUpdatedText: {
+    fontSize: 11,
+    color: colors.gray400,
+    textAlign: "right",
   },
   center: {
     flex: 1,

--- a/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
@@ -49,6 +49,7 @@ let mockUseApprovalsReturn = {
   isRefetching: false,
   error: null as string | null,
   refetch: jest.fn(),
+  dataUpdatedAt: Date.now(),
 };
 
 jest.mock("../../../hooks/useApprovals", () => ({
@@ -115,6 +116,7 @@ describe("ApprovalListScreen", () => {
       isRefetching: false,
       error: null,
       refetch: jest.fn(),
+      dataUpdatedAt: Date.now(),
     };
   });
 
@@ -188,5 +190,47 @@ describe("ApprovalListScreen", () => {
     });
     const allText = getAllText(renderer);
     expect(allText).toContain("No pending requests");
+  });
+
+  it("shows 'Updated just now' indicator when data was recently fetched", async () => {
+    mockUseApprovalsReturn = {
+      ...mockUseApprovalsReturn,
+      dataUpdatedAt: Date.now(),
+    };
+    await act(async () => {
+      renderer = renderList();
+    });
+    const allText = getAllText(renderer);
+    expect(allText).toContain("Updated just now");
+  });
+
+  it("hides last-updated indicator while loading", async () => {
+    mockUseApprovalsReturn = {
+      ...mockUseApprovalsReturn,
+      approvals: [],
+      isLoading: true,
+      dataUpdatedAt: Date.now(),
+    };
+    await act(async () => {
+      renderer = renderList();
+    });
+    const lastUpdated = renderer.root.findAll(
+      (node) => node.props.testID === "last-updated",
+    );
+    expect(lastUpdated).toHaveLength(0);
+  });
+
+  it("hides last-updated indicator when data has never been fetched", async () => {
+    mockUseApprovalsReturn = {
+      ...mockUseApprovalsReturn,
+      dataUpdatedAt: 0,
+    };
+    await act(async () => {
+      renderer = renderList();
+    });
+    const lastUpdated = renderer.root.findAll(
+      (node) => node.props.testID === "last-updated",
+    );
+    expect(lastUpdated).toHaveLength(0);
   });
 });

--- a/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
@@ -79,6 +79,10 @@ jest.mock("react-native-safe-area-context", () => ({
   SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+jest.mock("@react-navigation/native", () => ({
+  useIsFocused: () => true,
+}));
+
 import ApprovalListScreen from "../ApprovalListScreen";
 
 // --- Helpers ---

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -4,6 +4,7 @@ import {
   humanizeActionType,
   buildActionSummary,
   formatRelativeTime,
+  formatLastUpdated,
   safeParams,
   isExpired,
   formatParamValue,
@@ -128,6 +129,28 @@ describe("formatRelativeTime", () => {
     const result = formatRelativeTime(oldDate);
     // Should contain a month abbreviation, not "ago"
     expect(result).not.toContain("ago");
+  });
+});
+
+describe("formatLastUpdated", () => {
+  it("returns null when epochMs is 0", () => {
+    expect(formatLastUpdated(0)).toBeNull();
+  });
+
+  it("returns 'Updated just now' for very recent timestamps", () => {
+    expect(formatLastUpdated(Date.now() - 3_000)).toBe("Updated just now");
+  });
+
+  it("returns seconds for timestamps 10-59 seconds ago", () => {
+    expect(formatLastUpdated(Date.now() - 30_000)).toBe("Updated 30s ago");
+  });
+
+  it("returns minutes for timestamps 1-59 minutes ago", () => {
+    expect(formatLastUpdated(Date.now() - 5 * 60_000)).toBe("Updated 5m ago");
+  });
+
+  it("returns hours for timestamps 1+ hours ago", () => {
+    expect(formatLastUpdated(Date.now() - 2 * 3600_000)).toBe("Updated 2h ago");
   });
 });
 

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -133,24 +133,39 @@ describe("formatRelativeTime", () => {
 });
 
 describe("formatLastUpdated", () => {
+  const NOW = new Date("2026-03-04T12:00:00Z").getTime();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("returns null when epochMs is 0", () => {
     expect(formatLastUpdated(0)).toBeNull();
   });
 
   it("returns 'Updated just now' for very recent timestamps", () => {
-    expect(formatLastUpdated(Date.now() - 3_000)).toBe("Updated just now");
+    expect(formatLastUpdated(NOW - 3_000)).toBe("Updated just now");
+  });
+
+  it("returns 'Updated just now' for future timestamps (clock skew)", () => {
+    expect(formatLastUpdated(NOW + 5_000)).toBe("Updated just now");
   });
 
   it("returns seconds for timestamps 10-59 seconds ago", () => {
-    expect(formatLastUpdated(Date.now() - 30_000)).toBe("Updated 30s ago");
+    expect(formatLastUpdated(NOW - 30_000)).toBe("Updated 30s ago");
   });
 
   it("returns minutes for timestamps 1-59 minutes ago", () => {
-    expect(formatLastUpdated(Date.now() - 5 * 60_000)).toBe("Updated 5m ago");
+    expect(formatLastUpdated(NOW - 5 * 60_000)).toBe("Updated 5m ago");
   });
 
   it("returns hours for timestamps 1+ hours ago", () => {
-    expect(formatLastUpdated(Date.now() - 2 * 3600_000)).toBe("Updated 2h ago");
+    expect(formatLastUpdated(NOW - 2 * 3600_000)).toBe("Updated 2h ago");
   });
 });
 

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -197,7 +197,8 @@ function formatValue(value: unknown): string | null {
  */
 export function formatLastUpdated(epochMs: number): string | null {
   if (epochMs === 0) return null;
-  const diffSec = Math.floor((Date.now() - epochMs) / 1_000);
+  // Clamp to 0 so clock skew (epochMs in the future) still shows "just now".
+  const diffSec = Math.max(0, Math.floor((Date.now() - epochMs) / 1_000));
   if (diffSec < 10) return "Updated just now";
   if (diffSec < 60) return `Updated ${diffSec}s ago`;
   const diffMin = Math.floor(diffSec / 60);

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -192,6 +192,20 @@ function formatValue(value: unknown): string | null {
 }
 
 /**
+ * Formats an epoch-ms timestamp as a human-friendly "last updated" string.
+ * Returns null when the timestamp is 0 (data never fetched).
+ */
+export function formatLastUpdated(epochMs: number): string | null {
+  if (epochMs === 0) return null;
+  const diffSec = Math.floor((Date.now() - epochMs) / 1_000);
+  if (diffSec < 10) return "Updated just now";
+  if (diffSec < 60) return `Updated ${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `Updated ${diffMin}m ago`;
+  return `Updated ${Math.floor(diffMin / 60)}h ago`;
+}
+
+/**
  * Formats an ISO timestamp as a relative time string for list rows.
  * Shows "Just now", "2m ago", "1h ago", or falls back to date for older items.
  */


### PR DESCRIPTION
## Summary

- Configures React Query's `focusManager` with React Native's `AppState` so all queries automatically refetch when the app returns to the foreground
- Changes pending tab polling from 30s → 10s (pending approvals are time-sensitive)
- Disables polling for historical tabs (approved/denied) since they rarely change
- Adds a subtle "Updated just now" / "Updated Xs ago" indicator below the tab bar
- Adds `formatLastUpdated` utility with full test coverage

## Changes

| File | What changed |
|------|-------------|
| `mobile/App.tsx` | Added `AppState` listener → `focusManager.setFocused()` for foreground refetch |
| `mobile/src/hooks/useApprovals.ts` | Smart polling (10s pending, disabled for historical), `refetchOnWindowFocus: true`, exposed `dataUpdatedAt` |
| `mobile/src/screens/approvals/ApprovalListScreen.tsx` | Added "last updated" indicator bar with 15s tick refresh |
| `mobile/src/screens/approvals/approvalUtils.ts` | New `formatLastUpdated()` pure utility |
| `mobile/src/screens/approvals/__tests__/*` | Tests for indicator visibility, hiding during loading, and `formatLastUpdated` |

## Test plan

- [x] All 73 mobile tests pass (`npx jest --ci`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual test: pull down on pending list triggers refresh
- [ ] Manual test: switch away from app and back — data refetches immediately
- [ ] Manual test: "Updated just now" text appears and updates over time
- [ ] Manual test: approved/denied tabs do NOT show polling network requests

Closes #9 (Pull-to-refresh and auto-refresh for pending list checklist item)

https://claude.ai/code/session_016Emb1zjBEJr84AvdecHvWo