### PR TITLE
Register Expedia Rapid connector at startup (Phase 3)

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/api"
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/connectors/amadeus"
+	"github.com/supersuit-tech/permission-slip-web/connectors/expedia"
 	ghconnector "github.com/supersuit-tech/permission-slip-web/connectors/github"
 	"github.com/supersuit-tech/permission-slip-web/connectors/hubspot"
 	"github.com/supersuit-tech/permission-slip-web/connectors/mongodb"
@@ -325,6 +326,7 @@ func main() {
 	registry.Register(redisconnector.New())
 	registry.Register(square.New())
 	registry.Register(amadeus.New())
+	registry.Register(expedia.New())
 
 	// Auto-seed built-in connectors from their manifests.
 	if deps.DB != nil {


### PR DESCRIPTION
## Summary

- Registers the Expedia Rapid connector in `main.go` so it's included in the built-in connector registry and auto-seeded on startup
- Completes Phase 3 of #97 — the ManifestProvider with all 6 action schemas, required credentials, and 6 configuration templates was already implemented in Phase 2

## What was already done (Phases 1-2)

- `ExpediaConnector` struct with SHA-512 signature auth
- All 6 actions: `search_hotels`, `get_hotel`, `price_check`, `create_booking`, `cancel_booking`, `get_booking`
- `ManifestProvider` implementation with full JSON schemas for all actions
- 6 configuration templates (read-only search, hotel details, price check, booking with approval, cancellation with approval, booking lookup)
- `create_booking` and `cancel_booking` marked as `high` risk level and templates note "Requires human approval"

## What this PR adds

- Import and `registry.Register(expedia.New())` call in `main.go`
- Auto-seeding happens automatically via `seedRegisteredConnectors()` for any connector implementing `ManifestProvider`

## Test plan

- [x] `go test ./connectors/expedia/...` passes
- [x] `go build ./connectors/expedia/...` passes
- [x] `go vet ./connectors/expedia/...` passes
- [ ] Verify auto-seeding populates DB rows on server startup (CI/staging)

Closes #97

https://claude.ai/code/session_01MH4K4EuKCRiaq71Nx33CYi