### PR TITLE
Add Google Docs actions to Google connector

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -1,6 +1,6 @@
 # Google Connector
 
-The Google connector integrates Permission Slip with [Gmail](https://developers.google.com/gmail/api) and [Google Calendar](https://developers.google.com/calendar/api) APIs. It uses plain `net/http` with OAuth 2.0 access tokens provided by the platform — no third-party Google SDK.
+The Google connector integrates Permission Slip with [Gmail](https://developers.google.com/gmail/api), [Google Calendar](https://developers.google.com/calendar/api), [Google Docs](https://developers.google.com/docs/api), and [Google Drive](https://developers.google.com/drive/api) APIs. It uses plain `net/http` with OAuth 2.0 access tokens provided by the platform — no third-party Google SDK.
 
 ## Connector ID
 
@@ -21,6 +21,8 @@ The credential `auth_type` is `oauth2` with `oauth_provider` set to `google` (a 
 | `gmail.send` | `google.send_email` |
 | `gmail.readonly` | `google.list_emails` |
 | `calendar.events` | `google.create_calendar_event`, `google.list_calendar_events` |
+| `documents` | `google.create_document`, `google.get_document`, `google.update_document` |
+| `drive.readonly` | `google.list_documents` |
 
 Scopes follow the principle of least privilege — `calendar.events` (event-level access) is used instead of the broader `calendar` scope (full calendar management).
 
@@ -168,6 +170,138 @@ Lists upcoming events from Google Calendar.
 
 Events are returned as single instances (recurring events expanded) ordered by start time. All-day events use a date string (e.g., `2024-01-15`) instead of a full RFC 3339 timestamp.
 
+---
+
+### `google.create_document`
+
+Creates a new Google Doc with a title and optional initial body content.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `title` | string | Yes | Title of the new Google Doc |
+| `body` | string | No | Optional initial body content (plain text) |
+
+**Response:**
+
+```json
+{
+  "document_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+  "title": "Meeting Notes",
+  "document_url": "https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit"
+}
+```
+
+**Docs API:** `POST /v1/documents` ([docs](https://developers.google.com/docs/api/reference/rest/v1/documents/create))
+
+**Implementation notes:**
+- Document creation and body insertion are two separate API calls. If the create succeeds but body insertion fails, the response includes a `warning` field with the error details and the document info (to avoid orphaning).
+- Document IDs are URL-encoded in all constructed URLs.
+
+---
+
+### `google.get_document`
+
+Retrieves the content and metadata of a Google Doc by document ID. Returns plain text content extracted from the Docs API structural content (paragraphs and text runs).
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `document_id` | string | Yes | The ID of the Google Doc (e.g., `1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms`) |
+
+**Response:**
+
+```json
+{
+  "document_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+  "title": "Meeting Notes",
+  "body_text": "Full plain text content of the document...",
+  "document_url": "https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit",
+  "word_count": 42
+}
+```
+
+**Docs API:** `GET /v1/documents/{documentId}` ([docs](https://developers.google.com/docs/api/reference/rest/v1/documents/get))
+
+**Implementation notes:**
+- The Google Docs API returns structural content (paragraphs, text runs, inline objects). This action extracts plain text only — formatting, images, tables, and other rich content are not preserved.
+- `word_count` is a whitespace-separated count of the extracted text.
+
+---
+
+### `google.update_document`
+
+Appends or inserts text into an existing Google Doc using the Docs API batchUpdate.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `document_id` | string | Yes | — | The ID of the Google Doc to update |
+| `text` | string | Yes | — | Text to insert into the document |
+| `index` | integer | No | end | Character index to insert at (1-based). Defaults to end of document. |
+
+**Response:**
+
+```json
+{
+  "document_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+  "status": "updated"
+}
+```
+
+**Docs API:** `POST /v1/documents/{documentId}:batchUpdate` ([docs](https://developers.google.com/docs/api/reference/rest/v1/documents/batchUpdate))
+
+**Validation:**
+- `index` must be >= 1 when provided (Google Docs uses 1-based indexing where index 1 is the start of the document body).
+- When `index` is omitted (or 0), text is appended to the end of the document using `endOfSegmentLocation`.
+
+---
+
+### `google.list_documents`
+
+Searches and lists Google Docs from Drive, filtered by the Google Docs MIME type.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `query` | string | No | — | Search query to filter documents by name |
+| `max_results` | integer | No | `10` | Maximum number of documents to return (1-100) |
+
+**Response:**
+
+```json
+{
+  "documents": [
+    {
+      "id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+      "name": "Meeting Notes",
+      "created_time": "2024-01-15T09:00:00.000Z",
+      "modified_time": "2024-01-16T10:00:00.000Z",
+      "web_view_link": "https://docs.google.com/document/d/1Bxi.../edit"
+    }
+  ],
+  "count": 1
+}
+```
+
+**Drive API:** `GET /drive/v3/files` ([docs](https://developers.google.com/drive/api/v3/reference/files/list))
+
+**Security notes:**
+- The `query` parameter is escaped (single quotes and backslashes) before being inserted into the Drive query string to prevent query injection.
+- Results are ordered by `modifiedTime desc` and capped at 100 items.
+
 ## Error Handling
 
 The connector maps Google API HTTP status codes to typed connector errors:
@@ -195,6 +329,11 @@ The connector ships with constrained templates that demonstrate parameter lockin
 | Create calendar events | `create_calendar_event` | Nothing — agent controls all parameters |
 | Create personal calendar events | `create_calendar_event` | `calendar_id` locked to `primary`, no attendees |
 | List calendar events | `list_calendar_events` | Nothing — agent controls all parameters |
+| Create documents | `create_document` | Nothing — agent controls title and body |
+| Create empty documents | `create_document` | `body` omitted — title only |
+| Read any document | `get_document` | Nothing — agent can read any doc by ID |
+| Edit any document | `update_document` | Nothing — agent controls all parameters |
+| Search documents | `list_documents` | Nothing — agent controls query and count |
 
 ## Adding a New Action
 
@@ -206,23 +345,32 @@ Each action lives in its own file. To add one (e.g., `google.delete_calendar_eve
 4. Return `connectors.JSONResult(respBody)` to wrap the response into an `ActionResult`.
 5. Register the action in `Actions()` inside `google.go`.
 6. Add the action to the `Manifest()` return value inside `google.go` with a `ParametersSchema`.
-7. Add tests in `delete_calendar_event_test.go` using `httptest.NewServer` and `newForTest()`.
+7. Add tests in `delete_calendar_event_test.go` using `httptest.NewServer` and `newForTest()` (for Gmail/Calendar) or `newForTestDocs()` (for Docs/Drive).
 
 ## File Structure
 
 ```
 connectors/google/
 ├── google.go                       # GoogleConnector struct, New(), Manifest(), doJSON(), ValidateCredentials()
+├── docs_types.go                   # Shared Docs API types (batchUpdate request) and helpers (documentEditURL)
 ├── send_email.go                   # google.send_email action
 ├── list_emails.go                  # google.list_emails action
 ├── create_calendar_event.go        # google.create_calendar_event action
 ├── list_calendar_events.go         # google.list_calendar_events action
+├── create_document.go              # google.create_document action
+├── get_document.go                 # google.get_document action
+├── update_document.go              # google.update_document action
+├── list_documents.go               # google.list_documents action
 ├── google_test.go                  # Connector-level tests (ID, Actions, Manifest, ValidateCredentials)
 ├── helpers_test.go                 # Shared test helpers (validCreds)
 ├── send_email_test.go              # Send email action tests (including MIME injection, base64 encoding)
 ├── list_emails_test.go             # List emails action tests
 ├── create_calendar_event_test.go   # Create event tests (including time validation, URL encoding)
 ├── list_calendar_events_test.go    # List events action tests
+├── create_document_test.go         # Create document tests (including partial failure handling)
+├── get_document_test.go            # Get document tests (including plain text extraction)
+├── update_document_test.go         # Update document tests (append and insert-at-index)
+├── list_documents_test.go          # List documents tests (including query escaping)
 └── README.md                       # This file
 ```
 

--- a/connectors/google/create_document.go
+++ b/connectors/google/create_document.go
@@ -59,6 +59,8 @@ func (a *createDocumentAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
+	documentURL := "https://docs.google.com/document/d/" + url.PathEscape(resp.DocumentID) + "/edit"
+
 	// If body text was provided, insert it via batchUpdate.
 	if params.Body != "" {
 		batchReq := docsBatchUpdateRequest{
@@ -73,11 +75,17 @@ func (a *createDocumentAction) Execute(ctx context.Context, req connectors.Actio
 		}
 		updateURL := a.conn.docsBaseURL + "/v1/documents/" + url.PathEscape(resp.DocumentID) + ":batchUpdate"
 		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, updateURL, batchReq, nil); err != nil {
-			return nil, err
+			// Document was created but body insertion failed. Return the
+			// document info so the caller knows what was created, rather
+			// than silently orphaning it.
+			return connectors.JSONResult(map[string]string{
+				"document_id":  resp.DocumentID,
+				"title":        resp.Title,
+				"document_url": documentURL,
+				"warning":      fmt.Sprintf("document created but body insertion failed: %v", err),
+			})
 		}
 	}
-
-	documentURL := "https://docs.google.com/document/d/" + resp.DocumentID + "/edit"
 
 	return connectors.JSONResult(map[string]string{
 		"document_id":  resp.DocumentID,

--- a/connectors/google/create_document.go
+++ b/connectors/google/create_document.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -53,8 +54,8 @@ func (a *createDocumentAction) Execute(ctx context.Context, req connectors.Actio
 	body := docsCreateRequest{Title: params.Title}
 	var resp docsCreateResponse
 
-	url := a.conn.docsBaseURL + "/v1/documents"
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, url, body, &resp); err != nil {
+	createURL := a.conn.docsBaseURL + "/v1/documents"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, createURL, body, &resp); err != nil {
 		return nil, err
 	}
 
@@ -70,7 +71,7 @@ func (a *createDocumentAction) Execute(ctx context.Context, req connectors.Actio
 				},
 			},
 		}
-		updateURL := a.conn.docsBaseURL + "/v1/documents/" + resp.DocumentID + ":batchUpdate"
+		updateURL := a.conn.docsBaseURL + "/v1/documents/" + url.PathEscape(resp.DocumentID) + ":batchUpdate"
 		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, updateURL, batchReq, nil); err != nil {
 			return nil, err
 		}

--- a/connectors/google/create_document.go
+++ b/connectors/google/create_document.go
@@ -59,7 +59,7 @@ func (a *createDocumentAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
-	documentURL := "https://docs.google.com/document/d/" + url.PathEscape(resp.DocumentID) + "/edit"
+	documentURL := documentEditURL(resp.DocumentID)
 
 	// If body text was provided, insert it via batchUpdate.
 	if params.Body != "" {

--- a/connectors/google/create_document.go
+++ b/connectors/google/create_document.go
@@ -1,0 +1,86 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createDocumentAction implements connectors.Action for google.create_document.
+// It creates a new Google Doc via the Docs API POST /v1/documents, then
+// optionally inserts body text via a batchUpdate.
+type createDocumentAction struct {
+	conn *GoogleConnector
+}
+
+// createDocumentParams is the user-facing parameter schema.
+type createDocumentParams struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+func (p *createDocumentParams) validate() error {
+	if p.Title == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: title"}
+	}
+	return nil
+}
+
+// docsCreateRequest is the Google Docs API request body for documents.create.
+type docsCreateRequest struct {
+	Title string `json:"title"`
+}
+
+// docsCreateResponse is the Google Docs API response from documents.create.
+type docsCreateResponse struct {
+	DocumentID string `json:"documentId"`
+	Title      string `json:"title"`
+}
+
+// Execute creates a new Google Doc and returns its metadata.
+func (a *createDocumentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createDocumentParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := docsCreateRequest{Title: params.Title}
+	var resp docsCreateResponse
+
+	url := a.conn.docsBaseURL + "/v1/documents"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, url, body, &resp); err != nil {
+		return nil, err
+	}
+
+	// If body text was provided, insert it via batchUpdate.
+	if params.Body != "" {
+		batchReq := docsBatchUpdateRequest{
+			Requests: []docsRequest{
+				{
+					InsertText: &docsInsertTextRequest{
+						Text:               params.Body,
+						EndOfSegmentLocation: &docsEndOfSegmentLocation{},
+					},
+				},
+			},
+		}
+		updateURL := a.conn.docsBaseURL + "/v1/documents/" + resp.DocumentID + ":batchUpdate"
+		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, updateURL, batchReq, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	documentURL := "https://docs.google.com/document/d/" + resp.DocumentID + "/edit"
+
+	return connectors.JSONResult(map[string]string{
+		"document_id":  resp.DocumentID,
+		"title":        resp.Title,
+		"document_url": documentURL,
+	})
+}

--- a/connectors/google/create_document_test.go
+++ b/connectors/google/create_document_test.go
@@ -1,0 +1,221 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateDocument_Success(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		calls++
+		if r.URL.Path == "/v1/documents" {
+			var body docsCreateRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			if body.Title != "My New Doc" {
+				t.Errorf("expected title 'My New Doc', got %q", body.Title)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(docsCreateResponse{
+				DocumentID: "doc-abc-123",
+				Title:      "My New Doc",
+			})
+		} else if r.URL.Path == "/v1/documents/doc-abc-123:batchUpdate" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		} else {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(createDocumentParams{
+		Title: "My New Doc",
+		Body:  "Hello, world!",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["document_id"] != "doc-abc-123" {
+		t.Errorf("expected document_id 'doc-abc-123', got %q", data["document_id"])
+	}
+	if data["title"] != "My New Doc" {
+		t.Errorf("expected title 'My New Doc', got %q", data["title"])
+	}
+	if data["document_url"] != "https://docs.google.com/document/d/doc-abc-123/edit" {
+		t.Errorf("unexpected document_url: %q", data["document_url"])
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 API calls (create + batchUpdate), got %d", calls)
+	}
+}
+
+func TestCreateDocument_SuccessNoBody(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/v1/documents" {
+			t.Errorf("unexpected path for no-body create: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(docsCreateResponse{
+			DocumentID: "doc-xyz",
+			Title:      "Empty Doc",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(createDocumentParams{Title: "Empty Doc"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["document_id"] != "doc-xyz" {
+		t.Errorf("expected document_id 'doc-xyz', got %q", data["document_id"])
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 API call (create only), got %d", calls)
+	}
+}
+
+func TestCreateDocument_MissingTitle(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"body": "some text"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing title")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateDocument_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(createDocumentParams{Title: "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T (%v)", err, err)
+	}
+}
+
+func TestCreateDocument_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(createDocumentParams{Title: "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestCreateDocument_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createDocumentAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/create_document_test.go
+++ b/connectors/google/create_document_test.go
@@ -219,3 +219,53 @@ func TestCreateDocument_InvalidJSON(t *testing.T) {
 		t.Errorf("expected ValidationError, got: %T", err)
 	}
 }
+
+func TestCreateDocument_BodyInsertionFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/documents" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(docsCreateResponse{
+				DocumentID: "doc-partial",
+				Title:      "Partial Doc",
+			})
+		} else if r.URL.Path == "/v1/documents/doc-partial:batchUpdate" {
+			// batchUpdate fails
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 500, "message": "Internal error"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(createDocumentParams{
+		Title: "Partial Doc",
+		Body:  "some text",
+	})
+
+	// Should succeed with a warning, not error — the document was created.
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("expected no error (partial success), got: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["document_id"] != "doc-partial" {
+		t.Errorf("expected document_id 'doc-partial', got %q", data["document_id"])
+	}
+	if data["warning"] == "" {
+		t.Error("expected warning about body insertion failure")
+	}
+}

--- a/connectors/google/docs_types.go
+++ b/connectors/google/docs_types.go
@@ -1,0 +1,31 @@
+package google
+
+import "net/url"
+
+// Shared Docs API batchUpdate request types, used by both create_document
+// (for inserting initial body) and update_document.
+
+type docsBatchUpdateRequest struct {
+	Requests []docsRequest `json:"requests"`
+}
+
+type docsRequest struct {
+	InsertText *docsInsertTextRequest `json:"insertText,omitempty"`
+}
+
+type docsInsertTextRequest struct {
+	Text                 string                    `json:"text"`
+	Location             *docsLocation             `json:"location,omitempty"`
+	EndOfSegmentLocation *docsEndOfSegmentLocation `json:"endOfSegmentLocation,omitempty"`
+}
+
+type docsLocation struct {
+	Index int `json:"index"`
+}
+
+type docsEndOfSegmentLocation struct{}
+
+// documentEditURL returns the Google Docs web editor URL for the given document ID.
+func documentEditURL(documentID string) string {
+	return "https://docs.google.com/document/d/" + url.PathEscape(documentID) + "/edit"
+}

--- a/connectors/google/get_document.go
+++ b/connectors/google/get_document.go
@@ -94,7 +94,7 @@ func (a *getDocumentAction) Execute(ctx context.Context, req connectors.ActionRe
 	}
 
 	bodyText := extractPlainText(resp.Body.Content)
-	documentURL := "https://docs.google.com/document/d/" + url.PathEscape(resp.DocumentID) + "/edit"
+	documentURL := documentEditURL(resp.DocumentID)
 
 	return connectors.JSONResult(map[string]any{
 		"document_id":  resp.DocumentID,

--- a/connectors/google/get_document.go
+++ b/connectors/google/get_document.go
@@ -94,7 +94,7 @@ func (a *getDocumentAction) Execute(ctx context.Context, req connectors.ActionRe
 	}
 
 	bodyText := extractPlainText(resp.Body.Content)
-	documentURL := "https://docs.google.com/document/d/" + resp.DocumentID + "/edit"
+	documentURL := "https://docs.google.com/document/d/" + url.PathEscape(resp.DocumentID) + "/edit"
 
 	return connectors.JSONResult(map[string]any{
 		"document_id":  resp.DocumentID,

--- a/connectors/google/get_document.go
+++ b/connectors/google/get_document.go
@@ -1,0 +1,98 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getDocumentAction implements connectors.Action for google.get_document.
+// It retrieves a Google Doc via the Docs API GET /v1/documents/{documentId}.
+type getDocumentAction struct {
+	conn *GoogleConnector
+}
+
+// getDocumentParams is the user-facing parameter schema.
+type getDocumentParams struct {
+	DocumentID string `json:"document_id"`
+}
+
+func (p *getDocumentParams) validate() error {
+	if p.DocumentID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: document_id"}
+	}
+	return nil
+}
+
+// docsGetResponse is the Google Docs API response from documents.get.
+type docsGetResponse struct {
+	DocumentID string  `json:"documentId"`
+	Title      string  `json:"title"`
+	Body       docsBody `json:"body"`
+}
+
+type docsBody struct {
+	Content []docsStructuralElement `json:"content"`
+}
+
+type docsStructuralElement struct {
+	Paragraph *docsParagraph `json:"paragraph,omitempty"`
+}
+
+type docsParagraph struct {
+	Elements []docsParagraphElement `json:"elements"`
+}
+
+type docsParagraphElement struct {
+	TextRun *docsTextRun `json:"textRun,omitempty"`
+}
+
+type docsTextRun struct {
+	Content string `json:"content"`
+}
+
+// extractPlainText walks the structural content tree and extracts plain text.
+func extractPlainText(content []docsStructuralElement) string {
+	var sb strings.Builder
+	for _, elem := range content {
+		if elem.Paragraph == nil {
+			continue
+		}
+		for _, pe := range elem.Paragraph.Elements {
+			if pe.TextRun != nil {
+				sb.WriteString(pe.TextRun.Content)
+			}
+		}
+	}
+	return sb.String()
+}
+
+// Execute retrieves a Google Doc and returns its metadata and plain text content.
+func (a *getDocumentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getDocumentParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	var resp docsGetResponse
+	docURL := a.conn.docsBaseURL + "/v1/documents/" + url.PathEscape(params.DocumentID)
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, docURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	bodyText := extractPlainText(resp.Body.Content)
+
+	return connectors.JSONResult(map[string]string{
+		"document_id": resp.DocumentID,
+		"title":       resp.Title,
+		"body_text":   bodyText,
+	})
+}

--- a/connectors/google/get_document.go
+++ b/connectors/google/get_document.go
@@ -72,6 +72,11 @@ func extractPlainText(content []docsStructuralElement) string {
 	return sb.String()
 }
 
+// wordCount counts the number of whitespace-separated words in s.
+func wordCount(s string) int {
+	return len(strings.Fields(s))
+}
+
 // Execute retrieves a Google Doc and returns its metadata and plain text content.
 func (a *getDocumentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params getDocumentParams
@@ -89,10 +94,13 @@ func (a *getDocumentAction) Execute(ctx context.Context, req connectors.ActionRe
 	}
 
 	bodyText := extractPlainText(resp.Body.Content)
+	documentURL := "https://docs.google.com/document/d/" + resp.DocumentID + "/edit"
 
-	return connectors.JSONResult(map[string]string{
-		"document_id": resp.DocumentID,
-		"title":       resp.Title,
-		"body_text":   bodyText,
+	return connectors.JSONResult(map[string]any{
+		"document_id":  resp.DocumentID,
+		"title":        resp.Title,
+		"body_text":    bodyText,
+		"document_url": documentURL,
+		"word_count":   wordCount(bodyText),
 	})
 }

--- a/connectors/google/get_document_test.go
+++ b/connectors/google/get_document_test.go
@@ -64,7 +64,7 @@ func TestGetDocument_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var data map[string]string
+	var data map[string]any
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
@@ -76,6 +76,13 @@ func TestGetDocument_Success(t *testing.T) {
 	}
 	if data["body_text"] != "Hello, world!\nSecond paragraph.\n" {
 		t.Errorf("unexpected body_text: %q", data["body_text"])
+	}
+	if data["document_url"] != "https://docs.google.com/document/d/doc-abc-123/edit" {
+		t.Errorf("unexpected document_url: %q", data["document_url"])
+	}
+	// word_count: "Hello," "world!" "Second" "paragraph." = 4 words
+	if wc, ok := data["word_count"].(float64); !ok || int(wc) != 4 {
+		t.Errorf("expected word_count 4, got %v", data["word_count"])
 	}
 }
 
@@ -106,12 +113,15 @@ func TestGetDocument_EmptyDocument(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var data map[string]string
+	var data map[string]any
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
 	if data["body_text"] != "" {
 		t.Errorf("expected empty body_text, got %q", data["body_text"])
+	}
+	if wc, ok := data["word_count"].(float64); !ok || int(wc) != 0 {
+		t.Errorf("expected word_count 0, got %v", data["word_count"])
 	}
 }
 

--- a/connectors/google/get_document_test.go
+++ b/connectors/google/get_document_test.go
@@ -1,0 +1,212 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetDocument_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/documents/doc-abc-123" {
+			t.Errorf("expected path /v1/documents/doc-abc-123, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(docsGetResponse{
+			DocumentID: "doc-abc-123",
+			Title:      "Test Doc",
+			Body: docsBody{
+				Content: []docsStructuralElement{
+					{
+						Paragraph: &docsParagraph{
+							Elements: []docsParagraphElement{
+								{TextRun: &docsTextRun{Content: "Hello, "}},
+								{TextRun: &docsTextRun{Content: "world!\n"}},
+							},
+						},
+					},
+					{
+						Paragraph: &docsParagraph{
+							Elements: []docsParagraphElement{
+								{TextRun: &docsTextRun{Content: "Second paragraph.\n"}},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &getDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(getDocumentParams{DocumentID: "doc-abc-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["document_id"] != "doc-abc-123" {
+		t.Errorf("expected document_id 'doc-abc-123', got %q", data["document_id"])
+	}
+	if data["title"] != "Test Doc" {
+		t.Errorf("expected title 'Test Doc', got %q", data["title"])
+	}
+	if data["body_text"] != "Hello, world!\nSecond paragraph.\n" {
+		t.Errorf("unexpected body_text: %q", data["body_text"])
+	}
+}
+
+func TestGetDocument_EmptyDocument(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(docsGetResponse{
+			DocumentID: "doc-empty",
+			Title:      "Empty Doc",
+			Body:       docsBody{Content: nil},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &getDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(getDocumentParams{DocumentID: "doc-empty"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["body_text"] != "" {
+		t.Errorf("expected empty body_text, got %q", data["body_text"])
+	}
+}
+
+func TestGetDocument_MissingDocumentID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing document_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDocument_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &getDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(getDocumentParams{DocumentID: "doc-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T (%v)", err, err)
+	}
+}
+
+func TestGetDocument_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &getDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(getDocumentParams{DocumentID: "doc-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestGetDocument_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDocumentAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.get_document",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -19,6 +19,8 @@ import (
 const (
 	defaultGmailBaseURL    = "https://gmail.googleapis.com"
 	defaultCalendarBaseURL = "https://www.googleapis.com/calendar/v3"
+	defaultDocsBaseURL     = "https://docs.googleapis.com"
+	defaultDriveBaseURL    = "https://www.googleapis.com"
 	defaultTimeout         = 30 * time.Second
 	credKeyAccessToken     = "access_token"
 
@@ -38,6 +40,8 @@ type GoogleConnector struct {
 	client          *http.Client
 	gmailBaseURL    string
 	calendarBaseURL string
+	docsBaseURL     string
+	driveBaseURL    string
 }
 
 // New creates a GoogleConnector with sensible defaults.
@@ -46,6 +50,8 @@ func New() *GoogleConnector {
 		client:          &http.Client{Timeout: defaultTimeout},
 		gmailBaseURL:    defaultGmailBaseURL,
 		calendarBaseURL: defaultCalendarBaseURL,
+		docsBaseURL:     defaultDocsBaseURL,
+		driveBaseURL:    defaultDriveBaseURL,
 	}
 }
 
@@ -58,6 +64,16 @@ func newForTest(client *http.Client, gmailBaseURL, calendarBaseURL string) *Goog
 	}
 }
 
+// newForTestDocs creates a GoogleConnector that points at a test server for
+// Google Docs and Drive API calls.
+func newForTestDocs(client *http.Client, docsBaseURL, driveBaseURL string) *GoogleConnector {
+	return &GoogleConnector{
+		client:       client,
+		docsBaseURL:  docsBaseURL,
+		driveBaseURL: driveBaseURL,
+	}
+}
+
 // ID returns "google", matching the connectors.id in the database.
 func (c *GoogleConnector) ID() string { return "google" }
 
@@ -67,7 +83,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "google",
 		Name:        "Google",
-		Description: "Google integration for Gmail and Calendar",
+		Description: "Google integration for Gmail, Calendar, and Docs",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "google.send_email",
@@ -184,6 +200,89 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "google.create_document",
+				Name:        "Create Document",
+				Description: "Create a new Google Doc with a title and optional body content",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["title"],
+					"properties": {
+						"title": {
+							"type": "string",
+							"description": "Title of the new Google Doc"
+						},
+						"body": {
+							"type": "string",
+							"description": "Optional initial body content (plain text)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.get_document",
+				Name:        "Get Document",
+				Description: "Retrieve the content and metadata of a Google Doc by document ID",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["document_id"],
+					"properties": {
+						"document_id": {
+							"type": "string",
+							"description": "The ID of the Google Doc to retrieve"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.update_document",
+				Name:        "Update Document",
+				Description: "Append or insert text into an existing Google Doc",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["document_id", "text"],
+					"properties": {
+						"document_id": {
+							"type": "string",
+							"description": "The ID of the Google Doc to update"
+						},
+						"text": {
+							"type": "string",
+							"description": "Text to insert into the document"
+						},
+						"index": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Character index to insert at (1-based). Defaults to end of document."
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "google.list_documents",
+				Name:        "List Documents",
+				Description: "Search and list Google Docs from Drive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string",
+							"description": "Search query to filter documents by name"
+						},
+						"max_results": {
+							"type": "integer",
+							"default": 10,
+							"minimum": 1,
+							"maximum": 100,
+							"description": "Maximum number of documents to return (1-100, default 10)"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -194,6 +293,8 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					"https://www.googleapis.com/auth/gmail.send",
 					"https://www.googleapis.com/auth/gmail.readonly",
 					"https://www.googleapis.com/auth/calendar.events",
+					"https://www.googleapis.com/auth/documents",
+					"https://www.googleapis.com/auth/drive.readonly",
 				},
 			},
 		},
@@ -247,6 +348,34 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can list upcoming events from any calendar.",
 				Parameters:  json.RawMessage(`{"calendar_id":"*","max_results":"*","time_min":"*","time_max":"*"}`),
 			},
+			{
+				ID:          "tpl_google_create_document",
+				ActionType:  "google.create_document",
+				Name:        "Create documents",
+				Description: "Agent can create new Google Docs with any title and body.",
+				Parameters:  json.RawMessage(`{"title":"*","body":"*"}`),
+			},
+			{
+				ID:          "tpl_google_get_document",
+				ActionType:  "google.get_document",
+				Name:        "Read any document",
+				Description: "Agent can read the content of any Google Doc by ID.",
+				Parameters:  json.RawMessage(`{"document_id":"*"}`),
+			},
+			{
+				ID:          "tpl_google_update_document",
+				ActionType:  "google.update_document",
+				Name:        "Edit any document",
+				Description: "Agent can insert or append text to any Google Doc.",
+				Parameters:  json.RawMessage(`{"document_id":"*","text":"*","index":"*"}`),
+			},
+			{
+				ID:          "tpl_google_list_documents",
+				ActionType:  "google.list_documents",
+				Name:        "Search documents",
+				Description: "Agent can search and list Google Docs from Drive.",
+				Parameters:  json.RawMessage(`{"query":"*","max_results":"*"}`),
+			},
 		},
 	}
 }
@@ -258,6 +387,10 @@ func (c *GoogleConnector) Actions() map[string]connectors.Action {
 		"google.list_emails":           &listEmailsAction{conn: c},
 		"google.create_calendar_event": &createCalendarEventAction{conn: c},
 		"google.list_calendar_events":  &listCalendarEventsAction{conn: c},
+		"google.create_document":       &createDocumentAction{conn: c},
+		"google.get_document":          &getDocumentAction{conn: c},
+		"google.update_document":       &updateDocumentAction{conn: c},
+		"google.list_documents":        &listDocumentsAction{conn: c},
 	}
 }
 

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -223,7 +223,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "google.get_document",
 				Name:        "Get Document",
-				Description: "Retrieve the content and metadata of a Google Doc by document ID",
+				Description: "Retrieve the content and metadata of a Google Doc by document ID. Returns plain text content, word count, and a direct link to the document.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -231,7 +231,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"document_id": {
 							"type": "string",
-							"description": "The ID of the Google Doc to retrieve"
+							"description": "The ID of the Google Doc to retrieve (e.g. '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms')"
 						}
 					}
 				}`)),
@@ -239,7 +239,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "google.update_document",
 				Name:        "Update Document",
-				Description: "Append or insert text into an existing Google Doc",
+				Description: "Append or insert text into an existing Google Doc. By default text is appended to the end; specify an index to insert at a specific position.",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -247,7 +247,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"document_id": {
 							"type": "string",
-							"description": "The ID of the Google Doc to update"
+							"description": "The ID of the Google Doc to update (e.g. '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms')"
 						},
 						"text": {
 							"type": "string",
@@ -375,6 +375,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Search documents",
 				Description: "Agent can search and list Google Docs from Drive.",
 				Parameters:  json.RawMessage(`{"query":"*","max_results":"*"}`),
+			},
+			{
+				ID:          "tpl_google_create_document_title_only",
+				ActionType:  "google.create_document",
+				Name:        "Create empty documents",
+				Description: "Agent can create new Google Docs with any title but no initial body content.",
+				Parameters:  json.RawMessage(`{"title":"*"}`),
 			},
 		},
 	}

--- a/connectors/google/google_test.go
+++ b/connectors/google/google_test.go
@@ -24,6 +24,10 @@ func TestGoogleConnector_Actions(t *testing.T) {
 		"google.list_emails",
 		"google.create_calendar_event",
 		"google.list_calendar_events",
+		"google.create_document",
+		"google.get_document",
+		"google.update_document",
+		"google.list_documents",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -91,8 +95,8 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 	if m.Name != "Google" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Google")
 	}
-	if len(m.Actions) != 4 {
-		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	if len(m.Actions) != 8 {
+		t.Fatalf("Manifest().Actions has %d items, want 8", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -103,6 +107,10 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 		"google.list_emails",
 		"google.create_calendar_event",
 		"google.list_calendar_events",
+		"google.create_document",
+		"google.get_document",
+		"google.update_document",
+		"google.list_documents",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)

--- a/connectors/google/list_documents.go
+++ b/connectors/google/list_documents.go
@@ -93,6 +93,7 @@ func (a *listDocumentsAction) Execute(ctx context.Context, req connectors.Action
 
 	return connectors.JSONResult(map[string]any{
 		"documents": documents,
+		"count":     len(documents),
 	})
 }
 

--- a/connectors/google/list_documents.go
+++ b/connectors/google/list_documents.go
@@ -63,7 +63,7 @@ func (a *listDocumentsAction) Execute(ctx context.Context, req connectors.Action
 	}
 	params.normalize()
 
-	q := "mimeType='application/vnd.google-apps.document'"
+	q := "mimeType='application/vnd.google-apps.document' and trashed=false"
 	if params.Query != "" {
 		q += " and name contains '" + escapeDriveQuery(params.Query) + "'"
 	}

--- a/connectors/google/list_documents.go
+++ b/connectors/google/list_documents.go
@@ -1,0 +1,114 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listDocumentsAction implements connectors.Action for google.list_documents.
+// It lists Google Docs via the Drive API GET /drive/v3/files with a
+// mimeType filter for Google Docs.
+type listDocumentsAction struct {
+	conn *GoogleConnector
+}
+
+// listDocumentsParams is the user-facing parameter schema.
+type listDocumentsParams struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+func (p *listDocumentsParams) normalize() {
+	if p.MaxResults <= 0 {
+		p.MaxResults = 10
+	}
+	if p.MaxResults > 100 {
+		p.MaxResults = 100
+	}
+}
+
+// driveListResponse is the Google Drive API response from files.list.
+type driveListResponse struct {
+	Files []driveFile `json:"files"`
+}
+
+type driveFile struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	CreatedTime  string `json:"createdTime"`
+	ModifiedTime string `json:"modifiedTime"`
+	WebViewLink  string `json:"webViewLink"`
+}
+
+// documentSummary is the shape returned to the agent.
+type documentSummary struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	CreatedTime  string `json:"created_time,omitempty"`
+	ModifiedTime string `json:"modified_time,omitempty"`
+	WebViewLink  string `json:"web_view_link,omitempty"`
+}
+
+// Execute lists Google Docs from Drive and returns their metadata.
+func (a *listDocumentsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listDocumentsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	params.normalize()
+
+	q := "mimeType='application/vnd.google-apps.document'"
+	if params.Query != "" {
+		q += " and name contains '" + escapeDriveQuery(params.Query) + "'"
+	}
+
+	queryParams := url.Values{}
+	queryParams.Set("q", q)
+	queryParams.Set("pageSize", strconv.Itoa(params.MaxResults))
+	queryParams.Set("fields", "files(id,name,createdTime,modifiedTime,webViewLink)")
+	queryParams.Set("orderBy", "modifiedTime desc")
+
+	var resp driveListResponse
+	listURL := a.conn.driveBaseURL + "/drive/v3/files?" + queryParams.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, listURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	documents := make([]documentSummary, 0, len(resp.Files))
+	for _, f := range resp.Files {
+		documents = append(documents, documentSummary{
+			ID:           f.ID,
+			Name:         f.Name,
+			CreatedTime:  f.CreatedTime,
+			ModifiedTime: f.ModifiedTime,
+			WebViewLink:  f.WebViewLink,
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"documents": documents,
+	})
+}
+
+// escapeDriveQuery escapes single quotes and backslashes in a Drive query
+// string value to prevent query injection.
+func escapeDriveQuery(s string) string {
+	var result []byte
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			result = append(result, '\\', '\\')
+		case '\'':
+			result = append(result, '\\', '\'')
+		default:
+			result = append(result, s[i])
+		}
+	}
+	return string(result)
+}

--- a/connectors/google/list_documents_test.go
+++ b/connectors/google/list_documents_test.go
@@ -67,12 +67,16 @@ func TestListDocuments_Success(t *testing.T) {
 
 	var data struct {
 		Documents []documentSummary `json:"documents"`
+		Count     int               `json:"count"`
 	}
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
 	if len(data.Documents) != 2 {
 		t.Fatalf("expected 2 documents, got %d", len(data.Documents))
+	}
+	if data.Count != 2 {
+		t.Errorf("expected count 2, got %d", data.Count)
 	}
 	if data.Documents[0].Name != "Meeting Notes" {
 		t.Errorf("expected first doc name 'Meeting Notes', got %q", data.Documents[0].Name)

--- a/connectors/google/list_documents_test.go
+++ b/connectors/google/list_documents_test.go
@@ -1,0 +1,286 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListDocuments_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.HasPrefix(r.URL.Path, "/drive/v3/files") {
+			t.Errorf("expected path /drive/v3/files, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		q := r.URL.Query().Get("q")
+		if !strings.Contains(q, "mimeType='application/vnd.google-apps.document'") {
+			t.Errorf("expected mimeType filter in query, got %q", q)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{
+			Files: []driveFile{
+				{
+					ID:           "doc-1",
+					Name:         "Meeting Notes",
+					CreatedTime:  "2024-01-15T09:00:00Z",
+					ModifiedTime: "2024-01-16T10:00:00Z",
+					WebViewLink:  "https://docs.google.com/document/d/doc-1/edit",
+				},
+				{
+					ID:           "doc-2",
+					Name:         "Project Plan",
+					CreatedTime:  "2024-01-10T08:00:00Z",
+					ModifiedTime: "2024-01-14T12:00:00Z",
+					WebViewLink:  "https://docs.google.com/document/d/doc-2/edit",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), "", srv.URL)
+	action := &listDocumentsAction{conn: conn}
+
+	params, _ := json.Marshal(listDocumentsParams{MaxResults: 10})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Documents []documentSummary `json:"documents"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Documents) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(data.Documents))
+	}
+	if data.Documents[0].Name != "Meeting Notes" {
+		t.Errorf("expected first doc name 'Meeting Notes', got %q", data.Documents[0].Name)
+	}
+	if data.Documents[1].ID != "doc-2" {
+		t.Errorf("expected second doc ID 'doc-2', got %q", data.Documents[1].ID)
+	}
+}
+
+func TestListDocuments_WithQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if !strings.Contains(q, "name contains 'meeting'") {
+			t.Errorf("expected name filter in query, got %q", q)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{
+			Files: []driveFile{
+				{ID: "doc-1", Name: "Meeting Notes"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), "", srv.URL)
+	action := &listDocumentsAction{conn: conn}
+
+	params, _ := json.Marshal(listDocumentsParams{Query: "meeting", MaxResults: 5})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Documents []documentSummary `json:"documents"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(data.Documents))
+	}
+}
+
+func TestListDocuments_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{Files: nil})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), "", srv.URL)
+	action := &listDocumentsAction{conn: conn}
+
+	params, _ := json.Marshal(listDocumentsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Documents []documentSummary `json:"documents"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Documents) != 0 {
+		t.Errorf("expected 0 documents, got %d", len(data.Documents))
+	}
+}
+
+func TestListDocuments_QueryEscaping(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		// The single quote in "it's" should be escaped.
+		if !strings.Contains(q, `name contains 'it\'s'`) {
+			t.Errorf("expected escaped query, got %q", q)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(driveListResponse{Files: nil})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), "", srv.URL)
+	action := &listDocumentsAction{conn: conn}
+
+	params, _ := json.Marshal(listDocumentsParams{Query: "it's"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListDocuments_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), "", srv.URL)
+	action := &listDocumentsAction{conn: conn}
+
+	params, _ := json.Marshal(listDocumentsParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T (%v)", err, err)
+	}
+}
+
+func TestListDocuments_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), "", srv.URL)
+	action := &listDocumentsAction{conn: conn}
+
+	params, _ := json.Marshal(listDocumentsParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestListDocuments_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDocumentsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.list_documents",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestEscapeDriveQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"it's", `it\'s`},
+		{`back\slash`, `back\\slash`},
+		{`it's a "test"`, `it\'s a "test"`},
+	}
+
+	for _, tt := range tests {
+		got := escapeDriveQuery(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeDriveQuery(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/connectors/google/list_documents_test.go
+++ b/connectors/google/list_documents_test.go
@@ -28,6 +28,9 @@ func TestListDocuments_Success(t *testing.T) {
 		if !strings.Contains(q, "mimeType='application/vnd.google-apps.document'") {
 			t.Errorf("expected mimeType filter in query, got %q", q)
 		}
+		if !strings.Contains(q, "trashed=false") {
+			t.Errorf("expected trashed=false filter in query, got %q", q)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(driveListResponse{

--- a/connectors/google/update_document.go
+++ b/connectors/google/update_document.go
@@ -1,0 +1,99 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// updateDocumentAction implements connectors.Action for google.update_document.
+// It inserts text into an existing Google Doc via the Docs API
+// POST /v1/documents/{documentId}:batchUpdate.
+type updateDocumentAction struct {
+	conn *GoogleConnector
+}
+
+// updateDocumentParams is the user-facing parameter schema.
+type updateDocumentParams struct {
+	DocumentID string `json:"document_id"`
+	Text       string `json:"text"`
+	Index      int    `json:"index"`
+}
+
+func (p *updateDocumentParams) validate() error {
+	if p.DocumentID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: document_id"}
+	}
+	if p.Text == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: text"}
+	}
+	if p.Index < 0 {
+		return &connectors.ValidationError{Message: "index must be non-negative"}
+	}
+	return nil
+}
+
+// Shared Docs API batchUpdate request types, used by both create_document
+// (for inserting initial body) and update_document.
+
+type docsBatchUpdateRequest struct {
+	Requests []docsRequest `json:"requests"`
+}
+
+type docsRequest struct {
+	InsertText *docsInsertTextRequest `json:"insertText,omitempty"`
+}
+
+type docsInsertTextRequest struct {
+	Text                 string                      `json:"text"`
+	Location             *docsLocation               `json:"location,omitempty"`
+	EndOfSegmentLocation *docsEndOfSegmentLocation   `json:"endOfSegmentLocation,omitempty"`
+}
+
+type docsLocation struct {
+	Index int `json:"index"`
+}
+
+type docsEndOfSegmentLocation struct{}
+
+// Execute inserts text into a Google Doc and returns success status.
+func (a *updateDocumentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params updateDocumentParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	var insertReq docsRequest
+	if params.Index > 0 {
+		insertReq.InsertText = &docsInsertTextRequest{
+			Text:     params.Text,
+			Location: &docsLocation{Index: params.Index},
+		}
+	} else {
+		insertReq.InsertText = &docsInsertTextRequest{
+			Text:                 params.Text,
+			EndOfSegmentLocation: &docsEndOfSegmentLocation{},
+		}
+	}
+
+	batchReq := docsBatchUpdateRequest{
+		Requests: []docsRequest{insertReq},
+	}
+
+	updateURL := a.conn.docsBaseURL + "/v1/documents/" + url.PathEscape(params.DocumentID) + ":batchUpdate"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, updateURL, batchReq, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"document_id": params.DocumentID,
+		"status":      "updated",
+	})
+}

--- a/connectors/google/update_document.go
+++ b/connectors/google/update_document.go
@@ -37,29 +37,6 @@ func (p *updateDocumentParams) validate() error {
 	return nil
 }
 
-// Shared Docs API batchUpdate request types, used by both create_document
-// (for inserting initial body) and update_document.
-
-type docsBatchUpdateRequest struct {
-	Requests []docsRequest `json:"requests"`
-}
-
-type docsRequest struct {
-	InsertText *docsInsertTextRequest `json:"insertText,omitempty"`
-}
-
-type docsInsertTextRequest struct {
-	Text                 string                      `json:"text"`
-	Location             *docsLocation               `json:"location,omitempty"`
-	EndOfSegmentLocation *docsEndOfSegmentLocation   `json:"endOfSegmentLocation,omitempty"`
-}
-
-type docsLocation struct {
-	Index int `json:"index"`
-}
-
-type docsEndOfSegmentLocation struct{}
-
 // Execute inserts text into a Google Doc and returns success status.
 func (a *updateDocumentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params updateDocumentParams

--- a/connectors/google/update_document_test.go
+++ b/connectors/google/update_document_test.go
@@ -1,0 +1,272 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUpdateDocument_SuccessAppend(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/documents/doc-abc-123:batchUpdate" {
+			t.Errorf("expected path /v1/documents/doc-abc-123:batchUpdate, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		var body docsBatchUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if len(body.Requests) != 1 {
+			t.Fatalf("expected 1 request, got %d", len(body.Requests))
+		}
+		req := body.Requests[0]
+		if req.InsertText == nil {
+			t.Fatal("expected InsertText request")
+		}
+		if req.InsertText.Text != "appended text" {
+			t.Errorf("expected text 'appended text', got %q", req.InsertText.Text)
+		}
+		if req.InsertText.EndOfSegmentLocation == nil {
+			t.Error("expected EndOfSegmentLocation for append")
+		}
+		if req.InsertText.Location != nil {
+			t.Error("expected nil Location for append")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(updateDocumentParams{
+		DocumentID: "doc-abc-123",
+		Text:       "appended text",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["document_id"] != "doc-abc-123" {
+		t.Errorf("expected document_id 'doc-abc-123', got %q", data["document_id"])
+	}
+	if data["status"] != "updated" {
+		t.Errorf("expected status 'updated', got %q", data["status"])
+	}
+}
+
+func TestUpdateDocument_SuccessInsertAtIndex(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body docsBatchUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		req := body.Requests[0]
+		if req.InsertText.Location == nil {
+			t.Fatal("expected Location for index insert")
+		}
+		if req.InsertText.Location.Index != 5 {
+			t.Errorf("expected index 5, got %d", req.InsertText.Location.Index)
+		}
+		if req.InsertText.EndOfSegmentLocation != nil {
+			t.Error("expected nil EndOfSegmentLocation for index insert")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(updateDocumentParams{
+		DocumentID: "doc-abc-123",
+		Text:       "inserted text",
+		Index:      5,
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["status"] != "updated" {
+		t.Errorf("expected status 'updated', got %q", data["status"])
+	}
+}
+
+func TestUpdateDocument_MissingDocumentID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"text": "hello"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing document_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateDocument_MissingText(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"document_id": "doc-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing text")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateDocument_NegativeIndex(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{
+		"document_id": "doc-123",
+		"text":        "hello",
+		"index":       -1,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for negative index")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateDocument_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(updateDocumentParams{DocumentID: "doc-123", Text: "hello"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T (%v)", err, err)
+	}
+}
+
+func TestUpdateDocument_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(updateDocumentParams{DocumentID: "doc-123", Text: "hello"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestUpdateDocument_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDocumentAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -23,6 +23,7 @@ const mockActions: ConnectorAction[] = [
     name: "Create Issue",
     description: "Create a new issue in a repository",
     risk_level: "low",
+    requires_payment_method: false,
     parameters_schema: {
       type: "object",
       required: ["repo", "title"],
@@ -38,6 +39,7 @@ const mockActions: ConnectorAction[] = [
     name: "Merge Pull Request",
     description: "Merge an open pull request",
     risk_level: "high",
+    requires_payment_method: false,
     parameters_schema: {
       type: "object",
       required: ["repo", "pr"],


### PR DESCRIPTION
## Summary

Adds four new document management actions to the existing Google connector, enabling agents to create, read, update, and search Google Docs.

- **`google.create_document`** (medium risk) — Create a new Google Doc with a title and optional body content via the Docs API
- **`google.get_document`** (low risk) — Retrieve content/metadata of a Google Doc, extracting plain text from structural content
- **`google.update_document`** (medium risk) — Append or insert text at a specific index in an existing Google Doc via batchUpdate
- **`google.list_documents`** (low risk) — Search/list Google Docs from Drive with query filtering and pagination

### Changes

- `connectors/google/google.go` — Added `docsBaseURL`/`driveBaseURL` fields, 4 new manifest actions, 4 new action handlers, 4 new templates, 2 new OAuth scopes (`documents`, `drive.readonly`)
- `connectors/google/create_document.go` + test — Create action with optional body text insertion
- `connectors/google/get_document.go` + test — Get action with plain text extraction from Docs API structural content
- `connectors/google/update_document.go` + test — Update action supporting both append (end of doc) and insert-at-index
- `connectors/google/list_documents.go` + test — List action using Drive API with query escaping to prevent injection
- `connectors/google/google_test.go` — Updated expected action count from 4 to 8

### Notes

- No migration needed — manifest upsert handles action registration on startup
- `get_document` extracts plain text only; richer content handling can be added later
- Adding OAuth scopes means existing tokens will need re-authorization (handled automatically by the OAuth flow)
- Drive query strings are escaped to prevent query injection via user-supplied search terms

## Test plan

- [x] All 45 Google connector tests pass (including ~30 new tests for the 4 new actions)
- [x] All connector tests pass (`go test ./connectors/...`)
- [x] `go vet` passes with no issues
- [ ] Manual testing with real Google API credentials
- [ ] Verify OAuth re-authorization flow works for existing tokens

Closes #237

https://claude.ai/code/session_01SB59mtyw1jKgrxD4gvrGPx