### PR TITLE
Add OneDrive actions to Microsoft connector

### DIFF
--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -16,7 +16,7 @@ This connector uses OAuth 2.0 — credentials are managed automatically by the p
 
 The credential `auth_type` in the database is `oauth2` with `oauth_provider: "microsoft"`. The platform handles the full OAuth lifecycle: redirect, token exchange, encrypted storage in Supabase Vault, and automatic refresh before expiry. The connector never touches OAuth code — it receives a valid access token in `Credentials` at execution time.
 
-**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`
+**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`, `Files.ReadWrite`
 
 ## Actions
 
@@ -147,6 +147,141 @@ Lists upcoming events from the user's calendar.
 
 **Graph API:** `GET /me/events` ([docs](https://learn.microsoft.com/en-us/graph/api/user-list-events))
 
+---
+
+### `microsoft.list_drive_files`
+
+Lists files and folders in OneDrive.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `folder_path` | string | No | root | Relative folder path (e.g., `Documents/Work`) |
+| `top` | integer | No | `10` | Number of items to return (1–50) |
+
+**Response:**
+
+```json
+{
+  "folder_path": "Documents",
+  "items": [
+    {
+      "id": "abc123",
+      "name": "report.docx",
+      "type": "file",
+      "size": 1024,
+      "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "web_url": "https://onedrive.live.com/...",
+      "created_at": "2024-01-15T09:00:00Z",
+      "modified_at": "2024-01-16T10:00:00Z"
+    }
+  ]
+}
+```
+
+**Graph API:** `GET /me/drive/root/children` or `GET /me/drive/root:/{path}:/children` ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-list-children))
+
+**Security:** `folder_path` is validated to reject path traversal (`..`), backslashes, absolute paths, and URL-special characters (`?#%`).
+
+---
+
+### `microsoft.get_drive_file`
+
+Gets file metadata and optionally downloads text content.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID |
+| `include_content` | boolean | No | `false` | Download file content (text files only) |
+
+**Response:**
+
+```json
+{
+  "id": "abc123",
+  "name": "notes.txt",
+  "type": "file",
+  "size": 256,
+  "mime_type": "text/plain",
+  "web_url": "https://onedrive.live.com/...",
+  "created_at": "2024-01-15T09:00:00Z",
+  "modified_at": "2024-01-16T10:00:00Z",
+  "content": "File content here..."
+}
+```
+
+**Graph API:** `GET /me/drive/items/{id}` for metadata, `GET /me/drive/items/{id}/content` for download ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-get))
+
+**Security:** Only text MIME types can be downloaded (`text/*`, `application/json`, `application/xml`, etc.). Binary files and files with unknown MIME types are rejected. `item_id` is validated to reject path separators, traversal sequences, and URL-special characters.
+
+---
+
+### `microsoft.upload_drive_file`
+
+Uploads or creates a file in OneDrive (max 4 MB).
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `file_path` | string | Yes | — | Relative file path (e.g., `Documents/report.txt`) |
+| `content` | string | Yes | — | File content to upload (max 4 MB) |
+| `conflict_behavior` | string | No | `"rename"` | Behavior when file exists: `rename`, `replace`, or `fail` |
+
+**Response:**
+
+```json
+{
+  "id": "abc123",
+  "name": "report.txt",
+  "size": 17,
+  "web_url": "https://onedrive.live.com/...",
+  "created_at": "2024-01-15T09:00:00Z",
+  "modified_at": "2024-01-15T09:00:00Z"
+}
+```
+
+**Graph API:** `PUT /me/drive/root:/{path}:/content` ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-put-content))
+
+**Security:** Content size is capped at 4 MB. `file_path` is validated to reject path traversal, backslashes, absolute paths, and URL-special characters.
+
+---
+
+### `microsoft.delete_drive_file`
+
+Moves a file to the OneDrive recycle bin (recoverable — not permanent deletion).
+
+**Risk level:** high
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `item_id` | string | Yes | — | OneDrive item ID to delete |
+
+**Response:**
+
+```json
+{
+  "status": "deleted",
+  "item_id": "abc123",
+  "message": "File moved to recycle bin and can be recovered"
+}
+```
+
+**Graph API:** `DELETE /me/drive/items/{id}` ([docs](https://learn.microsoft.com/en-us/graph/api/driveitem-delete))
+
+**Security:** `item_id` is validated to reject path separators, traversal sequences, and URL-special characters. The delete operation moves the item to the recycle bin — it is recoverable and not a permanent deletion.
+
 ## Error Handling
 
 The connector maps Microsoft Graph API responses to typed connector errors:
@@ -172,7 +307,13 @@ Each action lives in its own file. To add one (e.g., `microsoft.list_contacts`):
 5. Add the action to the `Manifest()` return value inside `microsoft.go` — include a `ParametersSchema`.
 6. Add tests in `list_contacts_test.go` using `httptest.NewServer` and `newForTest()`.
 
-The `doRequest` method means each action file only contains what's unique: parameter parsing, validation, request body shape, and response shape. All shared HTTP concerns (auth, Content-Type, rate limiting, error mapping) are handled once.
+Three request helpers are available depending on the content type:
+
+- `doRequest` — JSON request/response (most actions)
+- `doRequestRaw` — Returns raw string response (file content download)
+- `doPutRaw` — Sends raw bytes, returns raw bytes (file upload)
+
+All three share a common `executeRequest` lifecycle handler for auth, rate limiting, error mapping, and timeout detection. Each action file only contains what's unique: parameter parsing, validation, request body shape, and response shape.
 
 ## Manifest
 
@@ -184,20 +325,21 @@ When adding a new action, add it to the `Manifest()` return value with a `Parame
 
 ```
 connectors/microsoft/
-├── microsoft.go                  # MicrosoftConnector struct, New(), Manifest(), doRequest(), ValidateCredentials()
-├── types.go                      # Shared Microsoft Graph API types (graphEmailBody, graphMailAddress, etc.)
+├── microsoft.go                  # MicrosoftConnector struct, Manifest(), request helpers, ValidateCredentials()
+├── types.go                      # Shared Microsoft Graph API types (email, calendar, drive)
 ├── response.go                   # Graph API error response → typed connector error mapping
 ├── validation.go                 # Shared validation helpers (validateEmail, detectContentType)
 ├── send_email.go                 # microsoft.send_email action
-├── list_emails.go                # microsoft.list_emails action
+├── list_emails.go                # microsoft.list_emails action + path validation helpers
 ├── create_calendar_event.go      # microsoft.create_calendar_event action
 ├── list_calendar_events.go       # microsoft.list_calendar_events action
+├── list_drive_files.go           # microsoft.list_drive_files action
+├── get_drive_file.go             # microsoft.get_drive_file action + item ID validation
+├── upload_drive_file.go          # microsoft.upload_drive_file action
+├── delete_drive_file.go          # microsoft.delete_drive_file action
 ├── microsoft_test.go             # Connector-level tests
 ├── helpers_test.go               # Shared test helpers (validCreds)
-├── send_email_test.go            # Send email action tests
-├── list_emails_test.go           # List emails action tests
-├── create_calendar_event_test.go # Create calendar event action tests
-├── list_calendar_events_test.go  # List calendar events action tests
+├── *_test.go                     # Per-action test files
 └── README.md                     # This file
 ```
 

--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -16,7 +16,7 @@ This connector uses OAuth 2.0 — credentials are managed automatically by the p
 
 The credential `auth_type` in the database is `oauth2` with `oauth_provider: "microsoft"`. The platform handles the full OAuth lifecycle: redirect, token exchange, encrypted storage in Supabase Vault, and automatic refresh before expiry. The connector never touches OAuth code — it receives a valid access token in `Credentials` at execution time.
 
-**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`, `Files.ReadWrite`
+**Required OAuth scopes:** `Mail.Send`, `Mail.Read`, `Calendars.ReadWrite`, `Files.ReadWrite`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Send`, `ChannelMessage.Read.All`
 
 ## Actions
 
@@ -326,7 +326,7 @@ When adding a new action, add it to the `Manifest()` return value with a `Parame
 ```
 connectors/microsoft/
 ├── microsoft.go                  # MicrosoftConnector struct, Manifest(), request helpers, ValidateCredentials()
-├── types.go                      # Shared Microsoft Graph API types (email, calendar, drive)
+├── types.go                      # Shared Microsoft Graph API types (email, calendar, drive, Teams)
 ├── response.go                   # Graph API error response → typed connector error mapping
 ├── validation.go                 # Shared validation helpers (validateEmail, detectContentType)
 ├── send_email.go                 # microsoft.send_email action
@@ -337,6 +337,10 @@ connectors/microsoft/
 ├── get_drive_file.go             # microsoft.get_drive_file action + item ID validation
 ├── upload_drive_file.go          # microsoft.upload_drive_file action
 ├── delete_drive_file.go          # microsoft.delete_drive_file action
+├── list_teams.go                 # microsoft.list_teams action
+├── list_channels.go              # microsoft.list_channels action
+├── send_channel_message.go       # microsoft.send_channel_message action
+├── list_channel_messages.go      # microsoft.list_channel_messages action
 ├── microsoft_test.go             # Connector-level tests
 ├── helpers_test.go               # Shared test helpers (validCreds)
 ├── *_test.go                     # Per-action test files

--- a/connectors/microsoft/delete_drive_file.go
+++ b/connectors/microsoft/delete_drive_file.go
@@ -1,0 +1,51 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// deleteDriveFileAction implements connectors.Action for microsoft.delete_drive_file.
+// It moves a file to the OneDrive recycle bin (recoverable) via DELETE /me/drive/items/{id}.
+type deleteDriveFileAction struct {
+	conn *MicrosoftConnector
+}
+
+type deleteDriveFileParams struct {
+	ItemID string `json:"item_id"`
+}
+
+func (p *deleteDriveFileParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: item_id"}
+	}
+	if err := validateItemID(p.ItemID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *deleteDriveFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params deleteDriveFileParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/items/%s", params.ItemID)
+
+	// DELETE returns 204 No Content on success.
+	if err := a.conn.doRequest(ctx, http.MethodDelete, path, req.Credentials, nil, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status": "deleted",
+	})
+}

--- a/connectors/microsoft/delete_drive_file.go
+++ b/connectors/microsoft/delete_drive_file.go
@@ -46,6 +46,8 @@ func (a *deleteDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 	}
 
 	return connectors.JSONResult(map[string]string{
-		"status": "deleted",
+		"status":  "deleted",
+		"item_id": params.ItemID,
+		"message": "File moved to recycle bin and can be recovered",
 	})
 }

--- a/connectors/microsoft/delete_drive_file_test.go
+++ b/connectors/microsoft/delete_drive_file_test.go
@@ -83,18 +83,32 @@ func TestDeleteDriveFile_InvalidItemID(t *testing.T) {
 	conn := New()
 	action := &deleteDriveFileAction{conn: conn}
 
-	params, _ := json.Marshal(deleteDriveFileParams{ItemID: "../../../etc"})
-
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
-		ActionType:  "microsoft.delete_drive_file",
-		Parameters:  params,
-		Credentials: validCreds(),
-	})
-	if err == nil {
-		t.Fatal("expected error for invalid item_id")
+	cases := []struct {
+		name   string
+		itemID string
+	}{
+		{"path-traversal", "../../../etc"},
+		{"path-separator-slash", "a/b"},
+		{"path-separator-backslash", "a\\b"},
+		{"query-injection", "file-123?$expand=malicious"},
+		{"fragment-injection", "file-123#fragment"},
+		{"percent-encoding", "file-123%2F..%2Fetc"},
 	}
-	if !connectors.IsValidationError(err) {
-		t.Errorf("expected ValidationError, got: %T", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(deleteDriveFileParams{ItemID: tc.itemID})
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "microsoft.delete_drive_file",
+				Parameters:  params,
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("expected error for invalid item_id")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got: %T", err)
+			}
+		})
 	}
 }
 

--- a/connectors/microsoft/delete_drive_file_test.go
+++ b/connectors/microsoft/delete_drive_file_test.go
@@ -1,0 +1,178 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestDeleteDriveFile_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/me/drive/items/file-123" {
+			t.Errorf("expected path /me/drive/items/file-123, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{ItemID: "file-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["status"] != "deleted" {
+		t.Errorf("expected status 'deleted', got %q", data["status"])
+	}
+}
+
+func TestDeleteDriveFile_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_InvalidItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{ItemID: "../../../etc"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "InvalidAuthenticationToken",
+				"message": "Access token is empty.",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{ItemID: "file-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "itemNotFound",
+				"message": "The resource could not be found.",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &deleteDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(deleteDriveFileParams{ItemID: "nonexistent"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.delete_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got: %T", err)
+	}
+}
+
+func TestDeleteDriveFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteDriveFileAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.delete_drive_file",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/delete_drive_file_test.go
+++ b/connectors/microsoft/delete_drive_file_test.go
@@ -48,6 +48,12 @@ func TestDeleteDriveFile_Success(t *testing.T) {
 	if data["status"] != "deleted" {
 		t.Errorf("expected status 'deleted', got %q", data["status"])
 	}
+	if data["item_id"] != "file-123" {
+		t.Errorf("expected item_id 'file-123', got %q", data["item_id"])
+	}
+	if data["message"] == "" {
+		t.Error("expected non-empty message")
+	}
 }
 
 func TestDeleteDriveFile_MissingItemID(t *testing.T) {

--- a/connectors/microsoft/get_drive_file.go
+++ b/connectors/microsoft/get_drive_file.go
@@ -33,15 +33,16 @@ func (p *getDriveFileParams) validate() error {
 
 // driveFileDetail is the detailed response for a single drive item.
 type driveFileDetail struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Size       int64  `json:"size"`
-	MimeType   string `json:"mime_type,omitempty"`
-	WebURL     string `json:"web_url,omitempty"`
-	CreatedAt  string `json:"created_at,omitempty"`
-	ModifiedAt string `json:"modified_at,omitempty"`
-	Content    string `json:"content,omitempty"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Size           int64  `json:"size"`
+	MimeType       string `json:"mime_type,omitempty"`
+	WebURL         string `json:"web_url,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+	ModifiedAt     string `json:"modified_at,omitempty"`
+	Content        string `json:"content,omitempty"`
+	ContentSkipped string `json:"content_skipped,omitempty"`
 }
 
 // textMimeTypes lists MIME type prefixes that are safe to download as text.
@@ -101,6 +102,9 @@ func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionR
 	}
 
 	// Optionally download text content.
+	if params.IncludeContent && detail.Type == "folder" {
+		detail.ContentSkipped = "content download is not available for folders"
+	}
 	if params.IncludeContent && detail.Type == "file" {
 		if detail.MimeType != "" && !isTextMimeType(detail.MimeType) {
 			return nil, &connectors.ValidationError{
@@ -118,10 +122,13 @@ func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionR
 	return connectors.JSONResult(detail)
 }
 
-// validateItemID rejects item IDs containing path separators or special characters.
+// validateItemID rejects item IDs containing path separators or traversal sequences.
 func validateItemID(id string) error {
-	if strings.ContainsAny(id, "/\\..") {
-		return &connectors.ValidationError{Message: "invalid item_id: must not contain path separators or special characters"}
+	if strings.ContainsAny(id, "/\\") {
+		return &connectors.ValidationError{Message: "invalid item_id: must not contain path separators"}
+	}
+	if strings.Contains(id, "..") {
+		return &connectors.ValidationError{Message: "invalid item_id: must not contain path traversal sequences"}
 	}
 	return nil
 }

--- a/connectors/microsoft/get_drive_file.go
+++ b/connectors/microsoft/get_drive_file.go
@@ -106,7 +106,12 @@ func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionR
 		detail.ContentSkipped = "content download is not available for folders"
 	}
 	if params.IncludeContent && detail.Type == "file" {
-		if detail.MimeType != "" && !isTextMimeType(detail.MimeType) {
+		if detail.MimeType == "" {
+			return nil, &connectors.ValidationError{
+				Message: "cannot download content: file has no MIME type; only text files are supported",
+			}
+		}
+		if !isTextMimeType(detail.MimeType) {
 			return nil, &connectors.ValidationError{
 				Message: fmt.Sprintf("cannot download content for binary file type %q; only text files are supported", detail.MimeType),
 			}
@@ -122,13 +127,17 @@ func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionR
 	return connectors.JSONResult(detail)
 }
 
-// validateItemID rejects item IDs containing path separators or traversal sequences.
+// validateItemID rejects item IDs containing path separators, traversal sequences,
+// or URL-special characters that could be used for query/fragment injection.
 func validateItemID(id string) error {
 	if strings.ContainsAny(id, "/\\") {
 		return &connectors.ValidationError{Message: "invalid item_id: must not contain path separators"}
 	}
 	if strings.Contains(id, "..") {
 		return &connectors.ValidationError{Message: "invalid item_id: must not contain path traversal sequences"}
+	}
+	if strings.ContainsAny(id, "?#%") {
+		return &connectors.ValidationError{Message: "invalid item_id: must not contain URL-special characters"}
 	}
 	return nil
 }

--- a/connectors/microsoft/get_drive_file.go
+++ b/connectors/microsoft/get_drive_file.go
@@ -1,0 +1,127 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getDriveFileAction implements connectors.Action for microsoft.get_drive_file.
+// It retrieves file metadata and optionally downloads text content via the Graph API.
+type getDriveFileAction struct {
+	conn *MicrosoftConnector
+}
+
+type getDriveFileParams struct {
+	ItemID         string `json:"item_id"`
+	IncludeContent bool   `json:"include_content"`
+}
+
+func (p *getDriveFileParams) validate() error {
+	if p.ItemID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: item_id"}
+	}
+	if err := validateItemID(p.ItemID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// driveFileDetail is the detailed response for a single drive item.
+type driveFileDetail struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Size       int64  `json:"size"`
+	MimeType   string `json:"mime_type,omitempty"`
+	WebURL     string `json:"web_url,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	ModifiedAt string `json:"modified_at,omitempty"`
+	Content    string `json:"content,omitempty"`
+}
+
+// textMimeTypes lists MIME type prefixes that are safe to download as text.
+var textMimeTypes = []string{
+	"text/",
+	"application/json",
+	"application/xml",
+	"application/javascript",
+	"application/x-yaml",
+	"application/x-sh",
+	"application/sql",
+	"application/xhtml+xml",
+}
+
+func isTextMimeType(mimeType string) bool {
+	lower := strings.ToLower(mimeType)
+	for _, prefix := range textMimeTypes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *getDriveFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getDriveFileParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// Get file metadata.
+	metadataPath := fmt.Sprintf("/me/drive/items/%s?$select=id,name,size,webUrl,createdDateTime,lastModifiedDateTime,folder,file", params.ItemID)
+
+	var item graphDriveItem
+	if err := a.conn.doRequest(ctx, http.MethodGet, metadataPath, req.Credentials, nil, &item); err != nil {
+		return nil, err
+	}
+
+	detail := driveFileDetail{
+		ID:         item.ID,
+		Name:       item.Name,
+		Size:       item.Size,
+		WebURL:     item.WebURL,
+		CreatedAt:  item.CreatedDateTime,
+		ModifiedAt: item.ModifiedDateTime,
+	}
+	if item.Folder != nil {
+		detail.Type = "folder"
+	} else {
+		detail.Type = "file"
+		if item.File != nil {
+			detail.MimeType = item.File.MimeType
+		}
+	}
+
+	// Optionally download text content.
+	if params.IncludeContent && detail.Type == "file" {
+		if detail.MimeType != "" && !isTextMimeType(detail.MimeType) {
+			return nil, &connectors.ValidationError{
+				Message: fmt.Sprintf("cannot download content for binary file type %q; only text files are supported", detail.MimeType),
+			}
+		}
+		contentPath := fmt.Sprintf("/me/drive/items/%s/content", params.ItemID)
+		content, err := a.conn.doRequestRaw(ctx, http.MethodGet, contentPath, req.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		detail.Content = content
+	}
+
+	return connectors.JSONResult(detail)
+}
+
+// validateItemID rejects item IDs containing path separators or special characters.
+func validateItemID(id string) error {
+	if strings.ContainsAny(id, "/\\..") {
+		return &connectors.ValidationError{Message: "invalid item_id: must not contain path separators or special characters"}
+	}
+	return nil
+}

--- a/connectors/microsoft/get_drive_file_test.go
+++ b/connectors/microsoft/get_drive_file_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -70,25 +71,23 @@ func TestGetDriveFile_MetadataOnly(t *testing.T) {
 func TestGetDriveFile_WithContent(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if callCount == 1 {
-			// Metadata request
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{
-				"id":   "file-123",
-				"name": "notes.txt",
-				"size": 13,
-				"file": map[string]string{
-					"mimeType": "text/plain",
-				},
-			})
+		if strings.HasSuffix(r.URL.Path, "/content") {
+			// Content download request
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("Hello, World!"))
 			return
 		}
-		// Content download request
-		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte("Hello, World!"))
+		// Metadata request
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "file-123",
+			"name": "notes.txt",
+			"size": 13,
+			"file": map[string]string{
+				"mimeType": "text/plain",
+			},
+		})
 	}))
 	defer srv.Close()
 

--- a/connectors/microsoft/get_drive_file_test.go
+++ b/connectors/microsoft/get_drive_file_test.go
@@ -1,0 +1,268 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetDriveFile_MetadataOnly(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":                   "file-123",
+			"name":                 "notes.txt",
+			"size":                 256,
+			"webUrl":               "https://onedrive.live.com/file-123",
+			"createdDateTime":      "2024-01-15T09:00:00Z",
+			"lastModifiedDateTime": "2024-01-16T10:00:00Z",
+			"file": map[string]string{
+				"mimeType": "text/plain",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "file-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail driveFileDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if detail.ID != "file-123" {
+		t.Errorf("expected id 'file-123', got %q", detail.ID)
+	}
+	if detail.Name != "notes.txt" {
+		t.Errorf("expected name 'notes.txt', got %q", detail.Name)
+	}
+	if detail.Type != "file" {
+		t.Errorf("expected type 'file', got %q", detail.Type)
+	}
+	if detail.Content != "" {
+		t.Errorf("expected no content, got %q", detail.Content)
+	}
+}
+
+func TestGetDriveFile_WithContent(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// Metadata request
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":   "file-123",
+				"name": "notes.txt",
+				"size": 13,
+				"file": map[string]string{
+					"mimeType": "text/plain",
+				},
+			})
+			return
+		}
+		// Content download request
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("Hello, World!"))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "file-123", IncludeContent: true})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail driveFileDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if detail.Content != "Hello, World!" {
+		t.Errorf("expected content 'Hello, World!', got %q", detail.Content)
+	}
+}
+
+func TestGetDriveFile_BinaryContentRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "file-123",
+			"name": "photo.png",
+			"size": 1024,
+			"file": map[string]string{
+				"mimeType": "image/png",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "file-123", IncludeContent: true})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for binary file content download")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_MissingItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_InvalidItemID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "../../../etc/passwd"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid item_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getDriveFileAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetDriveFile_FolderMetadata(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "folder-1",
+			"name": "Documents",
+			"size": 0,
+			"folder": map[string]any{
+				"childCount": 3,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "folder-1"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail driveFileDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if detail.Type != "folder" {
+		t.Errorf("expected type 'folder', got %q", detail.Type)
+	}
+}
+
+func TestValidateItemID(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"abc123", "ABC-123-DEF", "item!123"}
+	for _, id := range valid {
+		if err := validateItemID(id); err != nil {
+			t.Errorf("expected valid item_id %q, got error: %v", id, err)
+		}
+	}
+
+	invalid := []string{"../etc", "a/b", "a\\b", "a..b"}
+	for _, id := range invalid {
+		if err := validateItemID(id); err == nil {
+			t.Errorf("expected invalid item_id %q to be rejected", id)
+		}
+	}
+}

--- a/connectors/microsoft/get_drive_file_test.go
+++ b/connectors/microsoft/get_drive_file_test.go
@@ -249,10 +249,49 @@ func TestGetDriveFile_FolderMetadata(t *testing.T) {
 	}
 }
 
+func TestGetDriveFile_FolderContentSkipped(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "folder-1",
+			"name": "Documents",
+			"size": 0,
+			"folder": map[string]any{
+				"childCount": 3,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "folder-1", IncludeContent: true})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail driveFileDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if detail.ContentSkipped == "" {
+		t.Error("expected content_skipped to be set for folder with include_content=true")
+	}
+}
+
 func TestValidateItemID(t *testing.T) {
 	t.Parallel()
 
-	valid := []string{"abc123", "ABC-123-DEF", "item!123"}
+	valid := []string{"abc123", "ABC-123-DEF", "item!123", "item.with.dots"}
 	for _, id := range valid {
 		if err := validateItemID(id); err != nil {
 			t.Errorf("expected valid item_id %q, got error: %v", id, err)

--- a/connectors/microsoft/get_drive_file_test.go
+++ b/connectors/microsoft/get_drive_file_test.go
@@ -149,6 +149,38 @@ func TestGetDriveFile_BinaryContentRejected(t *testing.T) {
 	}
 }
 
+func TestGetDriveFile_NoMimeTypeContentRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "file-123",
+			"name": "unknown-file",
+			"size": 1024,
+			"file": map[string]string{},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(getDriveFileParams{ItemID: "file-123", IncludeContent: true})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.get_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for file with no MIME type")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestGetDriveFile_MissingItemID(t *testing.T) {
 	t.Parallel()
 
@@ -298,7 +330,7 @@ func TestValidateItemID(t *testing.T) {
 		}
 	}
 
-	invalid := []string{"../etc", "a/b", "a\\b", "a..b"}
+	invalid := []string{"../etc", "a/b", "a\\b", "a..b", "id?inject", "id#frag", "id%00"}
 	for _, id := range invalid {
 		if err := validateItemID(id); err == nil {
 			t.Errorf("expected invalid item_id %q to be rejected", id)

--- a/connectors/microsoft/list_drive_files.go
+++ b/connectors/microsoft/list_drive_files.go
@@ -90,6 +90,11 @@ func (a *listDriveFilesAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
+	folderDisplay := params.FolderPath
+	if folderDisplay == "" {
+		folderDisplay = "/"
+	}
+
 	summaries := make([]driveFileSummary, len(resp.Value))
 	for i, item := range resp.Value {
 		summary := driveFileSummary{
@@ -112,7 +117,13 @@ func (a *listDriveFilesAction) Execute(ctx context.Context, req connectors.Actio
 		summaries[i] = summary
 	}
 
-	return connectors.JSONResult(summaries)
+	return connectors.JSONResult(struct {
+		FolderPath string             `json:"folder_path"`
+		Items      []driveFileSummary `json:"items"`
+	}{
+		FolderPath: folderDisplay,
+		Items:      summaries,
+	})
 }
 
 // validateFolderPath rejects paths with traversal sequences, absolute paths, or backslashes.
@@ -120,14 +131,20 @@ func validateFolderPath(p string) error {
 	if p == "" {
 		return nil
 	}
+	return validateRelativePath("folder_path", p)
+}
+
+// validateRelativePath validates that a path is relative and safe from traversal attacks.
+// Used by both folder_path and file_path validation.
+func validateRelativePath(field, p string) error {
 	if strings.Contains(p, "..") {
-		return &connectors.ValidationError{Message: "invalid folder_path: must not contain path traversal sequences"}
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not contain path traversal sequences", field)}
 	}
 	if strings.Contains(p, "\\") {
-		return &connectors.ValidationError{Message: "invalid folder_path: must not contain backslashes"}
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not contain backslashes", field)}
 	}
 	if strings.HasPrefix(p, "/") {
-		return &connectors.ValidationError{Message: "invalid folder_path: must be a relative path"}
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must be a relative path", field)}
 	}
 	return nil
 }

--- a/connectors/microsoft/list_drive_files.go
+++ b/connectors/microsoft/list_drive_files.go
@@ -1,0 +1,133 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listDriveFilesAction implements connectors.Action for microsoft.list_drive_files.
+// It lists files and folders in OneDrive via the Microsoft Graph API.
+type listDriveFilesAction struct {
+	conn *MicrosoftConnector
+}
+
+type listDriveFilesParams struct {
+	FolderPath string `json:"folder_path"`
+	Top        int    `json:"top"`
+}
+
+func (p *listDriveFilesParams) defaults() {
+	if p.Top <= 0 {
+		p.Top = 10
+	}
+	if p.Top > 50 {
+		p.Top = 50
+	}
+}
+
+// graphDriveItemsResponse is the Microsoft Graph API response for listing drive items.
+type graphDriveItemsResponse struct {
+	Value []graphDriveItem `json:"value"`
+}
+
+type graphDriveItem struct {
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	Size             int64           `json:"size"`
+	WebURL           string          `json:"webUrl,omitempty"`
+	CreatedDateTime  string          `json:"createdDateTime,omitempty"`
+	ModifiedDateTime string          `json:"lastModifiedDateTime,omitempty"`
+	Folder           *graphFolder    `json:"folder,omitempty"`
+	File             *graphFileFacet `json:"file,omitempty"`
+}
+
+type graphFolder struct {
+	ChildCount int `json:"childCount"`
+}
+
+type graphFileFacet struct {
+	MimeType string `json:"mimeType"`
+}
+
+// driveFileSummary is the simplified response returned to the caller.
+type driveFileSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Size        int64  `json:"size"`
+	MimeType    string `json:"mime_type,omitempty"`
+	ChildCount  int    `json:"child_count,omitempty"`
+	WebURL      string `json:"web_url,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	ModifiedAt  string `json:"modified_at,omitempty"`
+}
+
+func (a *listDriveFilesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listDriveFilesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	params.defaults()
+
+	if err := validateFolderPath(params.FolderPath); err != nil {
+		return nil, err
+	}
+
+	var path string
+	if params.FolderPath == "" {
+		path = fmt.Sprintf("/me/drive/root/children?$top=%d&$select=id,name,size,webUrl,createdDateTime,lastModifiedDateTime,folder,file", params.Top)
+	} else {
+		path = fmt.Sprintf("/me/drive/root:/%s:/children?$top=%d&$select=id,name,size,webUrl,createdDateTime,lastModifiedDateTime,folder,file", params.FolderPath, params.Top)
+	}
+
+	var resp graphDriveItemsResponse
+	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	summaries := make([]driveFileSummary, len(resp.Value))
+	for i, item := range resp.Value {
+		summary := driveFileSummary{
+			ID:         item.ID,
+			Name:       item.Name,
+			Size:       item.Size,
+			WebURL:     item.WebURL,
+			CreatedAt:  item.CreatedDateTime,
+			ModifiedAt: item.ModifiedDateTime,
+		}
+		if item.Folder != nil {
+			summary.Type = "folder"
+			summary.ChildCount = item.Folder.ChildCount
+		} else {
+			summary.Type = "file"
+			if item.File != nil {
+				summary.MimeType = item.File.MimeType
+			}
+		}
+		summaries[i] = summary
+	}
+
+	return connectors.JSONResult(summaries)
+}
+
+// validateFolderPath rejects paths with traversal sequences, absolute paths, or backslashes.
+func validateFolderPath(p string) error {
+	if p == "" {
+		return nil
+	}
+	if strings.Contains(p, "..") {
+		return &connectors.ValidationError{Message: "invalid folder_path: must not contain path traversal sequences"}
+	}
+	if strings.Contains(p, "\\") {
+		return &connectors.ValidationError{Message: "invalid folder_path: must not contain backslashes"}
+	}
+	if strings.HasPrefix(p, "/") {
+		return &connectors.ValidationError{Message: "invalid folder_path: must be a relative path"}
+	}
+	return nil
+}

--- a/connectors/microsoft/list_drive_files.go
+++ b/connectors/microsoft/list_drive_files.go
@@ -134,8 +134,8 @@ func validateFolderPath(p string) error {
 	return validateRelativePath("folder_path", p)
 }
 
-// validateRelativePath validates that a path is relative and safe from traversal attacks.
-// Used by both folder_path and file_path validation.
+// validateRelativePath validates that a path is relative and safe from traversal
+// and URL injection attacks. Used by both folder_path and file_path validation.
 func validateRelativePath(field, p string) error {
 	if strings.Contains(p, "..") {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not contain path traversal sequences", field)}
@@ -145,6 +145,9 @@ func validateRelativePath(field, p string) error {
 	}
 	if strings.HasPrefix(p, "/") {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must be a relative path", field)}
+	}
+	if strings.ContainsAny(p, "?#%") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not contain URL-special characters", field)}
 	}
 	return nil
 }

--- a/connectors/microsoft/list_drive_files.go
+++ b/connectors/microsoft/list_drive_files.go
@@ -30,30 +30,6 @@ func (p *listDriveFilesParams) defaults() {
 	}
 }
 
-// graphDriveItemsResponse is the Microsoft Graph API response for listing drive items.
-type graphDriveItemsResponse struct {
-	Value []graphDriveItem `json:"value"`
-}
-
-type graphDriveItem struct {
-	ID               string          `json:"id"`
-	Name             string          `json:"name"`
-	Size             int64           `json:"size"`
-	WebURL           string          `json:"webUrl,omitempty"`
-	CreatedDateTime  string          `json:"createdDateTime,omitempty"`
-	ModifiedDateTime string          `json:"lastModifiedDateTime,omitempty"`
-	Folder           *graphFolder    `json:"folder,omitempty"`
-	File             *graphFileFacet `json:"file,omitempty"`
-}
-
-type graphFolder struct {
-	ChildCount int `json:"childCount"`
-}
-
-type graphFileFacet struct {
-	MimeType string `json:"mimeType"`
-}
-
 // driveFileSummary is the simplified response returned to the caller.
 type driveFileSummary struct {
 	ID          string `json:"id"`

--- a/connectors/microsoft/list_drive_files_test.go
+++ b/connectors/microsoft/list_drive_files_test.go
@@ -1,0 +1,195 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListDriveFiles_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{
+				{
+					"id":                   "file-1",
+					"name":                 "report.docx",
+					"size":                 1024,
+					"webUrl":               "https://onedrive.live.com/file-1",
+					"createdDateTime":      "2024-01-15T09:00:00Z",
+					"lastModifiedDateTime": "2024-01-16T10:00:00Z",
+					"file": map[string]string{
+						"mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+					},
+				},
+				{
+					"id":                   "folder-1",
+					"name":                 "Documents",
+					"size":                 0,
+					"createdDateTime":      "2024-01-10T08:00:00Z",
+					"lastModifiedDateTime": "2024-01-14T12:00:00Z",
+					"folder": map[string]any{
+						"childCount": 5,
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var summaries []driveFileSummary
+	if err := json.Unmarshal(result.Data, &summaries); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(summaries))
+	}
+
+	// Check file
+	if summaries[0].ID != "file-1" {
+		t.Errorf("expected id 'file-1', got %q", summaries[0].ID)
+	}
+	if summaries[0].Type != "file" {
+		t.Errorf("expected type 'file', got %q", summaries[0].Type)
+	}
+	if summaries[0].MimeType == "" {
+		t.Error("expected non-empty mime_type for file")
+	}
+
+	// Check folder
+	if summaries[1].ID != "folder-1" {
+		t.Errorf("expected id 'folder-1', got %q", summaries[1].ID)
+	}
+	if summaries[1].Type != "folder" {
+		t.Errorf("expected type 'folder', got %q", summaries[1].Type)
+	}
+	if summaries[1].ChildCount != 5 {
+		t.Errorf("expected child_count 5, got %d", summaries[1].ChildCount)
+	}
+}
+
+func TestListDriveFiles_WithFolderPath(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listDriveFilesAction{conn: conn}
+
+	params, _ := json.Marshal(listDriveFilesParams{FolderPath: "Documents/Work"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_drive_files",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requestPath != "/me/drive/root:/Documents/Work:/children" {
+		t.Errorf("expected path with folder, got %q", requestPath)
+	}
+}
+
+func TestListDriveFiles_DefaultParams(t *testing.T) {
+	t.Parallel()
+
+	var params listDriveFilesParams
+	params.defaults()
+	if params.Top != 10 {
+		t.Errorf("expected default top 10, got %d", params.Top)
+	}
+}
+
+func TestListDriveFiles_TopClamped(t *testing.T) {
+	t.Parallel()
+
+	params := listDriveFilesParams{Top: 100}
+	params.defaults()
+	if params.Top != 50 {
+		t.Errorf("expected top clamped to 50, got %d", params.Top)
+	}
+}
+
+func TestListDriveFiles_PathTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDriveFilesAction{conn: conn}
+
+	cases := []struct {
+		name       string
+		folderPath string
+	}{
+		{"dot-dot", "../../admin"},
+		{"backslash", "Documents\\secret"},
+		{"absolute", "/root/files"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(listDriveFilesParams{FolderPath: tc.folderPath})
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "microsoft.list_drive_files",
+				Parameters:  params,
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("expected error for invalid folder_path")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got: %T", err)
+			}
+		})
+	}
+}
+
+func TestListDriveFiles_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDriveFilesAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_drive_files",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/list_drive_files_test.go
+++ b/connectors/microsoft/list_drive_files_test.go
@@ -162,6 +162,9 @@ func TestListDriveFiles_PathTraversalRejected(t *testing.T) {
 		{"dot-dot", "../../admin"},
 		{"backslash", "Documents\\secret"},
 		{"absolute", "/root/files"},
+		{"query-injection", "Documents?$filter=malicious"},
+		{"fragment-injection", "Documents#fragment"},
+		{"percent-encoding", "Documents%2F..%2Fetc"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/connectors/microsoft/list_drive_files_test.go
+++ b/connectors/microsoft/list_drive_files_test.go
@@ -63,34 +63,40 @@ func TestListDriveFiles_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var summaries []driveFileSummary
-	if err := json.Unmarshal(result.Data, &summaries); err != nil {
+	var resp struct {
+		FolderPath string             `json:"folder_path"`
+		Items      []driveFileSummary `json:"items"`
+	}
+	if err := json.Unmarshal(result.Data, &resp); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	if len(summaries) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(summaries))
+	if resp.FolderPath != "/" {
+		t.Errorf("expected folder_path '/', got %q", resp.FolderPath)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(resp.Items))
 	}
 
 	// Check file
-	if summaries[0].ID != "file-1" {
-		t.Errorf("expected id 'file-1', got %q", summaries[0].ID)
+	if resp.Items[0].ID != "file-1" {
+		t.Errorf("expected id 'file-1', got %q", resp.Items[0].ID)
 	}
-	if summaries[0].Type != "file" {
-		t.Errorf("expected type 'file', got %q", summaries[0].Type)
+	if resp.Items[0].Type != "file" {
+		t.Errorf("expected type 'file', got %q", resp.Items[0].Type)
 	}
-	if summaries[0].MimeType == "" {
+	if resp.Items[0].MimeType == "" {
 		t.Error("expected non-empty mime_type for file")
 	}
 
 	// Check folder
-	if summaries[1].ID != "folder-1" {
-		t.Errorf("expected id 'folder-1', got %q", summaries[1].ID)
+	if resp.Items[1].ID != "folder-1" {
+		t.Errorf("expected id 'folder-1', got %q", resp.Items[1].ID)
 	}
-	if summaries[1].Type != "folder" {
-		t.Errorf("expected type 'folder', got %q", summaries[1].Type)
+	if resp.Items[1].Type != "folder" {
+		t.Errorf("expected type 'folder', got %q", resp.Items[1].Type)
 	}
-	if summaries[1].ChildCount != 5 {
-		t.Errorf("expected child_count 5, got %d", summaries[1].ChildCount)
+	if resp.Items[1].ChildCount != 5 {
+		t.Errorf("expected child_count 5, got %d", resp.Items[1].ChildCount)
 	}
 }
 

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -65,7 +65,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "microsoft",
 		Name:        "Microsoft",
-		Description: "Microsoft 365 integration for email and calendar via Microsoft Graph API",
+		Description: "Microsoft 365 integration for email, calendar, and OneDrive via Microsoft Graph API",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "microsoft.send_email",
@@ -180,6 +180,91 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "microsoft.list_drive_files",
+				Name:        "List Drive Files",
+				Description: "List files and folders in OneDrive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"folder_path": {
+							"type": "string",
+							"description": "Relative folder path (e.g. Documents/Work). Defaults to root."
+						},
+						"top": {
+							"type": "integer",
+							"default": 10,
+							"minimum": 1,
+							"maximum": 50,
+							"description": "Number of items to return (max 50)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.get_drive_file",
+				Name:        "Get Drive File",
+				Description: "Get file metadata and optionally download text content from OneDrive",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID"
+						},
+						"include_content": {
+							"type": "boolean",
+							"default": false,
+							"description": "Download file content (text files only)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.upload_drive_file",
+				Name:        "Upload Drive File",
+				Description: "Upload or create a file in OneDrive",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["file_path", "content"],
+					"properties": {
+						"file_path": {
+							"type": "string",
+							"description": "Relative file path (e.g. Documents/report.txt)"
+						},
+						"content": {
+							"type": "string",
+							"description": "File content to upload (max 4 MB)"
+						},
+						"conflict_behavior": {
+							"type": "string",
+							"enum": ["rename", "replace", "fail"],
+							"default": "rename",
+							"description": "Behavior when a file with the same name exists"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "microsoft.delete_drive_file",
+				Name:        "Delete Drive File",
+				Description: "Move a file to the OneDrive recycle bin (recoverable)",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["item_id"],
+					"properties": {
+						"item_id": {
+							"type": "string",
+							"description": "OneDrive item ID to delete"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -190,6 +275,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 					"Mail.Send",
 					"Mail.Read",
 					"Calendars.ReadWrite",
+					"Files.ReadWrite",
 				},
 			},
 		},
@@ -222,6 +308,41 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can view upcoming calendar events.",
 				Parameters:  json.RawMessage(`{"top":"*"}`),
 			},
+			{
+				ID:          "tpl_microsoft_list_drive_files",
+				ActionType:  "microsoft.list_drive_files",
+				Name:        "Browse OneDrive files",
+				Description: "Agent can list files and folders in OneDrive.",
+				Parameters:  json.RawMessage(`{"folder_path":"*","top":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_get_drive_file",
+				ActionType:  "microsoft.get_drive_file",
+				Name:        "Read OneDrive files",
+				Description: "Agent can read file metadata and download text content from OneDrive.",
+				Parameters:  json.RawMessage(`{"item_id":"*","include_content":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_get_drive_file_metadata",
+				ActionType:  "microsoft.get_drive_file",
+				Name:        "View OneDrive file metadata",
+				Description: "Agent can view file metadata from OneDrive but cannot download content.",
+				Parameters:  json.RawMessage(`{"item_id":"*","include_content":false}`),
+			},
+			{
+				ID:          "tpl_microsoft_upload_drive_file",
+				ActionType:  "microsoft.upload_drive_file",
+				Name:        "Upload OneDrive files",
+				Description: "Agent can upload files to OneDrive.",
+				Parameters:  json.RawMessage(`{"file_path":"*","content":"*","conflict_behavior":"*"}`),
+			},
+			{
+				ID:          "tpl_microsoft_delete_drive_file",
+				ActionType:  "microsoft.delete_drive_file",
+				Name:        "Delete OneDrive files",
+				Description: "Agent can move files to the OneDrive recycle bin.",
+				Parameters:  json.RawMessage(`{"item_id":"*"}`),
+			},
 		},
 	}
 }
@@ -233,6 +354,10 @@ func (c *MicrosoftConnector) Actions() map[string]connectors.Action {
 		"microsoft.list_emails":           &listEmailsAction{conn: c},
 		"microsoft.create_calendar_event": &createCalendarEventAction{conn: c},
 		"microsoft.list_calendar_events":  &listCalendarEventsAction{conn: c},
+		"microsoft.list_drive_files":      &listDriveFilesAction{conn: c},
+		"microsoft.get_drive_file":        &getDriveFileAction{conn: c},
+		"microsoft.upload_drive_file":     &uploadDriveFileAction{conn: c},
+		"microsoft.delete_drive_file":     &deleteDriveFileAction{conn: c},
 	}
 }
 
@@ -323,4 +448,97 @@ func (c *MicrosoftConnector) doRequest(ctx context.Context, method, path string,
 	}
 
 	return nil
+}
+
+// doRequestRaw is like doRequest but returns the response body as a string
+// instead of JSON-unmarshaling it. Used for downloading file content.
+func (c *MicrosoftConnector) doRequestRaw(ctx context.Context, method, path string, creds connectors.Credentials) (string, error) {
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return "", &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return "", &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return "", &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
+		}
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
+		return "", &connectors.RateLimitError{
+			Message:    "Microsoft Graph API rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+	if err != nil {
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", mapGraphError(resp.StatusCode, respBody)
+	}
+
+	return string(respBody), nil
+}
+
+// doPutRaw sends a PUT request with a raw byte body (not JSON-encoded) and returns
+// the response body bytes. Used for uploading file content to OneDrive.
+func (c *MicrosoftConnector) doPutRaw(ctx context.Context, path string, creds connectors.Credentials, content []byte) ([]byte, error) {
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return nil, &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
+		}
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
+		return nil, &connectors.RateLimitError{
+			Message:    "Microsoft Graph API rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, mapGraphError(resp.StatusCode, respBody)
+	}
+
+	return respBody, nil
 }

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -371,146 +371,17 @@ func (c *MicrosoftConnector) ValidateCredentials(_ context.Context, creds connec
 	return nil
 }
 
-// doRequest is the shared request lifecycle for all Microsoft Graph actions.
-// It handles:
-//   - JSON marshaling of the request body (if non-nil)
-//   - Authorization header with the OAuth access token
+// executeRequest is the core request lifecycle shared by all Microsoft Graph
+// request methods. It handles:
+//   - Sending the HTTP request
+//   - Timeout and context cancellation detection
 //   - Rate limit detection (HTTP 429 → RateLimitError with Retry-After)
 //   - Response body size limiting (maxResponseBodySize) to prevent OOM
 //   - Error response mapping via mapGraphError (see response.go)
-//   - JSON unmarshaling of successful responses into dest (if non-nil)
-//   - 204 No Content handling (e.g. sendMail returns no body)
 //
-// Callers provide the HTTP method, Graph API path (e.g. "/me/sendMail"),
-// credentials, optional request body, and optional response destination.
-func (c *MicrosoftConnector) doRequest(ctx context.Context, method, path string, creds connectors.Credentials, body any, dest any) error {
-	token, ok := creds.Get(credKeyToken)
-	if !ok || token == "" {
-		return &connectors.ValidationError{Message: "access_token credential is missing or empty"}
-	}
-
-	var reqBody io.Reader
-	if body != nil {
-		payload, err := json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("marshaling request body: %w", err)
-		}
-		reqBody = bytes.NewReader(payload)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
-		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	// Microsoft Graph returns 429 for rate limiting.
-	if resp.StatusCode == http.StatusTooManyRequests {
-		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
-		return &connectors.RateLimitError{
-			Message:    "Microsoft Graph API rate limit exceeded",
-			RetryAfter: retryAfter,
-		}
-	}
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
-	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return mapGraphError(resp.StatusCode, respBody)
-	}
-
-	// Some endpoints return 204 No Content (e.g. sendMail).
-	if dest != nil && len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, dest); err != nil {
-			return &connectors.ExternalError{
-				StatusCode: resp.StatusCode,
-				Message:    "failed to decode Microsoft Graph API response",
-			}
-		}
-	}
-
-	return nil
-}
-
-// doRequestRaw is like doRequest but returns the response body as a string
-// instead of JSON-unmarshaling it. Used for downloading file content.
-func (c *MicrosoftConnector) doRequestRaw(ctx context.Context, method, path string, creds connectors.Credentials) (string, error) {
-	token, ok := creds.Get(credKeyToken)
-	if !ok || token == "" {
-		return "", &connectors.ValidationError{Message: "access_token credential is missing or empty"}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return "", &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return "", &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
-		}
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
-		return "", &connectors.RateLimitError{
-			Message:    "Microsoft Graph API rate limit exceeded",
-			RetryAfter: retryAfter,
-		}
-	}
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
-	if err != nil {
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", mapGraphError(resp.StatusCode, respBody)
-	}
-
-	return string(respBody), nil
-}
-
-// doPutRaw sends a PUT request with a raw byte body (not JSON-encoded) and returns
-// the response body bytes. Used for uploading file content to OneDrive.
-func (c *MicrosoftConnector) doPutRaw(ctx context.Context, path string, creds connectors.Credentials, content []byte) ([]byte, error) {
-	token, ok := creds.Get(credKeyToken)
-	if !ok || token == "" {
-		return nil, &connectors.ValidationError{Message: "access_token credential is missing or empty"}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(content))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/octet-stream")
-
+// Returns the raw response body on success. Callers handle request construction
+// and response interpretation.
+func (c *MicrosoftConnector) executeRequest(req *http.Request) ([]byte, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		if connectors.IsTimeout(err) {
@@ -541,4 +412,97 @@ func (c *MicrosoftConnector) doPutRaw(ctx context.Context, path string, creds co
 	}
 
 	return respBody, nil
+}
+
+// extractToken retrieves the OAuth access token from credentials.
+func extractToken(creds connectors.Credentials) (string, error) {
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return "", &connectors.ValidationError{Message: "access_token credential is missing or empty"}
+	}
+	return token, nil
+}
+
+// doRequest is the shared request lifecycle for all Microsoft Graph JSON actions.
+// It handles JSON marshaling/unmarshaling, authorization, and delegates to
+// executeRequest for the HTTP lifecycle.
+func (c *MicrosoftConnector) doRequest(ctx context.Context, method, path string, creds connectors.Credentials, body any, dest any) error {
+	token, err := extractToken(creds)
+	if err != nil {
+		return err
+	}
+
+	var reqBody io.Reader
+	if body != nil {
+		payload, marshalErr := json.Marshal(body)
+		if marshalErr != nil {
+			return fmt.Errorf("marshaling request body: %w", marshalErr)
+		}
+		reqBody = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	respBody, err := c.executeRequest(req)
+	if err != nil {
+		return err
+	}
+
+	// Some endpoints return 204 No Content (e.g. sendMail).
+	if dest != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, dest); err != nil {
+			return &connectors.ExternalError{
+				Message: "failed to decode Microsoft Graph API response",
+			}
+		}
+	}
+
+	return nil
+}
+
+// doRequestRaw is like doRequest but returns the response body as a string
+// instead of JSON-unmarshaling it. Used for downloading file content.
+func (c *MicrosoftConnector) doRequestRaw(ctx context.Context, method, path string, creds connectors.Credentials) (string, error) {
+	token, err := extractToken(creds)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	respBody, execErr := c.executeRequest(req)
+	if execErr != nil {
+		return "", execErr
+	}
+
+	return string(respBody), nil
+}
+
+// doPutRaw sends a PUT request with a raw byte body (not JSON-encoded) and returns
+// the response body bytes. Used for uploading file content to OneDrive.
+func (c *MicrosoftConnector) doPutRaw(ctx context.Context, path string, creds connectors.Credentials, content []byte) ([]byte, error) {
+	token, err := extractToken(creds)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	return c.executeRequest(req)
 }

--- a/connectors/microsoft/microsoft_test.go
+++ b/connectors/microsoft/microsoft_test.go
@@ -24,6 +24,10 @@ func TestMicrosoftConnector_Actions(t *testing.T) {
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
+		"microsoft.list_drive_files",
+		"microsoft.get_drive_file",
+		"microsoft.upload_drive_file",
+		"microsoft.delete_drive_file",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -91,8 +95,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	if m.Name != "Microsoft" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Microsoft")
 	}
-	if len(m.Actions) != 4 {
-		t.Fatalf("Manifest().Actions has %d items, want 4", len(m.Actions))
+	if len(m.Actions) != 8 {
+		t.Fatalf("Manifest().Actions has %d items, want 8", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -103,6 +107,10 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
+		"microsoft.list_drive_files",
+		"microsoft.get_drive_file",
+		"microsoft.upload_drive_file",
+		"microsoft.delete_drive_file",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)
@@ -126,8 +134,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	}
 
 	// Validate templates.
-	if len(m.Templates) != 4 {
-		t.Errorf("Manifest().Templates has %d items, want 4", len(m.Templates))
+	if len(m.Templates) != 9 {
+		t.Errorf("Manifest().Templates has %d items, want 9", len(m.Templates))
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/microsoft/types.go
+++ b/connectors/microsoft/types.go
@@ -41,3 +41,30 @@ type graphAttendee struct {
 	} `json:"emailAddress"`
 	Type string `json:"type"`
 }
+
+// graphDriveItem represents a file or folder in OneDrive in Graph API format.
+type graphDriveItem struct {
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	Size             int64           `json:"size"`
+	WebURL           string          `json:"webUrl,omitempty"`
+	CreatedDateTime  string          `json:"createdDateTime,omitempty"`
+	ModifiedDateTime string          `json:"lastModifiedDateTime,omitempty"`
+	Folder           *graphFolder    `json:"folder,omitempty"`
+	File             *graphFileFacet `json:"file,omitempty"`
+}
+
+// graphFolder represents the folder facet of a OneDrive item.
+type graphFolder struct {
+	ChildCount int `json:"childCount"`
+}
+
+// graphFileFacet represents the file facet of a OneDrive item.
+type graphFileFacet struct {
+	MimeType string `json:"mimeType"`
+}
+
+// graphDriveItemsResponse is the Microsoft Graph API response for listing drive items.
+type graphDriveItemsResponse struct {
+	Value []graphDriveItem `json:"value"`
+}

--- a/connectors/microsoft/upload_drive_file.go
+++ b/connectors/microsoft/upload_drive_file.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -39,7 +38,7 @@ func (p *uploadDriveFileParams) validate() error {
 	}
 	if len(p.Content) > maxUploadContentSize {
 		return &connectors.ValidationError{
-			Message: fmt.Sprintf("content exceeds maximum size of %d bytes", maxUploadContentSize),
+			Message: "content exceeds maximum upload size of 4 MB",
 		}
 	}
 	if err := validateFilePath(p.FilePath); err != nil {
@@ -101,14 +100,5 @@ func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 
 // validateFilePath rejects paths with traversal sequences, backslashes, or absolute paths.
 func validateFilePath(p string) error {
-	if strings.Contains(p, "..") {
-		return &connectors.ValidationError{Message: "invalid file_path: must not contain path traversal sequences"}
-	}
-	if strings.Contains(p, "\\") {
-		return &connectors.ValidationError{Message: "invalid file_path: must not contain backslashes"}
-	}
-	if strings.HasPrefix(p, "/") {
-		return &connectors.ValidationError{Message: "invalid file_path: must be a relative path"}
-	}
-	return nil
+	return validateRelativePath("file_path", p)
 }

--- a/connectors/microsoft/upload_drive_file.go
+++ b/connectors/microsoft/upload_drive_file.go
@@ -1,0 +1,114 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// maxUploadContentSize limits the upload content to 4 MB.
+const maxUploadContentSize = 4 * 1024 * 1024
+
+// uploadDriveFileAction implements connectors.Action for microsoft.upload_drive_file.
+// It uploads or creates a file in OneDrive via PUT /me/drive/root:/{path}:/content.
+type uploadDriveFileAction struct {
+	conn *MicrosoftConnector
+}
+
+type uploadDriveFileParams struct {
+	FilePath         string `json:"file_path"`
+	Content          string `json:"content"`
+	ConflictBehavior string `json:"conflict_behavior"`
+}
+
+func (p *uploadDriveFileParams) defaults() {
+	if p.ConflictBehavior == "" {
+		p.ConflictBehavior = "rename"
+	}
+}
+
+func (p *uploadDriveFileParams) validate() error {
+	if p.FilePath == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: file_path"}
+	}
+	if p.Content == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: content"}
+	}
+	if len(p.Content) > maxUploadContentSize {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("content exceeds maximum size of %d bytes", maxUploadContentSize),
+		}
+	}
+	if err := validateFilePath(p.FilePath); err != nil {
+		return err
+	}
+	switch p.ConflictBehavior {
+	case "rename", "replace", "fail":
+		// valid
+	default:
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid conflict_behavior %q: must be rename, replace, or fail", p.ConflictBehavior),
+		}
+	}
+	return nil
+}
+
+// uploadDriveFileResult is the simplified response for uploaded files.
+type uploadDriveFileResult struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	WebURL     string `json:"web_url,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	ModifiedAt string `json:"modified_at,omitempty"`
+}
+
+func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params uploadDriveFileParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	params.defaults()
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/me/drive/root:/%s:/content?@microsoft.graph.conflictBehavior=%s",
+		params.FilePath, params.ConflictBehavior)
+
+	content, err := a.conn.doPutRaw(ctx, path, req.Credentials, []byte(params.Content))
+	if err != nil {
+		return nil, err
+	}
+
+	var item graphDriveItem
+	if err := json.Unmarshal(content, &item); err != nil {
+		return nil, &connectors.ExternalError{Message: "failed to decode upload response"}
+	}
+
+	return connectors.JSONResult(uploadDriveFileResult{
+		ID:         item.ID,
+		Name:       item.Name,
+		Size:       item.Size,
+		WebURL:     item.WebURL,
+		CreatedAt:  item.CreatedDateTime,
+		ModifiedAt: item.ModifiedDateTime,
+	})
+}
+
+// validateFilePath rejects paths with traversal sequences, backslashes, or absolute paths.
+func validateFilePath(p string) error {
+	if strings.Contains(p, "..") {
+		return &connectors.ValidationError{Message: "invalid file_path: must not contain path traversal sequences"}
+	}
+	if strings.Contains(p, "\\") {
+		return &connectors.ValidationError{Message: "invalid file_path: must not contain backslashes"}
+	}
+	if strings.HasPrefix(p, "/") {
+		return &connectors.ValidationError{Message: "invalid file_path: must be a relative path"}
+	}
+	return nil
+}

--- a/connectors/microsoft/upload_drive_file_test.go
+++ b/connectors/microsoft/upload_drive_file_test.go
@@ -1,0 +1,260 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUploadDriveFile_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/octet-stream" {
+			t.Errorf("expected octet-stream content type, got %q", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "file content here" {
+			t.Errorf("expected body 'file content here', got %q", string(body))
+		}
+
+		// Check conflict behavior query param
+		if !strings.Contains(r.URL.RawQuery, "conflictBehavior=rename") {
+			t.Errorf("expected conflictBehavior=rename in query, got %q", r.URL.RawQuery)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":                   "new-file-1",
+			"name":                 "report.txt",
+			"size":                 17,
+			"webUrl":               "https://onedrive.live.com/new-file-1",
+			"createdDateTime":      "2024-01-15T09:00:00Z",
+			"lastModifiedDateTime": "2024-01-15T09:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		FilePath: "Documents/report.txt",
+		Content:  "file content here",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var res uploadDriveFileResult
+	if err := json.Unmarshal(result.Data, &res); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if res.ID != "new-file-1" {
+		t.Errorf("expected id 'new-file-1', got %q", res.ID)
+	}
+	if res.Name != "report.txt" {
+		t.Errorf("expected name 'report.txt', got %q", res.Name)
+	}
+}
+
+func TestUploadDriveFile_ConflictBehaviorReplace(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.RawQuery, "conflictBehavior=replace") {
+			t.Errorf("expected conflictBehavior=replace, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "file-1",
+			"name": "report.txt",
+			"size": 5,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		FilePath:         "report.txt",
+		Content:          "hello",
+		ConflictBehavior: "replace",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUploadDriveFile_MissingFilePath(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"content": "data"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing file_path")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_MissingContent(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"file_path": "test.txt"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_ContentTooLarge(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	bigContent := strings.Repeat("x", maxUploadContentSize+1)
+	params, _ := json.Marshal(uploadDriveFileParams{
+		FilePath: "big.txt",
+		Content:  bigContent,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for oversized content")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_InvalidConflictBehavior(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		FilePath:         "test.txt",
+		Content:          "data",
+		ConflictBehavior: "invalid",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid conflict_behavior")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUploadDriveFile_PathTraversalRejected(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	cases := []struct {
+		name     string
+		filePath string
+	}{
+		{"dot-dot", "../../etc/passwd"},
+		{"backslash", "Documents\\file.txt"},
+		{"absolute", "/root/file.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(uploadDriveFileParams{
+				FilePath: tc.filePath,
+				Content:  "data",
+			})
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "microsoft.upload_drive_file",
+				Parameters:  params,
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("expected error for invalid file_path")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got: %T", err)
+			}
+		})
+	}
+}
+
+func TestUploadDriveFile_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &uploadDriveFileAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/microsoft/upload_drive_file_test.go
+++ b/connectors/microsoft/upload_drive_file_test.go
@@ -218,6 +218,9 @@ func TestUploadDriveFile_PathTraversalRejected(t *testing.T) {
 		{"dot-dot", "../../etc/passwd"},
 		{"backslash", "Documents\\file.txt"},
 		{"absolute", "/root/file.txt"},
+		{"query-injection", "Documents/file.txt?$filter=malicious"},
+		{"fragment-injection", "Documents/file.txt#fragment"},
+		{"percent-encoding", "Documents%2F..%2Fetc/passwd"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds four new OneDrive file management actions to the Microsoft connector: `list_drive_files`, `get_drive_file`, `upload_drive_file`, and `delete_drive_file`
- Adds five new templates for OneDrive actions (including a metadata-only template for `get_drive_file`)
- Adds `Files.ReadWrite` OAuth scope and `doRequestRaw`/`doPutRaw` methods for raw content download/upload

## Security

- Path traversal validation on `folder_path` and `file_path` (rejects `..`, backslashes, absolute paths)
- Item ID validation rejects path separators and special characters
- Upload content capped at 4 MB
- Binary file content download rejected (text MIME types only)
- Delete sends to recycle bin (recoverable), not permanent deletion
- Response body size limited by existing `maxResponseBodySize` (10 MB)

## Test plan

- [x] All 47 Microsoft connector tests pass (including new OneDrive action tests)
- [x] `go vet` passes with no warnings
- [x] Microsoft connector package builds cleanly
- [ ] CI runs full test suite

Closes #242

https://claude.ai/code/session_011QnhF7tcXaSCzh2kEASdwv