### PR TITLE
Fix SSE streaming error on /approvals/events

### DIFF
--- a/api/approval_events.go
+++ b/api/approval_events.go
@@ -166,11 +166,12 @@ func sseTokenFromQuery(next http.Handler) http.Handler {
 
 func handleApprovalEvents(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Streaming not supported"))
-			return
-		}
+		// Use http.ResponseController to access Flush through middleware
+		// wrappers (e.g. statusRecorder) that implement Unwrap().
+		// A direct w.(http.Flusher) type assertion fails on wrapped writers
+		// because the wrapper type doesn't implement the interface, even
+		// though the underlying writer does.
+		rc := http.NewResponseController(w)
 
 		profile := Profile(r.Context())
 		userID := profile.ID
@@ -194,7 +195,9 @@ func handleApprovalEvents(deps *Deps) http.HandlerFunc {
 
 		// Send an initial connected event so the client knows the stream is live.
 		fmt.Fprintf(w, "event: connected\ndata: {}\n\n")
-		flusher.Flush()
+		if err := rc.Flush(); err != nil {
+			return
+		}
 
 		heartbeat := time.NewTicker(30 * time.Second)
 		defer heartbeat.Stop()
@@ -208,10 +211,10 @@ func handleApprovalEvents(deps *Deps) http.HandlerFunc {
 					return
 				}
 				fmt.Fprintf(w, "%s\n\n", event)
-				flusher.Flush()
+				rc.Flush()
 			case <-heartbeat.C:
 				fmt.Fprintf(w, ": heartbeat\n\n")
-				flusher.Flush()
+				rc.Flush()
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
 	github.com/pressly/goose/v3 v3.26.0
+	github.com/stripe/stripe-go/v82 v82.5.1
 )
 
 require (
@@ -24,7 +25,6 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
-	github.com/stripe/stripe-go/v82 v82.5.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect


### PR DESCRIPTION
## Summary
- Fixed the "Streaming not supported" error on `GET /approvals/events` SSE endpoint
- **Root cause:** The `statusRecorder` middleware in `request_logger.go` wraps `http.ResponseWriter` without implementing `http.Flusher`. The direct type assertion `w.(http.Flusher)` fails on the wrapper, even though the underlying writer supports flushing.
- **Fix:** Replaced the direct `w.(http.Flusher)` type assertion with `http.ResponseController` (Go 1.20+), which traverses the `Unwrap()` chain that `statusRecorder` already implements, correctly reaching the underlying Flusher.

## Test plan
- [x] All existing approval event tests pass
- [x] Build compiles successfully
- [ ] Verify SSE endpoint works in production (connect to `/approvals/events` and confirm `event: connected` is received)

https://claude.ai/code/session_01Lgszdszc6FchdR3kroYV23