### PR TITLE
Add Google Drive actions to Google connector

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -1,6 +1,6 @@
 # Google Connector
 
-The Google connector integrates Permission Slip with [Gmail](https://developers.google.com/gmail/api) and [Google Calendar](https://developers.google.com/calendar/api) APIs. It uses plain `net/http` with OAuth 2.0 access tokens provided by the platform — no third-party Google SDK.
+The Google connector integrates Permission Slip with [Gmail](https://developers.google.com/gmail/api), [Google Calendar](https://developers.google.com/calendar/api), and [Google Drive](https://developers.google.com/drive/api) APIs. It uses plain `net/http` with OAuth 2.0 access tokens provided by the platform — no third-party Google SDK.
 
 ## Connector ID
 
@@ -21,8 +21,9 @@ The credential `auth_type` is `oauth2` with `oauth_provider` set to `google` (a 
 | `gmail.send` | `google.send_email` |
 | `gmail.readonly` | `google.list_emails` |
 | `calendar.events` | `google.create_calendar_event`, `google.list_calendar_events` |
+| `drive` | `google.list_drive_files`, `google.get_drive_file`, `google.upload_drive_file`, `google.delete_drive_file` |
 
-Scopes follow the principle of least privilege — `calendar.events` (event-level access) is used instead of the broader `calendar` scope (full calendar management).
+Scopes follow the principle of least privilege — `calendar.events` (event-level access) is used instead of the broader `calendar` scope (full calendar management). The `drive` scope grants full Drive access; a narrower scope like `drive.file` would only allow access to files created by this app, which is too restrictive for file browsing and reading.
 
 ## Actions
 
@@ -168,6 +169,153 @@ Lists upcoming events from Google Calendar.
 
 Events are returned as single instances (recurring events expanded) ordered by start time. All-day events use a date string (e.g., `2024-01-15`) instead of a full RFC 3339 timestamp.
 
+### `google.list_drive_files`
+
+Lists or searches files in Google Drive.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `query` | string | No | — | Google Drive search query (e.g., `name contains 'report'`) |
+| `max_results` | integer | No | `10` | Maximum number of files to return (1-100) |
+| `folder_id` | string | No | — | Folder ID to filter by (lists files within that folder) |
+| `order_by` | string | No | relevance | Sort order (e.g., `modifiedTime desc`, `name`) |
+
+**Response:**
+
+```json
+{
+  "files": [
+    {
+      "id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+      "name": "Q4 Report",
+      "mime_type": "application/vnd.google-apps.document",
+      "modified_time": "2024-01-15T10:00:00.000Z",
+      "size": "",
+      "web_view_link": "https://docs.google.com/document/d/1Bxi.../edit"
+    }
+  ],
+  "count": 1
+}
+```
+
+**Drive API:** `GET /drive/v3/files` ([docs](https://developers.google.com/drive/api/reference/rest/v3/files/list))
+
+Trashed files are automatically excluded. Google Workspace files (Docs, Sheets, Slides) have no `size` — they report an empty string.
+
+---
+
+### `google.get_drive_file`
+
+Gets file metadata and optionally downloads content from Google Drive.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `file_id` | string | Yes | — | The ID of the file to retrieve |
+| `include_content` | boolean | No | `false` | Whether to include file content |
+
+**Response (metadata only):**
+
+```json
+{
+  "id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+  "name": "Q4 Report",
+  "mime_type": "application/vnd.google-apps.document",
+  "modified_time": "2024-01-15T10:00:00.000Z",
+  "web_view_link": "https://docs.google.com/document/d/1Bxi.../edit"
+}
+```
+
+**Response (with content):**
+
+```json
+{
+  "id": "...",
+  "name": "Q4 Report",
+  "mime_type": "application/vnd.google-apps.document",
+  "content": "The full text content of the document..."
+}
+```
+
+**Drive API:** `GET /drive/v3/files/{id}` for metadata, `GET /drive/v3/files/{id}/export` for Workspace content, `GET /drive/v3/files/{id}?alt=media` for regular files ([docs](https://developers.google.com/drive/api/reference/rest/v3/files/get))
+
+**Content export behavior:**
+- **Google Docs** → exported as `text/plain`
+- **Google Sheets** → exported as `text/csv`
+- **Google Slides** → exported as `text/plain`
+- **Text files** (text/\*, application/json, etc.) → downloaded directly
+- **Binary files** (images, PDFs, etc.) → content skipped, `content_skipped_reason` field explains why
+
+---
+
+### `google.upload_drive_file`
+
+Creates and uploads a text file to Google Drive.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `name` | string | Yes | — | File name |
+| `content` | string | Yes | — | File content (text, max 4 MB) |
+| `mime_type` | string | No | `text/plain` | MIME type of the file |
+| `folder_id` | string | No | — | Parent folder ID |
+
+**Response:**
+
+```json
+{
+  "id": "1newFileId123",
+  "name": "report.txt",
+  "web_view_link": "https://drive.google.com/file/d/1newFileId123/view"
+}
+```
+
+**Drive API:** `POST /upload/drive/v3/files?uploadType=multipart` ([docs](https://developers.google.com/drive/api/guides/manage-uploads#multipart))
+
+Uses multipart upload with JSON metadata in the first part and file content in the second. Content is capped at 4 MB to prevent oversized payloads.
+
+---
+
+### `google.delete_drive_file`
+
+Moves a file to trash in Google Drive (soft delete — not permanent).
+
+**Risk level:** high
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `file_id` | string | Yes | The ID of the file to move to trash |
+
+**Response:**
+
+```json
+{
+  "id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+  "name": "old-report.txt",
+  "trashed": true
+}
+```
+
+**Drive API:** `PATCH /drive/v3/files/{id}` with `{trashed: true}` ([docs](https://developers.google.com/drive/api/reference/rest/v3/files/update))
+
+**Security notes:**
+- This is a **soft delete only** — files are moved to the Google Drive trash and can be recovered by the user. The permanent delete endpoint is intentionally not exposed.
+- File IDs are validated with an allowlist pattern (alphanumeric, hyphens, underscores) to prevent query injection and path traversal.
+
+---
+
 ## Error Handling
 
 The connector maps Google API HTTP status codes to typed connector errors:
@@ -195,34 +343,49 @@ The connector ships with constrained templates that demonstrate parameter lockin
 | Create calendar events | `create_calendar_event` | Nothing — agent controls all parameters |
 | Create personal calendar events | `create_calendar_event` | `calendar_id` locked to `primary`, no attendees |
 | List calendar events | `list_calendar_events` | Nothing — agent controls all parameters |
+| Browse Drive files | `list_drive_files` | Nothing — agent controls query, folder, and sort |
+| Read Drive files | `get_drive_file` | Nothing — agent can read metadata and content |
+| View Drive file metadata | `get_drive_file` | `include_content` locked to `false` (metadata only) |
+| Upload files to Drive | `upload_drive_file` | Nothing — agent controls name, content, and destination |
+| Upload files to specific folder | `upload_drive_file` | `folder_id` locked to a specific folder |
+| Trash Drive files | `delete_drive_file` | Nothing — agent can trash any file |
 
 ## Adding a New Action
 
 Each action lives in its own file. To add one (e.g., `google.delete_calendar_event`):
 
 1. Create `connectors/google/delete_calendar_event.go` with a params struct, `validate()`, and an `Execute` method.
-2. Use `a.conn.doJSON(ctx, creds, method, url, reqBody, &resp)` for the HTTP lifecycle — it handles JSON marshaling, Bearer auth, rate limiting, response size limits, and timeout detection.
-3. Use `checkResponse()` (called automatically by `doJSON`) to map HTTP errors to typed connector errors.
+2. Use `a.conn.doJSON(ctx, creds, method, url, reqBody, &resp)` for JSON API calls — it handles marshaling, Bearer auth, rate limiting, response size limits, and timeout detection. For non-JSON responses (e.g., file downloads), use `a.conn.doRawGet()`.
+3. Use `checkResponse()` (called automatically by `doJSON` and `doRawGet`) to map HTTP errors to typed connector errors. Use `wrapHTTPError()` when making custom HTTP requests (e.g., multipart upload).
 4. Return `connectors.JSONResult(respBody)` to wrap the response into an `ActionResult`.
-5. Register the action in `Actions()` inside `google.go`.
-6. Add the action to the `Manifest()` return value inside `google.go` with a `ParametersSchema`.
-7. Add tests in `delete_calendar_event_test.go` using `httptest.NewServer` and `newForTest()`.
+5. Validate user-provided IDs (file IDs, folder IDs) with `isValidDriveID()` to prevent injection attacks.
+6. Register the action in `Actions()` inside `google.go`.
+7. Add the action to the `Manifest()` return value inside `google.go` with a `ParametersSchema`.
+8. Add tests in `delete_calendar_event_test.go` using `httptest.NewServer` and `newForTest()` (or `newDriveForTest()` for Drive actions).
 
 ## File Structure
 
 ```
 connectors/google/
-├── google.go                       # GoogleConnector struct, New(), Manifest(), doJSON(), ValidateCredentials()
+├── google.go                       # GoogleConnector struct, New(), Manifest(), doJSON(), doRawGet(), wrapHTTPError(), ValidateCredentials()
 ├── send_email.go                   # google.send_email action
 ├── list_emails.go                  # google.list_emails action
 ├── create_calendar_event.go        # google.create_calendar_event action
 ├── list_calendar_events.go         # google.list_calendar_events action
+├── list_drive_files.go             # google.list_drive_files action + shared Drive ID validation
+├── get_drive_file.go               # google.get_drive_file action (metadata + content export)
+├── upload_drive_file.go            # google.upload_drive_file action (multipart upload)
+├── delete_drive_file.go            # google.delete_drive_file action (soft delete via trash)
 ├── google_test.go                  # Connector-level tests (ID, Actions, Manifest, ValidateCredentials)
 ├── helpers_test.go                 # Shared test helpers (validCreds)
 ├── send_email_test.go              # Send email action tests (including MIME injection, base64 encoding)
 ├── list_emails_test.go             # List emails action tests
 ├── create_calendar_event_test.go   # Create event tests (including time validation, URL encoding)
 ├── list_calendar_events_test.go    # List events action tests
+├── list_drive_files_test.go        # List Drive files tests (including query injection prevention)
+├── get_drive_file_test.go          # Get Drive file tests (metadata, content export, binary skip)
+├── upload_drive_file_test.go       # Upload tests (multipart, size limit, folder targeting)
+├── delete_drive_file_test.go       # Delete tests (soft delete, ID validation, rate limiting)
 └── README.md                       # This file
 ```
 

--- a/connectors/google/delete_drive_file.go
+++ b/connectors/google/delete_drive_file.go
@@ -25,8 +25,8 @@ func (p *deleteDriveFileParams) validate() error {
 	if p.FileID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: file_id"}
 	}
-	if containsPathSeparator(p.FileID) {
-		return &connectors.ValidationError{Message: "file_id contains invalid characters"}
+	if !isValidDriveID(p.FileID) {
+		return &connectors.ValidationError{Message: "file_id contains invalid characters; expected alphanumeric ID"}
 	}
 	return nil
 }

--- a/connectors/google/delete_drive_file.go
+++ b/connectors/google/delete_drive_file.go
@@ -1,0 +1,69 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// deleteDriveFileAction implements connectors.Action for google.delete_drive_file.
+// It moves a file to trash (soft delete) via PATCH /drive/v3/files/{id}.
+type deleteDriveFileAction struct {
+	conn *GoogleConnector
+}
+
+// deleteDriveFileParams is the user-facing parameter schema.
+type deleteDriveFileParams struct {
+	FileID string `json:"file_id"`
+}
+
+func (p *deleteDriveFileParams) validate() error {
+	if p.FileID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: file_id"}
+	}
+	if containsPathSeparator(p.FileID) {
+		return &connectors.ValidationError{Message: "file_id contains invalid characters"}
+	}
+	return nil
+}
+
+// driveTrashRequest is the request body to move a file to trash.
+type driveTrashRequest struct {
+	Trashed bool `json:"trashed"`
+}
+
+// driveTrashResponse is the Google Drive API response after trashing.
+type driveTrashResponse struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Trashed bool   `json:"trashed"`
+}
+
+// Execute moves a file to trash in Google Drive.
+func (a *deleteDriveFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params deleteDriveFileParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := driveTrashRequest{Trashed: true}
+	var resp driveTrashResponse
+
+	patchURL := a.conn.driveBaseURL + "/drive/v3/files/" + url.PathEscape(params.FileID) + "?fields=id,name,trashed"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPatch, patchURL, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"id":      resp.ID,
+		"name":    resp.Name,
+		"trashed": resp.Trashed,
+	})
+}

--- a/connectors/google/delete_drive_file_test.go
+++ b/connectors/google/delete_drive_file_test.go
@@ -1,0 +1,184 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestDeleteDriveFile_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/drive/v3/files/file-to-delete" {
+			t.Errorf("expected path /drive/v3/files/file-to-delete, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		var body driveTrashRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if !body.Trashed {
+			t.Error("expected trashed=true in request body")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveTrashResponse{
+			ID:      "file-to-delete",
+			Name:    "old-report.txt",
+			Trashed: true,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{FileID: "file-to-delete"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "file-to-delete" {
+		t.Errorf("expected id 'file-to-delete', got %v", data["id"])
+	}
+	if data["trashed"] != true {
+		t.Errorf("expected trashed=true, got %v", data["trashed"])
+	}
+}
+
+func TestDeleteDriveFile_MissingFileID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing file_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_InvalidFileID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{FileID: "file/../../etc"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid file_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 403, "message": "Insufficient permissions"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{FileID: "file-abc"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{FileID: "file-abc"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteDriveFileAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.delete_drive_file",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/delete_drive_file_test.go
+++ b/connectors/google/delete_drive_file_test.go
@@ -93,18 +93,24 @@ func TestDeleteDriveFile_InvalidFileID(t *testing.T) {
 	conn := New()
 	action := &deleteDriveFileAction{conn: conn}
 
-	params, _ := json.Marshal(deleteDriveFileParams{FileID: "file/../../etc"})
-
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
-		ActionType:  "google.delete_drive_file",
-		Parameters:  params,
-		Credentials: validCreds(),
-	})
-	if err == nil {
-		t.Fatal("expected error for invalid file_id")
+	invalidIDs := []string{
+		"file/../../etc",    // path traversal
+		"file id spaces",    // spaces
+		"file'injection",    // quote
 	}
-	if !connectors.IsValidationError(err) {
-		t.Errorf("expected ValidationError, got: %T", err)
+	for _, id := range invalidIDs {
+		params, _ := json.Marshal(deleteDriveFileParams{FileID: id})
+		_, err := action.Execute(t.Context(), connectors.ActionRequest{
+			ActionType:  "google.delete_drive_file",
+			Parameters:  params,
+			Credentials: validCreds(),
+		})
+		if err == nil {
+			t.Fatalf("expected error for invalid file_id %q", id)
+		}
+		if !connectors.IsValidationError(err) {
+			t.Errorf("expected ValidationError for %q, got: %T", id, err)
+		}
 	}
 }
 

--- a/connectors/google/get_drive_file.go
+++ b/connectors/google/get_drive_file.go
@@ -29,8 +29,8 @@ func (p *getDriveFileParams) validate() error {
 	if p.FileID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: file_id"}
 	}
-	if containsPathSeparator(p.FileID) {
-		return &connectors.ValidationError{Message: "file_id contains invalid characters"}
+	if !isValidDriveID(p.FileID) {
+		return &connectors.ValidationError{Message: "file_id contains invalid characters; expected alphanumeric ID"}
 	}
 	return nil
 }

--- a/connectors/google/get_drive_file.go
+++ b/connectors/google/get_drive_file.go
@@ -47,13 +47,14 @@ type driveFileMetadata struct {
 
 // driveFileResult is the shape returned to the agent.
 type driveFileResult struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	MimeType     string `json:"mime_type"`
-	ModifiedTime string `json:"modified_time,omitempty"`
-	Size         string `json:"size,omitempty"`
-	WebViewLink  string `json:"web_view_link,omitempty"`
-	Content      string `json:"content,omitempty"`
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	MimeType             string `json:"mime_type"`
+	ModifiedTime         string `json:"modified_time,omitempty"`
+	Size                 string `json:"size,omitempty"`
+	WebViewLink          string `json:"web_view_link,omitempty"`
+	Content              string `json:"content,omitempty"`
+	ContentSkippedReason string `json:"content_skipped_reason,omitempty"`
 }
 
 // googleWorkspaceMimeTypes maps Google Workspace MIME types to their
@@ -108,8 +109,10 @@ func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionR
 				return nil, err
 			}
 			result.Content = content
+		} else {
+			// Binary files can't be exported as text.
+			result.ContentSkippedReason = "binary file type — content export is only supported for text files and Google Workspace documents"
 		}
-		// Binary files are silently skipped — no content field set.
 	}
 
 	return connectors.JSONResult(result)

--- a/connectors/google/get_drive_file.go
+++ b/connectors/google/get_drive_file.go
@@ -1,0 +1,175 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getDriveFileAction implements connectors.Action for google.get_drive_file.
+// It retrieves file metadata and optionally exports content for Google Workspace files.
+type getDriveFileAction struct {
+	conn *GoogleConnector
+}
+
+// getDriveFileParams is the user-facing parameter schema.
+type getDriveFileParams struct {
+	FileID         string `json:"file_id"`
+	IncludeContent bool   `json:"include_content"`
+}
+
+func (p *getDriveFileParams) validate() error {
+	if p.FileID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: file_id"}
+	}
+	if containsPathSeparator(p.FileID) {
+		return &connectors.ValidationError{Message: "file_id contains invalid characters"}
+	}
+	return nil
+}
+
+// driveFileMetadata is the Google Drive API response from files.get.
+type driveFileMetadata struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	MimeType     string `json:"mimeType"`
+	ModifiedTime string `json:"modifiedTime"`
+	Size         string `json:"size"`
+	WebViewLink  string `json:"webViewLink"`
+}
+
+// driveFileResult is the shape returned to the agent.
+type driveFileResult struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	MimeType     string `json:"mime_type"`
+	ModifiedTime string `json:"modified_time,omitempty"`
+	Size         string `json:"size,omitempty"`
+	WebViewLink  string `json:"web_view_link,omitempty"`
+	Content      string `json:"content,omitempty"`
+}
+
+// googleWorkspaceMimeTypes maps Google Workspace MIME types to their
+// text export MIME types. Only these types support content export.
+var googleWorkspaceMimeTypes = map[string]string{
+	"application/vnd.google-apps.document":     "text/plain",
+	"application/vnd.google-apps.spreadsheet":  "text/csv",
+	"application/vnd.google-apps.presentation": "text/plain",
+}
+
+// Execute retrieves file metadata and optionally exports content.
+func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getDriveFileParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// Step 1: fetch file metadata.
+	fields := "id,name,mimeType,modifiedTime,size,webViewLink"
+	metaURL := a.conn.driveBaseURL + "/drive/v3/files/" + url.PathEscape(params.FileID) + "?fields=" + url.QueryEscape(fields)
+
+	var meta driveFileMetadata
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, metaURL, nil, &meta); err != nil {
+		return nil, err
+	}
+
+	result := driveFileResult{
+		ID:           meta.ID,
+		Name:         meta.Name,
+		MimeType:     meta.MimeType,
+		ModifiedTime: meta.ModifiedTime,
+		Size:         meta.Size,
+		WebViewLink:  meta.WebViewLink,
+	}
+
+	// Step 2: optionally export content for Google Workspace files.
+	if params.IncludeContent {
+		exportMime, isWorkspace := googleWorkspaceMimeTypes[meta.MimeType]
+		if isWorkspace {
+			content, err := a.exportContent(ctx, req.Credentials, params.FileID, exportMime)
+			if err != nil {
+				return nil, err
+			}
+			result.Content = content
+		} else if isTextMimeType(meta.MimeType) {
+			// For regular text files, download content directly.
+			content, err := a.downloadContent(ctx, req.Credentials, params.FileID)
+			if err != nil {
+				return nil, err
+			}
+			result.Content = content
+		}
+		// Binary files are silently skipped — no content field set.
+	}
+
+	return connectors.JSONResult(result)
+}
+
+// exportContent exports a Google Workspace file as text.
+func (a *getDriveFileAction) exportContent(ctx context.Context, creds connectors.Credentials, fileID, exportMime string) (string, error) {
+	exportURL := a.conn.driveBaseURL + "/drive/v3/files/" + url.PathEscape(fileID) + "/export?mimeType=" + url.QueryEscape(exportMime)
+	return a.conn.doRawGet(ctx, creds, exportURL)
+}
+
+// downloadContent downloads a non-Google-Workspace file's content.
+func (a *getDriveFileAction) downloadContent(ctx context.Context, creds connectors.Credentials, fileID string) (string, error) {
+	downloadURL := a.conn.driveBaseURL + "/drive/v3/files/" + url.PathEscape(fileID) + "?alt=media"
+	return a.conn.doRawGet(ctx, creds, downloadURL)
+}
+
+// isTextMimeType returns true if the MIME type represents a text-based file
+// that can be safely downloaded and returned as a string.
+func isTextMimeType(mimeType string) bool {
+	return strings.HasPrefix(mimeType, "text/") ||
+		mimeType == "application/json" ||
+		mimeType == "application/xml" ||
+		mimeType == "application/javascript"
+}
+
+// doRawGet performs a GET request and returns the response body as a string.
+// Used for Drive file export/download endpoints that return non-JSON content.
+func (c *GoogleConnector) doRawGet(ctx context.Context, creds connectors.Credentials, rawURL string) (string, error) {
+	token, ok := creds.Get(credKeyAccessToken)
+	if !ok || token == "" {
+		return "", &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return "", &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return "", &connectors.TimeoutError{Message: "Google API request canceled"}
+		}
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, body); err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/connectors/google/get_drive_file.go
+++ b/connectors/google/get_drive_file.go
@@ -33,16 +33,6 @@ func (p *getDriveFileParams) validate() error {
 	return nil
 }
 
-// driveFileMetadata is the Google Drive API response from files.get.
-type driveFileMetadata struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	MimeType     string `json:"mimeType"`
-	ModifiedTime string `json:"modifiedTime"`
-	Size         string `json:"size"`
-	WebViewLink  string `json:"webViewLink"`
-}
-
 // driveFileResult is the shape returned to the agent.
 type driveFileResult struct {
 	ID                   string `json:"id"`
@@ -77,7 +67,7 @@ func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionR
 	fields := "id,name,mimeType,modifiedTime,size,webViewLink"
 	metaURL := a.conn.driveBaseURL + "/drive/v3/files/" + url.PathEscape(params.FileID) + "?fields=" + url.QueryEscape(fields)
 
-	var meta driveFileMetadata
+	var meta driveFileEntry
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, metaURL, nil, &meta); err != nil {
 		return nil, err
 	}

--- a/connectors/google/get_drive_file.go
+++ b/connectors/google/get_drive_file.go
@@ -3,9 +3,7 @@ package google
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -139,40 +137,3 @@ func isTextMimeType(mimeType string) bool {
 		mimeType == "application/javascript"
 }
 
-// doRawGet performs a GET request and returns the response body as a string.
-// Used for Drive file export/download endpoints that return non-JSON content.
-func (c *GoogleConnector) doRawGet(ctx context.Context, creds connectors.Credentials, rawURL string) (string, error) {
-	token, ok := creds.Get(credKeyAccessToken)
-	if !ok || token == "" {
-		return "", &connectors.ValidationError{Message: "access_token credential is missing or empty"}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return "", &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return "", &connectors.TimeoutError{Message: "Google API request canceled"}
-		}
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-	if err != nil {
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if err := checkResponse(resp.StatusCode, resp.Header, body); err != nil {
-		return "", err
-	}
-
-	return string(body), nil
-}

--- a/connectors/google/get_drive_file_test.go
+++ b/connectors/google/get_drive_file_test.go
@@ -283,6 +283,33 @@ func TestGetDriveFile_AuthFailure(t *testing.T) {
 	}
 }
 
+func TestGetDriveFile_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "file-abc"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
 func TestGetDriveFile_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/get_drive_file_test.go
+++ b/connectors/google/get_drive_file_test.go
@@ -21,7 +21,7 @@ func TestGetDriveFile_MetadataOnly(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(driveFileMetadata{
+		json.NewEncoder(w).Encode(driveFileEntry{
 			ID:           "file-abc",
 			Name:         "report.docx",
 			MimeType:     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -69,7 +69,7 @@ func TestGetDriveFile_WithGoogleDocsContent(t *testing.T) {
 		case "/drive/v3/files/doc-123":
 			// Metadata request.
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(driveFileMetadata{
+			json.NewEncoder(w).Encode(driveFileEntry{
 				ID:       "doc-123",
 				Name:     "My Document",
 				MimeType: "application/vnd.google-apps.document",
@@ -124,7 +124,7 @@ func TestGetDriveFile_WithTextFileContent(t *testing.T) {
 		case r.URL.Path == "/drive/v3/files/txt-456":
 			// Metadata request.
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(driveFileMetadata{
+			json.NewEncoder(w).Encode(driveFileEntry{
 				ID:       "txt-456",
 				Name:     "notes.txt",
 				MimeType: "text/plain",
@@ -170,7 +170,7 @@ func TestGetDriveFile_BinaryFileNoContent(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(driveFileMetadata{
+		json.NewEncoder(w).Encode(driveFileEntry{
 			ID:       "img-789",
 			Name:     "photo.png",
 			MimeType: "image/png",

--- a/connectors/google/get_drive_file_test.go
+++ b/connectors/google/get_drive_file_test.go
@@ -1,0 +1,293 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetDriveFile_MetadataOnly(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/drive/v3/files/file-abc" {
+			t.Errorf("expected path /drive/v3/files/file-abc, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveFileMetadata{
+			ID:           "file-abc",
+			Name:         "report.docx",
+			MimeType:     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+			ModifiedTime: "2024-01-15T10:00:00Z",
+			Size:         "12345",
+			WebViewLink:  "https://drive.google.com/file/d/file-abc/view",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "file-abc"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data driveFileResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.ID != "file-abc" {
+		t.Errorf("expected id 'file-abc', got %q", data.ID)
+	}
+	if data.Name != "report.docx" {
+		t.Errorf("expected name 'report.docx', got %q", data.Name)
+	}
+	if data.Content != "" {
+		t.Error("expected empty content for metadata-only request")
+	}
+}
+
+func TestGetDriveFile_WithGoogleDocsContent(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/drive/v3/files/doc-123":
+			// Metadata request.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(driveFileMetadata{
+				ID:       "doc-123",
+				Name:     "My Document",
+				MimeType: "application/vnd.google-apps.document",
+			})
+		case "/drive/v3/files/doc-123/export":
+			// Export request.
+			mimeType := r.URL.Query().Get("mimeType")
+			if mimeType != "text/plain" {
+				t.Errorf("expected export mimeType text/plain, got %q", mimeType)
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("Hello, this is the document content."))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "doc-123", IncludeContent: true})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data driveFileResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Content != "Hello, this is the document content." {
+		t.Errorf("unexpected content: %q", data.Content)
+	}
+}
+
+func TestGetDriveFile_WithTextFileContent(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/drive/v3/files/txt-456" && r.URL.Query().Get("alt") == "media":
+			// Download request.
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("Plain text file content."))
+		case r.URL.Path == "/drive/v3/files/txt-456":
+			// Metadata request.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(driveFileMetadata{
+				ID:       "txt-456",
+				Name:     "notes.txt",
+				MimeType: "text/plain",
+				Size:     "24",
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "txt-456", IncludeContent: true})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data driveFileResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Content != "Plain text file content." {
+		t.Errorf("unexpected content: %q", data.Content)
+	}
+}
+
+func TestGetDriveFile_BinaryFileNoContent(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/drive/v3/files/img-789" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveFileMetadata{
+			ID:       "img-789",
+			Name:     "photo.png",
+			MimeType: "image/png",
+			Size:     "1048576",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "img-789", IncludeContent: true})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data driveFileResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Content != "" {
+		t.Error("expected empty content for binary file")
+	}
+}
+
+func TestGetDriveFile_MissingFileID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing file_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_InvalidFileID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "../../etc/passwd"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid file_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 403, "message": "Insufficient permissions"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{FileID: "file-abc"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDriveFileAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_drive_file",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/get_drive_file_test.go
+++ b/connectors/google/get_drive_file_test.go
@@ -232,18 +232,25 @@ func TestGetDriveFile_InvalidFileID(t *testing.T) {
 	conn := New()
 	action := &getDriveFileAction{conn: conn}
 
-	params, _ := json.Marshal(getDriveFileParams{FileID: "../../etc/passwd"})
-
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
-		ActionType:  "google.get_drive_file",
-		Parameters:  params,
-		Credentials: validCreds(),
-	})
-	if err == nil {
-		t.Fatal("expected error for invalid file_id")
+	invalidIDs := []string{
+		"../../etc/passwd",               // path traversal
+		"file id with spaces",            // spaces
+		"file'--injection",               // quote injection
+		"<script>alert('xss')</script>",  // special characters
 	}
-	if !connectors.IsValidationError(err) {
-		t.Errorf("expected ValidationError, got: %T", err)
+	for _, id := range invalidIDs {
+		params, _ := json.Marshal(getDriveFileParams{FileID: id})
+		_, err := action.Execute(t.Context(), connectors.ActionRequest{
+			ActionType:  "google.get_drive_file",
+			Parameters:  params,
+			Credentials: validCreds(),
+		})
+		if err == nil {
+			t.Fatalf("expected error for invalid file_id %q", id)
+		}
+		if !connectors.IsValidationError(err) {
+			t.Errorf("expected ValidationError for %q, got: %T", id, err)
+		}
 	}
 }
 

--- a/connectors/google/get_drive_file_test.go
+++ b/connectors/google/get_drive_file_test.go
@@ -200,6 +200,9 @@ func TestGetDriveFile_BinaryFileNoContent(t *testing.T) {
 	if data.Content != "" {
 		t.Error("expected empty content for binary file")
 	}
+	if data.ContentSkippedReason == "" {
+		t.Error("expected content_skipped_reason for binary file with include_content=true")
+	}
 }
 
 func TestGetDriveFile_MissingFileID(t *testing.T) {

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -457,13 +457,7 @@ func (c *GoogleConnector) doJSON(ctx context.Context, creds connectors.Credentia
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Google API request canceled"}
-		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
+		return wrapHTTPError(err)
 	}
 	defer resp.Body.Close()
 
@@ -486,6 +480,51 @@ func (c *GoogleConnector) doJSON(ctx context.Context, creds connectors.Credentia
 	}
 
 	return nil
+}
+
+// doRawGet performs a GET request and returns the response body as a string.
+// Used for Drive file export/download endpoints that return non-JSON content.
+func (c *GoogleConnector) doRawGet(ctx context.Context, creds connectors.Credentials, rawURL string) (string, error) {
+	token, ok := creds.Get(credKeyAccessToken)
+	if !ok || token == "" {
+		return "", &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", wrapHTTPError(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, body); err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// wrapHTTPError converts HTTP client errors into typed connector errors.
+// This centralizes the timeout/cancel/external error mapping so it doesn't
+// need to be duplicated across doJSON, doRawGet, and multipart upload.
+func wrapHTTPError(err error) error {
+	if connectors.IsTimeout(err) {
+		return &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
+	}
+	if errors.Is(err, context.Canceled) {
+		return &connectors.TimeoutError{Message: "Google API request canceled"}
+	}
+	return &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
 }
 
 // checkResponse maps HTTP status codes to typed connector errors.

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -19,6 +19,7 @@ import (
 const (
 	defaultGmailBaseURL    = "https://gmail.googleapis.com"
 	defaultCalendarBaseURL = "https://www.googleapis.com/calendar/v3"
+	defaultDriveBaseURL    = "https://www.googleapis.com"
 	defaultTimeout         = 30 * time.Second
 	credKeyAccessToken     = "access_token"
 
@@ -38,6 +39,7 @@ type GoogleConnector struct {
 	client          *http.Client
 	gmailBaseURL    string
 	calendarBaseURL string
+	driveBaseURL    string
 }
 
 // New creates a GoogleConnector with sensible defaults.
@@ -46,6 +48,7 @@ func New() *GoogleConnector {
 		client:          &http.Client{Timeout: defaultTimeout},
 		gmailBaseURL:    defaultGmailBaseURL,
 		calendarBaseURL: defaultCalendarBaseURL,
+		driveBaseURL:    defaultDriveBaseURL,
 	}
 }
 
@@ -55,6 +58,15 @@ func newForTest(client *http.Client, gmailBaseURL, calendarBaseURL string) *Goog
 		client:          client,
 		gmailBaseURL:    gmailBaseURL,
 		calendarBaseURL: calendarBaseURL,
+		driveBaseURL:    gmailBaseURL, // reuse the test server URL
+	}
+}
+
+// newDriveForTest creates a GoogleConnector with only driveBaseURL set, for Drive action tests.
+func newDriveForTest(client *http.Client, driveBaseURL string) *GoogleConnector {
+	return &GoogleConnector{
+		client:       client,
+		driveBaseURL: driveBaseURL,
 	}
 }
 
@@ -67,7 +79,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "google",
 		Name:        "Google",
-		Description: "Google integration for Gmail and Calendar",
+		Description: "Google integration for Gmail, Calendar, and Drive",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "google.send_email",
@@ -184,6 +196,98 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "google.list_drive_files",
+				Name:        "List Drive Files",
+				Description: "List or search files in Google Drive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string",
+							"description": "Google Drive search query (e.g. \"name contains 'report'\")"
+						},
+						"max_results": {
+							"type": "integer",
+							"default": 10,
+							"minimum": 1,
+							"maximum": 100,
+							"description": "Maximum number of files to return (1-100, default 10)"
+						},
+						"folder_id": {
+							"type": "string",
+							"description": "Folder ID to list files from (defaults to all accessible files)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.get_drive_file",
+				Name:        "Get Drive File",
+				Description: "Get file metadata and optionally download content from Google Drive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["file_id"],
+					"properties": {
+						"file_id": {
+							"type": "string",
+							"description": "The ID of the file to retrieve"
+						},
+						"include_content": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to include file content (exports Google Docs/Sheets/Slides as plain text)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.upload_drive_file",
+				Name:        "Upload Drive File",
+				Description: "Create and upload a text file to Google Drive",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["name", "content"],
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "File name"
+						},
+						"content": {
+							"type": "string",
+							"description": "File content (text)"
+						},
+						"mime_type": {
+							"type": "string",
+							"default": "text/plain",
+							"description": "MIME type of the file (default: text/plain)"
+						},
+						"folder_id": {
+							"type": "string",
+							"description": "Parent folder ID (optional)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.delete_drive_file",
+				Name:        "Delete Drive File",
+				Description: "Move a file to trash in Google Drive (soft delete)",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["file_id"],
+					"properties": {
+						"file_id": {
+							"type": "string",
+							"description": "The ID of the file to move to trash"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -194,6 +298,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					"https://www.googleapis.com/auth/gmail.send",
 					"https://www.googleapis.com/auth/gmail.readonly",
 					"https://www.googleapis.com/auth/calendar.events",
+					"https://www.googleapis.com/auth/drive",
 				},
 			},
 		},
@@ -247,6 +352,48 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can list upcoming events from any calendar.",
 				Parameters:  json.RawMessage(`{"calendar_id":"*","max_results":"*","time_min":"*","time_max":"*"}`),
 			},
+			{
+				ID:          "tpl_google_list_drive_files",
+				ActionType:  "google.list_drive_files",
+				Name:        "Browse Drive files",
+				Description: "Agent can list and search files in Google Drive.",
+				Parameters:  json.RawMessage(`{"query":"*","max_results":"*","folder_id":"*"}`),
+			},
+			{
+				ID:          "tpl_google_get_drive_file",
+				ActionType:  "google.get_drive_file",
+				Name:        "Read Drive files",
+				Description: "Agent can read file metadata and content from Google Drive.",
+				Parameters:  json.RawMessage(`{"file_id":"*","include_content":"*"}`),
+			},
+			{
+				ID:          "tpl_google_get_drive_file_metadata",
+				ActionType:  "google.get_drive_file",
+				Name:        "View Drive file metadata",
+				Description: "Agent can view file metadata only (no content download).",
+				Parameters:  json.RawMessage(`{"file_id":"*","include_content":"false"}`),
+			},
+			{
+				ID:          "tpl_google_upload_drive_file",
+				ActionType:  "google.upload_drive_file",
+				Name:        "Upload files to Drive",
+				Description: "Agent can upload text files to Google Drive.",
+				Parameters:  json.RawMessage(`{"name":"*","content":"*","mime_type":"*","folder_id":"*"}`),
+			},
+			{
+				ID:          "tpl_google_upload_drive_file_to_folder",
+				ActionType:  "google.upload_drive_file",
+				Name:        "Upload files to specific folder",
+				Description: "Agent can upload text files to a specific locked folder in Google Drive.",
+				Parameters:  json.RawMessage(`{"name":"*","content":"*","mime_type":"*","folder_id":"folder-id-here"}`),
+			},
+			{
+				ID:          "tpl_google_delete_drive_file",
+				ActionType:  "google.delete_drive_file",
+				Name:        "Trash Drive files",
+				Description: "Agent can move files to trash in Google Drive.",
+				Parameters:  json.RawMessage(`{"file_id":"*"}`),
+			},
 		},
 	}
 }
@@ -258,6 +405,10 @@ func (c *GoogleConnector) Actions() map[string]connectors.Action {
 		"google.list_emails":           &listEmailsAction{conn: c},
 		"google.create_calendar_event": &createCalendarEventAction{conn: c},
 		"google.list_calendar_events":  &listCalendarEventsAction{conn: c},
+		"google.list_drive_files":      &listDriveFilesAction{conn: c},
+		"google.get_drive_file":        &getDriveFileAction{conn: c},
+		"google.upload_drive_file":     &uploadDriveFileAction{conn: c},
+		"google.delete_drive_file":     &deleteDriveFileAction{conn: c},
 	}
 }
 

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -218,6 +218,10 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"folder_id": {
 							"type": "string",
 							"description": "Folder ID to list files from (defaults to all accessible files)"
+						},
+						"order_by": {
+							"type": "string",
+							"description": "Sort order (e.g. 'modifiedTime desc', 'name'). Defaults to Drive's relevance ordering."
 						}
 					}
 				}`)),
@@ -357,7 +361,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "google.list_drive_files",
 				Name:        "Browse Drive files",
 				Description: "Agent can list and search files in Google Drive.",
-				Parameters:  json.RawMessage(`{"query":"*","max_results":"*","folder_id":"*"}`),
+				Parameters:  json.RawMessage(`{"query":"*","max_results":"*","folder_id":"*","order_by":"*"}`),
 			},
 			{
 				ID:          "tpl_google_get_drive_file",

--- a/connectors/google/google_test.go
+++ b/connectors/google/google_test.go
@@ -24,6 +24,10 @@ func TestGoogleConnector_Actions(t *testing.T) {
 		"google.list_emails",
 		"google.create_calendar_event",
 		"google.list_calendar_events",
+		"google.list_drive_files",
+		"google.get_drive_file",
+		"google.upload_drive_file",
+		"google.delete_drive_file",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -91,8 +95,8 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 	if m.Name != "Google" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Google")
 	}
-	if len(m.Actions) != 4 {
-		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	if len(m.Actions) != 8 {
+		t.Fatalf("Manifest().Actions has %d items, want 8", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -103,6 +107,10 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 		"google.list_emails",
 		"google.create_calendar_event",
 		"google.list_calendar_events",
+		"google.list_drive_files",
+		"google.get_drive_file",
+		"google.upload_drive_file",
+		"google.delete_drive_file",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)

--- a/connectors/google/list_drive_files.go
+++ b/connectors/google/list_drive_files.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -44,8 +45,8 @@ var validOrderByValues = map[string]bool{
 }
 
 func (p *listDriveFilesParams) validate() error {
-	if p.FolderID != "" && containsPathSeparator(p.FolderID) {
-		return &connectors.ValidationError{Message: "folder_id contains invalid characters"}
+	if p.FolderID != "" && !isValidDriveID(p.FolderID) {
+		return &connectors.ValidationError{Message: "folder_id contains invalid characters; expected alphanumeric ID"}
 	}
 	if !validOrderByValues[p.OrderBy] {
 		return &connectors.ValidationError{Message: "invalid order_by value; valid options: modifiedTime, modifiedTime desc, name, name desc, createdTime, createdTime desc, folder, recency, viewedByMeTime, viewedByMeTime desc, sharedWithMeTime, sharedWithMeTime desc"}
@@ -62,10 +63,14 @@ func (p *listDriveFilesParams) normalize() {
 	}
 }
 
-// containsPathSeparator returns true if s contains path separators or
-// other characters that should not appear in a Google Drive file ID.
-func containsPathSeparator(s string) bool {
-	return strings.ContainsAny(s, "/\\")
+// driveIDPattern matches valid Google Drive file/folder IDs.
+// Drive IDs are alphanumeric strings with hyphens and underscores, typically
+// 20-60 characters. This rejects injection attempts (quotes, slashes, spaces).
+var driveIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// isValidDriveID returns true if s looks like a valid Google Drive file or folder ID.
+func isValidDriveID(s string) bool {
+	return driveIDPattern.MatchString(s)
 }
 
 // driveListResponse is the Google Drive API response from files.list.

--- a/connectors/google/list_drive_files.go
+++ b/connectors/google/list_drive_files.go
@@ -23,11 +23,32 @@ type listDriveFilesParams struct {
 	Query      string `json:"query"`
 	MaxResults int    `json:"max_results"`
 	FolderID   string `json:"folder_id"`
+	OrderBy    string `json:"order_by"`
+}
+
+// validOrderByValues lists the allowed order_by values for Drive files.list.
+var validOrderByValues = map[string]bool{
+	"":                     true,
+	"modifiedTime":         true,
+	"modifiedTime desc":    true,
+	"name":                 true,
+	"name desc":            true,
+	"createdTime":          true,
+	"createdTime desc":     true,
+	"folder":               true,
+	"recency":              true,
+	"viewedByMeTime":       true,
+	"viewedByMeTime desc":  true,
+	"sharedWithMeTime":     true,
+	"sharedWithMeTime desc": true,
 }
 
 func (p *listDriveFilesParams) validate() error {
 	if p.FolderID != "" && containsPathSeparator(p.FolderID) {
 		return &connectors.ValidationError{Message: "folder_id contains invalid characters"}
+	}
+	if !validOrderByValues[p.OrderBy] {
+		return &connectors.ValidationError{Message: "invalid order_by value; valid options: modifiedTime, modifiedTime desc, name, name desc, createdTime, createdTime desc, folder, recency, viewedByMeTime, viewedByMeTime desc, sharedWithMeTime, sharedWithMeTime desc"}
 	}
 	return nil
 }
@@ -59,6 +80,7 @@ type driveFileEntry struct {
 	MimeType     string `json:"mimeType"`
 	ModifiedTime string `json:"modifiedTime"`
 	Size         string `json:"size"`
+	WebViewLink  string `json:"webViewLink"`
 }
 
 // driveFileSummary is the shape returned to the agent for file listings (snake_case).
@@ -68,6 +90,7 @@ type driveFileSummary struct {
 	MimeType     string `json:"mime_type"`
 	ModifiedTime string `json:"modified_time,omitempty"`
 	Size         string `json:"size,omitempty"`
+	WebViewLink  string `json:"web_view_link,omitempty"`
 }
 
 // Execute lists files from Google Drive and returns their metadata.
@@ -83,7 +106,11 @@ func (a *listDriveFilesAction) Execute(ctx context.Context, req connectors.Actio
 
 	q := url.Values{}
 	q.Set("pageSize", strconv.Itoa(params.MaxResults))
-	q.Set("fields", "files(id,name,mimeType,modifiedTime,size)")
+	q.Set("fields", "files(id,name,mimeType,modifiedTime,size,webViewLink)")
+
+	if params.OrderBy != "" {
+		q.Set("orderBy", params.OrderBy)
+	}
 
 	// Build the search query.
 	var queryParts []string
@@ -111,6 +138,7 @@ func (a *listDriveFilesAction) Execute(ctx context.Context, req connectors.Actio
 			MimeType:     f.MimeType,
 			ModifiedTime: f.ModifiedTime,
 			Size:         f.Size,
+			WebViewLink:  f.WebViewLink,
 		}
 	}
 

--- a/connectors/google/list_drive_files.go
+++ b/connectors/google/list_drive_files.go
@@ -1,0 +1,121 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listDriveFilesAction implements connectors.Action for google.list_drive_files.
+// It lists files via the Google Drive API GET /drive/v3/files.
+type listDriveFilesAction struct {
+	conn *GoogleConnector
+}
+
+// listDriveFilesParams is the user-facing parameter schema.
+type listDriveFilesParams struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+	FolderID   string `json:"folder_id"`
+}
+
+func (p *listDriveFilesParams) validate() error {
+	if p.FolderID != "" && containsPathSeparator(p.FolderID) {
+		return &connectors.ValidationError{Message: "folder_id contains invalid characters"}
+	}
+	return nil
+}
+
+func (p *listDriveFilesParams) normalize() {
+	if p.MaxResults <= 0 {
+		p.MaxResults = 10
+	}
+	if p.MaxResults > 100 {
+		p.MaxResults = 100
+	}
+}
+
+// containsPathSeparator returns true if s contains path separators or
+// other characters that should not appear in a Google Drive file ID.
+func containsPathSeparator(s string) bool {
+	return strings.ContainsAny(s, "/\\")
+}
+
+// driveListResponse is the Google Drive API response from files.list.
+type driveListResponse struct {
+	Files []driveFileEntry `json:"files"`
+}
+
+// driveFileEntry is a single file entry from the Google Drive API (camelCase fields).
+type driveFileEntry struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	MimeType     string `json:"mimeType"`
+	ModifiedTime string `json:"modifiedTime"`
+	Size         string `json:"size"`
+}
+
+// driveFileSummary is the shape returned to the agent for file listings (snake_case).
+type driveFileSummary struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	MimeType     string `json:"mime_type"`
+	ModifiedTime string `json:"modified_time,omitempty"`
+	Size         string `json:"size,omitempty"`
+}
+
+// Execute lists files from Google Drive and returns their metadata.
+func (a *listDriveFilesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listDriveFilesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.normalize()
+
+	q := url.Values{}
+	q.Set("pageSize", strconv.Itoa(params.MaxResults))
+	q.Set("fields", "files(id,name,mimeType,modifiedTime,size)")
+
+	// Build the search query.
+	var queryParts []string
+	if params.Query != "" {
+		queryParts = append(queryParts, params.Query)
+	}
+	if params.FolderID != "" {
+		queryParts = append(queryParts, fmt.Sprintf("'%s' in parents", params.FolderID))
+	}
+	// Exclude trashed files by default.
+	queryParts = append(queryParts, "trashed = false")
+	q.Set("q", strings.Join(queryParts, " and "))
+
+	var listResp driveListResponse
+	listURL := a.conn.driveBaseURL + "/drive/v3/files?" + q.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, listURL, nil, &listResp); err != nil {
+		return nil, err
+	}
+
+	summaries := make([]driveFileSummary, len(listResp.Files))
+	for i, f := range listResp.Files {
+		summaries[i] = driveFileSummary{
+			ID:           f.ID,
+			Name:         f.Name,
+			MimeType:     f.MimeType,
+			ModifiedTime: f.ModifiedTime,
+			Size:         f.Size,
+		}
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"files": summaries,
+		"count": len(summaries),
+	})
+}

--- a/connectors/google/list_drive_files_test.go
+++ b/connectors/google/list_drive_files_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -109,7 +110,7 @@ func TestListDriveFiles_WithFolderID(t *testing.T) {
 			t.Error("expected non-empty q parameter")
 		}
 		// Verify folder filter is present.
-		if !contains(q, "'folder-123' in parents") {
+		if !strings.Contains(q, "'folder-123' in parents") {
 			t.Errorf("expected folder filter in query, got %q", q)
 		}
 
@@ -216,16 +217,3 @@ func TestListDriveFiles_InvalidJSON(t *testing.T) {
 	}
 }
 
-// contains checks if s contains substr (used to avoid importing strings in test).
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
-}
-
-func containsSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/connectors/google/list_drive_files_test.go
+++ b/connectors/google/list_drive_files_test.go
@@ -1,0 +1,231 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListDriveFiles_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/drive/v3/files" {
+			t.Errorf("expected path /drive/v3/files, got %s", r.URL.Path)
+		}
+
+		// Verify trashed=false is in the query
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			t.Error("expected non-empty q parameter")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{
+			Files: []driveFileEntry{
+				{ID: "file-1", Name: "doc.txt", MimeType: "text/plain", ModifiedTime: "2024-01-15T10:00:00Z"},
+				{ID: "file-2", Name: "sheet.xlsx", MimeType: "application/vnd.google-apps.spreadsheet", ModifiedTime: "2024-01-16T10:00:00Z"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{MaxResults: 10})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Files []driveFileSummary `json:"files"`
+		Count int                `json:"count"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Count != 2 {
+		t.Errorf("expected count 2, got %d", data.Count)
+	}
+	if len(data.Files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(data.Files))
+	}
+}
+
+func TestListDriveFiles_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{Files: nil})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Files []driveFileSummary `json:"files"`
+		Count int                `json:"count"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Count != 0 {
+		t.Errorf("expected count 0, got %d", data.Count)
+	}
+}
+
+func TestListDriveFiles_WithFolderID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			t.Error("expected non-empty q parameter")
+		}
+		// Verify folder filter is present.
+		if !contains(q, "'folder-123' in parents") {
+			t.Errorf("expected folder filter in query, got %q", q)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{
+			Files: []driveFileEntry{
+				{ID: "file-1", Name: "doc.txt", MimeType: "text/plain"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{FolderID: "folder-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Count int `json:"count"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Count != 1 {
+		t.Errorf("expected count 1, got %d", data.Count)
+	}
+}
+
+func TestListDriveFiles_InvalidFolderID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{FolderID: "../etc/passwd"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid folder_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListDriveFiles_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestListDriveFiles_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDriveFilesAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+// contains checks if s contains substr (used to avoid importing strings in test).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/connectors/google/list_drive_files_test.go
+++ b/connectors/google/list_drive_files_test.go
@@ -154,15 +154,29 @@ func TestListDriveFiles_InvalidFolderID(t *testing.T) {
 	conn := New()
 	action := &listDriveFilesAction{conn: conn}
 
+	// Test path traversal.
 	params, _ := json.Marshal(listDriveFilesParams{FolderID: "../etc/passwd"})
-
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "google.list_drive_files",
 		Parameters:  params,
 		Credentials: validCreds(),
 	})
 	if err == nil {
-		t.Fatal("expected error for invalid folder_id")
+		t.Fatal("expected error for path traversal folder_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+
+	// Test query injection via single quotes in folder_id.
+	params, _ = json.Marshal(listDriveFilesParams{FolderID: "foo' or name contains 'secret"})
+	_, err = action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for query injection folder_id")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)

--- a/connectors/google/list_drive_files_test.go
+++ b/connectors/google/list_drive_files_test.go
@@ -212,6 +212,33 @@ func TestListDriveFiles_AuthFailure(t *testing.T) {
 	}
 }
 
+func TestListDriveFiles_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
 func TestListDriveFiles_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/upload_drive_file.go
+++ b/connectors/google/upload_drive_file.go
@@ -43,8 +43,8 @@ func (p *uploadDriveFileParams) validate() error {
 			Message: "content exceeds maximum upload size of 4 MB",
 		}
 	}
-	if p.FolderID != "" && containsPathSeparator(p.FolderID) {
-		return &connectors.ValidationError{Message: "folder_id contains invalid characters"}
+	if p.FolderID != "" && !isValidDriveID(p.FolderID) {
+		return &connectors.ValidationError{Message: "folder_id contains invalid characters; expected alphanumeric ID"}
 	}
 	return nil
 }

--- a/connectors/google/upload_drive_file.go
+++ b/connectors/google/upload_drive_file.go
@@ -1,0 +1,162 @@
+package google
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// maxUploadBytes is the maximum content size for file uploads (4 MB).
+const maxUploadBytes = 4 * 1024 * 1024
+
+// uploadDriveFileAction implements connectors.Action for google.upload_drive_file.
+// It creates a new file in Google Drive using multipart upload.
+type uploadDriveFileAction struct {
+	conn *GoogleConnector
+}
+
+// uploadDriveFileParams is the user-facing parameter schema.
+type uploadDriveFileParams struct {
+	Name     string `json:"name"`
+	Content  string `json:"content"`
+	MimeType string `json:"mime_type"`
+	FolderID string `json:"folder_id"`
+}
+
+func (p *uploadDriveFileParams) validate() error {
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	if p.Content == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: content"}
+	}
+	if len(p.Content) > maxUploadBytes {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("content exceeds maximum size of %d bytes", maxUploadBytes),
+		}
+	}
+	if p.FolderID != "" && containsPathSeparator(p.FolderID) {
+		return &connectors.ValidationError{Message: "folder_id contains invalid characters"}
+	}
+	return nil
+}
+
+func (p *uploadDriveFileParams) normalize() {
+	if p.MimeType == "" {
+		p.MimeType = "text/plain"
+	}
+}
+
+// driveUploadMetadata is the metadata part of the multipart upload.
+type driveUploadMetadata struct {
+	Name    string   `json:"name"`
+	Parents []string `json:"parents,omitempty"`
+}
+
+// driveUploadResponse is the Google Drive API response from files.create.
+type driveUploadResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Execute uploads a text file to Google Drive and returns the created file metadata.
+func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params uploadDriveFileParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.normalize()
+
+	token, ok := req.Credentials.Get(credKeyAccessToken)
+	if !ok || token == "" {
+		return nil, &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	// Build multipart request body.
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Part 1: JSON metadata.
+	meta := driveUploadMetadata{Name: params.Name}
+	if params.FolderID != "" {
+		meta.Parents = []string{params.FolderID}
+	}
+	metaHeader := make(textproto.MIMEHeader)
+	metaHeader.Set("Content-Type", "application/json")
+	metaPart, err := writer.CreatePart(metaHeader)
+	if err != nil {
+		return nil, fmt.Errorf("creating metadata part: %w", err)
+	}
+	if err := json.NewEncoder(metaPart).Encode(meta); err != nil {
+		return nil, fmt.Errorf("encoding metadata: %w", err)
+	}
+
+	// Part 2: File content.
+	contentHeader := make(textproto.MIMEHeader)
+	contentHeader.Set("Content-Type", params.MimeType)
+	contentPart, err := writer.CreatePart(contentHeader)
+	if err != nil {
+		return nil, fmt.Errorf("creating content part: %w", err)
+	}
+	if _, err := contentPart.Write([]byte(params.Content)); err != nil {
+		return nil, fmt.Errorf("writing content: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("closing multipart writer: %w", err)
+	}
+
+	// Send the multipart upload request.
+	uploadURL := a.conn.driveBaseURL + "/upload/drive/v3/files?uploadType=multipart&fields=id,name"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := a.conn.client.Do(httpReq)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, &connectors.TimeoutError{Message: "Google API request canceled"}
+		}
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return nil, err
+	}
+
+	var uploadResp driveUploadResponse
+	if err := json.Unmarshal(respBytes, &uploadResp); err != nil {
+		return nil, &connectors.ExternalError{
+			StatusCode: resp.StatusCode,
+			Message:    "failed to decode Google API response",
+		}
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":   uploadResp.ID,
+		"name": uploadResp.Name,
+	})
+}

--- a/connectors/google/upload_drive_file.go
+++ b/connectors/google/upload_drive_file.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -129,13 +128,7 @@ func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 
 	resp, err := a.conn.client.Do(httpReq)
 	if err != nil {
-		if connectors.IsTimeout(err) {
-			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return nil, &connectors.TimeoutError{Message: "Google API request canceled"}
-		}
-		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
+		return nil, wrapHTTPError(err)
 	}
 	defer resp.Body.Close()
 

--- a/connectors/google/upload_drive_file.go
+++ b/connectors/google/upload_drive_file.go
@@ -40,7 +40,7 @@ func (p *uploadDriveFileParams) validate() error {
 	}
 	if len(p.Content) > maxUploadBytes {
 		return &connectors.ValidationError{
-			Message: fmt.Sprintf("content exceeds maximum size of %d bytes", maxUploadBytes),
+			Message: "content exceeds maximum upload size of 4 MB",
 		}
 	}
 	if p.FolderID != "" && containsPathSeparator(p.FolderID) {
@@ -63,8 +63,9 @@ type driveUploadMetadata struct {
 
 // driveUploadResponse is the Google Drive API response from files.create.
 type driveUploadResponse struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	WebViewLink string `json:"webViewLink"`
 }
 
 // Execute uploads a text file to Google Drive and returns the created file metadata.
@@ -118,7 +119,7 @@ func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 	}
 
 	// Send the multipart upload request.
-	uploadURL := a.conn.driveBaseURL + "/upload/drive/v3/files?uploadType=multipart&fields=id,name"
+	uploadURL := a.conn.driveBaseURL + "/upload/drive/v3/files?uploadType=multipart&fields=id,name,webViewLink"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, &buf)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
@@ -155,8 +156,12 @@ func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 		}
 	}
 
-	return connectors.JSONResult(map[string]string{
+	result := map[string]string{
 		"id":   uploadResp.ID,
 		"name": uploadResp.Name,
-	})
+	}
+	if uploadResp.WebViewLink != "" {
+		result["web_view_link"] = uploadResp.WebViewLink
+	}
+	return connectors.JSONResult(result)
 }

--- a/connectors/google/upload_drive_file_test.go
+++ b/connectors/google/upload_drive_file_test.go
@@ -1,0 +1,287 @@
+package google
+
+import (
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUploadDriveFile_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/upload/drive/v3/files" {
+			t.Errorf("expected path /upload/drive/v3/files, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		// Verify multipart content.
+		contentType := r.Header.Get("Content-Type")
+		mediaType, params, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			t.Fatalf("failed to parse Content-Type: %v", err)
+		}
+		if !strings.HasPrefix(mediaType, "multipart/") {
+			t.Fatalf("expected multipart content type, got %s", mediaType)
+		}
+
+		reader := multipart.NewReader(r.Body, params["boundary"])
+
+		// Part 1: metadata.
+		part, err := reader.NextPart()
+		if err != nil {
+			t.Fatalf("failed to read metadata part: %v", err)
+		}
+		var meta driveUploadMetadata
+		if err := json.NewDecoder(part).Decode(&meta); err != nil {
+			t.Fatalf("failed to decode metadata: %v", err)
+		}
+		if meta.Name != "test.txt" {
+			t.Errorf("expected name 'test.txt', got %q", meta.Name)
+		}
+
+		// Part 2: content.
+		part, err = reader.NextPart()
+		if err != nil {
+			t.Fatalf("failed to read content part: %v", err)
+		}
+		content, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("failed to read content: %v", err)
+		}
+		if string(content) != "Hello, Drive!" {
+			t.Errorf("expected content 'Hello, Drive!', got %q", string(content))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveUploadResponse{
+			ID:   "new-file-123",
+			Name: "test.txt",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		Name:    "test.txt",
+		Content: "Hello, Drive!",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "new-file-123" {
+		t.Errorf("expected id 'new-file-123', got %q", data["id"])
+	}
+	if data["name"] != "test.txt" {
+		t.Errorf("expected name 'test.txt', got %q", data["name"])
+	}
+}
+
+func TestUploadDriveFile_WithFolder(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		_, params, _ := mime.ParseMediaType(contentType)
+		reader := multipart.NewReader(r.Body, params["boundary"])
+
+		part, _ := reader.NextPart()
+		var meta driveUploadMetadata
+		json.NewDecoder(part).Decode(&meta)
+
+		if len(meta.Parents) != 1 || meta.Parents[0] != "folder-abc" {
+			t.Errorf("expected parent folder-abc, got %v", meta.Parents)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveUploadResponse{ID: "file-1", Name: "doc.txt"})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		Name:     "doc.txt",
+		Content:  "Content here",
+		FolderID: "folder-abc",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUploadDriveFile_MissingName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"content": "hello"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_MissingContent(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"name": "test.txt"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_ContentTooLarge(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	// Create content larger than maxUploadBytes (4 MB).
+	largeContent := strings.Repeat("x", maxUploadBytes+1)
+	params, _ := json.Marshal(uploadDriveFileParams{
+		Name:    "large.txt",
+		Content: largeContent,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for oversized content")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_InvalidFolderID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		Name:     "test.txt",
+		Content:  "hello",
+		FolderID: "../etc",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid folder_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		Name:    "test.txt",
+		Content: "hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/upload_drive_file_test.go
+++ b/connectors/google/upload_drive_file_test.go
@@ -269,6 +269,36 @@ func TestUploadDriveFile_AuthFailure(t *testing.T) {
 	}
 }
 
+func TestUploadDriveFile_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newDriveForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		Name:    "test.txt",
+		Content: "hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
 func TestUploadDriveFile_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/upload_drive_file_test.go
+++ b/connectors/google/upload_drive_file_test.go
@@ -216,22 +216,24 @@ func TestUploadDriveFile_InvalidFolderID(t *testing.T) {
 	conn := New()
 	action := &uploadDriveFileAction{conn: conn}
 
-	params, _ := json.Marshal(uploadDriveFileParams{
-		Name:     "test.txt",
-		Content:  "hello",
-		FolderID: "../etc",
-	})
-
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
-		ActionType:  "google.upload_drive_file",
-		Parameters:  params,
-		Credentials: validCreds(),
-	})
-	if err == nil {
-		t.Fatal("expected error for invalid folder_id")
-	}
-	if !connectors.IsValidationError(err) {
-		t.Errorf("expected ValidationError, got: %T", err)
+	invalidIDs := []string{"../etc", "folder with spaces", "folder'inject"}
+	for _, id := range invalidIDs {
+		params, _ := json.Marshal(uploadDriveFileParams{
+			Name:     "test.txt",
+			Content:  "hello",
+			FolderID: id,
+		})
+		_, err := action.Execute(t.Context(), connectors.ActionRequest{
+			ActionType:  "google.upload_drive_file",
+			Parameters:  params,
+			Credentials: validCreds(),
+		})
+		if err == nil {
+			t.Fatalf("expected error for invalid folder_id %q", id)
+		}
+		if !connectors.IsValidationError(err) {
+			t.Errorf("expected ValidationError for %q, got: %T", id, err)
+		}
 	}
 }
 

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -23,6 +23,7 @@ const mockActions: ConnectorAction[] = [
     name: "Create Issue",
     description: "Create a new issue in a repository",
     risk_level: "low",
+    requires_payment_method: false,
     parameters_schema: {
       type: "object",
       required: ["repo", "title"],
@@ -38,6 +39,7 @@ const mockActions: ConnectorAction[] = [
     name: "Merge Pull Request",
     description: "Merge an open pull request",
     risk_level: "high",
+    requires_payment_method: false,
     parameters_schema: {
       type: "object",
       required: ["repo", "pr"],


### PR DESCRIPTION
## Summary

- Adds four new Google Drive actions: `list_drive_files` (low risk), `get_drive_file` (low risk), `upload_drive_file` (medium risk), and `delete_drive_file` (high risk / soft-delete only)
- Adds `driveBaseURL` field to `GoogleConnector` and the `https://www.googleapis.com/auth/drive` OAuth scope
- Adds 7 manifest templates for Drive actions (browse, read, metadata-only, upload, upload-to-folder, trash)
- Full test coverage: validation, auth failure, rate limiting, security (path traversal rejection), edge cases (binary files, Google Workspace exports)

## Security considerations

- File IDs and folder IDs are validated to reject path separators (`/`, `\`)
- Upload content capped at 4 MB
- Only text-based files and Google Workspace exports (as text/csv) are returned as content — binary files are silently skipped
- Delete is soft-delete only (moves to trash via `PATCH {trashed: true}`)
- Response bodies limited to `maxResponseBytes` (10 MB)

## Test plan

- [x] All 55 Google connector tests pass (`go test ./connectors/google/...`)
- [x] `go vet` clean
- [x] `go build ./connectors/...` clean
- [ ] CI passes

Closes #241

https://claude.ai/code/session_01CuCfHr4LcEdpJpgYyLph2U