### PR TITLE
Add mobile approve/deny flow with confirmation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,9 @@ go run ./cmd/generate-vapid-keys --format=heroku
 
 ## Mobile App
 
-The mobile approval app lives in `mobile/` (React Native / Expo). It's a thin client for approving and viewing requests from your phone.
+The mobile approval app lives in `mobile/` (React Native / Expo). It's a thin client for approving and viewing requests from your phone — similar to the Microsoft Authenticator approval flow.
+
+**Current capabilities:** login, browse pending/approved/denied requests, view full request details (action parameters, risk level, agent info, expiry countdown), approve with confirmation code display (copyable `XXX-XXX` format), and deny with confirmation.
 
 ```bash
 make mobile-install    # install mobile dependencies

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/supabase-js": "^2.98.0",
         "@tanstack/react-query": "^5.90.21",
         "expo": "~55.0.4",
+        "expo-clipboard": "^55.0.8",
         "expo-secure-store": "^55.0.8",
         "expo-status-bar": "~55.0.4",
         "openapi-fetch": "^0.17.0",
@@ -4927,6 +4928,17 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-55.0.8.tgz",
+      "integrity": "sha512-s0Hkop+dc6m09LwzUAWweNI0gzLAaX5CgEGR8TMdOdSPKTPc2rCl8h8Ji/cUNM1wYoJQ4Wysa15E8If/Vlu7WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "@supabase/supabase-js": "^2.98.0",
     "@tanstack/react-query": "^5.90.21",
     "expo": "~55.0.4",
+    "expo-clipboard": "^55.0.8",
     "expo-secure-store": "^55.0.8",
     "expo-status-bar": "~55.0.4",
     "openapi-fetch": "^0.17.0",

--- a/mobile/src/hooks/__tests__/useApproveApproval.test.tsx
+++ b/mobile/src/hooks/__tests__/useApproveApproval.test.tsx
@@ -1,0 +1,204 @@
+import { createElement } from "react";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "../../auth/AuthContext";
+import { useApproveApproval } from "../useApproveApproval";
+import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
+import { mockSession, createQueryClient, waitFor } from "../../__test-utils__";
+
+// --- Mocks ---
+
+const mockPost = jest.fn();
+
+jest.mock("../../api/client", () => ({
+  __esModule: true,
+  default: { POST: (...args: unknown[]) => mockPost(...args) },
+}));
+
+const authMocks = {
+  authChangeCallback: null as
+    | ((event: AuthChangeEvent, session: Session | null) => void)
+    | null,
+};
+
+jest.mock("../../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: jest.fn(
+        (cb: (event: AuthChangeEvent, session: Session | null) => void) => {
+          authMocks.authChangeCallback = cb;
+          Promise.resolve().then(() =>
+            cb("INITIAL_SESSION" as AuthChangeEvent, null),
+          );
+          return { data: { subscription: { unsubscribe: jest.fn() } } };
+        },
+      ),
+      signInWithOtp: jest.fn(),
+      verifyOtp: jest.fn(),
+      signOut: jest.fn(),
+      mfa: {
+        getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+          data: { currentLevel: "aal1", nextLevel: "aal1" },
+          error: null,
+        }),
+      },
+    },
+  },
+}));
+
+// --- Helpers ---
+
+interface HookCapture {
+  approveApproval: ((id: string) => Promise<unknown>) | null;
+  isPending: boolean;
+  error: Error | null;
+}
+
+function createHookCapture() {
+  const capture: HookCapture = { approveApproval: null, isPending: false, error: null };
+
+  function Consumer() {
+    const result = useApproveApproval();
+    capture.approveApproval = result.approveApproval;
+    capture.isPending = result.isPending;
+    capture.error = result.error;
+    return null;
+  }
+
+  return { capture, Consumer };
+}
+
+function renderWithProviders(Consumer: React.ComponentType, qc: QueryClient) {
+  return create(
+    createElement(
+      QueryClientProvider,
+      { client: qc },
+      createElement(AuthProvider, null, createElement(Consumer)),
+    ),
+  );
+}
+
+// --- Tests ---
+
+let currentRenderer: ReactTestRenderer | null = null;
+let currentQueryClient: QueryClient | null = null;
+
+describe("useApproveApproval", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (currentQueryClient) {
+      currentQueryClient.cancelQueries();
+      currentQueryClient.clear();
+      currentQueryClient = null;
+    }
+    if (currentRenderer) {
+      await act(async () => {
+        currentRenderer!.unmount();
+      });
+      currentRenderer = null;
+    }
+  });
+
+  it("calls POST /v1/approvals/{approval_id}/approve with correct params", async () => {
+    mockPost.mockResolvedValue({
+      data: {
+        approval_id: "appr_abc123",
+        status: "approved",
+        approved_at: "2026-03-02T13:25:00Z",
+        confirmation_code: "RK3-P7M",
+      },
+      error: undefined,
+    });
+
+    const { capture, Consumer } = createHookCapture();
+    currentQueryClient = createQueryClient();
+
+    await act(async () => {
+      currentRenderer = renderWithProviders(Consumer, currentQueryClient!);
+    });
+
+    // Authenticate
+    const session = mockSession();
+    await act(async () => {
+      authMocks.authChangeCallback!("SIGNED_IN" as AuthChangeEvent, session);
+    });
+
+    await waitFor(() => capture.approveApproval !== null);
+
+    let result: unknown;
+    await act(async () => {
+      result = await capture.approveApproval!("appr_abc123");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/approvals/{approval_id}/approve",
+      {
+        headers: { Authorization: expect.stringContaining("Bearer ") },
+        params: { path: { approval_id: "appr_abc123" } },
+      },
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ confirmation_code: "RK3-P7M" }),
+    );
+  });
+
+  it("throws on API error", async () => {
+    mockPost.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: "approval_expired", message: "Approval has expired" } },
+    });
+
+    const { capture, Consumer } = createHookCapture();
+    currentQueryClient = createQueryClient();
+
+    await act(async () => {
+      currentRenderer = renderWithProviders(Consumer, currentQueryClient!);
+    });
+
+    const session = mockSession();
+    await act(async () => {
+      authMocks.authChangeCallback!("SIGNED_IN" as AuthChangeEvent, session);
+    });
+
+    await waitFor(() => capture.approveApproval !== null);
+
+    let thrownError: Error | undefined;
+    await act(async () => {
+      try {
+        await capture.approveApproval!("appr_expired");
+      } catch (e) {
+        thrownError = e as Error;
+      }
+    });
+
+    expect(thrownError).toBeDefined();
+    expect(thrownError!.message).toBe("Approval has expired");
+  });
+
+  it("throws when not authenticated", async () => {
+    const { capture, Consumer } = createHookCapture();
+    currentQueryClient = createQueryClient();
+
+    await act(async () => {
+      currentRenderer = renderWithProviders(Consumer, currentQueryClient!);
+    });
+
+    await waitFor(() => capture.approveApproval !== null);
+
+    let thrownError: Error | undefined;
+    await act(async () => {
+      try {
+        await capture.approveApproval!("appr_abc123");
+      } catch (e) {
+        thrownError = e as Error;
+      }
+    });
+
+    expect(thrownError).toBeDefined();
+    expect(thrownError!.message).toBe("Not authenticated");
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/hooks/__tests__/useDenyApproval.test.tsx
+++ b/mobile/src/hooks/__tests__/useDenyApproval.test.tsx
@@ -1,0 +1,199 @@
+import { createElement } from "react";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "../../auth/AuthContext";
+import { useDenyApproval } from "../useDenyApproval";
+import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
+import { mockSession, createQueryClient, waitFor } from "../../__test-utils__";
+
+// --- Mocks ---
+
+const mockPost = jest.fn();
+
+jest.mock("../../api/client", () => ({
+  __esModule: true,
+  default: { POST: (...args: unknown[]) => mockPost(...args) },
+}));
+
+const authMocks = {
+  authChangeCallback: null as
+    | ((event: AuthChangeEvent, session: Session | null) => void)
+    | null,
+};
+
+jest.mock("../../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: jest.fn(
+        (cb: (event: AuthChangeEvent, session: Session | null) => void) => {
+          authMocks.authChangeCallback = cb;
+          Promise.resolve().then(() =>
+            cb("INITIAL_SESSION" as AuthChangeEvent, null),
+          );
+          return { data: { subscription: { unsubscribe: jest.fn() } } };
+        },
+      ),
+      signInWithOtp: jest.fn(),
+      verifyOtp: jest.fn(),
+      signOut: jest.fn(),
+      mfa: {
+        getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+          data: { currentLevel: "aal1", nextLevel: "aal1" },
+          error: null,
+        }),
+      },
+    },
+  },
+}));
+
+// --- Helpers ---
+
+interface HookCapture {
+  denyApproval: ((id: string) => Promise<void>) | null;
+  isPending: boolean;
+  error: Error | null;
+}
+
+function createHookCapture() {
+  const capture: HookCapture = { denyApproval: null, isPending: false, error: null };
+
+  function Consumer() {
+    const result = useDenyApproval();
+    capture.denyApproval = result.denyApproval;
+    capture.isPending = result.isPending;
+    capture.error = result.error;
+    return null;
+  }
+
+  return { capture, Consumer };
+}
+
+function renderWithProviders(Consumer: React.ComponentType, qc: QueryClient) {
+  return create(
+    createElement(
+      QueryClientProvider,
+      { client: qc },
+      createElement(AuthProvider, null, createElement(Consumer)),
+    ),
+  );
+}
+
+// --- Tests ---
+
+let currentRenderer: ReactTestRenderer | null = null;
+let currentQueryClient: QueryClient | null = null;
+
+describe("useDenyApproval", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (currentQueryClient) {
+      currentQueryClient.cancelQueries();
+      currentQueryClient.clear();
+      currentQueryClient = null;
+    }
+    if (currentRenderer) {
+      await act(async () => {
+        currentRenderer!.unmount();
+      });
+      currentRenderer = null;
+    }
+  });
+
+  it("calls POST /v1/approvals/{approval_id}/deny with correct params", async () => {
+    mockPost.mockResolvedValue({
+      data: {
+        approval_id: "appr_abc123",
+        status: "denied",
+        denied_at: "2026-03-02T13:25:00Z",
+      },
+      error: undefined,
+    });
+
+    const { capture, Consumer } = createHookCapture();
+    currentQueryClient = createQueryClient();
+
+    await act(async () => {
+      currentRenderer = renderWithProviders(Consumer, currentQueryClient!);
+    });
+
+    // Authenticate
+    const session = mockSession();
+    await act(async () => {
+      authMocks.authChangeCallback!("SIGNED_IN" as AuthChangeEvent, session);
+    });
+
+    await waitFor(() => capture.denyApproval !== null);
+
+    await act(async () => {
+      await capture.denyApproval!("appr_abc123");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/approvals/{approval_id}/deny",
+      {
+        headers: { Authorization: expect.stringContaining("Bearer ") },
+        params: { path: { approval_id: "appr_abc123" } },
+      },
+    );
+  });
+
+  it("throws on API error", async () => {
+    mockPost.mockResolvedValue({
+      data: undefined,
+      error: { error: { code: "approval_already_resolved", message: "Already resolved" } },
+    });
+
+    const { capture, Consumer } = createHookCapture();
+    currentQueryClient = createQueryClient();
+
+    await act(async () => {
+      currentRenderer = renderWithProviders(Consumer, currentQueryClient!);
+    });
+
+    const session = mockSession();
+    await act(async () => {
+      authMocks.authChangeCallback!("SIGNED_IN" as AuthChangeEvent, session);
+    });
+
+    await waitFor(() => capture.denyApproval !== null);
+
+    let thrownError: Error | undefined;
+    await act(async () => {
+      try {
+        await capture.denyApproval!("appr_resolved");
+      } catch (e) {
+        thrownError = e as Error;
+      }
+    });
+
+    expect(thrownError).toBeDefined();
+    expect(thrownError!.message).toBe("Already resolved");
+  });
+
+  it("throws when not authenticated", async () => {
+    const { capture, Consumer } = createHookCapture();
+    currentQueryClient = createQueryClient();
+
+    await act(async () => {
+      currentRenderer = renderWithProviders(Consumer, currentQueryClient!);
+    });
+
+    await waitFor(() => capture.denyApproval !== null);
+
+    let thrownError: Error | undefined;
+    await act(async () => {
+      try {
+        await capture.denyApproval!("appr_abc123");
+      } catch (e) {
+        thrownError = e as Error;
+      }
+    });
+
+    expect(thrownError).toBeDefined();
+    expect(thrownError!.message).toBe("Not authenticated");
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/hooks/useApproveApproval.ts
+++ b/mobile/src/hooks/useApproveApproval.ts
@@ -2,13 +2,14 @@
  * React Query mutation hook for approving an approval request.
  * Returns the confirmation code on success (XXX-XXX format).
  */
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "../auth/AuthContext";
 import client from "../api/client";
 import { getApiErrorMessage } from "../api/errors";
 
 export function useApproveApproval() {
   const { session } = useAuth();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (approvalId: string) => {
@@ -30,9 +31,11 @@ export function useApproveApproval() {
       }
       return data;
     },
-    // No query invalidation — the detail screen stays visible so the user
-    // can read/copy the confirmation code. The 30-second polling in
-    // useApprovals handles eventual list updates.
+    onSuccess: () => {
+      // Invalidate list cache so the approval moves from pending to approved
+      // when the user navigates back.
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+    },
   });
 
   return {

--- a/mobile/src/hooks/useApproveApproval.ts
+++ b/mobile/src/hooks/useApproveApproval.ts
@@ -1,0 +1,44 @@
+/**
+ * React Query mutation hook for approving an approval request.
+ * Returns the confirmation code on success (XXX-XXX format).
+ */
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+
+export function useApproveApproval() {
+  const { session } = useAuth();
+
+  const mutation = useMutation({
+    mutationFn: async (approvalId: string) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST(
+        "/v1/approvals/{approval_id}/approve",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { approval_id: approvalId } },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to approve request"),
+        );
+      }
+      return data;
+    },
+    // No query invalidation — the detail screen stays visible so the user
+    // can read/copy the confirmation code. The 30-second polling in
+    // useApprovals handles eventual list updates.
+  });
+
+  return {
+    approveApproval: (approvalId: string) => mutation.mutateAsync(approvalId),
+    isPending: mutation.isPending,
+    error: mutation.error,
+    reset: mutation.reset,
+  };
+}

--- a/mobile/src/hooks/useDenyApproval.ts
+++ b/mobile/src/hooks/useDenyApproval.ts
@@ -1,0 +1,44 @@
+/**
+ * React Query mutation hook for denying an approval request.
+ * Invalidates the approvals query cache on success so the list updates.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+
+export function useDenyApproval() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (approvalId: string) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { error } = await client.POST(
+        "/v1/approvals/{approval_id}/deny",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { approval_id: approvalId } },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to deny request"),
+        );
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+    },
+  });
+
+  return {
+    denyApproval: (approvalId: string) => mutation.mutateAsync(approvalId),
+    isPending: mutation.isPending,
+    error: mutation.error,
+    reset: mutation.reset,
+  };
+}

--- a/mobile/src/screens/approvals/ApprovalActions.tsx
+++ b/mobile/src/screens/approvals/ApprovalActions.tsx
@@ -1,0 +1,112 @@
+/**
+ * Approve/Deny action buttons shown at the bottom of the approval detail
+ * screen for pending, non-expired approvals.
+ */
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { colors } from "../../theme/colors";
+
+interface ApprovalActionsProps {
+  onApprove: () => void;
+  onDeny: () => void;
+  isApproving: boolean;
+  isDenying: boolean;
+  disabled: boolean;
+}
+
+export function ApprovalActions({
+  onApprove,
+  onDeny,
+  isApproving,
+  isDenying,
+  disabled,
+}: ApprovalActionsProps) {
+  const isBusy = isApproving || isDenying;
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[styles.denyButton, (disabled || isBusy) && styles.buttonDisabled]}
+        onPress={onDeny}
+        disabled={disabled || isBusy}
+        accessibilityLabel="Deny request"
+        accessibilityRole="button"
+        testID="deny-button"
+      >
+        {isDenying ? (
+          <ActivityIndicator size="small" color={colors.error} />
+        ) : (
+          <Text style={[styles.denyText, (disabled || isBusy) && styles.textDisabled]}>
+            Deny
+          </Text>
+        )}
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[styles.approveButton, (disabled || isBusy) && styles.approveButtonDisabled]}
+        onPress={onApprove}
+        disabled={disabled || isBusy}
+        accessibilityLabel="Approve request"
+        accessibilityRole="button"
+        testID="approve-button"
+      >
+        {isApproving ? (
+          <ActivityIndicator size="small" color={colors.white} />
+        ) : (
+          <Text style={[styles.approveText, (disabled || isBusy) && styles.approveTextDisabled]}>
+            Approve
+          </Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    gap: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  denyButton: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: colors.error,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  denyText: {
+    color: colors.error,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  approveButton: {
+    flex: 1,
+    backgroundColor: colors.success,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  approveText: {
+    color: colors.white,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  buttonDisabled: {
+    borderColor: colors.gray300,
+    opacity: 0.5,
+  },
+  textDisabled: {
+    color: colors.gray400,
+  },
+  approveButtonDisabled: {
+    backgroundColor: colors.gray300,
+    opacity: 0.5,
+  },
+  approveTextDisabled: {
+    color: colors.gray500,
+  },
+});

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -25,13 +25,13 @@ import {
   buildActionSummary,
   safeParams,
   isExpired as checkExpired,
-  formatParamValue,
   formatTimestamp,
 } from "./approvalUtils";
 import { RiskBadge } from "./RiskBadge";
 import { CountdownBadge } from "./CountdownBadge";
 import { ConfirmationCodeCard } from "./ConfirmationCodeCard";
 import { ApprovalActions } from "./ApprovalActions";
+import { KeyValueList, type KeyValueEntry } from "./KeyValueList";
 
 type Props = NativeStackScreenProps<RootStackParamList, "ApprovalDetail">;
 
@@ -42,6 +42,9 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
 
   const [confirmationCode, setConfirmationCode] = useState<string | null>(null);
   const [isDenied, setIsDenied] = useState(false);
+  // Capture the exact timestamp when the user approves/denies so the timeline
+  // doesn't flicker with a new Date() on every re-render.
+  const [resolvedAt, setResolvedAt] = useState<string | null>(null);
 
   const {
     approveApproval,
@@ -61,9 +64,14 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
     : `Agent ${approval.agent_id}`;
 
   const parameters = safeParams(approval.action.parameters);
-  const paramEntries = Object.entries(parameters);
-  const contextDetails = safeParams(approval.context.details);
-  const contextDetailEntries = Object.entries(contextDetails);
+  const paramEntries: KeyValueEntry[] = useMemo(
+    () => Object.entries(parameters).map(([label, value]) => ({ label, value })),
+    [parameters],
+  );
+  const contextDetailEntries: KeyValueEntry[] = useMemo(() => {
+    const details = safeParams(approval.context.details);
+    return Object.entries(details).map(([label, value]) => ({ label, value }));
+  }, [approval.context.details]);
 
   const isPending = approval.status === "pending" && !confirmationCode && !isDenied;
   const expired = checkExpired(approval.status, approval.expires_at);
@@ -71,9 +79,29 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
 
   const summary = buildActionSummary(approval.action.type, parameters);
 
+  const timelineEntries: KeyValueEntry[] = useMemo(() => {
+    const entries: KeyValueEntry[] = [
+      { label: "Created", value: formatTimestamp(approval.created_at) },
+      { label: "Expires", value: formatTimestamp(approval.expires_at) },
+    ];
+    const approvedTime = approval.approved_at ?? (confirmationCode ? resolvedAt : null);
+    if (approvedTime) {
+      entries.push({ label: "Approved", value: formatTimestamp(approvedTime) });
+    }
+    const deniedTime = approval.denied_at ?? (isDenied ? resolvedAt : null);
+    if (deniedTime) {
+      entries.push({ label: "Denied", value: formatTimestamp(deniedTime) });
+    }
+    if (approval.cancelled_at) {
+      entries.push({ label: "Cancelled", value: formatTimestamp(approval.cancelled_at) });
+    }
+    return entries;
+  }, [approval, confirmationCode, isDenied, resolvedAt]);
+
   const handleApprove = useCallback(async () => {
     try {
       const result = await approveApproval(approval.approval_id);
+      setResolvedAt(new Date().toISOString());
       setConfirmationCode(result.confirmation_code);
     } catch (err) {
       const message =
@@ -94,6 +122,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
           onPress: async () => {
             try {
               await denyApproval(approval.approval_id);
+              setResolvedAt(new Date().toISOString());
               setIsDenied(true);
             } catch (err) {
               const message =
@@ -231,7 +260,6 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
               <Text style={styles.actionSummary}>{summary}</Text>
             )}
 
-            {/* Context description — inline with the action for quick scanning */}
             {approval.context.description && (
               <View style={styles.contextInline}>
                 <Text style={styles.contextDescription}>
@@ -240,7 +268,6 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
               </View>
             )}
 
-            {/* Risk explanation — inline for high/medium risk */}
             {approval.context.risk_level &&
               approval.context.risk_level !== "low" && (
                 <View style={styles.riskRow}>
@@ -252,7 +279,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
           </View>
         </View>
 
-        {/* High risk warning — prominent, outside the card */}
+        {/* High risk warning */}
         {approval.context.risk_level === "high" && (
           <View style={styles.section}>
             <View
@@ -287,30 +314,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
           <View style={styles.section}>
             <Text style={styles.sectionLabel}>Parameters</Text>
             <View style={styles.card}>
-              {paramEntries.map(([key, value], index) => {
-                const formatted = formatParamValue(value);
-                const isLong = formatted.length > 40 || formatted.includes("\n");
-                const isLast = index === paramEntries.length - 1;
-                return (
-                  <View
-                    key={key}
-                    style={[
-                      isLong ? styles.paramRowVertical : styles.paramRow,
-                      isLast && styles.paramRowLast,
-                    ]}
-                  >
-                    <Text style={styles.paramKey}>{key}</Text>
-                    <Text
-                      style={
-                        isLong ? styles.paramValueFull : styles.paramValue
-                      }
-                      selectable
-                    >
-                      {formatted}
-                    </Text>
-                  </View>
-                );
-              })}
+              <KeyValueList entries={paramEntries} />
             </View>
           </View>
         )}
@@ -320,74 +324,16 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
           <View style={styles.section}>
             <Text style={styles.sectionLabel}>Additional Context</Text>
             <View style={styles.card}>
-              {contextDetailEntries.map(([key, value], index) => {
-                const formatted = formatParamValue(value);
-                const isLong = formatted.length > 40 || formatted.includes("\n");
-                const isLast = index === contextDetailEntries.length - 1;
-                return (
-                  <View
-                    key={key}
-                    style={[
-                      isLong ? styles.paramRowVertical : styles.paramRow,
-                      isLast && styles.paramRowLast,
-                    ]}
-                  >
-                    <Text style={styles.paramKey}>{key}</Text>
-                    <Text
-                      style={
-                        isLong ? styles.paramValueFull : styles.paramValue
-                      }
-                      selectable
-                    >
-                      {formatted}
-                    </Text>
-                  </View>
-                );
-              })}
+              <KeyValueList entries={contextDetailEntries} />
             </View>
           </View>
         )}
 
-        {/* Timestamps */}
+        {/* Timeline */}
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Timeline</Text>
           <View style={styles.card}>
-            <View style={styles.paramRow}>
-              <Text style={styles.paramKey}>Created</Text>
-              <Text style={styles.paramValue}>
-                {formatTimestamp(approval.created_at)}
-              </Text>
-            </View>
-            <View style={styles.paramRow}>
-              <Text style={styles.paramKey}>Expires</Text>
-              <Text style={styles.paramValue}>
-                {formatTimestamp(approval.expires_at)}
-              </Text>
-            </View>
-            {(approval.approved_at ?? (confirmationCode ? new Date().toISOString() : null)) && (
-              <View style={styles.paramRow}>
-                <Text style={styles.paramKey}>Approved</Text>
-                <Text style={styles.paramValue}>
-                  {formatTimestamp(approval.approved_at ?? new Date().toISOString())}
-                </Text>
-              </View>
-            )}
-            {(approval.denied_at ?? (isDenied ? new Date().toISOString() : null)) && (
-              <View style={styles.paramRow}>
-                <Text style={styles.paramKey}>Denied</Text>
-                <Text style={styles.paramValue}>
-                  {formatTimestamp(approval.denied_at ?? new Date().toISOString())}
-                </Text>
-              </View>
-            )}
-            {approval.cancelled_at && (
-              <View style={styles.paramRow}>
-                <Text style={styles.paramKey}>Cancelled</Text>
-                <Text style={styles.paramValue}>
-                  {formatTimestamp(approval.cancelled_at)}
-                </Text>
-              </View>
-            )}
+            <KeyValueList entries={timelineEntries} />
           </View>
         </View>
 
@@ -598,40 +544,6 @@ const styles = StyleSheet.create({
   expiryLabel: {
     fontSize: 14,
     color: colors.gray500,
-  },
-  paramRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.gray100,
-  },
-  paramRowVertical: {
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.gray100,
-  },
-  paramRowLast: {
-    borderBottomWidth: 0,
-  },
-  paramKey: {
-    fontSize: 13,
-    fontWeight: "500",
-    color: colors.gray500,
-    marginRight: 12,
-    flexShrink: 0,
-  },
-  paramValue: {
-    fontSize: 13,
-    color: colors.gray900,
-    flex: 1,
-    textAlign: "right",
-  },
-  paramValueFull: {
-    fontSize: 13,
-    color: colors.gray900,
-    marginTop: 4,
-    lineHeight: 19,
   },
   footerLabel: {
     fontSize: 11,

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -1,10 +1,12 @@
 /**
  * Approval detail screen — displays the full details of a single approval
  * request including agent info, action parameters, risk level, expiry
- * countdown, context, and timeline.
+ * countdown, context, and timeline. For pending approvals, shows
+ * approve/deny buttons. After approval, displays the confirmation code.
  */
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
+  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -14,11 +16,12 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useAgents, getAgentDisplayName } from "../../hooks/useAgents";
+import { useApproveApproval } from "../../hooks/useApproveApproval";
+import { useDenyApproval } from "../../hooks/useDenyApproval";
 import { colors } from "../../theme/colors";
 import {
   humanizeActionType,
   buildActionSummary,
-  secondsUntil,
   safeParams,
   isExpired as checkExpired,
   formatParamValue,
@@ -26,13 +29,27 @@ import {
 } from "./approvalUtils";
 import { RiskBadge } from "./RiskBadge";
 import { CountdownBadge } from "./CountdownBadge";
+import { ConfirmationCodeCard } from "./ConfirmationCodeCard";
+import { ApprovalActions } from "./ApprovalActions";
 
 type Props = NativeStackScreenProps<RootStackParamList, "ApprovalDetail">;
 
-export default function ApprovalDetailScreen({ route }: Props) {
+export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const { approval } = route.params;
   const { agents } = useAgents();
   const insets = useSafeAreaInsets();
+
+  const [confirmationCode, setConfirmationCode] = useState<string | null>(null);
+  const [isDenied, setIsDenied] = useState(false);
+
+  const {
+    approveApproval,
+    isPending: isApproving,
+  } = useApproveApproval();
+  const {
+    denyApproval,
+    isPending: isDenying,
+  } = useDenyApproval();
 
   const agent = useMemo(
     () => agents.find((a) => a.agent_id === approval.agent_id),
@@ -47,252 +64,331 @@ export default function ApprovalDetailScreen({ route }: Props) {
   const contextDetails = safeParams(approval.context.details);
   const contextDetailEntries = Object.entries(contextDetails);
 
-  const remaining = secondsUntil(approval.expires_at);
-  const isPending = approval.status === "pending";
+  const isPending = approval.status === "pending" && !confirmationCode && !isDenied;
   const expired = checkExpired(approval.status, approval.expires_at);
+  const canAct = isPending && !expired;
 
   const summary = buildActionSummary(approval.action.type, parameters);
 
+  const handleApprove = useCallback(async () => {
+    try {
+      const result = await approveApproval(approval.approval_id);
+      setConfirmationCode(result.confirmation_code);
+    } catch {
+      Alert.alert(
+        "Approval Failed",
+        "Failed to approve request. The request may have expired or already been resolved.",
+      );
+    }
+  }, [approveApproval, approval.approval_id]);
+
+  const handleDeny = useCallback(() => {
+    Alert.alert(
+      "Deny Request",
+      "Are you sure you want to deny this request?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Deny",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await denyApproval(approval.approval_id);
+              setIsDenied(true);
+            } catch {
+              Alert.alert(
+                "Denial Failed",
+                "Failed to deny request. The request may have expired or already been resolved.",
+              );
+            }
+          },
+        },
+      ],
+    );
+  }, [denyApproval, approval.approval_id]);
+
   return (
-    <ScrollView
-      style={styles.container}
-      contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
-    >
-      {/* Status banner for resolved approvals */}
-      {approval.status === "approved" && (
-        <View
-          style={styles.statusBannerApproved}
-          accessibilityRole="alert"
-        >
-          <Text style={styles.statusBannerTextApproved}>Approved</Text>
-        </View>
-      )}
-      {approval.status === "denied" && (
-        <View
-          style={styles.statusBannerDenied}
-          accessibilityRole="alert"
-        >
-          <Text style={styles.statusBannerTextDenied}>Denied</Text>
-        </View>
-      )}
-      {approval.status === "cancelled" && (
-        <View style={styles.statusBannerCancelled}>
-          <Text style={styles.statusBannerText}>Cancelled</Text>
-        </View>
-      )}
-      {expired && (
-        <View style={styles.statusBannerCancelled}>
-          <Text style={styles.statusBannerText}>Expired</Text>
-        </View>
-      )}
-
-      {/* Agent Info */}
-      <View style={styles.section}>
-        <Text style={styles.sectionLabel}>Agent</Text>
-        <View style={styles.agentRow}>
-          <View style={styles.agentAvatar}>
-            <Text style={styles.agentAvatarText}>
-              {agentName.charAt(0).toUpperCase()}
-            </Text>
-          </View>
-          <View style={styles.agentInfo}>
-            <Text style={styles.agentName}>{agentName}</Text>
-            {agentName !== `Agent ${approval.agent_id}` && (
-              <Text style={styles.agentId}>ID: {approval.agent_id}</Text>
-            )}
-          </View>
-        </View>
-      </View>
-
-      {/* Action & Risk */}
-      <View style={styles.section}>
-        <Text style={styles.sectionLabel}>Action</Text>
-        <View style={styles.card}>
-          <View style={styles.actionHeader}>
-            <View style={styles.actionTitleRow}>
-              <Text style={styles.actionName}>
-                {humanizeActionType(approval.action.type)}
-              </Text>
-              <RiskBadge level={approval.context.risk_level} />
+    <View style={styles.outerContainer}>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={{ paddingBottom: canAct ? 8 : insets.bottom + 24 }}
+      >
+        {/* Confirmation code — shown after successful approval */}
+        {confirmationCode && (
+          <View style={styles.section}>
+            <View style={styles.successBanner} accessibilityRole="alert">
+              <Text style={styles.successBannerText}>Request Approved</Text>
             </View>
-            <Text style={styles.actionType}>{approval.action.type}</Text>
-            {approval.action.version && (
-              <Text style={styles.actionVersion}>
-                v{approval.action.version}
-              </Text>
-            )}
+            <View style={styles.codeSection}>
+              <ConfirmationCodeCard code={confirmationCode} />
+            </View>
           </View>
-          {summary !== humanizeActionType(approval.action.type) && (
-            <Text style={styles.actionSummary}>{summary}</Text>
-          )}
+        )}
 
-          {/* Context description — inline with the action for quick scanning */}
-          {approval.context.description && (
-            <View style={styles.contextInline}>
-              <Text style={styles.contextDescription}>
-                {approval.context.description}
+        {/* Denied confirmation */}
+        {isDenied && (
+          <View
+            style={styles.statusBannerDenied}
+            accessibilityRole="alert"
+            testID="denied-banner"
+          >
+            <Text style={styles.statusBannerTextDenied}>Request Denied</Text>
+          </View>
+        )}
+
+        {/* Status banner for already-resolved approvals (loaded from list) */}
+        {!confirmationCode && !isDenied && (
+          <>
+            {approval.status === "approved" && (
+              <View
+                style={styles.statusBannerApproved}
+                accessibilityRole="alert"
+              >
+                <Text style={styles.statusBannerTextApproved}>Approved</Text>
+              </View>
+            )}
+            {approval.status === "denied" && (
+              <View
+                style={styles.statusBannerDenied}
+                accessibilityRole="alert"
+              >
+                <Text style={styles.statusBannerTextDenied}>Denied</Text>
+              </View>
+            )}
+            {approval.status === "cancelled" && (
+              <View style={styles.statusBannerCancelled}>
+                <Text style={styles.statusBannerText}>Cancelled</Text>
+              </View>
+            )}
+            {expired && (
+              <View style={styles.statusBannerCancelled}>
+                <Text style={styles.statusBannerText}>Expired</Text>
+              </View>
+            )}
+          </>
+        )}
+
+        {/* Agent Info */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Agent</Text>
+          <View style={styles.agentRow}>
+            <View style={styles.agentAvatar}>
+              <Text style={styles.agentAvatarText}>
+                {agentName.charAt(0).toUpperCase()}
               </Text>
             </View>
-          )}
+            <View style={styles.agentInfo}>
+              <Text style={styles.agentName}>{agentName}</Text>
+              {agentName !== `Agent ${approval.agent_id}` && (
+                <Text style={styles.agentId}>ID: {approval.agent_id}</Text>
+              )}
+            </View>
+          </View>
+        </View>
 
-          {/* Risk explanation — inline for high/medium risk */}
-          {approval.context.risk_level &&
-            approval.context.risk_level !== "low" && (
-              <View style={styles.riskRow}>
-                <Text style={styles.riskDescription}>
-                  {RISK_DESCRIPTIONS[approval.context.risk_level]}
+        {/* Action & Risk */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Action</Text>
+          <View style={styles.card}>
+            <View style={styles.actionHeader}>
+              <View style={styles.actionTitleRow}>
+                <Text style={styles.actionName}>
+                  {humanizeActionType(approval.action.type)}
+                </Text>
+                <RiskBadge level={approval.context.risk_level} />
+              </View>
+              <Text style={styles.actionType}>{approval.action.type}</Text>
+              {approval.action.version && (
+                <Text style={styles.actionVersion}>
+                  v{approval.action.version}
+                </Text>
+              )}
+            </View>
+            {summary !== humanizeActionType(approval.action.type) && (
+              <Text style={styles.actionSummary}>{summary}</Text>
+            )}
+
+            {/* Context description — inline with the action for quick scanning */}
+            {approval.context.description && (
+              <View style={styles.contextInline}>
+                <Text style={styles.contextDescription}>
+                  {approval.context.description}
                 </Text>
               </View>
             )}
-        </View>
-      </View>
 
-      {/* High risk warning — prominent, outside the card */}
-      {approval.context.risk_level === "high" && (
-        <View style={styles.section}>
-          <View
-            style={styles.highRiskWarning}
-            accessibilityRole="alert"
-          >
-            <Text style={styles.highRiskWarningText}>
-              This is a high-risk action. Review the details carefully before
-              approving.
-            </Text>
-          </View>
-        </View>
-      )}
-
-      {/* Expiry Countdown */}
-      {isPending && (
-        <View style={styles.section}>
-          <Text style={styles.sectionLabel}>Expiry</Text>
-          <View style={styles.card}>
-            <View style={styles.expiryRow}>
-              <CountdownBadge expiresAt={approval.expires_at} />
-              <Text style={styles.expiryLabel}>
-                {expired ? "This request has expired" : "remaining"}
-              </Text>
-            </View>
-          </View>
-        </View>
-      )}
-
-      {/* Parameters */}
-      {paramEntries.length > 0 && (
-        <View style={styles.section}>
-          <Text style={styles.sectionLabel}>Parameters</Text>
-          <View style={styles.card}>
-            {paramEntries.map(([key, value], index) => {
-              const formatted = formatParamValue(value);
-              const isLong = formatted.length > 40 || formatted.includes("\n");
-              const isLast = index === paramEntries.length - 1;
-              return (
-                <View
-                  key={key}
-                  style={[
-                    isLong ? styles.paramRowVertical : styles.paramRow,
-                    isLast && styles.paramRowLast,
-                  ]}
-                >
-                  <Text style={styles.paramKey}>{key}</Text>
-                  <Text
-                    style={
-                      isLong ? styles.paramValueFull : styles.paramValue
-                    }
-                    selectable
-                  >
-                    {formatted}
+            {/* Risk explanation — inline for high/medium risk */}
+            {approval.context.risk_level &&
+              approval.context.risk_level !== "low" && (
+                <View style={styles.riskRow}>
+                  <Text style={styles.riskDescription}>
+                    {RISK_DESCRIPTIONS[approval.context.risk_level]}
                   </Text>
                 </View>
-              );
-            })}
+              )}
           </View>
         </View>
-      )}
 
-      {/* Context Details */}
-      {contextDetailEntries.length > 0 && (
-        <View style={styles.section}>
-          <Text style={styles.sectionLabel}>Additional Context</Text>
-          <View style={styles.card}>
-            {contextDetailEntries.map(([key, value], index) => {
-              const formatted = formatParamValue(value);
-              const isLong = formatted.length > 40 || formatted.includes("\n");
-              const isLast = index === contextDetailEntries.length - 1;
-              return (
-                <View
-                  key={key}
-                  style={[
-                    isLong ? styles.paramRowVertical : styles.paramRow,
-                    isLast && styles.paramRowLast,
-                  ]}
-                >
-                  <Text style={styles.paramKey}>{key}</Text>
-                  <Text
-                    style={
-                      isLong ? styles.paramValueFull : styles.paramValue
-                    }
-                    selectable
+        {/* High risk warning — prominent, outside the card */}
+        {approval.context.risk_level === "high" && (
+          <View style={styles.section}>
+            <View
+              style={styles.highRiskWarning}
+              accessibilityRole="alert"
+            >
+              <Text style={styles.highRiskWarningText}>
+                This is a high-risk action. Review the details carefully before
+                approving.
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {/* Expiry Countdown */}
+        {approval.status === "pending" && !confirmationCode && !isDenied && (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Expiry</Text>
+            <View style={styles.card}>
+              <View style={styles.expiryRow}>
+                <CountdownBadge expiresAt={approval.expires_at} />
+                <Text style={styles.expiryLabel}>
+                  {expired ? "This request has expired" : "remaining"}
+                </Text>
+              </View>
+            </View>
+          </View>
+        )}
+
+        {/* Parameters */}
+        {paramEntries.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Parameters</Text>
+            <View style={styles.card}>
+              {paramEntries.map(([key, value], index) => {
+                const formatted = formatParamValue(value);
+                const isLong = formatted.length > 40 || formatted.includes("\n");
+                const isLast = index === paramEntries.length - 1;
+                return (
+                  <View
+                    key={key}
+                    style={[
+                      isLong ? styles.paramRowVertical : styles.paramRow,
+                      isLast && styles.paramRowLast,
+                    ]}
                   >
-                    {formatted}
-                  </Text>
-                </View>
-              );
-            })}
+                    <Text style={styles.paramKey}>{key}</Text>
+                    <Text
+                      style={
+                        isLong ? styles.paramValueFull : styles.paramValue
+                      }
+                      selectable
+                    >
+                      {formatted}
+                    </Text>
+                  </View>
+                );
+              })}
+            </View>
           </View>
+        )}
+
+        {/* Context Details */}
+        {contextDetailEntries.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Additional Context</Text>
+            <View style={styles.card}>
+              {contextDetailEntries.map(([key, value], index) => {
+                const formatted = formatParamValue(value);
+                const isLong = formatted.length > 40 || formatted.includes("\n");
+                const isLast = index === contextDetailEntries.length - 1;
+                return (
+                  <View
+                    key={key}
+                    style={[
+                      isLong ? styles.paramRowVertical : styles.paramRow,
+                      isLast && styles.paramRowLast,
+                    ]}
+                  >
+                    <Text style={styles.paramKey}>{key}</Text>
+                    <Text
+                      style={
+                        isLong ? styles.paramValueFull : styles.paramValue
+                      }
+                      selectable
+                    >
+                      {formatted}
+                    </Text>
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        )}
+
+        {/* Timestamps */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Timeline</Text>
+          <View style={styles.card}>
+            <View style={styles.paramRow}>
+              <Text style={styles.paramKey}>Created</Text>
+              <Text style={styles.paramValue}>
+                {formatTimestamp(approval.created_at)}
+              </Text>
+            </View>
+            <View style={styles.paramRow}>
+              <Text style={styles.paramKey}>Expires</Text>
+              <Text style={styles.paramValue}>
+                {formatTimestamp(approval.expires_at)}
+              </Text>
+            </View>
+            {(approval.approved_at ?? (confirmationCode ? new Date().toISOString() : null)) && (
+              <View style={styles.paramRow}>
+                <Text style={styles.paramKey}>Approved</Text>
+                <Text style={styles.paramValue}>
+                  {formatTimestamp(approval.approved_at ?? new Date().toISOString())}
+                </Text>
+              </View>
+            )}
+            {(approval.denied_at ?? (isDenied ? new Date().toISOString() : null)) && (
+              <View style={styles.paramRow}>
+                <Text style={styles.paramKey}>Denied</Text>
+                <Text style={styles.paramValue}>
+                  {formatTimestamp(approval.denied_at ?? new Date().toISOString())}
+                </Text>
+              </View>
+            )}
+            {approval.cancelled_at && (
+              <View style={styles.paramRow}>
+                <Text style={styles.paramKey}>Cancelled</Text>
+                <Text style={styles.paramValue}>
+                  {formatTimestamp(approval.cancelled_at)}
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        {/* Approval ID */}
+        <View style={styles.section}>
+          <Text style={styles.footerLabel}>
+            ID: {approval.approval_id}
+          </Text>
+        </View>
+      </ScrollView>
+
+      {/* Action buttons — fixed at bottom for pending approvals */}
+      {canAct && (
+        <View style={[styles.actionBar, { paddingBottom: insets.bottom + 8 }]}>
+          <ApprovalActions
+            onApprove={handleApprove}
+            onDeny={handleDeny}
+            isApproving={isApproving}
+            isDenying={isDenying}
+            disabled={expired}
+          />
         </View>
       )}
-
-      {/* Timestamps */}
-      <View style={styles.section}>
-        <Text style={styles.sectionLabel}>Timeline</Text>
-        <View style={styles.card}>
-          <View style={styles.paramRow}>
-            <Text style={styles.paramKey}>Created</Text>
-            <Text style={styles.paramValue}>
-              {formatTimestamp(approval.created_at)}
-            </Text>
-          </View>
-          <View style={styles.paramRow}>
-            <Text style={styles.paramKey}>Expires</Text>
-            <Text style={styles.paramValue}>
-              {formatTimestamp(approval.expires_at)}
-            </Text>
-          </View>
-          {approval.approved_at && (
-            <View style={styles.paramRow}>
-              <Text style={styles.paramKey}>Approved</Text>
-              <Text style={styles.paramValue}>
-                {formatTimestamp(approval.approved_at)}
-              </Text>
-            </View>
-          )}
-          {approval.denied_at && (
-            <View style={styles.paramRow}>
-              <Text style={styles.paramKey}>Denied</Text>
-              <Text style={styles.paramValue}>
-                {formatTimestamp(approval.denied_at)}
-              </Text>
-            </View>
-          )}
-          {approval.cancelled_at && (
-            <View style={styles.paramRow}>
-              <Text style={styles.paramKey}>Cancelled</Text>
-              <Text style={styles.paramValue}>
-                {formatTimestamp(approval.cancelled_at)}
-              </Text>
-            </View>
-          )}
-        </View>
-      </View>
-
-      {/* Approval ID */}
-      <View style={styles.section}>
-        <Text style={styles.footerLabel}>
-          ID: {approval.approval_id}
-        </Text>
-      </View>
-    </ScrollView>
+    </View>
   );
 }
 
@@ -305,9 +401,29 @@ const RISK_DESCRIPTIONS: Record<string, string> = {
 
 
 const styles = StyleSheet.create({
-  container: {
+  outerContainer: {
     flex: 1,
     backgroundColor: colors.gray50,
+  },
+  container: {
+    flex: 1,
+  },
+  successBanner: {
+    backgroundColor: colors.riskLowBg,
+    borderRadius: 12,
+    padding: 14,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#A7F3D0",
+    marginBottom: 16,
+  },
+  successBannerText: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.success,
+  },
+  codeSection: {
+    marginTop: 0,
   },
   statusBannerApproved: {
     backgroundColor: colors.riskLowBg,
@@ -499,5 +615,10 @@ const styles = StyleSheet.create({
     color: colors.gray400,
     textAlign: "center",
     fontFamily: "monospace",
+  },
+  actionBar: {
+    backgroundColor: colors.white,
+    borderTopWidth: 1,
+    borderTopColor: colors.gray200,
   },
 });

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -10,6 +10,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -74,11 +75,10 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
     try {
       const result = await approveApproval(approval.approval_id);
       setConfirmationCode(result.confirmation_code);
-    } catch {
-      Alert.alert(
-        "Approval Failed",
-        "Failed to approve request. The request may have expired or already been resolved.",
-      );
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to approve request";
+      Alert.alert("Approval Failed", message);
     }
   }, [approveApproval, approval.approval_id]);
 
@@ -95,17 +95,20 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
             try {
               await denyApproval(approval.approval_id);
               setIsDenied(true);
-            } catch {
-              Alert.alert(
-                "Denial Failed",
-                "Failed to deny request. The request may have expired or already been resolved.",
-              );
+            } catch (err) {
+              const message =
+                err instanceof Error ? err.message : "Failed to deny request";
+              Alert.alert("Denial Failed", message);
             }
           },
         },
       ],
     );
   }, [denyApproval, approval.approval_id]);
+
+  const handleDone = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   return (
     <View style={styles.outerContainer}>
@@ -122,17 +125,37 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
             <View style={styles.codeSection}>
               <ConfirmationCodeCard code={confirmationCode} />
             </View>
+            <TouchableOpacity
+              style={styles.doneButton}
+              onPress={handleDone}
+              accessibilityLabel="Done, go back to list"
+              accessibilityRole="button"
+              testID="done-button"
+            >
+              <Text style={styles.doneButtonText}>Done</Text>
+            </TouchableOpacity>
           </View>
         )}
 
         {/* Denied confirmation */}
         {isDenied && (
-          <View
-            style={styles.statusBannerDenied}
-            accessibilityRole="alert"
-            testID="denied-banner"
-          >
-            <Text style={styles.statusBannerTextDenied}>Request Denied</Text>
+          <View style={styles.section}>
+            <View
+              style={styles.statusBannerDenied}
+              accessibilityRole="alert"
+              testID="denied-banner"
+            >
+              <Text style={styles.statusBannerTextDenied}>Request Denied</Text>
+            </View>
+            <TouchableOpacity
+              style={styles.doneButton}
+              onPress={handleDone}
+              accessibilityLabel="Done, go back to list"
+              accessibilityRole="button"
+              testID="done-button"
+            >
+              <Text style={styles.doneButtonText}>Done</Text>
+            </TouchableOpacity>
           </View>
         )}
 
@@ -615,6 +638,18 @@ const styles = StyleSheet.create({
     color: colors.gray400,
     textAlign: "center",
     fontFamily: "monospace",
+  },
+  doneButton: {
+    marginTop: 16,
+    backgroundColor: colors.gray900,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  doneButtonText: {
+    color: colors.white,
+    fontSize: 16,
+    fontWeight: "600",
   },
   actionBar: {
     backgroundColor: colors.white,

--- a/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
+++ b/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
@@ -2,7 +2,7 @@
  * Displays the confirmation code after an approval in a large, prominent card.
  * The code is shown in XXX-XXX format with a copy-to-clipboard button.
  */
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import { colors } from "../../theme/colors";
@@ -13,11 +13,16 @@ interface ConfirmationCodeCardProps {
 
 export function ConfirmationCodeCard({ code }: ConfirmationCodeCardProps) {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Clean up timer on unmount to prevent state updates after navigation.
+  useEffect(() => () => clearTimeout(timerRef.current), []);
 
   const handleCopy = useCallback(async () => {
     await Clipboard.setStringAsync(code);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
   }, [code]);
 
   return (

--- a/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
+++ b/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
@@ -1,0 +1,89 @@
+/**
+ * Displays the confirmation code after an approval in a large, prominent card.
+ * The code is shown in XXX-XXX format with a copy-to-clipboard button.
+ */
+import { useCallback, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import * as Clipboard from "expo-clipboard";
+import { colors } from "../../theme/colors";
+
+interface ConfirmationCodeCardProps {
+  code: string;
+}
+
+export function ConfirmationCodeCard({ code }: ConfirmationCodeCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await Clipboard.setStringAsync(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [code]);
+
+  return (
+    <View style={styles.container} accessibilityRole="alert">
+      <Text style={styles.label}>Confirmation Code</Text>
+      <Text style={styles.code} selectable testID="confirmation-code">
+        {code}
+      </Text>
+      <TouchableOpacity
+        style={styles.copyButton}
+        onPress={handleCopy}
+        accessibilityLabel={copied ? "Code copied" : "Copy confirmation code"}
+        accessibilityRole="button"
+        testID="copy-code-button"
+      >
+        <Text style={styles.copyText}>
+          {copied ? "Copied!" : "Copy Code"}
+        </Text>
+      </TouchableOpacity>
+      <Text style={styles.hint}>
+        Share this code with the agent to authorize the action
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.primaryBg,
+    borderRadius: 12,
+    padding: 20,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#BFDBFE",
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: colors.gray500,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 8,
+  },
+  code: {
+    fontSize: 32,
+    fontWeight: "700",
+    fontFamily: "monospace",
+    letterSpacing: 4,
+    color: colors.gray900,
+    marginBottom: 12,
+  },
+  copyButton: {
+    backgroundColor: colors.primary,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    marginBottom: 12,
+  },
+  copyText: {
+    color: colors.white,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  hint: {
+    fontSize: 12,
+    color: colors.gray400,
+    textAlign: "center",
+  },
+});

--- a/mobile/src/screens/approvals/KeyValueList.tsx
+++ b/mobile/src/screens/approvals/KeyValueList.tsx
@@ -1,0 +1,84 @@
+/**
+ * Renders a list of key-value pairs in a card layout. Used for displaying
+ * approval parameters, context details, and timeline entries. Handles both
+ * short (inline) and long (stacked) values automatically.
+ */
+import { StyleSheet, Text, View } from "react-native";
+import { colors } from "../../theme/colors";
+import { formatParamValue } from "./approvalUtils";
+
+export interface KeyValueEntry {
+  label: string;
+  value: unknown;
+}
+
+interface KeyValueListProps {
+  entries: KeyValueEntry[];
+}
+
+export function KeyValueList({ entries }: KeyValueListProps) {
+  return (
+    <>
+      {entries.map(({ label, value }, index) => {
+        const formatted =
+          typeof value === "string" ? value : formatParamValue(value);
+        const isLong = formatted.length > 40 || formatted.includes("\n");
+        const isLast = index === entries.length - 1;
+        return (
+          <View
+            key={label}
+            style={[
+              isLong ? styles.rowVertical : styles.row,
+              isLast && styles.rowLast,
+            ]}
+          >
+            <Text style={styles.key}>{label}</Text>
+            <Text
+              style={isLong ? styles.valueFull : styles.value}
+              selectable
+            >
+              {formatted}
+            </Text>
+          </View>
+        );
+      })}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray100,
+  },
+  rowVertical: {
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray100,
+  },
+  rowLast: {
+    borderBottomWidth: 0,
+  },
+  key: {
+    fontSize: 13,
+    fontWeight: "500",
+    color: colors.gray500,
+    marginRight: 12,
+    flexShrink: 0,
+  },
+  value: {
+    fontSize: 13,
+    color: colors.gray900,
+    flex: 1,
+    textAlign: "right",
+  },
+  valueFull: {
+    fontSize: 13,
+    color: colors.gray900,
+    marginTop: 4,
+    lineHeight: 19,
+  },
+});

--- a/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
@@ -63,6 +63,8 @@ import ApprovalDetailScreen from "../ApprovalDetailScreen";
 
 // --- Helpers ---
 
+const mockGoBack = jest.fn();
+
 function renderDetail(approval: ApprovalSummary) {
   const route = {
     params: {
@@ -72,7 +74,7 @@ function renderDetail(approval: ApprovalSummary) {
     key: "test",
     name: "ApprovalDetail" as const,
   };
-  const navigation = { goBack: jest.fn() } as any;
+  const navigation = { goBack: mockGoBack } as any;
 
   return create(
     createElement(ApprovalDetailScreen, { route, navigation } as any),
@@ -432,5 +434,58 @@ describe("ApprovalDetailScreen", () => {
     });
 
     expect(hasTestId(renderer, "done-button")).toBe(true);
+  });
+
+  it("Done button navigates back to list", async () => {
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      confirmation_code: "AB3-CD5",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    const doneButton = findFirstByTestId(renderer, "done-button");
+    await act(async () => {
+      doneButton?.props.onPress();
+    });
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it("copies confirmation code to clipboard", async () => {
+    const Clipboard = require("expo-clipboard");
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      confirmation_code: "XK7-M9P",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    const copyButton = findFirstByTestId(renderer, "copy-code-button");
+    await act(async () => {
+      copyButton?.props.onPress();
+    });
+
+    expect(Clipboard.setStringAsync).toHaveBeenCalledWith("XK7-M9P");
   });
 });

--- a/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
@@ -316,7 +316,7 @@ describe("ApprovalDetailScreen", () => {
 
     expect(alertSpy).toHaveBeenCalledWith(
       "Approval Failed",
-      expect.stringContaining("Failed to approve"),
+      "Approval has expired",
     );
   });
 
@@ -382,10 +382,55 @@ describe("ApprovalDetailScreen", () => {
       await denyAction?.onPress?.();
     });
 
-    // Second alert call should be the error alert
+    // Second alert call should be the error alert with server message
     expect(alertSpy).toHaveBeenCalledWith(
       "Denial Failed",
-      expect.stringContaining("Failed to deny"),
+      "Already resolved",
     );
+  });
+
+  it("shows Done button after approval", async () => {
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      confirmation_code: "AB3-CD5",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    expect(hasTestId(renderer, "done-button")).toBe(true);
+  });
+
+  it("shows Done button after denial", async () => {
+    mockDenyApproval.mockResolvedValueOnce(undefined);
+    const alertSpy = jest.spyOn(Alert, "alert");
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const denyButton = findFirstByTestId(renderer, "deny-button");
+    await act(async () => {
+      denyButton?.props.onPress();
+    });
+
+    const denyAction = alertSpy.mock.calls[0]?.[2]?.find(
+      (btn) => btn.text === "Deny",
+    );
+    await act(async () => {
+      await denyAction?.onPress?.();
+    });
+
+    expect(hasTestId(renderer, "done-button")).toBe(true);
   });
 });

--- a/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
@@ -1,4 +1,5 @@
 import React, { createElement } from "react";
+import { Alert } from "react-native";
 import { create, act, type ReactTestRenderer } from "react-test-renderer";
 import type { ApprovalSummary } from "../../../hooks/useApprovals";
 import { makeApproval, MOCK_AGENTS, mockGetAgentDisplayName } from "../testFixtures";
@@ -28,9 +29,34 @@ jest.mock("../../../hooks/useAgents", () => ({
   getAgentDisplayName: mockGetAgentDisplayName,
 }));
 
+const mockApproveApproval = jest.fn();
+const mockDenyApproval = jest.fn();
+
+jest.mock("../../../hooks/useApproveApproval", () => ({
+  useApproveApproval: () => ({
+    approveApproval: mockApproveApproval,
+    isPending: false,
+    error: null,
+    reset: jest.fn(),
+  }),
+}));
+
+jest.mock("../../../hooks/useDenyApproval", () => ({
+  useDenyApproval: () => ({
+    denyApproval: mockDenyApproval,
+    isPending: false,
+    error: null,
+    reset: jest.fn(),
+  }),
+}));
+
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
   SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock("expo-clipboard", () => ({
+  setStringAsync: jest.fn(),
 }));
 
 import ApprovalDetailScreen from "../ApprovalDetailScreen";
@@ -46,11 +72,20 @@ function renderDetail(approval: ApprovalSummary) {
     key: "test",
     name: "ApprovalDetail" as const,
   };
-  const navigation = {} as any;
+  const navigation = { goBack: jest.fn() } as any;
 
   return create(
     createElement(ApprovalDetailScreen, { route, navigation } as any),
   );
+}
+
+function hasTestId(renderer: ReactTestRenderer, testID: string) {
+  return renderer.root.findAll((node) => node.props.testID === testID).length > 0;
+}
+
+function findFirstByTestId(renderer: ReactTestRenderer, testID: string) {
+  const matches = renderer.root.findAll((node) => node.props.testID === testID);
+  return matches[0];
 }
 
 // --- Tests ---
@@ -60,6 +95,7 @@ describe("ApprovalDetailScreen", () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.clearAllMocks();
   });
 
   afterEach(async () => {
@@ -169,5 +205,187 @@ describe("ApprovalDetailScreen", () => {
     });
     const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain("Agent 999");
+  });
+
+  // --- Approve/Deny flow tests ---
+
+  it("shows approve and deny buttons for pending approvals", async () => {
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+    expect(hasTestId(renderer, "approve-button")).toBe(true);
+    expect(hasTestId(renderer, "deny-button")).toBe(true);
+  });
+
+  it("does not show approve/deny buttons for approved approvals", async () => {
+    const approval = makeApproval({
+      status: "approved",
+      approved_at: new Date().toISOString(),
+    });
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+    expect(hasTestId(renderer, "approve-button")).toBe(false);
+    expect(hasTestId(renderer, "deny-button")).toBe(false);
+  });
+
+  it("does not show approve/deny buttons for denied approvals", async () => {
+    const approval = makeApproval({
+      status: "denied",
+      denied_at: new Date().toISOString(),
+    });
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+    expect(hasTestId(renderer, "approve-button")).toBe(false);
+  });
+
+  it("does not show approve/deny buttons for expired approvals", async () => {
+    const approval = makeApproval({
+      expires_at: new Date(Date.now() - 60_000).toISOString(),
+    });
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+    expect(hasTestId(renderer, "approve-button")).toBe(false);
+  });
+
+  it("shows confirmation code after successful approval", async () => {
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      confirmation_code: "RK3-P7M",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    // Press approve button
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    const json = JSON.stringify(renderer.toJSON());
+    expect(json).toContain("RK3-P7M");
+    expect(json).toContain("Confirmation Code");
+    expect(json).toContain("Request Approved");
+
+    // Approve/deny buttons should be gone
+    expect(hasTestId(renderer, "approve-button")).toBe(false);
+  });
+
+  it("shows copy button for confirmation code", async () => {
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      confirmation_code: "XK7-M9P",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    expect(hasTestId(renderer, "copy-code-button")).toBe(true);
+  });
+
+  it("shows alert on approve failure", async () => {
+    mockApproveApproval.mockRejectedValueOnce(new Error("Approval has expired"));
+    const alertSpy = jest.spyOn(Alert, "alert");
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Approval Failed",
+      expect.stringContaining("Failed to approve"),
+    );
+  });
+
+  it("shows deny confirmation dialog and processes denial", async () => {
+    mockDenyApproval.mockResolvedValueOnce(undefined);
+    const alertSpy = jest.spyOn(Alert, "alert");
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const denyButton = findFirstByTestId(renderer, "deny-button");
+    await act(async () => {
+      denyButton?.props.onPress();
+    });
+
+    // Alert.alert should be called with deny confirmation
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Deny Request",
+      "Are you sure you want to deny this request?",
+      expect.arrayContaining([
+        expect.objectContaining({ text: "Cancel" }),
+        expect.objectContaining({ text: "Deny", style: "destructive" }),
+      ]),
+    );
+
+    // Simulate pressing "Deny" in the alert
+    const denyAction = alertSpy.mock.calls[0]?.[2]?.find(
+      (btn) => btn.text === "Deny",
+    );
+    await act(async () => {
+      await denyAction?.onPress?.();
+    });
+
+    expect(mockDenyApproval).toHaveBeenCalledWith("appr_test123");
+
+    // Should show denied banner
+    expect(hasTestId(renderer, "denied-banner")).toBe(true);
+    const json = JSON.stringify(renderer.toJSON());
+    expect(json).toContain("Request Denied");
+  });
+
+  it("shows alert on deny failure", async () => {
+    mockDenyApproval.mockRejectedValueOnce(new Error("Already resolved"));
+    const alertSpy = jest.spyOn(Alert, "alert");
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const denyButton = findFirstByTestId(renderer, "deny-button");
+    await act(async () => {
+      denyButton?.props.onPress();
+    });
+
+    // Simulate pressing "Deny" in the alert
+    const denyAction = alertSpy.mock.calls[0]?.[2]?.find(
+      (btn) => btn.text === "Deny",
+    );
+    await act(async () => {
+      await denyAction?.onPress?.();
+    });
+
+    // Second alert call should be the error alert
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Denial Failed",
+      expect.stringContaining("Failed to deny"),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds approve/deny buttons to the mobile approval detail screen for pending, non-expired approvals
- After approval, displays the confirmation code in a large, copyable `XXX-XXX` format card
- After denial, shows a confirmation dialog then transitions to "Request Denied" state
- Adds `expo-clipboard` for copy-to-clipboard support

## Details

**New files:**
- `useApproveApproval` / `useDenyApproval` hooks — React Query mutations mirroring the web frontend pattern
- `ApprovalActions` — presentational component with Deny (outlined red) and Approve (solid green) buttons, loading spinners, and disabled states
- `ConfirmationCodeCard` — prominent code display with monospace font, "Copy Code" button, and hint text

**Modified:**
- `ApprovalDetailScreen` — integrates the approve/deny flow with state transitions (pending → approved with code, pending → denied), error handling via Alert, and fixed action bar at the bottom
- Detail screen tests updated with 8 new test cases covering button visibility, approval success/failure, deny confirmation dialog, and deny failure

Completes the Phase 2 approve/deny items from #9.

## Test plan
- [x] All 80 mobile tests pass (`make mobile-test`)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] Manual test: tap Approve on a pending request → see confirmation code → tap Copy Code
- [ ] Manual test: tap Deny on a pending request → see confirmation dialog → confirm → see "Request Denied"
- [ ] Manual test: buttons not shown for already-approved/denied/expired requests

https://claude.ai/code/session_014mrioeb29qTLpHTuxskkfv