### PR TITLE
Fix PostHog CSP: route through hydro.permissionslip.dev proxy

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,11 +10,12 @@ kill_timeout = '30s'
     VITE_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_4Db9aiXHjC7JG-K1w3V54g_qLLrDL4o"
     VITE_SENTRY_DSN = "https://b29c7ce913782b9aa81de0ac682428ba@o4510982091309056.ingest.us.sentry.io/4510982566051840"
     VITE_POSTHOG_KEY = "phc_PtcMEXOus86UQHAmXYUVqZKpwzVH6pI5Om7hIwcgHPG"
-    VITE_POSTHOG_HOST = "https://us.i.posthog.com"
+    VITE_POSTHOG_HOST = "https://hydro.permissionslip.dev"
 
 [env]
   PORT = '8080'
   CLOUDFLARE_INSIGHTS = 'true'
+  POSTHOG_HOST = 'https://hydro.permissionslip.dev'
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary
- Updated `VITE_POSTHOG_HOST` build arg to `https://hydro.permissionslip.dev` so the PostHog JS SDK sends events through the reverse proxy
- Added `POSTHOG_HOST` runtime env var pointing to the same proxy so the Go backend includes it in the CSP `connect-src` directive
- This fixes the CSP violation that was blocking all PostHog events on app.permissionslip.dev

## Test plan
- [ ] Deploy to Fly and verify no CSP violations in the browser console
- [ ] Verify PostHog events appear in the PostHog dashboard
- [ ] Confirm `hydro.permissionslip.dev` correctly proxies to PostHog

https://claude.ai/code/session_01Q7xH9GQTbtKYyfxfofyE5T