### PR TITLE
Add billing and plan page (frontend)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { AgentConfigPage } from "./pages/agents/AgentConfigPage";
 import { ConnectorConfigPage } from "./pages/agents/connectors/ConnectorConfigPage";
 import { ActivityPage } from "./pages/activity/ActivityPage";
 import { SettingsPage } from "./pages/settings/SettingsPage";
+import { BillingPage } from "./pages/billing/BillingPage";
 import { PrivacyPolicyPage } from "./pages/policy/PrivacyPolicyPage";
 import { TermsOfServicePage } from "./pages/policy/TermsOfServicePage";
 import { CookiePolicyPage } from "./pages/policy/CookiePolicyPage";
@@ -106,6 +107,7 @@ function App() {
           <Route path="/agents/:agentId/connectors/:connectorId" element={<RouteWithBoundary><ConnectorConfigPage /></RouteWithBoundary>} />
           <Route path="/activity" element={<RouteWithBoundary><ActivityPage /></RouteWithBoundary>} />
           <Route path="/settings" element={<RouteWithBoundary><SettingsPage /></RouteWithBoundary>} />
+          <Route path="/billing" element={<RouteWithBoundary><BillingPage /></RouteWithBoundary>} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </SentryRoutes>
       </AppLayout>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import { LayoutDashboard, Activity } from "lucide-react";
+import { LayoutDashboard, Activity, CreditCard } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useApprovals } from "@/hooks/useApprovals";
 import { Footer } from "./Footer";
@@ -114,6 +114,17 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           >
             <Activity className="size-5" aria-hidden="true" />
             Activity
+          </Link>
+          <Link
+            to="/billing"
+            aria-current={isBilling ? "page" : undefined}
+            className={cn(
+              "flex flex-col items-center gap-0.5 px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md",
+              isBilling ? "text-primary" : "text-muted-foreground"
+            )}
+          >
+            <CreditCard className="size-5" aria-hidden="true" />
+            Billing
           </Link>
         </div>
       </nav>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -11,6 +11,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const isHome = pathname === "/";
   const isActivity = pathname === "/activity";
   const isSettings = pathname === "/settings";
+  const isBilling = pathname === "/billing";
   const { approvals } = useApprovals();
   const pendingCount = approvals.length;
 
@@ -55,6 +56,14 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           </li>
           <li className="font-medium text-muted-foreground">
             Roles
+          </li>
+          <li className={cn(
+            "pb-1 font-medium",
+            isBilling
+              ? "border-b-2 border-secondary text-foreground"
+              : "text-muted-foreground"
+          )}>
+            <Link to="/billing" aria-current={isBilling ? "page" : undefined}>Billing</Link>
           </li>
           <li className={cn(
             "pb-1 font-medium",

--- a/frontend/src/hooks/useBillingInvoices.ts
+++ b/frontend/src/hooks/useBillingInvoices.ts
@@ -1,0 +1,43 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type Invoice = components["schemas"]["Invoice"];
+
+export function useBillingInvoices(limit = 10) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["billing", "invoices", userId ?? "", limit],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/billing/invoices", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { query: { limit } },
+      });
+      if (error) throw new Error("Failed to load invoices");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    invoices: query.data?.invoices ?? [],
+    hasMore: query.data?.has_more ?? false,
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load invoices. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useBillingPlan.ts
+++ b/frontend/src/hooks/useBillingPlan.ts
@@ -1,0 +1,44 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type BillingPlanResponse = components["schemas"]["BillingPlanResponse"];
+export type Plan = components["schemas"]["Plan"];
+export type Subscription = components["schemas"]["Subscription"];
+export type UsageSummary = components["schemas"]["UsageSummary"];
+
+export function useBillingPlan() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["billing", "plan", userId ?? ""],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/billing/plan", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (error) throw new Error("Failed to load billing plan");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    billingPlan: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load billing plan. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useBillingUsage.ts
+++ b/frontend/src/hooks/useBillingUsage.ts
@@ -1,0 +1,42 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type UsageDetail = components["schemas"]["UsageDetail"];
+
+export function useBillingUsage(periodStart?: string) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["billing", "usage", userId ?? "", periodStart ?? "current"],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/billing/usage", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { query: periodStart ? { period_start: periodStart } : {} },
+      });
+      if (error) throw new Error("Failed to load usage details");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    usage: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load usage details. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useDowngradePlan.ts
+++ b/frontend/src/hooks/useDowngradePlan.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+
+export function useDowngradePlan() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST("/v1/billing/downgrade", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to downgrade plan"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["billing"] });
+    },
+  });
+
+  return {
+    downgrade: () => mutation.mutateAsync(),
+    isDowngrading: mutation.isPending,
+    error: mutation.error?.message ?? null,
+  };
+}

--- a/frontend/src/hooks/useUpgradePlan.ts
+++ b/frontend/src/hooks/useUpgradePlan.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+
+export function useUpgradePlan() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST("/v1/billing/upgrade", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to initiate upgrade"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["billing"] });
+    },
+  });
+
+  return {
+    upgrade: () => mutation.mutateAsync(),
+    isUpgrading: mutation.isPending,
+    error: mutation.error?.message ?? null,
+  };
+}

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -1,0 +1,60 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/FormError";
+import { useBillingPlan } from "@/hooks/useBillingPlan";
+import { PlanCard } from "./PlanCard";
+import { UsageSummaryCard } from "./UsageSummaryCard";
+import { UpgradeCTA } from "./UpgradeCTA";
+import { PlanDetailsCard } from "./PlanDetailsCard";
+
+export function BillingPage() {
+  const { billingPlan, isLoading, error, refetch } = useBillingPlan();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Back to Dashboard"
+        >
+          <ArrowLeft className="size-5" />
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">Billing</h1>
+      </div>
+
+      {isLoading ? (
+        <div
+          className="flex items-center justify-center py-16"
+          role="status"
+          aria-label="Loading billing information"
+        >
+          <Loader2 className="text-muted-foreground size-5 animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="space-y-3">
+          <FormError error={error} />
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            Try Again
+          </Button>
+        </div>
+      ) : billingPlan ? (
+        <>
+          <PlanCard
+            plan={billingPlan.plan}
+            subscription={billingPlan.subscription}
+          />
+          <UsageSummaryCard
+            usage={billingPlan.usage}
+            plan={billingPlan.plan}
+          />
+          {billingPlan.subscription.can_upgrade && <UpgradeCTA />}
+          {billingPlan.subscription.can_downgrade && (
+            <PlanDetailsCard subscription={billingPlan.subscription} />
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/FormError";
 import { useBillingPlan } from "@/hooks/useBillingPlan";
@@ -7,6 +7,7 @@ import { PlanCard } from "./PlanCard";
 import { UsageSummaryCard } from "./UsageSummaryCard";
 import { UpgradeCTA } from "./UpgradeCTA";
 import { PlanDetailsCard } from "./PlanDetailsCard";
+import { BillingPageSkeleton } from "./BillingPageSkeleton";
 
 export function BillingPage() {
   const { billingPlan, isLoading, error, refetch } = useBillingPlan();
@@ -25,13 +26,7 @@ export function BillingPage() {
       </div>
 
       {isLoading ? (
-        <div
-          className="flex items-center justify-center py-16"
-          role="status"
-          aria-label="Loading billing information"
-        >
-          <Loader2 className="text-muted-foreground size-5 animate-spin" />
-        </div>
+        <BillingPageSkeleton />
       ) : error ? (
         <div className="space-y-3">
           <FormError error={error} />

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -44,7 +44,9 @@ export function BillingPage() {
             usage={billingPlan.usage}
             plan={billingPlan.plan}
           />
-          {billingPlan.subscription.can_upgrade && <UpgradeCTA />}
+          {billingPlan.subscription.can_upgrade && (
+            <UpgradeCTA plan={billingPlan.plan} />
+          )}
           {billingPlan.subscription.can_downgrade && (
             <PlanDetailsCard subscription={billingPlan.subscription} />
           )}

--- a/frontend/src/pages/billing/BillingPageSkeleton.tsx
+++ b/frontend/src/pages/billing/BillingPageSkeleton.tsx
@@ -1,0 +1,71 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+} from "@/components/ui/card";
+
+function SkeletonRow() {
+  return (
+    <div className="flex items-center justify-between">
+      <Skeleton className="h-4 w-28" />
+      <Skeleton className="h-4 w-20" />
+    </div>
+  );
+}
+
+function SkeletonUsageRow() {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-4 w-16" />
+      </div>
+      <Skeleton className="h-2 w-full rounded-full" />
+    </div>
+  );
+}
+
+export function BillingPageSkeleton() {
+  return (
+    <div className="space-y-6" role="status" aria-label="Loading billing information">
+      {/* Plan card skeleton */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-5 rounded" />
+            <Skeleton className="h-5 w-28" />
+          </div>
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border p-4 space-y-3">
+            <SkeletonRow />
+            <SkeletonRow />
+            <SkeletonRow />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Usage summary skeleton */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-5 rounded" />
+            <Skeleton className="h-5 w-16" />
+          </div>
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <SkeletonUsageRow />
+            <SkeletonUsageRow />
+            <SkeletonUsageRow />
+            <SkeletonUsageRow />
+            <SkeletonRow />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -8,18 +8,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Plan, Subscription } from "@/hooks/useBillingPlan";
+import { formatDate } from "./formatters";
 
 interface PlanCardProps {
   plan: Plan;
   subscription: Subscription;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
 }
 
 function StatusBadge({ status }: { status: Subscription["status"] }) {

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -1,0 +1,89 @@
+import { CreditCard } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Plan, Subscription } from "@/hooks/useBillingPlan";
+
+interface PlanCardProps {
+  plan: Plan;
+  subscription: Subscription;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function StatusBadge({ status }: { status: Subscription["status"] }) {
+  if (status === "active") {
+    return <Badge className="bg-emerald-600 text-white">Active</Badge>;
+  }
+  if (status === "past_due") {
+    return <Badge variant="destructive">Past Due</Badge>;
+  }
+  return <Badge variant="secondary">Cancelled</Badge>;
+}
+
+export function PlanCard({ plan, subscription }: PlanCardProps) {
+  const isFree = plan.id === "free";
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CreditCard className="text-muted-foreground size-5" />
+          <CardTitle>Current Plan</CardTitle>
+        </div>
+        <CardDescription>
+          Your subscription and billing period details.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="rounded-lg border p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Plan</span>
+              <div className="flex items-center gap-2">
+                <span className="text-sm">{plan.name}</span>
+                <Badge variant={isFree ? "outline" : "default"}>
+                  {isFree ? "Free" : "Pay-as-you-go"}
+                </Badge>
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Status</span>
+              <StatusBadge status={subscription.status} />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Billing Period</span>
+              <span className="text-sm text-muted-foreground">
+                {formatDate(subscription.current_period_start)} &ndash;{" "}
+                {formatDate(subscription.current_period_end)}
+              </span>
+            </div>
+          </div>
+          {subscription.status === "past_due" && (
+            <p className="text-sm text-destructive">
+              Your payment method failed. Please update it to avoid service interruption.
+            </p>
+          )}
+          {subscription.grace_period_ends_at && (
+            <p className="text-amber-700 dark:text-amber-300 text-xs">
+              Your paid plan features are preserved until{" "}
+              {formatDate(subscription.grace_period_ends_at)}. After that,
+              your account will revert to free plan limits.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -19,21 +19,10 @@ import { useDowngradePlan } from "@/hooks/useDowngradePlan";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { useBillingInvoices } from "@/hooks/useBillingInvoices";
 import type { Subscription } from "@/hooks/useBillingPlan";
+import { formatCents, formatDate } from "./formatters";
 
 interface PlanDetailsCardProps {
   subscription: Subscription;
-}
-
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
 }
 
 function CostEstimate() {
@@ -99,9 +88,12 @@ function DowngradeSection() {
 
   async function handleDowngrade() {
     try {
-      await downgrade();
+      const result = await downgrade();
       setShowConfirm(false);
-      toast.success("Your plan has been downgraded to Free.");
+      const graceMsg = result?.grace_period_ends_at
+        ? ` Your paid features remain active until ${formatDate(result.grace_period_ends_at)}.`
+        : "";
+      toast.success(`Your plan has been downgraded to Free.${graceMsg}`);
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to downgrade. Please try again.",

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -19,7 +19,7 @@ import { useDowngradePlan } from "@/hooks/useDowngradePlan";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { useBillingInvoices } from "@/hooks/useBillingInvoices";
 import type { Subscription } from "@/hooks/useBillingPlan";
-import { formatCents, formatDate } from "./formatters";
+import { formatCents, formatDate, isSafeUrl } from "./formatters";
 
 interface PlanDetailsCardProps {
   subscription: Subscription;
@@ -64,7 +64,7 @@ function InvoicesList() {
           </span>
           <div className="flex items-center gap-3">
             <span className="tabular-nums">{formatCents(invoice.amount_cents)}</span>
-            {invoice.stripe_invoice_url && (
+            {invoice.stripe_invoice_url && isSafeUrl(invoice.stripe_invoice_url) && (
               <a
                 href={invoice.stripe_invoice_url}
                 target="_blank"

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import {
+  Receipt,
+  CreditCard,
+  ExternalLink,
+  Loader2,
+  AlertTriangle,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useDowngradePlan } from "@/hooks/useDowngradePlan";
+import { useBillingUsage } from "@/hooks/useBillingUsage";
+import { useBillingInvoices } from "@/hooks/useBillingInvoices";
+import type { Subscription } from "@/hooks/useBillingPlan";
+
+interface PlanDetailsCardProps {
+  subscription: Subscription;
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function CostEstimate() {
+  const { usage, isLoading } = useBillingUsage();
+
+  if (isLoading) {
+    return <span className="text-sm text-muted-foreground">Calculating…</span>;
+  }
+
+  if (!usage) {
+    return <span className="text-sm text-muted-foreground">—</span>;
+  }
+
+  const totalCents = usage.requests.cost_cents + usage.sms.cost_cents;
+  return <span className="text-sm text-muted-foreground tabular-nums">{formatCents(totalCents)}</span>;
+}
+
+function InvoicesList() {
+  const { invoices, isLoading } = useBillingInvoices(5);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Loader2 className="text-muted-foreground size-4 animate-spin" />
+      </div>
+    );
+  }
+
+  if (invoices.length === 0) {
+    return <p className="text-sm text-muted-foreground">No invoices yet.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {invoices.map((invoice) => (
+        <div key={invoice.id} className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">
+            {formatDate(invoice.date)}
+          </span>
+          <div className="flex items-center gap-3">
+            <span className="tabular-nums">{formatCents(invoice.amount_cents)}</span>
+            {invoice.stripe_invoice_url && (
+              <a
+                href={invoice.stripe_invoice_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground"
+                aria-label={`View invoice from ${formatDate(invoice.date)}`}
+              >
+                <ExternalLink className="size-3.5" />
+              </a>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DowngradeSection() {
+  const { downgrade, isDowngrading } = useDowngradePlan();
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  async function handleDowngrade() {
+    try {
+      await downgrade();
+      setShowConfirm(false);
+      toast.success("Your plan has been downgraded to Free.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to downgrade. Please try again.",
+      );
+    }
+  }
+
+  if (!showConfirm) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setShowConfirm(true)}
+      >
+        Downgrade to Free
+      </Button>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-3">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Are you sure?</p>
+          <p className="text-xs text-muted-foreground">
+            You&apos;ll lose access to unlimited resources. Your data will be
+            preserved for 7 days before free plan limits apply.
+          </p>
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={handleDowngrade}
+          disabled={isDowngrading}
+        >
+          {isDowngrading && <Loader2 className="animate-spin" />}
+          Confirm Downgrade
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowConfirm(false)}
+          disabled={isDowngrading}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function PlanDetailsCard({ subscription }: PlanDetailsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Receipt className="text-muted-foreground size-5" />
+          <CardTitle>Plan Details</CardTitle>
+        </div>
+        <CardDescription>
+          Billing estimates, payment info, and invoices.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="rounded-lg border p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Estimated Cost (this month)</span>
+              <CostEstimate />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Payment Method</span>
+              <span className="text-sm text-muted-foreground">
+                {subscription.has_payment_method ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <CreditCard className="size-3.5" />
+                    On file
+                  </span>
+                ) : (
+                  "None"
+                )}
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">Recent Invoices</h3>
+            <InvoicesList />
+          </div>
+
+          {subscription.can_downgrade && (
+            <div className="border-t pt-4">
+              <DowngradeSection />
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -41,12 +41,23 @@ function CostEstimate() {
 }
 
 function InvoicesList() {
-  const { invoices, isLoading } = useBillingInvoices(5);
+  const { invoices, isLoading, error, refetch } = useBillingInvoices(5);
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-4">
         <Loader2 className="text-muted-foreground size-4 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-destructive">Failed to load invoices.</span>
+        <Button variant="ghost" size="sm" onClick={() => refetch()}>
+          Retry
+        </Button>
       </div>
     );
   }
@@ -120,8 +131,9 @@ function DowngradeSection() {
         <div className="space-y-1">
           <p className="text-sm font-medium">Are you sure?</p>
           <p className="text-xs text-muted-foreground">
-            You&apos;ll lose access to unlimited resources. Your data will be
-            preserved for 7 days before free plan limits apply.
+            You&apos;ll lose access to unlimited resources. Your 90-day audit
+            retention will be preserved for a 7-day grace period so you can
+            export your data before it reverts to 7 days.
           </p>
         </div>
       </div>

--- a/frontend/src/pages/billing/UpgradeCTA.tsx
+++ b/frontend/src/pages/billing/UpgradeCTA.tsx
@@ -10,15 +10,27 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useUpgradePlan } from "@/hooks/useUpgradePlan";
+import type { Plan } from "@/hooks/useBillingPlan";
 import { isSafeUrl } from "./formatters";
 
-const FREE_FEATURES = [
-  "1,000 requests/month",
-  "3 agents",
-  "5 standing approvals",
-  "5 credentials",
-  "7-day audit retention",
-];
+interface UpgradeCTAProps {
+  plan: Plan;
+}
+
+function formatLimit(value: number | null | undefined, unit: string): string {
+  if (value === null || value === undefined) return `Unlimited ${unit}`;
+  return `${value.toLocaleString()} ${unit}`;
+}
+
+function buildCurrentFeatures(plan: Plan): string[] {
+  return [
+    `${formatLimit(plan.max_requests_per_month, "requests/month")}`,
+    `${formatLimit(plan.max_agents, "agents")}`,
+    `${formatLimit(plan.max_standing_approvals, "standing approvals")}`,
+    `${formatLimit(plan.max_credentials, "credentials")}`,
+    `${plan.audit_retention_days}-day audit retention`,
+  ];
+}
 
 const PAID_FEATURES = [
   "Unlimited requests (pay per use)",
@@ -41,9 +53,10 @@ function FeatureList({ features, variant }: { features: string[]; variant: "free
   );
 }
 
-export function UpgradeCTA() {
+export function UpgradeCTA({ plan }: UpgradeCTAProps) {
   const { upgrade, isUpgrading } = useUpgradePlan();
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const currentFeatures = buildCurrentFeatures(plan);
 
   async function handleUpgrade() {
     try {
@@ -78,9 +91,9 @@ export function UpgradeCTA() {
       <CardContent>
         <div className="grid gap-6 sm:grid-cols-2">
           <div className="rounded-lg border p-4 space-y-3">
-            <h3 className="text-sm font-semibold">Free</h3>
+            <h3 className="text-sm font-semibold">{plan.name}</h3>
             <p className="text-xs text-muted-foreground">Your current plan</p>
-            <FeatureList features={FREE_FEATURES} variant="free" />
+            <FeatureList features={currentFeatures} variant="free" />
           </div>
           <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 space-y-3">
             <h3 className="text-sm font-semibold">Pay-as-you-go</h3>

--- a/frontend/src/pages/billing/UpgradeCTA.tsx
+++ b/frontend/src/pages/billing/UpgradeCTA.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { ArrowUpRight, Check, Loader2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useUpgradePlan } from "@/hooks/useUpgradePlan";
+
+const FREE_FEATURES = [
+  "1,000 requests/month",
+  "3 agents",
+  "5 standing approvals",
+  "5 credentials",
+  "7-day audit retention",
+];
+
+const PAID_FEATURES = [
+  "Unlimited requests (pay per use)",
+  "Unlimited agents",
+  "Unlimited standing approvals",
+  "Unlimited credentials",
+  "90-day audit retention",
+];
+
+function FeatureList({ features, variant }: { features: string[]; variant: "free" | "paid" }) {
+  return (
+    <ul className="space-y-2">
+      {features.map((feature) => (
+        <li key={feature} className="flex items-start gap-2 text-sm">
+          <Check className={`mt-0.5 size-4 shrink-0 ${variant === "paid" ? "text-emerald-600" : "text-muted-foreground"}`} />
+          <span>{feature}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function UpgradeCTA() {
+  const { upgrade, isUpgrading } = useUpgradePlan();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  async function handleUpgrade() {
+    try {
+      const result = await upgrade();
+      if (result?.checkout_url) {
+        setIsRedirecting(true);
+        window.location.href = result.checkout_url;
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to initiate upgrade. Please try again.",
+      );
+    }
+  }
+
+  const isPending = isUpgrading || isRedirecting;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Sparkles className="text-muted-foreground size-5" />
+          <CardTitle>Upgrade Your Plan</CardTitle>
+        </div>
+        <CardDescription>
+          Unlock unlimited resources with Pay-as-you-go.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-semibold">Free</h3>
+            <p className="text-xs text-muted-foreground">Your current plan</p>
+            <FeatureList features={FREE_FEATURES} variant="free" />
+          </div>
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 space-y-3">
+            <h3 className="text-sm font-semibold">Pay-as-you-go</h3>
+            <p className="text-xs text-muted-foreground">$0.005/request after free tier</p>
+            <FeatureList features={PAID_FEATURES} variant="paid" />
+          </div>
+        </div>
+        <div className="mt-6 flex justify-end">
+          <Button onClick={handleUpgrade} disabled={isPending}>
+            {isPending ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <ArrowUpRight />
+            )}
+            {isRedirecting ? "Redirecting…" : "Upgrade to Pay-as-you-go"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/billing/UpgradeCTA.tsx
+++ b/frontend/src/pages/billing/UpgradeCTA.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useUpgradePlan } from "@/hooks/useUpgradePlan";
+import { isSafeUrl } from "./formatters";
 
 const FREE_FEATURES = [
   "1,000 requests/month",
@@ -48,6 +49,9 @@ export function UpgradeCTA() {
     try {
       const result = await upgrade();
       if (result?.checkout_url) {
+        if (!isSafeUrl(result.checkout_url)) {
+          throw new Error("Invalid checkout URL received");
+        }
         setIsRedirecting(true);
         window.location.href = result.checkout_url;
       }

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -34,7 +34,7 @@ function UsageRow({ label, current, limit }: UsageRowProps) {
         </span>
       </div>
       {!isUnlimited && (
-        <div className="h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={limit}>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={limit} aria-label={`${label}: ${current.toLocaleString()} of ${limit.toLocaleString()} used`}>
           <div
             className={`h-full rounded-full transition-all ${
               isAtLimit

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -1,0 +1,98 @@
+import { BarChart3 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Plan, UsageSummary } from "@/hooks/useBillingPlan";
+
+interface UsageSummaryCardProps {
+  usage: UsageSummary;
+  plan: Plan;
+}
+
+interface UsageRowProps {
+  label: string;
+  current: number;
+  limit: number | null;
+}
+
+function UsageRow({ label, current, limit }: UsageRowProps) {
+  const isUnlimited = limit === null;
+  const percentage = isUnlimited ? 0 : limit > 0 ? Math.min((current / limit) * 100, 100) : 0;
+  const isNearLimit = !isUnlimited && limit > 0 && percentage >= 80;
+  const isAtLimit = !isUnlimited && limit > 0 && current >= limit;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground tabular-nums">
+          {current.toLocaleString()} / {isUnlimited ? "Unlimited" : limit.toLocaleString()}
+        </span>
+      </div>
+      {!isUnlimited && (
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={limit}>
+          <div
+            className={`h-full rounded-full transition-all ${
+              isAtLimit
+                ? "bg-destructive"
+                : isNearLimit
+                  ? "bg-amber-500"
+                  : "bg-primary"
+            }`}
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function UsageSummaryCard({ usage, plan }: UsageSummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <BarChart3 className="text-muted-foreground size-5" />
+          <CardTitle>Usage</CardTitle>
+        </div>
+        <CardDescription>
+          Current resource usage against your plan limits.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <UsageRow
+            label="Requests"
+            current={usage.requests}
+            limit={plan.max_requests_per_month ?? null}
+          />
+          <UsageRow
+            label="Agents"
+            current={usage.agents}
+            limit={plan.max_agents ?? null}
+          />
+          <UsageRow
+            label="Standing Approvals"
+            current={usage.standing_approvals}
+            limit={plan.max_standing_approvals ?? null}
+          />
+          <UsageRow
+            label="Credentials"
+            current={usage.credentials}
+            limit={plan.max_credentials ?? null}
+          />
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">Audit Retention</span>
+            <span className="text-muted-foreground">
+              {plan.audit_retention_days} days
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -34,7 +34,7 @@ function UsageRow({ label, current, limit }: UsageRowProps) {
         </span>
       </div>
       {!isUnlimited && (
-        <div className="h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={limit} aria-label={`${label}: ${current.toLocaleString()} of ${limit.toLocaleString()} used`}>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={Math.min(current, limit)} aria-valuemin={0} aria-valuemax={limit} aria-label={`${label}: ${current.toLocaleString()} of ${limit.toLocaleString()} used`}>
           <div
             className={`h-full rounded-full transition-all ${
               isAtLimit

--- a/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -1,0 +1,334 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import { mockGet, mockPost, resetClientMocks } from "../../../api/__mocks__/client";
+import { BillingPage } from "../BillingPage";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+const freePlanResponse = {
+  plan: {
+    id: "free",
+    name: "Free",
+    max_requests_per_month: 1000,
+    max_agents: 3,
+    max_standing_approvals: 5,
+    max_credentials: 5,
+    audit_retention_days: 7,
+  },
+  subscription: {
+    status: "active" as const,
+    current_period_start: "2026-03-01T00:00:00Z",
+    current_period_end: "2026-04-01T00:00:00Z",
+    has_payment_method: false,
+    can_upgrade: true,
+    can_downgrade: false,
+    grace_period_ends_at: null,
+  },
+  usage: {
+    requests: 450,
+    agents: 2,
+    standing_approvals: 3,
+    credentials: 1,
+  },
+};
+
+const paidPlanResponse = {
+  plan: {
+    id: "pay_as_you_go",
+    name: "Pay As You Go",
+    max_requests_per_month: null,
+    max_agents: null,
+    max_standing_approvals: null,
+    max_credentials: null,
+    audit_retention_days: 90,
+  },
+  subscription: {
+    status: "active" as const,
+    current_period_start: "2026-03-01T00:00:00Z",
+    current_period_end: "2026-04-01T00:00:00Z",
+    has_payment_method: true,
+    can_upgrade: false,
+    can_downgrade: true,
+    grace_period_ends_at: null,
+  },
+  usage: {
+    requests: 1542,
+    agents: 5,
+    standing_approvals: 10,
+    credentials: 8,
+  },
+};
+
+const usageDetailResponse = {
+  period_start: "2026-03-01T00:00:00Z",
+  period_end: "2026-04-01T00:00:00Z",
+  requests: { total: 1542, included: 1000, overage: 542, cost_cents: 271 },
+  sms: { total: 5, cost_cents: 5 },
+};
+
+const invoicesResponse = {
+  invoices: [
+    {
+      id: "inv_001",
+      date: "2026-02-01T00:00:00Z",
+      period_start: "2026-02-01T00:00:00Z",
+      period_end: "2026-03-01T00:00:00Z",
+      amount_cents: 271,
+      status: "paid",
+      stripe_invoice_url: "https://invoice.stripe.com/i/test",
+    },
+  ],
+  has_more: false,
+};
+
+function mockFreePlanApi() {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/billing/plan") {
+      return Promise.resolve({ data: freePlanResponse });
+    }
+    if (url === "/v1/billing/usage") {
+      return Promise.resolve({ data: usageDetailResponse });
+    }
+    if (url === "/v1/billing/invoices") {
+      return Promise.resolve({ data: invoicesResponse });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
+
+function mockPaidPlanApi() {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/billing/plan") {
+      return Promise.resolve({ data: paidPlanResponse });
+    }
+    if (url === "/v1/billing/usage") {
+      return Promise.resolve({ data: usageDetailResponse });
+    }
+    if (url === "/v1/billing/invoices") {
+      return Promise.resolve({ data: invoicesResponse });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
+
+function mockErrorApi() {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/billing/plan") {
+      return Promise.resolve({
+        data: undefined,
+        error: { error: { code: "internal_error", message: "Server error" } },
+      });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
+
+describe("BillingPage", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper(["/billing"]);
+  });
+
+  it("renders page title and back link", async () => {
+    mockFreePlanApi();
+
+    render(<BillingPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Billing")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("link", { name: "Back to Dashboard" }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("shows loading state", () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockImplementation(() => new Promise(() => {}));
+
+    render(<BillingPage />, { wrapper });
+
+    expect(screen.getByRole("status", { name: "Loading billing information" })).toBeInTheDocument();
+  });
+
+  it("shows error state with retry button", async () => {
+    mockErrorApi();
+
+    render(<BillingPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unable to load billing plan/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+  });
+
+  describe("Free plan", () => {
+    it("renders plan card with Free badge", async () => {
+      mockFreePlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Current Plan")).toBeInTheDocument();
+      });
+      expect(screen.getAllByText("Free").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Active")).toBeInTheDocument();
+    });
+
+    it("renders usage summary with progress indicators", async () => {
+      mockFreePlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Usage")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Requests")).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
+      expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
+      expect(screen.getByText("Credentials")).toBeInTheDocument();
+      expect(screen.getByText("Audit Retention")).toBeInTheDocument();
+      expect(screen.getByText("7 days")).toBeInTheDocument();
+    });
+
+    it("shows upgrade CTA for free plan", async () => {
+      mockFreePlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Upgrade Your Plan")).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ })).toBeInTheDocument();
+    });
+
+    it("does not show plan details card for free plan", async () => {
+      mockFreePlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Current Plan")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Plan Details")).not.toBeInTheDocument();
+    });
+
+    it("redirects to Stripe on upgrade click", async () => {
+      mockFreePlanApi();
+      mockPost.mockResolvedValue({
+        data: { checkout_url: "https://checkout.stripe.com/test" },
+      });
+
+      // Mock window.location for redirect
+      const originalLocation = window.location;
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: { ...originalLocation, href: "" },
+      });
+
+      const user = userEvent.setup();
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ }));
+
+      await waitFor(() => {
+        expect(window.location.href).toBe("https://checkout.stripe.com/test");
+      });
+
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: originalLocation,
+      });
+    });
+  });
+
+  describe("Paid plan", () => {
+    it("renders plan card with Pay-as-you-go badge", async () => {
+      mockPaidPlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Current Plan")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Pay-as-you-go")).toBeInTheDocument();
+    });
+
+    it("shows unlimited usage for paid plan", async () => {
+      mockPaidPlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Usage")).toBeInTheDocument();
+      });
+      // Paid plan has null limits, so usage rows show "Unlimited"
+      const unlimitedTexts = screen.getAllByText(/Unlimited/);
+      expect(unlimitedTexts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("does not show upgrade CTA for paid plan", async () => {
+      mockPaidPlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Current Plan")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Upgrade Your Plan")).not.toBeInTheDocument();
+    });
+
+    it("shows plan details card with invoices", async () => {
+      mockPaidPlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Plan Details")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Recent Invoices")).toBeInTheDocument();
+      expect(screen.getByText("Estimated Cost (this month)")).toBeInTheDocument();
+    });
+
+    it("shows downgrade button on paid plan", async () => {
+      mockPaidPlanApi();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Downgrade to Free" })).toBeInTheDocument();
+      });
+    });
+
+    it("shows downgrade confirmation on click", async () => {
+      mockPaidPlanApi();
+      const user = userEvent.setup();
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Downgrade to Free" })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Downgrade to Free" }));
+
+      expect(screen.getByText("Are you sure?")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Confirm Downgrade" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -5,107 +5,21 @@ import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
 import { createAuthWrapper } from "../../../test-helpers";
 import { mockGet, mockPost, resetClientMocks } from "../../../api/__mocks__/client";
 import { BillingPage } from "../BillingPage";
+import {
+  freePlanResponse,
+  paidPlanResponse,
+  usageDetailResponse,
+  invoicesResponse,
+} from "./fixtures";
 
 vi.mock("../../../lib/supabaseClient");
 vi.mock("../../../api/client");
 
-const freePlanResponse = {
-  plan: {
-    id: "free",
-    name: "Free",
-    max_requests_per_month: 1000,
-    max_agents: 3,
-    max_standing_approvals: 5,
-    max_credentials: 5,
-    audit_retention_days: 7,
-  },
-  subscription: {
-    status: "active" as const,
-    current_period_start: "2026-03-01T00:00:00Z",
-    current_period_end: "2026-04-01T00:00:00Z",
-    has_payment_method: false,
-    can_upgrade: true,
-    can_downgrade: false,
-    grace_period_ends_at: null,
-  },
-  usage: {
-    requests: 450,
-    agents: 2,
-    standing_approvals: 3,
-    credentials: 1,
-  },
-};
-
-const paidPlanResponse = {
-  plan: {
-    id: "pay_as_you_go",
-    name: "Pay As You Go",
-    max_requests_per_month: null,
-    max_agents: null,
-    max_standing_approvals: null,
-    max_credentials: null,
-    audit_retention_days: 90,
-  },
-  subscription: {
-    status: "active" as const,
-    current_period_start: "2026-03-01T00:00:00Z",
-    current_period_end: "2026-04-01T00:00:00Z",
-    has_payment_method: true,
-    can_upgrade: false,
-    can_downgrade: true,
-    grace_period_ends_at: null,
-  },
-  usage: {
-    requests: 1542,
-    agents: 5,
-    standing_approvals: 10,
-    credentials: 8,
-  },
-};
-
-const usageDetailResponse = {
-  period_start: "2026-03-01T00:00:00Z",
-  period_end: "2026-04-01T00:00:00Z",
-  requests: { total: 1542, included: 1000, overage: 542, cost_cents: 271 },
-  sms: { total: 5, cost_cents: 5 },
-};
-
-const invoicesResponse = {
-  invoices: [
-    {
-      id: "inv_001",
-      date: "2026-02-01T00:00:00Z",
-      period_start: "2026-02-01T00:00:00Z",
-      period_end: "2026-03-01T00:00:00Z",
-      amount_cents: 271,
-      status: "paid",
-      stripe_invoice_url: "https://invoice.stripe.com/i/test",
-    },
-  ],
-  has_more: false,
-};
-
-function mockFreePlanApi() {
+function mockBillingApi(planResponse: typeof freePlanResponse | typeof paidPlanResponse) {
   setupAuthMocks({ authenticated: true });
   mockGet.mockImplementation((url: string) => {
     if (url === "/v1/billing/plan") {
-      return Promise.resolve({ data: freePlanResponse });
-    }
-    if (url === "/v1/billing/usage") {
-      return Promise.resolve({ data: usageDetailResponse });
-    }
-    if (url === "/v1/billing/invoices") {
-      return Promise.resolve({ data: invoicesResponse });
-    }
-    return Promise.resolve({ data: null });
-  });
-}
-
-function mockPaidPlanApi() {
-  setupAuthMocks({ authenticated: true });
-  mockGet.mockImplementation((url: string) => {
-    if (url === "/v1/billing/plan") {
-      return Promise.resolve({ data: paidPlanResponse });
+      return Promise.resolve({ data: planResponse });
     }
     if (url === "/v1/billing/usage") {
       return Promise.resolve({ data: usageDetailResponse });
@@ -140,7 +54,7 @@ describe("BillingPage", () => {
   });
 
   it("renders page title and back link", async () => {
-    mockFreePlanApi();
+    mockBillingApi(freePlanResponse);
 
     render(<BillingPage />, { wrapper });
 
@@ -152,7 +66,7 @@ describe("BillingPage", () => {
     ).toHaveAttribute("href", "/");
   });
 
-  it("shows loading state", () => {
+  it("shows loading skeleton", () => {
     setupAuthMocks({ authenticated: true });
     mockGet.mockImplementation(() => new Promise(() => {}));
 
@@ -174,7 +88,7 @@ describe("BillingPage", () => {
 
   describe("Free plan", () => {
     it("renders plan card with Free badge", async () => {
-      mockFreePlanApi();
+      mockBillingApi(freePlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -186,7 +100,7 @@ describe("BillingPage", () => {
     });
 
     it("renders usage summary with progress indicators", async () => {
-      mockFreePlanApi();
+      mockBillingApi(freePlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -202,7 +116,7 @@ describe("BillingPage", () => {
     });
 
     it("shows upgrade CTA for free plan", async () => {
-      mockFreePlanApi();
+      mockBillingApi(freePlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -213,7 +127,7 @@ describe("BillingPage", () => {
     });
 
     it("does not show plan details card for free plan", async () => {
-      mockFreePlanApi();
+      mockBillingApi(freePlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -224,41 +138,42 @@ describe("BillingPage", () => {
     });
 
     it("redirects to Stripe on upgrade click", async () => {
-      mockFreePlanApi();
+      mockBillingApi(freePlanResponse);
       mockPost.mockResolvedValue({
         data: { checkout_url: "https://checkout.stripe.com/test" },
       });
 
-      // Mock window.location for redirect
       const originalLocation = window.location;
       Object.defineProperty(window, "location", {
         writable: true,
         value: { ...originalLocation, href: "" },
       });
 
-      const user = userEvent.setup();
-      render(<BillingPage />, { wrapper });
+      try {
+        const user = userEvent.setup();
+        render(<BillingPage />, { wrapper });
 
-      await waitFor(() => {
-        expect(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ })).toBeInTheDocument();
-      });
+        await waitFor(() => {
+          expect(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ })).toBeInTheDocument();
+        });
 
-      await user.click(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ }));
+        await user.click(screen.getByRole("button", { name: /Upgrade to Pay-as-you-go/ }));
 
-      await waitFor(() => {
-        expect(window.location.href).toBe("https://checkout.stripe.com/test");
-      });
-
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: originalLocation,
-      });
+        await waitFor(() => {
+          expect(window.location.href).toBe("https://checkout.stripe.com/test");
+        });
+      } finally {
+        Object.defineProperty(window, "location", {
+          writable: true,
+          value: originalLocation,
+        });
+      }
     });
   });
 
   describe("Paid plan", () => {
     it("renders plan card with Pay-as-you-go badge", async () => {
-      mockPaidPlanApi();
+      mockBillingApi(paidPlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -269,20 +184,19 @@ describe("BillingPage", () => {
     });
 
     it("shows unlimited usage for paid plan", async () => {
-      mockPaidPlanApi();
+      mockBillingApi(paidPlanResponse);
 
       render(<BillingPage />, { wrapper });
 
       await waitFor(() => {
         expect(screen.getByText("Usage")).toBeInTheDocument();
       });
-      // Paid plan has null limits, so usage rows show "Unlimited"
       const unlimitedTexts = screen.getAllByText(/Unlimited/);
       expect(unlimitedTexts.length).toBeGreaterThanOrEqual(1);
     });
 
     it("does not show upgrade CTA for paid plan", async () => {
-      mockPaidPlanApi();
+      mockBillingApi(paidPlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -293,7 +207,7 @@ describe("BillingPage", () => {
     });
 
     it("shows plan details card with invoices", async () => {
-      mockPaidPlanApi();
+      mockBillingApi(paidPlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -305,7 +219,7 @@ describe("BillingPage", () => {
     });
 
     it("shows downgrade button on paid plan", async () => {
-      mockPaidPlanApi();
+      mockBillingApi(paidPlanResponse);
 
       render(<BillingPage />, { wrapper });
 
@@ -315,7 +229,7 @@ describe("BillingPage", () => {
     });
 
     it("shows downgrade confirmation on click", async () => {
-      mockPaidPlanApi();
+      mockBillingApi(paidPlanResponse);
       const user = userEvent.setup();
 
       render(<BillingPage />, { wrapper });

--- a/frontend/src/pages/billing/__tests__/fixtures.ts
+++ b/frontend/src/pages/billing/__tests__/fixtures.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared test fixtures for billing page tests.
+ *
+ * Provides canonical mock data for billing API responses so individual
+ * test files don't duplicate boilerplate.
+ */
+
+export const freePlanResponse = {
+  plan: {
+    id: "free",
+    name: "Free",
+    max_requests_per_month: 1000,
+    max_agents: 3,
+    max_standing_approvals: 5,
+    max_credentials: 5,
+    audit_retention_days: 7,
+  },
+  subscription: {
+    status: "active" as const,
+    current_period_start: "2026-03-01T00:00:00Z",
+    current_period_end: "2026-04-01T00:00:00Z",
+    has_payment_method: false,
+    can_upgrade: true,
+    can_downgrade: false,
+    grace_period_ends_at: null,
+  },
+  usage: {
+    requests: 450,
+    agents: 2,
+    standing_approvals: 3,
+    credentials: 1,
+  },
+};
+
+export const paidPlanResponse = {
+  plan: {
+    id: "pay_as_you_go",
+    name: "Pay As You Go",
+    max_requests_per_month: null,
+    max_agents: null,
+    max_standing_approvals: null,
+    max_credentials: null,
+    audit_retention_days: 90,
+  },
+  subscription: {
+    status: "active" as const,
+    current_period_start: "2026-03-01T00:00:00Z",
+    current_period_end: "2026-04-01T00:00:00Z",
+    has_payment_method: true,
+    can_upgrade: false,
+    can_downgrade: true,
+    grace_period_ends_at: null,
+  },
+  usage: {
+    requests: 1542,
+    agents: 5,
+    standing_approvals: 10,
+    credentials: 8,
+  },
+};
+
+export const usageDetailResponse = {
+  period_start: "2026-03-01T00:00:00Z",
+  period_end: "2026-04-01T00:00:00Z",
+  requests: { total: 1542, included: 1000, overage: 542, cost_cents: 271 },
+  sms: { total: 5, cost_cents: 5 },
+};
+
+export const invoicesResponse = {
+  invoices: [
+    {
+      id: "inv_001",
+      date: "2026-02-01T00:00:00Z",
+      period_start: "2026-02-01T00:00:00Z",
+      period_end: "2026-03-01T00:00:00Z",
+      amount_cents: 271,
+      status: "paid",
+      stripe_invoice_url: "https://invoice.stripe.com/i/test",
+    },
+  ],
+  has_more: false,
+};

--- a/frontend/src/pages/billing/formatters.ts
+++ b/frontend/src/pages/billing/formatters.ts
@@ -6,6 +6,19 @@ export function formatCents(cents: number): string {
 }
 
 /**
+ * Validate that a URL is a safe HTTPS URL (not javascript:, data:, etc.).
+ * Returns true only for https:// URLs.
+ */
+export function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Format an ISO date string to a short locale string (e.g. "Mar 1, 2026").
  */
 export function formatDate(iso: string): string {

--- a/frontend/src/pages/billing/formatters.ts
+++ b/frontend/src/pages/billing/formatters.ts
@@ -1,0 +1,17 @@
+/**
+ * Format a dollar amount from cents (e.g. 271 → "$2.71").
+ */
+export function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/**
+ * Format an ISO date string to a short locale string (e.g. "Mar 1, 2026").
+ */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary

- Implements the `/billing` page with full billing management UI (#18)
- Adds 5 API hooks: `useBillingPlan`, `useBillingUsage`, `useBillingInvoices`, `useUpgradePlan`, `useDowngradePlan`
- Adds 4 presentational components: `PlanCard`, `UsageSummaryCard`, `UpgradeCTA`, `PlanDetailsCard`
- Adds `BillingPage` container that composes all sections based on plan type (free vs paid)
- Adds `/billing` route and nav item in `AppLayout`
- 12 tests covering free plan, paid plan, loading/error states, upgrade redirect, and downgrade confirmation

## Page Sections

| Section | Free Plan | Paid Plan |
|---------|-----------|-----------|
| **PlanCard** | Plan name, Free badge, billing period, status | Plan name, Pay-as-you-go badge, billing period, status |
| **UsageSummaryCard** | Progress bars with limits (e.g., 450/1,000 requests) | Usage counts with "Unlimited" labels |
| **UpgradeCTA** | Feature comparison + Stripe Checkout button | Hidden |
| **PlanDetailsCard** | Hidden | Cost estimate, payment method, invoices, downgrade option |

## Depends On

- #15 (billing API endpoints)

## Test plan

- [x] All 533 frontend tests pass (`make test-frontend`)
- [x] TypeScript compiles cleanly (`tsc -b`)
- [x] Vite build succeeds
- [ ] Manual: verify `/billing` page renders on free plan
- [ ] Manual: verify upgrade flow redirects to Stripe
- [ ] Manual: verify paid plan shows cost estimate and invoices
- [ ] Manual: verify downgrade confirmation flow

Closes #18

https://claude.ai/code/session_014sBgbzmiEtCgWKsBju7Hsg