### PR TITLE
Add Google connector (Gmail + Calendar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Permission Slip requires agents that can **(1) make HTTP requests to arbitrary U
 - **[OpenAPI Spec](spec/openapi/)** — machine-readable API definition
 - **[Architecture](docs/architecture.md)** — system diagrams and component overview
 - **[Agent Integration Guide](docs/agents.md)** — how to integrate an autonomous agent with Permission Slip
-- **[Creating Connectors](docs/creating-connectors.md)** — guide to building new built-in connectors (GitHub, Slack, MySQL as references)
+- **[Creating Connectors](docs/creating-connectors.md)** — guide to building new built-in connectors (GitHub, Slack, Google, MySQL as references)
 - **[Custom Connectors](docs/custom-connectors.md)** — add connectors from external Git repos (subprocess-based plugin system)
 - **[Community Connectors](docs/community-connectors.md)** — directory of third-party connectors built by the community
 - **[Consent Banner](docs/consent-banner.md)** — cross-subdomain cookie consent banner (shared between www and app)

--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -1,0 +1,236 @@
+# Google Connector
+
+The Google connector integrates Permission Slip with [Gmail](https://developers.google.com/gmail/api) and [Google Calendar](https://developers.google.com/calendar/api) APIs. It uses plain `net/http` with OAuth 2.0 access tokens provided by the platform — no third-party Google SDK.
+
+## Connector ID
+
+`google`
+
+## Credentials
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `access_token` | Yes | An OAuth 2.0 access token provided automatically by the platform's OAuth infrastructure. |
+
+The credential `auth_type` is `oauth2` with `oauth_provider` set to `google` (a built-in provider). The platform handles the full OAuth flow, token storage, and automatic refresh — the connector just receives a valid access token at execution time.
+
+**OAuth scopes requested:**
+
+| Scope | Used by |
+|-------|---------|
+| `gmail.send` | `google.send_email` |
+| `gmail.readonly` | `google.list_emails` |
+| `calendar.events` | `google.create_calendar_event`, `google.list_calendar_events` |
+
+Scopes follow the principle of least privilege — `calendar.events` (event-level access) is used instead of the broader `calendar` scope (full calendar management).
+
+## Actions
+
+### `google.send_email`
+
+Sends an email via the Gmail API.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `to` | string | Yes | Recipient email address |
+| `subject` | string | Yes | Email subject line |
+| `body` | string | Yes | Email body (plain text) |
+
+**Response:**
+
+```json
+{
+  "id": "18abc123def",
+  "thread_id": "18abc123def"
+}
+```
+
+**Gmail API:** `POST /gmail/v1/users/me/messages/send` ([docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/send))
+
+**Security notes:**
+- The `to` and `subject` fields are validated to reject newline characters (`\r`, `\n`) to prevent MIME header injection in the RFC 2822 message.
+- The message is encoded with unpadded base64url (`base64.RawURLEncoding`) per the Gmail API specification.
+
+---
+
+### `google.list_emails`
+
+Lists recent emails from the Gmail inbox with metadata.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `query` | string | No | — | Gmail search query (e.g., `from:user@example.com is:unread`) |
+| `max_results` | integer | No | `10` | Maximum number of emails to return (1-100) |
+
+**Response:**
+
+```json
+{
+  "emails": [
+    {
+      "id": "18abc123def",
+      "from": "sender@example.com",
+      "to": "you@example.com",
+      "subject": "Hello",
+      "snippet": "Preview of the email body...",
+      "date": "Mon, 15 Jan 2024 09:00:00 -0500"
+    }
+  ],
+  "total_estimate": 42
+}
+```
+
+**Gmail API:** `GET /gmail/v1/users/me/messages` + `GET /gmail/v1/users/me/messages/{id}` ([docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list))
+
+The action first lists message IDs matching the query, then fetches metadata (From, To, Subject, Date headers and snippet) for each message.
+
+---
+
+### `google.create_calendar_event`
+
+Creates a new event on Google Calendar.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `summary` | string | Yes | — | Event title |
+| `description` | string | No | — | Event description |
+| `start_time` | string | Yes | — | Start time in RFC 3339 format (e.g., `2024-01-15T09:00:00-05:00`) |
+| `end_time` | string | Yes | — | End time in RFC 3339 format (must be after `start_time`) |
+| `attendees` | string[] | No | — | List of attendee email addresses |
+| `calendar_id` | string | No | `primary` | Calendar ID (defaults to `primary`) |
+
+**Response:**
+
+```json
+{
+  "id": "abc123event",
+  "html_link": "https://calendar.google.com/event?eid=abc123",
+  "status": "confirmed"
+}
+```
+
+**Calendar API:** `POST /calendars/{calendarId}/events` ([docs](https://developers.google.com/calendar/api/v3/reference/events/insert))
+
+**Validation:**
+- `start_time` and `end_time` must be valid RFC 3339 timestamps.
+- `end_time` must be strictly after `start_time` — equal or earlier times are rejected with a clear validation error.
+- `calendar_id` is URL-encoded in the API path to safely handle IDs containing special characters (e.g., `user@group.calendar.google.com`).
+
+---
+
+### `google.list_calendar_events`
+
+Lists upcoming events from Google Calendar.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `calendar_id` | string | No | `primary` | Calendar ID |
+| `max_results` | integer | No | `10` | Maximum number of events to return (1-250) |
+| `time_min` | string | No | now | Lower bound for event start time (RFC 3339). Defaults to current time. |
+| `time_max` | string | No | — | Upper bound for event start time (RFC 3339) |
+
+**Response:**
+
+```json
+{
+  "events": [
+    {
+      "id": "event123",
+      "summary": "Team Standup",
+      "description": "Daily sync",
+      "start_time": "2024-01-15T09:00:00-05:00",
+      "end_time": "2024-01-15T09:30:00-05:00",
+      "status": "confirmed",
+      "html_link": "https://calendar.google.com/event?eid=...",
+      "attendees": ["alice@example.com", "bob@example.com"]
+    }
+  ]
+}
+```
+
+**Calendar API:** `GET /calendars/{calendarId}/events` ([docs](https://developers.google.com/calendar/api/v3/reference/events/list))
+
+Events are returned as single instances (recurring events expanded) ordered by start time. All-day events use a date string (e.g., `2024-01-15`) instead of a full RFC 3339 timestamp.
+
+## Error Handling
+
+The connector maps Google API HTTP status codes to typed connector errors:
+
+| HTTP Status | Connector Error | Meaning |
+|-------------|-----------------|---------|
+| 401 Unauthorized | `AuthError` | Access token is invalid or expired |
+| 403 Forbidden | `AuthError` | Missing required OAuth scope or permission |
+| 429 Too Many Requests | `RateLimitError` | Google API quota exceeded (includes `Retry-After`) |
+| Other 4xx/5xx | `ExternalError` | General API error (error message extracted from response) |
+| Client timeout | `TimeoutError` | Request didn't complete within 30s |
+
+Response bodies are capped at 10 MB via `io.LimitReader` to prevent out-of-memory from unexpectedly large responses.
+
+## Templates
+
+The connector ships with constrained templates that demonstrate parameter locking:
+
+| Template | Action | What's locked |
+|----------|--------|---------------|
+| Send emails freely | `send_email` | Nothing — agent controls all parameters |
+| Send email to specific recipient | `send_email` | `to` is locked to a placeholder; admin sets the real recipient |
+| Search emails | `list_emails` | Nothing — agent controls query and count |
+| List unread emails | `list_emails` | `query` locked to `is:unread` |
+| Create calendar events | `create_calendar_event` | Nothing — agent controls all parameters |
+| Create personal calendar events | `create_calendar_event` | `calendar_id` locked to `primary`, no attendees |
+| List calendar events | `list_calendar_events` | Nothing — agent controls all parameters |
+
+## Adding a New Action
+
+Each action lives in its own file. To add one (e.g., `google.delete_calendar_event`):
+
+1. Create `connectors/google/delete_calendar_event.go` with a params struct, `validate()`, and an `Execute` method.
+2. Use `a.conn.doJSON(ctx, creds, method, url, reqBody, &resp)` for the HTTP lifecycle — it handles JSON marshaling, Bearer auth, rate limiting, response size limits, and timeout detection.
+3. Use `checkResponse()` (called automatically by `doJSON`) to map HTTP errors to typed connector errors.
+4. Return `connectors.JSONResult(respBody)` to wrap the response into an `ActionResult`.
+5. Register the action in `Actions()` inside `google.go`.
+6. Add the action to the `Manifest()` return value inside `google.go` with a `ParametersSchema`.
+7. Add tests in `delete_calendar_event_test.go` using `httptest.NewServer` and `newForTest()`.
+
+## File Structure
+
+```
+connectors/google/
+├── google.go                       # GoogleConnector struct, New(), Manifest(), doJSON(), ValidateCredentials()
+├── send_email.go                   # google.send_email action
+├── list_emails.go                  # google.list_emails action
+├── create_calendar_event.go        # google.create_calendar_event action
+├── list_calendar_events.go         # google.list_calendar_events action
+├── google_test.go                  # Connector-level tests (ID, Actions, Manifest, ValidateCredentials)
+├── helpers_test.go                 # Shared test helpers (validCreds)
+├── send_email_test.go              # Send email action tests (including MIME injection, base64 encoding)
+├── list_emails_test.go             # List emails action tests
+├── create_calendar_event_test.go   # Create event tests (including time validation, URL encoding)
+├── list_calendar_events_test.go    # List events action tests
+└── README.md                       # This file
+```
+
+## Testing
+
+All tests use `httptest.NewServer` to mock the Google APIs — no real API calls are made. Tests pass the Go race detector (`-race` flag).
+
+```bash
+go test ./connectors/google/... -v
+go test ./connectors/google/... -race  # verify no race conditions
+```

--- a/connectors/google/create_calendar_event.go
+++ b/connectors/google/create_calendar_event.go
@@ -1,0 +1,114 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createCalendarEventAction implements connectors.Action for google.create_calendar_event.
+// It creates an event via the Google Calendar API POST /calendars/{calendarId}/events.
+type createCalendarEventAction struct {
+	conn *GoogleConnector
+}
+
+// createCalendarEventParams is the user-facing parameter schema.
+type createCalendarEventParams struct {
+	Summary     string   `json:"summary"`
+	Description string   `json:"description"`
+	StartTime   string   `json:"start_time"`
+	EndTime     string   `json:"end_time"`
+	Attendees   []string `json:"attendees"`
+	CalendarID  string   `json:"calendar_id"`
+}
+
+func (p *createCalendarEventParams) validate() error {
+	if p.Summary == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: summary"}
+	}
+	if p.StartTime == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: start_time"}
+	}
+	if p.EndTime == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: end_time"}
+	}
+	if _, err := time.Parse(time.RFC3339, p.StartTime); err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("start_time must be RFC 3339 format: %v", err)}
+	}
+	if _, err := time.Parse(time.RFC3339, p.EndTime); err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("end_time must be RFC 3339 format: %v", err)}
+	}
+	return nil
+}
+
+func (p *createCalendarEventParams) normalize() {
+	if p.CalendarID == "" {
+		p.CalendarID = "primary"
+	}
+}
+
+// calendarEventRequest is the Google Calendar API request body for events.insert.
+type calendarEventRequest struct {
+	Summary     string                `json:"summary"`
+	Description string                `json:"description,omitempty"`
+	Start       calendarEventDateTime `json:"start"`
+	End         calendarEventDateTime `json:"end"`
+	Attendees   []calendarAttendee    `json:"attendees,omitempty"`
+}
+
+type calendarEventDateTime struct {
+	DateTime string `json:"dateTime"`
+}
+
+type calendarAttendee struct {
+	Email string `json:"email"`
+}
+
+// calendarEventResponse is the Google Calendar API response from events.insert.
+type calendarEventResponse struct {
+	ID          string `json:"id"`
+	HTMLLink    string `json:"htmlLink"`
+	Summary     string `json:"summary"`
+	Status      string `json:"status"`
+	Created     string `json:"created"`
+	Updated     string `json:"updated"`
+	Description string `json:"description"`
+}
+
+// Execute creates a Google Calendar event and returns its metadata.
+func (a *createCalendarEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createCalendarEventParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.normalize()
+
+	body := calendarEventRequest{
+		Summary:     params.Summary,
+		Description: params.Description,
+		Start:       calendarEventDateTime{DateTime: params.StartTime},
+		End:         calendarEventDateTime{DateTime: params.EndTime},
+	}
+	for _, email := range params.Attendees {
+		body.Attendees = append(body.Attendees, calendarAttendee{Email: email})
+	}
+
+	var resp calendarEventResponse
+	url := a.conn.calendarBaseURL + "/calendars/" + params.CalendarID + "/events"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, url, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":        resp.ID,
+		"html_link": resp.HTMLLink,
+		"status":    resp.Status,
+	})
+}

--- a/connectors/google/create_calendar_event.go
+++ b/connectors/google/create_calendar_event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -36,11 +37,16 @@ func (p *createCalendarEventParams) validate() error {
 	if p.EndTime == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: end_time"}
 	}
-	if _, err := time.Parse(time.RFC3339, p.StartTime); err != nil {
+	start, err := time.Parse(time.RFC3339, p.StartTime)
+	if err != nil {
 		return &connectors.ValidationError{Message: fmt.Sprintf("start_time must be RFC 3339 format: %v", err)}
 	}
-	if _, err := time.Parse(time.RFC3339, p.EndTime); err != nil {
+	end, err := time.Parse(time.RFC3339, p.EndTime)
+	if err != nil {
 		return &connectors.ValidationError{Message: fmt.Sprintf("end_time must be RFC 3339 format: %v", err)}
+	}
+	if !end.After(start) {
+		return &connectors.ValidationError{Message: "end_time must be after start_time"}
 	}
 	return nil
 }
@@ -101,8 +107,8 @@ func (a *createCalendarEventAction) Execute(ctx context.Context, req connectors.
 	}
 
 	var resp calendarEventResponse
-	url := a.conn.calendarBaseURL + "/calendars/" + params.CalendarID + "/events"
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, url, body, &resp); err != nil {
+	calURL := a.conn.calendarBaseURL + "/calendars/" + url.PathEscape(params.CalendarID) + "/events"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, calURL, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/google/create_calendar_event_test.go
+++ b/connectors/google/create_calendar_event_test.go
@@ -1,0 +1,234 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateCalendarEvent_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/calendars/primary/events" {
+			t.Errorf("expected path /calendars/primary/events, got %s", r.URL.Path)
+		}
+
+		var body calendarEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Summary != "Team Meeting" {
+			t.Errorf("expected summary 'Team Meeting', got %q", body.Summary)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendarEventResponse{
+			ID:       "event-123",
+			HTMLLink: "https://calendar.google.com/event?eid=event-123",
+			Status:   "confirmed",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		Summary:   "Team Meeting",
+		StartTime: "2024-01-15T09:00:00-05:00",
+		EndTime:   "2024-01-15T10:00:00-05:00",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "event-123" {
+		t.Errorf("expected id 'event-123', got %q", data["id"])
+	}
+	if data["status"] != "confirmed" {
+		t.Errorf("expected status 'confirmed', got %q", data["status"])
+	}
+}
+
+func TestCreateCalendarEvent_WithAttendees(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body calendarEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if len(body.Attendees) != 2 {
+			t.Errorf("expected 2 attendees, got %d", len(body.Attendees))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendarEventResponse{
+			ID:     "event-456",
+			Status: "confirmed",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		Summary:   "Team Sync",
+		StartTime: "2024-01-15T09:00:00-05:00",
+		EndTime:   "2024-01-15T10:00:00-05:00",
+		Attendees: []string{"alice@example.com", "bob@example.com"},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateCalendarEvent_MissingSummary(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"start_time": "2024-01-15T09:00:00-05:00",
+		"end_time":   "2024-01-15T10:00:00-05:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing summary")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCalendarEvent_InvalidStartTime(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"summary":    "Meeting",
+		"start_time": "not-a-date",
+		"end_time":   "2024-01-15T10:00:00-05:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid start_time")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCalendarEvent_InvalidEndTime(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"summary":    "Meeting",
+		"start_time": "2024-01-15T09:00:00-05:00",
+		"end_time":   "not-a-date",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid end_time")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCalendarEvent_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		Summary:   "Meeting",
+		StartTime: "2024-01-15T09:00:00-05:00",
+		EndTime:   "2024-01-15T10:00:00-05:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestCreateCalendarEvent_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createCalendarEventAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/create_calendar_event_test.go
+++ b/connectors/google/create_calendar_event_test.go
@@ -181,6 +181,56 @@ func TestCreateCalendarEvent_InvalidEndTime(t *testing.T) {
 	}
 }
 
+func TestCreateCalendarEvent_EndBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"summary":    "Meeting",
+		"start_time": "2024-01-15T10:00:00-05:00",
+		"end_time":   "2024-01-15T09:00:00-05:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for end_time before start_time")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCalendarEvent_EndEqualsStart(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"summary":    "Meeting",
+		"start_time": "2024-01-15T09:00:00-05:00",
+		"end_time":   "2024-01-15T09:00:00-05:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for end_time equal to start_time")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestCreateCalendarEvent_AuthFailure(t *testing.T) {
 	t.Parallel()
 
@@ -211,6 +261,44 @@ func TestCreateCalendarEvent_AuthFailure(t *testing.T) {
 	}
 	if !connectors.IsAuthError(err) {
 		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestCreateCalendarEvent_CalendarIDURLEncoded(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Calendar ID with @ should be decoded to the correct path by the server.
+		wantPath := "/calendars/user@group.calendar.google.com/events"
+		if r.URL.Path != wantPath {
+			t.Errorf("expected path %q, got %q", wantPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendarEventResponse{
+			ID:     "event-789",
+			Status: "confirmed",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		Summary:    "Meeting",
+		StartTime:  "2024-01-15T09:00:00-05:00",
+		EndTime:    "2024-01-15T10:00:00-05:00",
+		CalendarID: "user@group.calendar.google.com",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -1,0 +1,347 @@
+// Package google implements the Google connector for the Permission Slip
+// connector execution layer. It uses Google REST APIs (Gmail, Calendar) with
+// plain net/http and OAuth 2.0 access tokens provided by the platform.
+package google
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+const (
+	defaultGmailBaseURL    = "https://gmail.googleapis.com"
+	defaultCalendarBaseURL = "https://www.googleapis.com/calendar/v3"
+	defaultTimeout         = 30 * time.Second
+	credKeyAccessToken     = "access_token"
+
+	// defaultRetryAfter is used when the Google API returns a rate limit
+	// response without a Retry-After header (or an unparseable one).
+	defaultRetryAfter = 60 * time.Second
+)
+
+// GoogleConnector owns the shared HTTP client and base URLs used by all
+// Google actions. Actions hold a pointer back to the connector to access
+// these shared resources.
+type GoogleConnector struct {
+	client          *http.Client
+	gmailBaseURL    string
+	calendarBaseURL string
+}
+
+// New creates a GoogleConnector with sensible defaults.
+func New() *GoogleConnector {
+	return &GoogleConnector{
+		client:          &http.Client{Timeout: defaultTimeout},
+		gmailBaseURL:    defaultGmailBaseURL,
+		calendarBaseURL: defaultCalendarBaseURL,
+	}
+}
+
+// newForTest creates a GoogleConnector that points at a test server.
+func newForTest(client *http.Client, gmailBaseURL, calendarBaseURL string) *GoogleConnector {
+	return &GoogleConnector{
+		client:          client,
+		gmailBaseURL:    gmailBaseURL,
+		calendarBaseURL: calendarBaseURL,
+	}
+}
+
+// ID returns "google", matching the connectors.id in the database.
+func (c *GoogleConnector) ID() string { return "google" }
+
+// Manifest returns the connector's metadata manifest. Used by the server to
+// auto-seed DB rows on startup, replacing manual seed.go files.
+func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "google",
+		Name:        "Google",
+		Description: "Google integration for Gmail and Calendar",
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "google.send_email",
+				Name:        "Send Email",
+				Description: "Send an email via Gmail",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["to", "subject", "body"],
+					"properties": {
+						"to": {
+							"type": "string",
+							"description": "Recipient email address"
+						},
+						"subject": {
+							"type": "string",
+							"description": "Email subject line"
+						},
+						"body": {
+							"type": "string",
+							"description": "Email body (plain text)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.list_emails",
+				Name:        "List Emails",
+				Description: "List recent emails from Gmail inbox",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string",
+							"description": "Gmail search query (e.g. 'from:user@example.com is:unread')"
+						},
+						"max_results": {
+							"type": "integer",
+							"default": 10,
+							"minimum": 1,
+							"maximum": 100,
+							"description": "Maximum number of emails to return (1-100, default 10)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.create_calendar_event",
+				Name:        "Create Calendar Event",
+				Description: "Create a new event on Google Calendar",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["summary", "start_time", "end_time"],
+					"properties": {
+						"summary": {
+							"type": "string",
+							"description": "Event title"
+						},
+						"description": {
+							"type": "string",
+							"description": "Event description"
+						},
+						"start_time": {
+							"type": "string",
+							"description": "Start time in RFC 3339 format (e.g. '2024-01-15T09:00:00-05:00')"
+						},
+						"end_time": {
+							"type": "string",
+							"description": "End time in RFC 3339 format (e.g. '2024-01-15T10:00:00-05:00')"
+						},
+						"attendees": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "List of attendee email addresses"
+						},
+						"calendar_id": {
+							"type": "string",
+							"default": "primary",
+							"description": "Calendar ID (defaults to 'primary')"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.list_calendar_events",
+				Name:        "List Calendar Events",
+				Description: "List upcoming events from Google Calendar",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"calendar_id": {
+							"type": "string",
+							"default": "primary",
+							"description": "Calendar ID (defaults to 'primary')"
+						},
+						"max_results": {
+							"type": "integer",
+							"default": 10,
+							"minimum": 1,
+							"maximum": 250,
+							"description": "Maximum number of events to return (1-250, default 10)"
+						},
+						"time_min": {
+							"type": "string",
+							"description": "Lower bound (inclusive) for event start time in RFC 3339 format. Defaults to now."
+						},
+						"time_max": {
+							"type": "string",
+							"description": "Upper bound (exclusive) for event start time in RFC 3339 format"
+						}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{
+				Service:       "google",
+				AuthType:      "oauth2",
+				OAuthProvider: "google",
+				OAuthScopes: []string{
+					"https://www.googleapis.com/auth/gmail.send",
+					"https://www.googleapis.com/auth/gmail.readonly",
+					"https://www.googleapis.com/auth/calendar",
+					"https://www.googleapis.com/auth/calendar.events",
+				},
+			},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_google_send_email",
+				ActionType:  "google.send_email",
+				Name:        "Send emails freely",
+				Description: "Agent can send emails to any recipient with any subject and body.",
+				Parameters:  json.RawMessage(`{"to":"*","subject":"*","body":"*"}`),
+			},
+			{
+				ID:          "tpl_google_list_emails",
+				ActionType:  "google.list_emails",
+				Name:        "List emails",
+				Description: "Agent can search and list emails from the inbox.",
+				Parameters:  json.RawMessage(`{"query":"*","max_results":"*"}`),
+			},
+			{
+				ID:          "tpl_google_create_calendar_event",
+				ActionType:  "google.create_calendar_event",
+				Name:        "Create calendar events",
+				Description: "Agent can create events on any calendar.",
+				Parameters:  json.RawMessage(`{"summary":"*","description":"*","start_time":"*","end_time":"*","attendees":"*","calendar_id":"*"}`),
+			},
+			{
+				ID:          "tpl_google_list_calendar_events",
+				ActionType:  "google.list_calendar_events",
+				Name:        "List calendar events",
+				Description: "Agent can list upcoming events from any calendar.",
+				Parameters:  json.RawMessage(`{"calendar_id":"*","max_results":"*","time_min":"*","time_max":"*"}`),
+			},
+		},
+	}
+}
+
+// Actions returns the registered action handlers keyed by action_type.
+func (c *GoogleConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"google.send_email":            &sendEmailAction{conn: c},
+		"google.list_emails":           &listEmailsAction{conn: c},
+		"google.create_calendar_event": &createCalendarEventAction{conn: c},
+		"google.list_calendar_events":  &listCalendarEventsAction{conn: c},
+	}
+}
+
+// ValidateCredentials checks that the provided credentials contain a
+// non-empty access_token. Since tokens are provided by the platform's
+// OAuth infrastructure, format validation is minimal.
+func (c *GoogleConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+	token, ok := creds.Get(credKeyAccessToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "missing required credential: access_token"}
+	}
+	return nil
+}
+
+// doJSON is the shared request lifecycle for Google API calls that send and
+// receive JSON. It marshals reqBody as JSON, sends the request with OAuth
+// bearer auth, handles rate limiting and timeouts, and unmarshals the
+// response into respBody.
+func (c *GoogleConnector) doJSON(ctx context.Context, creds connectors.Credentials, method, url string, reqBody, respBody any) error {
+	token, ok := creds.Get(credKeyAccessToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	var body io.Reader
+	if reqBody != nil {
+		payload, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("marshaling request body: %w", err)
+		}
+		body = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Google API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return err
+	}
+
+	if respBody != nil && len(respBytes) > 0 {
+		if err := json.Unmarshal(respBytes, respBody); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    "failed to decode Google API response",
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkResponse maps HTTP status codes to typed connector errors.
+func checkResponse(statusCode int, header http.Header, body []byte) error {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+
+	// Try to extract a Google API error message.
+	var apiErr struct {
+		Error struct {
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		} `json:"error"`
+	}
+	msg := "Google API error"
+	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error.Message != "" {
+		msg = apiErr.Error.Message
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return &connectors.AuthError{Message: fmt.Sprintf("Google auth error: %s", msg)}
+	case http.StatusForbidden:
+		return &connectors.AuthError{Message: fmt.Sprintf("Google permission denied: %s", msg)}
+	case http.StatusTooManyRequests:
+		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    fmt.Sprintf("Google API rate limit exceeded: %s", msg),
+			RetryAfter: retryAfter,
+		}
+	default:
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Google API error (HTTP %d): %s", statusCode, msg),
+		}
+	}
+}

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -25,6 +25,10 @@ const (
 	// defaultRetryAfter is used when the Google API returns a rate limit
 	// response without a Retry-After header (or an unparseable one).
 	defaultRetryAfter = 60 * time.Second
+
+	// maxResponseBytes is the maximum response body size we'll read from
+	// Google APIs. This prevents OOM from unexpectedly large responses.
+	maxResponseBytes = 10 * 1024 * 1024 // 10 MB
 )
 
 // GoogleConnector owns the shared HTTP client and base URLs used by all
@@ -189,7 +193,6 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				OAuthScopes: []string{
 					"https://www.googleapis.com/auth/gmail.send",
 					"https://www.googleapis.com/auth/gmail.readonly",
-					"https://www.googleapis.com/auth/calendar",
 					"https://www.googleapis.com/auth/calendar.events",
 				},
 			},
@@ -309,7 +312,7 @@ func (c *GoogleConnector) doJSON(ctx context.Context, creds connectors.Credentia
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := io.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
 	}

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -203,11 +203,25 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:  json.RawMessage(`{"to":"*","subject":"*","body":"*"}`),
 			},
 			{
+				ID:          "tpl_google_send_email_to_recipient",
+				ActionType:  "google.send_email",
+				Name:        "Send email to specific recipient",
+				Description: "Locks the recipient; agent chooses the subject and body.",
+				Parameters:  json.RawMessage(`{"to":"recipient@example.com","subject":"*","body":"*"}`),
+			},
+			{
 				ID:          "tpl_google_list_emails",
 				ActionType:  "google.list_emails",
-				Name:        "List emails",
+				Name:        "Search emails",
 				Description: "Agent can search and list emails from the inbox.",
 				Parameters:  json.RawMessage(`{"query":"*","max_results":"*"}`),
+			},
+			{
+				ID:          "tpl_google_list_unread_emails",
+				ActionType:  "google.list_emails",
+				Name:        "List unread emails",
+				Description: "Agent can list unread emails only. Query is locked to is:unread.",
+				Parameters:  json.RawMessage(`{"query":"is:unread","max_results":"*"}`),
 			},
 			{
 				ID:          "tpl_google_create_calendar_event",
@@ -215,6 +229,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Create calendar events",
 				Description: "Agent can create events on any calendar.",
 				Parameters:  json.RawMessage(`{"summary":"*","description":"*","start_time":"*","end_time":"*","attendees":"*","calendar_id":"*"}`),
+			},
+			{
+				ID:          "tpl_google_create_calendar_event_no_attendees",
+				ActionType:  "google.create_calendar_event",
+				Name:        "Create personal calendar events",
+				Description: "Agent can create events on the primary calendar without inviting attendees.",
+				Parameters:  json.RawMessage(`{"summary":"*","description":"*","start_time":"*","end_time":"*","calendar_id":"primary"}`),
 			},
 			{
 				ID:          "tpl_google_list_calendar_events",

--- a/connectors/google/google_test.go
+++ b/connectors/google/google_test.go
@@ -1,0 +1,161 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGoogleConnector_ID(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.ID() != "google" {
+		t.Errorf("expected ID 'google', got %q", c.ID())
+	}
+}
+
+func TestGoogleConnector_Actions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	expected := []string{
+		"google.send_email",
+		"google.list_emails",
+		"google.create_calendar_event",
+		"google.list_calendar_events",
+	}
+	for _, name := range expected {
+		if _, ok := actions[name]; !ok {
+			t.Errorf("expected action %q to be registered", name)
+		}
+	}
+
+	if len(actions) != len(expected) {
+		t.Errorf("expected %d actions, got %d", len(expected), len(actions))
+	}
+}
+
+func TestGoogleConnector_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	tests := []struct {
+		name    string
+		creds   connectors.Credentials
+		wantErr bool
+	}{
+		{
+			name:    "valid access_token",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": "ya29.test-token"}),
+			wantErr: false,
+		},
+		{
+			name:    "missing access_token",
+			creds:   connectors.NewCredentials(map[string]string{}),
+			wantErr: true,
+		},
+		{
+			name:    "empty access_token",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": ""}),
+			wantErr: true,
+		},
+		{
+			name:    "zero-value credentials",
+			creds:   connectors.Credentials{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.ValidateCredentials(t.Context(), tt.creds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("ValidateCredentials() returned %T, want *connectors.ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestGoogleConnector_Manifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+
+	if m.ID != "google" {
+		t.Errorf("Manifest().ID = %q, want %q", m.ID, "google")
+	}
+	if m.Name != "Google" {
+		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Google")
+	}
+	if len(m.Actions) != 4 {
+		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	}
+	actionTypes := make(map[string]bool)
+	for _, a := range m.Actions {
+		actionTypes[a.ActionType] = true
+	}
+	for _, want := range []string{
+		"google.send_email",
+		"google.list_emails",
+		"google.create_calendar_event",
+		"google.list_calendar_events",
+	} {
+		if !actionTypes[want] {
+			t.Errorf("Manifest().Actions missing %q", want)
+		}
+	}
+	if len(m.RequiredCredentials) != 1 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	}
+	cred := m.RequiredCredentials[0]
+	if cred.Service != "google" {
+		t.Errorf("credential service = %q, want %q", cred.Service, "google")
+	}
+	if cred.AuthType != "oauth2" {
+		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "oauth2")
+	}
+	if cred.OAuthProvider != "google" {
+		t.Errorf("credential oauth_provider = %q, want %q", cred.OAuthProvider, "google")
+	}
+	if len(cred.OAuthScopes) == 0 {
+		t.Error("credential oauth_scopes is empty, want at least one scope")
+	}
+
+	// Validate the manifest passes validation.
+	if err := m.Validate(); err != nil {
+		t.Errorf("Manifest().Validate() = %v", err)
+	}
+}
+
+func TestGoogleConnector_ActionsMatchManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+	manifest := c.Manifest()
+
+	manifestTypes := make(map[string]bool, len(manifest.Actions))
+	for _, a := range manifest.Actions {
+		manifestTypes[a.ActionType] = true
+	}
+
+	for actionType := range actions {
+		if !manifestTypes[actionType] {
+			t.Errorf("Actions() has %q but Manifest() does not", actionType)
+		}
+	}
+	for _, a := range manifest.Actions {
+		if _, ok := actions[a.ActionType]; !ok {
+			t.Errorf("Manifest() has %q but Actions() does not", a.ActionType)
+		}
+	}
+}
+
+func TestGoogleConnector_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+	var _ connectors.Connector = (*GoogleConnector)(nil)
+	var _ connectors.ManifestProvider = (*GoogleConnector)(nil)
+}

--- a/connectors/google/helpers_test.go
+++ b/connectors/google/helpers_test.go
@@ -1,0 +1,10 @@
+package google
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+// validCreds returns a Credentials value with a valid access token for tests.
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		"access_token": "ya29.test-access-token-123",
+	})
+}

--- a/connectors/google/list_calendar_events.go
+++ b/connectors/google/list_calendar_events.go
@@ -118,7 +118,7 @@ func (a *listCalendarEventsAction) Execute(ctx context.Context, req connectors.A
 	}
 
 	var listResp calendarListResponse
-	listURL := a.conn.calendarBaseURL + "/calendars/" + params.CalendarID + "/events?" + q.Encode()
+	listURL := a.conn.calendarBaseURL + "/calendars/" + url.PathEscape(params.CalendarID) + "/events?" + q.Encode()
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, listURL, nil, &listResp); err != nil {
 		return nil, err
 	}

--- a/connectors/google/list_calendar_events.go
+++ b/connectors/google/list_calendar_events.go
@@ -1,0 +1,159 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listCalendarEventsAction implements connectors.Action for google.list_calendar_events.
+// It lists events via the Google Calendar API GET /calendars/{calendarId}/events.
+type listCalendarEventsAction struct {
+	conn *GoogleConnector
+}
+
+// listCalendarEventsParams is the user-facing parameter schema.
+type listCalendarEventsParams struct {
+	CalendarID string `json:"calendar_id"`
+	MaxResults int    `json:"max_results"`
+	TimeMin    string `json:"time_min"`
+	TimeMax    string `json:"time_max"`
+}
+
+func (p *listCalendarEventsParams) normalize() {
+	if p.CalendarID == "" {
+		p.CalendarID = "primary"
+	}
+	if p.MaxResults <= 0 {
+		p.MaxResults = 10
+	}
+	if p.MaxResults > 250 {
+		p.MaxResults = 250
+	}
+}
+
+func (p *listCalendarEventsParams) validate() error {
+	if p.TimeMin != "" {
+		if _, err := time.Parse(time.RFC3339, p.TimeMin); err != nil {
+			return &connectors.ValidationError{Message: fmt.Sprintf("time_min must be RFC 3339 format: %v", err)}
+		}
+	}
+	if p.TimeMax != "" {
+		if _, err := time.Parse(time.RFC3339, p.TimeMax); err != nil {
+			return &connectors.ValidationError{Message: fmt.Sprintf("time_max must be RFC 3339 format: %v", err)}
+		}
+	}
+	return nil
+}
+
+// calendarListResponse is the Google Calendar API response from events.list.
+type calendarListResponse struct {
+	Items []calendarListItem `json:"items"`
+}
+
+type calendarListItem struct {
+	ID          string                 `json:"id"`
+	Summary     string                 `json:"summary"`
+	Description string                 `json:"description"`
+	Status      string                 `json:"status"`
+	HTMLLink    string                 `json:"htmlLink"`
+	Start       calendarListDateTime   `json:"start"`
+	End         calendarListDateTime   `json:"end"`
+	Attendees   []calendarListAttendee `json:"attendees"`
+	Created     string                 `json:"created"`
+	Updated     string                 `json:"updated"`
+}
+
+type calendarListDateTime struct {
+	DateTime string `json:"dateTime"`
+	Date     string `json:"date"`
+}
+
+type calendarListAttendee struct {
+	Email          string `json:"email"`
+	ResponseStatus string `json:"responseStatus"`
+}
+
+// eventSummary is the shape returned to the agent.
+type eventSummary struct {
+	ID          string   `json:"id"`
+	Summary     string   `json:"summary"`
+	Description string   `json:"description,omitempty"`
+	StartTime   string   `json:"start_time"`
+	EndTime     string   `json:"end_time"`
+	Status      string   `json:"status"`
+	HTMLLink    string   `json:"html_link"`
+	Attendees   []string `json:"attendees,omitempty"`
+}
+
+// Execute lists upcoming events from Google Calendar.
+func (a *listCalendarEventsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listCalendarEventsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.normalize()
+
+	q := url.Values{}
+	q.Set("maxResults", strconv.Itoa(params.MaxResults))
+	q.Set("singleEvents", "true")
+	q.Set("orderBy", "startTime")
+
+	if params.TimeMin != "" {
+		q.Set("timeMin", params.TimeMin)
+	} else {
+		q.Set("timeMin", time.Now().UTC().Format(time.RFC3339))
+	}
+	if params.TimeMax != "" {
+		q.Set("timeMax", params.TimeMax)
+	}
+
+	var listResp calendarListResponse
+	listURL := a.conn.calendarBaseURL + "/calendars/" + params.CalendarID + "/events?" + q.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, listURL, nil, &listResp); err != nil {
+		return nil, err
+	}
+
+	events := make([]eventSummary, 0, len(listResp.Items))
+	for _, item := range listResp.Items {
+		ev := eventSummary{
+			ID:          item.ID,
+			Summary:     item.Summary,
+			Description: item.Description,
+			Status:      item.Status,
+			HTMLLink:    item.HTMLLink,
+		}
+		// Prefer dateTime, fall back to date for all-day events.
+		if item.Start.DateTime != "" {
+			ev.StartTime = item.Start.DateTime
+		} else {
+			ev.StartTime = item.Start.Date
+		}
+		if item.End.DateTime != "" {
+			ev.EndTime = item.End.DateTime
+		} else {
+			ev.EndTime = item.End.Date
+		}
+		attendees := make([]string, 0, len(item.Attendees))
+		for _, att := range item.Attendees {
+			attendees = append(attendees, att.Email)
+		}
+		if len(attendees) > 0 {
+			ev.Attendees = attendees
+		}
+		events = append(events, ev)
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"events": events,
+	})
+}

--- a/connectors/google/list_calendar_events.go
+++ b/connectors/google/list_calendar_events.go
@@ -39,15 +39,23 @@ func (p *listCalendarEventsParams) normalize() {
 }
 
 func (p *listCalendarEventsParams) validate() error {
+	var tMin, tMax time.Time
+	var err error
+
 	if p.TimeMin != "" {
-		if _, err := time.Parse(time.RFC3339, p.TimeMin); err != nil {
+		tMin, err = time.Parse(time.RFC3339, p.TimeMin)
+		if err != nil {
 			return &connectors.ValidationError{Message: fmt.Sprintf("time_min must be RFC 3339 format: %v", err)}
 		}
 	}
 	if p.TimeMax != "" {
-		if _, err := time.Parse(time.RFC3339, p.TimeMax); err != nil {
+		tMax, err = time.Parse(time.RFC3339, p.TimeMax)
+		if err != nil {
 			return &connectors.ValidationError{Message: fmt.Sprintf("time_max must be RFC 3339 format: %v", err)}
 		}
+	}
+	if p.TimeMin != "" && p.TimeMax != "" && !tMax.After(tMin) {
+		return &connectors.ValidationError{Message: "time_max must be after time_min"}
 	}
 	return nil
 }

--- a/connectors/google/list_calendar_events_test.go
+++ b/connectors/google/list_calendar_events_test.go
@@ -1,0 +1,180 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListCalendarEvents_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/calendars/primary/events" {
+			t.Errorf("expected path /calendars/primary/events, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendarListResponse{
+			Items: []calendarListItem{
+				{
+					ID:      "event-1",
+					Summary: "Team Standup",
+					Status:  "confirmed",
+					Start:   calendarListDateTime{DateTime: "2024-01-15T09:00:00-05:00"},
+					End:     calendarListDateTime{DateTime: "2024-01-15T09:30:00-05:00"},
+				},
+				{
+					ID:      "event-2",
+					Summary: "All-day Review",
+					Status:  "confirmed",
+					Start:   calendarListDateTime{Date: "2024-01-16"},
+					End:     calendarListDateTime{Date: "2024-01-17"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &listCalendarEventsAction{conn: conn}
+
+	params, _ := json.Marshal(listCalendarEventsParams{MaxResults: 10})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Events []eventSummary `json:"events"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(data.Events))
+	}
+	if data.Events[0].Summary != "Team Standup" {
+		t.Errorf("expected first event summary 'Team Standup', got %q", data.Events[0].Summary)
+	}
+	// All-day event should use Date field.
+	if data.Events[1].StartTime != "2024-01-16" {
+		t.Errorf("expected all-day start '2024-01-16', got %q", data.Events[1].StartTime)
+	}
+}
+
+func TestListCalendarEvents_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendarListResponse{Items: nil})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &listCalendarEventsAction{conn: conn}
+
+	params, _ := json.Marshal(listCalendarEventsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Events []eventSummary `json:"events"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(data.Events))
+	}
+}
+
+func TestListCalendarEvents_InvalidTimeMin(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listCalendarEventsAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"time_min": "not-a-date",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid time_min")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListCalendarEvents_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", srv.URL)
+	action := &listCalendarEventsAction{conn: conn}
+
+	params, _ := json.Marshal(listCalendarEventsParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestListCalendarEvents_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listCalendarEventsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_calendar_events",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/list_calendar_events_test.go
+++ b/connectors/google/list_calendar_events_test.go
@@ -131,6 +131,30 @@ func TestListCalendarEvents_InvalidTimeMin(t *testing.T) {
 	}
 }
 
+func TestListCalendarEvents_TimeMaxBeforeTimeMin(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listCalendarEventsAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"time_min": "2024-01-15T10:00:00-05:00",
+		"time_max": "2024-01-15T09:00:00-05:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for time_max before time_min")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestListCalendarEvents_AuthFailure(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -67,6 +68,11 @@ type emailSummary struct {
 	Date    string `json:"date,omitempty"`
 }
 
+// maxConcurrentFetches limits concurrent Gmail API requests when fetching
+// message metadata. This avoids hammering the API while still being much
+// faster than sequential requests.
+const maxConcurrentFetches = 5
+
 // Execute lists recent emails from Gmail and returns their metadata.
 func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params listEmailsParams
@@ -90,37 +96,58 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 
 	if len(listResp.Messages) == 0 {
 		return connectors.JSONResult(map[string]any{
-			"emails":       []emailSummary{},
+			"emails":         []emailSummary{},
 			"total_estimate": listResp.ResultSizeEstimate,
 		})
 	}
 
-	// Step 2: fetch metadata for each message.
-	summaries := make([]emailSummary, 0, len(listResp.Messages))
-	for _, m := range listResp.Messages {
-		var msgResp gmailMessageResponse
-		msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(m.ID) + "?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date"
-		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, msgURL, nil, &msgResp); err != nil {
+	// Step 2: fetch metadata for each message concurrently (bounded).
+	summaries := make([]emailSummary, len(listResp.Messages))
+	errs := make([]error, len(listResp.Messages))
+	sem := make(chan struct{}, maxConcurrentFetches)
+
+	var wg sync.WaitGroup
+	for i, m := range listResp.Messages {
+		wg.Add(1)
+		go func(idx int, msgID string) {
+			defer wg.Done()
+
+			sem <- struct{}{}        // acquire
+			defer func() { <-sem }() // release
+
+			var msgResp gmailMessageResponse
+			msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(msgID) + "?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date"
+			if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, msgURL, nil, &msgResp); err != nil {
+				errs[idx] = err
+				return
+			}
+
+			summary := emailSummary{
+				ID:      msgResp.ID,
+				Snippet: msgResp.Snippet,
+			}
+			for _, h := range msgResp.Payload.Headers {
+				switch h.Name {
+				case "From":
+					summary.From = h.Value
+				case "To":
+					summary.To = h.Value
+				case "Subject":
+					summary.Subject = h.Value
+				case "Date":
+					summary.Date = h.Value
+				}
+			}
+			summaries[idx] = summary
+		}(i, m.ID)
+	}
+	wg.Wait()
+
+	// Return the first error encountered.
+	for _, err := range errs {
+		if err != nil {
 			return nil, err
 		}
-
-		summary := emailSummary{
-			ID:      msgResp.ID,
-			Snippet: msgResp.Snippet,
-		}
-		for _, h := range msgResp.Payload.Headers {
-			switch h.Name {
-			case "From":
-				summary.From = h.Value
-			case "To":
-				summary.To = h.Value
-			case "Subject":
-				summary.Subject = h.Value
-			case "Date":
-				summary.Date = h.Value
-			}
-		}
-		summaries = append(summaries, summary)
 	}
 
 	return connectors.JSONResult(map[string]any{

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -1,0 +1,130 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listEmailsAction implements connectors.Action for google.list_emails.
+// It lists messages via the Gmail API GET /gmail/v1/users/me/messages
+// and fetches metadata for each message.
+type listEmailsAction struct {
+	conn *GoogleConnector
+}
+
+// listEmailsParams is the user-facing parameter schema.
+type listEmailsParams struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+func (p *listEmailsParams) normalize() {
+	if p.MaxResults <= 0 {
+		p.MaxResults = 10
+	}
+	if p.MaxResults > 100 {
+		p.MaxResults = 100
+	}
+}
+
+// gmailListResponse is the Gmail API response from messages.list.
+type gmailListResponse struct {
+	Messages []struct {
+		ID       string `json:"id"`
+		ThreadID string `json:"threadId"`
+	} `json:"messages"`
+	ResultSizeEstimate int `json:"resultSizeEstimate"`
+}
+
+// gmailMessageResponse is the Gmail API response from messages.get
+// with format=metadata.
+type gmailMessageResponse struct {
+	ID       string `json:"id"`
+	ThreadID string `json:"threadId"`
+	Snippet  string `json:"snippet"`
+	Payload  struct {
+		Headers []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"headers"`
+	} `json:"payload"`
+	InternalDate string `json:"internalDate"`
+}
+
+// emailSummary is the shape returned to the agent.
+type emailSummary struct {
+	ID      string `json:"id"`
+	From    string `json:"from,omitempty"`
+	To      string `json:"to,omitempty"`
+	Subject string `json:"subject,omitempty"`
+	Snippet string `json:"snippet,omitempty"`
+	Date    string `json:"date,omitempty"`
+}
+
+// Execute lists recent emails from Gmail and returns their metadata.
+func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listEmailsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	params.normalize()
+
+	// Step 1: list message IDs.
+	q := url.Values{}
+	q.Set("maxResults", strconv.Itoa(params.MaxResults))
+	if params.Query != "" {
+		q.Set("q", params.Query)
+	}
+
+	var listResp gmailListResponse
+	listURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages?" + q.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, listURL, nil, &listResp); err != nil {
+		return nil, err
+	}
+
+	if len(listResp.Messages) == 0 {
+		return connectors.JSONResult(map[string]any{
+			"emails":       []emailSummary{},
+			"total_estimate": listResp.ResultSizeEstimate,
+		})
+	}
+
+	// Step 2: fetch metadata for each message.
+	summaries := make([]emailSummary, 0, len(listResp.Messages))
+	for _, m := range listResp.Messages {
+		var msgResp gmailMessageResponse
+		msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + m.ID + "?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date"
+		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, msgURL, nil, &msgResp); err != nil {
+			return nil, err
+		}
+
+		summary := emailSummary{
+			ID:      msgResp.ID,
+			Snippet: msgResp.Snippet,
+		}
+		for _, h := range msgResp.Payload.Headers {
+			switch h.Name {
+			case "From":
+				summary.From = h.Value
+			case "To":
+				summary.To = h.Value
+			case "Subject":
+				summary.Subject = h.Value
+			case "Date":
+				summary.Date = h.Value
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"emails":         summaries,
+		"total_estimate": listResp.ResultSizeEstimate,
+	})
+}

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -99,7 +99,7 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 	summaries := make([]emailSummary, 0, len(listResp.Messages))
 	for _, m := range listResp.Messages {
 		var msgResp gmailMessageResponse
-		msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + m.ID + "?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date"
+		msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(m.ID) + "?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date"
 		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, msgURL, nil, &msgResp); err != nil {
 			return nil, err
 		}

--- a/connectors/google/list_emails_test.go
+++ b/connectors/google/list_emails_test.go
@@ -12,7 +12,6 @@ import (
 func TestListEmails_Success(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
@@ -20,9 +19,10 @@ func TestListEmails_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		switch {
-		case r.URL.Path == "/gmail/v1/users/me/messages" && callCount == 0:
-			callCount++
+		// Route on the URL path: /messages is the list call,
+		// /messages/{id} is the get-metadata call.
+		switch r.URL.Path {
+		case "/gmail/v1/users/me/messages":
 			json.NewEncoder(w).Encode(gmailListResponse{
 				Messages: []struct {
 					ID       string `json:"id"`
@@ -33,7 +33,7 @@ func TestListEmails_Success(t *testing.T) {
 				ResultSizeEstimate: 1,
 			})
 		default:
-			// messages.get call
+			// messages.get call for individual message
 			json.NewEncoder(w).Encode(gmailMessageResponse{
 				ID:       "msg-1",
 				ThreadID: "thread-1",

--- a/connectors/google/list_emails_test.go
+++ b/connectors/google/list_emails_test.go
@@ -1,0 +1,166 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListEmails_Success(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/gmail/v1/users/me/messages" && callCount == 0:
+			callCount++
+			json.NewEncoder(w).Encode(gmailListResponse{
+				Messages: []struct {
+					ID       string `json:"id"`
+					ThreadID string `json:"threadId"`
+				}{
+					{ID: "msg-1", ThreadID: "thread-1"},
+				},
+				ResultSizeEstimate: 1,
+			})
+		default:
+			// messages.get call
+			json.NewEncoder(w).Encode(gmailMessageResponse{
+				ID:       "msg-1",
+				ThreadID: "thread-1",
+				Snippet:  "Hello there",
+				Payload: struct {
+					Headers []struct {
+						Name  string `json:"name"`
+						Value string `json:"value"`
+					} `json:"headers"`
+				}{
+					Headers: []struct {
+						Name  string `json:"name"`
+						Value string `json:"value"`
+					}{
+						{Name: "From", Value: "sender@example.com"},
+						{Name: "Subject", Value: "Test Email"},
+					},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "")
+	action := &listEmailsAction{conn: conn}
+
+	params, _ := json.Marshal(listEmailsParams{MaxResults: 5})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_emails",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if _, ok := data["emails"]; !ok {
+		t.Error("result missing 'emails' key")
+	}
+}
+
+func TestListEmails_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailListResponse{
+			Messages:           nil,
+			ResultSizeEstimate: 0,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "")
+	action := &listEmailsAction{conn: conn}
+
+	params, _ := json.Marshal(listEmailsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_emails",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Emails []emailSummary `json:"emails"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Emails) != 0 {
+		t.Errorf("expected 0 emails, got %d", len(data.Emails))
+	}
+}
+
+func TestListEmails_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "")
+	action := &listEmailsAction{conn: conn}
+
+	params, _ := json.Marshal(listEmailsParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_emails",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestListEmails_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listEmailsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_emails",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/send_email.go
+++ b/connectors/google/send_email.go
@@ -79,7 +79,7 @@ func (a *sendEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	msg.WriteString("\r\n")
 	msg.WriteString(params.Body)
 
-	raw := base64.URLEncoding.EncodeToString([]byte(msg.String()))
+	raw := base64.RawURLEncoding.EncodeToString([]byte(msg.String()))
 
 	body := gmailSendRequest{Raw: raw}
 	var resp gmailSendResponse

--- a/connectors/google/send_email.go
+++ b/connectors/google/send_email.go
@@ -1,0 +1,84 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// sendEmailAction implements connectors.Action for google.send_email.
+// It sends an email via the Gmail API POST /gmail/v1/users/me/messages/send.
+type sendEmailAction struct {
+	conn *GoogleConnector
+}
+
+// sendEmailParams is the user-facing parameter schema.
+type sendEmailParams struct {
+	To      string `json:"to"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+func (p *sendEmailParams) validate() error {
+	if p.To == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: to"}
+	}
+	if p.Subject == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: subject"}
+	}
+	if p.Body == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: body"}
+	}
+	return nil
+}
+
+// gmailSendRequest is the Gmail API request body for messages.send.
+type gmailSendRequest struct {
+	Raw string `json:"raw"`
+}
+
+// gmailSendResponse is the Gmail API response from messages.send.
+type gmailSendResponse struct {
+	ID       string   `json:"id"`
+	ThreadID string   `json:"threadId"`
+	LabelIDs []string `json:"labelIds"`
+}
+
+// Execute sends an email via Gmail and returns the message metadata.
+func (a *sendEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params sendEmailParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// Build RFC 2822 message and base64url-encode it for the Gmail API.
+	var msg strings.Builder
+	msg.WriteString("To: " + params.To + "\r\n")
+	msg.WriteString("Subject: " + params.Subject + "\r\n")
+	msg.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
+	msg.WriteString("\r\n")
+	msg.WriteString(params.Body)
+
+	raw := base64.URLEncoding.EncodeToString([]byte(msg.String()))
+
+	body := gmailSendRequest{Raw: raw}
+	var resp gmailSendResponse
+
+	url := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/send"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, url, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":        resp.ID,
+		"thread_id": resp.ThreadID,
+	})
+}

--- a/connectors/google/send_email.go
+++ b/connectors/google/send_email.go
@@ -34,7 +34,19 @@ func (p *sendEmailParams) validate() error {
 	if p.Body == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: body"}
 	}
+	if containsNewline(p.To) {
+		return &connectors.ValidationError{Message: "to must not contain newlines"}
+	}
+	if containsNewline(p.Subject) {
+		return &connectors.ValidationError{Message: "subject must not contain newlines"}
+	}
 	return nil
+}
+
+// containsNewline returns true if s contains CR or LF characters, which
+// would allow MIME header injection in RFC 2822 messages.
+func containsNewline(s string) bool {
+	return strings.ContainsAny(s, "\r\n")
 }
 
 // gmailSendRequest is the Gmail API request body for messages.send.

--- a/connectors/google/send_email_test.go
+++ b/connectors/google/send_email_test.go
@@ -1,0 +1,229 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestSendEmail_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/gmail/v1/users/me/messages/send" {
+			t.Errorf("expected path /gmail/v1/users/me/messages/send, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token in Authorization header, got %q", got)
+		}
+
+		var body gmailSendRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Raw == "" {
+			t.Error("expected non-empty raw message")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailSendResponse{
+			ID:       "msg-123",
+			ThreadID: "thread-456",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "")
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(sendEmailParams{
+		To:      "user@example.com",
+		Subject: "Test Subject",
+		Body:    "Hello, world!",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "msg-123" {
+		t.Errorf("expected id 'msg-123', got %q", data["id"])
+	}
+	if data["thread_id"] != "thread-456" {
+		t.Errorf("expected thread_id 'thread-456', got %q", data["thread_id"])
+	}
+}
+
+func TestSendEmail_MissingTo(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"subject": "Test",
+		"body":    "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing to")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendEmail_MissingSubject(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"to":   "user@example.com",
+		"body": "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing subject")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendEmail_MissingBody(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"to":      "user@example.com",
+		"subject": "Test",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing body")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendEmail_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    401,
+				"message": "Invalid Credentials",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "")
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(sendEmailParams{
+		To:      "user@example.com",
+		Subject: "Test",
+		Body:    "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T (%v)", err, err)
+	}
+}
+
+func TestSendEmail_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "")
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(sendEmailParams{
+		To:      "user@example.com",
+		Subject: "Test",
+		Body:    "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestSendEmail_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendEmailAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/send_email_test.go
+++ b/connectors/google/send_email_test.go
@@ -1,9 +1,11 @@
 package google
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -29,6 +31,26 @@ func TestSendEmail_Success(t *testing.T) {
 		}
 		if body.Raw == "" {
 			t.Error("expected non-empty raw message")
+		}
+
+		// Verify the raw message is valid unpadded base64url and decodes
+		// to a well-formed RFC 2822 message.
+		if strings.ContainsRune(body.Raw, '=') {
+			t.Error("raw message contains padding; Gmail API expects unpadded base64url")
+		}
+		decoded, err := base64.RawURLEncoding.DecodeString(body.Raw)
+		if err != nil {
+			t.Fatalf("raw message is not valid base64url: %v", err)
+		}
+		msg := string(decoded)
+		if !strings.Contains(msg, "To: user@example.com") {
+			t.Error("decoded message missing To header")
+		}
+		if !strings.Contains(msg, "Subject: Test Subject") {
+			t.Error("decoded message missing Subject header")
+		}
+		if !strings.Contains(msg, "Hello, world!") {
+			t.Error("decoded message missing body text")
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/connectors/google/send_email_test.go
+++ b/connectors/google/send_email_test.go
@@ -209,6 +209,56 @@ func TestSendEmail_RateLimit(t *testing.T) {
 	}
 }
 
+func TestSendEmail_HeaderInjectionTo(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"to":      "user@example.com\r\nBcc: attacker@evil.com",
+		"subject": "Test",
+		"body":    "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for newline in to")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendEmail_HeaderInjectionSubject(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendEmailAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"to":      "user@example.com",
+		"subject": "Test\r\nBcc: attacker@evil.com",
+		"body":    "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for newline in subject")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestSendEmail_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -2,7 +2,7 @@
 
 This guide walks through adding a new connector (an integration with an external service) and adding actions to it. It uses the existing GitHub, Slack, PostgreSQL, Amadeus, and Square connectors as reference implementations.
 
-**Which reference to follow:** Browse the existing connectors in [`connectors/`](../connectors/) for reference implementations covering API key auth, OAuth, custom auth, and more.
+**Which reference to follow:** Browse the existing connectors in [`connectors/`](../connectors/) for reference implementations covering API key auth (GitHub), OAuth 2.0 (Google), custom auth (Slack), and more.
 
 For architectural context, see [ADR-009: Connector Execution Architecture](adr/009-connector-execution-architecture.md).
 
@@ -903,6 +903,13 @@ connectors/
 │   ├── helpers_test.go       # validCreds(), newTestConnector() with sqlmock
 │   ├── mysql_test.go         # Connector-level tests
 │   └── *_test.go             # Per-action tests
+├── google/
+│   ├── google.go             # GoogleConnector struct, New(), Manifest(), doJSON(), OAuth2 auth
+│   ├── send_email.go         # google.send_email action (RFC 2822 + base64url)
+│   ├── list_emails.go        # google.list_emails action (list + metadata fetch)
+│   ├── create_calendar_event.go  # google.create_calendar_event action
+│   ├── list_calendar_events.go   # google.list_calendar_events action
+│   └── ...tests...
 ├── slack/
 │   ├── slack.go              # SlackConnector struct, New(), Manifest(), doPost(), error mapping
 │   ├── send_message.go       # slack.send_message action

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/connectors/amadeus"
 	ghconnector "github.com/supersuit-tech/permission-slip-web/connectors/github"
+	googleconnector "github.com/supersuit-tech/permission-slip-web/connectors/google"
 	"github.com/supersuit-tech/permission-slip-web/connectors/hubspot"
 	"github.com/supersuit-tech/permission-slip-web/connectors/mongodb"
 	mysqlconnector "github.com/supersuit-tech/permission-slip-web/connectors/mysql"
@@ -316,6 +317,7 @@ func main() {
 	// Initialize connector registry.
 	registry := connectors.NewRegistry()
 	registry.Register(ghconnector.New())
+	registry.Register(googleconnector.New())
 	registry.Register(hubspot.New())
 	registry.Register(mongodb.New())
 	registry.Register(mysqlconnector.New())


### PR DESCRIPTION
## Summary
- Adds the built-in Google connector (`connectors/google/`) with four actions: `send_email`, `list_emails`, `create_calendar_event`, `list_calendar_events`
- Uses OAuth 2.0 auth (`oauth_provider: "google"`) — the platform handles token lifecycle transparently
- Registers the connector in `main.go` for auto-seeding on startup

Implements the **Phase 7 Google connector** checklist item from #80.

## Test plan
- [x] All 27 Google connector tests pass (`go test ./connectors/google/... -v`)
- [x] `go vet ./connectors/google/...` clean
- [x] Manifest validates correctly (tested in `TestGoogleConnector_Manifest`)
- [x] Actions match manifest (tested in `TestGoogleConnector_ActionsMatchManifest`)
- [x] Interface compliance verified (`TestGoogleConnector_ImplementsInterface`)
- [ ] Full `make build` (blocked by network dependency download in CI environment — unrelated to this change)

https://claude.ai/code/session_01Fy9VmV7koxb23ukTr1wy1L