### PR TITLE
Add mobile-push notification channel

### DIFF
--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -36,9 +36,10 @@ type notificationPreferenceUpdate struct {
 // validChannels is the set of notification channels the DB schema allows.
 // This is the single source of truth — allChannels is derived from it.
 var validChannels = map[string]bool{
-	"email":    true,
-	"web-push": true,
-	"sms":      true,
+	"email":       true,
+	"web-push":    true,
+	"sms":         true,
+	"mobile-push": true,
 }
 
 // allChannels is derived from validChannels to avoid duplication.
@@ -47,7 +48,7 @@ var allChannels = func() []string {
 	for ch := range validChannels {
 		channels = append(channels, ch)
 	}
-	sort.Strings(channels) // deterministic order: email, sms, web-push
+	sort.Strings(channels) // deterministic order: email, mobile-push, sms, web-push
 	return channels
 }()
 

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -216,3 +216,64 @@ func TestGetNotificationPreferences_SMSUnavailable_FreeTier(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateNotificationPreferences_EnableMobilePush_FreeTier_Allowed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	// mobile-push is not plan-gated, so it should work on the free tier.
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"mobile-push","enabled":true}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetNotificationPreferences_IncludesMobilePush(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-preferences", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp notificationPreferencesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	found := false
+	for _, p := range resp.Preferences {
+		if p.Channel == "mobile-push" {
+			found = true
+			if !p.Available {
+				t.Error("expected mobile-push to be available on free tier")
+			}
+			if !p.Enabled {
+				t.Error("expected mobile-push to default to enabled")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected mobile-push channel in preferences response")
+	}
+}

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -327,17 +327,33 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	if len(resp.Preferences) != 4 {
 		t.Fatalf("expected 4 preferences, got %d", len(resp.Preferences))
 	}
+
+	// Index preferences by channel for explicit assertions.
+	prefsByChannel := make(map[string]notificationPreferenceResponse, len(resp.Preferences))
+	for _, p := range resp.Preferences {
+		prefsByChannel[p.Channel] = p
+	}
+
 	// All channels default to enabled when no preferences are set.
 	// SMS should not be available on the free plan.
-	for _, p := range resp.Preferences {
+	requiredChannels := []string{"email", "web-push", "sms", "mobile-push"}
+	for _, ch := range requiredChannels {
+		p, ok := prefsByChannel[ch]
+		if !ok {
+			t.Errorf("expected preference for channel %q", ch)
+			continue
+		}
 		if !p.Enabled {
-			t.Errorf("expected channel %q to default to enabled", p.Channel)
+			t.Errorf("expected channel %q to default to enabled", ch)
 		}
-		if p.Channel == "sms" && p.Available {
-			t.Error("expected SMS to be unavailable on free plan")
-		}
-		if p.Channel != "sms" && !p.Available {
-			t.Errorf("expected channel %q to be available", p.Channel)
+		if ch == "sms" {
+			if p.Available {
+				t.Error("expected SMS to be unavailable on free plan")
+			}
+		} else {
+			if !p.Available {
+				t.Errorf("expected channel %q to be available", ch)
+			}
 		}
 	}
 }

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -324,8 +324,8 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
-	if len(resp.Preferences) != 3 {
-		t.Fatalf("expected 3 preferences, got %d", len(resp.Preferences))
+	if len(resp.Preferences) != 4 {
+		t.Fatalf("expected 4 preferences, got %d", len(resp.Preferences))
 	}
 	// All channels default to enabled when no preferences are set.
 	// SMS should not be available on the free plan.

--- a/db/migrations/20260304040949_add_mobile_push_channel.sql
+++ b/db/migrations/20260304040949_add_mobile_push_channel.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- Add mobile-push as a valid notification channel alongside email, web-push, and sms.
+ALTER TABLE notification_preferences
+    DROP CONSTRAINT notification_preferences_channel_check,
+    ADD  CONSTRAINT notification_preferences_channel_check
+         CHECK (channel IN ('email', 'web-push', 'sms', 'mobile-push'));
+
+-- +goose Down
+-- Revert to the original three channels. Any existing mobile-push rows must be
+-- removed first to satisfy the restored constraint.
+DELETE FROM notification_preferences WHERE channel = 'mobile-push';
+ALTER TABLE notification_preferences
+    DROP CONSTRAINT notification_preferences_channel_check,
+    ADD  CONSTRAINT notification_preferences_channel_check
+         CHECK (channel IN ('email', 'web-push', 'sms'));

--- a/db/notification_preferences.go
+++ b/db/notification_preferences.go
@@ -9,7 +9,7 @@ import (
 // NotificationPreference represents a row from the notification_preferences table.
 type NotificationPreference struct {
 	UserID  string
-	Channel string // "email", "web-push", or "sms"
+	Channel string // "email", "web-push", "sms", or "mobile-push"
 	Enabled bool
 }
 

--- a/db/notification_preferences_test.go
+++ b/db/notification_preferences_test.go
@@ -177,3 +177,25 @@ func TestGetNotificationPreferences_Empty(t *testing.T) {
 		t.Errorf("expected 0 preferences, got %d", len(prefs))
 	}
 }
+
+func TestUpsertNotificationPreference_MobilePush(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+
+	// mobile-push should be accepted by the CHECK constraint.
+	if err := db.UpsertNotificationPreference(ctx, tx, uid, "mobile-push", true); err != nil {
+		t.Fatalf("upsert mobile-push: %v", err)
+	}
+
+	enabled, err := db.IsNotificationChannelEnabled(ctx, tx, uid, "mobile-push")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Error("expected mobile-push to be enabled")
+	}
+}

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -28,6 +28,11 @@ const CHANNEL_LABELS: Record<string, { name: string; description: string }> = {
     name: "SMS",
     description: "Text message notifications for urgent approval requests.",
   },
+  "mobile-push": {
+    name: "Mobile Push",
+    description:
+      "Push notifications to your mobile device for real-time approval alerts.",
+  },
 };
 
 export function NotificationSection() {
@@ -63,7 +68,7 @@ export function NotificationSection() {
   async function handleToggle(channel: string, currentEnabled: boolean) {
     try {
       await updatePreferences([
-        { channel: channel as "email" | "web-push" | "sms", enabled: !currentEnabled },
+        { channel: channel as "email" | "web-push" | "sms" | "mobile-push", enabled: !currentEnabled },
       ]);
       toast.success(
         `${CHANNEL_LABELS[channel]?.name ?? channel} notifications ${!currentEnabled ? "enabled" : "disabled"}.`,

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -5,6 +5,7 @@ import { useUpdateProfile } from "@/hooks/useUpdateProfile";
 import { trackEvent, PostHogEvents } from "@/lib/posthog";
 import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "@/hooks/useUpdateNotificationPreferences";
+import type { components } from "@/api/schema";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -68,7 +69,7 @@ export function NotificationSection() {
   async function handleToggle(channel: string, currentEnabled: boolean) {
     try {
       await updatePreferences([
-        { channel: channel as "email" | "web-push" | "sms" | "mobile-push", enabled: !currentEnabled },
+        { channel: channel as components["schemas"]["NotificationPreferenceUpdate"]["channel"], enabled: !currentEnabled },
       ]);
       toast.success(
         `${CHANNEL_LABELS[channel]?.name ?? channel} notifications ${!currentEnabled ? "enabled" : "disabled"}.`,

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -18,6 +18,7 @@ const allEnabled = [
   { channel: "email", enabled: true },
   { channel: "web-push", enabled: true },
   { channel: "sms", enabled: true },
+  { channel: "mobile-push", enabled: true },
 ];
 
 interface MockProfile {
@@ -80,7 +81,7 @@ describe("NotificationSection", () => {
     });
   });
 
-  it("renders all three channels", async () => {
+  it("renders all four channels", async () => {
     mockApiFetch();
 
     render(<NotificationSection />, { wrapper });
@@ -90,6 +91,7 @@ describe("NotificationSection", () => {
     });
     expect(screen.getByText("Web Push")).toBeInTheDocument();
     expect(screen.getByText("SMS")).toBeInTheDocument();
+    expect(screen.getByText("Mobile Push")).toBeInTheDocument();
   });
 
   it("shows loading state", () => {
@@ -110,6 +112,7 @@ describe("NotificationSection", () => {
       { channel: "email", enabled: true },
       { channel: "web-push", enabled: false },
       { channel: "sms", enabled: true },
+      { channel: "mobile-push", enabled: true },
     ];
     mockApiFetch(profileWithContact, prefs);
 
@@ -123,8 +126,8 @@ describe("NotificationSection", () => {
       const disabledButtons = buttons.filter(
         (b) => b.textContent === "Disabled",
       );
-      // 2 channel enabled (email, sms) + 2 disabled (web-push, product updates)
-      expect(enabledButtons).toHaveLength(2);
+      // 3 channels enabled (email, sms, mobile-push) + 2 disabled (web-push, product updates)
+      expect(enabledButtons).toHaveLength(3);
       expect(disabledButtons).toHaveLength(2);
     });
   });
@@ -178,6 +181,7 @@ describe("NotificationSection", () => {
       { channel: "email", enabled: false },
       { channel: "web-push", enabled: true },
       { channel: "sms", enabled: false },
+      { channel: "mobile-push", enabled: true },
     ];
     mockApiFetch(profileNoContact, prefs);
 
@@ -202,6 +206,7 @@ describe("NotificationSection", () => {
           { channel: "email", enabled: false },
           { channel: "web-push", enabled: true },
           { channel: "sms", enabled: true },
+          { channel: "mobile-push", enabled: true },
         ],
       },
     });
@@ -225,6 +230,43 @@ describe("NotificationSection", () => {
         expect.objectContaining({
           body: {
             preferences: [{ channel: "email", enabled: false }],
+          },
+        }),
+      );
+    });
+  });
+
+  it("can toggle mobile-push channel", async () => {
+    mockApiFetch();
+    mockPut.mockResolvedValue({
+      data: {
+        preferences: allEnabled.map((p) =>
+          p.channel === "mobile-push" ? { ...p, enabled: false } : p,
+        ),
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Mobile Push")).toBeInTheDocument();
+    });
+
+    // Find the Mobile Push row's Enabled button and click it
+    const enabledButtons = screen.getAllByRole("button").filter(
+      (b) => b.textContent === "Enabled",
+    );
+    // Mobile Push is the last enabled channel button (after email, web-push, sms)
+    const mobilePushBtn = enabledButtons[enabledButtons.length - 1]!;
+    await user.click(mobilePushBtn);
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalledWith(
+        "/v1/profile/notification-preferences",
+        expect.objectContaining({
+          body: {
+            preferences: [{ channel: "mobile-push", enabled: false }],
           },
         }),
       );

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -1,6 +1,6 @@
 // Package notify provides the notification dispatch infrastructure for
 // Permission Slip. It defines the Sender interface that individual channels
-// (email, web-push, SMS) implement, a Dispatcher that fans out to all
+// (email, web-push, SMS, mobile-push) implement, a Dispatcher that fans out to all
 // configured senders, and the shared types (Approval, Recipient) that
 // senders receive.
 //

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -1,8 +1,9 @@
 // Package notify provides the notification dispatch infrastructure for
 // Permission Slip. It defines the Sender interface that individual channels
-// (email, web-push, SMS, mobile-push) implement, a Dispatcher that fans out to all
+// (email, web-push, SMS) implement, a Dispatcher that fans out to all
 // configured senders, and the shared types (Approval, Recipient) that
-// senders receive.
+// senders receive. Additional channels (for example, mobile push) can be
+// added by implementing the Sender interface.
 //
 // Adding a new channel requires three steps:
 //  1. Implement the Sender interface.

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -77,6 +77,7 @@ NotificationPreference:
         - email
         - web-push
         - sms
+        - mobile-push
       example: "email"
     enabled:
       type: boolean
@@ -116,6 +117,7 @@ NotificationPreferenceUpdate:
         - email
         - web-push
         - sms
+        - mobile-push
       example: "email"
     enabled:
       type: boolean

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -8446,6 +8446,7 @@ components:
             - email
             - web-push
             - sms
+            - mobile-push
           example: email
         enabled:
           type: boolean
@@ -9586,6 +9587,7 @@ components:
             - email
             - web-push
             - sms
+            - mobile-push
           example: email
         enabled:
           type: boolean


### PR DESCRIPTION
## Summary
- Adds `mobile-push` as a new notification channel enum value alongside `email`, `web-push`, and `sms`
- Includes DB migration to extend the CHECK constraint, backend validation map, OpenAPI spec, frontend settings UI label, and tests
- The channel is not plan-gated (free tier) and defaults to enabled — no Sender implementation yet (FCM/APNs to follow)

Closes #9

## Changes
- **Migration:** `20260304040949_add_mobile_push_channel.sql` — extends CHECK constraint with reversible down path
- **Backend:** `validChannels` map updated (single source of truth); `allChannels` auto-derives sorted list
- **OpenAPI spec:** Both `NotificationPreference` and `NotificationPreferenceUpdate` enums updated + bundle regenerated
- **Frontend:** `CHANNEL_LABELS` and type cast in `NotificationSection.tsx` updated
- **Tests:** New API tests (enable on free tier, appears in GET response), new DB test (CHECK constraint accepts mobile-push), existing test updated for 4-channel count

## Test plan
- [x] Backend tests pass (`go test ./...`)
- [x] Go build passes (`go build ./...`)
- [x] Frontend TypeScript compiles (`tsc --noEmit`)
- [x] New DB test verifies CHECK constraint accepts mobile-push
- [x] New API test verifies mobile-push works on free tier (not plan-gated)
- [x] New API test verifies mobile-push appears in GET preferences response
- [x] Existing test updated from 3→4 channels

https://claude.ai/code/session_013Er5jLR3Lo9W9QoPhJUf1K