### PR TITLE
Add PowerPoint actions to Microsoft connector

### DIFF
--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -16,7 +16,7 @@ This connector uses OAuth 2.0 — credentials are managed automatically by the p
 
 The credential `auth_type` in the database is `oauth2` with `oauth_provider: "microsoft"`. The platform handles the full OAuth lifecycle: redirect, token exchange, encrypted storage in Supabase Vault, and automatic refresh before expiry. The connector never touches OAuth code — it receives a valid access token in `Credentials` at execution time.
 
-**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`
+**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`, `Files.ReadWrite`
 
 ## Actions
 
@@ -147,6 +147,94 @@ Lists upcoming events from the user's calendar.
 
 **Graph API:** `GET /me/events` ([docs](https://learn.microsoft.com/en-us/graph/api/user-list-events))
 
+---
+
+### `microsoft.create_presentation`
+
+Creates a new empty PowerPoint (.pptx) file in the user's OneDrive. The file is created using a minimal embedded PPTX template (~1.2 KB) uploaded via the OneDrive file upload endpoint.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `filename` | string | Yes | — | Name for the presentation (`.pptx` extension added if missing) |
+| `folder_path` | string | No | `"/"` (root) | OneDrive folder path (e.g., `Documents/Presentations`) |
+
+**Response:**
+
+```json
+{
+  "item_id": "01NBRZAA...",
+  "name": "Quarterly Report.pptx",
+  "web_url": "https://onedrive.live.com/edit.aspx?id=...",
+  "folder_path": "/Documents/Presentations"
+}
+```
+
+**Graph API:** `PUT /me/drive/root:/{path}/{filename}.pptx:/content` ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-put-content))
+
+---
+
+### `microsoft.list_presentations`
+
+Searches for PowerPoint files (.pptx) in the user's OneDrive, optionally scoped to a folder.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `folder_path` | string | No | — | OneDrive folder path to search in (searches all files if omitted) |
+| `top` | integer | No | `10` | Number of presentations to return (1–50) |
+
+**Response:**
+
+```json
+[
+  {
+    "item_id": "01NBRZAA...",
+    "name": "Q4 Review.pptx",
+    "web_url": "https://onedrive.live.com/edit.aspx?id=...",
+    "size": 1048576,
+    "last_modified": "2024-03-15T14:30:00Z"
+  }
+]
+```
+
+**Graph API:** `GET /me/drive/root/search(q='.pptx')` ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-search))
+
+---
+
+### `microsoft.get_presentation`
+
+Gets metadata about a specific PowerPoint file by its OneDrive item ID.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID of the presentation |
+
+**Response:**
+
+```json
+{
+  "item_id": "01NBRZAA...",
+  "name": "Q4 Review.pptx",
+  "web_url": "https://onedrive.live.com/edit.aspx?id=...",
+  "size": 2048576,
+  "last_modified_by": "Jane Smith",
+  "last_modified": "2024-03-15T14:30:00Z"
+}
+```
+
+**Graph API:** `GET /me/drive/items/{itemId}` ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-get))
+
 ## Error Handling
 
 The connector maps Microsoft Graph API responses to typed connector errors:
@@ -166,13 +254,18 @@ Rate limit responses include the `Retry-After` header value so callers know how 
 Each action lives in its own file. To add one (e.g., `microsoft.list_contacts`):
 
 1. Create `connectors/microsoft/list_contacts.go` with a params struct, `validate()` / `defaults()`, and an `Execute` method.
-2. Use `a.conn.doRequest(ctx, method, path, creds, body, &resp)` for the HTTP lifecycle — it handles JSON marshaling, auth headers, rate limiting, error mapping, and timeout detection.
+2. Use `a.conn.doRequest(ctx, method, path, creds, body, &resp)` for JSON API calls — it handles JSON marshaling, auth headers, rate limiting, error mapping, and timeout detection. For binary file uploads, use `a.conn.doPutFileRequest(ctx, path, creds, fileBytes, &resp)`.
 3. Return `connectors.JSONResult(respBody)` to wrap the response struct into an `ActionResult`.
 4. Register the action in `Actions()` inside `microsoft.go`.
-5. Add the action to the `Manifest()` return value inside `microsoft.go` — include a `ParametersSchema`.
+5. Add the action to the `Manifest()` return value inside `microsoft.go` — include a `ParametersSchema` and a template.
 6. Add tests in `list_contacts_test.go` using `httptest.NewServer` and `newForTest()`.
 
-The `doRequest` method means each action file only contains what's unique: parameter parsing, validation, request body shape, and response shape. All shared HTTP concerns (auth, Content-Type, rate limiting, error mapping) are handled once.
+Both `doRequest` and `doPutFileRequest` delegate to `executeAndHandleResponse` for shared response handling (rate limiting, error mapping, body parsing). Each action file only contains what's unique: parameter parsing, validation, request construction, and response shape.
+
+**Security notes for user-supplied path segments:**
+- Use `validatePathSegment()` for opaque IDs interpolated into URL paths (rejects `/`, `\`, `?`, `#`, `%`, `..`)
+- Use `validateFolderPath()` for folder paths (allows `/` for directory separators, rejects `..`, `?`, `#`, `%`, `\`)
+- URL-encode path segments with `url.PathEscape()` or `escapePathSegments()` as defense-in-depth
 
 ## Manifest
 
@@ -184,21 +277,28 @@ When adding a new action, add it to the `Manifest()` return value with a `Parame
 
 ```
 connectors/microsoft/
-├── microsoft.go                  # MicrosoftConnector struct, New(), Manifest(), doRequest(), ValidateCredentials()
-├── types.go                      # Shared Microsoft Graph API types (graphEmailBody, graphMailAddress, etc.)
-├── response.go                   # Graph API error response → typed connector error mapping
-├── validation.go                 # Shared validation helpers (validateEmail, detectContentType)
-├── send_email.go                 # microsoft.send_email action
-├── list_emails.go                # microsoft.list_emails action
-├── create_calendar_event.go      # microsoft.create_calendar_event action
-├── list_calendar_events.go       # microsoft.list_calendar_events action
-├── microsoft_test.go             # Connector-level tests
-├── helpers_test.go               # Shared test helpers (validCreds)
-├── send_email_test.go            # Send email action tests
-├── list_emails_test.go           # List emails action tests
-├── create_calendar_event_test.go # Create calendar event action tests
-├── list_calendar_events_test.go  # List calendar events action tests
-└── README.md                     # This file
+├── microsoft.go                    # MicrosoftConnector, Manifest(), doRequest(), doPutFileRequest(), executeAndHandleResponse()
+├── types.go                        # Shared Microsoft Graph API types (graphEmailBody, graphMailAddress, etc.)
+├── response.go                     # Graph API error response → typed connector error mapping
+├── validation.go                   # Shared validation helpers (validateEmail, validatePathSegment, escapePathSegments, etc.)
+├── pptx_template.go                # Minimal embedded .pptx template for create_presentation
+├── send_email.go                   # microsoft.send_email action
+├── list_emails.go                  # microsoft.list_emails action
+├── create_calendar_event.go        # microsoft.create_calendar_event action
+├── list_calendar_events.go         # microsoft.list_calendar_events action
+├── create_presentation.go          # microsoft.create_presentation action
+├── list_presentations.go           # microsoft.list_presentations action
+├── get_presentation.go             # microsoft.get_presentation action
+├── microsoft_test.go               # Connector-level tests
+├── helpers_test.go                 # Shared test helpers (validCreds)
+├── send_email_test.go              # Send email action tests
+├── list_emails_test.go             # List emails action tests
+├── create_calendar_event_test.go   # Create calendar event action tests
+├── list_calendar_events_test.go    # List calendar events action tests
+├── create_presentation_test.go     # Create presentation action tests
+├── list_presentations_test.go      # List presentations action tests
+├── get_presentation_test.go        # Get presentation action tests
+└── README.md                       # This file
 ```
 
 ## Testing

--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -263,7 +263,7 @@ Each action lives in its own file. To add one (e.g., `microsoft.list_contacts`):
 Both `doRequest` and `doPutFileRequest` delegate to `executeAndHandleResponse` for shared response handling (rate limiting, error mapping, body parsing). Each action file only contains what's unique: parameter parsing, validation, request construction, and response shape.
 
 **Security notes for user-supplied path segments:**
-- Use `validatePathSegment()` for opaque IDs interpolated into URL paths (rejects `/`, `\`, `?`, `#`, `%`, `..`)
+- Use `validateGraphID()` for opaque IDs interpolated into URL paths (rejects `/`, `\`, `?`, `#`, `%`, `..`)
 - Use `validateFolderPath()` for folder paths (allows `/` for directory separators, rejects `..`, `?`, `#`, `%`, `\`)
 - URL-encode path segments with `url.PathEscape()` or `escapePathSegments()` as defense-in-depth
 
@@ -280,7 +280,7 @@ connectors/microsoft/
 ├── microsoft.go                    # MicrosoftConnector, Manifest(), doRequest(), doPutFileRequest(), executeAndHandleResponse()
 ├── types.go                        # Shared Microsoft Graph API types (graphEmailBody, graphMailAddress, etc.)
 ├── response.go                     # Graph API error response → typed connector error mapping
-├── validation.go                   # Shared validation helpers (validateEmail, validatePathSegment, escapePathSegments, etc.)
+├── validation.go                   # Shared validation helpers (validateEmail, validateGraphID, escapePathSegments, etc.)
 ├── pptx_template.go                # Minimal embedded .pptx template for create_presentation
 ├── send_email.go                   # microsoft.send_email action
 ├── list_emails.go                  # microsoft.list_emails action

--- a/connectors/microsoft/create_presentation.go
+++ b/connectors/microsoft/create_presentation.go
@@ -23,17 +23,13 @@ type createPresentationParams struct {
 
 func (p *createPresentationParams) validate() error {
 	if p.Filename == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: filename"}
+		return &connectors.ValidationError{Message: "missing required parameter: filename (e.g. 'Quarterly Report')"}
 	}
 	// Reject path traversal or directory separators in filename.
 	if strings.Contains(p.Filename, "/") || strings.Contains(p.Filename, "\\") || strings.Contains(p.Filename, "..") {
-		return &connectors.ValidationError{Message: "invalid filename: must not contain path separators or traversal sequences"}
+		return &connectors.ValidationError{Message: "invalid filename: must be a simple name without path separators (e.g. 'My Deck' not 'folder/My Deck')"}
 	}
-	// Reject path traversal in folder_path.
-	if strings.Contains(p.FolderPath, "..") {
-		return &connectors.ValidationError{Message: "invalid folder_path: must not contain traversal sequences"}
-	}
-	return nil
+	return validateFolderPath(p.FolderPath)
 }
 
 // graphDriveItemResponse is the Microsoft Graph API response for a DriveItem.
@@ -70,22 +66,24 @@ func (a *createPresentationAction) Execute(ctx context.Context, req connectors.A
 
 	// Build the upload path.
 	var path string
+	folderDisplay := "/"
 	if params.FolderPath == "" || params.FolderPath == "/" {
 		path = fmt.Sprintf("/me/drive/root:/%s:/content", filename)
 	} else {
-		folder := strings.TrimPrefix(params.FolderPath, "/")
-		folder = strings.TrimSuffix(folder, "/")
+		folder := normalizeFolderPath(params.FolderPath)
+		folderDisplay = "/" + folder
 		path = fmt.Sprintf("/me/drive/root:/%s/%s:/content", folder, filename)
 	}
 
 	var resp graphDriveItemResponse
-	if err := a.conn.doPutFileRequest(ctx, path, req.Credentials, minimalPPTXBytes(), &resp); err != nil {
+	if err := a.conn.doPutFileRequest(ctx, path, req.Credentials, minimalPPTX, &resp); err != nil {
 		return nil, err
 	}
 
 	return connectors.JSONResult(map[string]string{
-		"item_id": resp.ID,
-		"name":    resp.Name,
-		"web_url": resp.WebURL,
+		"item_id":     resp.ID,
+		"name":        resp.Name,
+		"web_url":     resp.WebURL,
+		"folder_path": folderDisplay,
 	})
 }

--- a/connectors/microsoft/create_presentation.go
+++ b/connectors/microsoft/create_presentation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -64,15 +65,17 @@ func (a *createPresentationAction) Execute(ctx context.Context, req connectors.A
 		filename += ".pptx"
 	}
 
-	// Build the upload path.
+	// Build the upload path. URL-encode user-supplied segments to prevent
+	// path manipulation via special characters (?, #, etc.).
+	escapedFilename := url.PathEscape(filename)
 	var path string
 	folderDisplay := "/"
 	if params.FolderPath == "" || params.FolderPath == "/" {
-		path = fmt.Sprintf("/me/drive/root:/%s:/content", filename)
+		path = fmt.Sprintf("/me/drive/root:/%s:/content", escapedFilename)
 	} else {
 		folder := normalizeFolderPath(params.FolderPath)
 		folderDisplay = "/" + folder
-		path = fmt.Sprintf("/me/drive/root:/%s/%s:/content", folder, filename)
+		path = fmt.Sprintf("/me/drive/root:/%s/%s:/content", escapePathSegments(folder), escapedFilename)
 	}
 
 	var resp graphDriveItemResponse

--- a/connectors/microsoft/create_presentation.go
+++ b/connectors/microsoft/create_presentation.go
@@ -1,0 +1,91 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createPresentationAction implements connectors.Action for microsoft.create_presentation.
+// It creates a new empty .pptx file in the user's OneDrive via the Microsoft Graph API.
+type createPresentationAction struct {
+	conn *MicrosoftConnector
+}
+
+// createPresentationParams is the user-facing parameter schema.
+type createPresentationParams struct {
+	Filename   string `json:"filename"`
+	FolderPath string `json:"folder_path,omitempty"`
+}
+
+func (p *createPresentationParams) validate() error {
+	if p.Filename == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: filename"}
+	}
+	// Reject path traversal or directory separators in filename.
+	if strings.Contains(p.Filename, "/") || strings.Contains(p.Filename, "\\") || strings.Contains(p.Filename, "..") {
+		return &connectors.ValidationError{Message: "invalid filename: must not contain path separators or traversal sequences"}
+	}
+	// Reject path traversal in folder_path.
+	if strings.Contains(p.FolderPath, "..") {
+		return &connectors.ValidationError{Message: "invalid folder_path: must not contain traversal sequences"}
+	}
+	return nil
+}
+
+// graphDriveItemResponse is the Microsoft Graph API response for a DriveItem.
+type graphDriveItemResponse struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	WebURL         string `json:"webUrl"`
+	Size           int64  `json:"size"`
+	LastModifiedBy struct {
+		User struct {
+			DisplayName string `json:"displayName"`
+		} `json:"user"`
+	} `json:"lastModifiedBy"`
+	LastModified string `json:"lastModifiedDateTime"`
+}
+
+// Execute creates a new .pptx file in OneDrive.
+// It uses PUT /me/drive/root:/{path}/{filename}.pptx:/content with the minimal
+// PPTX template bytes as the request body.
+func (a *createPresentationAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createPresentationParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// Ensure filename ends with .pptx.
+	filename := params.Filename
+	if !strings.HasSuffix(strings.ToLower(filename), ".pptx") {
+		filename += ".pptx"
+	}
+
+	// Build the upload path.
+	var path string
+	if params.FolderPath == "" || params.FolderPath == "/" {
+		path = fmt.Sprintf("/me/drive/root:/%s:/content", filename)
+	} else {
+		folder := strings.TrimPrefix(params.FolderPath, "/")
+		folder = strings.TrimSuffix(folder, "/")
+		path = fmt.Sprintf("/me/drive/root:/%s/%s:/content", folder, filename)
+	}
+
+	var resp graphDriveItemResponse
+	if err := a.conn.doPutFileRequest(ctx, path, req.Credentials, minimalPPTXBytes(), &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"item_id": resp.ID,
+		"name":    resp.Name,
+		"web_url": resp.WebURL,
+	})
+}

--- a/connectors/microsoft/create_presentation_test.go
+++ b/connectors/microsoft/create_presentation_test.go
@@ -1,0 +1,293 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreatePresentation_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if got := r.URL.Path; got != "/me/drive/root:/Quarterly Report.pptx:/content" {
+			t.Errorf("expected path /me/drive/root:/Quarterly Report.pptx:/content, got %s", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/vnd.openxmlformats-officedocument.presentationml.presentation" {
+			t.Errorf("expected PPTX content type, got %q", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		if len(body) == 0 {
+			t.Error("expected non-empty request body with PPTX bytes")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":     "item-abc-123",
+			"name":   "Quarterly Report.pptx",
+			"webUrl": "https://onedrive.live.com/edit.aspx?id=item-abc-123",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename: "Quarterly Report",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["item_id"] != "item-abc-123" {
+		t.Errorf("expected item_id 'item-abc-123', got %q", data["item_id"])
+	}
+	if data["name"] != "Quarterly Report.pptx" {
+		t.Errorf("expected name 'Quarterly Report.pptx', got %q", data["name"])
+	}
+	if data["web_url"] != "https://onedrive.live.com/edit.aspx?id=item-abc-123" {
+		t.Errorf("expected web_url, got %q", data["web_url"])
+	}
+}
+
+func TestCreatePresentation_WithFolderPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/me/drive/root:/Documents/Presentations/deck.pptx:/content" {
+			t.Errorf("expected path with folder, got %s", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":     "item-456",
+			"name":   "deck.pptx",
+			"webUrl": "https://onedrive.live.com/edit.aspx?id=item-456",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename:   "deck.pptx",
+		FolderPath: "Documents/Presentations",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreatePresentation_AppendsPptxExtension(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/me/drive/root:/My Slides.pptx:/content" {
+			t.Errorf("expected .pptx appended, got path %s", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":     "item-789",
+			"name":   "My Slides.pptx",
+			"webUrl": "https://onedrive.live.com/edit.aspx?id=item-789",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename: "My Slides",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreatePresentation_MissingFilename(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing filename")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreatePresentation_FilenamePathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename: "../../evil.pptx",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in filename")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreatePresentation_FolderPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename:   "deck.pptx",
+		FolderPath: "../../../etc",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in folder_path")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreatePresentation_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createPresentationAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreatePresentation_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "InvalidAuthenticationToken",
+				"message": "Access token has expired",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename: "test.pptx",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestCreatePresentation_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename: "test.pptx",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/create_presentation_test.go
+++ b/connectors/microsoft/create_presentation_test.go
@@ -70,6 +70,9 @@ func TestCreatePresentation_Success(t *testing.T) {
 	if data["web_url"] != "https://onedrive.live.com/edit.aspx?id=item-abc-123" {
 		t.Errorf("expected web_url, got %q", data["web_url"])
 	}
+	if data["folder_path"] != "/" {
+		t.Errorf("expected folder_path '/', got %q", data["folder_path"])
+	}
 }
 
 func TestCreatePresentation_WithFolderPath(t *testing.T) {

--- a/connectors/microsoft/create_presentation_test.go
+++ b/connectors/microsoft/create_presentation_test.go
@@ -212,6 +212,30 @@ func TestCreatePresentation_FolderPathTraversal(t *testing.T) {
 	}
 }
 
+func TestCreatePresentation_FolderPathSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(createPresentationParams{
+		Filename:   "deck.pptx",
+		FolderPath: "folder?query=inject",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for special chars in folder_path")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestCreatePresentation_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/get_presentation.go
+++ b/connectors/microsoft/get_presentation.go
@@ -22,13 +22,7 @@ type getPresentationParams struct {
 }
 
 func (p *getPresentationParams) validate() error {
-	if p.ItemID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: item_id"}
-	}
-	if err := validatePathSegment("item_id", p.ItemID); err != nil {
-		return err
-	}
-	return nil
+	return validateGraphID("item_id", p.ItemID)
 }
 
 // Execute retrieves metadata for a PowerPoint file from OneDrive.

--- a/connectors/microsoft/get_presentation.go
+++ b/connectors/microsoft/get_presentation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -24,6 +25,9 @@ func (p *getPresentationParams) validate() error {
 	if p.ItemID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: item_id"}
 	}
+	if err := validatePathSegment("item_id", p.ItemID); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -37,7 +41,7 @@ func (a *getPresentationAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/me/drive/items/%s?$select=id,name,webUrl,size,lastModifiedBy,lastModifiedDateTime", params.ItemID)
+	path := fmt.Sprintf("/me/drive/items/%s?$select=id,name,webUrl,size,lastModifiedBy,lastModifiedDateTime", url.PathEscape(params.ItemID))
 
 	var resp graphDriveItemResponse
 	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {

--- a/connectors/microsoft/get_presentation.go
+++ b/connectors/microsoft/get_presentation.go
@@ -1,0 +1,55 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getPresentationAction implements connectors.Action for microsoft.get_presentation.
+// It retrieves metadata for a specific PowerPoint file by item ID via the Microsoft Graph API.
+type getPresentationAction struct {
+	conn *MicrosoftConnector
+}
+
+// getPresentationParams is the user-facing parameter schema.
+type getPresentationParams struct {
+	ItemID string `json:"item_id"`
+}
+
+func (p *getPresentationParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: item_id"}
+	}
+	return nil
+}
+
+// Execute retrieves metadata for a PowerPoint file from OneDrive.
+func (a *getPresentationAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getPresentationParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/items/%s?$select=id,name,webUrl,size,lastModifiedBy,lastModifiedDateTime", params.ItemID)
+
+	var resp graphDriveItemResponse
+	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"item_id":          resp.ID,
+		"name":             resp.Name,
+		"web_url":          resp.WebURL,
+		"size":             resp.Size,
+		"last_modified_by": resp.LastModifiedBy.User.DisplayName,
+		"last_modified":    resp.LastModified,
+	})
+}

--- a/connectors/microsoft/get_presentation_test.go
+++ b/connectors/microsoft/get_presentation_test.go
@@ -171,6 +171,54 @@ func TestGetPresentation_AuthFailure(t *testing.T) {
 	}
 }
 
+func TestGetPresentation_ItemIDPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getPresentationAction{conn: conn}
+
+	// A crafted item_id with path traversal could hit a different Graph endpoint.
+	params, _ := json.Marshal(getPresentationParams{
+		ItemID: "foo/../me/messages",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for item_id with path traversal")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetPresentation_ItemIDQueryInjection(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getPresentationAction{conn: conn}
+
+	// A crafted item_id with ? could alter the query string.
+	params, _ := json.Marshal(getPresentationParams{
+		ItemID: "item123?$select=content",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for item_id with query injection")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestGetPresentation_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/get_presentation_test.go
+++ b/connectors/microsoft/get_presentation_test.go
@@ -1,0 +1,191 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetPresentation_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.URL.Path; got != "/me/drive/items/item-abc-123" {
+			t.Errorf("expected path /me/drive/items/item-abc-123, got %s", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":     "item-abc-123",
+			"name":   "Q4 Review.pptx",
+			"webUrl": "https://onedrive.live.com/edit.aspx?id=item-abc-123",
+			"size":   2048576,
+			"lastModifiedBy": map[string]any{
+				"user": map[string]string{
+					"displayName": "Jane Smith",
+				},
+			},
+			"lastModifiedDateTime": "2024-03-15T14:30:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(getPresentationParams{
+		ItemID: "item-abc-123",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["item_id"] != "item-abc-123" {
+		t.Errorf("expected item_id 'item-abc-123', got %v", data["item_id"])
+	}
+	if data["name"] != "Q4 Review.pptx" {
+		t.Errorf("expected name 'Q4 Review.pptx', got %v", data["name"])
+	}
+	if data["web_url"] != "https://onedrive.live.com/edit.aspx?id=item-abc-123" {
+		t.Errorf("expected web_url, got %v", data["web_url"])
+	}
+	if data["last_modified_by"] != "Jane Smith" {
+		t.Errorf("expected last_modified_by 'Jane Smith', got %v", data["last_modified_by"])
+	}
+	if data["last_modified"] != "2024-03-15T14:30:00Z" {
+		t.Errorf("expected last_modified '2024-03-15T14:30:00Z', got %v", data["last_modified"])
+	}
+	// JSON numbers decode as float64.
+	if size, ok := data["size"].(float64); !ok || size != 2048576 {
+		t.Errorf("expected size 2048576, got %v", data["size"])
+	}
+}
+
+func TestGetPresentation_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(getPresentationParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetPresentation_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "itemNotFound",
+				"message": "Item does not exist",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(getPresentationParams{
+		ItemID: "nonexistent-item",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for not found item")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got: %T", err)
+	}
+}
+
+func TestGetPresentation_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "InvalidAuthenticationToken",
+				"message": "Access token has expired",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getPresentationAction{conn: conn}
+
+	params, _ := json.Marshal(getPresentationParams{
+		ItemID: "item-123",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestGetPresentation_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getPresentationAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_presentation",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/list_presentations.go
+++ b/connectors/microsoft/list_presentations.go
@@ -65,7 +65,7 @@ func (a *listPresentationsAction) Execute(ctx context.Context, req connectors.Ac
 		path = fmt.Sprintf("/me/drive/root/search(q='.pptx')?$top=%d&$select=id,name,webUrl,size,lastModifiedDateTime", params.Top)
 	} else {
 		folder := normalizeFolderPath(params.FolderPath)
-		path = fmt.Sprintf("/me/drive/root:/%s:/search(q='.pptx')?$top=%d&$select=id,name,webUrl,size,lastModifiedDateTime", folder, params.Top)
+		path = fmt.Sprintf("/me/drive/root:/%s:/search(q='.pptx')?$top=%d&$select=id,name,webUrl,size,lastModifiedDateTime", escapePathSegments(folder), params.Top)
 	}
 
 	var resp graphDriveSearchResponse

--- a/connectors/microsoft/list_presentations.go
+++ b/connectors/microsoft/list_presentations.go
@@ -32,10 +32,7 @@ func (p *listPresentationsParams) defaults() {
 }
 
 func (p *listPresentationsParams) validate() error {
-	if strings.Contains(p.FolderPath, "..") {
-		return &connectors.ValidationError{Message: "invalid folder_path: must not contain traversal sequences"}
-	}
-	return nil
+	return validateFolderPath(p.FolderPath)
 }
 
 // graphDriveSearchResponse is the Microsoft Graph API response for drive searches.
@@ -48,6 +45,7 @@ type presentationSummary struct {
 	ItemID       string `json:"item_id"`
 	Name         string `json:"name"`
 	WebURL       string `json:"web_url"`
+	Size         int64  `json:"size"`
 	LastModified string `json:"last_modified"`
 }
 
@@ -64,11 +62,10 @@ func (a *listPresentationsAction) Execute(ctx context.Context, req connectors.Ac
 
 	var path string
 	if params.FolderPath == "" || params.FolderPath == "/" {
-		path = fmt.Sprintf("/me/drive/root/search(q='.pptx')?$top=%d&$select=id,name,webUrl,lastModifiedDateTime", params.Top)
+		path = fmt.Sprintf("/me/drive/root/search(q='.pptx')?$top=%d&$select=id,name,webUrl,size,lastModifiedDateTime", params.Top)
 	} else {
-		folder := strings.TrimPrefix(params.FolderPath, "/")
-		folder = strings.TrimSuffix(folder, "/")
-		path = fmt.Sprintf("/me/drive/root:/%s:/search(q='.pptx')?$top=%d&$select=id,name,webUrl,lastModifiedDateTime", folder, params.Top)
+		folder := normalizeFolderPath(params.FolderPath)
+		path = fmt.Sprintf("/me/drive/root:/%s:/search(q='.pptx')?$top=%d&$select=id,name,webUrl,size,lastModifiedDateTime", folder, params.Top)
 	}
 
 	var resp graphDriveSearchResponse
@@ -86,6 +83,7 @@ func (a *listPresentationsAction) Execute(ctx context.Context, req connectors.Ac
 			ItemID:       item.ID,
 			Name:         item.Name,
 			WebURL:       item.WebURL,
+			Size:         item.Size,
 			LastModified: item.LastModified,
 		})
 	}

--- a/connectors/microsoft/list_presentations.go
+++ b/connectors/microsoft/list_presentations.go
@@ -1,0 +1,94 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listPresentationsAction implements connectors.Action for microsoft.list_presentations.
+// It searches for .pptx files in the user's OneDrive via the Microsoft Graph API.
+type listPresentationsAction struct {
+	conn *MicrosoftConnector
+}
+
+// listPresentationsParams is the user-facing parameter schema.
+type listPresentationsParams struct {
+	FolderPath string `json:"folder_path,omitempty"`
+	Top        int    `json:"top"`
+}
+
+func (p *listPresentationsParams) defaults() {
+	if p.Top <= 0 {
+		p.Top = 10
+	}
+	if p.Top > 50 {
+		p.Top = 50
+	}
+}
+
+func (p *listPresentationsParams) validate() error {
+	if strings.Contains(p.FolderPath, "..") {
+		return &connectors.ValidationError{Message: "invalid folder_path: must not contain traversal sequences"}
+	}
+	return nil
+}
+
+// graphDriveSearchResponse is the Microsoft Graph API response for drive searches.
+type graphDriveSearchResponse struct {
+	Value []graphDriveItemResponse `json:"value"`
+}
+
+// presentationSummary is the simplified response returned to the caller.
+type presentationSummary struct {
+	ItemID       string `json:"item_id"`
+	Name         string `json:"name"`
+	WebURL       string `json:"web_url"`
+	LastModified string `json:"last_modified"`
+}
+
+// Execute lists PowerPoint files from the user's OneDrive.
+func (a *listPresentationsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listPresentationsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.defaults()
+
+	var path string
+	if params.FolderPath == "" || params.FolderPath == "/" {
+		path = fmt.Sprintf("/me/drive/root/search(q='.pptx')?$top=%d&$select=id,name,webUrl,lastModifiedDateTime", params.Top)
+	} else {
+		folder := strings.TrimPrefix(params.FolderPath, "/")
+		folder = strings.TrimSuffix(folder, "/")
+		path = fmt.Sprintf("/me/drive/root:/%s:/search(q='.pptx')?$top=%d&$select=id,name,webUrl,lastModifiedDateTime", folder, params.Top)
+	}
+
+	var resp graphDriveSearchResponse
+	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	summaries := make([]presentationSummary, 0, len(resp.Value))
+	for _, item := range resp.Value {
+		// Only include actual .pptx files (search may return partial matches).
+		if !strings.HasSuffix(strings.ToLower(item.Name), ".pptx") {
+			continue
+		}
+		summaries = append(summaries, presentationSummary{
+			ItemID:       item.ID,
+			Name:         item.Name,
+			WebURL:       item.WebURL,
+			LastModified: item.LastModified,
+		})
+	}
+
+	return connectors.JSONResult(summaries)
+}

--- a/connectors/microsoft/list_presentations_test.go
+++ b/connectors/microsoft/list_presentations_test.go
@@ -1,0 +1,215 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListPresentations_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{
+				{
+					"id":                    "item-1",
+					"name":                  "Q4 Review.pptx",
+					"webUrl":                "https://onedrive.live.com/edit.aspx?id=item-1",
+					"lastModifiedDateTime":  "2024-03-15T14:30:00Z",
+				},
+				{
+					"id":                    "item-2",
+					"name":                  "Strategy.pptx",
+					"webUrl":                "https://onedrive.live.com/edit.aspx?id=item-2",
+					"lastModifiedDateTime":  "2024-03-10T09:00:00Z",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listPresentationsAction{conn: conn}
+
+	params, _ := json.Marshal(listPresentationsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_presentations",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var summaries []presentationSummary
+	if err := json.Unmarshal(result.Data, &summaries); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 presentations, got %d", len(summaries))
+	}
+	if summaries[0].ItemID != "item-1" {
+		t.Errorf("expected item_id 'item-1', got %q", summaries[0].ItemID)
+	}
+	if summaries[0].Name != "Q4 Review.pptx" {
+		t.Errorf("expected name 'Q4 Review.pptx', got %q", summaries[0].Name)
+	}
+}
+
+func TestListPresentations_WithFolderPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the path includes the folder.
+		if got := r.URL.Path; got != "/me/drive/root:/Documents/Decks:/search(q='.pptx')" {
+			t.Errorf("expected folder-scoped search path, got %s", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listPresentationsAction{conn: conn}
+
+	params, _ := json.Marshal(listPresentationsParams{
+		FolderPath: "Documents/Decks",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_presentations",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListPresentations_FiltersNonPptx(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{
+				{
+					"id":                   "item-1",
+					"name":                 "Slides.pptx",
+					"webUrl":               "https://example.com/1",
+					"lastModifiedDateTime": "2024-01-01T00:00:00Z",
+				},
+				{
+					"id":                   "item-2",
+					"name":                 "notes-about-pptx.docx",
+					"webUrl":               "https://example.com/2",
+					"lastModifiedDateTime": "2024-01-01T00:00:00Z",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listPresentationsAction{conn: conn}
+
+	params, _ := json.Marshal(listPresentationsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_presentations",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var summaries []presentationSummary
+	if err := json.Unmarshal(result.Data, &summaries); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 presentation (non-pptx filtered out), got %d", len(summaries))
+	}
+	if summaries[0].Name != "Slides.pptx" {
+		t.Errorf("expected 'Slides.pptx', got %q", summaries[0].Name)
+	}
+}
+
+func TestListPresentations_DefaultParams(t *testing.T) {
+	t.Parallel()
+
+	var params listPresentationsParams
+	params.defaults()
+	if params.Top != 10 {
+		t.Errorf("expected default top 10, got %d", params.Top)
+	}
+}
+
+func TestListPresentations_TopClamped(t *testing.T) {
+	t.Parallel()
+
+	params := listPresentationsParams{Top: 100}
+	params.defaults()
+	if params.Top != 50 {
+		t.Errorf("expected top clamped to 50, got %d", params.Top)
+	}
+}
+
+func TestListPresentations_FolderPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listPresentationsAction{conn: conn}
+
+	params, _ := json.Marshal(listPresentationsParams{
+		FolderPath: "../../secrets",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_presentations",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal in folder_path")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListPresentations_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listPresentationsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_presentations",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/list_presentations_test.go
+++ b/connectors/microsoft/list_presentations_test.go
@@ -24,16 +24,18 @@ func TestListPresentations_Success(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"value": []map[string]any{
 				{
-					"id":                    "item-1",
-					"name":                  "Q4 Review.pptx",
-					"webUrl":                "https://onedrive.live.com/edit.aspx?id=item-1",
-					"lastModifiedDateTime":  "2024-03-15T14:30:00Z",
+					"id":                   "item-1",
+					"name":                 "Q4 Review.pptx",
+					"webUrl":               "https://onedrive.live.com/edit.aspx?id=item-1",
+					"size":                 1048576,
+					"lastModifiedDateTime": "2024-03-15T14:30:00Z",
 				},
 				{
-					"id":                    "item-2",
-					"name":                  "Strategy.pptx",
-					"webUrl":                "https://onedrive.live.com/edit.aspx?id=item-2",
-					"lastModifiedDateTime":  "2024-03-10T09:00:00Z",
+					"id":                   "item-2",
+					"name":                 "Strategy.pptx",
+					"webUrl":               "https://onedrive.live.com/edit.aspx?id=item-2",
+					"size":                 524288,
+					"lastModifiedDateTime": "2024-03-10T09:00:00Z",
 				},
 			},
 		})
@@ -66,6 +68,9 @@ func TestListPresentations_Success(t *testing.T) {
 	}
 	if summaries[0].Name != "Q4 Review.pptx" {
 		t.Errorf("expected name 'Q4 Review.pptx', got %q", summaries[0].Name)
+	}
+	if summaries[0].Size != 1048576 {
+		t.Errorf("expected size 1048576, got %d", summaries[0].Size)
 	}
 }
 

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -330,9 +330,8 @@ func (c *MicrosoftConnector) ValidateCredentials(_ context.Context, creds connec
 }
 
 // doPutFileRequest uploads raw file bytes via PUT to a Microsoft Graph endpoint.
-// It handles the same lifecycle as doRequest (auth, rate limiting, error mapping,
-// response parsing) but sends raw bytes with the appropriate content type instead
-// of JSON-marshaling a request body. Used for OneDrive file upload endpoints.
+// Used for OneDrive file upload endpoints. Delegates to executeAndHandleResponse
+// for shared response handling.
 func (c *MicrosoftConnector) doPutFileRequest(ctx context.Context, path string, creds connectors.Credentials, fileBytes []byte, dest any) error {
 	token, ok := creds.Get(credKeyToken)
 	if !ok || token == "" {
@@ -346,59 +345,12 @@ func (c *MicrosoftConnector) doPutFileRequest(ctx context.Context, path string, 
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/vnd.openxmlformats-officedocument.presentationml.presentation")
 
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
-		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
-		return &connectors.RateLimitError{
-			Message:    "Microsoft Graph API rate limit exceeded",
-			RetryAfter: retryAfter,
-		}
-	}
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
-	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return mapGraphError(resp.StatusCode, respBody)
-	}
-
-	if dest != nil && len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, dest); err != nil {
-			return &connectors.ExternalError{
-				StatusCode: resp.StatusCode,
-				Message:    "failed to decode Microsoft Graph API response",
-			}
-		}
-	}
-
-	return nil
+	return c.executeAndHandleResponse(req, dest)
 }
 
-// doRequest is the shared request lifecycle for all Microsoft Graph actions.
-// It handles:
-//   - JSON marshaling of the request body (if non-nil)
-//   - Authorization header with the OAuth access token
-//   - Rate limit detection (HTTP 429 → RateLimitError with Retry-After)
-//   - Response body size limiting (maxResponseBodySize) to prevent OOM
-//   - Error response mapping via mapGraphError (see response.go)
-//   - JSON unmarshaling of successful responses into dest (if non-nil)
-//   - 204 No Content handling (e.g. sendMail returns no body)
-//
-// Callers provide the HTTP method, Graph API path (e.g. "/me/sendMail"),
-// credentials, optional request body, and optional response destination.
+// doRequest is the shared request lifecycle for JSON-based Microsoft Graph actions.
+// It handles JSON marshaling of the request body, auth, and delegates to
+// executeAndHandleResponse for rate limiting, error mapping, and response parsing.
 func (c *MicrosoftConnector) doRequest(ctx context.Context, method, path string, creds connectors.Credentials, body any, dest any) error {
 	token, ok := creds.Get(credKeyToken)
 	if !ok || token == "" {
@@ -423,6 +375,13 @@ func (c *MicrosoftConnector) doRequest(ctx context.Context, method, path string,
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	return c.executeAndHandleResponse(req, dest)
+}
+
+// executeAndHandleResponse executes an HTTP request and handles the response
+// lifecycle shared by all Graph API calls: transport errors, rate limiting,
+// response body reading with size limits, error mapping, and JSON decoding.
+func (c *MicrosoftConnector) executeAndHandleResponse(req *http.Request, dest any) error {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		if connectors.IsTimeout(err) {
@@ -435,7 +394,6 @@ func (c *MicrosoftConnector) doRequest(ctx context.Context, method, path string,
 	}
 	defer resp.Body.Close()
 
-	// Microsoft Graph returns 429 for rate limiting.
 	if resp.StatusCode == http.StatusTooManyRequests {
 		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
 		return &connectors.RateLimitError{

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -65,7 +65,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "microsoft",
 		Name:        "Microsoft",
-		Description: "Microsoft 365 integration for email and calendar via Microsoft Graph API",
+		Description: "Microsoft 365 integration for email, calendar, and presentations via Microsoft Graph API",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "microsoft.send_email",
@@ -180,6 +180,64 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "microsoft.create_presentation",
+				Name:        "Create Presentation",
+				Description: "Create a new PowerPoint presentation in OneDrive",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["filename"],
+					"properties": {
+						"filename": {
+							"type": "string",
+							"description": "Name for the presentation file (.pptx extension added if missing)"
+						},
+						"folder_path": {
+							"type": "string",
+							"description": "OneDrive folder path (e.g. Documents/Presentations). Defaults to root."
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.list_presentations",
+				Name:        "List Presentations",
+				Description: "Search for PowerPoint presentations in OneDrive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"folder_path": {
+							"type": "string",
+							"description": "OneDrive folder path to search in. Defaults to searching all files."
+						},
+						"top": {
+							"type": "integer",
+							"default": 10,
+							"minimum": 1,
+							"maximum": 50,
+							"description": "Number of presentations to return (max 50)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.get_presentation",
+				Name:        "Get Presentation",
+				Description: "Get metadata about a specific PowerPoint presentation",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID of the presentation"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -190,6 +248,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 					"Mail.Send",
 					"Mail.Read",
 					"Calendars.ReadWrite",
+					"Files.ReadWrite",
 				},
 			},
 		},
@@ -222,6 +281,27 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can view upcoming calendar events.",
 				Parameters:  json.RawMessage(`{"top":"*"}`),
 			},
+			{
+				ID:          "tpl_microsoft_create_presentation",
+				ActionType:  "microsoft.create_presentation",
+				Name:        "Create presentations",
+				Description: "Agent can create new PowerPoint presentations in OneDrive.",
+				Parameters:  json.RawMessage(`{"filename":"*","folder_path":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_list_presentations",
+				ActionType:  "microsoft.list_presentations",
+				Name:        "List presentations",
+				Description: "Agent can search for PowerPoint presentations in OneDrive.",
+				Parameters:  json.RawMessage(`{"folder_path":"*","top":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_get_presentation",
+				ActionType:  "microsoft.get_presentation",
+				Name:        "View presentation details",
+				Description: "Agent can view metadata about PowerPoint presentations.",
+				Parameters:  json.RawMessage(`{"item_id":"*"}`),
+			},
 		},
 	}
 }
@@ -233,6 +313,9 @@ func (c *MicrosoftConnector) Actions() map[string]connectors.Action {
 		"microsoft.list_emails":           &listEmailsAction{conn: c},
 		"microsoft.create_calendar_event": &createCalendarEventAction{conn: c},
 		"microsoft.list_calendar_events":  &listCalendarEventsAction{conn: c},
+		"microsoft.create_presentation":   &createPresentationAction{conn: c},
+		"microsoft.list_presentations":    &listPresentationsAction{conn: c},
+		"microsoft.get_presentation":      &getPresentationAction{conn: c},
 	}
 }
 
@@ -243,6 +326,64 @@ func (c *MicrosoftConnector) ValidateCredentials(_ context.Context, creds connec
 	if !ok || token == "" {
 		return &connectors.ValidationError{Message: "missing required credential: access_token"}
 	}
+	return nil
+}
+
+// doPutFileRequest uploads raw file bytes via PUT to a Microsoft Graph endpoint.
+// It handles the same lifecycle as doRequest (auth, rate limiting, error mapping,
+// response parsing) but sends raw bytes with the appropriate content type instead
+// of JSON-marshaling a request body. Used for OneDrive file upload endpoints.
+func (c *MicrosoftConnector) doPutFileRequest(ctx context.Context, path string, creds connectors.Credentials, fileBytes []byte, dest any) error {
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(fileBytes))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/vnd.openxmlformats-officedocument.presentationml.presentation")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    "Microsoft Graph API rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return mapGraphError(resp.StatusCode, respBody)
+	}
+
+	if dest != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, dest); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    "failed to decode Microsoft Graph API response",
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/connectors/microsoft/microsoft_test.go
+++ b/connectors/microsoft/microsoft_test.go
@@ -24,6 +24,9 @@ func TestMicrosoftConnector_Actions(t *testing.T) {
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
+		"microsoft.create_presentation",
+		"microsoft.list_presentations",
+		"microsoft.get_presentation",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -91,8 +94,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	if m.Name != "Microsoft" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Microsoft")
 	}
-	if len(m.Actions) != 4 {
-		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	if len(m.Actions) != 7 {
+		t.Fatalf("Manifest().Actions has %d items, want 7", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -103,6 +106,9 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
+		"microsoft.create_presentation",
+		"microsoft.list_presentations",
+		"microsoft.get_presentation",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)
@@ -126,8 +132,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	}
 
 	// Validate templates.
-	if len(m.Templates) != 4 {
-		t.Errorf("Manifest().Templates has %d items, want 4", len(m.Templates))
+	if len(m.Templates) != 7 {
+		t.Errorf("Manifest().Templates has %d items, want 7", len(m.Templates))
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/microsoft/pptx_template.go
+++ b/connectors/microsoft/pptx_template.go
@@ -33,12 +33,15 @@ const minimalPPTXBase64 = "" +
 	"ZXNlbnRhdGlvbi54bWxQSwECFAMUAAAACABCiGZcjA6F0H0AAACdAAAAHwAAAAAAAAAAAAAAgAEM" +
 	"AwAAcHB0L19yZWxzL3ByZXNlbnRhdGlvbi54bWwucmVsc1BLBQYAAAAABAAEAAkBAADGAwAAAAA="
 
-// minimalPPTXBytes returns the decoded minimal .pptx file content.
-// It panics if the embedded base64 is invalid (which would be a build-time bug).
-func minimalPPTXBytes() []byte {
-	b, err := base64.StdEncoding.DecodeString(minimalPPTXBase64)
+// minimalPPTX holds the decoded PPTX template bytes, computed once at init.
+// Decoding at init means any base64 corruption is caught immediately at startup
+// rather than on the first user request.
+var minimalPPTX []byte //nolint:gochecknoglobals // decoded once, read-only after init
+
+func init() {
+	var err error
+	minimalPPTX, err = base64.StdEncoding.DecodeString(minimalPPTXBase64)
 	if err != nil {
 		panic("microsoft: invalid embedded PPTX template: " + err.Error())
 	}
-	return b
 }

--- a/connectors/microsoft/pptx_template.go
+++ b/connectors/microsoft/pptx_template.go
@@ -1,0 +1,44 @@
+package microsoft
+
+import "encoding/base64"
+
+// minimalPPTXBase64 is a minimal valid .pptx file (Office Open XML) encoded as
+// base64. It contains the bare minimum structure: [Content_Types].xml, package
+// relationships, and an empty presentation with standard slide dimensions.
+//
+// A .pptx file is a ZIP archive with specific XML parts. Microsoft Graph's
+// PUT /me/drive/root:/{path}:/content endpoint requires actual file content,
+// so we embed this ~1.2 KB template rather than pulling in a dependency.
+const minimalPPTXBase64 = "" +
+	"UEsDBBQAAAAIAEKIZlxNR4pI7wAAAL0BAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbH2QzU7DMBCE" +
+	"730Ka68odsoBIZSkBwpH4FAeYOVsEgv/yd5W7dvjpCB+RDmu5puZ3W02R2fFgVI2wbewljUI8jr0" +
+	"xo8tvO4eqxsQmdH3aIOnFk6UYdOtmt0pUhbF7HMLE3O8UyrriRxmGSL5ogwhOeQyplFF1G84kru" +
+	"u6xulg2fyXPGcAd1KiGZLA+4ti4djUc67JLIZxP2ZnetawBit0chFVwff/yqqPkpkcS5MnkzMVwUA" +
+	"dalkFi93fFmfy4uS6Um8YOIndAVUMbKKiXKxLrj8P+yPhcMwGE190HtXLPJ7mLM/RunQ+M9TGrV8" +
+	"v3sHUEsDBBQAAAAIAEKIZlw62VMktAAAADEBAAALAAAAX3JlbHMvLnJlbHONz80KwjAMB/D7nqLk" +
+	"7rp5EBG7XUTYVeYDlDbrhusHTRX39hZPTjx4TPLPL+TYPu3MHhhp8k5AXVbA0CmvJ2cEXPvzZg+M" +
+	"knRazt6hgAUJ2qY4XnCWKe/QOAViGXEkYEwpHDgnNaKVVPqALk8GH61MuYyGB6lu0iDfVtWOx08D" +
+	"moKxFcs6LSB2ugbWLwH/4f0wTApPXt0tuvTjylciyzIaTAJCSDxEpNx8p8ssA8+P8tWnzQtQSwME" +
+	"FAAAAAgAQohmXPlVXkjdAAAAlwEAABQAAABwcHQvcHJlc2VudGF0aW9uLnhtbI2QwU4DMQxE7/2K" +
+	"yHeaLSrVstpsLwgJCU7AB0SJtxspcaI4QMvXE0pXpbcexx4/zbjf7oMXn5jZRVKwWjYgkEy0jnYK" +
+	"3t8eb1oQXDRZ7SOhggMybIdFn7qUkZGKLvVSVApxpxVMpaROSjYTBs3LmJDqbow56FJl3kmb9Vel" +
+	"By9vm2Yjg3YEC3Ei5GsIcRydwYdoPkIN8IfJ6I9JeHKJz7x0De9/k4tYQ+XUpuzti+aC+ck+c5Hn" +
+	"6eu3MHsF96v1umnq58xBwaa9a3/FbKNYkE/GeXc0zlfV2MvLdw4/UEsDBBQAAAAIAEKIZlyMDoXQ" +
+	"fQAAAJ0AAAAfAAAAcHB0L19yZWxzL3ByZXNlbnRhdGlvbi54bWwucmVsc1XMQQ7CIBCF4b2nILO3" +
+	"oAtjTGl3PYDRA0zoCI0wEIYYvb0sdfny533j/E5RvajKltnCYTCgiF1eN/YW7rdlfwYlDXnFmJks" +
+	"fEhgnnbjlSK2/pGwFVEdYbEQWisXrcUFSihDLsS9PHJN2PqsXhd0T/Skj8acdP01oKP6T52+UEsB" +
+	"AhQDFAAAAAgAQohmXE1HikjvAAAAvQEAABMAAAAAAAAAAAAAAIABAAAAAFtDb250ZW50X1R5cGVz" +
+	"XS54bWxQSwECFAMUAAAACABCiGZcOtlTJLQAAAAxAQAACwAAAAAAAAAAAAAAgAEgAQAAX3JlbHMv" +
+	"LnJlbHNQSwECFAMUAAAACABCiGZc+VVeSN0AAACXAQAAFAAAAAAAAAAAAAAAgAH9AQAAcHB0L3By" +
+	"ZXNlbnRhdGlvbi54bWxQSwECFAMUAAAACABCiGZcjA6F0H0AAACdAAAAHwAAAAAAAAAAAAAAgAEM" +
+	"AwAAcHB0L19yZWxzL3ByZXNlbnRhdGlvbi54bWwucmVsc1BLBQYAAAAABAAEAAkBAADGAwAAAAA="
+
+// minimalPPTXBytes returns the decoded minimal .pptx file content.
+// It panics if the embedded base64 is invalid (which would be a build-time bug).
+func minimalPPTXBytes() []byte {
+	b, err := base64.StdEncoding.DecodeString(minimalPPTXBase64)
+	if err != nil {
+		panic("microsoft: invalid embedded PPTX template: " + err.Error())
+	}
+	return b
+}

--- a/connectors/microsoft/validation.go
+++ b/connectors/microsoft/validation.go
@@ -2,6 +2,7 @@ package microsoft
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -27,11 +28,39 @@ func detectContentType(body string) string {
 	return "Text"
 }
 
-// validateFolderPath checks a OneDrive folder path for path traversal sequences.
+// validatePathSegment rejects values that contain URL-significant characters
+// which could alter the request path or query when interpolated into a Graph
+// API URL. This prevents a crafted item_id like "foo/../me/messages" or
+// "foo?$select=body" from hitting unintended endpoints.
+func validatePathSegment(field, value string) error {
+	for _, ch := range value {
+		switch ch {
+		case '/', '\\', '?', '#', '%':
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("invalid %s: must not contain URL-special characters (/, \\, ?, #, %%)", field),
+			}
+		}
+	}
+	if strings.Contains(value, "..") {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid %s: must not contain traversal sequences", field),
+		}
+	}
+	return nil
+}
+
+// validateFolderPath checks a OneDrive folder path for traversal sequences and
+// URL-significant characters that could manipulate the Graph API request.
+// Slashes are allowed since folder paths are naturally slash-separated.
 func validateFolderPath(folderPath string) error {
 	if strings.Contains(folderPath, "..") {
 		return &connectors.ValidationError{
 			Message: "invalid folder_path: must not contain '..' traversal sequences (e.g. use 'Documents/Presentations' instead)",
+		}
+	}
+	if strings.ContainsAny(folderPath, "?#%\\") {
+		return &connectors.ValidationError{
+			Message: "invalid folder_path: must not contain special characters (?, #, %, \\)",
 		}
 	}
 	return nil
@@ -43,4 +72,16 @@ func normalizeFolderPath(folderPath string) string {
 	folderPath = strings.TrimPrefix(folderPath, "/")
 	folderPath = strings.TrimSuffix(folderPath, "/")
 	return folderPath
+}
+
+// escapePathSegments URL-encodes each segment of a slash-separated path
+// individually. This preserves the directory structure (slashes are kept)
+// while encoding special characters within each segment name that could
+// otherwise manipulate the Graph API URL.
+func escapePathSegments(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	return strings.Join(segments, "/")
 }

--- a/connectors/microsoft/validation.go
+++ b/connectors/microsoft/validation.go
@@ -26,3 +26,21 @@ func detectContentType(body string) string {
 	}
 	return "Text"
 }
+
+// validateFolderPath checks a OneDrive folder path for path traversal sequences.
+func validateFolderPath(folderPath string) error {
+	if strings.Contains(folderPath, "..") {
+		return &connectors.ValidationError{
+			Message: "invalid folder_path: must not contain '..' traversal sequences (e.g. use 'Documents/Presentations' instead)",
+		}
+	}
+	return nil
+}
+
+// normalizeFolderPath strips leading/trailing slashes from a folder path
+// for consistent use in OneDrive API paths.
+func normalizeFolderPath(folderPath string) string {
+	folderPath = strings.TrimPrefix(folderPath, "/")
+	folderPath = strings.TrimSuffix(folderPath, "/")
+	return folderPath
+}

--- a/connectors/microsoft/validation.go
+++ b/connectors/microsoft/validation.go
@@ -21,16 +21,18 @@ func validateEmail(field string, idx int, addr string) error {
 }
 
 // validateGraphID rejects Graph API resource identifiers (team IDs, channel IDs,
-// message IDs, etc.) that contain path traversal sequences or path separators.
-// These values are interpolated into URL paths, so we must ensure they cannot
-// manipulate the request target. Microsoft Graph IDs are opaque strings (typically
-// UUIDs or base64-encoded values) that never contain slashes or dot-dot sequences.
+// message IDs, item IDs, etc.) that contain characters which could manipulate
+// the request URL when interpolated into API paths. These IDs are opaque strings
+// (typically UUIDs or base64-encoded values) from Microsoft Graph that never
+// contain slashes, query parameters, or traversal sequences.
 func validateGraphID(field, value string) error {
 	if value == "" {
 		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
 	}
-	if strings.Contains(value, "..") || strings.Contains(value, "/") || strings.Contains(value, "\\") {
-		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not contain path separators or traversal sequences", field)}
+	if strings.ContainsAny(value, "/\\?#%") || strings.Contains(value, "..") {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid %s: must not contain path separators or URL-special characters (/, \\, ?, #, %%)", field),
+		}
 	}
 	return nil
 }
@@ -41,27 +43,6 @@ func detectContentType(body string) string {
 		return "HTML"
 	}
 	return "Text"
-}
-
-// validatePathSegment rejects values that contain URL-significant characters
-// which could alter the request path or query when interpolated into a Graph
-// API URL. This prevents a crafted item_id like "foo/../me/messages" or
-// "foo?$select=body" from hitting unintended endpoints.
-func validatePathSegment(field, value string) error {
-	for _, ch := range value {
-		switch ch {
-		case '/', '\\', '?', '#', '%':
-			return &connectors.ValidationError{
-				Message: fmt.Sprintf("invalid %s: must not contain URL-special characters (/, \\, ?, #, %%)", field),
-			}
-		}
-	}
-	if strings.Contains(value, "..") {
-		return &connectors.ValidationError{
-			Message: fmt.Sprintf("invalid %s: must not contain traversal sequences", field),
-		}
-	}
-	return nil
 }
 
 // validateFolderPath checks a OneDrive folder path for traversal sequences and


### PR DESCRIPTION
## Summary
- Adds three new Microsoft connector actions: `create_presentation`, `list_presentations`, and `get_presentation` using OneDrive/DriveItem Graph API endpoints
- Embeds a minimal valid `.pptx` template (~1.2 KB) for creating new presentations without external dependencies
- Adds `doPutFileRequest` helper for binary file uploads and `Files.ReadWrite` OAuth scope

## Details
**New files:**
- `pptx_template.go` — minimal valid Office Open XML `.pptx` as embedded base64
- `create_presentation.go` — `PUT /me/drive/root:/{path}:/content` with PPTX template bytes
- `list_presentations.go` — `GET /me/drive/root/search(q='.pptx')` with folder scoping
- `get_presentation.go` — `GET /me/drive/items/{itemId}` for file metadata

**Modified files:**
- `microsoft.go` — 3 new manifest actions, templates, `Files.ReadWrite` scope, action registrations, `doPutFileRequest` method
- `microsoft_test.go` — updated manifest counts to include new actions

**Security:** Path traversal protection on `filename` and `folder_path` params. PPTX template is static embedded bytes.

## Test plan
- [x] All 42 Microsoft connector tests pass (`go test ./connectors/microsoft/...`)
- [x] `go vet` clean
- [x] `go build` clean for connector package
- [ ] CI validates full build and test suite

Closes #240

https://claude.ai/code/session_01UmggmJpdmLovhsu7FEqpuv