### PR TITLE
Provide PR creation link instead of auto-creating PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 - When asked a question, just answer it. Do not write or modify code unless explicitly asked.
 - Always ask for permission before writing any code.
 - Do not git push without confirming first
-- After making the first commit on a branch, create a pull request by default (no need to ask first). For subsequent commits, push to the existing PR branch.
-- Always include the pull request URL at the end of every message where a PR exists, formatted exactly as: `Pull request: <url>` — no bold, no markdown link syntax, just the plain text and URL so the link doesn't break.
+- After making the first commit on a branch, do NOT automatically create a pull request. Instead, provide a pre-filled GitHub PR creation link so the user can create it themselves. Format: `Click here to create PR: https://github.com/supersuit-tech/permission-slip/compare/main...BRANCH?expand=1&title=URL_ENCODED_TITLE&body=URL_ENCODED_BODY` — include a suggested title and body with a summary of changes. For subsequent commits, push to the existing PR branch.
+- Always include the pull request URL at the end of every message where a PR already exists, formatted exactly as: `Pull request: <url>` — no bold, no markdown link syntax, just the plain text and URL so the link doesn't break.
 - Whenever you bring up a problem, always suggest a recommendation for how to address it.
 - When asked to review for improvements or issues: fix anything you're confident should be fixed (commit & push), then mention any additional findings that are more subjective or optional so the user can decide.
 - If a file is getting large enough that splitting it would improve maintainability, just go ahead and split it — don't ask first.


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md so Claude provides a pre-filled GitHub PR creation link instead of automatically creating pull requests
- Once a PR exists, behavior is unchanged — the PR URL is still shown at the end of every message

## Test plan
- [ ] Verify the CLAUDE.md instructions are clear and unambiguous