### PR TITLE
Phase 4: Update docs for direct execution flow, add API types CI

### DIFF
--- a/.github/workflows/regenerate-api-types.yml
+++ b/.github/workflows/regenerate-api-types.yml
@@ -1,0 +1,50 @@
+name: Regenerate API Types
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "spec/openapi/**"
+
+jobs:
+  regenerate:
+    name: Regenerate API Types from OpenAPI Spec
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: cd frontend && npm ci
+
+      - name: Bundle OpenAPI spec
+        run: make bundle
+
+      - name: Generate API types
+        run: make generate
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push regenerated types
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add spec/openapi/openapi.bundle.yaml frontend/src/api/schema.d.ts
+          git commit -m "chore: regenerate API types from OpenAPI spec"
+          git push

--- a/docs-site/approvals/overview.mdx
+++ b/docs-site/approvals/overview.mdx
@@ -17,7 +17,7 @@ The default flow. An agent submits a request, you review it, and you decide. Eac
 1. Agent submits request → you get notified.
 2. You review the action type, parameters, and risk level.
 3. You approve or deny.
-4. If approved, the agent receives a confirmation code and can execute the action.
+4. If approved, Permission Slip executes the action immediately via the connector and the agent receives the result.
 
 ### Standing Approvals
 
@@ -35,7 +35,7 @@ Pre-authorizations for repeated actions. Instead of reviewing the same type of r
 | State | Description |
 |-------|-------------|
 | **Pending** | Awaiting your review. Has a countdown timer. |
-| **Approved** | You approved the request. Agent can verify and execute. |
+| **Approved** | You approved the request. Action is executed automatically. |
 | **Denied** | You denied the request. Agent is notified. |
 | **Cancelled** | Agent cancelled the request before you reviewed it. |
 
@@ -47,10 +47,6 @@ Every approval request includes a risk level set by the agent:
 - **Medium** — actions that modify data. Displayed with a yellow badge.
 - **High** — sensitive actions like financial transactions or data deletion. Displayed with a red badge and a prominent warning.
 
-## Confirmation Codes
+## Direct Execution
 
-After you approve a request, Permission Slip generates a 6-character confirmation code (format: `ABC-DEF`). This code is displayed on screen and can be copied. The agent uses this code to verify the approval and receive a single-use execution token.
-
-<Info>
-  Confirmation codes use an unambiguous character set — no `0/O` or `1/I` confusion. The agent has up to 5 attempts to submit the correct code.
-</Info>
+When you approve a request, Permission Slip immediately executes the action via the appropriate connector using your stored credentials. The execution result (success or failure) is recorded on the approval and visible in the dashboard. The agent can poll for the result or receive it via the real-time events stream.

--- a/docs-site/approvals/review-requests.mdx
+++ b/docs-site/approvals/review-requests.mdx
@@ -42,7 +42,7 @@ The review dialog shows:
 
 ## Making a Decision
 
-- Click **Approve** to authorize the action. A confirmation code will be displayed — share this with the agent.
+- Click **Approve** to authorize the action. Permission Slip immediately executes it via the connector and shows you the result.
 - Click **Deny** to reject the request. The agent is notified that the request was denied.
 
 <Warning>
@@ -53,9 +53,8 @@ The review dialog shows:
 
 When you approve a request:
 
-1. A **confirmation code** is displayed on screen (format: `ABC-DEF`).
-2. Copy the code and share it with the agent.
-3. The agent submits the code to receive a **single-use execution token**.
-4. The agent uses the token to execute the action.
+1. Permission Slip **executes the action** immediately via the connector using your stored credentials.
+2. The **execution result** (success or failure) is displayed in the review dialog.
+3. The agent receives the result by polling the approval status endpoint or via the real-time events stream.
 
 The approval and execution are recorded in the [Activity Log](/activity/audit-log).

--- a/docs-site/guides/agent-integration.mdx
+++ b/docs-site/guides/agent-integration.mdx
@@ -117,72 +117,52 @@ Response includes:
 - `status` — initially `"pending"`
 - `expires_at` — when the request expires
 
-### 2. Wait for Decision
+### 2. Wait for Decision and Result
 
-The approver reviews the request on their dashboard. You can either:
-- **Poll** by re-requesting and checking the status
-- **Cancel** the request if it's no longer needed via `POST /v1/approvals/{approval_id}/cancel`
+The approver reviews the request on their dashboard. When they approve it, Permission Slip immediately executes the action via the connector and records the result on the approval.
 
-### 3. Verify Approval
-
-Once approved, your user shares the 6-character confirmation code displayed on their screen.
+Poll for the approval status and execution result:
 
 ```
-POST /v1/approvals/{approval_id}/verify
+GET /v1/approvals/{approval_id}/status
 ```
 
-```json
-{
-  "request_id": "unique-uuid",
-  "confirmation_code": "RK3-P7M"
-}
-```
-
-On success, you receive a single-use JWT token:
+Response when the action has been executed:
 
 ```json
 {
   "status": "approved",
   "approved_at": "2026-02-11T13:20:45Z",
-  "token": {
-    "access_token": "eyJhbGci...",
-    "expires_at": "2026-02-11T13:25:45Z",
-    "scope": "github.create_issue",
-    "scope_version": "1"
+  "execution_status": "success",
+  "execution_result": {
+    "issue_number": 42,
+    "url": "https://github.com/acme/app/issues/42"
   }
 }
 ```
 
-<Warning>
-  You have a maximum of **5 attempts** to submit the correct confirmation code. After 5 failures, the approval is locked out.
-</Warning>
-
-### 4. Execute the Action
-
-```
-POST /v1/actions/execute
-```
-
-Pass the token in the JSON request body (not in the Authorization header). The request must also be signed with your Ed25519 key.
+If the request is denied:
 
 ```json
 {
-  "token": "<access_token from verify response>",
-  "action_id": "github.create_issue",
-  "parameters": {
-    "owner": "acme",
-    "repo": "app",
-    "title": "Bug report",
-    "body": "Description of the issue"
-  }
+  "status": "denied",
+  "denied_at": "2026-02-11T13:20:45Z"
 }
 ```
 
-Permission Slip verifies the token, fetches the user's stored credentials, calls the external service, and returns the result. The token is consumed after use — it cannot be reused.
+You can also cancel a pending request if it's no longer needed:
+
+```
+POST /v1/approvals/{approval_id}/cancel
+```
+
+<Info>
+  The execution result contains the raw response from the connector. The shape depends on the action type — check the connector documentation for details.
+</Info>
 
 ## Standing Approvals
 
-If your user has created a standing approval for your action type, you can skip the one-off approval flow. Submit the action directly to the execute endpoint without a token:
+If your user has created a standing approval for your action type, you can skip the one-off approval flow. Submit the action directly to the execute endpoint:
 
 ```json
 {
@@ -207,12 +187,12 @@ Permission Slip checks for matching standing approvals and executes automaticall
 | Status Code | Meaning |
 |-------------|---------|
 | `400` | Invalid request (missing fields, bad parameters, invalid action type) |
-| `401` | Invalid signature, unknown agent, or incorrect confirmation code |
-| `403` | Agent not authorized, token scope mismatch, or parameters don't match |
+| `401` | Invalid signature or unknown agent |
+| `403` | Agent not authorized or parameters don't match |
 | `404` | Approval/resource not found, or no matching standing approval |
 | `409` | Duplicate request ID (replay protection) |
 | `410` | Approval expired or standing approval expired |
-| `429` | Rate limited or too many verification attempts (max 5) |
+| `429` | Rate limited |
 | `502` | External service returned an error |
 
 ## Discovering Available Connectors

--- a/docs-site/how-it-works.mdx
+++ b/docs-site/how-it-works.mdx
@@ -27,8 +27,12 @@ Permission Slip sits between your AI agents and the actions they want to take. H
   Click **Approve** to let the action proceed, or **Deny** to block it. High-risk actions are flagged with a warning so you can review them more carefully.
 </Step>
 
+<Step title="Action Executes">
+  If approved, Permission Slip immediately executes the action via the appropriate connector using your stored credentials. The result is recorded on the approval.
+</Step>
+
 <Step title="Agent Gets the Result">
-  If approved, the agent receives a confirmation code it can use to verify the approval. If denied, the agent is notified and can handle the rejection gracefully.
+  The agent polls for the approval status and receives the execution result — including the connector's response data. If denied, the agent is notified and can handle the rejection gracefully.
 </Step>
 
 </Steps>

--- a/docs-site/introduction.mdx
+++ b/docs-site/introduction.mdx
@@ -48,7 +48,7 @@ Agent wants to act → Permission Slip intercepts → You approve or deny → Ac
 2. You **enable connectors** that define what the agent is allowed to request.
 3. When the agent wants to act, it **submits a request** through the Permission Slip API.
 4. You **review and approve** (or deny) the request from your dashboard or via notification.
-5. The agent receives a **confirmation code** and proceeds — or stops.
+5. If approved, Permission Slip **executes the action** immediately via the connector and the agent receives the **result** — or, if denied, the agent is notified and stops.
 
 Ready to get started? [Create your account →](/getting-started/create-account)
 


### PR DESCRIPTION
## Summary

Completes Phase 4 of the approval flow migration (#142):

- **Chunk E (Docs):** Updated all docs-site pages to reflect the new direct execution flow where Permission Slip executes actions immediately on approval, removing all references to confirmation codes, verification steps, and token-based execution
- **Chunk F (CI):** Added `regenerate-api-types.yml` GitHub Actions workflow that automatically rebundles the OpenAPI spec and regenerates frontend API types when spec files change on `main`

### Files changed

**Docs updates:**
- `introduction.mdx` — step 5 now describes direct execution
- `how-it-works.mdx` — added "Action Executes" step, updated result step
- `guides/agent-integration.mdx` — replaced verify/token/execute steps with `GET /v1/approvals/{id}/status` polling, cleaned up error table
- `approvals/overview.mdx` — replaced "Confirmation Codes" section with "Direct Execution"
- `approvals/review-requests.mdx` — updated approval flow and "After Approval" section

**CI workflow:**
- `.github/workflows/regenerate-api-types.yml` — triggers on `spec/openapi/**` changes to main, runs `make bundle` + `make generate`, auto-commits if types changed

### What's NOT changed
- Agent registration flow (confirmation codes for registration are untouched)
- Standing approvals documentation (already correct)

## Test plan

- [x] Verified all docs changes preserve agent registration confirmation code references
- [x] Frontend tests pass (595/595)
- [x] No code changes — only `.mdx` docs and `.yml` workflow

Closes #142

https://claude.ai/code/session_01Cc78nknfq8DrFdad2M62GV