### PR TITLE
Fix CSP blocking Sentry ingest on US regional subdomain

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -44,7 +44,7 @@ func TraceID(ctx context.Context) string {
 // Sentry events. Obtain the URL from your Sentry project under
 // Settings → Security Headers → report-uri.
 func SecurityHeadersMiddleware(sentryCSPEndpoint string, extraConnectSrc, extraScriptSrc []string) func(http.Handler) http.Handler {
-	connectSrc := "'self' https://*.ingest.sentry.io"
+	connectSrc := "'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io"
 	for _, src := range extraConnectSrc {
 		origin := sanitizeCSPOrigin(src)
 		if origin != "" {

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -44,7 +44,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 		"font-src 'self' https://fonts.gstatic.com",
 		"img-src 'self' data:",
-		"connect-src 'self' https://*.ingest.sentry.io",
+		"connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io",
 		"frame-ancestors 'none'",
 	}
 	for _, d := range requiredDirectives {
@@ -69,7 +69,7 @@ func TestSecurityHeadersMiddleware_ExtraConnectSrc(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	csp := rec.Header().Get("Content-Security-Policy")
-	if !strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io https://abc.supabase.co https://other.example.com") {
+	if !strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://abc.supabase.co https://other.example.com") {
 		t.Errorf("CSP connect-src missing extra origins; full CSP: %s", csp)
 	}
 }
@@ -145,7 +145,7 @@ func TestSecurityHeadersMiddleware_InvalidExtraConnectSrc(t *testing.T) {
 
 	csp := rec.Header().Get("Content-Security-Policy")
 	// connect-src should only contain 'self' + Sentry — all malicious entries rejected.
-	if !strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io; ") {
+	if !strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io; ") {
 		t.Errorf("CSP connect-src should be only 'self' + sentry; full CSP: %s", csp)
 	}
 	for _, m := range malicious {
@@ -231,11 +231,11 @@ func TestSecurityHeadersMiddleware_EmptyExtraConnectSrc(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	csp := rec.Header().Get("Content-Security-Policy")
-	// connect-src should be "'self' https://*.ingest.sentry.io" with no trailing spaces from empty inputs.
-	if !strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io; ") {
+	// connect-src should be "'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io" with no trailing spaces from empty inputs.
+	if !strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io; ") {
 		t.Errorf("CSP connect-src has incorrect base formatting; full CSP: %s", csp)
 	}
-	if strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io  ") {
+	if strings.Contains(csp, "connect-src 'self' https://*.ingest.sentry.io https://*.ingest.us.sentry.io  ") {
 		t.Errorf("CSP connect-src has trailing whitespace from empty extra sources; full CSP: %s", csp)
 	}
 }


### PR DESCRIPTION
## Summary
- The CSP `connect-src` wildcard `*.ingest.sentry.io` doesn't match Sentry's US regional ingest host `*.ingest.us.sentry.io` because CSP wildcards only cover one subdomain level
- Added `https://*.ingest.us.sentry.io` to `connect-src` to unblock the frontend Sentry SDK
- Fixes [PERMISSION-SLIP-GO-4](https://supersuit-technologies.sentry.io/issues/7309321600/)

## Test plan
- [x] All 12 `TestSecurityHeaders*` tests pass with updated assertions
- [x] Go build compiles cleanly
- [ ] Verify in production that CSP violations for `o4510982091309056.ingest.us.sentry.io` stop appearing in Sentry

https://claude.ai/code/session_01T62kaDuoWx6qssvt5zDhRu