### PR TITLE
Add Stripe publishable key build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ARG VITE_SUPABASE_PUBLISHABLE_KEY
 ARG VITE_SENTRY_DSN
 ARG VITE_POSTHOG_KEY
 ARG VITE_POSTHOG_HOST
+ARG VITE_STRIPE_PUBLISHABLE_KEY
 
 # Sentry source-map upload (optional — skip if not set).
 # @sentry/vite-plugin reads these during the Vite build to upload maps.

--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,7 @@ kill_timeout = '30s'
     VITE_SENTRY_DSN = "https://b29c7ce913782b9aa81de0ac682428ba@o4510982091309056.ingest.us.sentry.io/4510982566051840"
     VITE_POSTHOG_KEY = "phc_PtcMEXOus86UQHAmXYUVqZKpwzVH6pI5Om7hIwcgHPG"
     VITE_POSTHOG_HOST = "https://hydro.permissionslip.dev"
+    VITE_STRIPE_PUBLISHABLE_KEY = "pk_live_51NdlB8D4K62k2wCP4p4KlzxycPSnykYyC2Sy1ayWMjT8xT4K8B3wKbrS8hDDpL7iUUe8qUVmLzWVSjbdZ8edKOK900hXu42GLW"
 
 [env]
   PORT = '8080'


### PR DESCRIPTION
## Summary
- Adds `VITE_STRIPE_PUBLISHABLE_KEY` to `fly.toml` build args so it's passed to the frontend build on deploy
- Adds the corresponding `ARG` declaration to the Dockerfile so Vite can inline it into the JS bundle

Closes step 5 of #168.

## Test plan
- [ ] Verify next `fly deploy` picks up the new build arg
- [ ] Confirm Stripe checkout button initializes correctly in the deployed frontend

https://claude.ai/code/session_01FLXCpGHJp3QDvdZBq2Zvna