### PR TITLE
feat: OAuth 2.0 Phase 1 — core infrastructure for Google & Microsoft

### DIFF
--- a/api/connectors.go
+++ b/api/connectors.go
@@ -32,9 +32,11 @@ type connectorActionResponse struct {
 }
 
 type requiredCredentialResponse struct {
-	Service         string  `json:"service"`
-	AuthType        string  `json:"auth_type"`
-	InstructionsURL *string `json:"instructions_url,omitempty"`
+	Service         string   `json:"service"`
+	AuthType        string   `json:"auth_type"`
+	InstructionsURL *string  `json:"instructions_url,omitempty"`
+	OAuthProvider   *string  `json:"oauth_provider,omitempty"`
+	OAuthScopes     []string `json:"oauth_scopes,omitempty"`
 }
 
 type connectorDetailResponse struct {
@@ -129,6 +131,8 @@ func toConnectorDetailResponse(ctx context.Context, c db.ConnectorDetail) connec
 			Service:         rc.Service,
 			AuthType:        rc.AuthType,
 			InstructionsURL: rc.InstructionsURL,
+			OAuthProvider:   rc.OAuthProvider,
+			OAuthScopes:     rc.OAuthScopes,
 		}
 	}
 

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -16,12 +16,13 @@ import (
 // required credentials, and optional configuration templates so the server can
 // register and seed DB rows automatically on startup.
 type ConnectorManifest struct {
-	ID                  string               `json:"id"`
-	Name                string               `json:"name"`
-	Description         string               `json:"description"`
-	Actions             []ManifestAction     `json:"actions"`
-	RequiredCredentials []ManifestCredential `json:"required_credentials"`
-	Templates           []ManifestTemplate   `json:"templates,omitempty"`
+	ID                  string                  `json:"id"`
+	Name                string                  `json:"name"`
+	Description         string                  `json:"description"`
+	Actions             []ManifestAction        `json:"actions"`
+	RequiredCredentials []ManifestCredential    `json:"required_credentials"`
+	Templates           []ManifestTemplate      `json:"templates,omitempty"`
+	OAuthProviders      []ManifestOAuthProvider `json:"oauth_providers,omitempty"`
 }
 
 // ManifestAction describes a single action exposed by an external connector.
@@ -35,9 +36,21 @@ type ManifestAction struct {
 
 // ManifestCredential describes a credential requirement for an external connector.
 type ManifestCredential struct {
-	Service         string `json:"service"`
-	AuthType        string `json:"auth_type"`
-	InstructionsURL string `json:"instructions_url,omitempty"`
+	Service         string   `json:"service"`
+	AuthType        string   `json:"auth_type"`
+	InstructionsURL string   `json:"instructions_url,omitempty"`
+	OAuthProvider   string   `json:"oauth_provider,omitempty"`
+	OAuthScopes     []string `json:"oauth_scopes,omitempty"`
+}
+
+// ManifestOAuthProvider describes an OAuth 2.0 provider declared by an external
+// connector. This allows external connectors to register providers that the
+// platform doesn't have built-in support for (e.g. Salesforce, HubSpot).
+type ManifestOAuthProvider struct {
+	ID           string   `json:"id"`
+	AuthorizeURL string   `json:"authorize_url"`
+	TokenURL     string   `json:"token_url"`
+	Scopes       []string `json:"scopes,omitempty"`
 }
 
 // ManifestTemplate describes a predefined configuration preset for an action.
@@ -71,6 +84,7 @@ var validAuthTypes = map[string]bool{
 	"api_key": true,
 	"basic":   true,
 	"custom":  true,
+	"oauth2":  true,
 }
 
 // LoadManifest reads and validates a connector.json manifest from the given path.
@@ -177,7 +191,20 @@ func (m *ConnectorManifest) Validate() error {
 			return fmt.Errorf("manifest validation: required_credentials[%d].auth_type is required", i)
 		}
 		if !validAuthTypes[c.AuthType] {
-			return fmt.Errorf("manifest validation: required_credentials[%d].auth_type %q must be api_key, basic, or custom", i, c.AuthType)
+			return fmt.Errorf("manifest validation: required_credentials[%d].auth_type %q must be api_key, basic, custom, or oauth2", i, c.AuthType)
+		}
+		// OAuth2-specific validation.
+		if c.AuthType == "oauth2" {
+			if c.OAuthProvider == "" {
+				return fmt.Errorf("manifest validation: required_credentials[%d].oauth_provider is required when auth_type is oauth2", i)
+			}
+		} else {
+			if c.OAuthProvider != "" {
+				return fmt.Errorf("manifest validation: required_credentials[%d].oauth_provider must be empty when auth_type is %q", i, c.AuthType)
+			}
+			if len(c.OAuthScopes) > 0 {
+				return fmt.Errorf("manifest validation: required_credentials[%d].oauth_scopes must be empty when auth_type is %q", i, c.AuthType)
+			}
 		}
 		if c.InstructionsURL != "" {
 			if len(c.InstructionsURL) > maxInstructionsURLLen {
@@ -193,6 +220,40 @@ func (m *ConnectorManifest) Validate() error {
 			if u.Host == "" {
 				return fmt.Errorf("manifest validation: required_credentials[%d].instructions_url must include a host", i)
 			}
+		}
+	}
+
+	// Validate OAuth providers (optional, used by external connectors).
+	providerIDs := make(map[string]bool, len(m.OAuthProviders))
+	for i, p := range m.OAuthProviders {
+		if p.ID == "" {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].id is required", i)
+		}
+		if providerIDs[p.ID] {
+			return fmt.Errorf("manifest validation: duplicate oauth_provider id %q", p.ID)
+		}
+		providerIDs[p.ID] = true
+
+		if p.AuthorizeURL == "" {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].authorize_url is required", i)
+		}
+		au, err := url.Parse(p.AuthorizeURL)
+		if err != nil {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].authorize_url is not a valid URL: %w", i, err)
+		}
+		if au.Scheme != "https" {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].authorize_url must use https scheme", i)
+		}
+
+		if p.TokenURL == "" {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url is required", i)
+		}
+		tu, err := url.Parse(p.TokenURL)
+		if err != nil {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url is not a valid URL: %w", i, err)
+		}
+		if tu.Scheme != "https" {
+			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url must use https scheme", i)
 		}
 	}
 
@@ -222,6 +283,8 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 			Service:         c.Service,
 			AuthType:        c.AuthType,
 			InstructionsURL: c.InstructionsURL,
+			OAuthProvider:   c.OAuthProvider,
+			OAuthScopes:     c.OAuthScopes,
 		})
 	}
 	for _, tpl := range m.Templates {

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -223,6 +223,13 @@ func (m *ConnectorManifest) Validate() error {
 		}
 	}
 
+	// Collect all declared OAuth provider IDs (from OAuthProviders section)
+	// plus well-known built-in providers that don't need to be declared.
+	declaredProviders := map[string]bool{
+		"google":    true,
+		"microsoft": true,
+	}
+
 	// Validate OAuth providers (optional, used by external connectors).
 	providerIDs := make(map[string]bool, len(m.OAuthProviders))
 	for i, p := range m.OAuthProviders {
@@ -254,6 +261,15 @@ func (m *ConnectorManifest) Validate() error {
 		}
 		if tu.Scheme != "https" {
 			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url must use https scheme", i)
+		}
+
+		declaredProviders[p.ID] = true
+	}
+
+	// Cross-reference: verify oauth_provider in credentials references a known provider.
+	for i, c := range m.RequiredCredentials {
+		if c.AuthType == "oauth2" && !declaredProviders[c.OAuthProvider] {
+			return fmt.Errorf("manifest validation: required_credentials[%d].oauth_provider %q is not a built-in provider and not declared in oauth_providers", i, c.OAuthProvider)
 		}
 	}
 

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -87,6 +87,37 @@ var validAuthTypes = map[string]bool{
 	"oauth2":  true,
 }
 
+// BuiltInOAuthProviders lists OAuth provider IDs that the platform supports
+// natively. Connectors referencing these providers don't need to declare them
+// in their oauth_providers section. Add new built-in providers here.
+var BuiltInOAuthProviders = map[string]bool{
+	"google":    true,
+	"microsoft": true,
+}
+
+// validateURL parses a URL and checks scheme and host. allowedSchemes specifies
+// which schemes are accepted. Returns a descriptive error if invalid.
+func validateURL(raw, fieldName string, allowedSchemes ...string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid URL: %w", fieldName, err)
+	}
+	schemeOK := false
+	for _, s := range allowedSchemes {
+		if u.Scheme == s {
+			schemeOK = true
+			break
+		}
+	}
+	if !schemeOK {
+		return fmt.Errorf("%s must use %s scheme", fieldName, strings.Join(allowedSchemes, " or "))
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s must include a host", fieldName)
+	}
+	return nil
+}
+
 // LoadManifest reads and validates a connector.json manifest from the given path.
 func LoadManifest(path string) (*ConnectorManifest, error) {
 	data, err := os.ReadFile(path)
@@ -210,24 +241,17 @@ func (m *ConnectorManifest) Validate() error {
 			if len(c.InstructionsURL) > maxInstructionsURLLen {
 				return fmt.Errorf("manifest validation: required_credentials[%d].instructions_url exceeds %d characters", i, maxInstructionsURLLen)
 			}
-			u, err := url.Parse(c.InstructionsURL)
-			if err != nil {
-				return fmt.Errorf("manifest validation: required_credentials[%d].instructions_url is not a valid URL: %w", i, err)
-			}
-			if u.Scheme != "http" && u.Scheme != "https" {
-				return fmt.Errorf("manifest validation: required_credentials[%d].instructions_url must use http or https scheme", i)
-			}
-			if u.Host == "" {
-				return fmt.Errorf("manifest validation: required_credentials[%d].instructions_url must include a host", i)
+			field := fmt.Sprintf("manifest validation: required_credentials[%d].instructions_url", i)
+			if err := validateURL(c.InstructionsURL, field, "http", "https"); err != nil {
+				return err
 			}
 		}
 	}
 
-	// Collect all declared OAuth provider IDs (from OAuthProviders section)
-	// plus well-known built-in providers that don't need to be declared.
-	declaredProviders := map[string]bool{
-		"google":    true,
-		"microsoft": true,
+	// Collect all known OAuth provider IDs: built-in + declared in this manifest.
+	knownProviders := make(map[string]bool, len(BuiltInOAuthProviders)+len(m.OAuthProviders))
+	for id := range BuiltInOAuthProviders {
+		knownProviders[id] = true
 	}
 
 	// Validate OAuth providers (optional, used by external connectors).
@@ -244,31 +268,23 @@ func (m *ConnectorManifest) Validate() error {
 		if p.AuthorizeURL == "" {
 			return fmt.Errorf("manifest validation: oauth_providers[%d].authorize_url is required", i)
 		}
-		au, err := url.Parse(p.AuthorizeURL)
-		if err != nil {
-			return fmt.Errorf("manifest validation: oauth_providers[%d].authorize_url is not a valid URL: %w", i, err)
-		}
-		if au.Scheme != "https" {
-			return fmt.Errorf("manifest validation: oauth_providers[%d].authorize_url must use https scheme", i)
+		if err := validateURL(p.AuthorizeURL, fmt.Sprintf("manifest validation: oauth_providers[%d].authorize_url", i), "https"); err != nil {
+			return err
 		}
 
 		if p.TokenURL == "" {
 			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url is required", i)
 		}
-		tu, err := url.Parse(p.TokenURL)
-		if err != nil {
-			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url is not a valid URL: %w", i, err)
-		}
-		if tu.Scheme != "https" {
-			return fmt.Errorf("manifest validation: oauth_providers[%d].token_url must use https scheme", i)
+		if err := validateURL(p.TokenURL, fmt.Sprintf("manifest validation: oauth_providers[%d].token_url", i), "https"); err != nil {
+			return err
 		}
 
-		declaredProviders[p.ID] = true
+		knownProviders[p.ID] = true
 	}
 
 	// Cross-reference: verify oauth_provider in credentials references a known provider.
 	for i, c := range m.RequiredCredentials {
-		if c.AuthType == "oauth2" && !declaredProviders[c.OAuthProvider] {
+		if c.AuthType == "oauth2" && !knownProviders[c.OAuthProvider] {
 			return fmt.Errorf("manifest validation: required_credentials[%d].oauth_provider %q is not a built-in provider and not declared in oauth_providers", i, c.OAuthProvider)
 		}
 	}

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -103,13 +103,129 @@ func TestParseManifest_ValidationErrors(t *testing.T) {
 		{"missing cred service", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"auth_type":"api_key"}]}`},
 		{"missing auth_type", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s"}]}`},
 		{"invalid auth_type", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"magic"}]}`},
-		{"oauth2 auth_type rejected", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"oauth2"}]}`},
+		{"oauth2 missing oauth_provider", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"oauth2"}]}`},
 		{"invalid JSON", `{not json`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ParseManifest([]byte(tt.input))
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+// ── OAuth Validation ─────────────────────────────────────────────────────
+
+func TestParseManifest_OAuth2Credential(t *testing.T) {
+	input := `{
+		"id": "google",
+		"name": "Google",
+		"actions": [{"action_type": "google.send_email", "name": "Send Email"}],
+		"required_credentials": [
+			{"service": "google", "auth_type": "oauth2", "oauth_provider": "google", "oauth_scopes": ["https://www.googleapis.com/auth/gmail.send"]}
+		]
+	}`
+
+	m, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.RequiredCredentials) != 1 {
+		t.Fatalf("len(RequiredCredentials) = %d, want 1", len(m.RequiredCredentials))
+	}
+	cred := m.RequiredCredentials[0]
+	if cred.AuthType != "oauth2" {
+		t.Errorf("AuthType = %q, want %q", cred.AuthType, "oauth2")
+	}
+	if cred.OAuthProvider != "google" {
+		t.Errorf("OAuthProvider = %q, want %q", cred.OAuthProvider, "google")
+	}
+	if len(cred.OAuthScopes) != 1 || cred.OAuthScopes[0] != "https://www.googleapis.com/auth/gmail.send" {
+		t.Errorf("OAuthScopes = %v, want [https://www.googleapis.com/auth/gmail.send]", cred.OAuthScopes)
+	}
+}
+
+func TestParseManifest_OAuth2ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"oauth2 without oauth_provider", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"oauth2"}]}`},
+		{"non-oauth2 with oauth_provider", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"api_key","oauth_provider":"google"}]}`},
+		{"non-oauth2 with oauth_scopes", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"api_key","oauth_scopes":["scope1"]}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseManifest([]byte(tt.input))
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseManifest_OAuthProviders(t *testing.T) {
+	input := `{
+		"id": "salesforce",
+		"name": "Salesforce",
+		"actions": [{"action_type": "salesforce.query", "name": "Query"}],
+		"required_credentials": [
+			{"service": "salesforce", "auth_type": "oauth2", "oauth_provider": "salesforce"}
+		],
+		"oauth_providers": [
+			{
+				"id": "salesforce",
+				"authorize_url": "https://login.salesforce.com/services/oauth2/authorize",
+				"token_url": "https://login.salesforce.com/services/oauth2/token",
+				"scopes": ["api", "refresh_token"]
+			}
+		]
+	}`
+
+	m, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.OAuthProviders) != 1 {
+		t.Fatalf("len(OAuthProviders) = %d, want 1", len(m.OAuthProviders))
+	}
+	p := m.OAuthProviders[0]
+	if p.ID != "salesforce" {
+		t.Errorf("OAuthProvider ID = %q, want %q", p.ID, "salesforce")
+	}
+	if p.AuthorizeURL != "https://login.salesforce.com/services/oauth2/authorize" {
+		t.Errorf("OAuthProvider AuthorizeURL = %q", p.AuthorizeURL)
+	}
+	if p.TokenURL != "https://login.salesforce.com/services/oauth2/token" {
+		t.Errorf("OAuthProvider TokenURL = %q", p.TokenURL)
+	}
+	if len(p.Scopes) != 2 {
+		t.Errorf("OAuthProvider Scopes = %v, want [api refresh_token]", p.Scopes)
+	}
+}
+
+func TestParseManifest_OAuthProviderValidationErrors(t *testing.T) {
+	base := `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"oauth_providers":[%s]}`
+
+	tests := []struct {
+		name     string
+		provider string
+	}{
+		{"missing provider id", `{"authorize_url":"https://example.com/auth","token_url":"https://example.com/token"}`},
+		{"missing authorize_url", `{"id":"p","token_url":"https://example.com/token"}`},
+		{"missing token_url", `{"id":"p","authorize_url":"https://example.com/auth"}`},
+		{"non-https authorize_url", `{"id":"p","authorize_url":"http://example.com/auth","token_url":"https://example.com/token"}`},
+		{"non-https token_url", `{"id":"p","authorize_url":"https://example.com/auth","token_url":"http://example.com/token"}`},
+		{"duplicate provider id", `{"id":"p","authorize_url":"https://a.com/auth","token_url":"https://a.com/token"},{"id":"p","authorize_url":"https://b.com/auth","token_url":"https://b.com/token"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(base, tt.provider)
+			_, err := ParseManifest([]byte(input))
 			if err == nil {
 				t.Error("expected error, got nil")
 			}

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -207,6 +207,59 @@ func TestParseManifest_OAuthProviders(t *testing.T) {
 	}
 }
 
+func TestParseManifest_OAuthProviderCrossReference(t *testing.T) {
+	// Built-in providers (google, microsoft) should be accepted without declaration.
+	t.Run("built-in provider accepted", func(t *testing.T) {
+		input := `{
+			"id": "x",
+			"name": "X",
+			"actions": [{"action_type": "x.a", "name": "A"}],
+			"required_credentials": [
+				{"service": "s", "auth_type": "oauth2", "oauth_provider": "microsoft"}
+			]
+		}`
+		_, err := ParseManifest([]byte(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Custom provider declared in oauth_providers should be accepted.
+	t.Run("declared custom provider accepted", func(t *testing.T) {
+		input := `{
+			"id": "x",
+			"name": "X",
+			"actions": [{"action_type": "x.a", "name": "A"}],
+			"required_credentials": [
+				{"service": "s", "auth_type": "oauth2", "oauth_provider": "hubspot"}
+			],
+			"oauth_providers": [
+				{"id": "hubspot", "authorize_url": "https://app.hubspot.com/oauth/authorize", "token_url": "https://api.hubapi.com/oauth/v1/token"}
+			]
+		}`
+		_, err := ParseManifest([]byte(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Unknown provider not declared should fail.
+	t.Run("undeclared custom provider rejected", func(t *testing.T) {
+		input := `{
+			"id": "x",
+			"name": "X",
+			"actions": [{"action_type": "x.a", "name": "A"}],
+			"required_credentials": [
+				{"service": "s", "auth_type": "oauth2", "oauth_provider": "hubspot"}
+			]
+		}`
+		_, err := ParseManifest([]byte(input))
+		if err == nil {
+			t.Error("expected error for undeclared oauth_provider, got nil")
+		}
+	})
+}
+
 func TestParseManifest_OAuthProviderValidationErrors(t *testing.T) {
 	base := `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"oauth_providers":[%s]}`
 

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -40,6 +40,8 @@ type RequiredCredential struct {
 	Service         string
 	AuthType        string
 	InstructionsURL *string
+	OAuthProvider   *string
+	OAuthScopes     []string
 }
 
 // ListConnectors returns all connectors with their action types and required credential services.
@@ -111,7 +113,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	// Fetch required credentials.
 	credRows, err := db.Query(ctx,
-		`SELECT service, auth_type, instructions_url
+		`SELECT service, auth_type, instructions_url, oauth_provider, oauth_scopes
 		 FROM connector_required_credentials
 		 WHERE connector_id = $1
 		 ORDER BY service`,
@@ -124,7 +126,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	for credRows.Next() {
 		var rc RequiredCredential
-		if err := credRows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL); err != nil {
+		if err := credRows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
 			return nil, err
 		}
 		cd.RequiredCredentials = append(cd.RequiredCredentials, rc)
@@ -226,6 +228,8 @@ type ExternalConnectorCredential struct {
 	Service         string
 	AuthType        string
 	InstructionsURL string
+	OAuthProvider   string
+	OAuthScopes     []string
 }
 
 // ExternalConnectorTemplate describes a configuration template from a connector manifest.
@@ -297,12 +301,14 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 	for _, c := range m.Credentials {
 		services = append(services, c.Service)
 		_, err := tx.Exec(ctx, `
-			INSERT INTO connector_required_credentials (connector_id, service, auth_type, instructions_url)
-			VALUES ($1, $2, $3, $4)
+			INSERT INTO connector_required_credentials (connector_id, service, auth_type, instructions_url, oauth_provider, oauth_scopes)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT (connector_id, service) DO UPDATE SET
 				auth_type = EXCLUDED.auth_type,
-				instructions_url = EXCLUDED.instructions_url`,
-			m.ID, c.Service, c.AuthType, nilIfEmpty(c.InstructionsURL))
+				instructions_url = EXCLUDED.instructions_url,
+				oauth_provider = EXCLUDED.oauth_provider,
+				oauth_scopes = EXCLUDED.oauth_scopes`,
+			m.ID, c.Service, c.AuthType, nilIfEmpty(c.InstructionsURL), nilIfEmpty(c.OAuthProvider), c.OAuthScopes)
 		if err != nil {
 			return err
 		}

--- a/db/connectors_test.go
+++ b/db/connectors_test.go
@@ -24,6 +24,20 @@ func TestConnectorsSchema(t *testing.T) {
 	t.Run("connector_required_credentials", func(t *testing.T) {
 		testhelper.RequireColumns(t, tx, "connector_required_credentials", []string{
 			"connector_id", "service", "auth_type", "instructions_url",
+			"oauth_provider", "oauth_scopes",
+		})
+	})
+	t.Run("oauth_connections", func(t *testing.T) {
+		testhelper.RequireColumns(t, tx, "oauth_connections", []string{
+			"id", "user_id", "provider", "access_token_vault_id",
+			"refresh_token_vault_id", "scopes", "token_expiry",
+			"status", "created_at", "updated_at",
+		})
+	})
+	t.Run("oauth_provider_configs", func(t *testing.T) {
+		testhelper.RequireColumns(t, tx, "oauth_provider_configs", []string{
+			"id", "user_id", "provider", "client_id_vault_id",
+			"client_secret_vault_id", "created_at",
 		})
 	})
 }

--- a/db/connectors_test.go
+++ b/db/connectors_test.go
@@ -37,7 +37,7 @@ func TestConnectorsSchema(t *testing.T) {
 	t.Run("oauth_provider_configs", func(t *testing.T) {
 		testhelper.RequireColumns(t, tx, "oauth_provider_configs", []string{
 			"id", "user_id", "provider", "client_id_vault_id",
-			"client_secret_vault_id", "created_at",
+			"client_secret_vault_id", "created_at", "updated_at",
 		})
 	})
 }

--- a/db/migrations/20260305045041_oauth_connections.sql
+++ b/db/migrations/20260305045041_oauth_connections.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+CREATE TABLE oauth_connections (
+    id                     text        PRIMARY KEY CHECK (char_length(id) <= 255),
+    user_id                uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    provider               text        NOT NULL CHECK (char_length(provider) <= 255),
+    access_token_vault_id  uuid        NOT NULL,
+    refresh_token_vault_id uuid,
+    scopes                 text[]      NOT NULL DEFAULT '{}',
+    token_expiry           timestamptz,
+    status                 text        NOT NULL DEFAULT 'active'
+                           CHECK (status IN ('active', 'needs_reauth', 'revoked')),
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    updated_at             timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, provider)
+);
+
+CREATE INDEX idx_oauth_connections_user ON oauth_connections (user_id);
+CREATE INDEX idx_oauth_connections_status ON oauth_connections (user_id, status);
+
+-- +goose Down
+DROP TABLE IF EXISTS oauth_connections;

--- a/db/migrations/20260305045105_oauth_provider_configs.sql
+++ b/db/migrations/20260305045105_oauth_provider_configs.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+CREATE TABLE oauth_provider_configs (
+    id                     text        PRIMARY KEY CHECK (char_length(id) <= 255),
+    user_id                uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    provider               text        NOT NULL CHECK (char_length(provider) <= 255),
+    client_id_vault_id     uuid        NOT NULL,
+    client_secret_vault_id uuid        NOT NULL,
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, provider)
+);
+
+CREATE INDEX idx_oauth_provider_configs_user ON oauth_provider_configs (user_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS oauth_provider_configs;

--- a/db/migrations/20260305045117_add_oauth2_auth_type_and_columns.sql
+++ b/db/migrations/20260305045117_add_oauth2_auth_type_and_columns.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+
+-- Re-add oauth2 to the auth_type CHECK constraint (it was removed in
+-- 20260222200000 when OAuth wasn't yet implemented).
+ALTER TABLE connector_required_credentials
+    DROP CONSTRAINT IF EXISTS connector_required_credentials_auth_type_check;
+ALTER TABLE connector_required_credentials
+    ADD CONSTRAINT connector_required_credentials_auth_type_check
+    CHECK (auth_type IN ('api_key', 'basic', 'custom', 'oauth2'));
+
+-- Add OAuth-specific columns for connectors that use oauth2 auth.
+ALTER TABLE connector_required_credentials
+    ADD COLUMN oauth_provider text CHECK (char_length(oauth_provider) <= 255),
+    ADD COLUMN oauth_scopes   text[] DEFAULT '{}';
+
+-- Enforce: oauth_provider is required when auth_type is oauth2,
+-- and must be NULL for other auth types.
+ALTER TABLE connector_required_credentials
+    ADD CONSTRAINT chk_oauth_provider_required
+    CHECK (
+        (auth_type = 'oauth2' AND oauth_provider IS NOT NULL)
+        OR (auth_type != 'oauth2' AND oauth_provider IS NULL)
+    );
+
+-- +goose Down
+
+ALTER TABLE connector_required_credentials
+    DROP CONSTRAINT IF EXISTS chk_oauth_provider_required;
+
+ALTER TABLE connector_required_credentials
+    DROP COLUMN IF EXISTS oauth_scopes,
+    DROP COLUMN IF EXISTS oauth_provider;
+
+ALTER TABLE connector_required_credentials
+    DROP CONSTRAINT IF EXISTS connector_required_credentials_auth_type_check;
+ALTER TABLE connector_required_credentials
+    ADD CONSTRAINT connector_required_credentials_auth_type_check
+    CHECK (auth_type IN ('api_key', 'basic', 'custom'));

--- a/db/migrations/20260305045137_enable_rls_oauth_tables.sql
+++ b/db/migrations/20260305045137_enable_rls_oauth_tables.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+ALTER TABLE oauth_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE oauth_provider_configs ENABLE ROW LEVEL SECURITY;
+
+-- +goose Down
+
+ALTER TABLE oauth_provider_configs DISABLE ROW LEVEL SECURITY;
+ALTER TABLE oauth_connections DISABLE ROW LEVEL SECURITY;

--- a/db/migrations/20260305102631_add_updated_at_to_oauth_provider_configs.sql
+++ b/db/migrations/20260305102631_add_updated_at_to_oauth_provider_configs.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+ALTER TABLE oauth_provider_configs
+    ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+
+-- +goose Down
+
+ALTER TABLE oauth_provider_configs
+    DROP COLUMN IF EXISTS updated_at;

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -1,0 +1,207 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// OAuthConnection represents a row from the oauth_connections table.
+type OAuthConnection struct {
+	ID                   string
+	UserID               string
+	Provider             string
+	AccessTokenVaultID   string
+	RefreshTokenVaultID  *string
+	Scopes               []string
+	TokenExpiry          *time.Time
+	Status               string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// CreateOAuthConnectionParams holds the parameters for inserting a new OAuth connection.
+type CreateOAuthConnectionParams struct {
+	ID                   string
+	UserID               string
+	Provider             string
+	AccessTokenVaultID   string
+	RefreshTokenVaultID  *string
+	Scopes               []string
+	TokenExpiry          *time.Time
+}
+
+// OAuthConnectionError represents a domain-specific error from OAuth connection operations.
+type OAuthConnectionError struct {
+	Code    OAuthConnectionErrCode
+	Message string
+}
+
+func (e *OAuthConnectionError) Error() string { return e.Message }
+
+// OAuthConnectionErrCode enumerates OAuth connection error codes.
+type OAuthConnectionErrCode int
+
+const (
+	OAuthConnectionErrNotFound  OAuthConnectionErrCode = iota
+	OAuthConnectionErrDuplicate                        // unique (user_id, provider) violation
+)
+
+// ListOAuthConnectionsByUser returns all OAuth connections for the given user,
+// ordered by created_at descending (newest first). Tokens are never returned.
+func ListOAuthConnectionsByUser(ctx context.Context, db DBTX, userID string) ([]OAuthConnection, error) {
+	rows, err := db.Query(ctx, `
+		SELECT id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
+		       scopes, token_expiry, status, created_at, updated_at
+		FROM oauth_connections
+		WHERE user_id = $1
+		ORDER BY created_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var conns []OAuthConnection
+	for rows.Next() {
+		var c OAuthConnection
+		if err := rows.Scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
+			&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
+			&c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, err
+		}
+		conns = append(conns, c)
+	}
+	return conns, rows.Err()
+}
+
+// GetOAuthConnectionByProvider returns the OAuth connection for a given user and provider.
+// Returns nil if no connection exists.
+func GetOAuthConnectionByProvider(ctx context.Context, db DBTX, userID, provider string) (*OAuthConnection, error) {
+	var c OAuthConnection
+	err := db.QueryRow(ctx, `
+		SELECT id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
+		       scopes, token_expiry, status, created_at, updated_at
+		FROM oauth_connections
+		WHERE user_id = $1 AND provider = $2`,
+		userID, provider,
+	).Scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
+		&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
+		&c.CreatedAt, &c.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// CreateOAuthConnection inserts a new OAuth connection row.
+// Returns a *OAuthConnectionError with code OAuthConnectionErrDuplicate if
+// the (user_id, provider) unique constraint is violated.
+func CreateOAuthConnection(ctx context.Context, db DBTX, p CreateOAuthConnectionParams) (*OAuthConnection, error) {
+	var c OAuthConnection
+	err := db.QueryRow(ctx, `
+		INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, refresh_token_vault_id, scopes, token_expiry)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
+		          scopes, token_expiry, status, created_at, updated_at`,
+		p.ID, p.UserID, p.Provider, p.AccessTokenVaultID, p.RefreshTokenVaultID, p.Scopes, p.TokenExpiry,
+	).Scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
+		&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
+		&c.CreatedAt, &c.UpdatedAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
+			return nil, &OAuthConnectionError{Code: OAuthConnectionErrDuplicate, Message: "OAuth connection already exists for this provider"}
+		}
+		return nil, err
+	}
+	return &c, nil
+}
+
+// UpdateOAuthConnectionTokens updates the vault secret IDs and expiry for a connection
+// after a successful token refresh.
+func UpdateOAuthConnectionTokens(ctx context.Context, db DBTX, id string, accessTokenVaultID string, refreshTokenVaultID *string, tokenExpiry *time.Time) error {
+	result, err := db.Exec(ctx, `
+		UPDATE oauth_connections
+		SET access_token_vault_id = $2,
+		    refresh_token_vault_id = $3,
+		    token_expiry = $4,
+		    status = 'active',
+		    updated_at = now()
+		WHERE id = $1`,
+		id, accessTokenVaultID, refreshTokenVaultID, tokenExpiry)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return &OAuthConnectionError{Code: OAuthConnectionErrNotFound, Message: "OAuth connection not found"}
+	}
+	return nil
+}
+
+// UpdateOAuthConnectionStatus updates the status of an OAuth connection.
+func UpdateOAuthConnectionStatus(ctx context.Context, db DBTX, id, status string) error {
+	result, err := db.Exec(ctx, `
+		UPDATE oauth_connections
+		SET status = $2, updated_at = now()
+		WHERE id = $1`,
+		id, status)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return &OAuthConnectionError{Code: OAuthConnectionErrNotFound, Message: "OAuth connection not found"}
+	}
+	return nil
+}
+
+// DeleteOAuthConnectionResult holds the result of an OAuth connection deletion.
+type DeleteOAuthConnectionResult struct {
+	AccessTokenVaultID  string
+	RefreshTokenVaultID *string
+}
+
+// DeleteOAuthConnection deletes an OAuth connection by user and provider.
+// Returns the vault secret IDs so the caller can delete the vault secrets too.
+func DeleteOAuthConnection(ctx context.Context, db DBTX, userID, provider string) (*DeleteOAuthConnectionResult, error) {
+	var result DeleteOAuthConnectionResult
+	err := db.QueryRow(ctx, `
+		DELETE FROM oauth_connections
+		WHERE user_id = $1 AND provider = $2
+		RETURNING access_token_vault_id, refresh_token_vault_id`,
+		userID, provider,
+	).Scan(&result.AccessTokenVaultID, &result.RefreshTokenVaultID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, &OAuthConnectionError{Code: OAuthConnectionErrNotFound, Message: "OAuth connection not found"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetRequiredCredentialByActionType returns the required credential for the connector
+// that owns the given action type. Used to determine auth_type at execution time.
+func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType string) (*RequiredCredential, error) {
+	var rc RequiredCredential
+	err := db.QueryRow(ctx, `
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		FROM connector_actions ca
+		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
+		WHERE ca.action_type = $1
+		LIMIT 1`,
+		actionType,
+	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &rc, nil
+}

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -9,6 +9,14 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+// OAuth connection status values. Must match the CHECK constraint on
+// oauth_connections.status in the migration.
+const (
+	OAuthStatusActive      = "active"
+	OAuthStatusNeedsReauth = "needs_reauth"
+	OAuthStatusRevoked     = "revoked"
+)
+
 // OAuthConnection represents a row from the oauth_connections table.
 type OAuthConnection struct {
 	ID                   string
@@ -50,12 +58,24 @@ const (
 	OAuthConnectionErrDuplicate                        // unique (user_id, provider) violation
 )
 
+// oauthConnectionColumns is the shared SELECT column list for oauth_connections queries.
+const oauthConnectionColumns = `id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
+		       scopes, token_expiry, status, created_at, updated_at`
+
+// scanOAuthConnection scans an OAuthConnection from a row scanner (pgx.Row or pgx.Rows).
+func scanOAuthConnection(scan func(dest ...any) error) (OAuthConnection, error) {
+	var c OAuthConnection
+	err := scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
+		&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
+		&c.CreatedAt, &c.UpdatedAt)
+	return c, err
+}
+
 // ListOAuthConnectionsByUser returns all OAuth connections for the given user,
 // ordered by created_at descending (newest first). Tokens are never returned.
 func ListOAuthConnectionsByUser(ctx context.Context, db DBTX, userID string) ([]OAuthConnection, error) {
 	rows, err := db.Query(ctx, `
-		SELECT id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
-		       scopes, token_expiry, status, created_at, updated_at
+		SELECT `+oauthConnectionColumns+`
 		FROM oauth_connections
 		WHERE user_id = $1
 		ORDER BY created_at DESC`, userID)
@@ -66,10 +86,8 @@ func ListOAuthConnectionsByUser(ctx context.Context, db DBTX, userID string) ([]
 
 	var conns []OAuthConnection
 	for rows.Next() {
-		var c OAuthConnection
-		if err := rows.Scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
-			&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
-			&c.CreatedAt, &c.UpdatedAt); err != nil {
+		c, err := scanOAuthConnection(rows.Scan)
+		if err != nil {
 			return nil, err
 		}
 		conns = append(conns, c)
@@ -80,16 +98,13 @@ func ListOAuthConnectionsByUser(ctx context.Context, db DBTX, userID string) ([]
 // GetOAuthConnectionByProvider returns the OAuth connection for a given user and provider.
 // Returns nil if no connection exists.
 func GetOAuthConnectionByProvider(ctx context.Context, db DBTX, userID, provider string) (*OAuthConnection, error) {
-	var c OAuthConnection
-	err := db.QueryRow(ctx, `
-		SELECT id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
-		       scopes, token_expiry, status, created_at, updated_at
+	row := db.QueryRow(ctx, `
+		SELECT `+oauthConnectionColumns+`
 		FROM oauth_connections
 		WHERE user_id = $1 AND provider = $2`,
 		userID, provider,
-	).Scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
-		&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
-		&c.CreatedAt, &c.UpdatedAt)
+	)
+	c, err := scanOAuthConnection(row.Scan)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -103,21 +118,35 @@ func GetOAuthConnectionByProvider(ctx context.Context, db DBTX, userID, provider
 // Returns a *OAuthConnectionError with code OAuthConnectionErrDuplicate if
 // the (user_id, provider) unique constraint is violated.
 func CreateOAuthConnection(ctx context.Context, db DBTX, p CreateOAuthConnectionParams) (*OAuthConnection, error) {
-	var c OAuthConnection
-	err := db.QueryRow(ctx, `
+	row := db.QueryRow(ctx, `
 		INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, refresh_token_vault_id, scopes, token_expiry)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-		RETURNING id, user_id, provider, access_token_vault_id, refresh_token_vault_id,
-		          scopes, token_expiry, status, created_at, updated_at`,
+		RETURNING `+oauthConnectionColumns,
 		p.ID, p.UserID, p.Provider, p.AccessTokenVaultID, p.RefreshTokenVaultID, p.Scopes, p.TokenExpiry,
-	).Scan(&c.ID, &c.UserID, &c.Provider, &c.AccessTokenVaultID,
-		&c.RefreshTokenVaultID, &c.Scopes, &c.TokenExpiry, &c.Status,
-		&c.CreatedAt, &c.UpdatedAt)
+	)
+	c, err := scanOAuthConnection(row.Scan)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
 			return nil, &OAuthConnectionError{Code: OAuthConnectionErrDuplicate, Message: "OAuth connection already exists for this provider"}
 		}
+		return nil, err
+	}
+	return &c, nil
+}
+
+// GetOAuthConnectionByID returns a single OAuth connection by its ID.
+// Returns nil if not found. Useful for token refresh and status update flows.
+func GetOAuthConnectionByID(ctx context.Context, db DBTX, id string) (*OAuthConnection, error) {
+	row := db.QueryRow(ctx, `
+		SELECT `+oauthConnectionColumns+`
+		FROM oauth_connections
+		WHERE id = $1`, id)
+	c, err := scanOAuthConnection(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
 		return nil, err
 	}
 	return &c, nil
@@ -131,10 +160,10 @@ func UpdateOAuthConnectionTokens(ctx context.Context, db DBTX, id string, access
 		SET access_token_vault_id = $2,
 		    refresh_token_vault_id = $3,
 		    token_expiry = $4,
-		    status = 'active',
+		    status = $5,
 		    updated_at = now()
 		WHERE id = $1`,
-		id, accessTokenVaultID, refreshTokenVaultID, tokenExpiry)
+		id, accessTokenVaultID, refreshTokenVaultID, tokenExpiry, OAuthStatusActive)
 	if err != nil {
 		return err
 	}

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -153,8 +154,9 @@ func GetOAuthConnectionByID(ctx context.Context, db DBTX, id string) (*OAuthConn
 }
 
 // UpdateOAuthConnectionTokens updates the vault secret IDs and expiry for a connection
-// after a successful token refresh.
-func UpdateOAuthConnectionTokens(ctx context.Context, db DBTX, id string, accessTokenVaultID string, refreshTokenVaultID *string, tokenExpiry *time.Time) error {
+// after a successful token refresh. The userID parameter ensures the caller
+// owns the connection (defense-in-depth against horizontal privilege escalation).
+func UpdateOAuthConnectionTokens(ctx context.Context, db DBTX, id, userID string, accessTokenVaultID string, refreshTokenVaultID *string, tokenExpiry *time.Time) error {
 	result, err := db.Exec(ctx, `
 		UPDATE oauth_connections
 		SET access_token_vault_id = $2,
@@ -162,8 +164,8 @@ func UpdateOAuthConnectionTokens(ctx context.Context, db DBTX, id string, access
 		    token_expiry = $4,
 		    status = $5,
 		    updated_at = now()
-		WHERE id = $1`,
-		id, accessTokenVaultID, refreshTokenVaultID, tokenExpiry, OAuthStatusActive)
+		WHERE id = $1 AND user_id = $6`,
+		id, accessTokenVaultID, refreshTokenVaultID, tokenExpiry, OAuthStatusActive, userID)
 	if err != nil {
 		return err
 	}
@@ -173,13 +175,26 @@ func UpdateOAuthConnectionTokens(ctx context.Context, db DBTX, id string, access
 	return nil
 }
 
+// validOAuthStatuses is the set of valid OAuth connection statuses.
+// Must match the CHECK constraint on oauth_connections.status.
+var validOAuthStatuses = map[string]bool{
+	OAuthStatusActive:      true,
+	OAuthStatusNeedsReauth: true,
+	OAuthStatusRevoked:     true,
+}
+
 // UpdateOAuthConnectionStatus updates the status of an OAuth connection.
-func UpdateOAuthConnectionStatus(ctx context.Context, db DBTX, id, status string) error {
+// Returns an error if the status value is not one of the valid constants.
+// The userID parameter ensures the caller owns the connection.
+func UpdateOAuthConnectionStatus(ctx context.Context, db DBTX, id, userID, status string) error {
+	if !validOAuthStatuses[status] {
+		return fmt.Errorf("invalid OAuth connection status %q", status)
+	}
 	result, err := db.Exec(ctx, `
 		UPDATE oauth_connections
 		SET status = $2, updated_at = now()
-		WHERE id = $1`,
-		id, status)
+		WHERE id = $1 AND user_id = $3`,
+		id, status, userID)
 	if err != nil {
 		return err
 	}

--- a/db/oauth_provider_configs.go
+++ b/db/oauth_provider_configs.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// OAuthProviderConfig represents a row from the oauth_provider_configs table.
+// This stores user-provided ("bring your own app") OAuth client credentials.
+type OAuthProviderConfig struct {
+	ID                   string
+	UserID               string
+	Provider             string
+	ClientIDVaultID      string
+	ClientSecretVaultID  string
+	CreatedAt            time.Time
+}
+
+// CreateOAuthProviderConfigParams holds the parameters for inserting a new provider config.
+type CreateOAuthProviderConfigParams struct {
+	ID                   string
+	UserID               string
+	Provider             string
+	ClientIDVaultID      string
+	ClientSecretVaultID  string
+}
+
+// OAuthProviderConfigError represents a domain-specific error from provider config operations.
+type OAuthProviderConfigError struct {
+	Code    OAuthProviderConfigErrCode
+	Message string
+}
+
+func (e *OAuthProviderConfigError) Error() string { return e.Message }
+
+// OAuthProviderConfigErrCode enumerates provider config error codes.
+type OAuthProviderConfigErrCode int
+
+const (
+	OAuthProviderConfigErrNotFound  OAuthProviderConfigErrCode = iota
+	OAuthProviderConfigErrDuplicate                            // unique (user_id, provider) violation
+)
+
+// ListOAuthProviderConfigsByUser returns all OAuth provider configs for the given user.
+func ListOAuthProviderConfigsByUser(ctx context.Context, db DBTX, userID string) ([]OAuthProviderConfig, error) {
+	rows, err := db.Query(ctx, `
+		SELECT id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at
+		FROM oauth_provider_configs
+		WHERE user_id = $1
+		ORDER BY created_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var configs []OAuthProviderConfig
+	for rows.Next() {
+		var c OAuthProviderConfig
+		if err := rows.Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		configs = append(configs, c)
+	}
+	return configs, rows.Err()
+}
+
+// GetOAuthProviderConfig returns the provider config for a given user and provider.
+// Returns nil if no config exists.
+func GetOAuthProviderConfig(ctx context.Context, db DBTX, userID, provider string) (*OAuthProviderConfig, error) {
+	var c OAuthProviderConfig
+	err := db.QueryRow(ctx, `
+		SELECT id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at
+		FROM oauth_provider_configs
+		WHERE user_id = $1 AND provider = $2`,
+		userID, provider,
+	).Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// CreateOAuthProviderConfig inserts a new provider config row.
+func CreateOAuthProviderConfig(ctx context.Context, db DBTX, p CreateOAuthProviderConfigParams) (*OAuthProviderConfig, error) {
+	var c OAuthProviderConfig
+	err := db.QueryRow(ctx, `
+		INSERT INTO oauth_provider_configs (id, user_id, provider, client_id_vault_id, client_secret_vault_id)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at`,
+		p.ID, p.UserID, p.Provider, p.ClientIDVaultID, p.ClientSecretVaultID,
+	).Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
+			return nil, &OAuthProviderConfigError{Code: OAuthProviderConfigErrDuplicate, Message: "OAuth provider config already exists for this provider"}
+		}
+		return nil, err
+	}
+	return &c, nil
+}
+
+// DeleteOAuthProviderConfigResult holds the result of a provider config deletion.
+type DeleteOAuthProviderConfigResult struct {
+	ClientIDVaultID     string
+	ClientSecretVaultID string
+}
+
+// DeleteOAuthProviderConfig deletes a provider config by user and provider.
+// Returns the vault secret IDs so the caller can delete the vault secrets too.
+func DeleteOAuthProviderConfig(ctx context.Context, db DBTX, userID, provider string) (*DeleteOAuthProviderConfigResult, error) {
+	var result DeleteOAuthProviderConfigResult
+	err := db.QueryRow(ctx, `
+		DELETE FROM oauth_provider_configs
+		WHERE user_id = $1 AND provider = $2
+		RETURNING client_id_vault_id, client_secret_vault_id`,
+		userID, provider,
+	).Scan(&result.ClientIDVaultID, &result.ClientSecretVaultID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, &OAuthProviderConfigError{Code: OAuthProviderConfigErrNotFound, Message: "OAuth provider config not found"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/db/oauth_provider_configs.go
+++ b/db/oauth_provider_configs.go
@@ -18,6 +18,7 @@ type OAuthProviderConfig struct {
 	ClientIDVaultID      string
 	ClientSecretVaultID  string
 	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 // CreateOAuthProviderConfigParams holds the parameters for inserting a new provider config.
@@ -48,7 +49,7 @@ const (
 // ListOAuthProviderConfigsByUser returns all OAuth provider configs for the given user.
 func ListOAuthProviderConfigsByUser(ctx context.Context, db DBTX, userID string) ([]OAuthProviderConfig, error) {
 	rows, err := db.Query(ctx, `
-		SELECT id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at
+		SELECT id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at, updated_at
 		FROM oauth_provider_configs
 		WHERE user_id = $1
 		ORDER BY created_at DESC`, userID)
@@ -60,7 +61,7 @@ func ListOAuthProviderConfigsByUser(ctx context.Context, db DBTX, userID string)
 	var configs []OAuthProviderConfig
 	for rows.Next() {
 		var c OAuthProviderConfig
-		if err := rows.Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt); err != nil {
+		if err := rows.Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
 		configs = append(configs, c)
@@ -73,11 +74,11 @@ func ListOAuthProviderConfigsByUser(ctx context.Context, db DBTX, userID string)
 func GetOAuthProviderConfig(ctx context.Context, db DBTX, userID, provider string) (*OAuthProviderConfig, error) {
 	var c OAuthProviderConfig
 	err := db.QueryRow(ctx, `
-		SELECT id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at
+		SELECT id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at, updated_at
 		FROM oauth_provider_configs
 		WHERE user_id = $1 AND provider = $2`,
 		userID, provider,
-	).Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt)
+	).Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -93,9 +94,9 @@ func CreateOAuthProviderConfig(ctx context.Context, db DBTX, p CreateOAuthProvid
 	err := db.QueryRow(ctx, `
 		INSERT INTO oauth_provider_configs (id, user_id, provider, client_id_vault_id, client_secret_vault_id)
 		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at`,
+		RETURNING id, user_id, provider, client_id_vault_id, client_secret_vault_id, created_at, updated_at`,
 		p.ID, p.UserID, p.Provider, p.ClientIDVaultID, p.ClientSecretVaultID,
-	).Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt)
+	).Scan(&c.ID, &c.UserID, &c.Provider, &c.ClientIDVaultID, &c.ClientSecretVaultID, &c.CreatedAt, &c.UpdatedAt)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -341,9 +341,43 @@ Use `connectors.TrimIndent()` to keep inline JSON readable while stripping the s
 |----------------|----------|---------|
 | Top-level fields | `connectors` | One row per connector (id, name, description) |
 | `actions[]` | `connector_actions` | One row per action (action_type, risk_level, optional parameters_schema) |
-| `required_credentials[]` | `connector_required_credentials` | What credentials this connector needs (service, auth_type, instructions_url) |
+| `required_credentials[]` | `connector_required_credentials` | What credentials this connector needs (service, auth_type, instructions_url, oauth_provider, oauth_scopes) |
 
-**Auth types:** `api_key`, `basic`, `custom`
+**Auth types:** `api_key`, `basic`, `custom`, `oauth2`
+
+When using `oauth2`, the credential entry must include `oauth_provider` (e.g., `"google"`, `"microsoft"`) and optionally `oauth_scopes`. Built-in providers (`google`, `microsoft`) are supported out of the box. External connectors can declare custom providers in the manifest's `oauth_providers` section (see below).
+
+```go
+// Example: OAuth2 credential in a manifest
+RequiredCredentials: []connectors.ManifestCredential{
+    {
+        Service:       "google",
+        AuthType:      "oauth2",
+        OAuthProvider: "google",
+        OAuthScopes:   []string{"https://www.googleapis.com/auth/gmail.send"},
+    },
+},
+```
+
+#### Declaring custom OAuth providers
+
+External connectors that use OAuth providers not built into the platform (anything other than `google` or `microsoft`) must declare them in the manifest's `oauth_providers` section. The platform uses these URLs to drive the OAuth authorization flow.
+
+```go
+OAuthProviders: []connectors.ManifestOAuthProvider{
+    {
+        ID:           "salesforce",
+        AuthorizeURL: "https://login.salesforce.com/services/oauth2/authorize",
+        TokenURL:     "https://login.salesforce.com/services/oauth2/token",
+        Scopes:       []string{"api", "refresh_token"},
+    },
+},
+```
+
+Requirements:
+- `authorize_url` and `token_url` must use HTTPS
+- Provider IDs must be unique within the manifest
+- Any `oauth_provider` referenced in `required_credentials` must either be a built-in provider or declared in `oauth_providers`
 
 **Risk levels:** `low`, `medium`, `high`
 
@@ -817,8 +851,10 @@ CREATE TABLE connector_actions (
 CREATE TABLE connector_required_credentials (
     connector_id    text NOT NULL REFERENCES connectors(id),
     service         text NOT NULL,              -- credential service identifier
-    auth_type       text NOT NULL,              -- 'api_key' | 'basic' | 'custom'
+    auth_type       text NOT NULL,              -- 'api_key' | 'basic' | 'custom' | 'oauth2'
     instructions_url text,                      -- optional URL for credential setup docs
+    oauth_provider  text,                       -- required when auth_type = 'oauth2'
+    oauth_scopes    text[] DEFAULT '{}',        -- OAuth scopes when auth_type = 'oauth2'
     PRIMARY KEY (connector_id, service)
 );
 ```

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -48,7 +48,10 @@ Credential types required by a connector. The `service` column is a join key to 
 |---|---|---|
 | `connector_id` | text | PK (composite), FK → connectors ON DELETE CASCADE, max 255 chars |
 | `service` | text | PK (composite), max 255 chars (join key to `credentials.service`) |
-| `auth_type` | text | NOT NULL, CHECK IN ('api_key', 'basic', 'custom') |
+| `auth_type` | text | NOT NULL, CHECK IN ('api_key', 'basic', 'custom', 'oauth2') |
+| `instructions_url` | text | max 2048 chars, optional URL for credential setup docs |
+| `oauth_provider` | text | max 255 chars, required when auth_type = 'oauth2', NULL otherwise |
+| `oauth_scopes` | text[] | DEFAULT '{}', OAuth scopes required when auth_type = 'oauth2' |
 
 ### `registration_invites`
 
@@ -165,6 +168,45 @@ User credentials stored via Supabase Vault. The table holds a reference to the V
 **Constraints:** UNIQUE NULLS NOT DISTINCT on `(user_id, service, label)` — prevents duplicate credentials including when label is NULL.
 
 **Indexes:** `idx_credentials_user_service` on `(user_id, service)`
+
+### `oauth_connections`
+
+Stores OAuth 2.0 connections for users. Each row represents a user's authenticated connection to an OAuth provider (e.g., Google, Microsoft). Tokens are stored in the Vault — this table only holds Vault references.
+
+| Column | Type | Constraints |
+|---|---|---|
+| `id` | text | PK, max 255 chars |
+| `user_id` | uuid | NOT NULL, FK → profiles(id) ON DELETE CASCADE |
+| `provider` | text | NOT NULL, max 255 chars (e.g., "google", "microsoft") |
+| `access_token_vault_id` | uuid | NOT NULL |
+| `refresh_token_vault_id` | uuid | Nullable |
+| `scopes` | text[] | NOT NULL, DEFAULT '{}' |
+| `token_expiry` | timestamptz | Nullable |
+| `status` | text | NOT NULL, DEFAULT 'active', CHECK IN ('active', 'needs_reauth', 'revoked') |
+| `created_at` | timestamptz | NOT NULL, DEFAULT now() |
+| `updated_at` | timestamptz | NOT NULL, DEFAULT now() |
+
+**Constraints:** UNIQUE on `(user_id, provider)` — one connection per provider per user.
+
+**Indexes:** `idx_oauth_connections_user` on `(user_id)`, `idx_oauth_connections_status` on `(user_id, status)`
+
+### `oauth_provider_configs`
+
+Stores user-provided ("bring your own app") OAuth client credentials. Users register their own OAuth app's client ID and secret for a provider, rather than using a platform-managed app.
+
+| Column | Type | Constraints |
+|---|---|---|
+| `id` | text | PK, max 255 chars |
+| `user_id` | uuid | NOT NULL, FK → profiles(id) ON DELETE CASCADE |
+| `provider` | text | NOT NULL, max 255 chars |
+| `client_id_vault_id` | uuid | NOT NULL |
+| `client_secret_vault_id` | uuid | NOT NULL |
+| `created_at` | timestamptz | NOT NULL, DEFAULT now() |
+| `updated_at` | timestamptz | NOT NULL, DEFAULT now() |
+
+**Constraints:** UNIQUE on `(user_id, provider)` — one config per provider per user.
+
+**Indexes:** `idx_oauth_provider_configs_user` on `(user_id)`
 
 ### `agent_connectors`
 
@@ -351,6 +393,8 @@ auth.users
         ├── agents (approver_id → profiles, CASCADE)
         ├── approvals (approver_id → profiles, CASCADE)
         ├── credentials (user_id → profiles, CASCADE)
+        ├── oauth_connections (user_id → profiles, CASCADE)
+        ├── oauth_provider_configs (user_id → profiles, CASCADE)
         ├── standing_approvals (user_id → profiles, CASCADE)
         └── audit_events (user_id → profiles, RESTRICT)
 

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -262,8 +262,10 @@ RequiredCredential:
         - api_key
         - basic
         - custom
+        - oauth2
       description: |
-        Authentication type required by the external service.
+        Authentication type required by the external service. When `oauth2`, the user
+        must connect their account via the OAuth flow instead of providing static credentials.
       example: "api_key"
 
     instructions_url:
@@ -274,6 +276,23 @@ RequiredCredential:
         URL to human-readable documentation explaining how to obtain credentials
         for this service. Only present when the connector provides setup instructions.
       example: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
+
+    oauth_provider:
+      type: string
+      maxLength: 255
+      description: |
+        OAuth provider identifier. Only present when `auth_type` is `oauth2`.
+        Identifies which OAuth provider the user must connect to (e.g. "google", "microsoft").
+      example: "google"
+
+    oauth_scopes:
+      type: array
+      items:
+        type: string
+      description: |
+        OAuth scopes required by this connector. Only present when `auth_type` is `oauth2`.
+      example:
+        - "https://www.googleapis.com/auth/gmail.send"
 
   example:
     service: "github"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -6762,8 +6762,10 @@ components:
             - api_key
             - basic
             - custom
+            - oauth2
           description: |
-            Authentication type required by the external service.
+            Authentication type required by the external service. When `oauth2`, the user
+            must connect their account via the OAuth flow instead of providing static credentials.
           example: api_key
         instructions_url:
           type: string
@@ -6773,6 +6775,21 @@ components:
             URL to human-readable documentation explaining how to obtain credentials
             for this service. Only present when the connector provides setup instructions.
           example: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+        oauth_provider:
+          type: string
+          maxLength: 255
+          description: |
+            OAuth provider identifier. Only present when `auth_type` is `oauth2`.
+            Identifies which OAuth provider the user must connect to (e.g. "google", "microsoft").
+          example: google
+        oauth_scopes:
+          type: array
+          items:
+            type: string
+          description: |
+            OAuth scopes required by this connector. Only present when `auth_type` is `oauth2`.
+          example:
+            - https://www.googleapis.com/auth/gmail.send
       example:
         service: github
         auth_type: api_key


### PR DESCRIPTION
## Summary

Implements Phase 1 of [OAuth 2.0 support (#80)](https://github.com/supersuit-tech/permission-slip/issues/80): core database schema, Go types, and validation for OAuth 2.0 connector authentication.

- **4 database migrations**: `oauth_connections` table (vault-encrypted tokens, per-user-provider unique constraint), `oauth_provider_configs` table (BYOA client credentials), re-added `oauth2` to `auth_type` enum with `oauth_provider`/`oauth_scopes` columns on `connector_required_credentials`, RLS enabled on new tables
- **Manifest extensions**: `ManifestCredential` gains `OAuthProvider` and `OAuthScopes` fields; new `ManifestOAuthProvider` type for external connectors to declare custom OAuth providers; `ConnectorManifest` gains `OAuthProviders` field
- **Validation rules**: `oauth2` auth type requires `oauth_provider`; non-oauth2 types reject OAuth fields; OAuth provider URLs must use HTTPS; duplicate provider IDs rejected
- **DB layer**: Full CRUD for `oauth_connections` (create, list, get-by-provider, update tokens, update status, delete) and `oauth_provider_configs` (create, list, get, delete); new `GetRequiredCredentialByActionType` for execution-time auth type resolution
- **API response types**: `requiredCredentialResponse` now includes `oauth_provider` and `oauth_scopes` fields
- **OpenAPI spec**: `oauth2` added to `auth_type` enum; new `oauth_provider` and `oauth_scopes` fields on `RequiredCredential` schema

### What this enables (next phases)
- Phase 2: OAuth provider registry with built-in Google/Microsoft configs
- Phase 3: OAuth API endpoints (authorize, callback, connections list, disconnect)
- Phase 4: Token refresh (pre-execution + background)
- Phase 5: Connector execution integration (resolve OAuth tokens instead of static credentials)

## Test plan

- [x] All backend tests pass (`make test-backend` — 0 failures)
- [x] All frontend tests pass (`make test-frontend` — 595 tests)
- [x] Full build succeeds (`make build`)
- [x] Migrations apply cleanly against fresh database
- [x] New manifest validation tests cover OAuth credential rules and OAuth provider rules
- [x] Schema column assertions verify new tables and columns exist
- [ ] Manual: verify `make migrate-up` then `make migrate-down` round-trips cleanly

https://claude.ai/code/session_01FPtn9oZchXXVTui8y3xq6Z