### PR TITLE
fix: rename checkout response field url → checkout_url

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -36,7 +36,7 @@ type usageInfo struct {
 }
 
 type checkoutResponse struct {
-	URL string `json:"url"`
+	CheckoutURL string `json:"checkout_url"`
 }
 
 // usageResponse is the JSON shape returned by GET /billing/usage.
@@ -348,7 +348,7 @@ func handleCreateCheckout(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		RespondJSON(w, http.StatusOK, checkoutResponse{URL: sess.URL})
+		RespondJSON(w, http.StatusOK, checkoutResponse{CheckoutURL: sess.URL})
 	}
 }
 


### PR DESCRIPTION
## Problem

The billing upgrade flow was failing with "No checkout URL returned. Please try again." when clicking checkout.

## Root Cause

The backend `checkoutResponse` struct was serializing as `{ "url": "..." }` but the frontend (`UpgradeCTA.tsx`) and the OpenAPI spec both expect `{ "checkout_url": "..." }`.

## Fix

Renamed the struct field from `URL` to `CheckoutURL` with the correct JSON tag `checkout_url`.

```go
// Before
type checkoutResponse struct {
    URL string `json:"url"`
}

// After
type checkoutResponse struct {
    CheckoutURL string `json:"checkout_url"`
}
```

## Testing

Verified end-to-end in local dev — clicking "Upgrade to Pay-as-you-go" now redirects to the Stripe test checkout page.