### PR TITLE
Phase 3: Update tests for direct execution on approval

### DIFF
--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -722,6 +722,108 @@ func TestAgentApprovalStatus_NotFound(t *testing.T) {
 	}
 }
 
+func TestAgentApprovalStatus_Denied(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	approvalID := "appr_status_denied"
+	testhelper.InsertApprovalWithStatus(t, tx, approvalID, agentID, uid, "denied")
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	r := signedJSONRequest(t, http.MethodGet, "/approvals/"+approvalID+"/status", "", privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var statusResp agentApprovalStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &statusResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if statusResp.Status != "denied" {
+		t.Errorf("expected status 'denied', got %q", statusResp.Status)
+	}
+	if statusResp.ExecutionStatus != nil {
+		t.Errorf("expected nil execution_status for denied approval, got %v", *statusResp.ExecutionStatus)
+	}
+	if statusResp.ExecutionResult != nil {
+		t.Error("expected nil execution_result for denied approval")
+	}
+}
+
+func TestAgentApprovalStatus_FullApproveFlow(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// 1. Agent requests approval.
+	reqBody := `{"request_id":"req_full_flow","action":{"type":"test.action"},"context":{"description":"test"}}`
+	r1 := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("request: expected 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+	var createResp agentRequestApprovalResponse
+	json.Unmarshal(w1.Body.Bytes(), &createResp)
+
+	// 2. User approves the approval (execution happens inline).
+	r2 := authenticatedRequest(t, http.MethodPost, "/approvals/"+createResp.ApprovalID+"/approve", uid)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("approve: expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+
+	// 3. Agent polls for status — should see approved with execution result.
+	r3 := signedJSONRequest(t, http.MethodGet, "/approvals/"+createResp.ApprovalID+"/status", "", privKey, agentID)
+	w3 := httptest.NewRecorder()
+	router.ServeHTTP(w3, r3)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("status: expected 200, got %d: %s", w3.Code, w3.Body.String())
+	}
+
+	var statusResp agentApprovalStatusResponse
+	if err := json.Unmarshal(w3.Body.Bytes(), &statusResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if statusResp.Status != "approved" {
+		t.Errorf("expected status 'approved', got %q", statusResp.Status)
+	}
+	// No connector in test, so execution_status should be "error".
+	if statusResp.ExecutionStatus == nil {
+		t.Fatal("expected execution_status to be set after approval")
+	}
+	if *statusResp.ExecutionStatus != "error" {
+		t.Errorf("expected execution_status 'error' (no connector), got %q", *statusResp.ExecutionStatus)
+	}
+	if statusResp.ExecutionResult == nil {
+		t.Fatal("expected execution_result to be set after approval")
+	}
+}
+
 func TestAgentApprovalStatus_OtherAgentAccess(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/api/approvals_test.go
+++ b/api/approvals_test.go
@@ -534,6 +534,17 @@ func TestApproveApproval_Success(t *testing.T) {
 		t.Error("expected approved_at to be set")
 	}
 
+	// Execution should have been attempted (no connector in test → "error").
+	if resp.ExecutionStatus == nil {
+		t.Fatal("expected execution_status to be set")
+	}
+	if *resp.ExecutionStatus != "error" {
+		t.Errorf("expected execution_status 'error' (no connector in test), got %q", *resp.ExecutionStatus)
+	}
+	if resp.ExecutionResult == nil {
+		t.Fatal("expected execution_result to be set")
+	}
+
 	// Verify it no longer appears in pending list
 	r2 := authenticatedRequest(t, http.MethodGet, "/approvals", uid)
 	w2 := httptest.NewRecorder()

--- a/frontend/src/hooks/__tests__/useApproveApproval.test.tsx
+++ b/frontend/src/hooks/__tests__/useApproveApproval.test.tsx
@@ -12,6 +12,8 @@ const mockApproveResponse = {
   approval_id: "approval-abc",
   status: "approved",
   approved_at: "2026-02-21T12:00:00Z",
+  execution_status: "success" as const,
+  execution_result: { data: "ok" },
 };
 
 describe("useApproveApproval", () => {
@@ -60,6 +62,8 @@ describe("useApproveApproval", () => {
 
     expect(response!.approval_id).toBe("approval-abc");
     expect(response!.status).toBe("approved");
+    expect(response!.execution_status).toBe("success");
+    expect(response!.execution_result).toEqual({ data: "ok" });
   });
 
   it("throws when not authenticated", async () => {

--- a/frontend/src/pages/dashboard/__tests__/PendingApprovalsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/PendingApprovalsCard.test.tsx
@@ -229,6 +229,8 @@ describe("PendingApprovalsCard", () => {
         approval_id: "appr_abc123",
         status: "approved",
         approved_at: "2026-02-21T10:00:05Z",
+        execution_status: "success",
+        execution_result: { data: "ok" },
       },
     });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -252,9 +254,9 @@ describe("PendingApprovalsCard", () => {
     await user.click(screen.getByRole("button", { name: "Approve" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Request Approved")).toBeInTheDocument();
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
     });
-    expect(screen.getByText(/The agent has been notified/)).toBeInTheDocument();
+    expect(screen.getByText(/The action has been executed/)).toBeInTheDocument();
     // "Done" button should be visible in the success state
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Completes Phase 3 of #142 — update tests to match the new direct-execution-on-approval flow.

### Changes

- **`api/approvals_test.go`**: Added `execution_status` and `execution_result` assertions to `TestApproveApproval_Success` (no connector in tests → expects "error" status)
- **`api/agent_approvals_test.go`**: Added `TestAgentApprovalStatus_Denied` (verifies nil execution fields for denied approvals) and `TestAgentApprovalStatus_FullApproveFlow` (end-to-end request→approve→poll test)
- **`api/action_execute_test.go`**: Already clean — no token-based execution tests existed
- **`api/action_token_test.go`**: Already removed in earlier phases
- **`db/approvals_test.go`**: Already clean — no verification-related tests existed
- **`db/consumed_tokens_test.go`**: Already removed in earlier phases
- **`useApproveApproval.test.tsx`**: Updated mock response to include `execution_status`/`execution_result`, added assertions for new fields
- **`PendingApprovalsCard.test.tsx`**: Updated approve mock to include execution fields, updated assertions to match "Action Executed Successfully" banner text

## Test plan

- [x] `make test-backend` — all API and DB tests pass (note: pre-existing `TestEnsureAllUsersSubscribed_Idempotent` failure is unrelated)
- [x] `make test-frontend` — all 595 tests pass
- [x] `go build` compiles cleanly

https://claude.ai/code/session_01Pb8k2TDYer2HnfgJ4y9SvW