### PR TITLE
fix: add confirmation_code to approve response type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,32 @@ jobs:
       - name: Run frontend tests
         run: make test-frontend
 
+  mobile:
+    name: Mobile Tests & Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: cd mobile && npm ci
+
+      - name: Run mobile tests
+        run: make mobile-test
+
+      - name: Typecheck
+        run: make mobile-typecheck
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [backend, frontend]
+    needs: [backend, frontend, mobile]
 
     steps:
       - uses: actions/checkout@v4

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -36,11 +36,12 @@ type approvalListResponse struct {
 }
 
 type approveResponse struct {
-	ApprovalID      string           `json:"approval_id"`
-	Status          string           `json:"status"`
-	ApprovedAt      time.Time        `json:"approved_at"`
-	ExecutionStatus *string          `json:"execution_status,omitempty"`
-	ExecutionResult *json.RawMessage `json:"execution_result,omitempty"`
+	ApprovalID       string           `json:"approval_id"`
+	Status           string           `json:"status"`
+	ApprovedAt       time.Time        `json:"approved_at"`
+	ConfirmationCode string           `json:"confirmation_code"`
+	ExecutionStatus  *string          `json:"execution_status,omitempty"`
+	ExecutionResult  *json.RawMessage `json:"execution_result,omitempty"`
 }
 
 type denyResponse struct {
@@ -139,6 +140,15 @@ func handleApproveApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Generate an ephemeral confirmation code for the approver to share
+		// with the agent as a visual receipt of the approval.
+		confirmCode, err := generateConfirmationCodePlaintext()
+		if err != nil {
+			log.Printf("[%s] generateConfirmationCodePlaintext: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to generate confirmation code"))
+			return
+		}
+
 		// Execute the action via the connector now that the approval is granted.
 		// Detach from the request context so a client disconnect doesn't abort
 		// the connector call or DB update mid-flight.
@@ -154,10 +164,11 @@ func handleApproveApproval(deps *Deps) http.HandlerFunc {
 		notifyApprovalExecuted(deps, profile.ID, appr.ApprovalID, execStatus)
 
 		resp := approveResponse{
-			ApprovalID:      appr.ApprovalID,
-			Status:          appr.Status,
-			ApprovedAt:      *appr.ApprovedAt,
-			ExecutionStatus: &execStatus,
+			ApprovalID:       appr.ApprovalID,
+			Status:           appr.Status,
+			ApprovedAt:       *appr.ApprovedAt,
+			ConfirmationCode: confirmCode,
+			ExecutionStatus:  &execStatus,
 		}
 		if execResultJSON != nil {
 			raw := json.RawMessage(execResultJSON)

--- a/api/approvals_test.go
+++ b/api/approvals_test.go
@@ -533,6 +533,12 @@ func TestApproveApproval_Success(t *testing.T) {
 	if resp.ApprovedAt.IsZero() {
 		t.Error("expected approved_at to be set")
 	}
+	if resp.ConfirmationCode == "" {
+		t.Error("expected confirmation_code to be set")
+	}
+	if len(resp.ConfirmationCode) != 7 || resp.ConfirmationCode[3] != '-' {
+		t.Errorf("expected confirmation_code in XXX-XXX format, got %q", resp.ConfirmationCode)
+	}
 
 	// Execution should have been attempted (no connector in test → "error").
 	if resp.ExecutionStatus == nil {

--- a/spec/openapi/components/paths/approvals.yaml
+++ b/spec/openapi/components/paths/approvals.yaml
@@ -718,6 +718,7 @@ approveApproval:
                   approval_id: "appr_xyz789"
                   status: "approved"
                   approved_at: "2026-02-21T10:30:00Z"
+                  confirmation_code: "RK3-P7M"
                   execution_status: "success"
                   execution_result:
                     message_id: "msg_abc123"
@@ -728,6 +729,7 @@ approveApproval:
                   approval_id: "appr_xyz789"
                   status: "approved"
                   approved_at: "2026-02-21T10:30:00Z"
+                  confirmation_code: "RK3-P7M"
                   execution_status: "error"
                   execution_result:
                     error: "upstream_error"

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -298,6 +298,7 @@ ApproveApprovalResponse:
     - approval_id
     - status
     - approved_at
+    - confirmation_code
     - execution_status
   properties:
     approval_id:
@@ -315,6 +316,14 @@ ApproveApprovalResponse:
       format: date-time
       description: When the approval was approved
       example: "2026-02-21T10:30:00Z"
+    confirmation_code:
+      type: string
+      description: |
+        Ephemeral confirmation code in `XXX-XXX` format. Displayed to the
+        approver as a visual receipt and shared with the agent to confirm
+        the approval. Generated at approval time and not persisted.
+      pattern: "^[A-Z2-9]{3}-[A-Z2-9]{3}$"
+      example: "RK3-P7M"
     execution_status:
       $ref: './shared.yaml#/ExecutionStatus'
     execution_result:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -2524,6 +2524,7 @@ paths:
                     approval_id: appr_xyz789
                     status: approved
                     approved_at: '2026-02-21T10:30:00Z'
+                    confirmation_code: RK3-P7M
                     execution_status: success
                     execution_result:
                       message_id: msg_abc123
@@ -2534,6 +2535,7 @@ paths:
                     approval_id: appr_xyz789
                     status: approved
                     approved_at: '2026-02-21T10:30:00Z'
+                    confirmation_code: RK3-P7M
                     execution_status: error
                     execution_result:
                       error: upstream_error
@@ -5732,6 +5734,7 @@ components:
         - approval_id
         - status
         - approved_at
+        - confirmation_code
         - execution_status
       properties:
         approval_id:
@@ -5749,6 +5752,14 @@ components:
           format: date-time
           description: When the approval was approved
           example: '2026-02-21T10:30:00Z'
+        confirmation_code:
+          type: string
+          description: |
+            Ephemeral confirmation code in `XXX-XXX` format. Displayed to the
+            approver as a visual receipt and shared with the agent to confirm
+            the approval. Generated at approval time and not persisted.
+          pattern: ^[A-Z2-9]{3}-[A-Z2-9]{3}$
+          example: RK3-P7M
         execution_status:
           $ref: '#/components/schemas/ExecutionStatus'
         execution_result:


### PR DESCRIPTION
## Summary

- Added `confirmation_code` (string, `XXX-XXX` format) to the backend `approveResponse` struct and the `ApproveApprovalResponse` OpenAPI schema, fixing the TS2339 error in `ApprovalDetailScreen.tsx`
- The confirmation code is generated ephemerally at approval time using the existing `generateConfirmationCodePlaintext()` function — not persisted to the DB
- Added a `mobile` CI job to `.github/workflows/ci.yml` that runs `make mobile-test` and `make mobile-typecheck`

## Test plan

- [x] `make mobile-typecheck` passes (previously failed with TS2339)
- [x] `make test-frontend` — 75 suites, 595 tests pass
- [x] `make mobile-test` — 20 suites, 182 tests pass
- [x] Go compiles cleanly (`go build ./...`)
- [x] Backend test updated to assert `confirmation_code` format
- [ ] Backend tests (`make test-backend`) — could not run in this environment due to Go toolchain network issue, but the change is minimal and well-covered

Fixes #165

https://claude.ai/code/session_01WXpYhB63qT7eLNNT2s7huo