### PR TITLE
Fix Fly.io deployment: trigger CI on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- The CI workflow was set to `workflow_dispatch` only, which broke automatic deployments
- The Deploy workflow uses `workflow_run` to trigger after CI completes on `main` — but since CI never ran automatically, deploys never happened
- This adds `push: branches: [main]` back to the CI trigger while keeping manual dispatch available
- PR triggers are intentionally excluded per user preference

## Test plan

- [ ] Merge this PR and push a change to main
- [ ] Verify CI workflow runs automatically
- [ ] Verify Deploy workflow triggers after CI succeeds
- [ ] Confirm app is deployed to Fly.io

https://claude.ai/code/session_017mJsGhMJtypooWHnsTSk8Z