### PR TITLE
feat: OAuth token refresh (Phase 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,11 @@ SUPABASE_URL=http://127.0.0.1:54321
 # the OAuth authorization flow. Falls back to SUPABASE_JWT_SECRET if not set.
 # For production, set a dedicated secret: openssl rand -hex 32
 # OAUTH_STATE_SECRET=
+#
+# OAuth token refresh interval — how often the background job checks for
+# tokens expiring soon. Tokens within 15 minutes of expiry are proactively
+# refreshed. Accepts Go duration format (e.g., "10m", "5m"). Minimum: 1m.
+# OAUTH_REFRESH_INTERVAL=10m
 
 # Allowed CORS origins — comma-separated list of origins permitted to make
 # cross-origin requests to the API. When empty, the server operates in

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For the full protocol design, architecture, and security model, see [SPEC.md](SP
 - **Self-hostable** — run your own instance for full control
 - **Single binary deployment** — Go server with embedded React frontend
 - **Audit trail** — every request, approval, and execution is logged
-- **OAuth 2.0 connections** — connect Google, Microsoft, or custom OAuth providers; tokens encrypted in vault
+- **OAuth 2.0 connections** — connect Google, Microsoft, or custom OAuth providers; tokens encrypted in vault with automatic background refresh before expiry
 - **User preferences** — per-channel notification settings, contact info, and credential vault management
 
 ## Agent Compatibility
@@ -258,6 +258,7 @@ Beyond the variables in `.env.example`, these require attention for production:
 | `POSTHOG_HOST` | Optional | PostHog API host added to CSP `connect-src` — must match `VITE_POSTHOG_HOST` (runtime) |
 | `SHUTDOWN_TIMEOUT` | Optional | Graceful shutdown timeout for draining in-flight requests (default: `30s`) |
 | `AUDIT_PURGE_INTERVAL` | Optional | How often expired audit events are purged — Go duration format, minimum `1m` (default: `1h`) |
+| `OAUTH_REFRESH_INTERVAL` | Optional | How often the background job checks for expiring OAuth tokens — Go duration format, minimum `1m` (default: `10m`). Tokens within 15 minutes of expiry are proactively refreshed. |
 | `VAPID_PUBLIC_KEY` | For Web Push | VAPID public key for Web Push notifications |
 | `VAPID_PRIVATE_KEY` | For Web Push | VAPID private key — keep secret, never commit to git |
 | `VAPID_SUBJECT` | For Web Push | `mailto:` URL identifying the operator (e.g. `mailto:admin@mycompany.com`) |

--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"log"
 	"net/http"
 
@@ -37,6 +38,19 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		log.Printf("[%s] connector external error: %v", traceID, err)
 		CaptureError(r.Context(), err)
 		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, "External service returned an error", true))
+		return true
+
+	case connectors.IsOAuthRefreshError(err):
+		log.Printf("[%s] OAuth refresh error: %v", traceID, err)
+		var oauthErr *connectors.OAuthRefreshError
+		msg := "OAuth authorization required — user must re-connect the provider in Settings"
+		details := map[string]any{}
+		if errors.As(err, &oauthErr) {
+			details["provider"] = oauthErr.Provider
+		}
+		resp := newErrorResponse(ErrOAuthRefreshFailed, msg, false)
+		resp.Error.Details = details
+		RespondError(w, r, http.StatusUnauthorized, resp)
 		return true
 
 	case connectors.IsAuthError(err):

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -152,8 +152,8 @@ func resolveOAuthCredentials(ctx context.Context, deps *Deps, userID string, req
 		}
 	}
 
-	// Check if the token needs refreshing (expired or within 5-minute buffer).
-	if conn.TokenExpiry != nil && time.Now().After(conn.TokenExpiry.Add(-5*time.Minute)) {
+	// Check if the token needs refreshing (expired or within pre-emptive buffer).
+	if conn.TokenExpiry != nil && time.Now().After(conn.TokenExpiry.Add(-oauth.TokenExpiryBuffer)) {
 		if err := refreshOAuthConnection(ctx, deps, conn, providerID); err != nil {
 			return zero, err
 		}
@@ -199,16 +199,21 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 		return fmt.Errorf("read refresh token from vault: %w", err)
 	}
 
-	// Perform the refresh.
-	result, err := oauth.RefreshTokens(ctx, provider, string(refreshTokenBytes))
+	// Perform the refresh with a dedicated timeout so the OAuth provider call
+	// gets a fair chance even if the incoming request context has little time left.
+	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer refreshCancel()
+	result, err := oauth.RefreshTokens(refreshCtx, provider, string(refreshTokenBytes))
 	if err != nil {
 		// Refresh failed (token revoked, expired, etc.). Mark as needs_reauth.
+		// Log the full error server-side for debugging; return a sanitized message to the caller.
+		log.Printf("oauth refresh failed for provider %q connection %s: %v", providerID, conn.ID, err)
 		if statusErr := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); statusErr != nil {
 			log.Printf("failed to update OAuth connection status to needs_reauth: %v", statusErr)
 		}
 		return &connectors.OAuthRefreshError{
 			Provider: providerID,
-			Message:  fmt.Sprintf("token refresh failed — user must re-authorize: %v", err),
+			Message:  "token refresh failed — user must re-authorize",
 		}
 	}
 
@@ -223,7 +228,9 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 	}
 
 	// Delete old access token and create new one.
-	_ = deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID)
+	if delErr := deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID); delErr != nil {
+		log.Printf("oauth refresh: failed to delete old access token %s from vault: %v", conn.AccessTokenVaultID, delErr)
+	}
 	newAccessVaultID, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_access", []byte(result.AccessToken))
 	if err != nil {
 		return fmt.Errorf("vault create refreshed access token: %w", err)
@@ -233,7 +240,9 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 	var newRefreshVaultID *string
 	if result.RefreshToken != string(refreshTokenBytes) {
 		// Provider rotated the refresh token — store the new one.
-		_ = deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID)
+		if delErr := deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID); delErr != nil {
+			log.Printf("oauth refresh: failed to delete old refresh token %s from vault: %v", *conn.RefreshTokenVaultID, delErr)
+		}
 		id, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_refresh", []byte(result.RefreshToken))
 		if err != nil {
 			return fmt.Errorf("vault create rotated refresh token: %w", err)

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -201,7 +201,9 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 
 	// Perform the refresh with a dedicated timeout so the OAuth provider call
 	// gets a fair chance even if the incoming request context has little time left.
-	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Use WithoutCancel to preserve context values (trace IDs, Sentry spans) while
+	// detaching from the parent's cancellation signal.
+	refreshCtx, refreshCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer refreshCancel()
 	result, err := oauth.RefreshTokens(refreshCtx, provider, string(refreshTokenBytes))
 	if err != nil {

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -171,8 +171,14 @@ func resolveOAuthCredentials(ctx context.Context, deps *Deps, userID string, req
 }
 
 // refreshOAuthConnection performs a token refresh for the given OAuth connection.
-// On success, it updates the vault secrets and DB row. On failure, it marks
-// the connection as needs_reauth and returns an OAuthRefreshError.
+// On success, it updates the vault secrets and DB row, and sets
+// conn.AccessTokenVaultID to the new vault ID so the caller reads the fresh token.
+// On failure, it marks the connection as needs_reauth and returns an OAuthRefreshError.
+//
+// Note: if the background refresh job refreshes the same connection concurrently,
+// both paths produce valid tokens. The last writer wins in the DB, and the other's
+// vault secrets become orphaned. This is safe (no data loss or auth failure) but
+// may leave unused vault entries until the connection is deleted or re-authorized.
 func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConnection, providerID string) error {
 	provider, ok := deps.OAuthProviders.Get(providerID)
 	if !ok {
@@ -238,7 +244,6 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 	newAccessVaultID, err := oauth.StoreRefreshedTokens(ctx, vaultOps,
 		oauth.StoreRefreshedTokensParams{
 			ConnID:            conn.ID,
-			UserID:            conn.UserID,
 			OldAccessVaultID:  conn.AccessTokenVaultID,
 			OldRefreshVaultID: conn.RefreshTokenVaultID,
 			Result:            result,

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -219,8 +219,7 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 		}
 	}
 
-	// Store the new access token in the vault (update in place by deleting
-	// old and creating new, since vault doesn't have an update operation).
+	// Store the new tokens in the vault and update the DB row.
 	tx, owned, txErr := db.BeginOrContinue(ctx, deps.DB)
 	if txErr != nil {
 		return fmt.Errorf("begin tx for token refresh: %w", txErr)
@@ -229,38 +228,31 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
 	}
 
-	// Delete old access token and create new one.
-	if delErr := deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID); delErr != nil {
-		log.Printf("oauth refresh: failed to delete old access token %s from vault: %v", conn.AccessTokenVaultID, delErr)
+	vaultOps := oauth.VaultOperations{
+		DeleteSecret: func(ctx context.Context, id string) error { return deps.Vault.DeleteSecret(ctx, tx, id) },
+		CreateSecret: func(ctx context.Context, name string, secret []byte) (string, error) {
+			return deps.Vault.CreateSecret(ctx, tx, name, secret)
+		},
 	}
-	newAccessVaultID, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_access", []byte(result.AccessToken))
+
+	newAccessVaultID, err := oauth.StoreRefreshedTokens(ctx, vaultOps,
+		oauth.StoreRefreshedTokensParams{
+			ConnID:            conn.ID,
+			UserID:            conn.UserID,
+			OldAccessVaultID:  conn.AccessTokenVaultID,
+			OldRefreshVaultID: conn.RefreshTokenVaultID,
+			Result:            result,
+			OldRefreshToken:   string(refreshTokenBytes),
+		},
+		func(what, vaultID string, delErr error) {
+			log.Printf("oauth refresh: failed to delete old %s %s from vault: %v", what, vaultID, delErr)
+		},
+		func(ctx context.Context, accessVaultID string, refreshVaultID *string, expiry *time.Time) error {
+			return db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, accessVaultID, refreshVaultID, expiry)
+		},
+	)
 	if err != nil {
-		return fmt.Errorf("vault create refreshed access token: %w", err)
-	}
-
-	// Handle refresh token rotation.
-	var newRefreshVaultID *string
-	if result.RefreshToken != string(refreshTokenBytes) {
-		// Provider rotated the refresh token — store the new one.
-		if delErr := deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID); delErr != nil {
-			log.Printf("oauth refresh: failed to delete old refresh token %s from vault: %v", *conn.RefreshTokenVaultID, delErr)
-		}
-		id, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_refresh", []byte(result.RefreshToken))
-		if err != nil {
-			return fmt.Errorf("vault create rotated refresh token: %w", err)
-		}
-		newRefreshVaultID = &id
-	} else {
-		newRefreshVaultID = conn.RefreshTokenVaultID
-	}
-
-	var tokenExpiry *time.Time
-	if !result.Expiry.IsZero() {
-		tokenExpiry = &result.Expiry
-	}
-
-	if err := db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, newAccessVaultID, newRefreshVaultID, tokenExpiry); err != nil {
-		return fmt.Errorf("update OAuth connection tokens: %w", err)
+		return err
 	}
 
 	if owned {

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/oauth"
 )
 
 // executeConnectorAction looks up the action in the connector registry,
@@ -25,44 +28,26 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 		return nil, nil
 	}
 
-	// Look up which credential services this connector requires.
-	services, err := db.GetRequiredServicesByActionType(ctx, deps.DB, actionType)
+	// Check auth_type for this connector's required credentials.
+	reqCred, err := db.GetRequiredCredentialByActionType(ctx, deps.DB, actionType)
 	if err != nil {
-		return nil, fmt.Errorf("look up required services: %w", err)
+		return nil, fmt.Errorf("look up required credential: %w", err)
 	}
 
-	// Fetch and decrypt credentials for each required service.
-	credMap := make(map[string]string, len(services))
-	for _, service := range services {
-		if deps.Vault == nil {
-			return nil, fmt.Errorf("credential vault is not configured but connector requires service %q", service)
-		}
-		decrypted, err := db.GetDecryptedCredentials(ctx, deps.DB, deps.Vault.ReadSecret, userID, service, nil)
+	var creds connectors.Credentials
+	if reqCred != nil && reqCred.AuthType == "oauth2" {
+		// OAuth2 path: resolve access token from oauth_connections.
+		creds, err = resolveOAuthCredentials(ctx, deps, userID, reqCred)
 		if err != nil {
-			var credErr *db.CredentialError
-			if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
-				return nil, &connectors.ValidationError{
-					Message: fmt.Sprintf("no credentials stored for service %q", service),
-				}
-			}
-			return nil, fmt.Errorf("decrypt credentials for service %q: %w", service, err)
+			return nil, err
 		}
-		// Flatten decrypted JSON map into string values for the Credentials type.
-		for k, v := range decrypted {
-			switch vv := v.(type) {
-			case string:
-				credMap[k] = vv
-			default:
-				b, err := json.Marshal(v)
-				if err != nil {
-					return nil, fmt.Errorf("marshal credential %q for service %q: %w", k, service, err)
-				}
-				credMap[k] = string(b)
-			}
+	} else {
+		// Static credential path (api_key, basic, custom): existing behavior.
+		creds, err = resolveStaticCredentials(ctx, deps, userID, actionType)
+		if err != nil {
+			return nil, err
 		}
 	}
-
-	creds := connectors.NewCredentials(credMap)
 
 	// Validate credentials before executing the action.
 	connectorID := strings.SplitN(actionType, ".", 2)[0]
@@ -81,4 +66,200 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 		return nil, err
 	}
 	return result, nil
+}
+
+// resolveStaticCredentials fetches and decrypts static credentials (api_key, basic, custom)
+// for the given action type.
+func resolveStaticCredentials(ctx context.Context, deps *Deps, userID, actionType string) (connectors.Credentials, error) {
+	services, err := db.GetRequiredServicesByActionType(ctx, deps.DB, actionType)
+	if err != nil {
+		return connectors.Credentials{}, fmt.Errorf("look up required services: %w", err)
+	}
+
+	var zero connectors.Credentials
+	credMap := make(map[string]string, len(services))
+	for _, service := range services {
+		if deps.Vault == nil {
+			return zero, fmt.Errorf("credential vault is not configured but connector requires service %q", service)
+		}
+		decrypted, err := db.GetDecryptedCredentials(ctx, deps.DB, deps.Vault.ReadSecret, userID, service, nil)
+		if err != nil {
+			var credErr *db.CredentialError
+			if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
+				return zero, &connectors.ValidationError{
+					Message: fmt.Sprintf("no credentials stored for service %q", service),
+				}
+			}
+			return zero, fmt.Errorf("decrypt credentials for service %q: %w", service, err)
+		}
+		// Flatten decrypted JSON map into string values for the Credentials type.
+		for k, v := range decrypted {
+			switch vv := v.(type) {
+			case string:
+				credMap[k] = vv
+			default:
+				b, err := json.Marshal(v)
+				if err != nil {
+					return zero, fmt.Errorf("marshal credential %q for service %q: %w", k, service, err)
+				}
+				credMap[k] = string(b)
+			}
+		}
+	}
+
+	return connectors.NewCredentials(credMap), nil
+}
+
+// resolveOAuthCredentials looks up the user's OAuth connection for the required
+// provider, refreshes the token if it's expired or near-expiry, and returns
+// credentials containing the valid access token.
+func resolveOAuthCredentials(ctx context.Context, deps *Deps, userID string, reqCred *db.RequiredCredential) (connectors.Credentials, error) {
+	var zero connectors.Credentials
+	if deps.Vault == nil {
+		return zero, fmt.Errorf("credential vault is not configured but connector requires OAuth credentials")
+	}
+	if deps.OAuthProviders == nil {
+		return zero, fmt.Errorf("OAuth provider registry is not configured")
+	}
+
+	providerID := ""
+	if reqCred.OAuthProvider != nil {
+		providerID = *reqCred.OAuthProvider
+	}
+	if providerID == "" {
+		return zero, &connectors.ValidationError{
+			Message: "connector requires OAuth but no oauth_provider is configured",
+		}
+	}
+
+	// Look up the user's OAuth connection for this provider.
+	conn, err := db.GetOAuthConnectionByProvider(ctx, deps.DB, userID, providerID)
+	if err != nil {
+		return zero, fmt.Errorf("look up OAuth connection for provider %q: %w", providerID, err)
+	}
+	if conn == nil {
+		return zero, &connectors.OAuthRefreshError{
+			Provider: providerID,
+			Message:  fmt.Sprintf("no OAuth connection for provider %q — user must connect via Settings", providerID),
+		}
+	}
+
+	// Check connection status.
+	if conn.Status == db.OAuthStatusNeedsReauth || conn.Status == db.OAuthStatusRevoked {
+		return zero, &connectors.OAuthRefreshError{
+			Provider: providerID,
+			Message:  fmt.Sprintf("OAuth connection for %q has status %q — user must re-authorize", providerID, conn.Status),
+		}
+	}
+
+	// Check if the token needs refreshing (expired or within 5-minute buffer).
+	if conn.TokenExpiry != nil && time.Now().After(conn.TokenExpiry.Add(-5*time.Minute)) {
+		if err := refreshOAuthConnection(ctx, deps, conn, providerID); err != nil {
+			return zero, err
+		}
+	}
+
+	// Read the (possibly refreshed) access token from the vault.
+	accessTokenBytes, err := deps.Vault.ReadSecret(ctx, deps.DB, conn.AccessTokenVaultID)
+	if err != nil {
+		return zero, fmt.Errorf("read access token from vault: %w", err)
+	}
+
+	return connectors.NewCredentials(map[string]string{
+		"access_token": string(accessTokenBytes),
+	}), nil
+}
+
+// refreshOAuthConnection performs a token refresh for the given OAuth connection.
+// On success, it updates the vault secrets and DB row. On failure, it marks
+// the connection as needs_reauth and returns an OAuthRefreshError.
+func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConnection, providerID string) error {
+	provider, ok := deps.OAuthProviders.Get(providerID)
+	if !ok {
+		return &connectors.OAuthRefreshError{
+			Provider: providerID,
+			Message:  fmt.Sprintf("OAuth provider %q is not registered", providerID),
+		}
+	}
+
+	if conn.RefreshTokenVaultID == nil {
+		// No refresh token — can't refresh. Mark as needs_reauth.
+		if statusErr := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); statusErr != nil {
+			log.Printf("failed to update OAuth connection status to needs_reauth: %v", statusErr)
+		}
+		return &connectors.OAuthRefreshError{
+			Provider: providerID,
+			Message:  "token expired and no refresh token available — user must re-authorize",
+		}
+	}
+
+	// Read the refresh token from the vault.
+	refreshTokenBytes, err := deps.Vault.ReadSecret(ctx, deps.DB, *conn.RefreshTokenVaultID)
+	if err != nil {
+		return fmt.Errorf("read refresh token from vault: %w", err)
+	}
+
+	// Perform the refresh.
+	result, err := oauth.RefreshTokens(ctx, provider, string(refreshTokenBytes))
+	if err != nil {
+		// Refresh failed (token revoked, expired, etc.). Mark as needs_reauth.
+		if statusErr := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); statusErr != nil {
+			log.Printf("failed to update OAuth connection status to needs_reauth: %v", statusErr)
+		}
+		return &connectors.OAuthRefreshError{
+			Provider: providerID,
+			Message:  fmt.Sprintf("token refresh failed — user must re-authorize: %v", err),
+		}
+	}
+
+	// Store the new access token in the vault (update in place by deleting
+	// old and creating new, since vault doesn't have an update operation).
+	tx, owned, txErr := db.BeginOrContinue(ctx, deps.DB)
+	if txErr != nil {
+		return fmt.Errorf("begin tx for token refresh: %w", txErr)
+	}
+	if owned {
+		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
+	}
+
+	// Delete old access token and create new one.
+	_ = deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID)
+	newAccessVaultID, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_access", []byte(result.AccessToken))
+	if err != nil {
+		return fmt.Errorf("vault create refreshed access token: %w", err)
+	}
+
+	// Handle refresh token rotation.
+	var newRefreshVaultID *string
+	if result.RefreshToken != string(refreshTokenBytes) {
+		// Provider rotated the refresh token — store the new one.
+		_ = deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID)
+		id, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_refresh", []byte(result.RefreshToken))
+		if err != nil {
+			return fmt.Errorf("vault create rotated refresh token: %w", err)
+		}
+		newRefreshVaultID = &id
+	} else {
+		newRefreshVaultID = conn.RefreshTokenVaultID
+	}
+
+	var tokenExpiry *time.Time
+	if !result.Expiry.IsZero() {
+		tokenExpiry = &result.Expiry
+	}
+
+	if err := db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, newAccessVaultID, newRefreshVaultID, tokenExpiry); err != nil {
+		return fmt.Errorf("update OAuth connection tokens: %w", err)
+	}
+
+	if owned {
+		if err := db.CommitTx(ctx, tx); err != nil {
+			return fmt.Errorf("commit token refresh: %w", err)
+		}
+	}
+
+	// Update the in-memory connection so the caller reads the new vault ID.
+	conn.AccessTokenVaultID = newAccessVaultID
+
+	return nil
 }

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -60,6 +60,7 @@ const (
 	ErrOAuthConnectionExists     ErrorCode = "oauth_connection_exists"
 	ErrOAuthStateMismatch        ErrorCode = "oauth_state_mismatch"
 	ErrOAuthExchangeFailed       ErrorCode = "oauth_exchange_failed"
+	ErrOAuthRefreshFailed        ErrorCode = "oauth_refresh_failed"
 	// 429 Too Many Requests (quota)
 	ErrMonthlyQuotaExceeded ErrorCode = "monthly_quota_exceeded"
 )

--- a/background_oauth.go
+++ b/background_oauth.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/oauth"
+	"github.com/supersuit-tech/permission-slip-web/vault"
+)
+
+// oauthRefreshHorizon is the time window before token expiry within which
+// the background job proactively refreshes tokens. This prevents execution-time
+// latency from refresh calls.
+const oauthRefreshHorizon = 15 * time.Minute
+
+// OAuthRefreshDeps holds the dependencies for the background OAuth token refresh job.
+type OAuthRefreshDeps struct {
+	DB       db.DBTX
+	Vault    vault.VaultStore
+	Registry *oauth.Registry
+}
+
+// startOAuthRefresh runs a periodic background job that proactively refreshes
+// OAuth tokens expiring within the refresh horizon. It returns a channel that
+// is closed when the goroutine exits, so callers can wait for it during shutdown.
+func startOAuthRefresh(ctx context.Context, deps OAuthRefreshDeps, logger *slog.Logger) <-chan struct{} {
+	interval := oauthRefreshInterval(logger)
+	logger.Info("oauth refresh: scheduled", "interval", interval.String(),
+		"horizon", oauthRefreshHorizon.String())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		// Run once immediately on startup.
+		runOAuthRefresh(ctx, deps, logger)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info("oauth refresh: stopped")
+				return
+			case <-ticker.C:
+				runOAuthRefresh(ctx, deps, logger)
+			}
+		}
+	}()
+	return done
+}
+
+// runOAuthRefresh executes a single refresh pass with a 2-minute timeout.
+func runOAuthRefresh(ctx context.Context, deps OAuthRefreshDeps, logger *slog.Logger) {
+	if deps.DB == nil {
+		logger.Debug("oauth refresh: skipped (no database)")
+		return
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	conns, err := db.ListExpiringOAuthConnections(refreshCtx, deps.DB, oauthRefreshHorizon)
+	if err != nil {
+		if ctx.Err() != nil {
+			logger.Info("oauth refresh: cancelled", "error", err)
+			return
+		}
+		logger.Error("oauth refresh: failed to list expiring connections", "error", err)
+		sentry.CaptureException(err)
+		return
+	}
+
+	if len(conns) == 0 {
+		logger.Debug("oauth refresh: no tokens expiring soon")
+		return
+	}
+
+	var refreshed, failed int
+	for _, conn := range conns {
+		if err := refreshSingleConnection(refreshCtx, deps, conn); err != nil {
+			failed++
+			logger.Warn("oauth refresh: failed",
+				"connection_id", conn.ID,
+				"provider", conn.Provider,
+				"error", err)
+		} else {
+			refreshed++
+		}
+	}
+
+	logger.Info("oauth refresh: completed",
+		"total", len(conns), "refreshed", refreshed, "failed", failed)
+}
+
+// refreshSingleConnection refreshes the tokens for a single OAuth connection.
+func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, conn db.OAuthConnection) error {
+	provider, ok := deps.Registry.Get(conn.Provider)
+	if !ok {
+		return fmt.Errorf("provider %q not found in registry", conn.Provider)
+	}
+
+	if conn.RefreshTokenVaultID == nil {
+		// Mark as needs_reauth — no refresh token available.
+		if err := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); err != nil {
+			log.Printf("oauth refresh: failed to mark connection %s as needs_reauth: %v", conn.ID, err)
+		}
+		return fmt.Errorf("no refresh token for connection %s", conn.ID)
+	}
+
+	refreshTokenBytes, err := deps.Vault.ReadSecret(ctx, deps.DB, *conn.RefreshTokenVaultID)
+	if err != nil {
+		return fmt.Errorf("read refresh token: %w", err)
+	}
+
+	result, err := oauth.RefreshTokens(ctx, provider, string(refreshTokenBytes))
+	if err != nil {
+		// Refresh failed — mark as needs_reauth.
+		if statusErr := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); statusErr != nil {
+			log.Printf("oauth refresh: failed to mark connection %s as needs_reauth: %v", conn.ID, statusErr)
+		}
+		return fmt.Errorf("token refresh: %w", err)
+	}
+
+	// Store refreshed tokens in a transaction.
+	tx, owned, txErr := db.BeginOrContinue(ctx, deps.DB)
+	if txErr != nil {
+		return fmt.Errorf("begin tx: %w", txErr)
+	}
+	if owned {
+		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
+	}
+
+	_ = deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID)
+	newAccessVaultID, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_access", []byte(result.AccessToken))
+	if err != nil {
+		return fmt.Errorf("vault create access token: %w", err)
+	}
+
+	var newRefreshVaultID *string
+	if result.RefreshToken != string(refreshTokenBytes) {
+		_ = deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID)
+		id, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_refresh", []byte(result.RefreshToken))
+		if err != nil {
+			return fmt.Errorf("vault create refresh token: %w", err)
+		}
+		newRefreshVaultID = &id
+	} else {
+		newRefreshVaultID = conn.RefreshTokenVaultID
+	}
+
+	var tokenExpiry *time.Time
+	if !result.Expiry.IsZero() {
+		tokenExpiry = &result.Expiry
+	}
+
+	if err := db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, newAccessVaultID, newRefreshVaultID, tokenExpiry); err != nil {
+		return fmt.Errorf("update connection tokens: %w", err)
+	}
+
+	if owned {
+		if err := db.CommitTx(ctx, tx); err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// oauthRefreshInterval returns the refresh ticker interval from the
+// OAUTH_REFRESH_INTERVAL env var, defaulting to 10 minutes. Values below
+// 1 minute are rejected.
+func oauthRefreshInterval(logger *slog.Logger) time.Duration {
+	const minInterval = time.Minute
+
+	if v := os.Getenv("OAUTH_REFRESH_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err == nil && d >= minInterval {
+			return d
+		}
+		logger.Warn("invalid OAUTH_REFRESH_INTERVAL, using default 10m",
+			"value", v, "error", err, "min", minInterval.String())
+	}
+	return 10 * time.Minute
+}

--- a/background_oauth.go
+++ b/background_oauth.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"time"
@@ -83,9 +82,10 @@ func runOAuthRefresh(ctx context.Context, deps OAuthRefreshDeps, logger *slog.Lo
 		return
 	}
 
+	start := time.Now()
 	var refreshed, failed int
 	for _, conn := range conns {
-		if err := refreshSingleConnection(refreshCtx, deps, conn); err != nil {
+		if err := refreshSingleConnection(refreshCtx, deps, logger, conn); err != nil {
 			failed++
 			logger.Warn("oauth refresh: failed",
 				"connection_id", conn.ID,
@@ -97,20 +97,29 @@ func runOAuthRefresh(ctx context.Context, deps OAuthRefreshDeps, logger *slog.Lo
 	}
 
 	logger.Info("oauth refresh: completed",
-		"total", len(conns), "refreshed", refreshed, "failed", failed)
+		"total", len(conns), "refreshed", refreshed, "failed", failed,
+		"duration_ms", time.Since(start).Milliseconds())
 }
 
 // refreshSingleConnection refreshes the tokens for a single OAuth connection.
-func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, conn db.OAuthConnection) error {
+func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, logger *slog.Logger, conn db.OAuthConnection) error {
 	provider, ok := deps.Registry.Get(conn.Provider)
 	if !ok {
 		return fmt.Errorf("provider %q not found in registry", conn.Provider)
 	}
 
+	logAttrs := []any{
+		"connection_id", conn.ID,
+		"provider", conn.Provider,
+		"user_id", conn.UserID,
+	}
+
 	if conn.RefreshTokenVaultID == nil {
 		// Mark as needs_reauth — no refresh token available.
 		if err := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); err != nil {
-			log.Printf("oauth refresh: failed to mark connection %s as needs_reauth: %v", conn.ID, err)
+			logger.Error("oauth refresh: failed to mark connection as needs_reauth",
+				append(logAttrs, "error", err)...)
+			sentry.CaptureException(fmt.Errorf("oauth refresh status update failed for %s: %w", conn.ID, err))
 		}
 		return fmt.Errorf("no refresh token for connection %s", conn.ID)
 	}
@@ -124,7 +133,9 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, conn db
 	if err != nil {
 		// Refresh failed — mark as needs_reauth.
 		if statusErr := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); statusErr != nil {
-			log.Printf("oauth refresh: failed to mark connection %s as needs_reauth: %v", conn.ID, statusErr)
+			logger.Error("oauth refresh: failed to mark connection as needs_reauth",
+				append(logAttrs, "error", statusErr)...)
+			sentry.CaptureException(fmt.Errorf("oauth refresh status update failed for %s: %w", conn.ID, statusErr))
 		}
 		return fmt.Errorf("token refresh: %w", err)
 	}
@@ -138,7 +149,10 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, conn db
 		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
 	}
 
-	_ = deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID)
+	if err := deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID); err != nil {
+		logger.Warn("oauth refresh: failed to delete old access token from vault",
+			append(logAttrs, "vault_id", conn.AccessTokenVaultID, "error", err)...)
+	}
 	newAccessVaultID, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_access", []byte(result.AccessToken))
 	if err != nil {
 		return fmt.Errorf("vault create access token: %w", err)
@@ -146,7 +160,10 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, conn db
 
 	var newRefreshVaultID *string
 	if result.RefreshToken != string(refreshTokenBytes) {
-		_ = deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID)
+		if err := deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID); err != nil {
+			logger.Warn("oauth refresh: failed to delete old refresh token from vault",
+				append(logAttrs, "vault_id", *conn.RefreshTokenVaultID, "error", err)...)
+		}
 		id, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_refresh", []byte(result.RefreshToken))
 		if err != nil {
 			return fmt.Errorf("vault create refresh token: %w", err)

--- a/background_oauth.go
+++ b/background_oauth.go
@@ -149,37 +149,32 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, logger 
 		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
 	}
 
-	if err := deps.Vault.DeleteSecret(ctx, tx, conn.AccessTokenVaultID); err != nil {
-		logger.Warn("oauth refresh: failed to delete old access token from vault",
-			append(logAttrs, "vault_id", conn.AccessTokenVaultID, "error", err)...)
+	vaultOps := oauth.VaultOperations{
+		DeleteSecret: func(ctx context.Context, id string) error { return deps.Vault.DeleteSecret(ctx, tx, id) },
+		CreateSecret: func(ctx context.Context, name string, secret []byte) (string, error) {
+			return deps.Vault.CreateSecret(ctx, tx, name, secret)
+		},
 	}
-	newAccessVaultID, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_access", []byte(result.AccessToken))
+
+	_, err = oauth.StoreRefreshedTokens(ctx, vaultOps,
+		oauth.StoreRefreshedTokensParams{
+			ConnID:            conn.ID,
+			UserID:            conn.UserID,
+			OldAccessVaultID:  conn.AccessTokenVaultID,
+			OldRefreshVaultID: conn.RefreshTokenVaultID,
+			Result:            result,
+			OldRefreshToken:   string(refreshTokenBytes),
+		},
+		func(what, vaultID string, delErr error) {
+			logger.Warn("oauth refresh: failed to delete old "+what+" from vault",
+				append(logAttrs, "vault_id", vaultID, "error", delErr)...)
+		},
+		func(ctx context.Context, accessVaultID string, refreshVaultID *string, expiry *time.Time) error {
+			return db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, accessVaultID, refreshVaultID, expiry)
+		},
+	)
 	if err != nil {
-		return fmt.Errorf("vault create access token: %w", err)
-	}
-
-	var newRefreshVaultID *string
-	if result.RefreshToken != string(refreshTokenBytes) {
-		if err := deps.Vault.DeleteSecret(ctx, tx, *conn.RefreshTokenVaultID); err != nil {
-			logger.Warn("oauth refresh: failed to delete old refresh token from vault",
-				append(logAttrs, "vault_id", *conn.RefreshTokenVaultID, "error", err)...)
-		}
-		id, err := deps.Vault.CreateSecret(ctx, tx, conn.ID+"_refresh", []byte(result.RefreshToken))
-		if err != nil {
-			return fmt.Errorf("vault create refresh token: %w", err)
-		}
-		newRefreshVaultID = &id
-	} else {
-		newRefreshVaultID = conn.RefreshTokenVaultID
-	}
-
-	var tokenExpiry *time.Time
-	if !result.Expiry.IsZero() {
-		tokenExpiry = &result.Expiry
-	}
-
-	if err := db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, newAccessVaultID, newRefreshVaultID, tokenExpiry); err != nil {
-		return fmt.Errorf("update connection tokens: %w", err)
+		return err
 	}
 
 	if owned {

--- a/background_oauth.go
+++ b/background_oauth.go
@@ -108,17 +108,18 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, logger 
 		return fmt.Errorf("provider %q not found in registry", conn.Provider)
 	}
 
-	logAttrs := []any{
+	// Create a scoped logger with connection-level attributes so all log lines
+	// from this function include the connection context automatically.
+	connLog := logger.With(
 		"connection_id", conn.ID,
 		"provider", conn.Provider,
 		"user_id", conn.UserID,
-	}
+	)
 
 	if conn.RefreshTokenVaultID == nil {
 		// Mark as needs_reauth — no refresh token available.
 		if err := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); err != nil {
-			logger.Error("oauth refresh: failed to mark connection as needs_reauth",
-				append(logAttrs, "error", err)...)
+			connLog.Error("oauth refresh: failed to mark connection as needs_reauth", "error", err)
 			sentry.CaptureException(fmt.Errorf("oauth refresh status update failed for %s: %w", conn.ID, err))
 		}
 		return fmt.Errorf("no refresh token for connection %s", conn.ID)
@@ -133,8 +134,7 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, logger 
 	if err != nil {
 		// Refresh failed — mark as needs_reauth.
 		if statusErr := db.UpdateOAuthConnectionStatus(ctx, deps.DB, conn.ID, conn.UserID, db.OAuthStatusNeedsReauth); statusErr != nil {
-			logger.Error("oauth refresh: failed to mark connection as needs_reauth",
-				append(logAttrs, "error", statusErr)...)
+			connLog.Error("oauth refresh: failed to mark connection as needs_reauth", "error", statusErr)
 			sentry.CaptureException(fmt.Errorf("oauth refresh status update failed for %s: %w", conn.ID, statusErr))
 		}
 		return fmt.Errorf("token refresh: %w", err)
@@ -159,15 +159,14 @@ func refreshSingleConnection(ctx context.Context, deps OAuthRefreshDeps, logger 
 	_, err = oauth.StoreRefreshedTokens(ctx, vaultOps,
 		oauth.StoreRefreshedTokensParams{
 			ConnID:            conn.ID,
-			UserID:            conn.UserID,
 			OldAccessVaultID:  conn.AccessTokenVaultID,
 			OldRefreshVaultID: conn.RefreshTokenVaultID,
 			Result:            result,
 			OldRefreshToken:   string(refreshTokenBytes),
 		},
 		func(what, vaultID string, delErr error) {
-			logger.Warn("oauth refresh: failed to delete old "+what+" from vault",
-				append(logAttrs, "vault_id", vaultID, "error", delErr)...)
+			connLog.Warn("oauth refresh: failed to delete old "+what+" from vault",
+				"vault_id", vaultID, "error", delErr)
 		},
 		func(ctx context.Context, accessVaultID string, refreshVaultID *string, expiry *time.Time) error {
 			return db.UpdateOAuthConnectionTokens(ctx, tx, conn.ID, conn.UserID, accessVaultID, refreshVaultID, expiry)

--- a/background_oauth_test.go
+++ b/background_oauth_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOAuthRefreshInterval(t *testing.T) {
+	// Cannot use t.Parallel() because subtests use t.Setenv.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{name: "default when unset", envValue: "", want: 10 * time.Minute},
+		{name: "valid duration 5m", envValue: "5m", want: 5 * time.Minute},
+		{name: "valid duration 1m (minimum)", envValue: "1m", want: time.Minute},
+		{name: "valid duration 30m", envValue: "30m", want: 30 * time.Minute},
+		{name: "invalid string falls back", envValue: "notaduration", want: 10 * time.Minute},
+		{name: "zero duration falls back", envValue: "0s", want: 10 * time.Minute},
+		{name: "negative duration falls back", envValue: "-5m", want: 10 * time.Minute},
+		{name: "below minimum falls back", envValue: "30s", want: 10 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OAUTH_REFRESH_INTERVAL", tt.envValue)
+			got := oauthRefreshInterval(logger)
+			if got != tt.want {
+				t.Errorf("oauthRefreshInterval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartOAuthRefresh_StopsOnContextCancel(t *testing.T) {
+	// Cannot use t.Parallel() because we set OAUTH_REFRESH_INTERVAL via Setenv.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Setenv("OAUTH_REFRESH_INTERVAL", "1m")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Use a nil DB/vault/registry — runOAuthRefresh will fail to list connections
+	// but the goroutine lifecycle is what we're testing.
+	deps := OAuthRefreshDeps{}
+
+	done := startOAuthRefresh(ctx, deps, logger)
+
+	// Give the goroutine time to run the initial pass.
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+		// Success — goroutine exited.
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit within 2s after context cancel")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "oauth refresh: scheduled") {
+		t.Errorf("expected startup log message, got: %s", output)
+	}
+}

--- a/connectors/errors.go
+++ b/connectors/errors.go
@@ -93,3 +93,21 @@ func IsValidationError(err error) bool {
 func AsRateLimitError(err error, target **RateLimitError) bool {
 	return errors.As(err, target)
 }
+
+// OAuthRefreshError indicates that the OAuth token refresh failed and the user
+// needs to re-authorize. Maps to HTTP 401 with a message telling the agent
+// the user needs to reconnect the OAuth provider.
+type OAuthRefreshError struct {
+	Provider string // OAuth provider ID (e.g. "google")
+	Message  string // human-readable description
+}
+
+func (e *OAuthRefreshError) Error() string {
+	return fmt.Sprintf("OAuth token refresh failed for provider %q: %s", e.Provider, e.Message)
+}
+
+// IsOAuthRefreshError reports whether err is or wraps an *OAuthRefreshError.
+func IsOAuthRefreshError(err error) bool {
+	var target *OAuthRefreshError
+	return errors.As(err, &target)
+}

--- a/connectors/errors_test.go
+++ b/connectors/errors_test.go
@@ -112,6 +112,31 @@ func TestIsValidationError(t *testing.T) {
 	}
 }
 
+func TestOAuthRefreshError(t *testing.T) {
+	t.Parallel()
+	err := &OAuthRefreshError{Provider: "google", Message: "token revoked"}
+
+	expected := `OAuth token refresh failed for provider "google": token revoked`
+	if err.Error() != expected {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestIsOAuthRefreshError(t *testing.T) {
+	t.Parallel()
+	err := &OAuthRefreshError{Provider: "google", Message: "expired"}
+
+	if !IsOAuthRefreshError(err) {
+		t.Error("expected IsOAuthRefreshError to return true for *OAuthRefreshError")
+	}
+	if IsOAuthRefreshError(errors.New("other")) {
+		t.Error("expected IsOAuthRefreshError to return false for non-OAuthRefreshError")
+	}
+	if IsOAuthRefreshError(nil) {
+		t.Error("expected IsOAuthRefreshError(nil) = false")
+	}
+}
+
 func TestIsChecks_WrappedErrors(t *testing.T) {
 	t.Parallel()
 
@@ -125,6 +150,7 @@ func TestIsChecks_WrappedErrors(t *testing.T) {
 		{"wrapped RateLimitError", fmt.Errorf("wrap: %w", &RateLimitError{Message: "slow down", RetryAfter: time.Second}), IsRateLimitError},
 		{"wrapped TimeoutError", fmt.Errorf("wrap: %w", &TimeoutError{Message: "timeout"}), IsTimeoutError},
 		{"wrapped ValidationError", fmt.Errorf("wrap: %w", &ValidationError{Message: "invalid"}), IsValidationError},
+		{"wrapped OAuthRefreshError", fmt.Errorf("wrap: %w", &OAuthRefreshError{Provider: "google", Message: "fail"}), IsOAuthRefreshError},
 	}
 
 	for _, tt := range tests {

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -229,6 +229,37 @@ func DeleteOAuthConnection(ctx context.Context, db DBTX, userID, provider string
 	return &result, nil
 }
 
+// ListExpiringOAuthConnections returns all active OAuth connections whose
+// token_expiry is within the given horizon from now. Used by the background
+// refresh job to proactively refresh tokens before they expire.
+// Only returns connections that have a refresh token (refresh_token_vault_id IS NOT NULL).
+func ListExpiringOAuthConnections(ctx context.Context, db DBTX, horizon time.Duration) ([]OAuthConnection, error) {
+	rows, err := db.Query(ctx, `
+		SELECT `+oauthConnectionColumns+`
+		FROM oauth_connections
+		WHERE status = $1
+		  AND refresh_token_vault_id IS NOT NULL
+		  AND token_expiry IS NOT NULL
+		  AND token_expiry <= now() + $2::interval
+		ORDER BY token_expiry ASC`,
+		OAuthStatusActive, fmt.Sprintf("%d seconds", int(horizon.Seconds())),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var conns []OAuthConnection
+	for rows.Next() {
+		c, err := scanOAuthConnection(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		conns = append(conns, c)
+	}
+	return conns, rows.Err()
+}
+
 // GetRequiredCredentialByActionType returns the required credential for the connector
 // that owns the given action type. Used to determine auth_type at execution time.
 func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType string) (*RequiredCredential, error) {

--- a/db/oauth_connections_refresh_test.go
+++ b/db/oauth_connections_refresh_test.go
@@ -1,0 +1,133 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestListExpiringOAuthConnections_NoConnections(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	conns, err := db.ListExpiringOAuthConnections(context.Background(), tx, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conns) != 0 {
+		t.Fatalf("expected 0 connections, got %d", len(conns))
+	}
+}
+
+func TestListExpiringOAuthConnections_FindsExpiringSoon(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	// Connection expiring in 10 minutes (within 15-minute horizon).
+	expiryWithin := time.Now().Add(10 * time.Minute)
+	refreshVaultID := "00000000-0000-0000-0000-000000000002"
+	testhelper.InsertOAuthConnectionFull(t, tx, "oconn_expiring", uid, "google", testhelper.OAuthConnectionOpts{
+		RefreshTokenVaultID: &refreshVaultID,
+		TokenExpiry:         &expiryWithin,
+		Scopes:              []string{"openid"},
+	})
+
+	// Connection expiring in 2 hours (outside 15-minute horizon).
+	expiryLater := time.Now().Add(2 * time.Hour)
+	testhelper.InsertOAuthConnectionFull(t, tx, "oconn_later", uid, "microsoft", testhelper.OAuthConnectionOpts{
+		RefreshTokenVaultID: &refreshVaultID,
+		TokenExpiry:         &expiryLater,
+		Scopes:              []string{"openid"},
+	})
+
+	conns, err := db.ListExpiringOAuthConnections(context.Background(), tx, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Fatalf("expected 1 expiring connection, got %d", len(conns))
+	}
+	if conns[0].ID != "oconn_expiring" {
+		t.Errorf("expected connection 'oconn_expiring', got %q", conns[0].ID)
+	}
+}
+
+func TestListExpiringOAuthConnections_SkipsWithoutRefreshToken(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	// Connection expiring soon but WITHOUT a refresh token.
+	expiryWithin := time.Now().Add(5 * time.Minute)
+	testhelper.InsertOAuthConnectionFull(t, tx, "oconn_no_refresh", uid, "google", testhelper.OAuthConnectionOpts{
+		TokenExpiry: &expiryWithin,
+		Scopes:      []string{"openid"},
+	})
+
+	conns, err := db.ListExpiringOAuthConnections(context.Background(), tx, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conns) != 0 {
+		t.Fatalf("expected 0 connections (no refresh token), got %d", len(conns))
+	}
+}
+
+func TestListExpiringOAuthConnections_SkipsNonActive(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	expiryWithin := time.Now().Add(5 * time.Minute)
+	refreshVaultID := "00000000-0000-0000-0000-000000000002"
+	testhelper.InsertOAuthConnectionFull(t, tx, "oconn_needs_reauth", uid, "google", testhelper.OAuthConnectionOpts{
+		RefreshTokenVaultID: &refreshVaultID,
+		TokenExpiry:         &expiryWithin,
+		Status:              "needs_reauth",
+		Scopes:              []string{"openid"},
+	})
+
+	conns, err := db.ListExpiringOAuthConnections(context.Background(), tx, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conns) != 0 {
+		t.Fatalf("expected 0 connections (non-active status), got %d", len(conns))
+	}
+}
+
+func TestGetRequiredCredentialByActionType_OAuth(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	testhelper.InsertConnector(t, tx, "google")
+	testhelper.InsertConnectorAction(t, tx, "google", "google.send_email", "Send Email")
+	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, "google", "google", "google", []string{"https://www.googleapis.com/auth/gmail.send"})
+
+	rc, err := db.GetRequiredCredentialByActionType(context.Background(), tx, "google.send_email")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rc == nil {
+		t.Fatal("expected non-nil required credential")
+	}
+	if rc.AuthType != "oauth2" {
+		t.Errorf("expected auth_type 'oauth2', got %q", rc.AuthType)
+	}
+	if rc.OAuthProvider == nil || *rc.OAuthProvider != "google" {
+		t.Errorf("expected oauth_provider 'google', got %v", rc.OAuthProvider)
+	}
+	if len(rc.OAuthScopes) != 1 || rc.OAuthScopes[0] != "https://www.googleapis.com/auth/gmail.send" {
+		t.Errorf("unexpected scopes: %v", rc.OAuthScopes)
+	}
+}

--- a/db/testhelper/fixtures_oauth.go
+++ b/db/testhelper/fixtures_oauth.go
@@ -1,0 +1,54 @@
+package testhelper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// InsertOAuthConnection creates an OAuth connection for the given user and provider.
+// Uses placeholder vault IDs. The user must already exist via InsertUser.
+func InsertOAuthConnection(t *testing.T, d db.DBTX, connID, userID, provider string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, scopes, status)
+		 VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000001', '{}', 'active')`,
+		connID, userID, provider)
+}
+
+// OAuthConnectionOpts holds optional fields for InsertOAuthConnectionFull.
+type OAuthConnectionOpts struct {
+	AccessTokenVaultID  string
+	RefreshTokenVaultID *string
+	Scopes              []string
+	TokenExpiry         *time.Time
+	Status              string
+}
+
+// InsertOAuthConnectionFull creates an OAuth connection with full control over all fields.
+func InsertOAuthConnectionFull(t *testing.T, d db.DBTX, connID, userID, provider string, opts OAuthConnectionOpts) {
+	t.Helper()
+	status := opts.Status
+	if status == "" {
+		status = "active"
+	}
+	accessVaultID := opts.AccessTokenVaultID
+	if accessVaultID == "" {
+		accessVaultID = "00000000-0000-0000-0000-000000000001"
+	}
+	mustExec(t, d,
+		`INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, refresh_token_vault_id, scopes, token_expiry, status)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		connID, userID, provider, accessVaultID, opts.RefreshTokenVaultID, opts.Scopes, opts.TokenExpiry, status)
+}
+
+// InsertConnectorRequiredCredentialOAuth creates an OAuth-type required credential entry.
+// The connector must already exist via InsertConnector.
+func InsertConnectorRequiredCredentialOAuth(t *testing.T, d db.DBTX, connectorID, service, oauthProvider string, oauthScopes []string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO connector_required_credentials (connector_id, service, auth_type, oauth_provider, oauth_scopes)
+		 VALUES ($1, $2, 'oauth2', $3, $4)`,
+		connectorID, service, oauthProvider, oauthScopes)
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,15 @@ graph TB
     style CE fill:#9AA0A6,color:#fff,stroke:#7A8086
 ```
 
+## Background Jobs
+
+The server runs periodic background jobs when a database connection is configured. Both jobs are started on server boot, run immediately once, then repeat on a configurable interval. They respect context cancellation for graceful shutdown.
+
+| Job | Default Interval | Description |
+|-----|-----------------|-------------|
+| **Audit log purge** | 1 hour (`AUDIT_PURGE_INTERVAL`) | Deletes expired audit events to prevent unbounded table growth. |
+| **OAuth token refresh** | 10 minutes (`OAUTH_REFRESH_INTERVAL`) | Proactively refreshes OAuth access tokens expiring within 15 minutes. Tokens that fail to refresh (revoked, expired refresh token) are marked `needs_reauth`, prompting the user to re-authorize. |
+
 ## Agent Registration Flow
 
 > Registration is **user-initiated** via invite codes. See [ADR-005](adr/005-user-initiated-registration.md) for the rationale.

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -173,18 +173,22 @@ User credentials stored via Supabase Vault. The table holds a reference to the V
 
 Stores OAuth 2.0 connections for users. Each row represents a user's authenticated connection to an OAuth provider (e.g., Google, Microsoft). Tokens are stored in the Vault — this table only holds Vault references.
 
-| Column | Type | Constraints |
-|---|---|---|
-| `id` | text | PK, max 255 chars |
-| `user_id` | uuid | NOT NULL, FK → profiles(id) ON DELETE CASCADE |
-| `provider` | text | NOT NULL, max 255 chars (e.g., "google", "microsoft") |
-| `access_token_vault_id` | uuid | NOT NULL |
-| `refresh_token_vault_id` | uuid | Nullable |
-| `scopes` | text[] | NOT NULL, DEFAULT '{}' |
-| `token_expiry` | timestamptz | Nullable |
-| `status` | text | NOT NULL, DEFAULT 'active', CHECK IN ('active', 'needs_reauth', 'revoked') |
-| `created_at` | timestamptz | NOT NULL, DEFAULT now() |
-| `updated_at` | timestamptz | NOT NULL, DEFAULT now() |
+A background job proactively refreshes tokens within 15 minutes of expiry (`token_expiry`). If refresh fails (token revoked, no refresh token available), the connection's `status` is set to `needs_reauth`, signaling the user to re-authorize via the Settings page.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | text | PK, max 255 chars | |
+| `user_id` | uuid | NOT NULL, FK → profiles(id) ON DELETE CASCADE | |
+| `provider` | text | NOT NULL, max 255 chars (e.g., "google", "microsoft") | |
+| `access_token_vault_id` | uuid | NOT NULL | Vault reference; rotated on each refresh |
+| `refresh_token_vault_id` | uuid | Nullable | Nullable — some providers don't issue refresh tokens. If NULL, the connection cannot be refreshed and will be marked `needs_reauth` on expiry. |
+| `scopes` | text[] | NOT NULL, DEFAULT '{}' | |
+| `token_expiry` | timestamptz | Nullable | When the access token expires. The background refresh job queries for tokens where this is within 15 minutes of now. NULL means the token doesn't expire. |
+| `status` | text | NOT NULL, DEFAULT 'active', CHECK IN ('active', 'needs_reauth', 'revoked') | See status lifecycle below |
+| `created_at` | timestamptz | NOT NULL, DEFAULT now() | |
+| `updated_at` | timestamptz | NOT NULL, DEFAULT now() | Updated on token refresh and status change |
+
+**Status lifecycle:** `active` → `needs_reauth` (on refresh failure or token expiry without refresh token) → `active` (on user re-authorization). Users can also set `revoked` by disconnecting the provider.
 
 **Constraints:** UNIQUE on `(user_id, provider)` — one connection per provider per user.
 

--- a/main.go
+++ b/main.go
@@ -188,6 +188,7 @@ func main() {
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	defer bgCancel()
 	var auditPurgeDone <-chan struct{}
+	var oauthRefreshDone <-chan struct{}
 
 	// Connect to Postgres if DATABASE_URL is set
 	if dbURL := os.Getenv("DATABASE_URL"); dbURL != "" {
@@ -335,6 +336,15 @@ func main() {
 		}
 	}
 
+	// Start background OAuth token refresh job (requires DB, vault, and OAuth registry).
+	if deps.DB != nil && deps.Vault != nil {
+		oauthRefreshDone = startOAuthRefresh(bgCtx, OAuthRefreshDeps{
+			DB:       deps.DB,
+			Vault:    deps.Vault,
+			Registry: oauthRegistry,
+		}, logger)
+	}
+
 	log.Printf("Connector registry: %d connector(s) registered", len(registry.IDs()))
 
 	// Parse allowed CORS origins from a comma-separated list.
@@ -471,6 +481,13 @@ func main() {
 		case <-auditPurgeDone:
 		case <-time.After(5 * time.Second):
 			logger.Warn("audit purge goroutine did not exit in time")
+		}
+	}
+	if oauthRefreshDone != nil {
+		select {
+		case <-oauthRefreshDone:
+		case <-time.After(5 * time.Second):
+			logger.Warn("oauth refresh goroutine did not exit in time")
 		}
 	}
 

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -90,10 +90,11 @@ type TokenSet struct {
 	Scopes []string
 }
 
-// tokenExpiryBuffer is the time before actual expiry at which a token is
+// TokenExpiryBuffer is the time before actual expiry at which a token is
 // considered expired. This allows pre-emptive refresh so actions don't fail
-// mid-execution due to an expired token.
-const tokenExpiryBuffer = 5 * time.Minute
+// mid-execution due to an expired token. Used by both the background refresh
+// job and synchronous execution-time refresh.
+const TokenExpiryBuffer = 5 * time.Minute
 
 // IsExpired reports whether the access token has expired or is within the
 // pre-emptive refresh buffer (5 minutes before actual expiry).
@@ -101,7 +102,7 @@ func (ts TokenSet) IsExpired() bool {
 	if ts.Expiry.IsZero() {
 		return false
 	}
-	return time.Now().After(ts.Expiry.Add(-tokenExpiryBuffer))
+	return time.Now().After(ts.Expiry.Add(-TokenExpiryBuffer))
 }
 
 // HasClientCredentials reports whether the provider has both a client ID and

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -47,6 +47,10 @@ func RefreshTokens(ctx context.Context, provider Provider, refreshToken string) 
 		return nil, fmt.Errorf("refresh token exchange for provider %q: %w", provider.ID, err)
 	}
 
+	if newToken.AccessToken == "" {
+		return nil, fmt.Errorf("provider %q returned an empty access token during refresh", provider.ID)
+	}
+
 	result := &RefreshResult{
 		AccessToken: newToken.AccessToken,
 		Expiry:      newToken.Expiry,

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -1,0 +1,64 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// RefreshResult holds the new tokens and expiry from a successful token refresh.
+type RefreshResult struct {
+	AccessToken  string
+	RefreshToken string // May differ from the original if the provider rotates refresh tokens.
+	Expiry       time.Time
+}
+
+// RefreshTokens uses the provider's token endpoint to exchange a refresh token
+// for a new access token. Returns the new tokens and expiry. The provider must
+// have client credentials configured; the caller must have a valid refresh token.
+//
+// The context controls the HTTP timeout for the token exchange request.
+func RefreshTokens(ctx context.Context, provider Provider, refreshToken string) (*RefreshResult, error) {
+	if !provider.HasClientCredentials() {
+		return nil, fmt.Errorf("oauth provider %q has no client credentials configured", provider.ID)
+	}
+	if refreshToken == "" {
+		return nil, fmt.Errorf("refresh token is empty for provider %q", provider.ID)
+	}
+
+	cfg := &oauth2.Config{
+		ClientID:     provider.ClientID,
+		ClientSecret: provider.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: provider.TokenURL,
+		},
+	}
+
+	// Create a token source from the existing refresh token.
+	// oauth2.TokenSource will exchange the refresh token for a new access token.
+	token := &oauth2.Token{
+		RefreshToken: refreshToken,
+	}
+	ts := cfg.TokenSource(ctx, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("refresh token exchange for provider %q: %w", provider.ID, err)
+	}
+
+	result := &RefreshResult{
+		AccessToken: newToken.AccessToken,
+		Expiry:      newToken.Expiry,
+	}
+
+	// Some providers rotate refresh tokens on each refresh. Use the new one
+	// if provided, otherwise keep the original.
+	if newToken.RefreshToken != "" {
+		result.RefreshToken = newToken.RefreshToken
+	} else {
+		result.RefreshToken = refreshToken
+	}
+
+	return result, nil
+}

--- a/oauth/refresh_test.go
+++ b/oauth/refresh_test.go
@@ -119,6 +119,37 @@ func TestRefreshTokens_EmptyRefreshToken(t *testing.T) {
 	}
 }
 
+func TestRefreshTokens_EmptyAccessTokenResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	provider := Provider{
+		ID:           "test",
+		TokenURL:     srv.URL,
+		ClientID:     "id",
+		ClientSecret: "secret",
+	}
+
+	_, err := RefreshTokens(context.Background(), provider, "some-token")
+	if err == nil {
+		t.Fatal("expected error when provider returns empty access token")
+	}
+	// The oauth2 library or our validation should catch this — either message is acceptable.
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "empty access token") && !strings.Contains(errMsg, "missing access_token") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestRefreshTokens_TokenEndpointError(t *testing.T) {
 	t.Parallel()
 

--- a/oauth/refresh_test.go
+++ b/oauth/refresh_test.go
@@ -1,0 +1,149 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshTokens_Success(t *testing.T) {
+	t.Parallel()
+
+	// Set up a mock OAuth token endpoint.
+	expiry := time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer srv.Close()
+
+	provider := Provider{
+		ID:           "test-provider",
+		TokenURL:     srv.URL,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	result, err := RefreshTokens(context.Background(), provider, "old-refresh-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.AccessToken != "new-access-token" {
+		t.Errorf("expected access_token 'new-access-token', got %q", result.AccessToken)
+	}
+	if result.RefreshToken != "new-refresh-token" {
+		t.Errorf("expected refresh_token 'new-refresh-token', got %q", result.RefreshToken)
+	}
+	if result.Expiry.Before(expiry.Add(-5 * time.Second)) {
+		t.Errorf("expected expiry around %v, got %v", expiry, result.Expiry)
+	}
+}
+
+func TestRefreshTokens_KeepsOriginalRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Provider does NOT return a new refresh token.
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	provider := Provider{
+		ID:           "test-provider",
+		TokenURL:     srv.URL,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	result, err := RefreshTokens(context.Background(), provider, "original-refresh-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RefreshToken != "original-refresh-token" {
+		t.Errorf("expected original refresh token to be preserved, got %q", result.RefreshToken)
+	}
+}
+
+func TestRefreshTokens_NoClientCredentials(t *testing.T) {
+	t.Parallel()
+
+	provider := Provider{
+		ID:       "no-creds",
+		TokenURL: "https://example.com/token",
+	}
+
+	_, err := RefreshTokens(context.Background(), provider, "some-token")
+	if err == nil {
+		t.Fatal("expected error when provider has no client credentials")
+	}
+	if !strings.Contains(err.Error(), "no client credentials") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRefreshTokens_EmptyRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	provider := Provider{
+		ID:           "test",
+		TokenURL:     "https://example.com/token",
+		ClientID:     "id",
+		ClientSecret: "secret",
+	}
+
+	_, err := RefreshTokens(context.Background(), provider, "")
+	if err == nil {
+		t.Fatal("expected error when refresh token is empty")
+	}
+	if !strings.Contains(err.Error(), "refresh token is empty") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRefreshTokens_TokenEndpointError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "Token has been revoked",
+		})
+	}))
+	defer srv.Close()
+
+	provider := Provider{
+		ID:           "test",
+		TokenURL:     srv.URL,
+		ClientID:     "id",
+		ClientSecret: "secret",
+	}
+
+	_, err := RefreshTokens(context.Background(), provider, "revoked-token")
+	if err == nil {
+		t.Fatal("expected error when token endpoint returns error")
+	}
+	if !strings.Contains(err.Error(), "refresh token exchange") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/oauth/store.go
+++ b/oauth/store.go
@@ -9,7 +9,6 @@ import (
 // StoreRefreshedTokensParams holds the inputs for persisting refreshed OAuth tokens.
 type StoreRefreshedTokensParams struct {
 	ConnID            string         // OAuth connection ID (used for vault secret naming).
-	UserID            string         // Connection owner (for authorization checks).
 	OldAccessVaultID  string         // Current access token vault secret ID.
 	OldRefreshVaultID *string        // Current refresh token vault secret ID (nil if none).
 	Result            *RefreshResult // The new tokens from the provider.

--- a/oauth/store.go
+++ b/oauth/store.go
@@ -1,0 +1,78 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// StoreRefreshedTokensParams holds the inputs for persisting refreshed OAuth tokens.
+type StoreRefreshedTokensParams struct {
+	ConnID            string         // OAuth connection ID (used for vault secret naming).
+	UserID            string         // Connection owner (for authorization checks).
+	OldAccessVaultID  string         // Current access token vault secret ID.
+	OldRefreshVaultID *string        // Current refresh token vault secret ID (nil if none).
+	Result            *RefreshResult // The new tokens from the provider.
+	OldRefreshToken   string         // The old refresh token value (for rotation detection).
+}
+
+// VaultOperations defines the vault operations needed to store refreshed tokens.
+// Callers provide these as closures bound to the current transaction.
+type VaultOperations struct {
+	DeleteSecret func(ctx context.Context, id string) error
+	CreateSecret func(ctx context.Context, name string, secret []byte) (string, error)
+}
+
+// StoreRefreshedTokens persists refreshed OAuth tokens in the vault and updates
+// the database row. It handles refresh token rotation (storing the new refresh
+// token when the provider rotates it) and old secret cleanup.
+//
+// The updateDB callback should update the oauth_connections row with the new
+// vault IDs and expiry within the same transaction used for vault operations.
+//
+// Returns the new access token vault ID so callers can update in-memory state.
+func StoreRefreshedTokens(
+	ctx context.Context,
+	vault VaultOperations,
+	p StoreRefreshedTokensParams,
+	logDeleteErr func(what, vaultID string, err error),
+	updateDB func(ctx context.Context, accessVaultID string, refreshVaultID *string, expiry *time.Time) error,
+) (newAccessVaultID string, err error) {
+	// Delete old access token (best-effort) and create the new one.
+	if delErr := vault.DeleteSecret(ctx, p.OldAccessVaultID); delErr != nil && logDeleteErr != nil {
+		logDeleteErr("access token", p.OldAccessVaultID, delErr)
+	}
+	newAccessVaultID, err = vault.CreateSecret(ctx, p.ConnID+"_access", []byte(p.Result.AccessToken))
+	if err != nil {
+		return "", fmt.Errorf("vault create access token: %w", err)
+	}
+
+	// Handle refresh token rotation.
+	var newRefreshVaultID *string
+	if p.Result.RefreshToken != p.OldRefreshToken {
+		// Provider rotated the refresh token — store the new one.
+		if p.OldRefreshVaultID != nil {
+			if delErr := vault.DeleteSecret(ctx, *p.OldRefreshVaultID); delErr != nil && logDeleteErr != nil {
+				logDeleteErr("refresh token", *p.OldRefreshVaultID, delErr)
+			}
+		}
+		id, createErr := vault.CreateSecret(ctx, p.ConnID+"_refresh", []byte(p.Result.RefreshToken))
+		if createErr != nil {
+			return "", fmt.Errorf("vault create refresh token: %w", createErr)
+		}
+		newRefreshVaultID = &id
+	} else {
+		newRefreshVaultID = p.OldRefreshVaultID
+	}
+
+	var tokenExpiry *time.Time
+	if !p.Result.Expiry.IsZero() {
+		tokenExpiry = &p.Result.Expiry
+	}
+
+	if err := updateDB(ctx, newAccessVaultID, newRefreshVaultID, tokenExpiry); err != nil {
+		return "", fmt.Errorf("update connection tokens: %w", err)
+	}
+
+	return newAccessVaultID, nil
+}

--- a/oauth/store_test.go
+++ b/oauth/store_test.go
@@ -35,7 +35,7 @@ func TestStoreRefreshedTokens_Success(t *testing.T) {
 		context.Background(), vaultOps,
 		StoreRefreshedTokensParams{
 			ConnID:            "conn-123",
-			UserID:            "user-456",
+
 			OldAccessVaultID:  "old-access-vault-id",
 			OldRefreshVaultID: &oldRefreshVaultID,
 			Result: &RefreshResult{
@@ -113,7 +113,7 @@ func TestStoreRefreshedTokens_NoRotation(t *testing.T) {
 		context.Background(), vaultOps,
 		StoreRefreshedTokensParams{
 			ConnID:            "conn-123",
-			UserID:            "user-456",
+
 			OldAccessVaultID:  "old-access-vault-id",
 			OldRefreshVaultID: &oldRefreshVaultID,
 			Result: &RefreshResult{

--- a/oauth/store_test.go
+++ b/oauth/store_test.go
@@ -1,0 +1,218 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStoreRefreshedTokens_Success(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Now().Add(1 * time.Hour)
+	oldRefreshVaultID := "old-refresh-vault-id"
+
+	var deletedIDs []string
+	var createdNames []string
+
+	vaultOps := VaultOperations{
+		DeleteSecret: func(_ context.Context, id string) error {
+			deletedIDs = append(deletedIDs, id)
+			return nil
+		},
+		CreateSecret: func(_ context.Context, name string, _ []byte) (string, error) {
+			createdNames = append(createdNames, name)
+			return "new-" + name, nil
+		},
+	}
+
+	var dbAccessVaultID string
+	var dbRefreshVaultID *string
+	var dbExpiry *time.Time
+
+	newAccessVaultID, err := StoreRefreshedTokens(
+		context.Background(), vaultOps,
+		StoreRefreshedTokensParams{
+			ConnID:            "conn-123",
+			UserID:            "user-456",
+			OldAccessVaultID:  "old-access-vault-id",
+			OldRefreshVaultID: &oldRefreshVaultID,
+			Result: &RefreshResult{
+				AccessToken:  "new-access-token",
+				RefreshToken: "new-refresh-token", // rotated
+				Expiry:       expiry,
+			},
+			OldRefreshToken: "old-refresh-token",
+		},
+		nil, // no delete error logging
+		func(_ context.Context, accessVaultID string, refreshVaultID *string, exp *time.Time) error {
+			dbAccessVaultID = accessVaultID
+			dbRefreshVaultID = refreshVaultID
+			dbExpiry = exp
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if newAccessVaultID != "new-conn-123_access" {
+		t.Errorf("unexpected access vault ID: %s", newAccessVaultID)
+	}
+
+	// Old access and refresh tokens should be deleted.
+	if len(deletedIDs) != 2 {
+		t.Fatalf("expected 2 deletions, got %d: %v", len(deletedIDs), deletedIDs)
+	}
+	if deletedIDs[0] != "old-access-vault-id" {
+		t.Errorf("expected first deletion of old access token, got %s", deletedIDs[0])
+	}
+	if deletedIDs[1] != "old-refresh-vault-id" {
+		t.Errorf("expected second deletion of old refresh token, got %s", deletedIDs[1])
+	}
+
+	// New access and refresh tokens should be created.
+	if len(createdNames) != 2 {
+		t.Fatalf("expected 2 creations, got %d: %v", len(createdNames), createdNames)
+	}
+
+	// DB should be updated with new vault IDs.
+	if dbAccessVaultID != "new-conn-123_access" {
+		t.Errorf("unexpected DB access vault ID: %s", dbAccessVaultID)
+	}
+	if dbRefreshVaultID == nil || *dbRefreshVaultID != "new-conn-123_refresh" {
+		t.Errorf("unexpected DB refresh vault ID: %v", dbRefreshVaultID)
+	}
+	if dbExpiry == nil || !dbExpiry.Equal(expiry) {
+		t.Errorf("unexpected DB expiry: %v", dbExpiry)
+	}
+}
+
+func TestStoreRefreshedTokens_NoRotation(t *testing.T) {
+	t.Parallel()
+
+	oldRefreshVaultID := "old-refresh-vault-id"
+	sameToken := "same-refresh-token"
+
+	var deletedIDs []string
+
+	vaultOps := VaultOperations{
+		DeleteSecret: func(_ context.Context, id string) error {
+			deletedIDs = append(deletedIDs, id)
+			return nil
+		},
+		CreateSecret: func(_ context.Context, name string, _ []byte) (string, error) {
+			return "new-" + name, nil
+		},
+	}
+
+	var dbRefreshVaultID *string
+
+	_, err := StoreRefreshedTokens(
+		context.Background(), vaultOps,
+		StoreRefreshedTokensParams{
+			ConnID:            "conn-123",
+			UserID:            "user-456",
+			OldAccessVaultID:  "old-access-vault-id",
+			OldRefreshVaultID: &oldRefreshVaultID,
+			Result: &RefreshResult{
+				AccessToken:  "new-access-token",
+				RefreshToken: sameToken, // same as old — no rotation
+				Expiry:       time.Now().Add(1 * time.Hour),
+			},
+			OldRefreshToken: sameToken,
+		},
+		nil,
+		func(_ context.Context, _ string, refreshVaultID *string, _ *time.Time) error {
+			dbRefreshVaultID = refreshVaultID
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only old access token should be deleted (no refresh token rotation).
+	if len(deletedIDs) != 1 {
+		t.Fatalf("expected 1 deletion, got %d: %v", len(deletedIDs), deletedIDs)
+	}
+
+	// DB should retain the old refresh vault ID.
+	if dbRefreshVaultID == nil || *dbRefreshVaultID != "old-refresh-vault-id" {
+		t.Errorf("expected old refresh vault ID preserved, got %v", dbRefreshVaultID)
+	}
+}
+
+func TestStoreRefreshedTokens_CreateAccessTokenFails(t *testing.T) {
+	t.Parallel()
+
+	vaultOps := VaultOperations{
+		DeleteSecret: func(_ context.Context, _ string) error { return nil },
+		CreateSecret: func(_ context.Context, _ string, _ []byte) (string, error) {
+			return "", errors.New("vault unavailable")
+		},
+	}
+
+	_, err := StoreRefreshedTokens(
+		context.Background(), vaultOps,
+		StoreRefreshedTokensParams{
+			ConnID:           "conn-123",
+			OldAccessVaultID: "old-access",
+			Result: &RefreshResult{
+				AccessToken:  "token",
+				RefreshToken: "token",
+			},
+			OldRefreshToken: "token",
+		},
+		nil,
+		func(_ context.Context, _ string, _ *string, _ *time.Time) error { return nil },
+	)
+	if err == nil {
+		t.Fatal("expected error when vault create fails")
+	}
+	if !errors.Is(err, errors.Unwrap(err)) {
+		// Just check the error message mentions vault
+		if got := err.Error(); got == "" {
+			t.Error("expected non-empty error message")
+		}
+	}
+}
+
+func TestStoreRefreshedTokens_ZeroExpiry(t *testing.T) {
+	t.Parallel()
+
+	vaultOps := VaultOperations{
+		DeleteSecret: func(_ context.Context, _ string) error { return nil },
+		CreateSecret: func(_ context.Context, name string, _ []byte) (string, error) {
+			return "new-" + name, nil
+		},
+	}
+
+	var dbExpiry *time.Time
+
+	_, err := StoreRefreshedTokens(
+		context.Background(), vaultOps,
+		StoreRefreshedTokensParams{
+			ConnID:           "conn-123",
+			OldAccessVaultID: "old-access",
+			Result: &RefreshResult{
+				AccessToken:  "token",
+				RefreshToken: "same",
+				Expiry:       time.Time{}, // zero — token doesn't expire
+			},
+			OldRefreshToken: "same",
+		},
+		nil,
+		func(_ context.Context, _ string, _ *string, exp *time.Time) error {
+			dbExpiry = exp
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dbExpiry != nil {
+		t.Errorf("expected nil expiry for zero time, got %v", dbExpiry)
+	}
+}

--- a/spec/openapi/components/schemas/oauth.yaml
+++ b/spec/openapi/components/schemas/oauth.yaml
@@ -58,7 +58,11 @@ OAuthConnection:
     status:
       type: string
       enum: ["active", "needs_reauth", "revoked"]
-      description: The current status of the connection
+      description: >
+        The current status of the connection.
+        `active` — connection is valid and tokens are current (automatically refreshed before expiry).
+        `needs_reauth` — token refresh failed (token revoked, expired refresh token, or no refresh token available); user must re-authorize via Settings.
+        `revoked` — user explicitly disconnected the provider.
       example: "active"
     connected_at:
       type: string

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -9732,7 +9732,8 @@ components:
             - active
             - needs_reauth
             - revoked
-          description: The current status of the connection
+          description: |
+            The current status of the connection. `active` — connection is valid and tokens are current (automatically refreshed before expiry). `needs_reauth` — token refresh failed (token revoked, expired refresh token, or no refresh token available); user must re-authorize via Settings. `revoked` — user explicitly disconnected the provider.
           example: active
         connected_at:
           type: string


### PR DESCRIPTION
## Summary

Implements Phase 4 (Token Refresh) from #80 — the OAuth token refresh infrastructure that enables Phase 5 (Execution Integration).

- **Pre-execution refresh hook**: When `auth_type=oauth2`, `connector_execution.go` now resolves OAuth connections instead of static credentials, auto-refreshing tokens within a 5-minute expiry buffer
- **Background refresh job**: Proactively refreshes tokens expiring within 15 minutes to prevent execution-time latency (configurable via `OAUTH_REFRESH_INTERVAL`, default 10m)
- **OAuthRefreshError**: New error type in `connectors/errors.go` maps to HTTP 401, telling the agent the user needs to re-authorize
- **ListExpiringOAuthConnections**: DB query for the background job to find tokens needing refresh

## Key design decisions

- Pre-execution refresh is the **primary** mechanism; background refresh is **secondary** (reduces latency for frequently-used connections)
- On refresh failure, the connection is marked `needs_reauth` so the user sees a clear re-authorization prompt
- Refresh token rotation is handled transparently (some providers rotate refresh tokens on each use)
- The background job follows the same lifecycle pattern as the existing audit purge job

## Test plan

- [x] `oauth/refresh_test.go` — token refresh success, rotation, error handling
- [x] `db/oauth_connections_refresh_test.go` — expiring connections query, filters
- [x] `connectors/errors_test.go` — OAuthRefreshError type and Is* checks
- [x] `background_oauth_test.go` — interval config, goroutine lifecycle
- [x] All existing tests pass (`go test ./...`)
- [x] `go build` and `go vet` pass clean

Closes Phase 4 checklist items in #80.

https://claude.ai/code/session_01HWeTVDiycPSSAw8bSG9x3h