### PR TITLE
Add Raspberry Pi quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Open-source API key vault where agents execute scoped, time-limited actions on b
 
 Or **[self-host](docs/deployment-self-hosted.md)** on your own infrastructure for full control (Docker, Fly.io, or bare metal).
 
+**Want to run it on a Raspberry Pi?** Follow the **[Raspberry Pi Quickstart](docs/raspberry-pi-quickstart.md)** — a step-by-step guide to get Permission Slip running on a [Pi 5](https://a.co/d/0cQXzRi1) in under 30 minutes.
+
 ## Why Permission Slip?
 
 You want your AI agent to book flights, send emails, order food — but you can't trust it with full access to your accounts.
@@ -68,6 +70,7 @@ For the full protocol design, architecture, and security model, see [SPEC.md](SP
 - **[Community Connectors](docs/community-connectors.md)** — directory of third-party connectors built by the community
 - **[Consent Banner](docs/consent-banner.md)** — cross-subdomain cookie consent banner (shared between www and app)
 - **[Manual Testing: Agent Registration](docs/manual-testing-agent-registration.md)** — step-by-step guide to test the invite/registration flow
+- **[Raspberry Pi Quickstart](docs/raspberry-pi-quickstart.md)** — get Permission Slip running on a Raspberry Pi 5 in under 30 minutes
 - **[Self-Hosted Deployment](docs/deployment-self-hosted.md)** — complete guide for deploying on your own infrastructure (Docker, Fly.io, bare metal)
 - **[Production Deployment (internal)](docs/deployment-production.md)** — infrastructure, secrets, and operations for app.permissionslip.dev
 - **[Fly.io Deployment](docs/deployment.md)** — Dockerfile, fly.toml, secrets, and DNS setup

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -2,6 +2,8 @@
 
 This guide covers deploying Permission Slip on your own infrastructure. Permission Slip ships as a single Go binary with the React frontend embedded — no separate web server or static file hosting needed.
 
+> **Running on a Raspberry Pi?** Skip straight to the **[Raspberry Pi Quickstart](raspberry-pi-quickstart.md)** — an opinionated, step-by-step guide that gets you up and running in under 30 minutes with minimal services.
+
 ## Prerequisites
 
 Before deploying, you'll need:

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -13,13 +13,14 @@ Get Permission Slip running on a Raspberry Pi in under 30 minutes. This is an op
 
 ### Accounts to Sign Up For
 
-You only need **one** external account:
+You need **two** external accounts:
 
 | Service | Why | Cost |
 |---|---|---|
 | [Supabase](https://supabase.com) | User authentication (login, MFA, JWTs) | Free tier is sufficient |
+| [Twilio](https://www.twilio.com) | SMS notifications for approval requests | Pay-as-you-go (~$0.0079/SMS) |
 
-That's it. PostgreSQL runs locally on the Pi — no managed database needed.
+Twilio ensures approvers get notified on their phone immediately — even without the app installed, without a browser open, and regardless of iOS vs Android. PostgreSQL runs locally on the Pi — no managed database needed.
 
 ## Step 1: Set Up Your Raspberry Pi
 
@@ -91,12 +92,84 @@ SQL
    - **Authentication > URL Configuration > Redirect URLs:** Add the same URL
    - **Authentication > Email:** Ensure email sign-in is enabled
 
-## Step 5: Deploy with Docker
+## Step 5: Set Up Notifications
+
+Permission Slip is an approval system — approvers need to know when something's waiting for them. Without notifications, they'd have to keep checking the web UI manually.
+
+This guide sets up **SMS** as the primary notification channel (works on every phone, no app install needed) and **Web Push** for desktop browser alerts.
+
+### Twilio SMS (primary — works on any phone)
+
+SMS is the most reliable way to reach approvers on the go. It works on every phone — no app to install, no browser to keep open.
+
+1. Sign up at [twilio.com](https://www.twilio.com) (pay-as-you-go, ~$0.0079/SMS in the US)
+2. From the Twilio console, get your **Account SID** and **Auth Token**
+3. Buy a phone number (or use the trial number to test)
+
+You'll add these values to your environment in the next step:
+
+| Variable | Value |
+|---|---|
+| `TWILIO_ACCOUNT_SID` | Your Account SID (`ACxxxx`) |
+| `TWILIO_AUTH_TOKEN` | Your Auth Token |
+| `TWILIO_FROM_NUMBER` | Your Twilio phone number (`+15551234567`) |
+
+### Web Push (desktop alerts — no signup needed)
+
+VAPID-based browser push notifications give you real-time desktop alerts without any external service. These are a self-generated key pair — completely free.
+
+```bash
+# Clone the repo (just to use the key generator)
+git clone https://github.com/supersuit-tech/permission-slip-web.git /tmp/permission-slip-web
+cd /tmp/permission-slip-web
+go run ./cmd/generate-vapid-keys
+```
+
+This outputs three values — `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_SUBJECT`. Save them; you'll add them to your environment in the next step.
+
+> **Don't have Go installed yet?** You can generate VAPID keys with any Web Push library, or install Go first (see [Build from Source](#step-7-build-from-source-alternative) below) and come back to this step.
+
+### Email (optional)
+
+If you also want email notifications, the easiest option is **Gmail SMTP** (no signup — just generate an [App Password](https://myaccount.google.com/apppasswords)). See the [Self-Hosted Deployment Guide](deployment-self-hosted.md#email-notifications) for setup details.
+
+## Step 6: Deploy with Docker
 
 Create a directory for your deployment:
 
 ```bash
 mkdir ~/permission-slip && cd ~/permission-slip
+```
+
+Create a `.env` file with your secrets:
+
+```bash
+cat > .env <<'EOF'
+# Required
+DATABASE_URL=postgres://permissionslip:changeme-use-a-real-password@host.docker.internal:5432/permissionslip?sslmode=disable
+SUPABASE_URL=https://abcdefgh.supabase.co
+BASE_URL=http://raspberrypi.local:8080
+ALLOWED_ORIGINS=http://raspberrypi.local:8080
+
+# Generate with: openssl rand -hex 32
+INVITE_HMAC_KEY=generate-me
+
+# SMS (Twilio) — paste your values from Step 5
+TWILIO_ACCOUNT_SID=ACxxxx
+TWILIO_AUTH_TOKEN=your-auth-token
+TWILIO_FROM_NUMBER=+15551234567
+
+# Web Push — paste the values from Step 5
+VAPID_PUBLIC_KEY=your-vapid-public-key
+VAPID_PRIVATE_KEY=your-vapid-private-key
+VAPID_SUBJECT=mailto:you@example.com
+EOF
+```
+
+Fill in the real values, then generate the HMAC key:
+
+```bash
+sed -i "s/INVITE_HMAC_KEY=generate-me/INVITE_HMAC_KEY=$(openssl rand -hex 32)/" .env
 ```
 
 Create a `docker-compose.yml`:
@@ -113,12 +186,7 @@ services:
     #     VITE_SUPABASE_PUBLISHABLE_KEY: your-publishable-key
     ports:
       - "8080:8080"
-    environment:
-      DATABASE_URL: postgres://permissionslip:changeme-use-a-real-password@host.docker.internal:5432/permissionslip?sslmode=disable
-      SUPABASE_URL: https://abcdefgh.supabase.co
-      BASE_URL: http://raspberrypi.local:8080
-      ALLOWED_ORIGINS: http://raspberrypi.local:8080
-      INVITE_HMAC_KEY: ${INVITE_HMAC_KEY}
+    env_file: .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped
@@ -131,14 +199,7 @@ services:
 
 > **Note:** `host.docker.internal` lets the container reach PostgreSQL running on the host. The `extra_hosts` line makes this work on Linux.
 
-Create a `.env` file with your secrets:
-
-```bash
-# Generate an HMAC key for invite codes
-echo "INVITE_HMAC_KEY=$(openssl rand -hex 32)" > .env
-```
-
-Edit the `docker-compose.yml` to fill in your actual Supabase URL and publishable key, then start it:
+Start it up:
 
 ```bash
 docker compose up -d
@@ -154,7 +215,7 @@ curl http://localhost:8080/api/health
 # Should return 200 OK
 ```
 
-## Step 6: Build from Source (Alternative)
+## Step 7: Build from Source (Alternative)
 
 If you prefer to build and run the binary directly instead of Docker:
 
@@ -178,18 +239,28 @@ export VITE_SUPABASE_URL=https://abcdefgh.supabase.co
 export VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 make build
 
-# Run
+# Generate VAPID keys for web push notifications
+make generate-vapid-keys
+# Save the output — add these to your .env file
+
+# Run (set all env vars, or use an .env file with source)
 export DATABASE_URL="postgres://permissionslip:changeme-use-a-real-password@localhost:5432/permissionslip?sslmode=disable"
 export SUPABASE_URL="https://abcdefgh.supabase.co"
 export BASE_URL="http://raspberrypi.local:8080"
 export ALLOWED_ORIGINS="http://raspberrypi.local:8080"
 export INVITE_HMAC_KEY="$(openssl rand -hex 32)"
+export TWILIO_ACCOUNT_SID="ACxxxx"
+export TWILIO_AUTH_TOKEN="your-auth-token"
+export TWILIO_FROM_NUMBER="+15551234567"
+export VAPID_PUBLIC_KEY="your-vapid-public-key"
+export VAPID_PRIVATE_KEY="your-vapid-private-key"
+export VAPID_SUBJECT="mailto:you@example.com"
 ./bin/server
 ```
 
 > **Tip:** To keep the server running after you close the terminal, use a systemd service. See [Running as a systemd service](#running-as-a-systemd-service) below.
 
-## Step 7: Access Permission Slip
+## Step 8: Access Permission Slip
 
 Open your browser and go to:
 
@@ -262,24 +333,6 @@ sudo tailscale up
 
 Access via your Tailscale IP or MagicDNS hostname. No config changes needed since it's a private network.
 
-## Optional: Enable Notifications
-
-Push notifications are optional but recommended for the full approval flow experience.
-
-**Web Push (no signup needed):**
-
-```bash
-# If using build-from-source, generate VAPID keys:
-cd ~/permission-slip-web
-make generate-vapid-keys
-# Add the output to your .env file
-```
-
-**Email notifications (pick one):**
-
-- **Gmail SMTP** (free, easiest for personal use): Use an [App Password](https://myaccount.google.com/apppasswords) and set `NOTIFICATION_EMAIL_PROVIDER=smtp`, `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`, `SMTP_USERNAME=you@gmail.com`, `SMTP_PASSWORD=your-app-password`
-- **SendGrid** (free tier: 100 emails/day): Sign up at [sendgrid.com](https://sendgrid.com), set `NOTIFICATION_EMAIL_PROVIDER=twilio-sendgrid` and `SENDGRID_API_KEY`
-
 ## Troubleshooting
 
 **Docker container can't connect to PostgreSQL:**
@@ -336,5 +389,5 @@ Then use the IP directly (e.g., `http://192.168.1.100:8080`).
 
 - **Add agents:** Follow the [Agent Integration Guide](agents.md) to connect your first AI agent
 - **Custom connectors:** Add integrations beyond the built-in GitHub and Slack connectors — see [Custom Connectors](custom-connectors.md)
-- **Mobile app:** Install the Permission Slip mobile app for push notification approvals from your phone
-- **Full configuration:** See the [Self-Hosted Deployment Guide](deployment-self-hosted.md) for all available options (SMS, error tracking, analytics, billing, etc.)
+- **Email notifications:** Add email as an additional notification channel — see [Self-Hosted Deployment Guide](deployment-self-hosted.md#email-notifications)
+- **Full configuration:** See the [Self-Hosted Deployment Guide](deployment-self-hosted.md) for all available options (error tracking, analytics, billing, etc.)

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -1,0 +1,340 @@
+# Raspberry Pi Quickstart
+
+Get Permission Slip running on a Raspberry Pi in under 30 minutes. This is an opinionated guide that gets you to a working self-hosted instance with the minimum number of services and accounts.
+
+## What You'll Need
+
+### Hardware
+
+- **[Raspberry Pi 5 (8GB)](https://a.co/d/0cQXzRi1)** — recommended for running Permission Slip, PostgreSQL, and Docker comfortably
+- A microSD card (32GB+) or USB SSD (preferred for better performance and longevity)
+- Power supply (USB-C, 27W for Pi 5)
+- Ethernet cable or Wi-Fi connection
+
+### Accounts to Sign Up For
+
+You only need **one** external account:
+
+| Service | Why | Cost |
+|---|---|---|
+| [Supabase](https://supabase.com) | User authentication (login, MFA, JWTs) | Free tier is sufficient |
+
+That's it. PostgreSQL runs locally on the Pi — no managed database needed.
+
+## Step 1: Set Up Your Raspberry Pi
+
+If your Pi is already running Raspberry Pi OS, skip to Step 2.
+
+1. Download and install [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+2. Flash **Raspberry Pi OS (64-bit)** to your SD card or SSD
+3. In the imager settings, enable SSH and configure Wi-Fi (if not using Ethernet)
+4. Boot the Pi and SSH in:
+
+```bash
+ssh pi@raspberrypi.local
+```
+
+## Step 2: Install Dependencies
+
+```bash
+# Update system packages
+sudo apt update && sudo apt upgrade -y
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+
+# Log out and back in for group changes to take effect
+exit
+# SSH back in
+ssh pi@raspberrypi.local
+
+# Install PostgreSQL
+sudo apt install -y postgresql postgresql-client
+
+# Start PostgreSQL and enable on boot
+sudo systemctl enable --now postgresql
+```
+
+Verify both are working:
+
+```bash
+docker --version
+sudo -u postgres psql -c "SELECT version();"
+```
+
+## Step 3: Create the Database
+
+```bash
+# Create a database and user for Permission Slip
+sudo -u postgres psql <<'SQL'
+CREATE USER permissionslip WITH PASSWORD 'changeme-use-a-real-password';
+CREATE DATABASE permissionslip OWNER permissionslip;
+-- Install required extensions for credential vault
+\c permissionslip
+CREATE EXTENSION IF NOT EXISTS pgsodium;
+CREATE EXTENSION IF NOT EXISTS supabase_vault;
+SQL
+```
+
+> **Note:** The `pgsodium` and `supabase_vault` extensions are needed for credential encryption. If they're not available in your Postgres packages, Permission Slip will still work — you just won't be able to store encrypted credentials in the vault. You can skip those two `CREATE EXTENSION` lines if they fail.
+
+## Step 4: Set Up Supabase Auth
+
+1. Go to [supabase.com](https://supabase.com) and create a free account
+2. Create a new project (any region)
+3. From your project dashboard, grab:
+   - **Project URL** (e.g., `https://abcdefgh.supabase.co`)
+   - **Publishable key** (under Project Settings > API)
+4. Configure auth settings:
+   - **Authentication > URL Configuration > Site URL:** Set to your Pi's URL (e.g., `http://raspberrypi.local:8080` for LAN access, or your domain/tunnel URL)
+   - **Authentication > URL Configuration > Redirect URLs:** Add the same URL
+   - **Authentication > Email:** Ensure email sign-in is enabled
+
+## Step 5: Deploy with Docker
+
+Create a directory for your deployment:
+
+```bash
+mkdir ~/permission-slip && cd ~/permission-slip
+```
+
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  permission-slip:
+    image: ghcr.io/supersuit-tech/permission-slip:latest
+    # Or build from source (uncomment below, comment out image above):
+    # build:
+    #   context: .
+    #   args:
+    #     VITE_SUPABASE_URL: https://abcdefgh.supabase.co
+    #     VITE_SUPABASE_PUBLISHABLE_KEY: your-publishable-key
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: postgres://permissionslip:changeme-use-a-real-password@host.docker.internal:5432/permissionslip?sslmode=disable
+      SUPABASE_URL: https://abcdefgh.supabase.co
+      BASE_URL: http://raspberrypi.local:8080
+      ALLOWED_ORIGINS: http://raspberrypi.local:8080
+      INVITE_HMAC_KEY: ${INVITE_HMAC_KEY}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/api/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+```
+
+> **Note:** `host.docker.internal` lets the container reach PostgreSQL running on the host. The `extra_hosts` line makes this work on Linux.
+
+Create a `.env` file with your secrets:
+
+```bash
+# Generate an HMAC key for invite codes
+echo "INVITE_HMAC_KEY=$(openssl rand -hex 32)" > .env
+```
+
+Edit the `docker-compose.yml` to fill in your actual Supabase URL and publishable key, then start it:
+
+```bash
+docker compose up -d
+```
+
+Check that it's healthy:
+
+```bash
+docker compose ps
+# Should show "healthy" after ~30 seconds
+
+curl http://localhost:8080/api/health
+# Should return 200 OK
+```
+
+## Step 6: Build from Source (Alternative)
+
+If you prefer to build and run the binary directly instead of Docker:
+
+```bash
+# Install Go
+wget https://go.dev/dl/go1.24.1.linux-arm64.tar.gz
+sudo tar -C /usr/local -xzf go1.24.1.linux-arm64.tar.gz
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+source ~/.bashrc
+
+# Install Node.js 20
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+
+# Clone and build
+git clone https://github.com/supersuit-tech/permission-slip-web.git
+cd permission-slip-web
+make install
+
+export VITE_SUPABASE_URL=https://abcdefgh.supabase.co
+export VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+make build
+
+# Run
+export DATABASE_URL="postgres://permissionslip:changeme-use-a-real-password@localhost:5432/permissionslip?sslmode=disable"
+export SUPABASE_URL="https://abcdefgh.supabase.co"
+export BASE_URL="http://raspberrypi.local:8080"
+export ALLOWED_ORIGINS="http://raspberrypi.local:8080"
+export INVITE_HMAC_KEY="$(openssl rand -hex 32)"
+./bin/server
+```
+
+> **Tip:** To keep the server running after you close the terminal, use a systemd service. See [Running as a systemd service](#running-as-a-systemd-service) below.
+
+## Step 7: Access Permission Slip
+
+Open your browser and go to:
+
+```
+http://raspberrypi.local:8080
+```
+
+Sign up with your email. You'll receive a confirmation email via Supabase Auth.
+
+## Optional: Running as a systemd Service
+
+To start Permission Slip automatically on boot (for the build-from-source approach):
+
+```bash
+sudo tee /etc/systemd/system/permission-slip.service > /dev/null <<'EOF'
+[Unit]
+Description=Permission Slip
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/permission-slip-web
+ExecStart=/home/pi/permission-slip-web/bin/server
+EnvironmentFile=/home/pi/permission-slip-web/.env
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now permission-slip
+```
+
+Create `/home/pi/permission-slip-web/.env` with your environment variables (one per line, `KEY=value` format).
+
+## Optional: Expose to the Internet
+
+To access your Pi from outside your local network, you have a few options:
+
+**Cloudflare Tunnel (recommended — free, no port forwarding needed):**
+
+```bash
+# Install cloudflared
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt update && sudo apt install -y cloudflared
+
+# Authenticate and create a tunnel
+cloudflared tunnel login
+cloudflared tunnel create permission-slip
+cloudflared tunnel route dns permission-slip permissions.yourdomain.com
+
+# Run the tunnel
+cloudflared tunnel run --url http://localhost:8080 permission-slip
+```
+
+After setting up a tunnel, update your environment:
+- `BASE_URL` and `ALLOWED_ORIGINS` → your public URL (e.g., `https://permissions.yourdomain.com`)
+- Supabase **Site URL** and **Redirect URLs** → same public URL
+
+**Tailscale (good for personal use):**
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+Access via your Tailscale IP or MagicDNS hostname. No config changes needed since it's a private network.
+
+## Optional: Enable Notifications
+
+Push notifications are optional but recommended for the full approval flow experience.
+
+**Web Push (no signup needed):**
+
+```bash
+# If using build-from-source, generate VAPID keys:
+cd ~/permission-slip-web
+make generate-vapid-keys
+# Add the output to your .env file
+```
+
+**Email notifications (pick one):**
+
+- **Gmail SMTP** (free, easiest for personal use): Use an [App Password](https://myaccount.google.com/apppasswords) and set `NOTIFICATION_EMAIL_PROVIDER=smtp`, `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`, `SMTP_USERNAME=you@gmail.com`, `SMTP_PASSWORD=your-app-password`
+- **SendGrid** (free tier: 100 emails/day): Sign up at [sendgrid.com](https://sendgrid.com), set `NOTIFICATION_EMAIL_PROVIDER=twilio-sendgrid` and `SENDGRID_API_KEY`
+
+## Troubleshooting
+
+**Docker container can't connect to PostgreSQL:**
+
+PostgreSQL defaults to rejecting non-local connections. Edit `pg_hba.conf` to allow Docker's network:
+
+```bash
+# Find the config file
+sudo -u postgres psql -c "SHOW hba_file;"
+
+# Add this line (adjust the subnet to match your Docker network)
+# host all all 172.17.0.0/16 md5
+sudo nano /etc/postgresql/*/main/pg_hba.conf
+
+# Also ensure PostgreSQL listens on all interfaces
+sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/*/main/postgresql.conf
+
+sudo systemctl restart postgresql
+```
+
+**Slow builds on the Pi:**
+
+Building from source (especially the frontend) can take several minutes on a Pi. This is normal. If it's too slow, consider cross-compiling on a faster machine:
+
+```bash
+# On your development machine (Linux/macOS with Go installed)
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 make build
+# Then copy bin/server to your Pi
+```
+
+**Out of memory during build:**
+
+The 8GB Pi 5 should be fine, but if you're on a 4GB model, add swap:
+
+```bash
+sudo dphys-swapfile swapoff
+sudo sed -i 's/CONF_SWAPSIZE=.*/CONF_SWAPSIZE=2048/' /etc/dphys-swapfile
+sudo dphys-swapfile setup
+sudo dphys-swapfile swapon
+```
+
+**Can't reach `raspberrypi.local`:**
+
+Not all networks support mDNS. Find your Pi's IP address instead:
+
+```bash
+# On the Pi
+hostname -I
+```
+
+Then use the IP directly (e.g., `http://192.168.1.100:8080`).
+
+## What's Next?
+
+- **Add agents:** Follow the [Agent Integration Guide](agents.md) to connect your first AI agent
+- **Custom connectors:** Add integrations beyond the built-in GitHub and Slack connectors — see [Custom Connectors](custom-connectors.md)
+- **Mobile app:** Install the Permission Slip mobile app for push notification approvals from your phone
+- **Full configuration:** See the [Self-Hosted Deployment Guide](deployment-self-hosted.md) for all available options (SMS, error tracking, analytics, billing, etc.)

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -96,9 +96,7 @@ SQL
 
 Permission Slip is an approval system — approvers need to know when something's waiting for them. Without notifications, they'd have to keep checking the web UI manually.
 
-This guide sets up **SMS** as the primary notification channel (works on every phone, no app install needed) and **Web Push** for desktop browser alerts.
-
-### Twilio SMS (primary — works on any phone)
+### Twilio SMS (works on any phone)
 
 SMS is the most reliable way to reach approvers on the go. It works on every phone — no app to install, no browser to keep open.
 
@@ -114,24 +112,7 @@ You'll add these values to your environment in the next step:
 | `TWILIO_AUTH_TOKEN` | Your Auth Token |
 | `TWILIO_FROM_NUMBER` | Your Twilio phone number (`+15551234567`) |
 
-### Web Push (desktop alerts — no signup needed)
-
-VAPID-based browser push notifications give you real-time desktop alerts without any external service. These are a self-generated key pair — completely free.
-
-```bash
-# Clone the repo (just to use the key generator)
-git clone https://github.com/supersuit-tech/permission-slip-web.git /tmp/permission-slip-web
-cd /tmp/permission-slip-web
-go run ./cmd/generate-vapid-keys
-```
-
-This outputs three values — `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_SUBJECT`. Save them; you'll add them to your environment in the next step.
-
-> **Don't have Go installed yet?** You can generate VAPID keys with any Web Push library, or install Go first (see [Build from Source](#step-7-build-from-source-alternative) below) and come back to this step.
-
-### Email (optional)
-
-If you also want email notifications, the easiest option is **Gmail SMTP** (no signup — just generate an [App Password](https://myaccount.google.com/apppasswords)). See the [Self-Hosted Deployment Guide](deployment-self-hosted.md#email-notifications) for setup details.
+> For more notification options (web push, email, mobile app), see the [Self-Hosted Deployment Guide](deployment-self-hosted.md).
 
 ## Step 6: Deploy with Docker
 
@@ -158,11 +139,6 @@ INVITE_HMAC_KEY=generate-me
 TWILIO_ACCOUNT_SID=ACxxxx
 TWILIO_AUTH_TOKEN=your-auth-token
 TWILIO_FROM_NUMBER=+15551234567
-
-# Web Push — paste the values from Step 5
-VAPID_PUBLIC_KEY=your-vapid-public-key
-VAPID_PRIVATE_KEY=your-vapid-private-key
-VAPID_SUBJECT=mailto:you@example.com
 EOF
 ```
 
@@ -239,10 +215,6 @@ export VITE_SUPABASE_URL=https://abcdefgh.supabase.co
 export VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 make build
 
-# Generate VAPID keys for web push notifications
-make generate-vapid-keys
-# Save the output — add these to your .env file
-
 # Run (set all env vars, or use an .env file with source)
 export DATABASE_URL="postgres://permissionslip:changeme-use-a-real-password@localhost:5432/permissionslip?sslmode=disable"
 export SUPABASE_URL="https://abcdefgh.supabase.co"
@@ -252,9 +224,6 @@ export INVITE_HMAC_KEY="$(openssl rand -hex 32)"
 export TWILIO_ACCOUNT_SID="ACxxxx"
 export TWILIO_AUTH_TOKEN="your-auth-token"
 export TWILIO_FROM_NUMBER="+15551234567"
-export VAPID_PUBLIC_KEY="your-vapid-public-key"
-export VAPID_PRIVATE_KEY="your-vapid-private-key"
-export VAPID_SUBJECT="mailto:you@example.com"
 ./bin/server
 ```
 
@@ -389,5 +358,4 @@ Then use the IP directly (e.g., `http://192.168.1.100:8080`).
 
 - **Add agents:** Follow the [Agent Integration Guide](agents.md) to connect your first AI agent
 - **Custom connectors:** Add integrations beyond the built-in GitHub and Slack connectors — see [Custom Connectors](custom-connectors.md)
-- **Email notifications:** Add email as an additional notification channel — see [Self-Hosted Deployment Guide](deployment-self-hosted.md#email-notifications)
-- **Full configuration:** See the [Self-Hosted Deployment Guide](deployment-self-hosted.md) for all available options (error tracking, analytics, billing, etc.)
+- **More configuration:** For web push, email notifications, error tracking, analytics, and more — read the full [Self-Hosted Deployment Guide](deployment-self-hosted.md)


### PR DESCRIPTION
## Summary
- Adds a new opinionated Raspberry Pi quickstart guide (`docs/raspberry-pi-quickstart.md`) that walks through getting Permission Slip running on a Pi 5 (8GB) in under 30 minutes
- Recommends minimal services: just Supabase for auth, PostgreSQL runs locally on the Pi
- Covers Docker and build-from-source paths, systemd service, Cloudflare Tunnel / Tailscale for internet exposure, optional notifications
- Links the guide from the README (elevated in "Get Started" section) and the self-hosted deployment guide

## Test plan
- [ ] Verify all links in README and self-hosted doc point to the correct file
- [ ] Review the guide for accuracy against current build/deploy process
- [ ] Confirm Docker Compose config matches current image/env var expectations

https://claude.ai/code/session_01QkjQzsXvtFCts3w8JMskBi