### PR TITLE
Replace connector listing with link to connectors directory

### DIFF
--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -2,12 +2,7 @@
 
 This guide walks through adding a new connector (an integration with an external service) and adding actions to it. It uses the existing GitHub, Slack, PostgreSQL, Amadeus, and Square connectors as reference implementations.
 
-**Which reference to follow:**
-- **GitHub** (`connectors/github/`) — simple API key auth (Bearer token), good starting point
-- **Slack** (`connectors/slack/`) — API key with format validation (token prefix check), Slack-specific response envelope
-- **PostgreSQL** (`connectors/postgresql/`) — custom auth (host + port + user + password + database)
-- **Amadeus** (`connectors/amadeus/`) — OAuth client credentials grant (client_id + client_secret → short-lived bearer token with caching and auto-refresh)
-- **Square** (`connectors/square/`) — environment-aware base URLs (sandbox/production), idempotency key generation, structured error envelope parsing
+**Which reference to follow:** Browse the existing connectors in [`connectors/`](../connectors/) for reference implementations covering API key auth, OAuth, custom auth, and more.
 
 For architectural context, see [ADR-009: Connector Execution Architecture](adr/009-connector-execution-architecture.md).
 


### PR DESCRIPTION
## Summary
- Replaced the hardcoded list of connectors in `docs/creating-connectors.md` with a single link to the `connectors/` directory
- Keeps docs current without needing manual updates when connectors are added or removed

## Test plan
- [x] Verify the markdown link resolves correctly to `../connectors/`
- [x] No code changes — docs only, no tests needed

https://claude.ai/code/session_01J6eMZP9fp4SXY1hLDoDNc6