### PR TITLE
Add Square connector Phase 3: manifest templates & registration

### DIFF
--- a/connectors/square/manifest.go
+++ b/connectors/square/manifest.go
@@ -26,9 +26,9 @@ var moneySchema = `{
 	}
 }`
 
-// Manifest returns the connector's metadata manifest. Action metadata is
-// declared here for DB seeding; the actual Action handlers are wired in
-// Actions() as they are implemented in Phase 2.
+// Manifest returns the connector's metadata manifest for DB auto-seeding.
+// Includes full parameter JSON schemas for all 6 actions and configuration
+// templates for common use cases.
 func (c *SquareConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "square",
@@ -47,6 +47,57 @@ func (c *SquareConnector) Manifest() *connectors.ConnectorManifest {
 				Service:         "square",
 				AuthType:        "api_key",
 				InstructionsURL: "https://developer.squareup.com/docs/build-basics/access-tokens",
+			},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_square_create_order",
+				ActionType:  "square.create_order",
+				Name:        "Create orders at a location",
+				Description: "Agent can create orders at a specific Square location. Set location_id to lock to one location, or use \"*\" for any.",
+				Parameters:  json.RawMessage(`{"location_id":"*","line_items":"*","customer_id":"*","note":"*"}`),
+			},
+			{
+				ID:          "tpl_square_create_payment_cash",
+				ActionType:  "square.create_payment",
+				Name:        "Process cash payments only",
+				Description: "Agent can process cash payments only (no card charges). Amount and order are agent-controlled. Requires human approval per payment.",
+				Parameters:  json.RawMessage(`{"source_id":"CASH","amount_money":"*","order_id":"*","customer_id":"*","note":"*","reference_id":"*"}`),
+			},
+			{
+				ID:          "tpl_square_create_payment",
+				ActionType:  "square.create_payment",
+				Name:        "Process payments (all sources)",
+				Description: "Agent can process payments from any source including cards. WARNING: can charge real money. Requires human approval per payment.",
+				Parameters:  json.RawMessage(`{"source_id":"*","amount_money":"*","order_id":"*","customer_id":"*","note":"*","reference_id":"*"}`),
+			},
+			{
+				ID:          "tpl_square_list_catalog",
+				ActionType:  "square.list_catalog",
+				Name:        "Browse catalog (read-only)",
+				Description: "Agent can browse the merchant's full catalog of items, categories, and modifiers.",
+				Parameters:  json.RawMessage(`{"types":"*","cursor":"*"}`),
+			},
+			{
+				ID:          "tpl_square_create_customer",
+				ActionType:  "square.create_customer",
+				Name:        "Create customer profiles",
+				Description: "Agent can create customer records with any contact details.",
+				Parameters:  json.RawMessage(`{"given_name":"*","family_name":"*","email_address":"*","phone_number":"*","company_name":"*","note":"*"}`),
+			},
+			{
+				ID:          "tpl_square_create_booking",
+				ActionType:  "square.create_booking",
+				Name:        "Book appointments",
+				Description: "Agent can schedule appointments at any location for any service. Requires human approval per booking.",
+				Parameters:  json.RawMessage(`{"location_id":"*","customer_id":"*","start_at":"*","service_variation_id":"*","team_member_id":"*","customer_note":"*"}`),
+			},
+			{
+				ID:          "tpl_square_search_orders",
+				ActionType:  "square.search_orders",
+				Name:        "Search orders (read-only)",
+				Description: "Agent can search and filter orders across locations.",
+				Parameters:  json.RawMessage(`{"location_ids":"*","query":"*","limit":"*","cursor":"*"}`),
 			},
 		},
 	}

--- a/connectors/square/square_test.go
+++ b/connectors/square/square_test.go
@@ -169,6 +169,87 @@ func TestSquareConnector_Manifest(t *testing.T) {
 	}
 }
 
+func TestSquareConnector_ActionsMatchManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+	manifest := c.Manifest()
+
+	manifestTypes := make(map[string]bool, len(manifest.Actions))
+	for _, a := range manifest.Actions {
+		manifestTypes[a.ActionType] = true
+	}
+
+	for actionType := range actions {
+		if !manifestTypes[actionType] {
+			t.Errorf("Actions() has %q but Manifest() does not", actionType)
+		}
+	}
+	for _, a := range manifest.Actions {
+		if _, ok := actions[a.ActionType]; !ok {
+			t.Errorf("Manifest() has %q but Actions() does not", a.ActionType)
+		}
+	}
+}
+
+func TestSquareConnector_ManifestTemplates(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+
+	if len(m.Templates) == 0 {
+		t.Fatal("Manifest().Templates is empty, want at least one template")
+	}
+
+	// Build a set of valid action types for cross-reference.
+	actionTypes := make(map[string]bool, len(m.Actions))
+	for _, a := range m.Actions {
+		actionTypes[a.ActionType] = true
+	}
+
+	seenIDs := make(map[string]bool)
+	for _, tpl := range m.Templates {
+		if seenIDs[tpl.ID] {
+			t.Errorf("duplicate template ID %q", tpl.ID)
+		}
+		seenIDs[tpl.ID] = true
+
+		if !actionTypes[tpl.ActionType] {
+			t.Errorf("template %q references unknown action_type %q", tpl.ID, tpl.ActionType)
+		}
+		if tpl.Name == "" {
+			t.Errorf("template %q has empty name", tpl.ID)
+		}
+		if len(tpl.Parameters) == 0 {
+			t.Errorf("template %q has empty parameters", tpl.ID)
+		}
+		// Verify Parameters is valid JSON.
+		var params map[string]interface{}
+		if err := json.Unmarshal(tpl.Parameters, &params); err != nil {
+			t.Errorf("template %q has invalid Parameters JSON: %v", tpl.ID, err)
+		}
+	}
+
+	// Verify create_payment template constrains source_id to CASH.
+	var foundCashTemplate bool
+	for _, tpl := range m.Templates {
+		if tpl.ActionType != "square.create_payment" {
+			continue
+		}
+		var params map[string]interface{}
+		if err := json.Unmarshal(tpl.Parameters, &params); err != nil {
+			continue
+		}
+		if params["source_id"] == "CASH" {
+			foundCashTemplate = true
+			break
+		}
+	}
+	if !foundCashTemplate {
+		t.Error("expected a create_payment template that constrains source_id to \"CASH\"")
+	}
+}
+
 func TestSquareConnector_ImplementsInterface(t *testing.T) {
 	t.Parallel()
 	var _ connectors.Connector = (*SquareConnector)(nil)


### PR DESCRIPTION
## Summary

- Add 7 configuration templates to the Square connector manifest covering all 6 actions
- `create_payment` has two templates: cash-only (constrains `source_id` to `"CASH"`) and all-sources (requires human approval)
- Add `ActionsMatchManifest` test to guard against action/manifest drift
- Add `ManifestTemplates` test validating template uniqueness, JSON validity, action type cross-references, and the cash payment constraint

Completes Phase 3 of #96. The connector was already registered in `main.go` (Phase 1) and auto-seeding is verified by existing DB upsert tests.

## Test plan

- [x] All Square connector tests pass (`go test ./connectors/square/...`)
- [x] DB upsert tests pass (`go test ./db/... -run TestUpsert`)
- [x] `go vet ./connectors/square/...` clean
- [x] `go build ./connectors/square/...` clean
- [x] Manifest validates via `Manifest().Validate()`

https://claude.ai/code/session_01DiYtP6dVhXc749rwhwg3MA