### PR TITLE
Fix PostHog config.js CSP block via reverse proxy

### DIFF
--- a/frontend/src/lib/posthog.ts
+++ b/frontend/src/lib/posthog.ts
@@ -47,6 +47,11 @@ export function initPostHog(): void {
   devLog("initializing →", POSTHOG_HOST);
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
+    // Route SDK asset requests (config.js, toolbar, surveys widget) through
+    // the same reverse proxy so they aren't blocked by our CSP. Without this,
+    // posthog-js fetches from us-assets.i.posthog.com which isn't in our
+    // script-src allowlist.
+    ui_host: POSTHOG_HOST,
     // Start opted out — no events are sent until the user consents.
     opt_out_capturing_by_default: true,
     // Memory-only persistence avoids writing cookies/localStorage

--- a/main.go
+++ b/main.go
@@ -372,19 +372,22 @@ func main() {
 			extraConnectSrc = append(extraConnectSrc, parsed.Scheme+"://"+parsed.Host)
 		}
 	}
-	// PostHog product analytics — allow the frontend to send events to the
-	// PostHog API host. Only added when POSTHOG_HOST is set.
+	var extraScriptSrc []string
+	// PostHog product analytics — allow the frontend to send events and load
+	// SDK assets (config.js, toolbar, surveys) from the PostHog proxy host.
+	// Added to both connect-src (event ingestion) and script-src (asset loading).
 	if posthogHost := strings.TrimSpace(os.Getenv("POSTHOG_HOST")); posthogHost != "" {
 		parsed, err := url.Parse(posthogHost)
 		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-			log.Printf("Warning: POSTHOG_HOST %q is not a valid URL; skipping CSP connect-src entry", posthogHost)
+			log.Printf("Warning: POSTHOG_HOST %q is not a valid URL; skipping CSP entries", posthogHost)
 		} else {
-			extraConnectSrc = append(extraConnectSrc, parsed.Scheme+"://"+parsed.Host)
+			origin := parsed.Scheme + "://" + parsed.Host
+			extraConnectSrc = append(extraConnectSrc, origin)
+			extraScriptSrc = append(extraScriptSrc, origin)
 		}
 	}
 	// Cloudflare Web Analytics — when CLOUDFLARE_INSIGHTS is "true", allow the
 	// auto-injected beacon.min.js script and its data reporting endpoint.
-	var extraScriptSrc []string
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("CLOUDFLARE_INSIGHTS")), "true") {
 		extraScriptSrc = append(extraScriptSrc, "https://static.cloudflareinsights.com")
 		extraConnectSrc = append(extraConnectSrc, "https://cloudflareinsights.com")


### PR DESCRIPTION
## Summary
- PostHog JS SDK was fetching `config.js` from `us-assets.i.posthog.com`, which isn't in our CSP allowlist — causing a `script-src` violation even though event ingestion was correctly proxied through `hydro.permissionslip.dev`
- Added `ui_host` option to `posthog.init()` so the SDK routes asset requests (config.js, toolbar, surveys widget) through our reverse proxy instead
- Added the PostHog proxy host to CSP `script-src` directive (previously only in `connect-src`) so scripts loaded from the proxy are allowed to execute

## Test plan
- [x] Frontend tests pass (534/534)
- [ ] Verify in production that `config.js` is now fetched from `hydro.permissionslip.dev` instead of `us-assets.i.posthog.com`
- [ ] Confirm no CSP violations in browser console for PostHog-related resources
- [ ] Verify PostHog events still flow correctly after consent is granted

https://claude.ai/code/session_01T1AoixKxtR41skT8EduG3a