### PR TITLE
feat: integrate payment methods into connector execution flow

### DIFF
--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -18,6 +18,8 @@ type executeActionRequest struct {
 	RequestID       string      `json:"request_id"`
 	ConfigurationID string      `json:"configuration_id"`
 	Action          *actionBody `json:"action"`
+	PaymentMethodID string      `json:"payment_method_id,omitempty"`
+	AmountCents     *int        `json:"amount_cents,omitempty"`
 }
 
 type actionBody struct {
@@ -179,7 +181,10 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 
 	// ── Execute the action via connector ─────────────────────────
 
-	result, execErr := executeConnectorAction(r.Context(), deps, exec.UserID, req.Action.Type, params)
+	result, execErr := executeConnectorAction(r.Context(), deps, exec.UserID, req.Action.Type, params, &paymentParams{
+		PaymentMethodID: req.PaymentMethodID,
+		AmountCents:     req.AmountCents,
+	})
 
 	// Always emit the audit event with the actual execution result,
 	// regardless of success or failure (best-effort).

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -193,7 +193,7 @@ func executeApprovalAction(ctx context.Context, deps *Deps, userID string, appr 
 		_ = json.Unmarshal(appr.Action, &actionObj)
 	}
 
-	result, execErr := executeConnectorAction(ctx, deps, userID, actionType, actionObj.Parameters)
+	result, execErr := executeConnectorAction(ctx, deps, userID, actionType, actionObj.Parameters, nil)
 
 	var execStatus string
 	var resultJSON json.RawMessage

--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -17,6 +17,22 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 	traceID := TraceID(r.Context())
 
 	switch {
+	case connectors.IsPaymentError(err):
+		var pe *connectors.PaymentError
+		connectors.AsPaymentError(err, &pe)
+		switch pe.Code {
+		case connectors.PaymentErrMissing, connectors.PaymentErrAmountRequired:
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrPaymentMethodRequired, pe.Message))
+		case connectors.PaymentErrNotFound:
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrPaymentMethodNotFound, pe.Message))
+		case connectors.PaymentErrPerTxLimit, connectors.PaymentErrMonthlyLimit:
+			resp := newErrorResponse(ErrPaymentLimitExceeded, pe.Message, false)
+			RespondError(w, r, http.StatusForbidden, resp)
+		default:
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pe.Message))
+		}
+		return true
+
 	case connectors.IsValidationError(err):
 		// ValidationError messages are safe to surface — they describe
 		// parameter/credential issues the caller can fix.

--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -32,7 +32,7 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 			}
 			RespondError(w, r, http.StatusForbidden, resp)
 		case connectors.PaymentErrInvalidAmount:
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrPaymentMethodRequired, pe.Message))
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pe.Message))
 		default:
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pe.Message))
 		}

--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -27,7 +27,12 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrPaymentMethodNotFound, pe.Message))
 		case connectors.PaymentErrPerTxLimit, connectors.PaymentErrMonthlyLimit:
 			resp := newErrorResponse(ErrPaymentLimitExceeded, pe.Message, false)
+			if pe.Details != nil {
+				resp.Error.Details = pe.Details
+			}
 			RespondError(w, r, http.StatusForbidden, resp)
+		case connectors.PaymentErrInvalidAmount:
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrPaymentMethodRequired, pe.Message))
 		default:
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pe.Message))
 		}

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -28,8 +28,9 @@ type paymentParams struct {
 //
 // When the action declares requires_payment_method, the caller must provide
 // a paymentParams with a valid payment_method_id and amount_cents. The function
-// resolves the payment method, enforces spending limits, records the transaction,
-// and passes the Stripe token to the connector.
+// validates the payment method and enforces spending limits before execution,
+// then records the transaction only after the connector succeeds. This ensures
+// failed executions don't count against the user's spending limits.
 func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType string, parameters json.RawMessage, pp *paymentParams) (*connectors.ActionResult, error) {
 	if deps.Connectors == nil {
 		return nil, nil
@@ -69,17 +70,26 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 		}
 	}
 
-	// ── Payment method resolution ──────────────────────────────────
+	// ── Payment method validation ─────────────────────────────────
+	// Validate the payment method and enforce spending limits before execution.
+	// The transaction is recorded after execution succeeds (see below).
 	var paymentInfo *connectors.PaymentInfo
+	var resolvedPM *resolvedPaymentMethod
 	requiresPayment, err := db.GetActionRequiresPaymentMethod(ctx, deps.DB, actionType)
 	if err != nil {
 		return nil, fmt.Errorf("check requires_payment_method: %w", err)
 	}
 
 	if requiresPayment {
-		paymentInfo, err = resolvePaymentMethod(ctx, deps, userID, connectorID, actionType, pp)
+		resolvedPM, err = validatePaymentMethod(ctx, deps, userID, pp)
 		if err != nil {
 			return nil, err
+		}
+		paymentInfo = &connectors.PaymentInfo{
+			StripePaymentMethodID: resolvedPM.stripePaymentMethodID,
+			Brand:                 resolvedPM.brand,
+			Last4:                 resolvedPM.last4,
+			AmountCents:           resolvedPM.amount,
 		}
 	}
 
@@ -92,13 +102,55 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 	if err != nil {
 		return nil, err
 	}
+
+	// ── Record payment transaction (only on success) ──────────────
+	// The transaction is recorded after the connector succeeds to avoid
+	// counting failed executions against the user's spending limits.
+	if resolvedPM != nil {
+		_, txErr := db.CreatePaymentMethodTransaction(ctx, deps.DB, &db.PaymentMethodTransaction{
+			PaymentMethodID: resolvedPM.paymentMethodID,
+			UserID:          userID,
+			ConnectorID:     connectorID,
+			ActionType:      actionType,
+			AmountCents:     resolvedPM.amount,
+			Description:     fmt.Sprintf("Action execution: %s", actionType),
+		})
+		if txErr != nil {
+			// The connector already executed successfully. Log the failure but
+			// don't fail the request — the payment transaction is for limit
+			// tracking, not for billing. A missing record means slightly lax
+			// monthly limit enforcement, which is safer than discarding a
+			// successful execution result.
+			log.Printf("[payment] failed to record transaction for %s (pm=%s amount=%d): %v",
+				actionType, resolvedPM.paymentMethodID, resolvedPM.amount, txErr)
+		}
+	}
+
 	return result, nil
 }
 
-// resolvePaymentMethod validates, resolves, and enforces spending limits for a
-// payment method. On success it records the transaction and returns PaymentInfo
-// with the Stripe token (never raw card details).
-func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, actionType string, pp *paymentParams) (*connectors.PaymentInfo, error) {
+// resolvedPaymentMethod holds the validated payment method state between
+// validation (pre-execution) and transaction recording (post-execution).
+type resolvedPaymentMethod struct {
+	paymentMethodID      string
+	stripePaymentMethodID string
+	brand                string
+	last4                string
+	amount               int
+}
+
+// validatePaymentMethod validates the payment method, enforces ownership and
+// spending limits, and returns the resolved payment info. Does NOT record the
+// transaction — that happens after successful connector execution.
+//
+// Note: there is a small TOCTOU window between the monthly spend check here
+// and the transaction recording after execution. A concurrent request could
+// pass the limit check in this window, resulting in a slight overspend. This
+// is an acceptable trade-off: the window is small (duration of connector
+// execution), the consequence is minor (slightly exceeding a soft limit), and
+// the alternative (locking the payment method row for the entire execution)
+// would create unacceptable contention for connectors with slow external calls.
+func validatePaymentMethod(ctx context.Context, deps *Deps, userID string, pp *paymentParams) (*resolvedPaymentMethod, error) {
 	if pp == nil || pp.PaymentMethodID == "" {
 		return nil, &connectors.PaymentError{
 			Code:    connectors.PaymentErrMissing,
@@ -137,8 +189,8 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 			Code:    connectors.PaymentErrPerTxLimit,
 			Message: fmt.Sprintf("amount %d cents exceeds per-transaction limit of %d cents", amount, *pm.PerTransactionLimit),
 			Details: map[string]any{
-				"requested_amount_cents":       amount,
-				"per_transaction_limit_cents":  *pm.PerTransactionLimit,
+				"requested_amount_cents":      amount,
+				"per_transaction_limit_cents": *pm.PerTransactionLimit,
 			},
 		}
 	}
@@ -149,7 +201,8 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 		if err != nil {
 			return nil, fmt.Errorf("check monthly spend: %w", err)
 		}
-		if monthlySpend+amount > *pm.MonthlyLimit {
+		remaining := *pm.MonthlyLimit - monthlySpend
+		if amount > remaining {
 			return nil, &connectors.PaymentError{
 				Code:    connectors.PaymentErrMonthlyLimit,
 				Message: fmt.Sprintf("amount %d cents would exceed monthly limit of %d cents (current spend: %d cents)", amount, *pm.MonthlyLimit, monthlySpend),
@@ -157,30 +210,18 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 					"requested_amount_cents": amount,
 					"monthly_limit_cents":    *pm.MonthlyLimit,
 					"current_spend_cents":    monthlySpend,
-					"remaining_cents":        *pm.MonthlyLimit - monthlySpend,
+					"remaining_cents":        remaining,
 				},
 			}
 		}
 	}
 
-	// Record the transaction for monthly limit tracking.
-	_, err = db.CreatePaymentMethodTransaction(ctx, deps.DB, &db.PaymentMethodTransaction{
-		PaymentMethodID: pm.ID,
-		UserID:          userID,
-		ConnectorID:     connectorID,
-		ActionType:      actionType,
-		AmountCents:     amount,
-		Description:     fmt.Sprintf("Action execution: %s", actionType),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("record payment transaction: %w", err)
-	}
-
-	return &connectors.PaymentInfo{
-		StripePaymentMethodID: pm.StripePaymentMethodID,
-		Brand:                 pm.Brand,
-		Last4:                 pm.Last4,
-		AmountCents:           amount,
+	return &resolvedPaymentMethod{
+		paymentMethodID:       pm.ID,
+		stripePaymentMethodID: pm.StripePaymentMethodID,
+		brand:                 pm.Brand,
+		last4:                 pm.Last4,
+		amount:                amount,
 	}, nil
 }
 

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -114,7 +114,7 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 	amount := *pp.AmountCents
 	if amount < 0 {
 		return nil, &connectors.PaymentError{
-			Code:    connectors.PaymentErrAmountRequired,
+			Code:    connectors.PaymentErrInvalidAmount,
 			Message: "amount_cents must be non-negative",
 		}
 	}
@@ -136,6 +136,10 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 		return nil, &connectors.PaymentError{
 			Code:    connectors.PaymentErrPerTxLimit,
 			Message: fmt.Sprintf("amount %d cents exceeds per-transaction limit of %d cents", amount, *pm.PerTransactionLimit),
+			Details: map[string]any{
+				"requested_amount_cents":       amount,
+				"per_transaction_limit_cents":  *pm.PerTransactionLimit,
+			},
 		}
 	}
 
@@ -149,6 +153,12 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 			return nil, &connectors.PaymentError{
 				Code:    connectors.PaymentErrMonthlyLimit,
 				Message: fmt.Sprintf("amount %d cents would exceed monthly limit of %d cents (current spend: %d cents)", amount, *pm.MonthlyLimit, monthlySpend),
+				Details: map[string]any{
+					"requested_amount_cents": amount,
+					"monthly_limit_cents":    *pm.MonthlyLimit,
+					"current_spend_cents":    monthlySpend,
+					"remaining_cents":        *pm.MonthlyLimit - monthlySpend,
+				},
 			}
 		}
 	}
@@ -170,6 +180,7 @@ func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, 
 		StripePaymentMethodID: pm.StripePaymentMethodID,
 		Brand:                 pm.Brand,
 		Last4:                 pm.Last4,
+		AmountCents:           amount,
 	}, nil
 }
 

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -14,11 +14,23 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/oauth"
 )
 
+// paymentParams holds optional payment-related fields from the execute request.
+// When nil, no payment method processing is performed.
+type paymentParams struct {
+	PaymentMethodID string
+	AmountCents     *int
+}
+
 // executeConnectorAction looks up the action in the connector registry,
 // fetches and decrypts the user's credentials, and executes the action.
 // Returns (nil, nil) if no connector is registered for the action type
 // (graceful degradation during the transition period).
-func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType string, parameters json.RawMessage) (*connectors.ActionResult, error) {
+//
+// When the action declares requires_payment_method, the caller must provide
+// a paymentParams with a valid payment_method_id and amount_cents. The function
+// resolves the payment method, enforces spending limits, records the transaction,
+// and passes the Stripe token to the connector.
+func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType string, parameters json.RawMessage, pp *paymentParams) (*connectors.ActionResult, error) {
 	if deps.Connectors == nil {
 		return nil, nil
 	}
@@ -57,15 +69,108 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 		}
 	}
 
+	// ── Payment method resolution ──────────────────────────────────
+	var paymentInfo *connectors.PaymentInfo
+	requiresPayment, err := db.GetActionRequiresPaymentMethod(ctx, deps.DB, actionType)
+	if err != nil {
+		return nil, fmt.Errorf("check requires_payment_method: %w", err)
+	}
+
+	if requiresPayment {
+		paymentInfo, err = resolvePaymentMethod(ctx, deps, userID, connectorID, actionType, pp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	result, err := action.Execute(ctx, connectors.ActionRequest{
 		ActionType:  actionType,
 		Parameters:  parameters,
 		Credentials: creds,
+		Payment:     paymentInfo,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return result, nil
+}
+
+// resolvePaymentMethod validates, resolves, and enforces spending limits for a
+// payment method. On success it records the transaction and returns PaymentInfo
+// with the Stripe token (never raw card details).
+func resolvePaymentMethod(ctx context.Context, deps *Deps, userID, connectorID, actionType string, pp *paymentParams) (*connectors.PaymentInfo, error) {
+	if pp == nil || pp.PaymentMethodID == "" {
+		return nil, &connectors.PaymentError{
+			Code:    connectors.PaymentErrMissing,
+			Message: "this action requires a payment_method_id",
+		}
+	}
+	if pp.AmountCents == nil {
+		return nil, &connectors.PaymentError{
+			Code:    connectors.PaymentErrAmountRequired,
+			Message: "amount_cents is required for actions that require a payment method",
+		}
+	}
+	amount := *pp.AmountCents
+	if amount < 0 {
+		return nil, &connectors.PaymentError{
+			Code:    connectors.PaymentErrAmountRequired,
+			Message: "amount_cents must be non-negative",
+		}
+	}
+
+	// Look up the payment method, scoped to the user.
+	pm, err := db.GetPaymentMethodByID(ctx, deps.DB, userID, pp.PaymentMethodID)
+	if err != nil {
+		return nil, fmt.Errorf("look up payment method: %w", err)
+	}
+	if pm == nil {
+		return nil, &connectors.PaymentError{
+			Code:    connectors.PaymentErrNotFound,
+			Message: "payment method not found or does not belong to this user",
+		}
+	}
+
+	// Enforce per-transaction limit.
+	if pm.PerTransactionLimit != nil && amount > *pm.PerTransactionLimit {
+		return nil, &connectors.PaymentError{
+			Code:    connectors.PaymentErrPerTxLimit,
+			Message: fmt.Sprintf("amount %d cents exceeds per-transaction limit of %d cents", amount, *pm.PerTransactionLimit),
+		}
+	}
+
+	// Enforce monthly limit.
+	if pm.MonthlyLimit != nil {
+		monthlySpend, err := db.GetMonthlySpend(ctx, deps.DB, pm.ID)
+		if err != nil {
+			return nil, fmt.Errorf("check monthly spend: %w", err)
+		}
+		if monthlySpend+amount > *pm.MonthlyLimit {
+			return nil, &connectors.PaymentError{
+				Code:    connectors.PaymentErrMonthlyLimit,
+				Message: fmt.Sprintf("amount %d cents would exceed monthly limit of %d cents (current spend: %d cents)", amount, *pm.MonthlyLimit, monthlySpend),
+			}
+		}
+	}
+
+	// Record the transaction for monthly limit tracking.
+	_, err = db.CreatePaymentMethodTransaction(ctx, deps.DB, &db.PaymentMethodTransaction{
+		PaymentMethodID: pm.ID,
+		UserID:          userID,
+		ConnectorID:     connectorID,
+		ActionType:      actionType,
+		AmountCents:     amount,
+		Description:     fmt.Sprintf("Action execution: %s", actionType),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("record payment transaction: %w", err)
+	}
+
+	return &connectors.PaymentInfo{
+		StripePaymentMethodID: pm.StripePaymentMethodID,
+		Brand:                 pm.Brand,
+		Last4:                 pm.Last4,
+	}, nil
 }
 
 // resolveStaticCredentials fetches and decrypts static credentials (api_key, basic, custom)

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -225,7 +225,7 @@ func TestExecuteConnectorAction_OAuthPath_Success(t *testing.T) {
 		t.Fatalf("update tokens: %v", err)
 	}
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestExecuteConnectorAction_OAuthPath_NoConnection(t *testing.T) {
 		// No Connection — tests the "user hasn't connected" case.
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when no OAuth connection exists")
 	}
@@ -269,7 +269,7 @@ func TestExecuteConnectorAction_OAuthPath_NeedsReauth(t *testing.T) {
 		Connection: &testhelper.OAuthConnectionOpts{Status: "needs_reauth"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for needs_reauth connection")
 	}
@@ -286,7 +286,7 @@ func TestExecuteConnectorAction_OAuthPath_RevokedConnection(t *testing.T) {
 		Connection: &testhelper.OAuthConnectionOpts{Status: "revoked"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.list_emails", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.list_emails", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for revoked connection")
 	}
@@ -300,7 +300,7 @@ func TestExecuteConnectorAction_OAuthPath_NoVault(t *testing.T) {
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{NoVault: true})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when vault is nil")
 	}
@@ -311,7 +311,7 @@ func TestExecuteConnectorAction_OAuthPath_NoOAuthRegistry(t *testing.T) {
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{NoOAuthRegistry: true})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when OAuth registry is nil")
 	}
@@ -330,7 +330,7 @@ func TestExecuteConnectorAction_OAuthPath_ExpiredTokenNoRefreshToken(t *testing.
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, &pastExpiry)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for expired token without refresh token")
 	}
@@ -363,7 +363,7 @@ func TestExecuteConnectorAction_OAuthPath_NonExpiredTokenSkipsRefresh(t *testing
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, &farFuture)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestExecuteConnectorAction_OAuthPath_NilTokenExpirySkipsRefresh(t *testing.
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, nil)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestExecuteConnectorAction_OAuthPath_RefreshesExpiredToken(t *testing.T) {
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, &refreshVaultID, &pastExpiry)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestExecuteConnectorAction_OAuthPath_RefreshFailsTokenRevoked(t *testing.T)
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, &refreshVaultID, &pastExpiry)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`))
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when refresh token is revoked")
 	}
@@ -569,7 +569,7 @@ func TestExecuteConnectorAction_StaticPath_StillWorks(t *testing.T) {
 
 	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
 
-	result, err := executeConnectorAction(t.Context(), deps, uid, "testslack.send_message", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(t.Context(), deps, uid, "testslack.send_message", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -592,7 +592,7 @@ func TestExecuteConnectorAction_NilConnectorRegistry(t *testing.T) {
 	t.Parallel()
 
 	deps := &Deps{Connectors: nil}
-	result, err := executeConnectorAction(context.Background(), deps, "any-user", "any.action", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(context.Background(), deps, "any-user", "any.action", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -608,7 +608,7 @@ func TestExecuteConnectorAction_UnknownAction(t *testing.T) {
 	reg.Register(newTestStubConnector("github", "github.create_issue"))
 
 	deps := &Deps{Connectors: reg}
-	result, err := executeConnectorAction(context.Background(), deps, "any-user", "unknown.action", json.RawMessage(`{}`))
+	result, err := executeConnectorAction(context.Background(), deps, "any-user", "unknown.action", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("expected nil error for unknown action, got %v", err)
 	}
@@ -697,5 +697,348 @@ func TestHandleConnectorError_NonOAuthError_NotHandled(t *testing.T) {
 	handled := handleConnectorError(w, r, context.DeadlineExceeded)
 	if handled {
 		t.Error("expected handleConnectorError to NOT handle generic errors")
+	}
+}
+
+// ── executeConnectorAction: payment method integration ──────────────────────
+
+func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testpay"
+	actionType := connID + ".book"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	// Store credential.
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
+	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	// Insert payment method with limits.
+	perTx := 10000
+	monthly := 50000
+	pmID := testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{
+		PerTransactionLimit: &perTx,
+		MonthlyLimit:        &monthly,
+	})
+
+	var capturedPayment *connectors.PaymentInfo
+	reg := connectors.NewRegistry()
+	reg.Register(&paymentCapturingConnector{
+		id:         connID,
+		actionType: actionType,
+		onExec:     func(pi *connectors.PaymentInfo) { capturedPayment = pi },
+	})
+
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+	amount := 5000
+	result, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+		PaymentMethodID: pmID,
+		AmountCents:     &amount,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if capturedPayment == nil {
+		t.Fatal("expected payment info to be passed to connector")
+	}
+	if capturedPayment.Brand != "visa" {
+		t.Errorf("expected brand %q, got %q", "visa", capturedPayment.Brand)
+	}
+	if capturedPayment.Last4 != "4242" {
+		t.Errorf("expected last4 %q, got %q", "4242", capturedPayment.Last4)
+	}
+	if capturedPayment.StripePaymentMethodID == "" {
+		t.Error("expected non-empty StripePaymentMethodID")
+	}
+
+	// Verify transaction was recorded.
+	spend, err := db.GetMonthlySpend(t.Context(), tx, pmID)
+	if err != nil {
+		t.Fatalf("get monthly spend: %v", err)
+	}
+	if spend != 5000 {
+		t.Errorf("expected monthly spend of 5000, got %d", spend)
+	}
+}
+
+func TestExecuteConnectorAction_PaymentMethod_MissingRequired(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testpay2"
+	actionType := connID + ".book"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
+	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, actionType))
+
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+
+	// No payment params provided.
+	_, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), nil)
+	if err == nil {
+		t.Fatal("expected error when payment_method_id is missing")
+	}
+	if !connectors.IsPaymentError(err) {
+		t.Errorf("expected PaymentError, got %T: %v", err, err)
+	}
+	var pe *connectors.PaymentError
+	if connectors.AsPaymentError(err, &pe) && pe.Code != connectors.PaymentErrMissing {
+		t.Errorf("expected PaymentErrMissing, got %d", pe.Code)
+	}
+}
+
+func TestExecuteConnectorAction_PaymentMethod_PerTxLimitExceeded(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testpay3"
+	actionType := connID + ".book"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
+	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	perTx := 1000
+	pmID := testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{
+		PerTransactionLimit: &perTx,
+	})
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, actionType))
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+
+	amount := 5000 // Exceeds 1000 limit
+	_, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+		PaymentMethodID: pmID,
+		AmountCents:     &amount,
+	})
+	if err == nil {
+		t.Fatal("expected error when per-transaction limit is exceeded")
+	}
+	var pe *connectors.PaymentError
+	if !connectors.AsPaymentError(err, &pe) {
+		t.Fatalf("expected PaymentError, got %T: %v", err, err)
+	}
+	if pe.Code != connectors.PaymentErrPerTxLimit {
+		t.Errorf("expected PaymentErrPerTxLimit, got %d", pe.Code)
+	}
+}
+
+func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testpay4"
+	actionType := connID + ".book"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
+	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	monthly := 10000
+	pmID := testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{
+		MonthlyLimit: &monthly,
+	})
+
+	// Pre-seed a transaction to use up most of the monthly limit.
+	_, err := db.CreatePaymentMethodTransaction(t.Context(), tx, &db.PaymentMethodTransaction{
+		PaymentMethodID: pmID,
+		UserID:          uid,
+		ConnectorID:     connID,
+		ActionType:      actionType,
+		AmountCents:     9000,
+		Description:     "prior tx",
+	})
+	if err != nil {
+		t.Fatalf("seed transaction: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, actionType))
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+
+	amount := 2000 // 9000 + 2000 = 11000 > 10000 monthly limit
+	_, err = executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+		PaymentMethodID: pmID,
+		AmountCents:     &amount,
+	})
+	if err == nil {
+		t.Fatal("expected error when monthly limit is exceeded")
+	}
+	var pe *connectors.PaymentError
+	if !connectors.AsPaymentError(err, &pe) {
+		t.Fatalf("expected PaymentError, got %T: %v", err, err)
+	}
+	if pe.Code != connectors.PaymentErrMonthlyLimit {
+		t.Errorf("expected PaymentErrMonthlyLimit, got %d", pe.Code)
+	}
+}
+
+func TestExecuteConnectorAction_PaymentMethod_NotFound(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testpay5"
+	actionType := connID + ".book"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
+	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, actionType))
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+
+	amount := 100
+	_, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+		PaymentMethodID: "00000000-0000-0000-0000-000000000099",
+		AmountCents:     &amount,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent payment method")
+	}
+	var pe *connectors.PaymentError
+	if !connectors.AsPaymentError(err, &pe) {
+		t.Fatalf("expected PaymentError, got %T: %v", err, err)
+	}
+	if pe.Code != connectors.PaymentErrNotFound {
+		t.Errorf("expected PaymentErrNotFound, got %d", pe.Code)
+	}
+}
+
+func TestExecuteConnectorAction_NoPaymentMethod_WhenNotRequired(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testfree"
+	actionType := connID + ".search"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, actionType, "Search") // no payment required
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
+	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, actionType))
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+
+	// No payment params — should succeed because action doesn't require payment.
+	result, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// paymentCapturingConnector is a test connector that captures PaymentInfo.
+type paymentCapturingConnector struct {
+	id         string
+	actionType string
+	onExec     func(*connectors.PaymentInfo)
+}
+
+func (c *paymentCapturingConnector) ID() string { return c.id }
+func (c *paymentCapturingConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		c.actionType: &paymentCapturingAction{onExec: c.onExec},
+	}
+}
+func (c *paymentCapturingConnector) ValidateCredentials(_ context.Context, _ connectors.Credentials) error {
+	return nil
+}
+
+type paymentCapturingAction struct {
+	onExec func(*connectors.PaymentInfo)
+}
+
+func (a *paymentCapturingAction) Execute(_ context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	if a.onExec != nil {
+		a.onExec(req.Payment)
+	}
+	return &connectors.ActionResult{}, nil
+}
+
+// ── handleConnectorError: PaymentError mapping ──────────────────────────────
+
+func TestHandleConnectorError_PaymentError_Missing(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_pm1"))
+
+	pe := &connectors.PaymentError{Code: connectors.PaymentErrMissing, Message: "payment_method_id required"}
+	handled := handleConnectorError(w, r, pe)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle PaymentError")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestHandleConnectorError_PaymentError_LimitExceeded(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_pm2"))
+
+	pe := &connectors.PaymentError{Code: connectors.PaymentErrPerTxLimit, Message: "exceeds limit"}
+	handled := handleConnectorError(w, r, pe)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle PaymentError")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected status 403, got %d", w.Code)
 	}
 }

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -761,6 +761,9 @@ func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
 	if capturedPayment.StripePaymentMethodID == "" {
 		t.Error("expected non-empty StripePaymentMethodID")
 	}
+	if capturedPayment.AmountCents != 5000 {
+		t.Errorf("expected AmountCents 5000, got %d", capturedPayment.AmountCents)
+	}
 
 	// Verify transaction was recorded.
 	spend, err := db.GetMonthlySpend(t.Context(), tx, pmID)
@@ -851,6 +854,15 @@ func TestExecuteConnectorAction_PaymentMethod_PerTxLimitExceeded(t *testing.T) {
 	if pe.Code != connectors.PaymentErrPerTxLimit {
 		t.Errorf("expected PaymentErrPerTxLimit, got %d", pe.Code)
 	}
+	if pe.Details == nil {
+		t.Fatal("expected Details to be populated for limit errors")
+	}
+	if pe.Details["requested_amount_cents"] != 5000 {
+		t.Errorf("expected requested_amount_cents=5000, got %v", pe.Details["requested_amount_cents"])
+	}
+	if pe.Details["per_transaction_limit_cents"] != 1000 {
+		t.Errorf("expected per_transaction_limit_cents=1000, got %v", pe.Details["per_transaction_limit_cents"])
+	}
 }
 
 func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T) {
@@ -907,6 +919,21 @@ func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T)
 	}
 	if pe.Code != connectors.PaymentErrMonthlyLimit {
 		t.Errorf("expected PaymentErrMonthlyLimit, got %d", pe.Code)
+	}
+	if pe.Details == nil {
+		t.Fatal("expected Details to be populated for monthly limit errors")
+	}
+	if pe.Details["requested_amount_cents"] != 2000 {
+		t.Errorf("expected requested_amount_cents=2000, got %v", pe.Details["requested_amount_cents"])
+	}
+	if pe.Details["monthly_limit_cents"] != 10000 {
+		t.Errorf("expected monthly_limit_cents=10000, got %v", pe.Details["monthly_limit_cents"])
+	}
+	if pe.Details["current_spend_cents"] != 9000 {
+		t.Errorf("expected current_spend_cents=9000, got %v", pe.Details["current_spend_cents"])
+	}
+	if pe.Details["remaining_cents"] != 1000 {
+		t.Errorf("expected remaining_cents=1000, got %v", pe.Details["remaining_cents"])
 	}
 }
 

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -1037,3 +1037,31 @@ func TestHandleConnectorError_PaymentError_LimitExceeded(t *testing.T) {
 		t.Errorf("expected status 403, got %d", w.Code)
 	}
 }
+
+func TestHandleConnectorError_PaymentError_InvalidAmount(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_pm3"))
+
+	pe := &connectors.PaymentError{Code: connectors.PaymentErrInvalidAmount, Message: "amount_cents must be non-negative"}
+	handled := handleConnectorError(w, r, pe)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle PaymentError")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	// Verify it uses ErrInvalidRequest, not ErrPaymentMethodRequired
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatal("expected error object in response")
+	}
+	if code, _ := errObj["code"].(string); code != string(ErrInvalidRequest) {
+		t.Errorf("expected error code %q, got %q", ErrInvalidRequest, code)
+	}
+}

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -702,44 +702,102 @@ func TestHandleConnectorError_NonOAuthError_NotHandled(t *testing.T) {
 
 // ── executeConnectorAction: payment method integration ──────────────────────
 
-func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
-	t.Parallel()
+// paymentExecFixture holds common setup for payment method execution tests.
+type paymentExecFixture struct {
+	TX         db.DBTX
+	UserID     string
+	ConnID     string
+	ActionType string
+	Vault      *vault.MockVaultStore
+	Deps       *Deps
+}
+
+// paymentExecOpts configures setupPaymentExecTest.
+type paymentExecOpts struct {
+	// RequiresPayment controls whether the action requires a payment method.
+	// Defaults to true.
+	RequiresPayment *bool
+	// Connector overrides the default stub connector registration.
+	// When nil, a newTestStubConnector is used.
+	Connector connectors.Connector
+}
+
+// setupPaymentExecTest creates a user, connector, action, credentials, and
+// returns everything needed to call executeConnectorAction. Each call generates
+// a unique connector ID to allow parallel tests without conflicts.
+func setupPaymentExecTest(t *testing.T, opts paymentExecOpts) *paymentExecFixture {
+	t.Helper()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 
-	connID := "testpay"
+	connID := "tpay_" + testhelper.GenerateID(t, "")[:8]
 	actionType := connID + ".book"
 	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+
+	requiresPayment := true
+	if opts.RequiresPayment != nil {
+		requiresPayment = *opts.RequiresPayment
+	}
+	if requiresPayment {
+		testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
+	} else {
+		testhelper.InsertConnectorAction(t, tx, connID, actionType, "Search")
+	}
 	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
 
-	// Store credential.
 	v := vault.NewMockVaultStore()
 	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
 	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
 
-	// Insert payment method with limits.
+	reg := connectors.NewRegistry()
+	if opts.Connector != nil {
+		reg.Register(opts.Connector)
+	} else {
+		reg.Register(newTestStubConnector(connID, actionType))
+	}
+
+	return &paymentExecFixture{
+		TX:         tx,
+		UserID:     uid,
+		ConnID:     connID,
+		ActionType: actionType,
+		Vault:      v,
+		Deps:       &Deps{DB: tx, Vault: v, Connectors: reg},
+	}
+}
+
+func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
+	t.Parallel()
+
+	var capturedPayment *connectors.PaymentInfo
+	// Use a temporary connID for the capturing connector — we need to know
+	// it before calling setup, so we generate the connector inline.
+	f := setupPaymentExecTest(t, paymentExecOpts{
+		Connector: nil, // will be overridden below
+	})
+
+	// Replace the stub connector with a payment-capturing one.
+	capConn := &paymentCapturingConnector{
+		id:         f.ConnID,
+		actionType: f.ActionType,
+		onExec:     func(pi *connectors.PaymentInfo) { capturedPayment = pi },
+	}
+	reg := connectors.NewRegistry()
+	reg.Register(capConn)
+	f.Deps.Connectors = reg
+
 	perTx := 10000
 	monthly := 50000
-	pmID := testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{
+	pmID := testhelper.InsertPaymentMethod(t, f.TX, f.UserID, testhelper.PaymentMethodOpts{
 		PerTransactionLimit: &perTx,
 		MonthlyLimit:        &monthly,
 	})
 
-	var capturedPayment *connectors.PaymentInfo
-	reg := connectors.NewRegistry()
-	reg.Register(&paymentCapturingConnector{
-		id:         connID,
-		actionType: actionType,
-		onExec:     func(pi *connectors.PaymentInfo) { capturedPayment = pi },
-	})
-
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
 	amount := 5000
-	result, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
 	})
@@ -765,8 +823,8 @@ func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
 		t.Errorf("expected AmountCents 5000, got %d", capturedPayment.AmountCents)
 	}
 
-	// Verify transaction was recorded.
-	spend, err := db.GetMonthlySpend(t.Context(), tx, pmID)
+	// Verify transaction was recorded (only on success).
+	spend, err := db.GetMonthlySpend(t.Context(), f.TX, pmID)
 	if err != nil {
 		t.Fatalf("get monthly spend: %v", err)
 	}
@@ -777,29 +835,10 @@ func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
 
 func TestExecuteConnectorAction_PaymentMethod_MissingRequired(t *testing.T) {
 	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testpay2"
-	actionType := connID + ".book"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
-
-	v := vault.NewMockVaultStore()
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
-	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
-
-	reg := connectors.NewRegistry()
-	reg.Register(newTestStubConnector(connID, actionType))
-
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	// No payment params provided.
-	_, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when payment_method_id is missing")
 	}
@@ -814,33 +853,15 @@ func TestExecuteConnectorAction_PaymentMethod_MissingRequired(t *testing.T) {
 
 func TestExecuteConnectorAction_PaymentMethod_PerTxLimitExceeded(t *testing.T) {
 	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testpay3"
-	actionType := connID + ".book"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
-
-	v := vault.NewMockVaultStore()
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
-	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	perTx := 1000
-	pmID := testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{
+	pmID := testhelper.InsertPaymentMethod(t, f.TX, f.UserID, testhelper.PaymentMethodOpts{
 		PerTransactionLimit: &perTx,
 	})
 
-	reg := connectors.NewRegistry()
-	reg.Register(newTestStubConnector(connID, actionType))
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
-
 	amount := 5000 // Exceeds 1000 limit
-	_, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
 	})
@@ -867,33 +888,19 @@ func TestExecuteConnectorAction_PaymentMethod_PerTxLimitExceeded(t *testing.T) {
 
 func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T) {
 	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testpay4"
-	actionType := connID + ".book"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
-
-	v := vault.NewMockVaultStore()
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
-	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	monthly := 10000
-	pmID := testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{
+	pmID := testhelper.InsertPaymentMethod(t, f.TX, f.UserID, testhelper.PaymentMethodOpts{
 		MonthlyLimit: &monthly,
 	})
 
 	// Pre-seed a transaction to use up most of the monthly limit.
-	_, err := db.CreatePaymentMethodTransaction(t.Context(), tx, &db.PaymentMethodTransaction{
+	_, err := db.CreatePaymentMethodTransaction(t.Context(), f.TX, &db.PaymentMethodTransaction{
 		PaymentMethodID: pmID,
-		UserID:          uid,
-		ConnectorID:     connID,
-		ActionType:      actionType,
+		UserID:          f.UserID,
+		ConnectorID:     f.ConnID,
+		ActionType:      f.ActionType,
 		AmountCents:     9000,
 		Description:     "prior tx",
 	})
@@ -901,12 +908,8 @@ func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T)
 		t.Fatalf("seed transaction: %v", err)
 	}
 
-	reg := connectors.NewRegistry()
-	reg.Register(newTestStubConnector(connID, actionType))
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
-
 	amount := 2000 // 9000 + 2000 = 11000 > 10000 monthly limit
-	_, err = executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+	_, err = executeConnectorAction(t.Context(), f.Deps, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
 	})
@@ -939,28 +942,10 @@ func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T)
 
 func TestExecuteConnectorAction_PaymentMethod_NotFound(t *testing.T) {
 	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testpay5"
-	actionType := connID + ".book"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorActionWithPayment(t, tx, connID, actionType, "Book")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
-
-	v := vault.NewMockVaultStore()
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
-	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
-
-	reg := connectors.NewRegistry()
-	reg.Register(newTestStubConnector(connID, actionType))
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	amount := 100
-	_, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), &paymentParams{
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: "00000000-0000-0000-0000-000000000099",
 		AmountCents:     &amount,
 	})
@@ -978,28 +963,11 @@ func TestExecuteConnectorAction_PaymentMethod_NotFound(t *testing.T) {
 
 func TestExecuteConnectorAction_NoPaymentMethod_WhenNotRequired(t *testing.T) {
 	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testfree"
-	actionType := connID + ".search"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, actionType, "Search") // no payment required
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
-
-	v := vault.NewMockVaultStore()
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
-	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
-
-	reg := connectors.NewRegistry()
-	reg.Register(newTestStubConnector(connID, actionType))
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+	noPayment := false
+	f := setupPaymentExecTest(t, paymentExecOpts{RequiresPayment: &noPayment})
 
 	// No payment params — should succeed because action doesn't require payment.
-	result, err := executeConnectorAction(t.Context(), deps, uid, actionType, json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/connectors.go
+++ b/api/connectors.go
@@ -24,11 +24,12 @@ type connectorListResponse struct {
 }
 
 type connectorActionResponse struct {
-	ActionType       string `json:"action_type"`
-	Name             string `json:"name"`
-	Description      *string `json:"description,omitempty"`
-	RiskLevel        *string `json:"risk_level,omitempty"`
-	ParametersSchema any    `json:"parameters_schema,omitempty"`
+	ActionType            string  `json:"action_type"`
+	Name                  string  `json:"name"`
+	Description           *string `json:"description,omitempty"`
+	RiskLevel             *string `json:"risk_level,omitempty"`
+	ParametersSchema      any     `json:"parameters_schema,omitempty"`
+	RequiresPaymentMethod bool    `json:"requires_payment_method"`
 }
 
 type requiredCredentialResponse struct {
@@ -109,10 +110,11 @@ func toConnectorDetailResponse(ctx context.Context, c db.ConnectorDetail) connec
 	actions := make([]connectorActionResponse, len(c.Actions))
 	for i, a := range c.Actions {
 		resp := connectorActionResponse{
-			ActionType:  a.ActionType,
-			Name:        a.Name,
-			Description: a.Description,
-			RiskLevel:   a.RiskLevel,
+			ActionType:            a.ActionType,
+			Name:                  a.Name,
+			Description:           a.Description,
+			RiskLevel:             a.RiskLevel,
+			RequiresPaymentMethod: a.RequiresPaymentMethod,
 		}
 		if len(a.ParametersSchema) > 0 {
 			var schema any

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -64,7 +64,9 @@ const (
 	ErrOAuthProviderConfigExists   ErrorCode = "oauth_provider_config_exists"
 	ErrOAuthProviderConfigNotFound ErrorCode = "oauth_provider_config_not_found"
 	// Payment Methods
-	ErrPaymentMethodNotFound ErrorCode = "payment_method_not_found"
+	ErrPaymentMethodNotFound    ErrorCode = "payment_method_not_found"
+	ErrPaymentMethodRequired    ErrorCode = "payment_method_required"
+	ErrPaymentLimitExceeded     ErrorCode = "payment_limit_exceeded"
 
 	// 429 Too Many Requests (quota)
 	ErrMonthlyQuotaExceeded ErrorCode = "monthly_quota_exceeded"

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -361,7 +361,7 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 		// Attempt connector execution. If no connector is registered for this
 		// action type, the existing behavior (record execution, emit audit event)
 		// still works — execution just returns no external result (graceful degradation).
-		result, execErr := executeConnectorAction(r.Context(), deps, profile.ID, exec.ActionType, req.Parameters)
+		result, execErr := executeConnectorAction(r.Context(), deps, profile.ID, exec.ActionType, req.Parameters, nil)
 
 		// Always emit the audit event with the actual execution result (best-effort).
 		emitStandingApprovalAuditEvent(r.Context(), deps.DB, profile.ID, exec.AgentID, saID, exec.ActionType, exec.AgentMeta, execErr)

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -49,6 +49,7 @@ type PaymentInfo struct {
 	StripePaymentMethodID string // Stripe payment method token (e.g. "pm_...")
 	Brand                 string // card brand (e.g. "visa")
 	Last4                 string // last 4 digits of the card
+	AmountCents           int    // authorized transaction amount in cents
 }
 
 // ActionResult is returned from a successful execution.

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -39,6 +39,16 @@ type ActionRequest struct {
 	ActionType  string          // e.g., "github.create_issue"
 	Parameters  json.RawMessage // validated against schema before reaching here
 	Credentials Credentials     // decrypted at execution time; redacted in logs and JSON
+	Payment     *PaymentInfo    // non-nil when the action requires a payment method
+}
+
+// PaymentInfo contains the resolved payment method details passed to connectors
+// that declare requires_payment_method: true. Raw card data is never included —
+// only the Stripe payment method token and safe display metadata.
+type PaymentInfo struct {
+	StripePaymentMethodID string // Stripe payment method token (e.g. "pm_...")
+	Brand                 string // card brand (e.g. "visa")
+	Last4                 string // last 4 digits of the card
 }
 
 // ActionResult is returned from a successful execution.

--- a/connectors/errors.go
+++ b/connectors/errors.go
@@ -117,3 +117,37 @@ func IsOAuthRefreshError(err error) bool {
 func AsOAuthRefreshError(err error, target **OAuthRefreshError) bool {
 	return errors.As(err, target)
 }
+
+// PaymentError indicates a payment method-related failure (missing, limit
+// exceeded, etc.). Maps to HTTP 402 Payment Required or 400 Bad Request
+// depending on the error code.
+type PaymentError struct {
+	Code    PaymentErrorCode
+	Message string // human-readable description
+}
+
+func (e *PaymentError) Error() string {
+	return fmt.Sprintf("payment error: %s", e.Message)
+}
+
+// PaymentErrorCode enumerates payment-specific error codes.
+type PaymentErrorCode int
+
+const (
+	PaymentErrMissing      PaymentErrorCode = iota // payment_method_id not provided
+	PaymentErrNotFound                             // payment method does not exist or doesn't belong to user
+	PaymentErrPerTxLimit                           // amount exceeds per-transaction limit
+	PaymentErrMonthlyLimit                         // amount would exceed monthly limit
+	PaymentErrAmountRequired                       // amount_cents is required but not provided
+)
+
+// IsPaymentError reports whether err is or wraps a *PaymentError.
+func IsPaymentError(err error) bool {
+	var target *PaymentError
+	return errors.As(err, &target)
+}
+
+// AsPaymentError extracts a *PaymentError from err if present.
+func AsPaymentError(err error, target **PaymentError) bool {
+	return errors.As(err, target)
+}

--- a/connectors/errors.go
+++ b/connectors/errors.go
@@ -119,11 +119,12 @@ func AsOAuthRefreshError(err error, target **OAuthRefreshError) bool {
 }
 
 // PaymentError indicates a payment method-related failure (missing, limit
-// exceeded, etc.). Maps to HTTP 402 Payment Required or 400 Bad Request
-// depending on the error code.
+// exceeded, etc.). Maps to HTTP 400 Bad Request or 403 Forbidden depending
+// on the error code.
 type PaymentError struct {
 	Code    PaymentErrorCode
-	Message string // human-readable description
+	Message string         // human-readable description
+	Details map[string]any // optional structured details for limit errors
 }
 
 func (e *PaymentError) Error() string {
@@ -134,11 +135,12 @@ func (e *PaymentError) Error() string {
 type PaymentErrorCode int
 
 const (
-	PaymentErrMissing      PaymentErrorCode = iota // payment_method_id not provided
-	PaymentErrNotFound                             // payment method does not exist or doesn't belong to user
-	PaymentErrPerTxLimit                           // amount exceeds per-transaction limit
-	PaymentErrMonthlyLimit                         // amount would exceed monthly limit
-	PaymentErrAmountRequired                       // amount_cents is required but not provided
+	PaymentErrMissing        PaymentErrorCode = iota // payment_method_id not provided
+	PaymentErrNotFound                               // payment method does not exist or doesn't belong to user
+	PaymentErrPerTxLimit                             // amount exceeds per-transaction limit
+	PaymentErrMonthlyLimit                           // amount would exceed monthly limit
+	PaymentErrAmountRequired                         // amount_cents is required but not provided
+	PaymentErrInvalidAmount                          // amount_cents is negative or otherwise invalid
 )
 
 // IsPaymentError reports whether err is or wraps a *PaymentError.

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -27,11 +27,12 @@ type ConnectorManifest struct {
 
 // ManifestAction describes a single action exposed by an external connector.
 type ManifestAction struct {
-	ActionType       string          `json:"action_type"`
-	Name             string          `json:"name"`
-	Description      string          `json:"description"`
-	RiskLevel        string          `json:"risk_level"`
-	ParametersSchema json.RawMessage `json:"parameters_schema,omitempty"`
+	ActionType            string          `json:"action_type"`
+	Name                  string          `json:"name"`
+	Description           string          `json:"description"`
+	RiskLevel             string          `json:"risk_level"`
+	ParametersSchema      json.RawMessage `json:"parameters_schema,omitempty"`
+	RequiresPaymentMethod bool            `json:"requires_payment_method,omitempty"`
 }
 
 // ManifestCredential describes a credential requirement for an external connector.
@@ -303,11 +304,12 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 	}
 	for _, a := range m.Actions {
 		out.Actions = append(out.Actions, db.ExternalConnectorAction{
-			ActionType:       a.ActionType,
-			Name:             a.Name,
-			Description:      a.Description,
-			RiskLevel:        a.RiskLevel,
-			ParametersSchema: a.ParametersSchema,
+			ActionType:            a.ActionType,
+			Name:                  a.Name,
+			Description:           a.Description,
+			RiskLevel:             a.RiskLevel,
+			ParametersSchema:      a.ParametersSchema,
+			RequiresPaymentMethod: a.RequiresPaymentMethod,
 		})
 	}
 	for _, c := range m.RequiredCredentials {

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -28,11 +28,12 @@ type ConnectorDetail struct {
 
 // ConnectorAction represents a row from the connector_actions table.
 type ConnectorAction struct {
-	ActionType       string
-	Name             string
-	Description      *string
-	RiskLevel        *string
-	ParametersSchema []byte // raw JSONB
+	ActionType            string
+	Name                  string
+	Description           *string
+	RiskLevel             *string
+	ParametersSchema      []byte // raw JSONB
+	RequiresPaymentMethod bool
 }
 
 // RequiredCredential represents a row from the connector_required_credentials table.
@@ -89,7 +90,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	// Fetch actions.
 	actionRows, err := db.Query(ctx,
-		`SELECT action_type, name, description, risk_level, parameters_schema
+		`SELECT action_type, name, description, risk_level, parameters_schema, requires_payment_method
 		 FROM connector_actions
 		 WHERE connector_id = $1
 		 ORDER BY action_type`,
@@ -102,7 +103,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	for actionRows.Next() {
 		var a ConnectorAction
-		if err := actionRows.Scan(&a.ActionType, &a.Name, &a.Description, &a.RiskLevel, &a.ParametersSchema); err != nil {
+		if err := actionRows.Scan(&a.ActionType, &a.Name, &a.Description, &a.RiskLevel, &a.ParametersSchema, &a.RequiresPaymentMethod); err != nil {
 			return nil, err
 		}
 		cd.Actions = append(cd.Actions, a)
@@ -202,6 +203,25 @@ func ListConnectorIDs(ctx context.Context, db DBTX) ([]string, error) {
 	return ids, rows.Err()
 }
 
+// GetActionRequiresPaymentMethod checks whether the given action type requires
+// a payment method. Returns (true, nil) if the action exists and requires payment,
+// (false, nil) if it exists but doesn't require payment, and (false, error) if
+// the action type is not found or a query error occurs.
+func GetActionRequiresPaymentMethod(ctx context.Context, db DBTX, actionType string) (bool, error) {
+	var requires bool
+	err := db.QueryRow(ctx,
+		`SELECT requires_payment_method FROM connector_actions WHERE action_type = $1`,
+		actionType,
+	).Scan(&requires)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return requires, nil
+}
+
 // ExternalConnectorManifest contains the data needed to upsert a connector
 // from an external connector's manifest. This is a plain struct (no dependency
 // on the connectors package) to keep the db package import-free of connectors/.
@@ -216,11 +236,12 @@ type ExternalConnectorManifest struct {
 
 // ExternalConnectorAction describes an action from an external connector manifest.
 type ExternalConnectorAction struct {
-	ActionType       string
-	Name             string
-	Description      string
-	RiskLevel        string
-	ParametersSchema []byte // raw JSON
+	ActionType            string
+	Name                  string
+	Description           string
+	RiskLevel             string
+	ParametersSchema      []byte // raw JSON
+	RequiresPaymentMethod bool
 }
 
 // ExternalConnectorCredential describes a required credential from an external connector manifest.
@@ -270,14 +291,15 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 	for _, a := range m.Actions {
 		actionTypes = append(actionTypes, a.ActionType)
 		_, err := tx.Exec(ctx, `
-			INSERT INTO connector_actions (connector_id, action_type, name, description, risk_level, parameters_schema)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO connector_actions (connector_id, action_type, name, description, risk_level, parameters_schema, requires_payment_method)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (connector_id, action_type) DO UPDATE SET
 				name = EXCLUDED.name,
 				description = EXCLUDED.description,
 				risk_level = EXCLUDED.risk_level,
-				parameters_schema = EXCLUDED.parameters_schema`,
-			m.ID, a.ActionType, a.Name, nilIfEmpty(a.Description), nilIfEmpty(a.RiskLevel), nilIfEmptyBytes(a.ParametersSchema))
+				parameters_schema = EXCLUDED.parameters_schema,
+				requires_payment_method = EXCLUDED.requires_payment_method`,
+			m.ID, a.ActionType, a.Name, nilIfEmpty(a.Description), nilIfEmpty(a.RiskLevel), nilIfEmptyBytes(a.ParametersSchema), a.RequiresPaymentMethod)
 		if err != nil {
 			return err
 		}

--- a/db/migrations/20260306135859_add_requires_payment_method_to_connector_actions.sql
+++ b/db/migrations/20260306135859_add_requires_payment_method_to_connector_actions.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE connector_actions ADD COLUMN requires_payment_method BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE connector_actions DROP COLUMN IF EXISTS requires_payment_method;

--- a/db/testhelper/fixtures_connectors.go
+++ b/db/testhelper/fixtures_connectors.go
@@ -23,6 +23,14 @@ func InsertConnectorAction(t *testing.T, d db.DBTX, connectorID, actionType, nam
 		connectorID, actionType, name)
 }
 
+// InsertConnectorActionWithPayment creates an action that requires a payment method.
+func InsertConnectorActionWithPayment(t *testing.T, d db.DBTX, connectorID, actionType, name string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO connector_actions (connector_id, action_type, name, requires_payment_method) VALUES ($1, $2, $3, true)`,
+		connectorID, actionType, name)
+}
+
 // ConnectorActionOpts holds optional fields for InsertConnectorActionFull.
 type ConnectorActionOpts struct {
 	Description      *string

--- a/db/testhelper/fixtures_payment_methods.go
+++ b/db/testhelper/fixtures_payment_methods.go
@@ -1,0 +1,50 @@
+package testhelper
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// PaymentMethodOpts holds optional fields for InsertPaymentMethod.
+type PaymentMethodOpts struct {
+	Label               string
+	Brand               string
+	Last4               string
+	PerTransactionLimit *int
+	MonthlyLimit        *int
+	IsDefault           bool
+}
+
+// InsertPaymentMethod inserts a payment method for the given user with a generated
+// Stripe payment method ID. Returns the payment method ID.
+func InsertPaymentMethod(t *testing.T, d db.DBTX, userID string, opts PaymentMethodOpts) string {
+	t.Helper()
+
+	stripeID := "pm_test_" + GenerateID(t, "")
+	if opts.Brand == "" {
+		opts.Brand = "visa"
+	}
+	if opts.Last4 == "" {
+		opts.Last4 = "4242"
+	}
+
+	pm := &db.PaymentMethod{
+		UserID:                userID,
+		StripePaymentMethodID: stripeID,
+		Label:                 opts.Label,
+		Brand:                 opts.Brand,
+		Last4:                 opts.Last4,
+		ExpMonth:              12,
+		ExpYear:               2030,
+		IsDefault:             opts.IsDefault,
+		PerTransactionLimit:   opts.PerTransactionLimit,
+		MonthlyLimit:          opts.MonthlyLimit,
+	}
+
+	created, err := db.CreatePaymentMethod(t.Context(), d, pm)
+	if err != nil {
+		t.Fatalf("InsertPaymentMethod: %v", err)
+	}
+	return created.ID
+}

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -342,7 +342,7 @@ Use `connectors.TrimIndent()` to keep inline JSON readable while stripping the s
 | Manifest Field | DB Table | Purpose |
 |----------------|----------|---------|
 | Top-level fields | `connectors` | One row per connector (id, name, description) |
-| `actions[]` | `connector_actions` | One row per action (action_type, risk_level, optional parameters_schema) |
+| `actions[]` | `connector_actions` | One row per action (action_type, risk_level, optional parameters_schema, requires_payment_method) |
 | `required_credentials[]` | `connector_required_credentials` | What credentials this connector needs (service, auth_type, instructions_url, oauth_provider, oauth_scopes) |
 
 **Auth types:** `api_key`, `basic`, `custom`, `oauth2`
@@ -384,6 +384,28 @@ Requirements:
 **How it works at runtime:** On startup, the platform builds an OAuth Provider Registry (`oauth.Registry`). Built-in providers (Google, Microsoft) are registered first with endpoints and default scopes. Then, providers declared in connector manifests are merged in. The registry uses a priority system (BYOA > Manifest > BuiltIn) so that user-provided "bring your own app" credentials overlay the platform's built-in configuration. When a BYOA user registers credentials for a provider, only their client ID and secret are required — endpoints and scopes are inherited from the built-in or manifest definition.
 
 **Risk levels:** `low`, `medium`, `high`
+
+#### Payment-requiring actions
+
+If an action involves a financial transaction (e.g., booking, purchasing), set `RequiresPaymentMethod: true` in the manifest action:
+
+```go
+{
+    ActionType:            "travel.book_flight",
+    Name:                  "Book Flight",
+    Description:           "Book a flight itinerary",
+    RiskLevel:             "high",
+    RequiresPaymentMethod: true,
+    ParametersSchema:      json.RawMessage(`{...}`),
+},
+```
+
+When this flag is set:
+- The API layer requires `payment_method_id` and `amount_cents` in the execute request
+- Per-transaction and monthly spending limits are enforced before execution
+- `req.Payment` is populated with a `*PaymentInfo` containing the Stripe token and card metadata
+- The action implementation can use `req.Payment` to pass billing details to the external service
+- A transaction record is created after successful execution for monthly spend tracking
 
 ### Step 5: Register in main.go
 
@@ -759,7 +781,7 @@ Use this checklist when adding a new connector or action.
 - [ ] Define params struct with `validate()` method
 - [ ] Implement `Execute` following the parse → validate → call → return pattern
 - [ ] Register in connector's `Actions()` map
-- [ ] Add action to connector's `Manifest()` return value with `ParametersSchema`
+- [ ] Add action to connector's `Manifest()` return value with `ParametersSchema` (and `RequiresPaymentMethod: true` if applicable)
 - [ ] Write tests: `connectors/<connector>/<action_name>_test.go`
 - [ ] Update connector-level test's expected action list
 - [ ] Run `make test-backend` — all tests pass
@@ -793,6 +815,16 @@ type ActionRequest struct {
 	ActionType  string          // e.g., "github.create_issue"
 	Parameters  json.RawMessage // validated against schema before reaching here
 	Credentials Credentials     // decrypted at execution time; redacted in logs and JSON
+	Payment     *PaymentInfo    // non-nil when the action requires a payment method
+}
+
+// PaymentInfo is set when the action declares RequiresPaymentMethod: true.
+// Raw card data is never included — only the Stripe token and safe metadata.
+type PaymentInfo struct {
+	StripePaymentMethodID string // Stripe payment method token (e.g. "pm_...")
+	Brand                 string // card brand (e.g. "visa")
+	Last4                 string // last 4 digits of the card
+	AmountCents           int    // authorized transaction amount in cents
 }
 
 type ActionResult struct {
@@ -809,6 +841,21 @@ type ActionResult struct {
 | `*ExternalError` | 502 | External service returned a non-success response |
 | `*RateLimitError` | 429 | External service rate-limited the request (include `RetryAfter`) |
 | `*TimeoutError` | 504 | External service didn't respond in time |
+| `*OAuthRefreshError` | 401 | OAuth token refresh failed — user must re-authorize the provider |
+| `*PaymentError` | 400/403 | Payment method missing, not found, or limit exceeded (see codes below) |
+
+**Payment error codes** (`PaymentError.Code`):
+
+| Code | HTTP Status | Meaning |
+|------|-------------|---------|
+| `PaymentErrMissing` | 400 | `payment_method_id` not provided for an action that requires payment |
+| `PaymentErrNotFound` | 400 | Payment method does not exist or doesn't belong to the user |
+| `PaymentErrAmountRequired` | 400 | `amount_cents` is required but not provided |
+| `PaymentErrInvalidAmount` | 400 | `amount_cents` is negative or otherwise invalid |
+| `PaymentErrPerTxLimit` | 403 | Amount exceeds the payment method's per-transaction limit |
+| `PaymentErrMonthlyLimit` | 403 | Amount would exceed the payment method's monthly spending limit |
+
+Limit errors (`PaymentErrPerTxLimit`, `PaymentErrMonthlyLimit`) include a `Details` map with structured information (e.g., `limit`, `current_spend`, `requested_amount`) to help agents display actionable messages.
 
 ### Helper functions (`connectors/helpers.go`)
 
@@ -843,12 +890,13 @@ CREATE TABLE connectors (
 
 -- One row per action
 CREATE TABLE connector_actions (
-    connector_id      text NOT NULL REFERENCES connectors(id),
-    action_type       text NOT NULL,         -- "github.create_issue"
-    name              text NOT NULL,         -- "Create Issue"
-    description       text,
-    risk_level        text,                  -- 'low' | 'medium' | 'high'
-    parameters_schema jsonb,                 -- optional JSON Schema
+    connector_id              text NOT NULL REFERENCES connectors(id),
+    action_type               text NOT NULL,         -- "github.create_issue"
+    name                      text NOT NULL,         -- "Create Issue"
+    description               text,
+    risk_level                text,                  -- 'low' | 'medium' | 'high'
+    parameters_schema         jsonb,                 -- optional JSON Schema
+    requires_payment_method   boolean NOT NULL DEFAULT false,
     PRIMARY KEY (connector_id, action_type)
 );
 
@@ -943,8 +991,13 @@ connectors/
 ```
 Agent request → API validates auth → Registry.GetAction(actionType)
   → Decrypt credentials from Vault → connector.ValidateCredentials()
-  → action.Execute(ctx, ActionRequest{...}) → External API call
-  → ActionResult or typed error → HTTP response to agent
+  → If requires_payment_method: validate payment method + check limits
+  → action.Execute(ctx, ActionRequest{Payment: &PaymentInfo{...}})
+  → External API call → ActionResult or typed error
+  → If success + payment: record transaction against monthly spend
+  → HTTP response to agent
 ```
 
-The API layer handles credential decryption, validation orchestration, and error-to-HTTP mapping. Action implementations only need to focus on calling the external API and returning results or typed errors.
+The API layer handles credential decryption, validation orchestration, payment method resolution, and error-to-HTTP mapping. Action implementations only need to focus on calling the external API and returning results or typed errors.
+
+**Payment flow details:** When an action declares `RequiresPaymentMethod: true`, the execution layer validates the payment method and checks per-transaction and monthly limits *before* calling `Execute`. The `Payment` field on `ActionRequest` is populated only for payment-requiring actions. Transactions are recorded *after* successful execution to avoid charging users for failed actions.

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -39,6 +39,7 @@ Actions available on a connector (e.g., "send email" on Gmail).
 | `description` | text | max 4096 chars |
 | `risk_level` | text | CHECK IN ('low', 'medium', 'high') |
 | `parameters_schema` | jsonb | max 64 KB |
+| `requires_payment_method` | boolean | NOT NULL, DEFAULT false — when true, execute requests must include `payment_method_id` and `amount_cents` |
 
 ### `connector_required_credentials`
 

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -232,11 +232,22 @@ ConnectorAction:
           body:
             type: "string"
 
+    requires_payment_method:
+      type: boolean
+      default: false
+      description: |
+        Whether this action requires a payment method to execute. When `true`, the
+        agent must include `payment_method_id` and `amount_cents` in the execute request.
+        The payment method is resolved to a Stripe token at execution time — raw card
+        details are never exposed to the agent.
+      example: false
+
   example:
     action_type: "github.create_issue"
     name: "Create Issue"
     description: "Create a new issue in a repository"
     risk_level: "low"
+    requires_payment_method: false
     parameters_schema:
       type: "object"
       required:

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -412,6 +412,24 @@ StandingApprovalExecuteRequest:
     action:
       $ref: './shared.yaml#/Action'
 
+    payment_method_id:
+      type: string
+      format: uuid
+      description: |
+        ID of a stored payment method to use for this action. Required when the
+        action declares `requires_payment_method: true`. The payment method must
+        belong to the user who owns the agent. Permission Slip resolves it to a
+        Stripe token at execution time — raw card details are never exposed.
+      example: "550e8400-e29b-41d4-a716-446655440000"
+
+    amount_cents:
+      type: integer
+      minimum: 0
+      description: |
+        Transaction amount in cents. Required when `payment_method_id` is provided.
+        Used for spending limit enforcement (per-transaction and monthly limits).
+      example: 4999
+
   example:
     request_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
     configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -426,8 +426,10 @@ StandingApprovalExecuteRequest:
       type: integer
       minimum: 0
       description: |
-        Transaction amount in cents. Required when `payment_method_id` is provided.
-        Used for spending limit enforcement (per-transaction and monthly limits).
+        Transaction amount in cents. Required when the action declares
+        `requires_payment_method: true`. Used for spending limit enforcement
+        (per-transaction and monthly limits). The authorized amount is passed to
+        the connector alongside the Stripe payment method token.
       example: 4999
 
   example:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7422,11 +7422,21 @@ components:
                 type: string
               body:
                 type: string
+        requires_payment_method:
+          type: boolean
+          default: false
+          description: |
+            Whether this action requires a payment method to execute. When `true`, the
+            agent must include `payment_method_id` and `amount_cents` in the execute request.
+            The payment method is resolved to a Stripe token at execution time — raw card
+            details are never exposed to the agent.
+          example: false
       example:
         action_type: github.create_issue
         name: Create Issue
         description: Create a new issue in a repository
         risk_level: low
+        requires_payment_method: false
         parameters_schema:
           type: object
           required:
@@ -7656,6 +7666,24 @@ components:
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         action:
           $ref: '#/components/schemas/Action'
+        payment_method_id:
+          type: string
+          format: uuid
+          description: |
+            ID of a stored payment method to use for this action. Required when the
+            action declares `requires_payment_method: true`. The payment method must
+            belong to the user who owns the agent. Permission Slip resolves it to a
+            Stripe token at execution time — raw card details are never exposed.
+          example: 550e8400-e29b-41d4-a716-446655440000
+        amount_cents:
+          type: integer
+          minimum: 0
+          description: |
+            Transaction amount in cents. Required when the action declares
+            `requires_payment_method: true`. Used for spending limit enforcement
+            (per-transaction and monthly limits). The authorized amount is passed to
+            the connector alongside the Stripe payment method token.
+          example: 4999
       example:
         request_id: f47ac10b-58cc-4372-a567-0e02b2c3d479
         configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d


### PR DESCRIPTION
## Summary
- Adds `requires_payment_method` flag to connector actions so connectors can declare they need a payment method for execution
- Implements payment method resolution, spending limit enforcement (per-transaction and monthly), and transaction recording in the connector execution flow
- Passes only the Stripe payment method token to connectors — raw card details are never exposed to agents

## Changes
- **Migration**: Adds `requires_payment_method` boolean column to `connector_actions` table
- **Connectors package**: New `PaymentInfo` struct on `ActionRequest`, new `PaymentError` type with typed error codes
- **API execution flow**: `resolvePaymentMethod()` validates ownership, enforces per-tx and monthly limits, records transactions
- **Error handling**: Maps `PaymentError` codes to appropriate HTTP status codes (400, 403)
- **OpenAPI spec**: Documents `requires_payment_method` on actions, `payment_method_id` and `amount_cents` on execute requests
- **Tests**: 6 new integration tests covering success, missing payment, per-tx limit, monthly limit, not found, and non-required paths
- **Test fixtures**: New `InsertPaymentMethod` and `InsertConnectorActionWithPayment` helpers

## Test plan
- [ ] CI passes backend tests
- [ ] Verify payment method validation rejects missing payment_method_id when action requires it
- [ ] Verify per-transaction and monthly spending limits are enforced
- [ ] Verify transaction is recorded for monthly limit tracking
- [ ] Verify non-payment actions still work without payment params
- [ ] Verify Stripe token (not card details) is passed to connectors

https://claude.ai/code/session_018rDsPQNyRqcTXX63LMQK8X