### PR TITLE
Add Amadeus configuration templates (Phase 3)

### DIFF
--- a/connectors/amadeus/manifest.go
+++ b/connectors/amadeus/manifest.go
@@ -152,7 +152,71 @@ func (c *AmadeusConnector) Manifest() *connectors.ConnectorManifest {
 				InstructionsURL: "https://developers.amadeus.com/get-started/get-started-with-self-service-apis-335",
 			},
 		},
-		Templates: []connectors.ManifestTemplate{},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_amadeus_search_airports",
+				ActionType:  "amadeus.search_airports",
+				Name:        "Look up airports",
+				Description: "Agent can search for airports by name or IATA code. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"keyword":"*","subtype":"*"}`),
+			},
+			{
+				ID:          "tpl_amadeus_search_flights_economy",
+				ActionType:  "amadeus.search_flights",
+				Name:        "Search economy flights",
+				Description: "Agent can search for economy-class flights between any airports. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"origin":"*","destination":"*","departure_date":"*","return_date":"*","adults":"*","cabin":"ECONOMY","nonstop":"*","max_results":"*"}`),
+			},
+			{
+				ID:          "tpl_amadeus_search_flights_any",
+				ActionType:  "amadeus.search_flights",
+				Name:        "Search flights (all cabins)",
+				Description: "Agent can search flights in any cabin class between any airports. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"origin":"*","destination":"*","departure_date":"*","return_date":"*","adults":"*","cabin":"*","nonstop":"*","max_results":"*"}`),
+			},
+			{
+				ID:          "tpl_amadeus_price_flight",
+				ActionType:  "amadeus.price_flight",
+				Name:        "Confirm flight pricing",
+				Description: "Agent can confirm real-time pricing for flight offers. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"flight_offer":"*"}`),
+			},
+			{
+				ID:          "tpl_amadeus_book_flight_solo",
+				ActionType:  "amadeus.book_flight",
+				Name:        "Book flights (1 traveler)",
+				Description: "Agent can book flights for a single traveler. HIGH RISK — creates real reservations. Requires human approval per booking.",
+				Parameters:  json.RawMessage(`{"flight_offer":"*","travelers":"*","payment_method_id":"*","idempotency_key":"*","remarks":"*","_max_travelers":1}`),
+			},
+			{
+				ID:          "tpl_amadeus_book_flight_duo",
+				ActionType:  "amadeus.book_flight",
+				Name:        "Book flights (up to 2 travelers)",
+				Description: "Agent can book flights for up to 2 travelers. HIGH RISK — creates real reservations. Requires human approval per booking.",
+				Parameters:  json.RawMessage(`{"flight_offer":"*","travelers":"*","payment_method_id":"*","idempotency_key":"*","remarks":"*","_max_travelers":2}`),
+			},
+			{
+				ID:          "tpl_amadeus_search_hotels_4star",
+				ActionType:  "amadeus.search_hotels",
+				Name:        "Search 4-star hotels",
+				Description: "Agent can search for 4- and 5-star hotels by city or coordinates. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"city_code":"*","latitude":"*","longitude":"*","check_in_date":"*","check_out_date":"*","adults":"*","room_quantity":"*","ratings":[4,5],"price_range":"*","currency":"*"}`),
+			},
+			{
+				ID:          "tpl_amadeus_search_hotels_any",
+				ActionType:  "amadeus.search_hotels",
+				Name:        "Search hotels (all ratings)",
+				Description: "Agent can search hotels of any star rating by city or coordinates. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"city_code":"*","latitude":"*","longitude":"*","check_in_date":"*","check_out_date":"*","adults":"*","room_quantity":"*","ratings":"*","price_range":"*","currency":"*"}`),
+			},
+			{
+				ID:          "tpl_amadeus_search_cars",
+				ActionType:  "amadeus.search_cars",
+				Name:        "Search rental cars",
+				Description: "Agent can search for available rental cars at any airport location. Read-only, no booking capability.",
+				Parameters:  json.RawMessage(`{"pickup_location":"*","pickup_date":"*","dropoff_date":"*","dropoff_location":"*","provider":"*"}`),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds 9 configuration templates to the Amadeus connector manifest, completing Phase 3 of #92
- Templates cover all 6 actions: search_airports, search_flights, price_flight, book_flight, search_hotels, search_cars
- `book_flight` templates constrain traveler count (1 or 2) and clearly mark as high-risk requiring human approval
- Includes variant templates: economy-only vs all-cabin flights, 4-star vs all-rating hotels

## Templates added

| Template | Action | Description |
|---|---|---|
| `tpl_amadeus_search_airports` | search_airports | Look up airports by name or code |
| `tpl_amadeus_search_flights_economy` | search_flights | Economy-only flight search |
| `tpl_amadeus_search_flights_any` | search_flights | All cabin classes |
| `tpl_amadeus_price_flight` | price_flight | Confirm flight pricing |
| `tpl_amadeus_book_flight_solo` | book_flight | Book for 1 traveler (high risk) |
| `tpl_amadeus_book_flight_duo` | book_flight | Book for up to 2 travelers (high risk) |
| `tpl_amadeus_search_hotels_4star` | search_hotels | 4- and 5-star hotels only |
| `tpl_amadeus_search_hotels_any` | search_hotels | All star ratings |
| `tpl_amadeus_search_cars` | search_cars | Rental car search |

## Test plan

- [ ] Verify manifest validation passes (`go test ./connectors/amadeus/...`)
- [ ] Verify auto-seeding creates template rows in `action_config_templates` table
- [ ] Verify `GET /action-config-templates?connector_id=amadeus` returns all 9 templates
- [ ] Verify `make build` compiles successfully

> Note: Go tests could not run in this session due to network restrictions blocking module downloads (`golang.org/x/text`, `golang.org/x/sync`). Changes are data-only (template definitions) and were manually verified against all manifest validation rules.

https://claude.ai/code/session_016NTr2u2FYhUsHpbkGBEsAg