### PR TITLE
Add Excel actions to Microsoft connector

### DIFF
--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -306,7 +306,8 @@ connectors/microsoft/
 ├── microsoft.go                  # MicrosoftConnector struct, New(), Manifest(), doRequest(), ValidateCredentials()
 ├── types.go                      # Shared Microsoft Graph API types (graphEmailBody, graphMailAddress, etc.)
 ├── response.go                   # Graph API error response → typed connector error mapping
-├── validation.go                 # Shared validation helpers (validateEmail, detectContentType)
+├── validation.go                 # Shared validation helpers (validateEmail, detectContentType, validatePathSegment, validateValuesGrid)
+├── excel_helpers.go              # Shared Excel helpers (excelWorkbookPath, newRangeResult, validateItemID)
 ├── send_email.go                 # microsoft.send_email action
 ├── list_emails.go                # microsoft.list_emails action
 ├── create_calendar_event.go      # microsoft.create_calendar_event action

--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -149,6 +149,14 @@ Lists upcoming events from the user's calendar.
 
 ---
 
+### Excel Actions
+
+All Excel actions operate on workbooks stored in OneDrive via the Microsoft Graph workbook API. They require the `Files.ReadWrite` OAuth scope.
+
+**Obtaining `item_id`:** The `item_id` parameter is the OneDrive item ID of the `.xlsx` file. You can find it by browsing OneDrive via the Graph API (`GET /me/drive/root/children`) or by using the OneDrive search endpoint (`GET /me/drive/search(q='.xlsx')`). The ID looks like `01BYE5RZ6QN3ZWBTUFOFD3GSPGOHDJD36K`.
+
+**Note on `excel_append_rows`:** This action operates on named [Excel tables](https://support.microsoft.com/en-us/office/create-and-format-tables-e81aa349-b006-4f8a-9806-5af9df0ac664), not raw ranges. The workbook must contain a table created via "Insert > Table" in Excel.
+
 ### `microsoft.excel_list_worksheets`
 
 Lists all worksheets in an Excel workbook stored in OneDrive.
@@ -200,7 +208,9 @@ Reads cell values from a worksheet range in an Excel workbook.
   "values": [
     ["Name", "Age"],
     ["Alice", 30]
-  ]
+  ],
+  "row_count": 2,
+  "column_count": 2
 }
 ```
 
@@ -221,7 +231,7 @@ Writes cell values to a worksheet range in an Excel workbook.
 | `item_id` | string | Yes | — | OneDrive item ID of the Excel workbook |
 | `sheet_name` | string | Yes | — | Name of the worksheet to write to |
 | `range` | string | Yes | — | Cell range to write (e.g., `A1:C3`) |
-| `values` | any[][] | Yes | — | 2D array of cell values to write |
+| `values` | any[][] | Yes | — | 2D array of cell values to write — all rows must have the same number of columns |
 
 **Response:**
 
@@ -231,7 +241,9 @@ Writes cell values to a worksheet range in an Excel workbook.
   "values": [
     ["Name", "Age"],
     ["Alice", 30]
-  ]
+  ],
+  "row_count": 2,
+  "column_count": 2
 }
 ```
 
@@ -251,7 +263,7 @@ Appends rows to a named table in an Excel workbook.
 |------|------|----------|---------|-------------|
 | `item_id` | string | Yes | — | OneDrive item ID of the Excel workbook |
 | `table_name` | string | Yes | — | Name of the table to append rows to |
-| `values` | any[][] | Yes | — | 2D array of row values to append |
+| `values` | any[][] | Yes | — | 2D array of row values to append — all rows must have the same number of columns |
 
 **Response:**
 
@@ -260,7 +272,8 @@ Appends rows to a named table in an Excel workbook.
   "index": 5,
   "values": [
     ["Widget", 100, 9.99]
-  ]
+  ],
+  "rows_added": 1
 }
 ```
 
@@ -318,6 +331,7 @@ connectors/microsoft/
 ├── excel_append.go               # microsoft.excel_append_rows action
 ├── microsoft_test.go             # Connector-level tests
 ├── helpers_test.go               # Shared test helpers (validCreds)
+├── validation_test.go            # Validation helper tests (path segment, values grid)
 ├── send_email_test.go            # Send email action tests
 ├── list_emails_test.go           # List emails action tests
 ├── create_calendar_event_test.go # Create calendar event action tests

--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -16,7 +16,7 @@ This connector uses OAuth 2.0 — credentials are managed automatically by the p
 
 The credential `auth_type` in the database is `oauth2` with `oauth_provider: "microsoft"`. The platform handles the full OAuth lifecycle: redirect, token exchange, encrypted storage in Supabase Vault, and automatic refresh before expiry. The connector never touches OAuth code — it receives a valid access token in `Credentials` at execution time.
 
-**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`
+**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`, `Files.ReadWrite`
 
 ## Actions
 
@@ -147,6 +147,125 @@ Lists upcoming events from the user's calendar.
 
 **Graph API:** `GET /me/events` ([docs](https://learn.microsoft.com/en-us/graph/api/user-list-events))
 
+---
+
+### `microsoft.excel_list_worksheets`
+
+Lists all worksheets in an Excel workbook stored in OneDrive.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID of the Excel workbook |
+
+**Response:**
+
+```json
+[
+  {
+    "id": "{00000000-0001-0000-0000-000000000000}",
+    "name": "Sheet1",
+    "position": 0,
+    "visibility": "Visible"
+  }
+]
+```
+
+**Graph API:** `GET /me/drive/items/{itemId}/workbook/worksheets` ([docs](https://learn.microsoft.com/en-us/graph/api/workbook-list-worksheets))
+
+---
+
+### `microsoft.excel_read_range`
+
+Reads cell values from a worksheet range in an Excel workbook.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID of the Excel workbook |
+| `sheet_name` | string | Yes | — | Name of the worksheet to read from |
+| `range` | string | Yes | — | Cell range to read (e.g., `A1:C10`) |
+
+**Response:**
+
+```json
+{
+  "address": "Sheet1!A1:B2",
+  "values": [
+    ["Name", "Age"],
+    ["Alice", 30]
+  ]
+}
+```
+
+**Graph API:** `GET /me/drive/items/{itemId}/workbook/worksheets/{sheetName}/range(address='{range}')` ([docs](https://learn.microsoft.com/en-us/graph/api/range-get))
+
+---
+
+### `microsoft.excel_write_range`
+
+Writes cell values to a worksheet range in an Excel workbook.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID of the Excel workbook |
+| `sheet_name` | string | Yes | — | Name of the worksheet to write to |
+| `range` | string | Yes | — | Cell range to write (e.g., `A1:C3`) |
+| `values` | any[][] | Yes | — | 2D array of cell values to write |
+
+**Response:**
+
+```json
+{
+  "address": "Sheet1!A1:B2",
+  "values": [
+    ["Name", "Age"],
+    ["Alice", 30]
+  ]
+}
+```
+
+**Graph API:** `PATCH /me/drive/items/{itemId}/workbook/worksheets/{sheetName}/range(address='{range}')` ([docs](https://learn.microsoft.com/en-us/graph/api/range-update))
+
+---
+
+### `microsoft.excel_append_rows`
+
+Appends rows to a named table in an Excel workbook.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID of the Excel workbook |
+| `table_name` | string | Yes | — | Name of the table to append rows to |
+| `values` | any[][] | Yes | — | 2D array of row values to append |
+
+**Response:**
+
+```json
+{
+  "index": 5,
+  "values": [
+    ["Widget", 100, 9.99]
+  ]
+}
+```
+
+**Graph API:** `POST /me/drive/items/{itemId}/workbook/tables/{tableName}/rows` ([docs](https://learn.microsoft.com/en-us/graph/api/table-post-rows))
+
 ## Error Handling
 
 The connector maps Microsoft Graph API responses to typed connector errors:
@@ -192,12 +311,20 @@ connectors/microsoft/
 ├── list_emails.go                # microsoft.list_emails action
 ├── create_calendar_event.go      # microsoft.create_calendar_event action
 ├── list_calendar_events.go       # microsoft.list_calendar_events action
+├── excel_list_worksheets.go      # microsoft.excel_list_worksheets action
+├── excel_read.go                 # microsoft.excel_read_range action
+├── excel_write.go                # microsoft.excel_write_range action
+├── excel_append.go               # microsoft.excel_append_rows action
 ├── microsoft_test.go             # Connector-level tests
 ├── helpers_test.go               # Shared test helpers (validCreds)
 ├── send_email_test.go            # Send email action tests
 ├── list_emails_test.go           # List emails action tests
 ├── create_calendar_event_test.go # Create calendar event action tests
 ├── list_calendar_events_test.go  # List calendar events action tests
+├── excel_list_worksheets_test.go # Excel list worksheets action tests
+├── excel_read_test.go            # Excel read range action tests
+├── excel_write_test.go           # Excel write range action tests
+├── excel_append_test.go          # Excel append rows action tests
 └── README.md                     # This file
 ```
 

--- a/connectors/microsoft/excel_append.go
+++ b/connectors/microsoft/excel_append.go
@@ -24,25 +24,19 @@ type excelAppendRowsParams struct {
 }
 
 func (p *excelAppendRowsParams) validate() error {
-	if p.ItemID == "" {
-		return &connectors.ValidationError{Message: "item_id is required"}
+	if err := validateItemID(p.ItemID); err != nil {
+		return err
 	}
 	if p.TableName == "" {
 		return &connectors.ValidationError{Message: "table_name is required"}
 	}
-	if len(p.Values) == 0 {
-		return &connectors.ValidationError{Message: "values is required and must not be empty"}
-	}
-	if err := validatePathSegment("item_id", p.ItemID); err != nil {
-		return err
-	}
 	if err := validatePathSegment("table_name", p.TableName); err != nil {
 		return err
 	}
-	if err := validateValuesGrid(p.Values); err != nil {
-		return err
+	if len(p.Values) == 0 {
+		return &connectors.ValidationError{Message: "values is required and must not be empty"}
 	}
-	return nil
+	return validateValuesGrid(p.Values)
 }
 
 // graphAddRowsRequest is the request body for the Graph API table row add.
@@ -73,7 +67,7 @@ func (a *excelAppendRowsAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s/workbook/tables/%s/rows", url.PathEscape(params.ItemID), url.PathEscape(params.TableName))
+	path := fmt.Sprintf("%s/tables/%s/rows", excelWorkbookPath(params.ItemID), url.PathEscape(params.TableName))
 
 	body := graphAddRowsRequest{Values: params.Values}
 

--- a/connectors/microsoft/excel_append.go
+++ b/connectors/microsoft/excel_append.go
@@ -1,0 +1,78 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// excelAppendRowsAction implements connectors.Action for microsoft.excel_append_rows.
+// It appends rows to a named table via
+// POST /me/drive/items/{itemId}/workbook/tables/{tableName}/rows.
+type excelAppendRowsAction struct {
+	conn *MicrosoftConnector
+}
+
+type excelAppendRowsParams struct {
+	ItemID    string  `json:"item_id"`
+	TableName string  `json:"table_name"`
+	Values    [][]any `json:"values"`
+}
+
+func (p *excelAppendRowsParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "item_id is required"}
+	}
+	if p.TableName == "" {
+		return &connectors.ValidationError{Message: "table_name is required"}
+	}
+	if len(p.Values) == 0 {
+		return &connectors.ValidationError{Message: "values is required and must not be empty"}
+	}
+	return nil
+}
+
+// graphAddRowsRequest is the request body for the Graph API table row add.
+type graphAddRowsRequest struct {
+	Values [][]any `json:"values"`
+}
+
+// graphAddRowsResponse is the Microsoft Graph API response for adding rows.
+type graphAddRowsResponse struct {
+	Index  int     `json:"index"`
+	Values [][]any `json:"values"`
+}
+
+// appendRowsResult is the simplified response returned to the caller.
+type appendRowsResult struct {
+	Index  int     `json:"index"`
+	Values [][]any `json:"values"`
+}
+
+// Execute appends rows to the specified table in the workbook.
+func (a *excelAppendRowsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params excelAppendRowsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/items/%s/workbook/tables/%s/rows", params.ItemID, params.TableName)
+
+	body := graphAddRowsRequest{Values: params.Values}
+
+	var resp graphAddRowsResponse
+	if err := a.conn.doRequest(ctx, http.MethodPost, path, req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(appendRowsResult{
+		Index:  resp.Index,
+		Values: resp.Values,
+	})
+}

--- a/connectors/microsoft/excel_append.go
+++ b/connectors/microsoft/excel_append.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -72,7 +73,7 @@ func (a *excelAppendRowsAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s/workbook/tables/%s/rows", params.ItemID, params.TableName)
+	path := fmt.Sprintf("/me/drive/items/%s/workbook/tables/%s/rows", url.PathEscape(params.ItemID), url.PathEscape(params.TableName))
 
 	body := graphAddRowsRequest{Values: params.Values}
 

--- a/connectors/microsoft/excel_append.go
+++ b/connectors/microsoft/excel_append.go
@@ -32,6 +32,15 @@ func (p *excelAppendRowsParams) validate() error {
 	if len(p.Values) == 0 {
 		return &connectors.ValidationError{Message: "values is required and must not be empty"}
 	}
+	if err := validatePathSegment("item_id", p.ItemID); err != nil {
+		return err
+	}
+	if err := validatePathSegment("table_name", p.TableName); err != nil {
+		return err
+	}
+	if err := validateValuesGrid(p.Values); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -48,8 +57,9 @@ type graphAddRowsResponse struct {
 
 // appendRowsResult is the simplified response returned to the caller.
 type appendRowsResult struct {
-	Index  int     `json:"index"`
-	Values [][]any `json:"values"`
+	Index     int     `json:"index"`
+	Values    [][]any `json:"values"`
+	RowsAdded int     `json:"rows_added"`
 }
 
 // Execute appends rows to the specified table in the workbook.
@@ -72,7 +82,8 @@ func (a *excelAppendRowsAction) Execute(ctx context.Context, req connectors.Acti
 	}
 
 	return connectors.JSONResult(appendRowsResult{
-		Index:  resp.Index,
-		Values: resp.Values,
+		Index:     resp.Index,
+		Values:    resp.Values,
+		RowsAdded: len(resp.Values),
 	})
 }

--- a/connectors/microsoft/excel_append.go
+++ b/connectors/microsoft/excel_append.go
@@ -17,6 +17,7 @@ type excelAppendRowsAction struct {
 	conn *MicrosoftConnector
 }
 
+// excelAppendRowsParams holds the validated parameters for appending rows to a table.
 type excelAppendRowsParams struct {
 	ItemID    string  `json:"item_id"`
 	TableName string  `json:"table_name"`
@@ -51,6 +52,7 @@ type graphAddRowsResponse struct {
 }
 
 // appendRowsResult is the simplified response returned to the caller.
+// RowsAdded is computed from len(Values) so callers don't need to count manually.
 type appendRowsResult struct {
 	Index     int     `json:"index"`
 	Values    [][]any `json:"values"`

--- a/connectors/microsoft/excel_append_test.go
+++ b/connectors/microsoft/excel_append_test.go
@@ -1,0 +1,207 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestExcelAppendRows_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+		expectedPath := "/me/drive/items/item-123/workbook/tables/SalesTable/rows"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %q, got %q", expectedPath, r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req graphAddRowsRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("failed to unmarshal request body: %v", err)
+		}
+		if len(req.Values) != 2 {
+			t.Errorf("expected 2 rows in request, got %d", len(req.Values))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"index": 5,
+			"values": [][]any{
+				{"Widget", 100, 9.99},
+				{"Gadget", 50, 19.99},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID:    "item-123",
+		TableName: "SalesTable",
+		Values: [][]any{
+			{"Widget", 100, 9.99},
+			{"Gadget", 50, 19.99},
+		},
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var ar appendRowsResult
+	if err := json.Unmarshal(result.Data, &ar); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if ar.Index != 5 {
+		t.Errorf("expected index 5, got %d", ar.Index)
+	}
+	if len(ar.Values) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(ar.Values))
+	}
+}
+
+func TestExcelAppendRows_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		TableName: "SalesTable",
+		Values:    [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelAppendRows_MissingTableName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID: "item-123",
+		Values: [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing table_name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelAppendRows_MissingValues(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID:    "item-123",
+		TableName: "SalesTable",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing values")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelAppendRows_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelAppendRows_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    "ErrorAccessDenied",
+				"message": "Access denied.",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID:    "item-123",
+		TableName: "SalesTable",
+		Values:    [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/excel_append_test.go
+++ b/connectors/microsoft/excel_append_test.go
@@ -76,6 +76,87 @@ func TestExcelAppendRows_Success(t *testing.T) {
 	if len(ar.Values) != 2 {
 		t.Errorf("expected 2 rows, got %d", len(ar.Values))
 	}
+	if ar.RowsAdded != 2 {
+		t.Errorf("expected rows_added 2, got %d", ar.RowsAdded)
+	}
+}
+
+func TestExcelAppendRows_PathTraversalItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID:    "../../admin",
+		TableName: "SalesTable",
+		Values:    [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelAppendRows_PathTraversalTableName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID:    "item-123",
+		TableName: "../../admin",
+		Values:    [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in table_name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelAppendRows_InconsistentColumnCount(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(excelAppendRowsParams{
+		ItemID:    "item-123",
+		TableName: "SalesTable",
+		Values: [][]any{
+			{"A", "B", "C"},
+			{"D", "E"},
+		},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for inconsistent column count")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
 }
 
 func TestExcelAppendRows_MissingItemID(t *testing.T) {

--- a/connectors/microsoft/excel_helpers.go
+++ b/connectors/microsoft/excel_helpers.go
@@ -1,0 +1,40 @@
+package microsoft
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// excelWorkbookPath returns the Graph API path prefix for a workbook,
+// with the item ID properly URL-encoded. All Excel actions share this
+// path prefix, so centralizing it prevents encoding inconsistencies.
+func excelWorkbookPath(itemID string) string {
+	return fmt.Sprintf("/me/drive/items/%s/workbook", url.PathEscape(itemID))
+}
+
+// newRangeResult constructs a rangeResult from a Graph API range response,
+// computing row and column counts from the values grid. Used by both
+// excel_read and excel_write to avoid duplicating this logic.
+func newRangeResult(resp graphRangeResponse) rangeResult {
+	colCount := 0
+	if len(resp.Values) > 0 {
+		colCount = len(resp.Values[0])
+	}
+	return rangeResult{
+		Address:     resp.Address,
+		Values:      resp.Values,
+		RowCount:    len(resp.Values),
+		ColumnCount: colCount,
+	}
+}
+
+// validateItemID validates and sanitizes an item_id parameter. This
+// centralizes the common validation pattern used by all Excel actions.
+func validateItemID(itemID string) error {
+	if itemID == "" {
+		return &connectors.ValidationError{Message: "item_id is required"}
+	}
+	return validatePathSegment("item_id", itemID)
+}

--- a/connectors/microsoft/excel_list_worksheets.go
+++ b/connectors/microsoft/excel_list_worksheets.go
@@ -23,6 +23,9 @@ func (p *excelListWorksheetsParams) validate() error {
 	if p.ItemID == "" {
 		return &connectors.ValidationError{Message: "item_id is required"}
 	}
+	if err := validatePathSegment("item_id", p.ItemID); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/connectors/microsoft/excel_list_worksheets.go
+++ b/connectors/microsoft/excel_list_worksheets.go
@@ -15,6 +15,7 @@ type excelListWorksheetsAction struct {
 	conn *MicrosoftConnector
 }
 
+// excelListWorksheetsParams holds the validated parameters for listing worksheets.
 type excelListWorksheetsParams struct {
 	ItemID string `json:"item_id"`
 }

--- a/connectors/microsoft/excel_list_worksheets.go
+++ b/connectors/microsoft/excel_list_worksheets.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -59,7 +60,7 @@ func (a *excelListWorksheetsAction) Execute(ctx context.Context, req connectors.
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets", params.ItemID)
+	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets", url.PathEscape(params.ItemID))
 
 	var resp graphWorksheetsResponse
 	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {

--- a/connectors/microsoft/excel_list_worksheets.go
+++ b/connectors/microsoft/excel_list_worksheets.go
@@ -1,0 +1,77 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// excelListWorksheetsAction implements connectors.Action for microsoft.excel_list_worksheets.
+// It lists all worksheets in a workbook via GET /me/drive/items/{itemId}/workbook/worksheets.
+type excelListWorksheetsAction struct {
+	conn *MicrosoftConnector
+}
+
+type excelListWorksheetsParams struct {
+	ItemID string `json:"item_id"`
+}
+
+func (p *excelListWorksheetsParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "item_id is required"}
+	}
+	return nil
+}
+
+// graphWorksheetsResponse is the Microsoft Graph API response for listing worksheets.
+type graphWorksheetsResponse struct {
+	Value []graphWorksheet `json:"value"`
+}
+
+type graphWorksheet struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Position   int    `json:"position"`
+	Visibility string `json:"visibility"`
+}
+
+// worksheetSummary is the simplified response returned to the caller.
+type worksheetSummary struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Position   int    `json:"position"`
+	Visibility string `json:"visibility"`
+}
+
+// Execute lists all worksheets in the specified workbook.
+func (a *excelListWorksheetsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params excelListWorksheetsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets", params.ItemID)
+
+	var resp graphWorksheetsResponse
+	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	summaries := make([]worksheetSummary, len(resp.Value))
+	for i, ws := range resp.Value {
+		summaries[i] = worksheetSummary{
+			ID:         ws.ID,
+			Name:       ws.Name,
+			Position:   ws.Position,
+			Visibility: ws.Visibility,
+		}
+	}
+
+	return connectors.JSONResult(summaries)
+}

--- a/connectors/microsoft/excel_list_worksheets.go
+++ b/connectors/microsoft/excel_list_worksheets.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -21,13 +20,7 @@ type excelListWorksheetsParams struct {
 }
 
 func (p *excelListWorksheetsParams) validate() error {
-	if p.ItemID == "" {
-		return &connectors.ValidationError{Message: "item_id is required"}
-	}
-	if err := validatePathSegment("item_id", p.ItemID); err != nil {
-		return err
-	}
-	return nil
+	return validateItemID(p.ItemID)
 }
 
 // graphWorksheetsResponse is the Microsoft Graph API response for listing worksheets.
@@ -60,7 +53,7 @@ func (a *excelListWorksheetsAction) Execute(ctx context.Context, req connectors.
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets", url.PathEscape(params.ItemID))
+	path := excelWorkbookPath(params.ItemID) + "/worksheets"
 
 	var resp graphWorksheetsResponse
 	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {

--- a/connectors/microsoft/excel_list_worksheets_test.go
+++ b/connectors/microsoft/excel_list_worksheets_test.go
@@ -1,0 +1,147 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestExcelListWorksheets_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+		expectedPath := "/me/drive/items/item-123/workbook/worksheets"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %q, got %q", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{
+				{
+					"id":         "ws-1",
+					"name":       "Sheet1",
+					"position":   0,
+					"visibility": "Visible",
+				},
+				{
+					"id":         "ws-2",
+					"name":       "Sheet2",
+					"position":   1,
+					"visibility": "Visible",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelListWorksheetsAction{conn: conn}
+
+	params, _ := json.Marshal(excelListWorksheetsParams{ItemID: "item-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_list_worksheets",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var summaries []worksheetSummary
+	if err := json.Unmarshal(result.Data, &summaries); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 worksheets, got %d", len(summaries))
+	}
+	if summaries[0].Name != "Sheet1" {
+		t.Errorf("expected name 'Sheet1', got %q", summaries[0].Name)
+	}
+	if summaries[1].Name != "Sheet2" {
+		t.Errorf("expected name 'Sheet2', got %q", summaries[1].Name)
+	}
+}
+
+func TestExcelListWorksheets_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelListWorksheetsAction{conn: conn}
+
+	params, _ := json.Marshal(excelListWorksheetsParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_list_worksheets",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelListWorksheets_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelListWorksheetsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_list_worksheets",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelListWorksheets_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    "InvalidAuthenticationToken",
+				"message": "Access token is invalid.",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelListWorksheetsAction{conn: conn}
+
+	params, _ := json.Marshal(excelListWorksheetsParams{ItemID: "item-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_list_worksheets",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/excel_list_worksheets_test.go
+++ b/connectors/microsoft/excel_list_worksheets_test.go
@@ -94,6 +94,27 @@ func TestExcelListWorksheets_MissingItemID(t *testing.T) {
 	}
 }
 
+func TestExcelListWorksheets_PathTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelListWorksheetsAction{conn: conn}
+
+	params, _ := json.Marshal(excelListWorksheetsParams{ItemID: "../secret"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_list_worksheets",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestExcelListWorksheets_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/excel_read.go
+++ b/connectors/microsoft/excel_read.go
@@ -31,6 +31,9 @@ func (p *excelReadRangeParams) validate() error {
 	if p.SheetName == "" {
 		return &connectors.ValidationError{Message: "sheet_name is required"}
 	}
+	if err := validatePathSegment("sheet_name", p.SheetName); err != nil {
+		return err
+	}
 	if p.Range == "" {
 		return &connectors.ValidationError{Message: "range is required"}
 	}

--- a/connectors/microsoft/excel_read.go
+++ b/connectors/microsoft/excel_read.go
@@ -24,17 +24,14 @@ type excelReadRangeParams struct {
 }
 
 func (p *excelReadRangeParams) validate() error {
-	if p.ItemID == "" {
-		return &connectors.ValidationError{Message: "item_id is required"}
+	if err := validateItemID(p.ItemID); err != nil {
+		return err
 	}
 	if p.SheetName == "" {
 		return &connectors.ValidationError{Message: "sheet_name is required"}
 	}
 	if p.Range == "" {
 		return &connectors.ValidationError{Message: "range is required"}
-	}
-	if err := validatePathSegment("item_id", p.ItemID); err != nil {
-		return err
 	}
 	return nil
 }
@@ -65,8 +62,8 @@ func (a *excelReadRangeAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets/%s/range(address='%s')",
-		url.PathEscape(params.ItemID),
+	path := fmt.Sprintf("%s/worksheets/%s/range(address='%s')",
+		excelWorkbookPath(params.ItemID),
 		url.PathEscape(params.SheetName),
 		url.QueryEscape(params.Range),
 	)
@@ -76,15 +73,5 @@ func (a *excelReadRangeAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
-	colCount := 0
-	if len(resp.Values) > 0 {
-		colCount = len(resp.Values[0])
-	}
-
-	return connectors.JSONResult(rangeResult{
-		Address:     resp.Address,
-		Values:      resp.Values,
-		RowCount:    len(resp.Values),
-		ColumnCount: colCount,
-	})
+	return connectors.JSONResult(newRangeResult(resp))
 }

--- a/connectors/microsoft/excel_read.go
+++ b/connectors/microsoft/excel_read.go
@@ -66,7 +66,7 @@ func (a *excelReadRangeAction) Execute(ctx context.Context, req connectors.Actio
 	}
 
 	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets/%s/range(address='%s')",
-		params.ItemID,
+		url.PathEscape(params.ItemID),
 		url.PathEscape(params.SheetName),
 		url.QueryEscape(params.Range),
 	)

--- a/connectors/microsoft/excel_read.go
+++ b/connectors/microsoft/excel_read.go
@@ -17,6 +17,7 @@ type excelReadRangeAction struct {
 	conn *MicrosoftConnector
 }
 
+// excelReadRangeParams holds the validated parameters for reading a cell range.
 type excelReadRangeParams struct {
 	ItemID    string `json:"item_id"`
 	SheetName string `json:"sheet_name"`

--- a/connectors/microsoft/excel_read.go
+++ b/connectors/microsoft/excel_read.go
@@ -1,0 +1,76 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// excelReadRangeAction implements connectors.Action for microsoft.excel_read_range.
+// It reads cell values from a worksheet range via
+// GET /me/drive/items/{itemId}/workbook/worksheets/{sheetName}/range(address='{range}').
+type excelReadRangeAction struct {
+	conn *MicrosoftConnector
+}
+
+type excelReadRangeParams struct {
+	ItemID    string `json:"item_id"`
+	SheetName string `json:"sheet_name"`
+	Range     string `json:"range"`
+}
+
+func (p *excelReadRangeParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "item_id is required"}
+	}
+	if p.SheetName == "" {
+		return &connectors.ValidationError{Message: "sheet_name is required"}
+	}
+	if p.Range == "" {
+		return &connectors.ValidationError{Message: "range is required"}
+	}
+	return nil
+}
+
+// graphRangeResponse is the Microsoft Graph API response for reading a range.
+type graphRangeResponse struct {
+	Address string `json:"address"`
+	Values  [][]any `json:"values"`
+}
+
+// rangeResult is the simplified response returned to the caller.
+type rangeResult struct {
+	Address string  `json:"address"`
+	Values  [][]any `json:"values"`
+}
+
+// Execute reads cell values from the specified worksheet range.
+func (a *excelReadRangeAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params excelReadRangeParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets/%s/range(address='%s')",
+		params.ItemID,
+		url.PathEscape(params.SheetName),
+		url.QueryEscape(params.Range),
+	)
+
+	var resp graphRangeResponse
+	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(rangeResult{
+		Address: resp.Address,
+		Values:  resp.Values,
+	})
+}

--- a/connectors/microsoft/excel_read.go
+++ b/connectors/microsoft/excel_read.go
@@ -33,6 +33,9 @@ func (p *excelReadRangeParams) validate() error {
 	if p.Range == "" {
 		return &connectors.ValidationError{Message: "range is required"}
 	}
+	if err := validatePathSegment("item_id", p.ItemID); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -43,9 +46,13 @@ type graphRangeResponse struct {
 }
 
 // rangeResult is the simplified response returned to the caller.
+// RowCount and ColumnCount are computed from the values grid so callers
+// can work with data dimensions without counting manually.
 type rangeResult struct {
-	Address string  `json:"address"`
-	Values  [][]any `json:"values"`
+	Address     string  `json:"address"`
+	Values      [][]any `json:"values"`
+	RowCount    int     `json:"row_count"`
+	ColumnCount int     `json:"column_count"`
 }
 
 // Execute reads cell values from the specified worksheet range.
@@ -69,8 +76,15 @@ func (a *excelReadRangeAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
+	colCount := 0
+	if len(resp.Values) > 0 {
+		colCount = len(resp.Values[0])
+	}
+
 	return connectors.JSONResult(rangeResult{
-		Address: resp.Address,
-		Values:  resp.Values,
+		Address:     resp.Address,
+		Values:      resp.Values,
+		RowCount:    len(resp.Values),
+		ColumnCount: colCount,
 	})
 }

--- a/connectors/microsoft/excel_read_test.go
+++ b/connectors/microsoft/excel_read_test.go
@@ -59,6 +59,37 @@ func TestExcelReadRange_Success(t *testing.T) {
 	if len(rr.Values) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(rr.Values))
 	}
+	if rr.RowCount != 2 {
+		t.Errorf("expected row_count 2, got %d", rr.RowCount)
+	}
+	if rr.ColumnCount != 2 {
+		t.Errorf("expected column_count 2, got %d", rr.ColumnCount)
+	}
+}
+
+func TestExcelReadRange_PathTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{
+		ItemID:    "../../admin",
+		SheetName: "Sheet1",
+		Range:     "A1:B2",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
 }
 
 func TestExcelReadRange_MissingItemID(t *testing.T) {

--- a/connectors/microsoft/excel_read_test.go
+++ b/connectors/microsoft/excel_read_test.go
@@ -1,0 +1,175 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestExcelReadRange_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"address": "Sheet1!A1:B2",
+			"values": [][]any{
+				{"Name", "Age"},
+				{"Alice", 30.0},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{
+		ItemID:    "item-123",
+		SheetName: "Sheet1",
+		Range:     "A1:B2",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var rr rangeResult
+	if err := json.Unmarshal(result.Data, &rr); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if rr.Address != "Sheet1!A1:B2" {
+		t.Errorf("expected address 'Sheet1!A1:B2', got %q", rr.Address)
+	}
+	if len(rr.Values) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rr.Values))
+	}
+}
+
+func TestExcelReadRange_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{SheetName: "Sheet1", Range: "A1:B2"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelReadRange_MissingSheetName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{ItemID: "item-123", Range: "A1:B2"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing sheet_name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelReadRange_MissingRange(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{ItemID: "item-123", SheetName: "Sheet1"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing range")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelReadRange_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelReadRangeAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelReadRange_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{
+		ItemID:    "item-123",
+		SheetName: "Sheet1",
+		Range:     "A1:B2",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/excel_read_test.go
+++ b/connectors/microsoft/excel_read_test.go
@@ -92,6 +92,31 @@ func TestExcelReadRange_PathTraversalRejected(t *testing.T) {
 	}
 }
 
+func TestExcelReadRange_PathTraversalSheetName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelReadRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelReadRangeParams{
+		ItemID:    "item-123",
+		SheetName: "../../admin",
+		Range:     "A1:B2",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_read_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in sheet_name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestExcelReadRange_MissingItemID(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/excel_write.go
+++ b/connectors/microsoft/excel_write.go
@@ -32,6 +32,9 @@ func (p *excelWriteRangeParams) validate() error {
 	if p.SheetName == "" {
 		return &connectors.ValidationError{Message: "sheet_name is required"}
 	}
+	if err := validatePathSegment("sheet_name", p.SheetName); err != nil {
+		return err
+	}
 	if p.Range == "" {
 		return &connectors.ValidationError{Message: "range is required"}
 	}

--- a/connectors/microsoft/excel_write.go
+++ b/connectors/microsoft/excel_write.go
@@ -37,6 +37,12 @@ func (p *excelWriteRangeParams) validate() error {
 	if len(p.Values) == 0 {
 		return &connectors.ValidationError{Message: "values is required and must not be empty"}
 	}
+	if err := validatePathSegment("item_id", p.ItemID); err != nil {
+		return err
+	}
+	if err := validateValuesGrid(p.Values); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -68,8 +74,15 @@ func (a *excelWriteRangeAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
+	colCount := 0
+	if len(resp.Values) > 0 {
+		colCount = len(resp.Values[0])
+	}
+
 	return connectors.JSONResult(rangeResult{
-		Address: resp.Address,
-		Values:  resp.Values,
+		Address:     resp.Address,
+		Values:      resp.Values,
+		RowCount:    len(resp.Values),
+		ColumnCount: colCount,
 	})
 }

--- a/connectors/microsoft/excel_write.go
+++ b/connectors/microsoft/excel_write.go
@@ -62,7 +62,7 @@ func (a *excelWriteRangeAction) Execute(ctx context.Context, req connectors.Acti
 	}
 
 	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets/%s/range(address='%s')",
-		params.ItemID,
+		url.PathEscape(params.ItemID),
 		url.PathEscape(params.SheetName),
 		url.QueryEscape(params.Range),
 	)

--- a/connectors/microsoft/excel_write.go
+++ b/connectors/microsoft/excel_write.go
@@ -25,8 +25,8 @@ type excelWriteRangeParams struct {
 }
 
 func (p *excelWriteRangeParams) validate() error {
-	if p.ItemID == "" {
-		return &connectors.ValidationError{Message: "item_id is required"}
+	if err := validateItemID(p.ItemID); err != nil {
+		return err
 	}
 	if p.SheetName == "" {
 		return &connectors.ValidationError{Message: "sheet_name is required"}
@@ -37,13 +37,7 @@ func (p *excelWriteRangeParams) validate() error {
 	if len(p.Values) == 0 {
 		return &connectors.ValidationError{Message: "values is required and must not be empty"}
 	}
-	if err := validatePathSegment("item_id", p.ItemID); err != nil {
-		return err
-	}
-	if err := validateValuesGrid(p.Values); err != nil {
-		return err
-	}
-	return nil
+	return validateValuesGrid(p.Values)
 }
 
 // graphWriteRangeRequest is the request body for the Graph API range update.
@@ -61,8 +55,8 @@ func (a *excelWriteRangeAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets/%s/range(address='%s')",
-		url.PathEscape(params.ItemID),
+	path := fmt.Sprintf("%s/worksheets/%s/range(address='%s')",
+		excelWorkbookPath(params.ItemID),
 		url.PathEscape(params.SheetName),
 		url.QueryEscape(params.Range),
 	)
@@ -74,15 +68,5 @@ func (a *excelWriteRangeAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	colCount := 0
-	if len(resp.Values) > 0 {
-		colCount = len(resp.Values[0])
-	}
-
-	return connectors.JSONResult(rangeResult{
-		Address:     resp.Address,
-		Values:      resp.Values,
-		RowCount:    len(resp.Values),
-		ColumnCount: colCount,
-	})
+	return connectors.JSONResult(newRangeResult(resp))
 }

--- a/connectors/microsoft/excel_write.go
+++ b/connectors/microsoft/excel_write.go
@@ -1,0 +1,75 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// excelWriteRangeAction implements connectors.Action for microsoft.excel_write_range.
+// It writes cell values to a worksheet range via
+// PATCH /me/drive/items/{itemId}/workbook/worksheets/{sheetName}/range(address='{range}').
+type excelWriteRangeAction struct {
+	conn *MicrosoftConnector
+}
+
+type excelWriteRangeParams struct {
+	ItemID    string  `json:"item_id"`
+	SheetName string  `json:"sheet_name"`
+	Range     string  `json:"range"`
+	Values    [][]any `json:"values"`
+}
+
+func (p *excelWriteRangeParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "item_id is required"}
+	}
+	if p.SheetName == "" {
+		return &connectors.ValidationError{Message: "sheet_name is required"}
+	}
+	if p.Range == "" {
+		return &connectors.ValidationError{Message: "range is required"}
+	}
+	if len(p.Values) == 0 {
+		return &connectors.ValidationError{Message: "values is required and must not be empty"}
+	}
+	return nil
+}
+
+// graphWriteRangeRequest is the request body for the Graph API range update.
+type graphWriteRangeRequest struct {
+	Values [][]any `json:"values"`
+}
+
+// Execute writes cell values to the specified worksheet range.
+func (a *excelWriteRangeAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params excelWriteRangeParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/items/%s/workbook/worksheets/%s/range(address='%s')",
+		params.ItemID,
+		url.PathEscape(params.SheetName),
+		url.QueryEscape(params.Range),
+	)
+
+	body := graphWriteRangeRequest{Values: params.Values}
+
+	var resp graphRangeResponse
+	if err := a.conn.doRequest(ctx, http.MethodPatch, path, req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(rangeResult{
+		Address: resp.Address,
+		Values:  resp.Values,
+	})
+}

--- a/connectors/microsoft/excel_write.go
+++ b/connectors/microsoft/excel_write.go
@@ -17,6 +17,7 @@ type excelWriteRangeAction struct {
 	conn *MicrosoftConnector
 }
 
+// excelWriteRangeParams holds the validated parameters for writing to a cell range.
 type excelWriteRangeParams struct {
 	ItemID    string  `json:"item_id"`
 	SheetName string  `json:"sheet_name"`

--- a/connectors/microsoft/excel_write_test.go
+++ b/connectors/microsoft/excel_write_test.go
@@ -110,6 +110,32 @@ func TestExcelWriteRange_InconsistentColumnCount(t *testing.T) {
 	}
 }
 
+func TestExcelWriteRange_PathTraversalSheetName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelWriteRangeParams{
+		ItemID:    "item-123",
+		SheetName: "../../admin",
+		Range:     "A1:B2",
+		Values:    [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in sheet_name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestExcelWriteRange_MissingItemID(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/excel_write_test.go
+++ b/connectors/microsoft/excel_write_test.go
@@ -1,0 +1,145 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestExcelWriteRange_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req graphWriteRangeRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("failed to unmarshal request body: %v", err)
+		}
+		if len(req.Values) != 2 {
+			t.Errorf("expected 2 rows in request, got %d", len(req.Values))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"address": "Sheet1!A1:B2",
+			"values": [][]any{
+				{"Name", "Age"},
+				{"Alice", 30.0},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &excelWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelWriteRangeParams{
+		ItemID:    "item-123",
+		SheetName: "Sheet1",
+		Range:     "A1:B2",
+		Values: [][]any{
+			{"Name", "Age"},
+			{"Alice", 30},
+		},
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var rr rangeResult
+	if err := json.Unmarshal(result.Data, &rr); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if rr.Address != "Sheet1!A1:B2" {
+		t.Errorf("expected address 'Sheet1!A1:B2', got %q", rr.Address)
+	}
+}
+
+func TestExcelWriteRange_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelWriteRangeParams{
+		SheetName: "Sheet1",
+		Range:     "A1:B2",
+		Values:    [][]any{{"a"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelWriteRange_MissingValues(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelWriteRangeParams{
+		ItemID:    "item-123",
+		SheetName: "Sheet1",
+		Range:     "A1:B2",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing values")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestExcelWriteRange_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelWriteRangeAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_write_range",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/excel_write_test.go
+++ b/connectors/microsoft/excel_write_test.go
@@ -73,6 +73,41 @@ func TestExcelWriteRange_Success(t *testing.T) {
 	if rr.Address != "Sheet1!A1:B2" {
 		t.Errorf("expected address 'Sheet1!A1:B2', got %q", rr.Address)
 	}
+	if rr.RowCount != 2 {
+		t.Errorf("expected row_count 2, got %d", rr.RowCount)
+	}
+	if rr.ColumnCount != 2 {
+		t.Errorf("expected column_count 2, got %d", rr.ColumnCount)
+	}
+}
+
+func TestExcelWriteRange_InconsistentColumnCount(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &excelWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(excelWriteRangeParams{
+		ItemID:    "item-123",
+		SheetName: "Sheet1",
+		Range:     "A1:C2",
+		Values: [][]any{
+			{"A", "B", "C"},
+			{"D", "E"}, // only 2 columns instead of 3
+		},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.excel_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for inconsistent column count")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
 }
 
 func TestExcelWriteRange_MissingItemID(t *testing.T) {

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -65,7 +65,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "microsoft",
 		Name:        "Microsoft",
-		Description: "Microsoft 365 integration for email and calendar via Microsoft Graph API",
+		Description: "Microsoft 365 integration for email, calendar, and Excel via Microsoft Graph API",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "microsoft.send_email",
@@ -180,6 +180,106 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "microsoft.excel_list_worksheets",
+				Name:        "List Excel Worksheets",
+				Description: "List all worksheets in an Excel workbook stored in OneDrive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID of the Excel workbook"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.excel_read_range",
+				Name:        "Read Excel Range",
+				Description: "Read cell values from a worksheet range in an Excel workbook",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id", "sheet_name", "range"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID of the Excel workbook"
+						},
+						"sheet_name": {
+							"type": "string",
+							"description": "Name of the worksheet to read from"
+						},
+						"range": {
+							"type": "string",
+							"description": "Cell range to read (e.g. A1:C10)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.excel_write_range",
+				Name:        "Write Excel Range",
+				Description: "Write cell values to a worksheet range in an Excel workbook",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id", "sheet_name", "range", "values"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID of the Excel workbook"
+						},
+						"sheet_name": {
+							"type": "string",
+							"description": "Name of the worksheet to write to"
+						},
+						"range": {
+							"type": "string",
+							"description": "Cell range to write (e.g. A1:C3)"
+						},
+						"values": {
+							"type": "array",
+							"items": {
+								"type": "array",
+								"items": {}
+							},
+							"description": "2D array of cell values to write"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.excel_append_rows",
+				Name:        "Append Excel Rows",
+				Description: "Append rows to a named table in an Excel workbook",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id", "table_name", "values"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID of the Excel workbook"
+						},
+						"table_name": {
+							"type": "string",
+							"description": "Name of the table to append rows to"
+						},
+						"values": {
+							"type": "array",
+							"items": {
+								"type": "array",
+								"items": {}
+							},
+							"description": "2D array of row values to append"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -190,6 +290,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 					"Mail.Send",
 					"Mail.Read",
 					"Calendars.ReadWrite",
+					"Files.ReadWrite",
 				},
 			},
 		},
@@ -222,6 +323,34 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can view upcoming calendar events.",
 				Parameters:  json.RawMessage(`{"top":"*"}`),
 			},
+			{
+				ID:          "tpl_microsoft_excel_read_range",
+				ActionType:  "microsoft.excel_read_range",
+				Name:        "Read Excel range",
+				Description: "Agent can read any range from a specific workbook.",
+				Parameters:  json.RawMessage(`{"item_id":"*","sheet_name":"*","range":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_excel_write_range",
+				ActionType:  "microsoft.excel_write_range",
+				Name:        "Write Excel range",
+				Description: "Agent can write to any range in a specific workbook.",
+				Parameters:  json.RawMessage(`{"item_id":"*","sheet_name":"*","range":"*","values":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_excel_append_rows",
+				ActionType:  "microsoft.excel_append_rows",
+				Name:        "Append Excel rows",
+				Description: "Agent can append rows to a table in a specific workbook.",
+				Parameters:  json.RawMessage(`{"item_id":"*","table_name":"*","values":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_excel_read_any",
+				ActionType:  "microsoft.excel_read_range",
+				Name:        "Read from any workbook",
+				Description: "Agent can read from any Excel workbook the user has access to.",
+				Parameters:  json.RawMessage(`{"item_id":"*","sheet_name":"*","range":"*"}`),
+			},
 		},
 	}
 }
@@ -233,6 +362,10 @@ func (c *MicrosoftConnector) Actions() map[string]connectors.Action {
 		"microsoft.list_emails":           &listEmailsAction{conn: c},
 		"microsoft.create_calendar_event": &createCalendarEventAction{conn: c},
 		"microsoft.list_calendar_events":  &listCalendarEventsAction{conn: c},
+		"microsoft.excel_list_worksheets": &excelListWorksheetsAction{conn: c},
+		"microsoft.excel_read_range":      &excelReadRangeAction{conn: c},
+		"microsoft.excel_write_range":     &excelWriteRangeAction{conn: c},
+		"microsoft.excel_append_rows":     &excelAppendRowsAction{conn: c},
 	}
 }
 

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -324,6 +324,13 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:  json.RawMessage(`{"top":"*"}`),
 			},
 			{
+				ID:          "tpl_microsoft_excel_list_worksheets",
+				ActionType:  "microsoft.excel_list_worksheets",
+				Name:        "List Excel worksheets",
+				Description: "Agent can list worksheets in a specific workbook.",
+				Parameters:  json.RawMessage(`{"item_id":"*"}`),
+			},
+			{
 				ID:          "tpl_microsoft_excel_read_range",
 				ActionType:  "microsoft.excel_read_range",
 				Name:        "Read Excel range",

--- a/connectors/microsoft/microsoft_test.go
+++ b/connectors/microsoft/microsoft_test.go
@@ -134,8 +134,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	}
 
 	// Validate templates.
-	if len(m.Templates) != 8 {
-		t.Errorf("Manifest().Templates has %d items, want 8", len(m.Templates))
+	if len(m.Templates) != 9 {
+		t.Errorf("Manifest().Templates has %d items, want 9", len(m.Templates))
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/microsoft/microsoft_test.go
+++ b/connectors/microsoft/microsoft_test.go
@@ -24,6 +24,10 @@ func TestMicrosoftConnector_Actions(t *testing.T) {
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
+		"microsoft.excel_list_worksheets",
+		"microsoft.excel_read_range",
+		"microsoft.excel_write_range",
+		"microsoft.excel_append_rows",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -91,8 +95,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	if m.Name != "Microsoft" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Microsoft")
 	}
-	if len(m.Actions) != 4 {
-		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	if len(m.Actions) != 8 {
+		t.Fatalf("Manifest().Actions has %d items, want 8", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -103,6 +107,10 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
+		"microsoft.excel_list_worksheets",
+		"microsoft.excel_read_range",
+		"microsoft.excel_write_range",
+		"microsoft.excel_append_rows",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)
@@ -126,8 +134,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	}
 
 	// Validate templates.
-	if len(m.Templates) != 4 {
-		t.Errorf("Manifest().Templates has %d items, want 4", len(m.Templates))
+	if len(m.Templates) != 8 {
+		t.Errorf("Manifest().Templates has %d items, want 8", len(m.Templates))
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/microsoft/validation.go
+++ b/connectors/microsoft/validation.go
@@ -26,3 +26,34 @@ func detectContentType(body string) string {
 	}
 	return "Text"
 }
+
+// validatePathSegment checks that a value intended for use in a URL path segment
+// does not contain path traversal sequences or slash characters. This prevents
+// attackers from escaping the intended API path (e.g., using "../../admin" as
+// an item_id or table_name).
+func validatePathSegment(field, value string) error {
+	if strings.Contains(value, "..") || strings.Contains(value, "/") || strings.Contains(value, "\\") {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid %s: must not contain path separators or traversal sequences", field),
+		}
+	}
+	return nil
+}
+
+// validateValuesGrid checks that a 2D values array has consistent column counts
+// across all rows. Inconsistent dimensions cause cryptic Graph API errors, so
+// catching them early provides a better developer experience.
+func validateValuesGrid(values [][]any) error {
+	if len(values) == 0 {
+		return nil
+	}
+	cols := len(values[0])
+	for i, row := range values[1:] {
+		if len(row) != cols {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("values row %d has %d columns, but row 0 has %d — all rows must have the same number of columns", i+1, len(row), cols),
+			}
+		}
+	}
+	return nil
+}

--- a/connectors/microsoft/validation_test.go
+++ b/connectors/microsoft/validation_test.go
@@ -1,0 +1,66 @@
+package microsoft
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestValidatePathSegment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "valid id", value: "abc-123", wantErr: false},
+		{name: "valid guid", value: "{00000000-0000-0000-0000-000000000000}", wantErr: false},
+		{name: "dot-dot traversal", value: "../../admin", wantErr: true},
+		{name: "forward slash", value: "path/to/thing", wantErr: true},
+		{name: "backslash", value: "path\\to\\thing", wantErr: true},
+		{name: "embedded dot-dot", value: "ok..notok", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePathSegment("test_field", tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePathSegment(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}
+
+func TestValidateValuesGrid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		values  [][]any
+		wantErr bool
+	}{
+		{name: "empty", values: [][]any{}, wantErr: false},
+		{name: "single row", values: [][]any{{"a", "b"}}, wantErr: false},
+		{name: "consistent columns", values: [][]any{{"a", "b"}, {"c", "d"}}, wantErr: false},
+		{name: "inconsistent columns", values: [][]any{{"a", "b", "c"}, {"d", "e"}}, wantErr: true},
+		{name: "second row longer", values: [][]any{{"a"}, {"b", "c"}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateValuesGrid(tt.values)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateValuesGrid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds 4 Excel actions to the Microsoft connector: `excel_list_worksheets`, `excel_read_range`, `excel_write_range`, and `excel_append_rows`
- All actions use the Microsoft Graph API via the existing `doRequest` helper
- Adds `Files.ReadWrite` OAuth scope for OneDrive/Excel access
- Includes 4 templates for common Excel permission patterns

## Test plan
- [x] All 54 Microsoft connector tests pass (including 22 new Excel tests)
- [x] Microsoft connector package builds cleanly
- [ ] Verify manifest auto-seeds correctly on server startup
- [ ] Manual smoke test with a real Microsoft 365 account

Closes #244

https://claude.ai/code/session_01SftDKQEpqcQBEVKj7iZ5NJ