### PR TITLE
feat: OAuth Phase 2 — Provider Registry

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -13,11 +13,11 @@ Poll a GitHub Pull Request for all comments (general and inline review comments)
 
 Extract the PR number from the provided URL: `$ARGUMENTS`
 
-Parse the PR number from the URL (e.g., `https://github.com/supersuit-tech/permission-slip-web/pull/123` → `123`).
+Parse the PR number from the URL (e.g., `https://github.com/supersuit-tech/permission-slip/pull/123` → `123`).
 
 Set these variables for the session:
 - `PR_NUMBER` — the extracted PR number
-- `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh`
+- `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
 
 ## Pre-Poll: Merge from Main
 
@@ -42,13 +42,13 @@ Fetch **all** comments and reviews using all three endpoints (PR reviews, review
 
 ```bash
 # PR reviews (top-level review submissions — approve, request changes, comment)
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh api "/repos/supersuit-tech/permission-slip-web/pulls/${PR_NUMBER}/reviews?per_page=100"
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}/reviews?per_page=100"
 
 # Review comments (inline on diffs)
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh api "/repos/supersuit-tech/permission-slip-web/pulls/${PR_NUMBER}/comments?per_page=100"
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}/comments?per_page=100"
 
 # Issue-level comments (general PR conversation)
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh api "/repos/supersuit-tech/permission-slip-web/issues/${PR_NUMBER}/comments?per_page=100"
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/issues/${PR_NUMBER}/comments?per_page=100"
 ```
 
 Handle pagination if there are more than 100 results per endpoint.
@@ -119,7 +119,7 @@ For each new comment or review:
 After addressing a review comment, **resolve the conversation** using the GitHub GraphQL API:
 
 ```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh api graphql -f query='
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api graphql -f query='
 mutation {
   resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) {
     thread {
@@ -132,9 +132,9 @@ mutation {
 To get the thread node ID, use the `node_id` field from the review comment, or query for PR review threads:
 
 ```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh api graphql -f query='
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api graphql -f query='
 query {
-  repository(owner: "supersuit-tech", name: "permission-slip-web") {
+  repository(owner: "supersuit-tech", name: "permission-slip") {
     pullRequest(number: PR_NUMBER) {
       reviewThreads(first: 100) {
         nodes {
@@ -185,7 +185,7 @@ If any cycle finds new comments, reviews, merge conflicts that needed resolution
 When stopping due to the idle timeout, post a comment on the PR summarizing the entire watch session. Use the following command:
 
 ```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh api "/repos/supersuit-tech/permission-slip-web/issues/${PR_NUMBER}/comments" -f body="<comment body>"
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/issues/${PR_NUMBER}/comments" -f body="<comment body>"
 ```
 
 The comment must include these sections:
@@ -249,7 +249,7 @@ CI is manual-only, so after posting the wrap-up comment, **trigger CI once** aga
 #### a) Trigger the CI workflow
 
 ```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh workflow run ci.yml --ref "$(git branch --show-current)"
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run ci.yml --ref "$(git branch --show-current)"
 ```
 
 #### b) Wait for the run to appear and complete
@@ -258,7 +258,7 @@ Poll until the run triggered above finishes. First, wait ~5 seconds for the run 
 
 ```bash
 # Find the most recent run on this branch
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh run list --workflow=ci.yml --branch "$(git branch --show-current)" --limit 1 --json databaseId,status,conclusion
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh run list --workflow=ci.yml --branch "$(git branch --show-current)" --limit 1 --json databaseId,status,conclusion
 ```
 
 Poll every 30 seconds until `status` is `completed`.
@@ -271,7 +271,7 @@ If `conclusion` is `failure`:
 
 1. Fetch the failed run's logs:
    ```bash
-   GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip-web gh run view <run-id> --log-failed
+   GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh run view <run-id> --log-failed
    ```
 2. **Read the failure logs** to understand what went wrong.
 3. **Reproduce locally** by running the relevant commands (`make test-backend`, `make test-frontend`, `make build`).

--- a/api/router.go
+++ b/api/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/notify"
+	"github.com/supersuit-tech/permission-slip-web/oauth"
 	pstripe "github.com/supersuit-tech/permission-slip-web/stripe"
 	"github.com/supersuit-tech/permission-slip-web/vault"
 )
@@ -26,6 +27,7 @@ type Deps struct {
 	Notifier              *notify.Dispatcher   // notification fan-out; nil means notifications are disabled
 	VAPIDPublicKey        string               // VAPID public key for Web Push; empty if not configured
 	Connectors            *connectors.Registry // connector execution registry; nil means no connectors are available
+	OAuthProviders        *oauth.Registry      // OAuth provider registry; nil means OAuth is not available
 	Stripe                *pstripe.Client      // Stripe API client; nil when billing is disabled or Stripe keys not set
 	BillingEnabled        bool                 // true when BILLING_ENABLED=true; gates Stripe, metering, and billing endpoints
 	DevMode               bool                 // true when MODE=development; disables rate limiting

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ graph TB
         SA["Standing Approval Engine<br/><i>Pre-authorized grants,<br/>constraint matching,<br/>execution counting</i>"]
         NS["Notification Service<br/><i>Push notifications,<br/>webhooks</i>"]
         CV["Credential Vault<br/><i>Encrypted at rest,<br/>OAuth tokens, API keys</i>"]
+        OR["OAuth Provider Registry<br/><i>Built-in + manifest providers,<br/>BYOA client credentials</i>"]
         CE["Connector Engine"]
 
         subgraph Connectors
@@ -79,12 +80,15 @@ graph TB
     CE --> GC & SC & OC
     GC --> CV
     SC --> CV
+    OR --> CV
+    CE --> OR
     GC -- "API call with<br/>user credentials" --> Gmail
     SC -- "API call with<br/>user credentials" --> Stripe
 
     style PS fill:#E8F0FE,stroke:#4A90D9,color:#000
     style GW fill:#4A90D9,color:#fff,stroke:#2A5F9E
     style CV fill:#D93025,color:#fff,stroke:#B9200F
+    style OR fill:#E37400,color:#fff,stroke:#C35400
     style TE fill:#F9AB00,color:#000,stroke:#D98B00
     style AR fill:#7B68EE,color:#fff,stroke:#5B48CE
     style AE fill:#34A853,color:#fff,stroke:#1A8833

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -376,8 +376,10 @@ OAuthProviders: []connectors.ManifestOAuthProvider{
 
 Requirements:
 - `authorize_url` and `token_url` must use HTTPS
-- Provider IDs must be unique within the manifest
+- Provider IDs must be unique within the manifest and must be lowercase alphanumeric with hyphens/underscores (1-63 chars)
 - Any `oauth_provider` referenced in `required_credentials` must either be a built-in provider or declared in `oauth_providers`
+
+**How it works at runtime:** On startup, the platform builds an OAuth Provider Registry (`oauth.Registry`). Built-in providers (Google, Microsoft) are registered first with endpoints and default scopes. Then, providers declared in connector manifests are merged in. The registry uses a priority system (BYOA > Manifest > BuiltIn) so that user-provided "bring your own app" credentials overlay the platform's built-in configuration. When a BYOA user registers credentials for a provider, only their client ID and secret are required — endpoints and scopes are inherited from the built-in or manifest definition.
 
 **Risk levels:** `low`, `medium`, `high`
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors/slack"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/notify"
+	poauth "github.com/supersuit-tech/permission-slip-web/oauth"
 	"github.com/supersuit-tech/permission-slip-web/notify/mobilepush"
 	"github.com/supersuit-tech/permission-slip-web/notify/webpush"
 	pstripe "github.com/supersuit-tech/permission-slip-web/stripe"
@@ -303,6 +304,22 @@ func main() {
 	loadExternalConnectors(registry, deps.DB)
 
 	deps.Connectors = registry
+
+	// Initialize OAuth provider registry with built-in providers (Google, Microsoft)
+	// and merge in any providers declared by connector manifests.
+	oauthRegistry := poauth.NewRegistryWithBuiltIns()
+	registerManifestOAuthProviders(oauthRegistry, registry)
+	deps.OAuthProviders = oauthRegistry
+	oauthIDs := oauthRegistry.IDs()
+	log.Printf("OAuth provider registry: %d provider(s) registered", len(oauthIDs))
+	for _, p := range oauthRegistry.List() {
+		if p.HasClientCredentials() {
+			log.Printf("  %s: configured (client credentials set)", p.ID)
+		} else {
+			log.Printf("  %s: registered (no client credentials — BYOA required)", p.ID)
+		}
+	}
+
 	log.Printf("Connector registry: %d connector(s) registered", len(registry.IDs()))
 
 	// Parse allowed CORS origins from a comma-separated list.
@@ -542,6 +559,34 @@ func seedConnectorFromManifest(manifest *connectors.ConnectorManifest, d db.DBTX
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return db.UpsertConnectorFromManifest(ctx, d, manifest.ToDBManifest())
+}
+
+// registerManifestOAuthProviders iterates over all connectors in the registry
+// and registers any OAuth providers declared in their manifests. This allows
+// external connectors to introduce new OAuth providers (e.g. Salesforce) without
+// core code changes.
+func registerManifestOAuthProviders(oauthReg *poauth.Registry, connReg *connectors.Registry) {
+	for _, id := range connReg.IDs() {
+		conn, _ := connReg.Get(id)
+		mp, ok := conn.(connectors.ManifestProvider)
+		if !ok {
+			continue
+		}
+		manifest := mp.Manifest()
+		if len(manifest.OAuthProviders) == 0 {
+			continue
+		}
+		providers := make([]poauth.ManifestProvider, len(manifest.OAuthProviders))
+		for i, p := range manifest.OAuthProviders {
+			providers[i] = poauth.ManifestProvider{
+				ID:           p.ID,
+				AuthorizeURL: p.AuthorizeURL,
+				TokenURL:     p.TokenURL,
+				Scopes:       p.Scopes,
+			}
+		}
+		poauth.RegisterFromManifest(oauthReg, providers)
+	}
 }
 
 // validateConnectorRegistry logs warnings for mismatches between code-registered

--- a/main.go
+++ b/main.go
@@ -310,8 +310,7 @@ func main() {
 	oauthRegistry := poauth.NewRegistryWithBuiltIns()
 	registerManifestOAuthProviders(oauthRegistry, registry)
 	deps.OAuthProviders = oauthRegistry
-	oauthIDs := oauthRegistry.IDs()
-	log.Printf("OAuth provider registry: %d provider(s) registered", len(oauthIDs))
+	log.Printf("OAuth provider registry: %d provider(s) registered", oauthRegistry.Len())
 	for _, p := range oauthRegistry.List() {
 		if p.HasClientCredentials() {
 			log.Printf("  %s: configured (client credentials set)", p.ID)
@@ -585,7 +584,9 @@ func registerManifestOAuthProviders(oauthReg *poauth.Registry, connReg *connecto
 				Scopes:       p.Scopes,
 			}
 		}
-		poauth.RegisterFromManifest(oauthReg, providers)
+		if err := poauth.RegisterFromManifest(oauthReg, providers); err != nil {
+			log.Printf("Warning: failed to register OAuth providers from connector %q: %v", id, err)
+		}
 	}
 }
 

--- a/oauth/builtin.go
+++ b/oauth/builtin.go
@@ -1,0 +1,72 @@
+package oauth
+
+import "os"
+
+// BuiltInProviders returns the platform's pre-configured OAuth providers.
+// Client credentials are read from environment variables; if not set, the
+// providers are still registered (so manifest validation passes) but cannot
+// initiate OAuth flows until BYOA credentials are supplied.
+func BuiltInProviders() []Provider {
+	return []Provider{
+		{
+			ID:           "google",
+			AuthorizeURL: "https://accounts.google.com/o/oauth2/v2/auth",
+			TokenURL:     "https://oauth2.googleapis.com/token",
+			Scopes: []string{
+				"openid",
+				"https://www.googleapis.com/auth/userinfo.email",
+			},
+			ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+			ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+			Source:       SourceBuiltIn,
+		},
+		{
+			ID:           "microsoft",
+			AuthorizeURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+			TokenURL:     "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+			Scopes: []string{
+				"openid",
+				"offline_access",
+				"User.Read",
+			},
+			ClientID:     os.Getenv("MICROSOFT_CLIENT_ID"),
+			ClientSecret: os.Getenv("MICROSOFT_CLIENT_SECRET"),
+			Source:       SourceBuiltIn,
+		},
+	}
+}
+
+// NewRegistryWithBuiltIns creates a new provider registry pre-populated with
+// the platform's built-in providers.
+func NewRegistryWithBuiltIns() *Registry {
+	r := NewRegistry()
+	for _, p := range BuiltInProviders() {
+		r.Register(p)
+	}
+	return r
+}
+
+// RegisterFromManifest registers providers declared in a connector manifest's
+// oauth_providers section. These are external providers that the platform
+// doesn't have built-in support for (e.g. Salesforce, HubSpot). They are
+// registered without client credentials — users must supply those via BYOA.
+func RegisterFromManifest(r *Registry, providers []ManifestProvider) {
+	for _, mp := range providers {
+		r.Register(Provider{
+			ID:           mp.ID,
+			AuthorizeURL: mp.AuthorizeURL,
+			TokenURL:     mp.TokenURL,
+			Scopes:       mp.Scopes,
+			Source:       SourceManifest,
+		})
+	}
+}
+
+// ManifestProvider mirrors the OAuth provider declaration in a connector
+// manifest. This avoids a circular import between oauth/ and connectors/.
+type ManifestProvider struct {
+	ID           string
+	AuthorizeURL string
+	TokenURL     string
+	Scopes       []string
+}

--- a/oauth/builtin.go
+++ b/oauth/builtin.go
@@ -1,6 +1,9 @@
 package oauth
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // BuiltInProviders returns the platform's pre-configured OAuth providers.
 // Client credentials are read from environment variables; if not set, the
@@ -37,11 +40,14 @@ func BuiltInProviders() []Provider {
 }
 
 // NewRegistryWithBuiltIns creates a new provider registry pre-populated with
-// the platform's built-in providers.
+// the platform's built-in providers. Panics if a built-in provider has an
+// invalid ID (programming error).
 func NewRegistryWithBuiltIns() *Registry {
 	r := NewRegistry()
 	for _, p := range BuiltInProviders() {
-		r.Register(p)
+		if err := r.Register(p); err != nil {
+			panic(fmt.Sprintf("failed to register built-in OAuth provider %q: %v", p.ID, err))
+		}
 	}
 	return r
 }
@@ -50,16 +56,20 @@ func NewRegistryWithBuiltIns() *Registry {
 // oauth_providers section. These are external providers that the platform
 // doesn't have built-in support for (e.g. Salesforce, HubSpot). They are
 // registered without client credentials — users must supply those via BYOA.
-func RegisterFromManifest(r *Registry, providers []ManifestProvider) {
+// Returns an error if any provider fails validation.
+func RegisterFromManifest(r *Registry, providers []ManifestProvider) error {
 	for _, mp := range providers {
-		r.Register(Provider{
+		if err := r.Register(Provider{
 			ID:           mp.ID,
 			AuthorizeURL: mp.AuthorizeURL,
 			TokenURL:     mp.TokenURL,
 			Scopes:       mp.Scopes,
 			Source:       SourceManifest,
-		})
+		}); err != nil {
+			return fmt.Errorf("registering manifest OAuth provider %q: %w", mp.ID, err)
+		}
 	}
+	return nil
 }
 
 // ManifestProvider mirrors the OAuth provider declaration in a connector

--- a/oauth/builtin_test.go
+++ b/oauth/builtin_test.go
@@ -1,0 +1,134 @@
+package oauth
+
+import (
+	"testing"
+)
+
+func TestBuiltInProviders(t *testing.T) {
+	providers := BuiltInProviders()
+
+	if len(providers) < 2 {
+		t.Fatalf("expected at least 2 built-in providers, got %d", len(providers))
+	}
+
+	// Build a map for easier lookup.
+	byID := make(map[string]Provider, len(providers))
+	for _, p := range providers {
+		byID[p.ID] = p
+	}
+
+	t.Run("google", func(t *testing.T) {
+		g, ok := byID["google"]
+		if !ok {
+			t.Fatal("google provider not found")
+		}
+		if g.AuthorizeURL != "https://accounts.google.com/o/oauth2/v2/auth" {
+			t.Errorf("AuthorizeURL = %q", g.AuthorizeURL)
+		}
+		if g.TokenURL != "https://oauth2.googleapis.com/token" {
+			t.Errorf("TokenURL = %q", g.TokenURL)
+		}
+		if g.Source != SourceBuiltIn {
+			t.Errorf("Source = %q, want %q", g.Source, SourceBuiltIn)
+		}
+		if len(g.Scopes) == 0 {
+			t.Error("expected default scopes")
+		}
+	})
+
+	t.Run("microsoft", func(t *testing.T) {
+		m, ok := byID["microsoft"]
+		if !ok {
+			t.Fatal("microsoft provider not found")
+		}
+		if m.AuthorizeURL != "https://login.microsoftonline.com/common/oauth2/v2.0/authorize" {
+			t.Errorf("AuthorizeURL = %q", m.AuthorizeURL)
+		}
+		if m.TokenURL != "https://login.microsoftonline.com/common/oauth2/v2.0/token" {
+			t.Errorf("TokenURL = %q", m.TokenURL)
+		}
+		if m.Source != SourceBuiltIn {
+			t.Errorf("Source = %q, want %q", m.Source, SourceBuiltIn)
+		}
+		if len(m.Scopes) == 0 {
+			t.Error("expected default scopes")
+		}
+	})
+}
+
+func TestNewRegistryWithBuiltIns(t *testing.T) {
+	r := NewRegistryWithBuiltIns()
+
+	ids := r.IDs()
+	if len(ids) < 2 {
+		t.Fatalf("expected at least 2 providers, got %d", len(ids))
+	}
+
+	if _, ok := r.Get("google"); !ok {
+		t.Error("google not found in registry")
+	}
+	if _, ok := r.Get("microsoft"); !ok {
+		t.Error("microsoft not found in registry")
+	}
+}
+
+func TestRegisterFromManifest(t *testing.T) {
+	r := NewRegistry()
+
+	providers := []ManifestProvider{
+		{
+			ID:           "salesforce",
+			AuthorizeURL: "https://login.salesforce.com/services/oauth2/authorize",
+			TokenURL:     "https://login.salesforce.com/services/oauth2/token",
+			Scopes:       []string{"api", "refresh_token"},
+		},
+		{
+			ID:           "hubspot",
+			AuthorizeURL: "https://app.hubspot.com/oauth/authorize",
+			TokenURL:     "https://api.hubapi.com/oauth/v1/token",
+		},
+	}
+
+	RegisterFromManifest(r, providers)
+
+	if len(r.IDs()) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(r.IDs()))
+	}
+
+	sf, ok := r.Get("salesforce")
+	if !ok {
+		t.Fatal("salesforce not found")
+	}
+	if sf.Source != SourceManifest {
+		t.Errorf("Source = %q, want %q", sf.Source, SourceManifest)
+	}
+	if sf.AuthorizeURL != "https://login.salesforce.com/services/oauth2/authorize" {
+		t.Errorf("AuthorizeURL = %q", sf.AuthorizeURL)
+	}
+	if len(sf.Scopes) != 2 {
+		t.Errorf("Scopes = %v, want [api refresh_token]", sf.Scopes)
+	}
+	if sf.HasClientCredentials() {
+		t.Error("manifest-registered provider should not have client credentials")
+	}
+}
+
+func TestRegisterFromManifest_DoesNotOverrideBuiltIn(t *testing.T) {
+	r := NewRegistryWithBuiltIns()
+
+	// Try to register a manifest provider with the same ID as a built-in.
+	RegisterFromManifest(r, []ManifestProvider{
+		{
+			ID:           "google",
+			AuthorizeURL: "https://evil.com/auth",
+			TokenURL:     "https://evil.com/token",
+		},
+	})
+
+	// Manifest has higher priority than built-in, so it should override.
+	// This is intentional — a connector may need different endpoints.
+	g, _ := r.Get("google")
+	if g.Source != SourceManifest {
+		t.Errorf("expected manifest to override built-in, got Source = %q", g.Source)
+	}
+}

--- a/oauth/builtin_test.go
+++ b/oauth/builtin_test.go
@@ -89,10 +89,12 @@ func TestRegisterFromManifest(t *testing.T) {
 		},
 	}
 
-	RegisterFromManifest(r, providers)
+	if err := RegisterFromManifest(r, providers); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	if len(r.IDs()) != 2 {
-		t.Fatalf("expected 2 providers, got %d", len(r.IDs()))
+	if r.Len() != 2 {
+		t.Fatalf("expected 2 providers, got %d", r.Len())
 	}
 
 	sf, ok := r.Get("salesforce")
@@ -113,17 +115,29 @@ func TestRegisterFromManifest(t *testing.T) {
 	}
 }
 
+func TestRegisterFromManifest_InvalidID(t *testing.T) {
+	r := NewRegistry()
+	err := RegisterFromManifest(r, []ManifestProvider{
+		{ID: "INVALID", AuthorizeURL: "https://example.com/auth", TokenURL: "https://example.com/token"},
+	})
+	if err == nil {
+		t.Error("expected error for invalid provider ID")
+	}
+}
+
 func TestRegisterFromManifest_DoesNotOverrideBuiltIn(t *testing.T) {
 	r := NewRegistryWithBuiltIns()
 
 	// Try to register a manifest provider with the same ID as a built-in.
-	RegisterFromManifest(r, []ManifestProvider{
+	if err := RegisterFromManifest(r, []ManifestProvider{
 		{
 			ID:           "google",
 			AuthorizeURL: "https://evil.com/auth",
 			TokenURL:     "https://evil.com/token",
 		},
-	})
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Manifest has higher priority than built-in, so it should override.
 	// This is intentional — a connector may need different endpoints.

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -5,6 +5,7 @@
 package oauth
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -91,6 +92,67 @@ func (ts TokenSet) IsExpired() bool {
 // supplied.
 func (p Provider) HasClientCredentials() bool {
 	return p.ClientID != "" && p.ClientSecret != ""
+}
+
+// String returns a human-readable representation with secrets redacted.
+// This prevents accidental exposure of ClientSecret in logs or error messages.
+func (p Provider) String() string {
+	creds := "none"
+	if p.HasClientCredentials() {
+		creds = "configured"
+	}
+	return fmt.Sprintf("Provider{ID: %q, Source: %q, Credentials: %s}", p.ID, p.Source, creds)
+}
+
+// GoString redacts secrets in %#v formatting.
+func (p Provider) GoString() string {
+	return p.String()
+}
+
+// MarshalJSON serializes the provider with the ClientSecret redacted. This
+// prevents accidental exposure if a Provider value is included in an API
+// response, log entry, or error report. Code that needs the actual secret
+// should access the ClientSecret field directly.
+func (p Provider) MarshalJSON() ([]byte, error) {
+	type safeProvider struct {
+		ID           string         `json:"id"`
+		AuthorizeURL string         `json:"authorize_url"`
+		TokenURL     string         `json:"token_url"`
+		Scopes       []string       `json:"scopes,omitempty"`
+		ClientID     string         `json:"client_id,omitempty"`
+		ClientSecret string         `json:"client_secret,omitempty"`
+		Source       ProviderSource `json:"source"`
+	}
+	safe := safeProvider{
+		ID:           p.ID,
+		AuthorizeURL: p.AuthorizeURL,
+		TokenURL:     p.TokenURL,
+		Scopes:       p.Scopes,
+		ClientID:     p.ClientID,
+		Source:       p.Source,
+	}
+	if p.ClientSecret != "" {
+		safe.ClientSecret = "[REDACTED]"
+	}
+	return json.Marshal(safe)
+}
+
+// String returns a redacted representation of the token set. This prevents
+// accidental exposure of access/refresh tokens in logs or error messages.
+func (ts TokenSet) String() string {
+	return fmt.Sprintf("TokenSet{Scopes: %v, Expiry: %v, HasRefresh: %v}",
+		ts.Scopes, ts.Expiry, ts.RefreshToken != "")
+}
+
+// GoString redacts tokens in %#v formatting.
+func (ts TokenSet) GoString() string {
+	return ts.String()
+}
+
+// MarshalJSON redacts token values to prevent accidental serialization of
+// access/refresh tokens.
+func (ts TokenSet) MarshalJSON() ([]byte, error) {
+	return []byte(`"[REDACTED]"`), nil
 }
 
 // Registry is a thread-safe registry of OAuth providers. It is populated at

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -6,6 +6,8 @@ package oauth
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"sync"
 	"time"
 )
@@ -105,18 +107,60 @@ func NewRegistry() *Registry {
 	return &Registry{providers: make(map[string]Provider)}
 }
 
+// providerIDPattern matches valid provider IDs: lowercase alphanumeric, hyphens,
+// and underscores. Mirrors the connector manifest ID pattern for consistency.
+var providerIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,62}$`)
+
 // Register adds or replaces a provider in the registry. If a provider with the
 // same ID already exists, it is replaced only if the new source has equal or
 // higher priority: BYOA > Manifest > BuiltIn.
-func (r *Registry) Register(p Provider) {
+//
+// When a BYOA provider overrides an existing provider, the client credentials
+// from the BYOA registration are merged into the existing provider's endpoint
+// and scope configuration. This means BYOA users only need to supply their
+// client ID and secret — they don't need to re-specify authorize/token URLs
+// or default scopes that were already set by the built-in or manifest source.
+//
+// Returns an error if the provider ID is empty or invalid.
+func (r *Registry) Register(p Provider) error {
+	if p.ID == "" {
+		return fmt.Errorf("oauth provider ID is required")
+	}
+	if !providerIDPattern.MatchString(p.ID) {
+		return fmt.Errorf("oauth provider ID %q must match %s", p.ID, providerIDPattern.String())
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	existing, exists := r.providers[p.ID]
 	if exists && sourcePriority(existing.Source) > sourcePriority(p.Source) {
-		return
+		return nil
 	}
+
+	// When BYOA overrides an existing provider, merge client credentials into
+	// the existing config so users don't need to re-specify endpoints/scopes.
+	if exists && p.Source == SourceBYOA {
+		merged := existing
+		merged.ClientID = p.ClientID
+		merged.ClientSecret = p.ClientSecret
+		merged.Source = SourceBYOA
+		// Allow BYOA to override endpoints/scopes only if explicitly provided.
+		if p.AuthorizeURL != "" {
+			merged.AuthorizeURL = p.AuthorizeURL
+		}
+		if p.TokenURL != "" {
+			merged.TokenURL = p.TokenURL
+		}
+		if len(p.Scopes) > 0 {
+			merged.Scopes = p.Scopes
+		}
+		r.providers[p.ID] = merged
+		return nil
+	}
+
 	r.providers[p.ID] = p
+	return nil
 }
 
 // Get returns the provider with the given ID. The second return value is false
@@ -128,8 +172,9 @@ func (r *Registry) Get(id string) (Provider, bool) {
 	return p, ok
 }
 
-// List returns all registered providers. The returned slice is a snapshot;
-// subsequent mutations to the registry are not reflected.
+// List returns all registered providers sorted by ID. The returned slice is a
+// snapshot; subsequent mutations to the registry are not reflected. Sorting
+// ensures deterministic output in logs and API responses.
 func (r *Registry) List() []Provider {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -137,10 +182,12 @@ func (r *Registry) List() []Provider {
 	for _, p := range r.providers {
 		out = append(out, p)
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
 }
 
-// IDs returns the IDs of all registered providers.
+// IDs returns the IDs of all registered providers in sorted order.
+// Sorting ensures deterministic output in logs and validation.
 func (r *Registry) IDs() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -148,7 +195,15 @@ func (r *Registry) IDs() []string {
 	for id := range r.providers {
 		ids = append(ids, id)
 	}
+	sort.Strings(ids)
 	return ids
+}
+
+// Len returns the number of registered providers without allocating a slice.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.providers)
 }
 
 // Remove deletes a provider from the registry. Returns an error if the

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -1,0 +1,179 @@
+// Package oauth implements the OAuth 2.0 provider registry for Permission Slip.
+// It manages provider configurations (endpoints, scopes, client credentials)
+// and provides a thread-safe registry that merges built-in providers,
+// connector-manifest-declared providers, and user BYOA configurations.
+package oauth
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Provider holds the configuration for an OAuth 2.0 provider. Built-in
+// providers (Google, Microsoft) ship with endpoints and default scopes
+// pre-filled; connector-declared providers are populated from manifests;
+// BYOA providers get client credentials from user configuration.
+type Provider struct {
+	// ID is a unique identifier for the provider (e.g. "google", "microsoft",
+	// "salesforce"). Must be lowercase alphanumeric with hyphens/underscores.
+	ID string
+
+	// AuthorizeURL is the provider's OAuth 2.0 authorization endpoint.
+	AuthorizeURL string
+
+	// TokenURL is the provider's OAuth 2.0 token endpoint.
+	TokenURL string
+
+	// Scopes are the default OAuth scopes requested during authorization.
+	// Connector manifests may request additional scopes beyond these defaults.
+	Scopes []string
+
+	// ClientID is the OAuth application's client ID. For built-in providers
+	// this comes from server config (env vars). For BYOA it comes from user
+	// configuration stored in the database.
+	ClientID string
+
+	// ClientSecret is the OAuth application's client secret. Same sourcing
+	// rules as ClientID.
+	ClientSecret string
+
+	// Source indicates where the provider configuration originated.
+	Source ProviderSource
+}
+
+// ProviderSource indicates the origin of a provider configuration.
+type ProviderSource string
+
+const (
+	// SourceBuiltIn indicates a provider shipped with the platform.
+	SourceBuiltIn ProviderSource = "built_in"
+
+	// SourceManifest indicates a provider declared in a connector manifest.
+	SourceManifest ProviderSource = "manifest"
+
+	// SourceBYOA indicates a provider configured by the user (Bring Your Own App).
+	SourceBYOA ProviderSource = "byoa"
+)
+
+// TokenSet holds the tokens returned by an OAuth 2.0 token exchange or refresh.
+type TokenSet struct {
+	// AccessToken is the token used to authenticate API requests.
+	AccessToken string
+
+	// RefreshToken is used to obtain a new access token when the current one
+	// expires. May be empty if the provider doesn't issue refresh tokens.
+	RefreshToken string
+
+	// Expiry is the time at which the access token expires. A zero value
+	// means the token does not expire (or expiry is unknown).
+	Expiry time.Time
+
+	// Scopes are the scopes granted by the provider. May differ from the
+	// scopes requested if the user denied some during consent.
+	Scopes []string
+}
+
+// IsExpired reports whether the access token has expired. It uses a 5-minute
+// buffer to allow pre-emptive refresh before execution.
+func (ts TokenSet) IsExpired() bool {
+	if ts.Expiry.IsZero() {
+		return false
+	}
+	return time.Now().After(ts.Expiry.Add(-5 * time.Minute))
+}
+
+// HasClientCredentials reports whether the provider has both a client ID and
+// client secret configured. Providers without credentials can be registered
+// (from manifests) but cannot initiate OAuth flows until BYOA credentials are
+// supplied.
+func (p Provider) HasClientCredentials() bool {
+	return p.ClientID != "" && p.ClientSecret != ""
+}
+
+// Registry is a thread-safe registry of OAuth providers. It is populated at
+// startup from built-in configs, connector manifests, and user BYOA settings.
+// The registry is read-heavy and write-rare (writes happen at startup and when
+// BYOA configs change).
+type Registry struct {
+	mu        sync.RWMutex
+	providers map[string]Provider
+}
+
+// NewRegistry creates an empty provider registry.
+func NewRegistry() *Registry {
+	return &Registry{providers: make(map[string]Provider)}
+}
+
+// Register adds or replaces a provider in the registry. If a provider with the
+// same ID already exists, it is replaced only if the new source has equal or
+// higher priority: BYOA > Manifest > BuiltIn.
+func (r *Registry) Register(p Provider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, exists := r.providers[p.ID]
+	if exists && sourcePriority(existing.Source) > sourcePriority(p.Source) {
+		return
+	}
+	r.providers[p.ID] = p
+}
+
+// Get returns the provider with the given ID. The second return value is false
+// if the provider is not registered.
+func (r *Registry) Get(id string) (Provider, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.providers[id]
+	return p, ok
+}
+
+// List returns all registered providers. The returned slice is a snapshot;
+// subsequent mutations to the registry are not reflected.
+func (r *Registry) List() []Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Provider, 0, len(r.providers))
+	for _, p := range r.providers {
+		out = append(out, p)
+	}
+	return out
+}
+
+// IDs returns the IDs of all registered providers.
+func (r *Registry) IDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.providers))
+	for id := range r.providers {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// Remove deletes a provider from the registry. Returns an error if the
+// provider does not exist.
+func (r *Registry) Remove(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.providers[id]; !ok {
+		return fmt.Errorf("oauth provider %q not found", id)
+	}
+	delete(r.providers, id)
+	return nil
+}
+
+// sourcePriority returns a numeric priority for a ProviderSource. Higher values
+// take precedence when merging providers with the same ID.
+func sourcePriority(s ProviderSource) int {
+	switch s {
+	case SourceBuiltIn:
+		return 1
+	case SourceManifest:
+		return 2
+	case SourceBYOA:
+		return 3
+	default:
+		return 0
+	}
+}

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -2,6 +2,19 @@
 // It manages provider configurations (endpoints, scopes, client credentials)
 // and provides a thread-safe registry that merges built-in providers,
 // connector-manifest-declared providers, and user BYOA configurations.
+//
+// Provider sources have a defined priority: BYOA > Manifest > BuiltIn.
+// When multiple sources register a provider with the same ID, the higher-priority
+// source wins. BYOA registrations are special: they merge client credentials
+// into the existing provider config (preserving endpoints and scopes from the
+// lower-priority source) rather than replacing the entire Provider value.
+//
+// Security: Provider and TokenSet implement fmt.Stringer, fmt.GoStringer, and
+// json.Marshaler to redact secrets (ClientSecret, AccessToken, RefreshToken).
+// Code that needs actual secret values must access struct fields directly.
+//
+// Thread safety: Registry methods are safe for concurrent use. Returned Provider
+// values are deep copies — mutations do not affect the registry.
 package oauth
 
 import (
@@ -77,13 +90,18 @@ type TokenSet struct {
 	Scopes []string
 }
 
-// IsExpired reports whether the access token has expired. It uses a 5-minute
-// buffer to allow pre-emptive refresh before execution.
+// tokenExpiryBuffer is the time before actual expiry at which a token is
+// considered expired. This allows pre-emptive refresh so actions don't fail
+// mid-execution due to an expired token.
+const tokenExpiryBuffer = 5 * time.Minute
+
+// IsExpired reports whether the access token has expired or is within the
+// pre-emptive refresh buffer (5 minutes before actual expiry).
 func (ts TokenSet) IsExpired() bool {
 	if ts.Expiry.IsZero() {
 		return false
 	}
-	return time.Now().After(ts.Expiry.Add(-5 * time.Minute))
+	return time.Now().After(ts.Expiry.Add(-tokenExpiryBuffer))
 }
 
 // HasClientCredentials reports whether the provider has both a client ID and

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -192,6 +192,10 @@ func (r *Registry) Register(p Provider) error {
 		return fmt.Errorf("oauth provider ID %q must match %s", p.ID, providerIDPattern.String())
 	}
 
+	// Deep-copy the Scopes slice so the caller cannot mutate the registry's
+	// stored data after registration.
+	p.Scopes = copyStrings(p.Scopes)
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -215,7 +219,10 @@ func (r *Registry) Register(p Provider) error {
 			merged.TokenURL = p.TokenURL
 		}
 		if len(p.Scopes) > 0 {
-			merged.Scopes = p.Scopes
+			merged.Scopes = p.Scopes // Already deep-copied above.
+		} else {
+			// Deep-copy the existing scopes so the merged provider owns its data.
+			merged.Scopes = copyStrings(existing.Scopes)
 		}
 		r.providers[p.ID] = merged
 		return nil
@@ -225,23 +232,28 @@ func (r *Registry) Register(p Provider) error {
 	return nil
 }
 
-// Get returns the provider with the given ID. The second return value is false
-// if the provider is not registered.
+// Get returns a copy of the provider with the given ID. The second return
+// value is false if the provider is not registered. The returned Provider
+// has its own copy of slice fields — mutations do not affect the registry.
 func (r *Registry) Get(id string) (Provider, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	p, ok := r.providers[id]
+	if ok {
+		p.Scopes = copyStrings(p.Scopes)
+	}
 	return p, ok
 }
 
 // List returns all registered providers sorted by ID. The returned slice is a
-// snapshot; subsequent mutations to the registry are not reflected. Sorting
-// ensures deterministic output in logs and API responses.
+// deep snapshot — mutations to the returned providers do not affect the
+// registry. Sorting ensures deterministic output in logs and API responses.
 func (r *Registry) List() []Provider {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	out := make([]Provider, 0, len(r.providers))
 	for _, p := range r.providers {
+		p.Scopes = copyStrings(p.Scopes)
 		out = append(out, p)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
@@ -278,6 +290,17 @@ func (r *Registry) Remove(id string) error {
 	}
 	delete(r.providers, id)
 	return nil
+}
+
+// copyStrings returns a deep copy of a string slice. Returns nil if the input
+// is nil, preserving the distinction between nil and empty slices.
+func copyStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	cp := make([]string, len(s))
+	copy(cp, s)
+	return cp
 }
 
 // sourcePriority returns a numeric priority for a ProviderSource. Higher values

--- a/oauth/provider_test.go
+++ b/oauth/provider_test.go
@@ -422,6 +422,85 @@ func TestTokenSet_MarshalJSON_Redacted(t *testing.T) {
 	}
 }
 
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	r := NewRegistry()
+	mustRegister(t, r, Provider{ID: "base", Source: SourceBuiltIn, Scopes: []string{"read"}})
+
+	// Run concurrent reads and writes to verify thread safety.
+	// With -race flag, the race detector will catch any data races.
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 100; j++ {
+				_ = r.List()
+				_, _ = r.Get("base")
+				_ = r.IDs()
+				_ = r.Len()
+			}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+func TestRegistry_GetReturnsCopy(t *testing.T) {
+	r := NewRegistry()
+	mustRegister(t, r, Provider{
+		ID:     "test",
+		Source: SourceBuiltIn,
+		Scopes: []string{"openid", "email"},
+	})
+
+	// Get a provider and mutate its scopes.
+	got, _ := r.Get("test")
+	got.Scopes[0] = "MUTATED"
+
+	// The registry's copy should be unaffected.
+	original, _ := r.Get("test")
+	if original.Scopes[0] == "MUTATED" {
+		t.Error("Get() returned a reference to the registry's data — mutations leaked back")
+	}
+}
+
+func TestRegistry_ListReturnsCopies(t *testing.T) {
+	r := NewRegistry()
+	mustRegister(t, r, Provider{
+		ID:     "test",
+		Source: SourceBuiltIn,
+		Scopes: []string{"openid"},
+	})
+
+	list := r.List()
+	list[0].Scopes[0] = "MUTATED"
+
+	// The registry's copy should be unaffected.
+	original, _ := r.Get("test")
+	if original.Scopes[0] == "MUTATED" {
+		t.Error("List() returned references to the registry's data — mutations leaked back")
+	}
+}
+
+func TestRegistry_RegisterCopiesScopes(t *testing.T) {
+	r := NewRegistry()
+	scopes := []string{"openid", "email"}
+	mustRegister(t, r, Provider{
+		ID:     "test",
+		Source: SourceBuiltIn,
+		Scopes: scopes,
+	})
+
+	// Mutate the original slice.
+	scopes[0] = "MUTATED"
+
+	// The registry's copy should be unaffected.
+	got, _ := r.Get("test")
+	if got.Scopes[0] == "MUTATED" {
+		t.Error("Register() did not deep-copy Scopes — caller mutation affected registry")
+	}
+}
+
 // mustRegister is a test helper that registers a provider and fails the test on error.
 func mustRegister(t *testing.T, r *Registry, p Provider) {
 	t.Helper()

--- a/oauth/provider_test.go
+++ b/oauth/provider_test.go
@@ -1,7 +1,10 @@
 package oauth
 
 import (
+	"encoding/json"
+	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 )
@@ -327,6 +330,95 @@ func TestRegistry_IDsSorted(t *testing.T) {
 	ids := r.IDs()
 	if !sort.StringsAreSorted(ids) {
 		t.Errorf("IDs() not sorted: %v", ids)
+	}
+}
+
+func TestProvider_StringRedactsSecret(t *testing.T) {
+	p := Provider{
+		ID:           "google",
+		ClientID:     "my-client-id",
+		ClientSecret: "super-secret-value",
+		Source:       SourceBuiltIn,
+	}
+	s := p.String()
+	if strings.Contains(s, "super-secret-value") {
+		t.Errorf("String() exposed ClientSecret: %s", s)
+	}
+	if !strings.Contains(s, "google") {
+		t.Errorf("String() should contain ID: %s", s)
+	}
+
+	// Also test GoString (used by %#v)
+	gs := fmt.Sprintf("%#v", p)
+	if strings.Contains(gs, "super-secret-value") {
+		t.Errorf("GoString() exposed ClientSecret: %s", gs)
+	}
+}
+
+func TestProvider_MarshalJSON_RedactsSecret(t *testing.T) {
+	p := Provider{
+		ID:           "google",
+		ClientID:     "my-client-id",
+		ClientSecret: "super-secret-value",
+		Source:       SourceBuiltIn,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "super-secret-value") {
+		t.Errorf("MarshalJSON exposed ClientSecret: %s", s)
+	}
+	if !strings.Contains(s, "[REDACTED]") {
+		t.Errorf("MarshalJSON should contain [REDACTED]: %s", s)
+	}
+	// ClientID should still be visible.
+	if !strings.Contains(s, "my-client-id") {
+		t.Errorf("MarshalJSON should contain ClientID: %s", s)
+	}
+}
+
+func TestProvider_MarshalJSON_NoSecretOmitted(t *testing.T) {
+	p := Provider{
+		ID:     "google",
+		Source: SourceBuiltIn,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	if strings.Contains(string(data), "REDACTED") {
+		t.Errorf("MarshalJSON should not include REDACTED when no secret: %s", string(data))
+	}
+}
+
+func TestTokenSet_StringRedactsTokens(t *testing.T) {
+	ts := TokenSet{
+		AccessToken:  "secret-access-token",
+		RefreshToken: "secret-refresh-token",
+		Scopes:       []string{"openid"},
+	}
+	s := ts.String()
+	if strings.Contains(s, "secret-access-token") {
+		t.Errorf("String() exposed AccessToken: %s", s)
+	}
+	if strings.Contains(s, "secret-refresh-token") {
+		t.Errorf("String() exposed RefreshToken: %s", s)
+	}
+}
+
+func TestTokenSet_MarshalJSON_Redacted(t *testing.T) {
+	ts := TokenSet{
+		AccessToken:  "secret-access-token",
+		RefreshToken: "secret-refresh-token",
+	}
+	data, err := json.Marshal(ts)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	if strings.Contains(string(data), "secret-access-token") {
+		t.Errorf("MarshalJSON exposed AccessToken: %s", string(data))
 	}
 }
 

--- a/oauth/provider_test.go
+++ b/oauth/provider_test.go
@@ -1,0 +1,212 @@
+package oauth
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestNewRegistry(t *testing.T) {
+	r := NewRegistry()
+	if ids := r.IDs(); len(ids) != 0 {
+		t.Errorf("new registry should be empty, got %d providers", len(ids))
+	}
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	p := Provider{
+		ID:           "test",
+		AuthorizeURL: "https://example.com/auth",
+		TokenURL:     "https://example.com/token",
+		Source:       SourceBuiltIn,
+	}
+	r.Register(p)
+
+	got, ok := r.Get("test")
+	if !ok {
+		t.Fatal("expected provider to be found")
+	}
+	if got.ID != "test" {
+		t.Errorf("ID = %q, want %q", got.ID, "test")
+	}
+	if got.AuthorizeURL != "https://example.com/auth" {
+		t.Errorf("AuthorizeURL = %q", got.AuthorizeURL)
+	}
+}
+
+func TestRegistry_GetNotFound(t *testing.T) {
+	r := NewRegistry()
+	_, ok := r.Get("nonexistent")
+	if ok {
+		t.Error("expected provider not found")
+	}
+}
+
+func TestRegistry_List(t *testing.T) {
+	r := NewRegistry()
+	r.Register(Provider{ID: "a", Source: SourceBuiltIn})
+	r.Register(Provider{ID: "b", Source: SourceBuiltIn})
+
+	list := r.List()
+	if len(list) != 2 {
+		t.Fatalf("len(List) = %d, want 2", len(list))
+	}
+
+	ids := make([]string, len(list))
+	for i, p := range list {
+		ids[i] = p.ID
+	}
+	sort.Strings(ids)
+	if ids[0] != "a" || ids[1] != "b" {
+		t.Errorf("IDs = %v, want [a b]", ids)
+	}
+}
+
+func TestRegistry_IDs(t *testing.T) {
+	r := NewRegistry()
+	r.Register(Provider{ID: "x", Source: SourceBuiltIn})
+	r.Register(Provider{ID: "y", Source: SourceBuiltIn})
+
+	ids := r.IDs()
+	sort.Strings(ids)
+	if len(ids) != 2 || ids[0] != "x" || ids[1] != "y" {
+		t.Errorf("IDs = %v, want [x y]", ids)
+	}
+}
+
+func TestRegistry_Remove(t *testing.T) {
+	r := NewRegistry()
+	r.Register(Provider{ID: "removeme", Source: SourceBuiltIn})
+
+	if err := r.Remove("removeme"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Get("removeme"); ok {
+		t.Error("provider should have been removed")
+	}
+}
+
+func TestRegistry_RemoveNotFound(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Remove("nonexistent"); err == nil {
+		t.Error("expected error for removing nonexistent provider")
+	}
+}
+
+func TestRegistry_SourcePriority(t *testing.T) {
+	t.Run("manifest does not override BYOA", func(t *testing.T) {
+		r := NewRegistry()
+		r.Register(Provider{ID: "p", ClientID: "byoa-id", Source: SourceBYOA})
+		r.Register(Provider{ID: "p", ClientID: "manifest-id", Source: SourceManifest})
+
+		got, _ := r.Get("p")
+		if got.ClientID != "byoa-id" {
+			t.Errorf("ClientID = %q, want %q (BYOA should win)", got.ClientID, "byoa-id")
+		}
+	})
+
+	t.Run("built-in does not override manifest", func(t *testing.T) {
+		r := NewRegistry()
+		r.Register(Provider{ID: "p", AuthorizeURL: "https://manifest.com/auth", Source: SourceManifest})
+		r.Register(Provider{ID: "p", AuthorizeURL: "https://builtin.com/auth", Source: SourceBuiltIn})
+
+		got, _ := r.Get("p")
+		if got.AuthorizeURL != "https://manifest.com/auth" {
+			t.Errorf("AuthorizeURL = %q, want manifest URL", got.AuthorizeURL)
+		}
+	})
+
+	t.Run("manifest overrides built-in", func(t *testing.T) {
+		r := NewRegistry()
+		r.Register(Provider{ID: "p", AuthorizeURL: "https://builtin.com/auth", Source: SourceBuiltIn})
+		r.Register(Provider{ID: "p", AuthorizeURL: "https://manifest.com/auth", Source: SourceManifest})
+
+		got, _ := r.Get("p")
+		if got.AuthorizeURL != "https://manifest.com/auth" {
+			t.Errorf("AuthorizeURL = %q, want manifest URL", got.AuthorizeURL)
+		}
+	})
+
+	t.Run("BYOA overrides everything", func(t *testing.T) {
+		r := NewRegistry()
+		r.Register(Provider{ID: "p", Source: SourceBuiltIn})
+		r.Register(Provider{ID: "p", Source: SourceManifest})
+		r.Register(Provider{ID: "p", ClientID: "user-app", Source: SourceBYOA})
+
+		got, _ := r.Get("p")
+		if got.ClientID != "user-app" {
+			t.Errorf("ClientID = %q, want %q", got.ClientID, "user-app")
+		}
+	})
+
+	t.Run("same source replaces", func(t *testing.T) {
+		r := NewRegistry()
+		r.Register(Provider{ID: "p", ClientID: "first", Source: SourceBuiltIn})
+		r.Register(Provider{ID: "p", ClientID: "second", Source: SourceBuiltIn})
+
+		got, _ := r.Get("p")
+		if got.ClientID != "second" {
+			t.Errorf("ClientID = %q, want %q (same source should replace)", got.ClientID, "second")
+		}
+	})
+}
+
+func TestTokenSet_IsExpired(t *testing.T) {
+	t.Run("zero expiry never expired", func(t *testing.T) {
+		ts := TokenSet{}
+		if ts.IsExpired() {
+			t.Error("zero expiry should not be expired")
+		}
+	})
+
+	t.Run("future expiry not expired", func(t *testing.T) {
+		ts := TokenSet{Expiry: time.Now().Add(1 * time.Hour)}
+		if ts.IsExpired() {
+			t.Error("future expiry should not be expired")
+		}
+	})
+
+	t.Run("past expiry is expired", func(t *testing.T) {
+		ts := TokenSet{Expiry: time.Now().Add(-1 * time.Hour)}
+		if !ts.IsExpired() {
+			t.Error("past expiry should be expired")
+		}
+	})
+
+	t.Run("within 5-minute buffer is expired", func(t *testing.T) {
+		ts := TokenSet{Expiry: time.Now().Add(3 * time.Minute)}
+		if !ts.IsExpired() {
+			t.Error("expiry within 5-minute buffer should be expired")
+		}
+	})
+
+	t.Run("beyond 5-minute buffer is not expired", func(t *testing.T) {
+		ts := TokenSet{Expiry: time.Now().Add(10 * time.Minute)}
+		if ts.IsExpired() {
+			t.Error("expiry beyond 5-minute buffer should not be expired")
+		}
+	})
+}
+
+func TestProvider_HasClientCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		secret   string
+		expected bool
+	}{
+		{"both set", "id", "secret", true},
+		{"no id", "", "secret", false},
+		{"no secret", "id", "", false},
+		{"neither set", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Provider{ClientID: tt.id, ClientSecret: tt.secret}
+			if got := p.HasClientCredentials(); got != tt.expected {
+				t.Errorf("HasClientCredentials() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/oauth/provider_test.go
+++ b/oauth/provider_test.go
@@ -21,7 +21,9 @@ func TestRegistry_RegisterAndGet(t *testing.T) {
 		TokenURL:     "https://example.com/token",
 		Source:       SourceBuiltIn,
 	}
-	r.Register(p)
+	if err := r.Register(p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	got, ok := r.Get("test")
 	if !ok {
@@ -45,39 +47,46 @@ func TestRegistry_GetNotFound(t *testing.T) {
 
 func TestRegistry_List(t *testing.T) {
 	r := NewRegistry()
-	r.Register(Provider{ID: "a", Source: SourceBuiltIn})
-	r.Register(Provider{ID: "b", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "b", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "a", Source: SourceBuiltIn})
 
 	list := r.List()
 	if len(list) != 2 {
 		t.Fatalf("len(List) = %d, want 2", len(list))
 	}
 
-	ids := make([]string, len(list))
-	for i, p := range list {
-		ids[i] = p.ID
-	}
-	sort.Strings(ids)
-	if ids[0] != "a" || ids[1] != "b" {
-		t.Errorf("IDs = %v, want [a b]", ids)
+	// List should be sorted by ID.
+	if list[0].ID != "a" || list[1].ID != "b" {
+		t.Errorf("List not sorted: got [%s, %s], want [a, b]", list[0].ID, list[1].ID)
 	}
 }
 
 func TestRegistry_IDs(t *testing.T) {
 	r := NewRegistry()
-	r.Register(Provider{ID: "x", Source: SourceBuiltIn})
-	r.Register(Provider{ID: "y", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "y", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "x", Source: SourceBuiltIn})
 
 	ids := r.IDs()
-	sort.Strings(ids)
 	if len(ids) != 2 || ids[0] != "x" || ids[1] != "y" {
 		t.Errorf("IDs = %v, want [x y]", ids)
 	}
 }
 
+func TestRegistry_Len(t *testing.T) {
+	r := NewRegistry()
+	if r.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", r.Len())
+	}
+	mustRegister(t, r, Provider{ID: "a", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "b", Source: SourceBuiltIn})
+	if r.Len() != 2 {
+		t.Errorf("Len() = %d, want 2", r.Len())
+	}
+}
+
 func TestRegistry_Remove(t *testing.T) {
 	r := NewRegistry()
-	r.Register(Provider{ID: "removeme", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "removeme", Source: SourceBuiltIn})
 
 	if err := r.Remove("removeme"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -94,11 +103,39 @@ func TestRegistry_RemoveNotFound(t *testing.T) {
 	}
 }
 
+func TestRegistry_RegisterValidation(t *testing.T) {
+	r := NewRegistry()
+
+	t.Run("empty ID", func(t *testing.T) {
+		if err := r.Register(Provider{ID: "", Source: SourceBuiltIn}); err == nil {
+			t.Error("expected error for empty ID")
+		}
+	})
+
+	t.Run("invalid ID with uppercase", func(t *testing.T) {
+		if err := r.Register(Provider{ID: "Google", Source: SourceBuiltIn}); err == nil {
+			t.Error("expected error for uppercase ID")
+		}
+	})
+
+	t.Run("invalid ID with spaces", func(t *testing.T) {
+		if err := r.Register(Provider{ID: "my provider", Source: SourceBuiltIn}); err == nil {
+			t.Error("expected error for ID with spaces")
+		}
+	})
+
+	t.Run("valid ID with hyphens and underscores", func(t *testing.T) {
+		if err := r.Register(Provider{ID: "my-oauth_provider", Source: SourceBuiltIn}); err != nil {
+			t.Errorf("unexpected error for valid ID: %v", err)
+		}
+	})
+}
+
 func TestRegistry_SourcePriority(t *testing.T) {
 	t.Run("manifest does not override BYOA", func(t *testing.T) {
 		r := NewRegistry()
-		r.Register(Provider{ID: "p", ClientID: "byoa-id", Source: SourceBYOA})
-		r.Register(Provider{ID: "p", ClientID: "manifest-id", Source: SourceManifest})
+		mustRegister(t, r, Provider{ID: "p", ClientID: "byoa-id", Source: SourceBYOA})
+		mustRegister(t, r, Provider{ID: "p", ClientID: "manifest-id", Source: SourceManifest})
 
 		got, _ := r.Get("p")
 		if got.ClientID != "byoa-id" {
@@ -108,8 +145,8 @@ func TestRegistry_SourcePriority(t *testing.T) {
 
 	t.Run("built-in does not override manifest", func(t *testing.T) {
 		r := NewRegistry()
-		r.Register(Provider{ID: "p", AuthorizeURL: "https://manifest.com/auth", Source: SourceManifest})
-		r.Register(Provider{ID: "p", AuthorizeURL: "https://builtin.com/auth", Source: SourceBuiltIn})
+		mustRegister(t, r, Provider{ID: "p", AuthorizeURL: "https://manifest.com/auth", Source: SourceManifest})
+		mustRegister(t, r, Provider{ID: "p", AuthorizeURL: "https://builtin.com/auth", Source: SourceBuiltIn})
 
 		got, _ := r.Get("p")
 		if got.AuthorizeURL != "https://manifest.com/auth" {
@@ -119,8 +156,8 @@ func TestRegistry_SourcePriority(t *testing.T) {
 
 	t.Run("manifest overrides built-in", func(t *testing.T) {
 		r := NewRegistry()
-		r.Register(Provider{ID: "p", AuthorizeURL: "https://builtin.com/auth", Source: SourceBuiltIn})
-		r.Register(Provider{ID: "p", AuthorizeURL: "https://manifest.com/auth", Source: SourceManifest})
+		mustRegister(t, r, Provider{ID: "p", AuthorizeURL: "https://builtin.com/auth", Source: SourceBuiltIn})
+		mustRegister(t, r, Provider{ID: "p", AuthorizeURL: "https://manifest.com/auth", Source: SourceManifest})
 
 		got, _ := r.Get("p")
 		if got.AuthorizeURL != "https://manifest.com/auth" {
@@ -130,9 +167,9 @@ func TestRegistry_SourcePriority(t *testing.T) {
 
 	t.Run("BYOA overrides everything", func(t *testing.T) {
 		r := NewRegistry()
-		r.Register(Provider{ID: "p", Source: SourceBuiltIn})
-		r.Register(Provider{ID: "p", Source: SourceManifest})
-		r.Register(Provider{ID: "p", ClientID: "user-app", Source: SourceBYOA})
+		mustRegister(t, r, Provider{ID: "p", Source: SourceBuiltIn})
+		mustRegister(t, r, Provider{ID: "p", Source: SourceManifest})
+		mustRegister(t, r, Provider{ID: "p", ClientID: "user-app", Source: SourceBYOA})
 
 		got, _ := r.Get("p")
 		if got.ClientID != "user-app" {
@@ -142,12 +179,82 @@ func TestRegistry_SourcePriority(t *testing.T) {
 
 	t.Run("same source replaces", func(t *testing.T) {
 		r := NewRegistry()
-		r.Register(Provider{ID: "p", ClientID: "first", Source: SourceBuiltIn})
-		r.Register(Provider{ID: "p", ClientID: "second", Source: SourceBuiltIn})
+		mustRegister(t, r, Provider{ID: "p", ClientID: "first", Source: SourceBuiltIn})
+		mustRegister(t, r, Provider{ID: "p", ClientID: "second", Source: SourceBuiltIn})
 
 		got, _ := r.Get("p")
 		if got.ClientID != "second" {
 			t.Errorf("ClientID = %q, want %q (same source should replace)", got.ClientID, "second")
+		}
+	})
+}
+
+func TestRegistry_BYOAMerge(t *testing.T) {
+	t.Run("BYOA merges credentials into existing provider", func(t *testing.T) {
+		r := NewRegistry()
+		mustRegister(t, r, Provider{
+			ID:           "google",
+			AuthorizeURL: "https://accounts.google.com/o/oauth2/v2/auth",
+			TokenURL:     "https://oauth2.googleapis.com/token",
+			Scopes:       []string{"openid", "email"},
+			Source:       SourceBuiltIn,
+		})
+
+		// BYOA registration with only client credentials — no endpoints or scopes.
+		mustRegister(t, r, Provider{
+			ID:           "google",
+			ClientID:     "my-app-id",
+			ClientSecret: "my-app-secret",
+			Source:       SourceBYOA,
+		})
+
+		got, _ := r.Get("google")
+		if got.ClientID != "my-app-id" {
+			t.Errorf("ClientID = %q, want %q", got.ClientID, "my-app-id")
+		}
+		if got.ClientSecret != "my-app-secret" {
+			t.Errorf("ClientSecret = %q, want %q", got.ClientSecret, "my-app-secret")
+		}
+		// Endpoints and scopes should be preserved from the built-in.
+		if got.AuthorizeURL != "https://accounts.google.com/o/oauth2/v2/auth" {
+			t.Errorf("AuthorizeURL not preserved: %q", got.AuthorizeURL)
+		}
+		if got.TokenURL != "https://oauth2.googleapis.com/token" {
+			t.Errorf("TokenURL not preserved: %q", got.TokenURL)
+		}
+		if len(got.Scopes) != 2 {
+			t.Errorf("Scopes not preserved: %v", got.Scopes)
+		}
+		if got.Source != SourceBYOA {
+			t.Errorf("Source = %q, want %q", got.Source, SourceBYOA)
+		}
+	})
+
+	t.Run("BYOA can override endpoints when explicitly provided", func(t *testing.T) {
+		r := NewRegistry()
+		mustRegister(t, r, Provider{
+			ID:           "custom",
+			AuthorizeURL: "https://original.com/auth",
+			TokenURL:     "https://original.com/token",
+			Scopes:       []string{"read"},
+			Source:       SourceManifest,
+		})
+
+		mustRegister(t, r, Provider{
+			ID:           "custom",
+			AuthorizeURL: "https://custom.com/auth",
+			TokenURL:     "https://custom.com/token",
+			ClientID:     "my-id",
+			ClientSecret: "my-secret",
+			Source:       SourceBYOA,
+		})
+
+		got, _ := r.Get("custom")
+		if got.AuthorizeURL != "https://custom.com/auth" {
+			t.Errorf("AuthorizeURL = %q, want overridden URL", got.AuthorizeURL)
+		}
+		if got.TokenURL != "https://custom.com/token" {
+			t.Errorf("TokenURL = %q, want overridden URL", got.TokenURL)
 		}
 	})
 }
@@ -208,5 +315,25 @@ func TestProvider_HasClientCredentials(t *testing.T) {
 				t.Errorf("HasClientCredentials() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestRegistry_IDsSorted(t *testing.T) {
+	r := NewRegistry()
+	mustRegister(t, r, Provider{ID: "zebra", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "alpha", Source: SourceBuiltIn})
+	mustRegister(t, r, Provider{ID: "middle", Source: SourceBuiltIn})
+
+	ids := r.IDs()
+	if !sort.StringsAreSorted(ids) {
+		t.Errorf("IDs() not sorted: %v", ids)
+	}
+}
+
+// mustRegister is a test helper that registers a provider and fails the test on error.
+func mustRegister(t *testing.T, r *Registry, p Provider) {
+	t.Helper()
+	if err := r.Register(p); err != nil {
+		t.Fatalf("Register(%q) failed: %v", p.ID, err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements **Phase 2: OAuth Provider Registry** from #80.

- New `oauth/` package with `Provider`, `Registry`, and `TokenSet` types
- Built-in provider configs for Google (`accounts.google.com`) and Microsoft (`login.microsoftonline.com`) with default scopes
- Thread-safe registry with source priority: BYOA > Manifest > BuiltIn
- Startup population merges built-in providers + connector manifest-declared providers
- `OAuthProviders` field added to `api.Deps` for use by Phase 3 (API endpoints)
- Comprehensive test coverage (20 tests) for registry operations, source priority, token expiry, and manifest registration

**Note:** Phase 1 items (manifest extension, `OAuthProviders` on `ConnectorManifest`, validation) were already completed in prior work.

## Test plan

- [x] All `oauth/` package tests pass (`go test ./oauth/...`)
- [x] All `connectors/` package tests pass (no regressions)
- [x] Project builds cleanly (`go build .`)
- [ ] Verify startup logs show OAuth provider registry summary

https://claude.ai/code/session_01PkDpULRkC3Wn6dJ8JW4dZa