### PR TITLE
feat: add PostgreSQL database connector

### DIFF
--- a/connectors/postgres/README.md
+++ b/connectors/postgres/README.md
@@ -1,0 +1,211 @@
+# PostgreSQL Connector
+
+The PostgreSQL connector integrates Permission Slip with PostgreSQL databases. It uses Go's `database/sql` with the [`pgx`](https://github.com/jackc/pgx) driver — no ORM or query builder.
+
+## Connector ID
+
+`postgres`
+
+## Credentials
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `connection_string` | Yes | A PostgreSQL connection string in URI format: `postgres://user:password@host:port/dbname?sslmode=require` |
+
+The credential `auth_type` in the database is `custom`. Connection strings are stored encrypted in Supabase Vault and decrypted only at execution time.
+
+**Connection string format:**
+```
+postgres://username:password@hostname:5432/database_name?sslmode=require
+```
+
+Common `sslmode` values: `disable`, `require`, `verify-ca`, `verify-full`. Use `require` or stricter for production.
+
+## Actions
+
+### `postgres.query`
+
+Execute a parameterized read-only SELECT query. The transaction is set to READ ONLY, preventing any writes even via CTEs.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `sql` | string | Yes | — | Parameterized SELECT query (use `$1`, `$2`, ... for placeholders) |
+| `params` | array | No | `[]` | Positional parameters for the query placeholders |
+| `max_rows` | integer | No | `1000` | Maximum rows to return (1–10,000) |
+| `timeout_seconds` | integer | No | `30` | Statement timeout in seconds (1–300) |
+
+**Response:**
+
+```json
+{
+  "columns": ["id", "name", "email"],
+  "rows": [
+    {"id": 1, "name": "Alice", "email": "alice@example.com"},
+    {"id": 2, "name": "Bob", "email": "bob@example.com"}
+  ],
+  "row_count": 2,
+  "truncated": false
+}
+```
+
+When `truncated` is `true`, more rows matched than `max_rows` — the result is capped.
+
+---
+
+### `postgres.insert`
+
+Insert one or more rows into a table using parameterized values.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `table` | string | Yes | Target table name (`schema.table` format supported) |
+| `rows` | array of objects | Yes | Row objects to insert (keys are column names) |
+| `columns` | array of strings | No | Explicit column list. If omitted, keys from the first row are used. |
+| `returning` | array of strings | No | Columns to return via `RETURNING` clause (use `["*"]` for all) |
+| `timeout_seconds` | integer | No | Statement timeout in seconds (default: 30) |
+
+**Response:**
+
+```json
+{
+  "rows_affected": 2,
+  "returned": [
+    {"id": 10, "name": "Alice"},
+    {"id": 11, "name": "Bob"}
+  ]
+}
+```
+
+The `returned` field is only present when `returning` is specified.
+
+---
+
+### `postgres.update`
+
+Update rows matching a WHERE clause. A WHERE clause is always required — unconditional updates are rejected.
+
+**Risk level:** high
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `table` | string | Yes | Target table name |
+| `set` | object | Yes | Column-value pairs to update |
+| `where` | object | Yes | Column-value pairs for WHERE (ANDed together). Use `null` values for `IS NULL`. |
+| `returning` | array of strings | No | Columns to return via `RETURNING` clause |
+| `timeout_seconds` | integer | No | Statement timeout in seconds (default: 30) |
+
+**Response:**
+
+```json
+{
+  "rows_affected": 1,
+  "returned": [
+    {"id": 5, "name": "Alice", "active": false}
+  ]
+}
+```
+
+---
+
+### `postgres.delete`
+
+Delete rows matching a WHERE clause. A WHERE clause is always required — unconditional deletes are rejected.
+
+**Risk level:** high
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `table` | string | Yes | Target table name |
+| `where` | object | Yes | Column-value pairs for WHERE (ANDed together). Use `null` values for `IS NULL`. |
+| `returning` | array of strings | No | Columns to return via `RETURNING` clause |
+| `timeout_seconds` | integer | No | Statement timeout in seconds (default: 30) |
+
+**Response:**
+
+```json
+{
+  "rows_affected": 3
+}
+```
+
+## Security Model
+
+| Protection | How it works |
+|-----------|--------------|
+| **No SQL interpolation** | All user-supplied values go through parameterized placeholders (`$1`, `$2`, ...) |
+| **Identifier validation** | Table and column names are validated against `^[a-zA-Z_][a-zA-Z0-9_]*$` and double-quoted in generated SQL |
+| **Read-only queries** | `postgres.query` uses `SET TRANSACTION READ ONLY` — even writable CTEs are blocked |
+| **Required WHERE** | `postgres.update` and `postgres.delete` reject empty WHERE clauses |
+| **Statement timeout** | Configurable per-action (default 30s, max 5min) — prevents runaway queries |
+| **Row limits** | `postgres.query` caps results (default 1000, max 10000) with truncation detection |
+| **Isolated connections** | Each action execution opens and closes its own `sql.DB` with `MaxOpenConns(1)` |
+| **Credentials at execution time** | Connection strings are decrypted from vault only when an action runs |
+
+## Error Handling
+
+The connector maps PostgreSQL error codes to typed connector errors:
+
+| PostgreSQL Error | Connector Error | HTTP Response |
+|------------------|-----------------|---------------|
+| SQLSTATE 28000/28P01 (auth failure) | `AuthError` | 502 Bad Gateway |
+| SQLSTATE 42501 (permission denied) | `AuthError` | 502 Bad Gateway |
+| SQLSTATE 42601 (syntax error) | `ValidationError` | 400 Bad Request |
+| SQLSTATE 42P01/42703 (object not found) | `ValidationError` | 400 Bad Request |
+| SQLSTATE 23xxx (constraint violation) | `ValidationError` | 400 Bad Request |
+| SQLSTATE 57014 (statement timeout) | `TimeoutError` | 504 Gateway Timeout |
+| Connection refused / unreachable | `ExternalError` | 502 Bad Gateway |
+| Context deadline exceeded | `TimeoutError` | 504 Gateway Timeout |
+
+## Adding a New Action
+
+Each action lives in its own file. To add one (e.g., `postgres.upsert`):
+
+1. Create `connectors/postgres/upsert.go` with a params struct, `validate()`, and an `Execute` method.
+2. Use `a.conn.openDB()` to get a `*sql.DB`, build your SQL with `quoteIdentifier()` for safety, and use parameterized placeholders.
+3. Return `connectors.JSONResult(result)` to wrap the response.
+4. Register the action in `Actions()` inside `postgres.go`.
+5. Add the action to the `Manifest()` return value with a `ParametersSchema`.
+6. Add tests using the real test database (see Testing below).
+
+## File Structure
+
+```
+connectors/postgres/
+├── postgres.go           # PostgresConnector struct, New(), Manifest(), Actions(), ValidateCredentials()
+├── query.go              # postgres.query action (read-only SELECT)
+├── insert.go             # postgres.insert action
+├── update.go             # postgres.update action
+├── delete.go             # postgres.delete action
+├── sanitize.go           # Identifier validation and quoting
+├── errors.go             # PostgreSQL error → typed connector error mapping, scanRows()
+├── postgres_test.go      # Connector-level tests (ID, manifest, credentials)
+├── query_test.go         # Query action tests
+├── insert_test.go        # Insert action tests
+├── update_test.go        # Update action tests
+├── delete_test.go        # Delete action tests
+├── sanitize_test.go      # Identifier validation tests
+├── helpers_test.go       # Shared test helpers (validCreds, setupTestTable)
+└── README.md             # This file
+```
+
+## Testing
+
+Tests run against a real PostgreSQL database (`permission_slip_test`). Each test creates a unique temporary table to allow parallel execution without conflicts.
+
+```bash
+go test ./connectors/postgres/... -v
+```
+
+Tests that require a database connection will skip automatically if the test database is unavailable.

--- a/connectors/postgres/delete.go
+++ b/connectors/postgres/delete.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -31,19 +30,10 @@ func (p *deleteParams) validate() error {
 	if len(p.Where) == 0 {
 		return &connectors.ValidationError{Message: "missing required parameter: where (unconditional deletes are not allowed)"}
 	}
-	for col := range p.Where {
-		if err := validateIdentifier(col, "where column"); err != nil {
-			return &connectors.ValidationError{Message: err.Error()}
-		}
+	if err := validateWhereCols(p.Where); err != nil {
+		return err
 	}
-	for _, col := range p.Returning {
-		if col != "*" {
-			if err := validateIdentifier(col, "returning column"); err != nil {
-				return &connectors.ValidationError{Message: err.Error()}
-			}
-		}
-	}
-	return nil
+	return validateReturningCols(p.Returning)
 }
 
 // Execute deletes rows from a table and returns the affected count.
@@ -56,101 +46,26 @@ func (a *deleteAction) Execute(ctx context.Context, req connectors.ActionRequest
 		return nil, err
 	}
 
-	connStr, ok := req.Credentials.Get("connection_string")
-	if !ok || connStr == "" {
-		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	connStr, err := getConnString(req)
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
 
-	db, err := a.conn.openDB(connStr, timeout)
+	env, err := prepareTx(ctx, a.conn, connStr, timeout)
 	if err != nil {
-		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+		return nil, err
 	}
-	defer db.Close()
+	defer env.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	whereSQL, args := buildWhereClause(params.Where, 1)
 
-	// Build WHERE clause.
-	whereCols := sortedKeys(params.Where)
-	var whereClauses []string
-	var args []interface{}
-	paramIdx := 1
-
-	for _, col := range whereCols {
-		val := params.Where[col]
-		if val == nil {
-			whereClauses = append(whereClauses, fmt.Sprintf("%s IS NULL", quoteIdentifier(col)))
-		} else {
-			whereClauses = append(whereClauses, fmt.Sprintf("%s = $%d", quoteIdentifier(col), paramIdx))
-			args = append(args, val)
-			paramIdx++
-		}
-	}
-
-	query := fmt.Sprintf("DELETE FROM %s WHERE %s",
+	query := fmt.Sprintf("DELETE FROM %s WHERE %s%s",
 		quoteIdentifier(params.Table),
-		strings.Join(whereClauses, " AND "),
+		whereSQL,
+		buildReturningClause(params.Returning),
 	)
 
-	hasReturning := len(params.Returning) > 0
-	if hasReturning {
-		quotedReturning := make([]string, len(params.Returning))
-		for i, col := range params.Returning {
-			if col == "*" {
-				quotedReturning[i] = "*"
-			} else {
-				quotedReturning[i] = quoteIdentifier(col)
-			}
-		}
-		query += " RETURNING " + strings.Join(quotedReturning, ", ")
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, mapPgError(err, "beginning transaction")
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	timeoutMS := int(timeout.Milliseconds())
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
-		return nil, mapPgError(err, "setting statement timeout")
-	}
-
-	if hasReturning {
-		rows, err := tx.QueryContext(ctx, query, args...)
-		if err != nil {
-			return nil, mapPgError(err, "executing delete")
-		}
-		defer rows.Close()
-
-		returned, err := scanRows(rows)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := tx.Commit(); err != nil {
-			return nil, mapPgError(err, "committing transaction")
-		}
-
-		return connectors.JSONResult(map[string]interface{}{
-			"rows_affected": len(returned),
-			"returned":      returned,
-		})
-	}
-
-	result, err := tx.ExecContext(ctx, query, args...)
-	if err != nil {
-		return nil, mapPgError(err, "executing delete")
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, mapPgError(err, "committing transaction")
-	}
-
-	affected, _ := result.RowsAffected()
-	return connectors.JSONResult(map[string]interface{}{
-		"rows_affected": affected,
-	})
+	return execMutation(env, query, args, len(params.Returning) > 0, "executing delete")
 }

--- a/connectors/postgres/delete.go
+++ b/connectors/postgres/delete.go
@@ -1,0 +1,156 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// deleteAction implements connectors.Action for postgres.delete.
+type deleteAction struct {
+	conn *PostgresConnector
+}
+
+type deleteParams struct {
+	Table          string                 `json:"table"`
+	Where          map[string]interface{} `json:"where"`
+	Returning      []string               `json:"returning"`
+	TimeoutSeconds int                    `json:"timeout_seconds"`
+}
+
+func (p *deleteParams) validate() error {
+	if p.Table == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: table"}
+	}
+	if err := validateIdentifier(p.Table, "table"); err != nil {
+		return &connectors.ValidationError{Message: err.Error()}
+	}
+	if len(p.Where) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: where (unconditional deletes are not allowed)"}
+	}
+	for col := range p.Where {
+		if err := validateIdentifier(col, "where column"); err != nil {
+			return &connectors.ValidationError{Message: err.Error()}
+		}
+	}
+	for _, col := range p.Returning {
+		if col != "*" {
+			if err := validateIdentifier(col, "returning column"); err != nil {
+				return &connectors.ValidationError{Message: err.Error()}
+			}
+		}
+	}
+	return nil
+}
+
+// Execute deletes rows from a table and returns the affected count.
+func (a *deleteAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params deleteParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	connStr, ok := req.Credentials.Get("connection_string")
+	if !ok || connStr == "" {
+		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	}
+
+	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
+
+	db, err := a.conn.openDB(connStr, timeout)
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Build WHERE clause.
+	whereCols := sortedKeys(params.Where)
+	var whereClauses []string
+	var args []interface{}
+	paramIdx := 1
+
+	for _, col := range whereCols {
+		val := params.Where[col]
+		if val == nil {
+			whereClauses = append(whereClauses, fmt.Sprintf("%s IS NULL", quoteIdentifier(col)))
+		} else {
+			whereClauses = append(whereClauses, fmt.Sprintf("%s = $%d", quoteIdentifier(col), paramIdx))
+			args = append(args, val)
+			paramIdx++
+		}
+	}
+
+	query := fmt.Sprintf("DELETE FROM %s WHERE %s",
+		quoteIdentifier(params.Table),
+		strings.Join(whereClauses, " AND "),
+	)
+
+	hasReturning := len(params.Returning) > 0
+	if hasReturning {
+		quotedReturning := make([]string, len(params.Returning))
+		for i, col := range params.Returning {
+			if col == "*" {
+				quotedReturning[i] = "*"
+			} else {
+				quotedReturning[i] = quoteIdentifier(col)
+			}
+		}
+		query += " RETURNING " + strings.Join(quotedReturning, ", ")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, mapPgError(err, "beginning transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	timeoutMS := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, mapPgError(err, "setting statement timeout")
+	}
+
+	if hasReturning {
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, mapPgError(err, "executing delete")
+		}
+		defer rows.Close()
+
+		returned, err := scanRows(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return nil, mapPgError(err, "committing transaction")
+		}
+
+		return connectors.JSONResult(map[string]interface{}{
+			"rows_affected": len(returned),
+			"returned":      returned,
+		})
+	}
+
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, mapPgError(err, "executing delete")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, mapPgError(err, "committing transaction")
+	}
+
+	affected, _ := result.RowsAffected()
+	return connectors.JSONResult(map[string]interface{}{
+		"rows_affected": affected,
+	})
+}

--- a/connectors/postgres/delete_test.go
+++ b/connectors/postgres/delete_test.go
@@ -1,0 +1,133 @@
+package postgres
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestDelete_Success(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.delete"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.delete",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"where": {"name": "beta"}
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["rows_affected"].(float64) != 1 {
+		t.Errorf("rows_affected = %v, want 1", data["rows_affected"])
+	}
+}
+
+func TestDelete_WithReturning(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.delete"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.delete",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"where": {"active": false},
+			"returning": ["name", "value"]
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	returned := data["returned"].([]interface{})
+	if len(returned) != 1 {
+		t.Fatalf("returned has %d rows, want 1", len(returned))
+	}
+	row := returned[0].(map[string]interface{})
+	if row["name"] != "beta" {
+		t.Errorf("returned name = %v, want beta", row["name"])
+	}
+}
+
+func TestDelete_NoMatchingRows(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.delete"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.delete",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"where": {"name": "nonexistent"}
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["rows_affected"].(float64) != 0 {
+		t.Errorf("rows_affected = %v, want 0", data["rows_affected"])
+	}
+}
+
+func TestDelete_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["postgres.delete"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing table", `{"where":{"id":1}}`},
+		{"missing where", `{"table":"test"}`},
+		{"empty where", `{"table":"test","where":{}}`},
+		{"invalid table", `{"table":"'; DROP--","where":{"id":1}}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "postgres.delete",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/postgres/errors.go
+++ b/connectors/postgres/errors.go
@@ -1,0 +1,113 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// mapPgError maps PostgreSQL errors to typed connector errors.
+func mapPgError(err error, action string) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+
+	// Check for context/timeout errors first.
+	if connectors.IsTimeout(err) {
+		return &connectors.TimeoutError{Message: fmt.Sprintf("PostgreSQL %s timed out: %v", action, err)}
+	}
+
+	// pgx error codes are embedded in the error message.
+	// SQLSTATE 28000 = invalid_authorization_specification
+	// SQLSTATE 28P01 = invalid_password
+	if containsAny(msg, "28000", "28P01", "password authentication failed", "no pg_hba.conf entry") {
+		return &connectors.AuthError{Message: fmt.Sprintf("PostgreSQL authentication failed: %v", err)}
+	}
+
+	// Connection refused / unreachable.
+	if containsAny(msg, "connection refused", "no such host", "could not connect", "connection reset") {
+		return &connectors.ExternalError{Message: fmt.Sprintf("PostgreSQL connection failed: %v", err)}
+	}
+
+	// Permission denied (SQLSTATE 42501).
+	if strings.Contains(msg, "42501") || strings.Contains(msg, "permission denied") {
+		return &connectors.AuthError{Message: fmt.Sprintf("PostgreSQL permission denied: %v", err)}
+	}
+
+	// Syntax error or invalid SQL (SQLSTATE 42xxx).
+	if strings.Contains(msg, "42601") || strings.Contains(msg, "syntax error") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("PostgreSQL SQL syntax error: %v", err)}
+	}
+
+	// Undefined table/column (SQLSTATE 42P01, 42703).
+	if containsAny(msg, "42P01", "42703", "does not exist") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("PostgreSQL object not found: %v", err)}
+	}
+
+	// Constraint violations (SQLSTATE 23xxx).
+	if strings.Contains(msg, "23") && containsAny(msg, "violates", "constraint", "duplicate key", "null value") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("PostgreSQL constraint violation: %v", err)}
+	}
+
+	// Statement timeout (SQLSTATE 57014).
+	if strings.Contains(msg, "57014") || strings.Contains(msg, "canceling statement due to statement timeout") {
+		return &connectors.TimeoutError{Message: fmt.Sprintf("PostgreSQL statement timed out: %v", err)}
+	}
+
+	// Read-only transaction violation (SQLSTATE 25006).
+	if strings.Contains(msg, "25006") || strings.Contains(msg, "cannot execute") && strings.Contains(msg, "read-only") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("PostgreSQL read-only transaction violation: %v", err)}
+	}
+
+	return &connectors.ExternalError{Message: fmt.Sprintf("PostgreSQL %s failed: %v", action, err)}
+}
+
+// containsAny returns true if s contains any of the substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanRows reads all rows from a sql.Rows into a slice of maps.
+func scanRows(rows *sql.Rows) ([]map[string]interface{}, error) {
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading column names: %v", err)}
+	}
+
+	var results []map[string]interface{}
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		valuePtrs := make([]interface{}, len(columns))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return nil, &connectors.ExternalError{Message: fmt.Sprintf("scanning row: %v", err)}
+		}
+		row := make(map[string]interface{}, len(columns))
+		for i, col := range columns {
+			if b, ok := values[i].([]byte); ok {
+				row[col] = string(b)
+			} else {
+				row[col] = values[i]
+			}
+		}
+		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, mapPgError(err, "iterating rows")
+	}
+	if results == nil {
+		results = []map[string]interface{}{}
+	}
+	return results, nil
+}

--- a/connectors/postgres/errors.go
+++ b/connectors/postgres/errors.go
@@ -61,7 +61,7 @@ func mapPgError(err error, action string) error {
 	}
 
 	// Read-only transaction violation (SQLSTATE 25006).
-	if strings.Contains(msg, "25006") || strings.Contains(msg, "cannot execute") && strings.Contains(msg, "read-only") {
+	if strings.Contains(msg, "25006") || (strings.Contains(msg, "cannot execute") && strings.Contains(msg, "read-only")) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("PostgreSQL read-only transaction violation: %v", err)}
 	}
 

--- a/connectors/postgres/errors.go
+++ b/connectors/postgres/errors.go
@@ -49,7 +49,9 @@ func mapPgError(err error, action string) error {
 	}
 
 	// Constraint violations (SQLSTATE 23xxx).
-	if strings.Contains(msg, "23") && containsAny(msg, "violates", "constraint", "duplicate key", "null value") {
+	// pgx formats these as "ERROR: ... (SQLSTATE 23NNN)" so we check for that pattern.
+	if containsAny(msg, "SQLSTATE 23", "violates unique constraint", "violates not-null constraint",
+		"violates foreign key constraint", "violates check constraint", "duplicate key value") {
 		return &connectors.ValidationError{Message: fmt.Sprintf("PostgreSQL constraint violation: %v", err)}
 	}
 

--- a/connectors/postgres/execute.go
+++ b/connectors/postgres/execute.go
@@ -1,0 +1,122 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// txEnv bundles a prepared transaction with its context and cancel function.
+// Every action creates one via prepareTx, uses it for queries, and defers cleanup.
+type txEnv struct {
+	Tx     *sql.Tx
+	Ctx    context.Context
+	Cancel context.CancelFunc
+	DB     *sql.DB
+}
+
+// Close cleans up the transaction environment. Call via defer after prepareTx.
+func (e *txEnv) Close() {
+	e.Tx.Rollback() //nolint:errcheck — cleanup only
+	e.Cancel()
+	e.DB.Close()
+}
+
+// prepareTx opens a database connection, begins a transaction, and sets the
+// statement timeout. This eliminates the repeated boilerplate across all actions.
+func prepareTx(ctx context.Context, c *PostgresConnector, connStr string, timeout time.Duration) (*txEnv, error) {
+	db, err := c.openDB(connStr, timeout)
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		cancel()
+		db.Close()
+		return nil, mapPgError(err, "beginning transaction")
+	}
+
+	timeoutMS := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
+		tx.Rollback() //nolint:errcheck
+		cancel()
+		db.Close()
+		return nil, mapPgError(err, "setting statement timeout")
+	}
+
+	return &txEnv{Tx: tx, Ctx: ctx, Cancel: cancel, DB: db}, nil
+}
+
+// getConnString extracts and validates the connection string from credentials.
+func getConnString(req connectors.ActionRequest) (string, error) {
+	connStr, ok := req.Credentials.Get("connection_string")
+	if !ok || connStr == "" {
+		return "", &connectors.ValidationError{Message: "missing credential: connection_string"}
+	}
+	return connStr, nil
+}
+
+// buildReturningClause builds a RETURNING clause from a list of column names.
+// Returns an empty string if cols is empty.
+func buildReturningClause(cols []string) string {
+	if len(cols) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(cols))
+	for i, col := range cols {
+		if col == "*" {
+			quoted[i] = "*"
+		} else {
+			quoted[i] = quoteIdentifier(col)
+		}
+	}
+	return " RETURNING " + strings.Join(quoted, ", ")
+}
+
+// execMutation runs a write query (INSERT/UPDATE/DELETE) within a transaction,
+// handling both the simple case (rows_affected) and the RETURNING case.
+// The action parameter is used for error messages (e.g., "executing insert").
+func execMutation(env *txEnv, query string, args []interface{}, hasReturning bool, action string) (*connectors.ActionResult, error) {
+	if hasReturning {
+		rows, err := env.Tx.QueryContext(env.Ctx, query, args...)
+		if err != nil {
+			return nil, mapPgError(err, action)
+		}
+		defer rows.Close()
+
+		returned, err := scanRows(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := env.Tx.Commit(); err != nil {
+			return nil, mapPgError(err, "committing transaction")
+		}
+
+		return connectors.JSONResult(map[string]interface{}{
+			"rows_affected": len(returned),
+			"returned":      returned,
+		})
+	}
+
+	result, err := env.Tx.ExecContext(env.Ctx, query, args...)
+	if err != nil {
+		return nil, mapPgError(err, action)
+	}
+
+	if err := env.Tx.Commit(); err != nil {
+		return nil, mapPgError(err, "committing transaction")
+	}
+
+	affected, _ := result.RowsAffected()
+	return connectors.JSONResult(map[string]interface{}{
+		"rows_affected": affected,
+	})
+}

--- a/connectors/postgres/execute.go
+++ b/connectors/postgres/execute.go
@@ -1,5 +1,12 @@
 package postgres
 
+// execute.go contains shared transaction lifecycle helpers used by all actions.
+// It eliminates boilerplate by providing:
+//   - prepareTx: open DB → begin transaction → set statement_timeout
+//   - execMutation: run a write query with optional RETURNING, commit, return result
+//   - getConnString: extract connection_string from action credentials
+//   - buildReturningClause: build a quoted RETURNING SQL fragment
+
 import (
 	"context"
 	"database/sql"

--- a/connectors/postgres/helpers_test.go
+++ b/connectors/postgres/helpers_test.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// validCreds returns a Credentials value with a valid connection string for tests.
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		"connection_string": "postgres://localhost:5432/permission_slip_test?sslmode=disable",
+	})
+}
+
+var tableCounter atomic.Int64
+
+// setupTestTable creates a unique temporary table for each test to avoid
+// race conditions when tests run in parallel. Returns the table name.
+func setupTestTable(t *testing.T) string {
+	t.Helper()
+
+	// Generate a unique table name per test invocation.
+	n := tableCounter.Add(1)
+	// Sanitize test name to be a valid lowercase identifier.
+	safe := strings.ToLower(strings.NewReplacer("/", "_", " ", "_", "-", "_", ".", "_").Replace(t.Name()))
+	tableName := fmt.Sprintf("ct_%s_%d", safe, n)
+	// Truncate to fit PostgreSQL's 63-char identifier limit.
+	if len(tableName) > 63 {
+		tableName = tableName[:63]
+	}
+
+	connStr := "postgres://localhost:5432/permission_slip_test?sslmode=disable"
+	db, err := sql.Open("pgx", connStr)
+	if err != nil {
+		t.Skipf("skipping: cannot connect to test database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Skipf("skipping: cannot ping test database: %v", err)
+	}
+
+	_, err = db.Exec(fmt.Sprintf(`
+		DROP TABLE IF EXISTS %s;
+		CREATE TABLE %s (
+			id SERIAL PRIMARY KEY,
+			name TEXT NOT NULL,
+			value INTEGER,
+			active BOOLEAN DEFAULT true
+		);
+		INSERT INTO %s (name, value, active) VALUES
+			('alpha', 10, true),
+			('beta', 20, false),
+			('gamma', 30, true);
+	`, tableName, tableName, tableName))
+	if err != nil {
+		t.Fatalf("setting up test table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db2, err := sql.Open("pgx", connStr)
+		if err != nil {
+			return
+		}
+		defer db2.Close()
+		db2.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) //nolint:errcheck
+	})
+
+	return tableName
+}

--- a/connectors/postgres/insert.go
+++ b/connectors/postgres/insert.go
@@ -32,6 +32,9 @@ func (p *insertParams) validate() error {
 	if len(p.Rows) == 0 {
 		return &connectors.ValidationError{Message: "missing required parameter: rows (must contain at least one row)"}
 	}
+	if len(p.Rows) > 1000 {
+		return &connectors.ValidationError{Message: "rows exceeds maximum of 1000 rows per insert"}
+	}
 
 	// Determine columns from explicit list or first row.
 	cols := p.Columns

--- a/connectors/postgres/insert.go
+++ b/connectors/postgres/insert.go
@@ -49,14 +49,7 @@ func (p *insertParams) validate() error {
 			return &connectors.ValidationError{Message: err.Error()}
 		}
 	}
-	for _, col := range p.Returning {
-		if col != "*" {
-			if err := validateIdentifier(col, "returning column"); err != nil {
-				return &connectors.ValidationError{Message: err.Error()}
-			}
-		}
-	}
-	return nil
+	return validateReturningCols(p.Returning)
 }
 
 // Execute inserts rows into a table and returns the count (and optionally RETURNING data).
@@ -69,21 +62,18 @@ func (a *insertAction) Execute(ctx context.Context, req connectors.ActionRequest
 		return nil, err
 	}
 
-	connStr, ok := req.Credentials.Get("connection_string")
-	if !ok || connStr == "" {
-		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	connStr, err := getConnString(req)
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
 
-	db, err := a.conn.openDB(connStr, timeout)
+	env, err := prepareTx(ctx, a.conn, connStr, timeout)
 	if err != nil {
-		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+		return nil, err
 	}
-	defer db.Close()
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	defer env.Close()
 
 	// Determine columns.
 	cols := params.Columns
@@ -111,96 +101,12 @@ func (a *insertAction) Execute(ctx context.Context, req connectors.ActionRequest
 		placeholders = append(placeholders, "("+strings.Join(rowPlaceholders, ", ")+")")
 	}
 
-	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s",
 		quoteIdentifier(params.Table),
 		strings.Join(quotedCols, ", "),
 		strings.Join(placeholders, ", "),
+		buildReturningClause(params.Returning),
 	)
 
-	hasReturning := len(params.Returning) > 0
-	if hasReturning {
-		quotedReturning := make([]string, len(params.Returning))
-		for i, col := range params.Returning {
-			if col == "*" {
-				quotedReturning[i] = "*"
-			} else {
-				quotedReturning[i] = quoteIdentifier(col)
-			}
-		}
-		query += " RETURNING " + strings.Join(quotedReturning, ", ")
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, mapPgError(err, "beginning transaction")
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	timeoutMS := int(timeout.Milliseconds())
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
-		return nil, mapPgError(err, "setting statement timeout")
-	}
-
-	if hasReturning {
-		rows, err := tx.QueryContext(ctx, query, args...)
-		if err != nil {
-			return nil, mapPgError(err, "executing insert")
-		}
-		defer rows.Close()
-
-		columns, err := rows.Columns()
-		if err != nil {
-			return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading column names: %v", err)}
-		}
-
-		var returned []map[string]interface{}
-		for rows.Next() {
-			values := make([]interface{}, len(columns))
-			valuePtrs := make([]interface{}, len(columns))
-			for i := range values {
-				valuePtrs[i] = &values[i]
-			}
-			if err := rows.Scan(valuePtrs...); err != nil {
-				return nil, &connectors.ExternalError{Message: fmt.Sprintf("scanning row: %v", err)}
-			}
-			row := make(map[string]interface{}, len(columns))
-			for i, col := range columns {
-				if b, ok := values[i].([]byte); ok {
-					row[col] = string(b)
-				} else {
-					row[col] = values[i]
-				}
-			}
-			returned = append(returned, row)
-		}
-		if err := rows.Err(); err != nil {
-			return nil, mapPgError(err, "iterating returned rows")
-		}
-
-		if err := tx.Commit(); err != nil {
-			return nil, mapPgError(err, "committing transaction")
-		}
-
-		if returned == nil {
-			returned = []map[string]interface{}{}
-		}
-		return connectors.JSONResult(map[string]interface{}{
-			"rows_affected": len(returned),
-			"returned":      returned,
-		})
-	}
-
-	result, err := tx.ExecContext(ctx, query, args...)
-	if err != nil {
-		return nil, mapPgError(err, "executing insert")
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, mapPgError(err, "committing transaction")
-	}
-
-	affected, _ := result.RowsAffected()
-	return connectors.JSONResult(map[string]interface{}{
-		"rows_affected": affected,
-	})
+	return execMutation(env, query, args, len(params.Returning) > 0, "executing insert")
 }

--- a/connectors/postgres/insert.go
+++ b/connectors/postgres/insert.go
@@ -1,0 +1,203 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// insertAction implements connectors.Action for postgres.insert.
+type insertAction struct {
+	conn *PostgresConnector
+}
+
+type insertParams struct {
+	Table          string                   `json:"table"`
+	Columns        []string                 `json:"columns"`
+	Rows           []map[string]interface{} `json:"rows"`
+	Returning      []string                 `json:"returning"`
+	TimeoutSeconds int                      `json:"timeout_seconds"`
+}
+
+func (p *insertParams) validate() error {
+	if p.Table == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: table"}
+	}
+	if err := validateIdentifier(p.Table, "table"); err != nil {
+		return &connectors.ValidationError{Message: err.Error()}
+	}
+	if len(p.Rows) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: rows (must contain at least one row)"}
+	}
+
+	// Determine columns from explicit list or first row.
+	cols := p.Columns
+	if len(cols) == 0 {
+		cols = sortedKeys(p.Rows[0])
+	}
+	if len(cols) == 0 {
+		return &connectors.ValidationError{Message: "rows must contain at least one column"}
+	}
+	for _, col := range cols {
+		if err := validateIdentifier(col, "column"); err != nil {
+			return &connectors.ValidationError{Message: err.Error()}
+		}
+	}
+	for _, col := range p.Returning {
+		if col != "*" {
+			if err := validateIdentifier(col, "returning column"); err != nil {
+				return &connectors.ValidationError{Message: err.Error()}
+			}
+		}
+	}
+	return nil
+}
+
+// Execute inserts rows into a table and returns the count (and optionally RETURNING data).
+func (a *insertAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params insertParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	connStr, ok := req.Credentials.Get("connection_string")
+	if !ok || connStr == "" {
+		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	}
+
+	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
+
+	db, err := a.conn.openDB(connStr, timeout)
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Determine columns.
+	cols := params.Columns
+	if len(cols) == 0 {
+		cols = sortedKeys(params.Rows[0])
+	}
+
+	// Build INSERT statement.
+	quotedCols := make([]string, len(cols))
+	for i, col := range cols {
+		quotedCols[i] = quoteIdentifier(col)
+	}
+
+	var placeholders []string
+	var args []interface{}
+	paramIdx := 1
+
+	for _, row := range params.Rows {
+		rowPlaceholders := make([]string, len(cols))
+		for i, col := range cols {
+			rowPlaceholders[i] = fmt.Sprintf("$%d", paramIdx)
+			paramIdx++
+			args = append(args, row[col])
+		}
+		placeholders = append(placeholders, "("+strings.Join(rowPlaceholders, ", ")+")")
+	}
+
+	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+		quoteIdentifier(params.Table),
+		strings.Join(quotedCols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	hasReturning := len(params.Returning) > 0
+	if hasReturning {
+		quotedReturning := make([]string, len(params.Returning))
+		for i, col := range params.Returning {
+			if col == "*" {
+				quotedReturning[i] = "*"
+			} else {
+				quotedReturning[i] = quoteIdentifier(col)
+			}
+		}
+		query += " RETURNING " + strings.Join(quotedReturning, ", ")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, mapPgError(err, "beginning transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	timeoutMS := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, mapPgError(err, "setting statement timeout")
+	}
+
+	if hasReturning {
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, mapPgError(err, "executing insert")
+		}
+		defer rows.Close()
+
+		columns, err := rows.Columns()
+		if err != nil {
+			return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading column names: %v", err)}
+		}
+
+		var returned []map[string]interface{}
+		for rows.Next() {
+			values := make([]interface{}, len(columns))
+			valuePtrs := make([]interface{}, len(columns))
+			for i := range values {
+				valuePtrs[i] = &values[i]
+			}
+			if err := rows.Scan(valuePtrs...); err != nil {
+				return nil, &connectors.ExternalError{Message: fmt.Sprintf("scanning row: %v", err)}
+			}
+			row := make(map[string]interface{}, len(columns))
+			for i, col := range columns {
+				if b, ok := values[i].([]byte); ok {
+					row[col] = string(b)
+				} else {
+					row[col] = values[i]
+				}
+			}
+			returned = append(returned, row)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, mapPgError(err, "iterating returned rows")
+		}
+
+		if err := tx.Commit(); err != nil {
+			return nil, mapPgError(err, "committing transaction")
+		}
+
+		if returned == nil {
+			returned = []map[string]interface{}{}
+		}
+		return connectors.JSONResult(map[string]interface{}{
+			"rows_affected": len(returned),
+			"returned":      returned,
+		})
+	}
+
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, mapPgError(err, "executing insert")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, mapPgError(err, "committing transaction")
+	}
+
+	affected, _ := result.RowsAffected()
+	return connectors.JSONResult(map[string]interface{}{
+		"rows_affected": affected,
+	})
+}

--- a/connectors/postgres/insert_test.go
+++ b/connectors/postgres/insert_test.go
@@ -1,0 +1,162 @@
+package postgres
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestInsert_Success(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.insert"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.insert",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"rows": [
+				{"name": "delta", "value": 40, "active": true},
+				{"name": "epsilon", "value": 50, "active": false}
+			]
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["rows_affected"].(float64) != 2 {
+		t.Errorf("rows_affected = %v, want 2", data["rows_affected"])
+	}
+}
+
+func TestInsert_WithReturning(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.insert"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.insert",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"rows": [{"name": "zeta", "value": 60}],
+			"returning": ["id", "name"]
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	returned := data["returned"].([]interface{})
+	if len(returned) != 1 {
+		t.Fatalf("returned has %d rows, want 1", len(returned))
+	}
+	row := returned[0].(map[string]interface{})
+	if row["name"] != "zeta" {
+		t.Errorf("returned name = %v, want zeta", row["name"])
+	}
+	if row["id"] == nil {
+		t.Error("returned id is nil, want a value")
+	}
+}
+
+func TestInsert_WithExplicitColumns(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.insert"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.insert",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"columns": ["name", "value"],
+			"rows": [{"name": "eta", "value": 70}]
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["rows_affected"].(float64) != 1 {
+		t.Errorf("rows_affected = %v, want 1", data["rows_affected"])
+	}
+}
+
+func TestInsert_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["postgres.insert"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing table", `{"rows":[{"name":"x"}]}`},
+		{"missing rows", `{"table":"test"}`},
+		{"empty rows", `{"table":"test","rows":[]}`},
+		{"invalid JSON", `{invalid}`},
+		{"invalid table name", `{"table":"'; DROP TABLE--","rows":[{"x":1}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "postgres.insert",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestInsert_ConstraintViolation(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.insert"]
+
+	// NOT NULL violation — name is required.
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.insert",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"columns": ["name"],
+			"rows": [{"name": null}]
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("Execute() expected error for NULL violation, got nil")
+	}
+}

--- a/connectors/postgres/postgres.go
+++ b/connectors/postgres/postgres.go
@@ -108,7 +108,8 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 								"type": "object"
 							},
 							"minItems": 1,
-							"description": "Array of row objects to insert (keys are column names)"
+							"maxItems": 1000,
+							"description": "Array of row objects to insert (keys are column names, max 1000 rows)"
 						},
 						"returning": {
 							"type": "array",

--- a/connectors/postgres/postgres.go
+++ b/connectors/postgres/postgres.go
@@ -1,0 +1,291 @@
+// Package postgres implements the PostgreSQL connector for the Permission Slip
+// connector execution layer. It uses database/sql with the pgx driver to execute
+// parameterized queries against user-provided PostgreSQL databases.
+//
+// Security model:
+//   - All queries use parameterized placeholders — no string interpolation
+//   - Statement timeouts prevent runaway queries
+//   - Row limits cap SELECT result sizes
+//   - Connection strings are decrypted only at execution time
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // pgx driver for database/sql
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+const (
+	defaultStatementTimeout = 30 * time.Second
+	defaultMaxRows          = 1000
+)
+
+// PostgresConnector owns the shared configuration used by all PostgreSQL actions.
+type PostgresConnector struct {
+	statementTimeout time.Duration
+	maxRows          int
+}
+
+// New creates a PostgresConnector with sensible defaults.
+func New() *PostgresConnector {
+	return &PostgresConnector{
+		statementTimeout: defaultStatementTimeout,
+		maxRows:          defaultMaxRows,
+	}
+}
+
+// ID returns "postgres", matching the connectors.id in the database.
+func (c *PostgresConnector) ID() string { return "postgres" }
+
+// Manifest returns the connector's metadata manifest.
+func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "postgres",
+		Name:        "PostgreSQL",
+		Description: "PostgreSQL database connector for parameterized queries",
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "postgres.query",
+				Name:        "Query",
+				Description: "Execute a parameterized SELECT query (read-only)",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["sql"],
+					"properties": {
+						"sql": {
+							"type": "string",
+							"description": "Parameterized SELECT query (use $1, $2, ... for placeholders)"
+						},
+						"params": {
+							"type": "array",
+							"items": {},
+							"description": "Positional parameters for the query placeholders"
+						},
+						"max_rows": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 10000,
+							"description": "Maximum number of rows to return (default: 1000)"
+						},
+						"timeout_seconds": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 300,
+							"description": "Statement timeout in seconds (default: 30)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "postgres.insert",
+				Name:        "Insert",
+				Description: "Insert rows into a table with parameterized values",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["table", "rows"],
+					"properties": {
+						"table": {
+							"type": "string",
+							"description": "Target table name (schema.table format supported)"
+						},
+						"columns": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Column names to insert into. If omitted, keys from the first row are used."
+						},
+						"rows": {
+							"type": "array",
+							"items": {
+								"type": "object"
+							},
+							"minItems": 1,
+							"description": "Array of row objects to insert (keys are column names)"
+						},
+						"returning": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Columns to return from inserted rows (RETURNING clause)"
+						},
+						"timeout_seconds": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 300,
+							"description": "Statement timeout in seconds (default: 30)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "postgres.update",
+				Name:        "Update",
+				Description: "Update rows in a table with parameterized SET and WHERE clauses",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["table", "set", "where"],
+					"properties": {
+						"table": {
+							"type": "string",
+							"description": "Target table name (schema.table format supported)"
+						},
+						"set": {
+							"type": "object",
+							"description": "Column-value pairs to update"
+						},
+						"where": {
+							"type": "object",
+							"description": "Column-value pairs for the WHERE clause (ANDed together)"
+						},
+						"returning": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Columns to return from updated rows (RETURNING clause)"
+						},
+						"timeout_seconds": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 300,
+							"description": "Statement timeout in seconds (default: 30)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "postgres.delete",
+				Name:        "Delete",
+				Description: "Delete rows from a table with a parameterized WHERE clause",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["table", "where"],
+					"properties": {
+						"table": {
+							"type": "string",
+							"description": "Target table name (schema.table format supported)"
+						},
+						"where": {
+							"type": "object",
+							"description": "Column-value pairs for the WHERE clause (ANDed together). At least one condition is required."
+						},
+						"returning": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Columns to return from deleted rows (RETURNING clause)"
+						},
+						"timeout_seconds": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 300,
+							"description": "Statement timeout in seconds (default: 30)"
+						}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{
+				Service:         "postgres",
+				AuthType:        "custom",
+				InstructionsURL: "https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING",
+			},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_postgres_query_readonly",
+				ActionType:  "postgres.query",
+				Name:        "Run read-only queries",
+				Description: "Agent can run any SELECT query. SQL and params are agent-controlled.",
+				Parameters:  json.RawMessage(`{"sql":"*","params":"*"}`),
+			},
+			{
+				ID:          "tpl_postgres_insert",
+				ActionType:  "postgres.insert",
+				Name:        "Insert rows",
+				Description: "Agent can insert rows into any table.",
+				Parameters:  json.RawMessage(`{"table":"*","columns":"*","rows":"*"}`),
+			},
+			{
+				ID:          "tpl_postgres_update",
+				ActionType:  "postgres.update",
+				Name:        "Update rows",
+				Description: "Agent can update rows in any table with WHERE constraints.",
+				Parameters:  json.RawMessage(`{"table":"*","set":"*","where":"*"}`),
+			},
+			{
+				ID:          "tpl_postgres_delete",
+				ActionType:  "postgres.delete",
+				Name:        "Delete rows",
+				Description: "Agent can delete rows from any table with WHERE constraints.",
+				Parameters:  json.RawMessage(`{"table":"*","where":"*"}`),
+			},
+		},
+	}
+}
+
+// Actions returns the registered action handlers keyed by action_type.
+func (c *PostgresConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"postgres.query":  &queryAction{conn: c},
+		"postgres.insert": &insertAction{conn: c},
+		"postgres.update": &updateAction{conn: c},
+		"postgres.delete": &deleteAction{conn: c},
+	}
+}
+
+// ValidateCredentials checks that the provided credentials contain a
+// valid connection_string.
+func (c *PostgresConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+	connStr, ok := creds.Get("connection_string")
+	if !ok || connStr == "" {
+		return &connectors.ValidationError{Message: "missing required credential: connection_string"}
+	}
+
+	// Validate the connection string is a parseable URL.
+	u, err := url.Parse(connStr)
+	if err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid connection_string: %v", err)}
+	}
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		return &connectors.ValidationError{Message: "connection_string must use postgres:// or postgresql:// scheme"}
+	}
+	return nil
+}
+
+// openDB opens a short-lived database connection using the provided connection
+// string. The caller must close the returned *sql.DB. A statement_timeout is
+// set on the connection to prevent runaway queries.
+func (c *PostgresConnector) openDB(connStr string, timeout time.Duration) (*sql.DB, error) {
+	db, err := sql.Open("pgx", connStr)
+	if err != nil {
+		return nil, fmt.Errorf("opening database connection: %w", err)
+	}
+
+	// Limit to a single connection — each action execution is isolated.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(timeout + 5*time.Second)
+
+	return db, nil
+}
+
+// resolveTimeout returns the effective statement timeout from the action
+// parameters, capped by the connector's default.
+func (c *PostgresConnector) resolveTimeout(paramTimeout int) time.Duration {
+	if paramTimeout > 0 {
+		t := time.Duration(paramTimeout) * time.Second
+		if t > 5*time.Minute {
+			t = 5 * time.Minute
+		}
+		return t
+	}
+	return c.statementTimeout
+}

--- a/connectors/postgres/postgres.go
+++ b/connectors/postgres/postgres.go
@@ -49,12 +49,12 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "postgres",
 		Name:        "PostgreSQL",
-		Description: "PostgreSQL database connector for parameterized queries",
+		Description: "Read and write PostgreSQL databases with parameterized queries, row limits, and statement timeouts",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "postgres.query",
-				Name:        "Query",
-				Description: "Execute a parameterized SELECT query (read-only)",
+				Name:        "Run SQL Query",
+				Description: "Execute a read-only SELECT query with parameterized values. Results are capped at max_rows.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -62,7 +62,7 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"sql": {
 							"type": "string",
-							"description": "Parameterized SELECT query (use $1, $2, ... for placeholders)"
+							"description": "Parameterized SELECT query. Use $1, $2, ... for placeholders. Example: SELECT * FROM users WHERE email = $1"
 						},
 						"params": {
 							"type": "array",
@@ -86,8 +86,8 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 			},
 			{
 				ActionType:  "postgres.insert",
-				Name:        "Insert",
-				Description: "Insert rows into a table with parameterized values",
+				Name:        "Insert Rows",
+				Description: "Insert one or more rows into a table. Supports bulk inserts and RETURNING clause.",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -126,8 +126,8 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 			},
 			{
 				ActionType:  "postgres.update",
-				Name:        "Update",
-				Description: "Update rows in a table with parameterized SET and WHERE clauses",
+				Name:        "Update Rows",
+				Description: "Update rows matching a WHERE clause. Unconditional updates are not allowed.",
 				RiskLevel:   "high",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -161,8 +161,8 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 			},
 			{
 				ActionType:  "postgres.delete",
-				Name:        "Delete",
-				Description: "Delete rows from a table with a parameterized WHERE clause",
+				Name:        "Delete Rows",
+				Description: "Delete rows matching a WHERE clause. Unconditional deletes are not allowed.",
 				RiskLevel:   "high",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -261,8 +261,8 @@ func (c *PostgresConnector) ValidateCredentials(_ context.Context, creds connect
 }
 
 // openDB opens a short-lived database connection using the provided connection
-// string. The caller must close the returned *sql.DB. A statement_timeout is
-// set on the connection to prevent runaway queries.
+// string and verifies connectivity with a Ping. The caller must close the
+// returned *sql.DB.
 func (c *PostgresConnector) openDB(connStr string, timeout time.Duration) (*sql.DB, error) {
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
@@ -273,6 +273,15 @@ func (c *PostgresConnector) openDB(connStr string, timeout time.Duration) (*sql.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	db.SetConnMaxLifetime(timeout + 5*time.Second)
+
+	// Ping to fail fast with a clear error if the database is unreachable,
+	// rather than surfacing cryptic errors on the first query.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("connecting to database: %w", err)
+	}
 
 	return db, nil
 }

--- a/connectors/postgres/postgres_test.go
+++ b/connectors/postgres/postgres_test.go
@@ -1,0 +1,156 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestPostgresConnector_ID(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if got := c.ID(); got != "postgres" {
+		t.Errorf("ID() = %q, want %q", got, "postgres")
+	}
+}
+
+func TestPostgresConnector_Actions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	want := []string{"postgres.query", "postgres.insert", "postgres.update", "postgres.delete"}
+	for _, at := range want {
+		if _, ok := actions[at]; !ok {
+			t.Errorf("Actions() missing %q", at)
+		}
+	}
+	if len(actions) != len(want) {
+		t.Errorf("Actions() returned %d actions, want %d", len(actions), len(want))
+	}
+}
+
+func TestPostgresConnector_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	tests := []struct {
+		name    string
+		creds   connectors.Credentials
+		wantErr bool
+	}{
+		{
+			name:    "valid connection_string",
+			creds:   connectors.NewCredentials(map[string]string{"connection_string": "postgres://user:pass@localhost:5432/mydb"}),
+			wantErr: false,
+		},
+		{
+			name:    "valid postgresql scheme",
+			creds:   connectors.NewCredentials(map[string]string{"connection_string": "postgresql://user:pass@localhost/mydb"}),
+			wantErr: false,
+		},
+		{
+			name:    "missing connection_string",
+			creds:   connectors.NewCredentials(map[string]string{}),
+			wantErr: true,
+		},
+		{
+			name:    "empty connection_string",
+			creds:   connectors.NewCredentials(map[string]string{"connection_string": ""}),
+			wantErr: true,
+		},
+		{
+			name:    "wrong scheme",
+			creds:   connectors.NewCredentials(map[string]string{"connection_string": "mysql://user:pass@localhost/mydb"}),
+			wantErr: true,
+		},
+		{
+			name:    "zero-value credentials",
+			creds:   connectors.Credentials{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.ValidateCredentials(t.Context(), tt.creds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("ValidateCredentials() returned %T, want *connectors.ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestPostgresConnector_Manifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+
+	if m.ID != "postgres" {
+		t.Errorf("Manifest().ID = %q, want %q", m.ID, "postgres")
+	}
+	if m.Name != "PostgreSQL" {
+		t.Errorf("Manifest().Name = %q, want %q", m.Name, "PostgreSQL")
+	}
+	if len(m.Actions) != 4 {
+		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	}
+	actionTypes := make(map[string]bool)
+	for _, a := range m.Actions {
+		actionTypes[a.ActionType] = true
+	}
+	for _, want := range []string{"postgres.query", "postgres.insert", "postgres.update", "postgres.delete"} {
+		if !actionTypes[want] {
+			t.Errorf("Manifest().Actions missing %q", want)
+		}
+	}
+	if len(m.RequiredCredentials) != 1 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	}
+	cred := m.RequiredCredentials[0]
+	if cred.Service != "postgres" {
+		t.Errorf("credential service = %q, want %q", cred.Service, "postgres")
+	}
+	if cred.AuthType != "custom" {
+		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "custom")
+	}
+	if cred.InstructionsURL == "" {
+		t.Error("credential instructions_url is empty, want a URL")
+	}
+
+	if err := m.Validate(); err != nil {
+		t.Errorf("Manifest().Validate() = %v", err)
+	}
+}
+
+func TestPostgresConnector_ActionsMatchManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+	manifest := c.Manifest()
+
+	manifestTypes := make(map[string]bool, len(manifest.Actions))
+	for _, a := range manifest.Actions {
+		manifestTypes[a.ActionType] = true
+	}
+
+	for actionType := range actions {
+		if !manifestTypes[actionType] {
+			t.Errorf("Actions() has %q but Manifest() does not", actionType)
+		}
+	}
+	for _, a := range manifest.Actions {
+		if _, ok := actions[a.ActionType]; !ok {
+			t.Errorf("Manifest() has %q but Actions() does not", a.ActionType)
+		}
+	}
+}
+
+func TestPostgresConnector_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+	var _ connectors.Connector = (*PostgresConnector)(nil)
+	var _ connectors.ManifestProvider = (*PostgresConnector)(nil)
+}

--- a/connectors/postgres/query.go
+++ b/connectors/postgres/query.go
@@ -1,0 +1,149 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// queryAction implements connectors.Action for postgres.query.
+// It executes parameterized SELECT queries in read-only mode.
+type queryAction struct {
+	conn *PostgresConnector
+}
+
+type queryParams struct {
+	SQL            string        `json:"sql"`
+	Params         []interface{} `json:"params"`
+	MaxRows        int           `json:"max_rows"`
+	TimeoutSeconds int           `json:"timeout_seconds"`
+}
+
+func (p *queryParams) validate() error {
+	if p.SQL == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: sql"}
+	}
+
+	// Only allow SELECT statements (and WITH/CTE that lead to SELECT).
+	normalized := strings.TrimSpace(strings.ToUpper(p.SQL))
+	if !strings.HasPrefix(normalized, "SELECT") && !strings.HasPrefix(normalized, "WITH") {
+		return &connectors.ValidationError{Message: "only SELECT queries are allowed (query must start with SELECT or WITH)"}
+	}
+
+	if p.MaxRows < 0 {
+		return &connectors.ValidationError{Message: "max_rows must be positive"}
+	}
+	if p.MaxRows > 10000 {
+		return &connectors.ValidationError{Message: "max_rows cannot exceed 10000"}
+	}
+	return nil
+}
+
+// Execute runs a read-only SELECT query and returns the result rows as JSON.
+func (a *queryAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params queryParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	connStr, ok := req.Credentials.Get("connection_string")
+	if !ok || connStr == "" {
+		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	}
+
+	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
+	maxRows := a.conn.maxRows
+	if params.MaxRows > 0 {
+		maxRows = params.MaxRows
+	}
+
+	db, err := a.conn.openDB(connStr, timeout)
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+	}
+	defer db.Close()
+
+	// Set statement timeout and read-only transaction.
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, mapPgError(err, "beginning transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck // read-only tx, rollback is cleanup
+
+	timeoutMS := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, mapPgError(err, "setting statement timeout")
+	}
+	if _, err := tx.ExecContext(ctx, "SET TRANSACTION READ ONLY"); err != nil {
+		return nil, mapPgError(err, "setting read-only mode")
+	}
+
+	rows, err := tx.QueryContext(ctx, params.SQL, params.Params...)
+	if err != nil {
+		return nil, mapPgError(err, "executing query")
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading column names: %v", err)}
+	}
+
+	// Read up to maxRows+1 to detect truncation.
+	var results []map[string]interface{}
+	for rows.Next() {
+		if len(results) >= maxRows+1 {
+			break
+		}
+
+		values := make([]interface{}, len(columns))
+		valuePtrs := make([]interface{}, len(columns))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return nil, &connectors.ExternalError{Message: fmt.Sprintf("scanning row: %v", err)}
+		}
+
+		row := make(map[string]interface{}, len(columns))
+		for i, col := range columns {
+			val := values[i]
+			// Convert []byte to string for JSON serialization.
+			if b, ok := val.([]byte); ok {
+				row[col] = string(b)
+			} else {
+				row[col] = val
+			}
+		}
+		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, mapPgError(err, "iterating rows")
+	}
+
+	// If we read more than maxRows, truncate and flag it.
+	truncated := len(results) > maxRows
+	if truncated {
+		results = results[:maxRows]
+	}
+	if results == nil {
+		results = []map[string]interface{}{}
+	}
+
+	return connectors.JSONResult(map[string]interface{}{
+		"columns":   columns,
+		"rows":      results,
+		"row_count": len(results),
+		"truncated": truncated,
+	})
+}

--- a/connectors/postgres/query.go
+++ b/connectors/postgres/query.go
@@ -52,9 +52,9 @@ func (a *queryAction) Execute(ctx context.Context, req connectors.ActionRequest)
 		return nil, err
 	}
 
-	connStr, ok := req.Credentials.Get("connection_string")
-	if !ok || connStr == "" {
-		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	connStr, err := getConnString(req)
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
@@ -63,31 +63,18 @@ func (a *queryAction) Execute(ctx context.Context, req connectors.ActionRequest)
 		maxRows = params.MaxRows
 	}
 
-	db, err := a.conn.openDB(connStr, timeout)
+	env, err := prepareTx(ctx, a.conn, connStr, timeout)
 	if err != nil {
-		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+		return nil, err
 	}
-	defer db.Close()
+	defer env.Close()
 
-	// Set statement timeout and read-only transaction.
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, mapPgError(err, "beginning transaction")
-	}
-	defer tx.Rollback() //nolint:errcheck // read-only tx, rollback is cleanup
-
-	timeoutMS := int(timeout.Milliseconds())
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
-		return nil, mapPgError(err, "setting statement timeout")
-	}
-	if _, err := tx.ExecContext(ctx, "SET TRANSACTION READ ONLY"); err != nil {
+	// Enforce read-only transaction to block writes even via CTEs.
+	if _, err := env.Tx.ExecContext(env.Ctx, "SET TRANSACTION READ ONLY"); err != nil {
 		return nil, mapPgError(err, "setting read-only mode")
 	}
 
-	rows, err := tx.QueryContext(ctx, params.SQL, params.Params...)
+	rows, err := env.Tx.QueryContext(env.Ctx, params.SQL, params.Params...)
 	if err != nil {
 		return nil, mapPgError(err, "executing query")
 	}

--- a/connectors/postgres/query_test.go
+++ b/connectors/postgres/query_test.go
@@ -131,6 +131,32 @@ func TestQuery_RejectsNonSelect(t *testing.T) {
 	}
 }
 
+func TestQuery_WithCTE(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	// Read-only CTE should succeed.
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(fmt.Sprintf(`{"sql":"WITH active AS (SELECT name, value FROM %s WHERE active = true) SELECT * FROM active ORDER BY name"}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["row_count"].(float64) != 2 {
+		t.Errorf("row_count = %v, want 2", data["row_count"])
+	}
+}
+
 func TestQuery_ReadOnlyEnforcement(t *testing.T) {
 	t.Parallel()
 	table := setupTestTable(t)

--- a/connectors/postgres/query_test.go
+++ b/connectors/postgres/query_test.go
@@ -1,0 +1,222 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestQuery_Success(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(fmt.Sprintf(`{"sql":"SELECT name, value FROM %s WHERE active = $1 ORDER BY name","params":[true]}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+
+	rowCount := data["row_count"].(float64)
+	if rowCount != 2 {
+		t.Errorf("row_count = %v, want 2", rowCount)
+	}
+	if data["truncated"].(bool) {
+		t.Error("truncated = true, want false")
+	}
+
+	rows := data["rows"].([]interface{})
+	firstRow := rows[0].(map[string]interface{})
+	if firstRow["name"] != "alpha" {
+		t.Errorf("first row name = %v, want alpha", firstRow["name"])
+	}
+}
+
+func TestQuery_EmptyResult(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(fmt.Sprintf(`{"sql":"SELECT * FROM %s WHERE value > $1","params":[9999]}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["row_count"].(float64) != 0 {
+		t.Errorf("row_count = %v, want 0", data["row_count"])
+	}
+}
+
+func TestQuery_MaxRows(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(fmt.Sprintf(`{"sql":"SELECT * FROM %s ORDER BY id","max_rows":2}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["row_count"].(float64) != 2 {
+		t.Errorf("row_count = %v, want 2", data["row_count"])
+	}
+	if !data["truncated"].(bool) {
+		t.Error("truncated = false, want true")
+	}
+}
+
+func TestQuery_RejectsNonSelect(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"INSERT", `{"sql":"INSERT INTO test VALUES (1)"}`},
+		{"UPDATE", `{"sql":"UPDATE test SET x = 1"}`},
+		{"DELETE", `{"sql":"DELETE FROM test"}`},
+		{"DROP", `{"sql":"DROP TABLE test"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "postgres.query",
+				Parameters:  json.RawMessage(tt.sql),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestQuery_ReadOnlyEnforcement(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	// CTE with write operation should be rejected by the read-only transaction.
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(fmt.Sprintf(`{"sql":"WITH d AS (DELETE FROM %s RETURNING *) SELECT * FROM d"}`, table)),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("Execute() expected error for write in read-only transaction, got nil")
+	}
+}
+
+func TestQuery_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing sql", `{}`},
+		{"empty sql", `{"sql":""}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "postgres.query",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestQuery_BadCredentials(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(`{"sql":"SELECT 1"}`),
+		Credentials: connectors.NewCredentials(map[string]string{"connection_string": "postgres://baduser:badpass@localhost:5432/nonexistent?sslmode=disable"}),
+	})
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	// Should be either AuthError or ExternalError depending on the failure mode.
+	if connectors.IsValidationError(err) {
+		t.Errorf("unexpected ValidationError for bad credentials: %v", err)
+	}
+}
+
+func TestQuery_Timeout(t *testing.T) {
+	t.Parallel()
+	setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.query"]
+
+	ctx, cancel := context.WithTimeout(t.Context(), 1)
+	defer cancel()
+
+	_, err := action.Execute(ctx, connectors.ActionRequest{
+		ActionType:  "postgres.query",
+		Parameters:  json.RawMessage(`{"sql":"SELECT pg_sleep(10)"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+}

--- a/connectors/postgres/sanitize.go
+++ b/connectors/postgres/sanitize.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -45,12 +46,7 @@ func sortedKeys(m map[string]interface{}) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	// Sort for deterministic output.
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
-			keys[j], keys[j-1] = keys[j-1], keys[j]
-		}
-	}
+	sort.Strings(keys)
 	return keys
 }
 

--- a/connectors/postgres/sanitize.go
+++ b/connectors/postgres/sanitize.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
 // identifierPattern matches valid PostgreSQL identifiers:
@@ -50,4 +52,49 @@ func sortedKeys(m map[string]interface{}) []string {
 		}
 	}
 	return keys
+}
+
+// validateWhereCols validates all column names in a WHERE map.
+func validateWhereCols(where map[string]interface{}) error {
+	for col := range where {
+		if err := validateIdentifier(col, "where column"); err != nil {
+			return &connectors.ValidationError{Message: err.Error()}
+		}
+	}
+	return nil
+}
+
+// validateReturningCols validates all column names in a RETURNING list.
+func validateReturningCols(cols []string) error {
+	for _, col := range cols {
+		if col != "*" {
+			if err := validateIdentifier(col, "returning column"); err != nil {
+				return &connectors.ValidationError{Message: err.Error()}
+			}
+		}
+	}
+	return nil
+}
+
+// buildWhereClause builds a parameterized WHERE clause from a column-value map.
+// NULL values produce IS NULL conditions; non-null values use $N placeholders.
+// startIdx is the first placeholder index to use.
+func buildWhereClause(where map[string]interface{}, startIdx int) (string, []interface{}) {
+	cols := sortedKeys(where)
+	var clauses []string
+	var args []interface{}
+	paramIdx := startIdx
+
+	for _, col := range cols {
+		val := where[col]
+		if val == nil {
+			clauses = append(clauses, fmt.Sprintf("%s IS NULL", quoteIdentifier(col)))
+		} else {
+			clauses = append(clauses, fmt.Sprintf("%s = $%d", quoteIdentifier(col), paramIdx))
+			args = append(args, val)
+			paramIdx++
+		}
+	}
+
+	return strings.Join(clauses, " AND "), args
 }

--- a/connectors/postgres/sanitize.go
+++ b/connectors/postgres/sanitize.go
@@ -1,0 +1,53 @@
+package postgres
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// identifierPattern matches valid PostgreSQL identifiers:
+// letters, digits, underscores, with optional schema prefix.
+var identifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$`)
+
+// validateIdentifier checks that name is a safe SQL identifier (table or column).
+// It rejects anything that could be used for SQL injection.
+func validateIdentifier(name, label string) error {
+	if name == "" {
+		return fmt.Errorf("%s cannot be empty", label)
+	}
+	if len(name) > 128 {
+		return fmt.Errorf("%s exceeds maximum length of 128 characters", label)
+	}
+	if !identifierPattern.MatchString(name) {
+		return fmt.Errorf("%s %q contains invalid characters (must be alphanumeric/underscore, optionally schema-qualified)", label, name)
+	}
+	return nil
+}
+
+// quoteIdentifier quotes a SQL identifier using double quotes to prevent
+// injection. It also escapes any embedded double quotes per SQL standard.
+func quoteIdentifier(name string) string {
+	// Handle schema.table format
+	if idx := strings.IndexByte(name, '.'); idx >= 0 {
+		schema := name[:idx]
+		table := name[idx+1:]
+		return `"` + strings.ReplaceAll(schema, `"`, `""`) + `"."` + strings.ReplaceAll(table, `"`, `""`) + `"`
+	}
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// sortedKeys returns the keys of a map in a stable order for deterministic SQL generation.
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Sort for deterministic output.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
+}

--- a/connectors/postgres/sanitize_test.go
+++ b/connectors/postgres/sanitize_test.go
@@ -1,0 +1,66 @@
+package postgres
+
+import "testing"
+
+func TestValidateIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple", "users", false},
+		{"with_underscore", "user_accounts", false},
+		{"schema_qualified", "public.users", false},
+		{"starts_with_underscore", "_private", false},
+		{"empty", "", true},
+		{"has_space", "user accounts", true},
+		{"has_semicolon", "users;", true},
+		{"has_quotes", `users"`, true},
+		{"has_dash", "user-accounts", true},
+		{"sql_injection", "'; DROP TABLE users--", true},
+		{"starts_with_number", "1users", true},
+		{"too_long", string(make([]byte, 200)), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIdentifier(tt.input, "test")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateIdentifier(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"users", `"users"`},
+		{"public.users", `"public"."users"`},
+		{`has"quote`, `"has""quote"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := quoteIdentifier(tt.input)
+			if got != tt.want {
+				t.Errorf("quoteIdentifier(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	t.Parallel()
+	m := map[string]interface{}{"c": 3, "a": 1, "b": 2}
+	keys := sortedKeys(m)
+	if len(keys) != 3 || keys[0] != "a" || keys[1] != "b" || keys[2] != "c" {
+		t.Errorf("sortedKeys() = %v, want [a b c]", keys)
+	}
+}

--- a/connectors/postgres/update.go
+++ b/connectors/postgres/update.go
@@ -40,19 +40,10 @@ func (p *updateParams) validate() error {
 			return &connectors.ValidationError{Message: err.Error()}
 		}
 	}
-	for col := range p.Where {
-		if err := validateIdentifier(col, "where column"); err != nil {
-			return &connectors.ValidationError{Message: err.Error()}
-		}
+	if err := validateWhereCols(p.Where); err != nil {
+		return err
 	}
-	for _, col := range p.Returning {
-		if col != "*" {
-			if err := validateIdentifier(col, "returning column"); err != nil {
-				return &connectors.ValidationError{Message: err.Error()}
-			}
-		}
-	}
-	return nil
+	return validateReturningCols(p.Returning)
 }
 
 // Execute updates rows in a table and returns the affected count.
@@ -65,21 +56,18 @@ func (a *updateAction) Execute(ctx context.Context, req connectors.ActionRequest
 		return nil, err
 	}
 
-	connStr, ok := req.Credentials.Get("connection_string")
-	if !ok || connStr == "" {
-		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	connStr, err := getConnString(req)
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
 
-	db, err := a.conn.openDB(connStr, timeout)
+	env, err := prepareTx(ctx, a.conn, connStr, timeout)
 	if err != nil {
-		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+		return nil, err
 	}
-	defer db.Close()
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	defer env.Close()
 
 	// Build SET clause.
 	setCols := sortedKeys(params.Set)
@@ -94,82 +82,15 @@ func (a *updateAction) Execute(ctx context.Context, req connectors.ActionRequest
 	}
 
 	// Build WHERE clause.
-	whereCols := sortedKeys(params.Where)
-	var whereClauses []string
-	for _, col := range whereCols {
-		val := params.Where[col]
-		if val == nil {
-			whereClauses = append(whereClauses, fmt.Sprintf("%s IS NULL", quoteIdentifier(col)))
-		} else {
-			whereClauses = append(whereClauses, fmt.Sprintf("%s = $%d", quoteIdentifier(col), paramIdx))
-			args = append(args, val)
-			paramIdx++
-		}
-	}
+	whereSQL, whereArgs := buildWhereClause(params.Where, paramIdx)
+	args = append(args, whereArgs...)
 
-	query := fmt.Sprintf("UPDATE %s SET %s WHERE %s",
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE %s%s",
 		quoteIdentifier(params.Table),
 		strings.Join(setClauses, ", "),
-		strings.Join(whereClauses, " AND "),
+		whereSQL,
+		buildReturningClause(params.Returning),
 	)
 
-	hasReturning := len(params.Returning) > 0
-	if hasReturning {
-		quotedReturning := make([]string, len(params.Returning))
-		for i, col := range params.Returning {
-			if col == "*" {
-				quotedReturning[i] = "*"
-			} else {
-				quotedReturning[i] = quoteIdentifier(col)
-			}
-		}
-		query += " RETURNING " + strings.Join(quotedReturning, ", ")
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, mapPgError(err, "beginning transaction")
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	timeoutMS := int(timeout.Milliseconds())
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
-		return nil, mapPgError(err, "setting statement timeout")
-	}
-
-	if hasReturning {
-		rows, err := tx.QueryContext(ctx, query, args...)
-		if err != nil {
-			return nil, mapPgError(err, "executing update")
-		}
-		defer rows.Close()
-
-		returned, err := scanRows(rows)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := tx.Commit(); err != nil {
-			return nil, mapPgError(err, "committing transaction")
-		}
-
-		return connectors.JSONResult(map[string]interface{}{
-			"rows_affected": len(returned),
-			"returned":      returned,
-		})
-	}
-
-	result, err := tx.ExecContext(ctx, query, args...)
-	if err != nil {
-		return nil, mapPgError(err, "executing update")
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, mapPgError(err, "committing transaction")
-	}
-
-	affected, _ := result.RowsAffected()
-	return connectors.JSONResult(map[string]interface{}{
-		"rows_affected": affected,
-	})
+	return execMutation(env, query, args, len(params.Returning) > 0, "executing update")
 }

--- a/connectors/postgres/update.go
+++ b/connectors/postgres/update.go
@@ -1,0 +1,175 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// updateAction implements connectors.Action for postgres.update.
+type updateAction struct {
+	conn *PostgresConnector
+}
+
+type updateParams struct {
+	Table          string                 `json:"table"`
+	Set            map[string]interface{} `json:"set"`
+	Where          map[string]interface{} `json:"where"`
+	Returning      []string               `json:"returning"`
+	TimeoutSeconds int                    `json:"timeout_seconds"`
+}
+
+func (p *updateParams) validate() error {
+	if p.Table == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: table"}
+	}
+	if err := validateIdentifier(p.Table, "table"); err != nil {
+		return &connectors.ValidationError{Message: err.Error()}
+	}
+	if len(p.Set) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: set (must contain at least one column to update)"}
+	}
+	if len(p.Where) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: where (unconditional updates are not allowed)"}
+	}
+	for col := range p.Set {
+		if err := validateIdentifier(col, "set column"); err != nil {
+			return &connectors.ValidationError{Message: err.Error()}
+		}
+	}
+	for col := range p.Where {
+		if err := validateIdentifier(col, "where column"); err != nil {
+			return &connectors.ValidationError{Message: err.Error()}
+		}
+	}
+	for _, col := range p.Returning {
+		if col != "*" {
+			if err := validateIdentifier(col, "returning column"); err != nil {
+				return &connectors.ValidationError{Message: err.Error()}
+			}
+		}
+	}
+	return nil
+}
+
+// Execute updates rows in a table and returns the affected count.
+func (a *updateAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params updateParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	connStr, ok := req.Credentials.Get("connection_string")
+	if !ok || connStr == "" {
+		return nil, &connectors.ValidationError{Message: "missing credential: connection_string"}
+	}
+
+	timeout := a.conn.resolveTimeout(params.TimeoutSeconds)
+
+	db, err := a.conn.openDB(connStr, timeout)
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("failed to open database: %v", err)}
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Build SET clause.
+	setCols := sortedKeys(params.Set)
+	var setClauses []string
+	var args []interface{}
+	paramIdx := 1
+
+	for _, col := range setCols {
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", quoteIdentifier(col), paramIdx))
+		args = append(args, params.Set[col])
+		paramIdx++
+	}
+
+	// Build WHERE clause.
+	whereCols := sortedKeys(params.Where)
+	var whereClauses []string
+	for _, col := range whereCols {
+		val := params.Where[col]
+		if val == nil {
+			whereClauses = append(whereClauses, fmt.Sprintf("%s IS NULL", quoteIdentifier(col)))
+		} else {
+			whereClauses = append(whereClauses, fmt.Sprintf("%s = $%d", quoteIdentifier(col), paramIdx))
+			args = append(args, val)
+			paramIdx++
+		}
+	}
+
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE %s",
+		quoteIdentifier(params.Table),
+		strings.Join(setClauses, ", "),
+		strings.Join(whereClauses, " AND "),
+	)
+
+	hasReturning := len(params.Returning) > 0
+	if hasReturning {
+		quotedReturning := make([]string, len(params.Returning))
+		for i, col := range params.Returning {
+			if col == "*" {
+				quotedReturning[i] = "*"
+			} else {
+				quotedReturning[i] = quoteIdentifier(col)
+			}
+		}
+		query += " RETURNING " + strings.Join(quotedReturning, ", ")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, mapPgError(err, "beginning transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	timeoutMS := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = %d", timeoutMS)); err != nil {
+		return nil, mapPgError(err, "setting statement timeout")
+	}
+
+	if hasReturning {
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, mapPgError(err, "executing update")
+		}
+		defer rows.Close()
+
+		returned, err := scanRows(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return nil, mapPgError(err, "committing transaction")
+		}
+
+		return connectors.JSONResult(map[string]interface{}{
+			"rows_affected": len(returned),
+			"returned":      returned,
+		})
+	}
+
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, mapPgError(err, "executing update")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, mapPgError(err, "committing transaction")
+	}
+
+	affected, _ := result.RowsAffected()
+	return connectors.JSONResult(map[string]interface{}{
+		"rows_affected": affected,
+	})
+}

--- a/connectors/postgres/update_test.go
+++ b/connectors/postgres/update_test.go
@@ -1,0 +1,138 @@
+package postgres
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUpdate_Success(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.update"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.update",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"set": {"value": 99},
+			"where": {"name": "alpha"}
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["rows_affected"].(float64) != 1 {
+		t.Errorf("rows_affected = %v, want 1", data["rows_affected"])
+	}
+}
+
+func TestUpdate_WithReturning(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.update"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.update",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"set": {"active": false},
+			"where": {"name": "alpha"},
+			"returning": ["name", "active"]
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	returned := data["returned"].([]interface{})
+	if len(returned) != 1 {
+		t.Fatalf("returned has %d rows, want 1", len(returned))
+	}
+	row := returned[0].(map[string]interface{})
+	if row["active"] != false {
+		t.Errorf("returned active = %v, want false", row["active"])
+	}
+}
+
+func TestUpdate_NoMatchingRows(t *testing.T) {
+	t.Parallel()
+	table := setupTestTable(t)
+
+	conn := New()
+	action := conn.Actions()["postgres.update"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "postgres.update",
+		Parameters: json.RawMessage(fmt.Sprintf(`{
+			"table": "%s",
+			"set": {"value": 0},
+			"where": {"name": "nonexistent"}
+		}`, table)),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["rows_affected"].(float64) != 0 {
+		t.Errorf("rows_affected = %v, want 0", data["rows_affected"])
+	}
+}
+
+func TestUpdate_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["postgres.update"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing table", `{"set":{"x":1},"where":{"id":1}}`},
+		{"missing set", `{"table":"test","where":{"id":1}}`},
+		{"missing where", `{"table":"test","set":{"x":1}}`},
+		{"empty set", `{"table":"test","set":{},"where":{"id":1}}`},
+		{"empty where", `{"table":"test","set":{"x":1},"where":{}}`},
+		{"invalid table", `{"table":"'; DROP--","set":{"x":1},"where":{"id":1}}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "postgres.update",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -1,6 +1,6 @@
 # Creating Connectors and Actions
 
-This guide walks through adding a new connector (an integration with an external service) and adding actions to it. It uses the existing GitHub and Slack connectors as reference implementations.
+This guide walks through adding a new connector (an integration with an external service) and adding actions to it. It uses the existing GitHub, Slack, and PostgreSQL connectors as reference implementations.
 
 For architectural context, see [ADR-009: Connector Execution Architecture](adr/009-connector-execution-architecture.md).
 
@@ -8,7 +8,7 @@ For architectural context, see [ADR-009: Connector Execution Architecture](adr/0
 
 ## Overview
 
-A **connector** represents an integration with an external service (e.g., GitHub, Slack, Jira). A connector owns shared configuration like HTTP clients, base URLs, and authentication helpers.
+A **connector** represents an integration with an external service or database (e.g., GitHub, Slack, PostgreSQL). A connector owns shared configuration like HTTP clients, base URLs, and authentication helpers.
 
 An **action** is a single operation within a connector (e.g., `github.create_issue`, `slack.send_message`). Each action has its own file, parameter struct, validation, and `Execute` method.
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -354,7 +354,7 @@ If using a reverse proxy other than Fly.io, set `TRUSTED_PROXY_HEADER` to the he
 
 ## Custom Connectors
 
-Permission Slip ships with built-in GitHub and Slack connectors. To add custom connectors:
+Permission Slip ships with built-in GitHub, Slack, and PostgreSQL connectors. To add custom connectors:
 
 **Option A — Inline JSON (recommended for containers):**
 

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -357,5 +357,5 @@ Then use the IP directly (e.g., `http://192.168.1.100:8080`).
 ## What's Next?
 
 - **Add agents:** Follow the [Agent Integration Guide](agents.md) to connect your first AI agent
-- **Custom connectors:** Add integrations beyond the built-in GitHub and Slack connectors — see [Custom Connectors](custom-connectors.md)
+- **Custom connectors:** Add integrations beyond the built-in GitHub, Slack, and PostgreSQL connectors — see [Custom Connectors](custom-connectors.md)
 - **More configuration:** For web push, email notifications, error tracking, analytics, and more — read the full [Self-Hosted Deployment Guide](deployment-self-hosted.md)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/api"
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	ghconnector "github.com/supersuit-tech/permission-slip-web/connectors/github"
+	pgconnector "github.com/supersuit-tech/permission-slip-web/connectors/postgres"
 	"github.com/supersuit-tech/permission-slip-web/connectors/slack"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/notify"
@@ -307,6 +308,7 @@ func main() {
 	// Initialize connector registry.
 	registry := connectors.NewRegistry()
 	registry.Register(ghconnector.New())
+	registry.Register(pgconnector.New())
 	registry.Register(slack.New())
 
 	// Auto-seed built-in connectors from their manifests.


### PR DESCRIPTION
## Summary

- Adds a built-in PostgreSQL connector with four actions: `postgres.query` (read-only SELECT), `postgres.insert`, `postgres.update`, and `postgres.delete`
- Enforces security at multiple layers: parameterized queries only, identifier validation against injection, statement timeouts, row limits, read-only transactions for queries, and required WHERE clauses for mutations
- Follows existing connector patterns (GitHub/Slack) with manifest-based auto-seeding, typed error mapping, and comprehensive test coverage (30 tests)

Closes #200

## Test plan

- [x] All 30 connector tests pass (`go test ./connectors/postgres/... -v`)
- [x] Full project builds successfully (`go build ./...`)
- [ ] Verify connector appears in UI after server startup (manifest auto-seeds DB)
- [ ] Test with a real PostgreSQL database connection string via the vault
- [ ] Verify SQL injection attempts are rejected by identifier validation
- [ ] Verify read-only enforcement prevents writes via `postgres.query`
- [ ] Verify statement timeout kills long-running queries

https://claude.ai/code/session_01NzbMWLvcQRWgVFesaRLoJV