### PR TITLE
feat: Phase 8 (Frontend) + Phase 9 (Config + Docs) for OAuth connectors

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -6,8 +6,10 @@ import "net/http"
 // Add new fields here as more server config needs to be exposed
 // (e.g., feature flags for upcoming features).
 type configResponse struct {
-	BillingEnabled bool `json:"billing_enabled"`
-	StripeTestMode bool `json:"stripe_test_mode"`
+	BillingEnabled       bool `json:"billing_enabled"`
+	StripeTestMode       bool `json:"stripe_test_mode"`
+	GoogleOAuthConfigured    bool `json:"google_oauth_configured"`
+	MicrosoftOAuthConfigured bool `json:"microsoft_oauth_configured"`
 }
 
 // RegisterConfigRoutes adds server configuration endpoints to the mux.
@@ -20,9 +22,20 @@ func RegisterConfigRoutes(mux *http.ServeMux, deps *Deps) {
 // to adapt its UI (e.g., showing or hiding billing-related pages).
 func handleGetConfig(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		var googleConfigured, microsoftConfigured bool
+		if deps.OAuthProviders != nil {
+			if p, ok := deps.OAuthProviders.Get("google"); ok {
+				googleConfigured = p.HasClientCredentials()
+			}
+			if p, ok := deps.OAuthProviders.Get("microsoft"); ok {
+				microsoftConfigured = p.HasClientCredentials()
+			}
+		}
 		RespondJSON(w, http.StatusOK, configResponse{
-			BillingEnabled: deps.BillingEnabled,
-			StripeTestMode: deps.StripeTestMode,
+			BillingEnabled:           deps.BillingEnabled,
+			StripeTestMode:           deps.StripeTestMode,
+			GoogleOAuthConfigured:    googleConfigured,
+			MicrosoftOAuthConfigured: microsoftConfigured,
 		})
 	}
 }

--- a/config.go
+++ b/config.go
@@ -146,6 +146,26 @@ func validateConfig() (errs []configError, warnings []configError) {
 		}
 	}
 
+	// OAuth — warn when Google or Microsoft client credentials are not set.
+	// These are non-fatal because BYOA still works, but the built-in
+	// Google/Microsoft connectors won't be usable without them.
+	hasGoogleClientID := os.Getenv("GOOGLE_CLIENT_ID") != ""
+	hasGoogleClientSecret := os.Getenv("GOOGLE_CLIENT_SECRET") != ""
+	hasMicrosoftClientID := os.Getenv("MICROSOFT_CLIENT_ID") != ""
+	hasMicrosoftClientSecret := os.Getenv("MICROSOFT_CLIENT_SECRET") != ""
+	if !hasGoogleClientID || !hasGoogleClientSecret {
+		warnings = append(warnings, configError{
+			envVar:  "GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET",
+			message: "not set; Google OAuth connector will require BYOA credentials (see docs/oauth-setup.md)",
+		})
+	}
+	if !hasMicrosoftClientID || !hasMicrosoftClientSecret {
+		warnings = append(warnings, configError{
+			envVar:  "MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET",
+			message: "not set; Microsoft OAuth connector will require BYOA credentials (see docs/oauth-setup.md)",
+		})
+	}
+
 	// Optional but recommended — warn in all modes.
 	if os.Getenv("SUPABASE_SERVICE_ROLE_KEY") == "" {
 		warnings = append(warnings, configError{

--- a/config_test.go
+++ b/config_test.go
@@ -63,6 +63,10 @@ func TestValidateConfig_DevelopmentModeNoWarningsWhenConfigured(t *testing.T) {
 		"SUPABASE_SERVICE_ROLE_KEY":  "test-key",
 		"INVITE_HMAC_KEY":            "test-key",
 		"BASE_URL":                   "https://example.com",
+		"GOOGLE_CLIENT_ID":           "test-google-id",
+		"GOOGLE_CLIENT_SECRET":       "test-google-secret",
+		"MICROSOFT_CLIENT_ID":        "test-msft-id",
+		"MICROSOFT_CLIENT_SECRET":    "test-msft-secret",
 	})
 
 	errs, warnings := validateConfig()
@@ -206,6 +210,10 @@ func TestValidateConfig_AllValid(t *testing.T) {
 		"VAPID_PUBLIC_KEY":          "BExamplePublicKey",
 		"VAPID_PRIVATE_KEY":         "examplePrivateKey",
 		"VAPID_SUBJECT":             "mailto:test@example.com",
+		"GOOGLE_CLIENT_ID":          "test-google-id",
+		"GOOGLE_CLIENT_SECRET":      "test-google-secret",
+		"MICROSOFT_CLIENT_ID":       "test-msft-id",
+		"MICROSOFT_CLIENT_SECRET":   "test-msft-secret",
 	})
 
 	errs, warnings := validateConfig()
@@ -413,6 +421,10 @@ func TestValidateConfig_BillingEnabled_NoErrorsWhenConfigured(t *testing.T) {
 		"VAPID_PUBLIC_KEY":          "",
 		"VAPID_PRIVATE_KEY":         "",
 		"VAPID_SUBJECT":             "",
+		"GOOGLE_CLIENT_ID":          "test-google-id",
+		"GOOGLE_CLIENT_SECRET":      "test-google-secret",
+		"MICROSOFT_CLIENT_ID":       "test-msft-id",
+		"MICROSOFT_CLIENT_SECRET":   "test-msft-secret",
 	})
 
 	errs, warnings := validateConfig()
@@ -512,6 +524,10 @@ func TestValidateConfig_StripeTestMode_NoWarningsWhenTestKeysSet(t *testing.T) {
 		"SUPABASE_SERVICE_ROLE_KEY":    "test-key",
 		"INVITE_HMAC_KEY":              "test-key",
 		"BASE_URL":                     "https://example.com",
+		"GOOGLE_CLIENT_ID":             "test-google-id",
+		"GOOGLE_CLIENT_SECRET":         "test-google-secret",
+		"MICROSOFT_CLIENT_ID":          "test-msft-id",
+		"MICROSOFT_CLIENT_SECRET":      "test-msft-secret",
 	})
 
 	errs, warnings := validateConfig()
@@ -520,5 +536,71 @@ func TestValidateConfig_StripeTestMode_NoWarningsWhenTestKeysSet(t *testing.T) {
 	}
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func TestValidateConfig_OAuthWarnings_MissingGoogleCredentials(t *testing.T) {
+	setEnvForTest(t, map[string]string{
+		"MODE":                      "development",
+		"GOOGLE_CLIENT_ID":          "",
+		"GOOGLE_CLIENT_SECRET":      "",
+		"MICROSOFT_CLIENT_ID":       "test-msft-id",
+		"MICROSOFT_CLIENT_SECRET":   "test-msft-secret",
+		"SUPABASE_SERVICE_ROLE_KEY": "test-key",
+		"INVITE_HMAC_KEY":           "test-key",
+		"BASE_URL":                  "https://example.com",
+	})
+
+	_, warnings := validateConfig()
+
+	found := false
+	for _, w := range warnings {
+		if w.envVar == "GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected warning for missing Google OAuth credentials")
+	}
+
+	// Microsoft should NOT have a warning.
+	for _, w := range warnings {
+		if w.envVar == "MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET" {
+			t.Error("unexpected warning for Microsoft OAuth when credentials are set")
+		}
+	}
+}
+
+func TestValidateConfig_OAuthWarnings_MissingMicrosoftCredentials(t *testing.T) {
+	setEnvForTest(t, map[string]string{
+		"MODE":                      "development",
+		"GOOGLE_CLIENT_ID":          "test-google-id",
+		"GOOGLE_CLIENT_SECRET":      "test-google-secret",
+		"MICROSOFT_CLIENT_ID":       "",
+		"MICROSOFT_CLIENT_SECRET":   "",
+		"SUPABASE_SERVICE_ROLE_KEY": "test-key",
+		"INVITE_HMAC_KEY":           "test-key",
+		"BASE_URL":                  "https://example.com",
+	})
+
+	_, warnings := validateConfig()
+
+	found := false
+	for _, w := range warnings {
+		if w.envVar == "MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected warning for missing Microsoft OAuth credentials")
+	}
+
+	// Google should NOT have a warning.
+	for _, w := range warnings {
+		if w.envVar == "GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET" {
+			t.Error("unexpected warning for Google OAuth when credentials are set")
+		}
 	}
 }

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -1,0 +1,183 @@
+# OAuth Setup Guide
+
+Permission Slip uses OAuth 2.0 to connect with Google and Microsoft services. This guide covers how to configure OAuth for both hosted and self-hosted deployments.
+
+## Overview
+
+Permission Slip supports two modes for OAuth provider credentials:
+
+1. **Platform-level (pre-configured)**: The server has Google/Microsoft client credentials set via environment variables. Users can connect their accounts immediately.
+2. **BYOA (Bring Your Own App)**: Users provide their own OAuth client credentials through the Settings UI. Required for self-hosted deployments or custom providers.
+
+## Environment Variables
+
+### Google OAuth
+
+| Variable | Description |
+|---|---|
+| `GOOGLE_CLIENT_ID` | OAuth 2.0 Client ID from Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | OAuth 2.0 Client Secret from Google Cloud Console |
+
+### Microsoft OAuth
+
+| Variable | Description |
+|---|---|
+| `MICROSOFT_CLIENT_ID` | Application (client) ID from Azure Portal |
+| `MICROSOFT_CLIENT_SECRET` | Client secret value from Azure Portal |
+
+### OAuth Infrastructure
+
+| Variable | Description | Default |
+|---|---|---|
+| `OAUTH_REDIRECT_BASE_URL` | Base URL for OAuth callbacks (e.g., `https://app.example.com/api`) | Falls back to `BASE_URL` |
+| `OAUTH_STATE_SECRET` | HMAC secret for signing OAuth CSRF state tokens | Falls back to `SUPABASE_JWT_SECRET` |
+| `OAUTH_REFRESH_INTERVAL` | Interval for background token refresh job | `10m` |
+
+## Google OAuth Setup
+
+### 1. Create a Google Cloud Project
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Enable the APIs your connectors need:
+   - **Gmail API** (for email actions)
+   - **Google Calendar API** (for calendar actions)
+
+### 2. Configure OAuth Consent Screen
+
+1. Navigate to **APIs & Services > OAuth consent screen**
+2. Select **External** user type (or **Internal** for Google Workspace)
+3. Fill in the required fields:
+   - App name: Your deployment name (e.g., "Permission Slip")
+   - User support email: Your support email
+   - Authorized domains: Your deployment domain
+4. Add the following scopes:
+   - `openid`
+   - `https://www.googleapis.com/auth/userinfo.email`
+   - `https://www.googleapis.com/auth/gmail.send`
+   - `https://www.googleapis.com/auth/gmail.readonly`
+   - `https://www.googleapis.com/auth/calendar.events`
+
+### 3. Create OAuth Credentials
+
+1. Navigate to **APIs & Services > Credentials**
+2. Click **Create Credentials > OAuth 2.0 Client ID**
+3. Application type: **Web application**
+4. Add authorized redirect URI:
+   ```
+   https://your-domain.com/api/v1/oauth/google/callback
+   ```
+5. Copy the **Client ID** and **Client Secret**
+
+### 4. Configure Environment
+
+```bash
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+```
+
+## Microsoft OAuth Setup
+
+### 1. Register an Application in Azure
+
+1. Go to [Azure Portal > App Registrations](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
+2. Click **New registration**
+3. Fill in the required fields:
+   - Name: Your deployment name (e.g., "Permission Slip")
+   - Supported account types: **Accounts in any organizational directory and personal Microsoft accounts**
+4. Add a redirect URI:
+   - Platform: **Web**
+   - URI: `https://your-domain.com/api/v1/oauth/microsoft/callback`
+
+### 2. Configure API Permissions
+
+1. Navigate to **API permissions**
+2. Add the following Microsoft Graph **delegated** permissions:
+   - `openid`
+   - `offline_access`
+   - `User.Read`
+   - `Mail.Send`
+   - `Mail.Read`
+   - `Calendars.ReadWrite`
+
+### 3. Create Client Secret
+
+1. Navigate to **Certificates & secrets**
+2. Click **New client secret**
+3. Set an expiration (recommended: 24 months)
+4. Copy the secret **value** (not the ID)
+
+### 4. Configure Environment
+
+```bash
+MICROSOFT_CLIENT_ID=your-application-client-id
+MICROSOFT_CLIENT_SECRET=your-client-secret-value
+```
+
+## Self-Hosted BYOA Setup
+
+For self-hosted deployments without platform-level OAuth credentials, users configure their own OAuth apps through the Settings UI:
+
+1. Follow the Google or Microsoft setup steps above to create an OAuth app
+2. In Permission Slip, go to **Settings > OAuth App Credentials**
+3. Click **Configure** next to the provider
+4. Enter your Client ID and Client Secret
+5. The credentials are encrypted and stored in the vault
+6. You can now connect your account via **Settings > Connected Accounts**
+
+## External Connector OAuth
+
+External connectors can declare their own OAuth providers in `connector.json`:
+
+```json
+{
+  "id": "salesforce",
+  "name": "Salesforce",
+  "oauth_providers": [
+    {
+      "id": "salesforce",
+      "authorize_url": "https://login.salesforce.com/services/oauth2/authorize",
+      "token_url": "https://login.salesforce.com/services/oauth2/token",
+      "scopes": ["api", "refresh_token"]
+    }
+  ],
+  "required_credentials": [
+    {
+      "service": "salesforce",
+      "auth_type": "oauth2",
+      "oauth_provider": "salesforce"
+    }
+  ]
+}
+```
+
+The platform reads `oauth_providers` from the manifest and registers them in the provider registry. Users then supply their own OAuth app credentials via the BYOA configuration in Settings.
+
+For more details on creating external connectors, see [Creating Connectors](creating-connectors.md).
+
+## Troubleshooting
+
+### "Provider not configured" error
+
+The OAuth provider doesn't have client credentials. Either:
+- Set the platform-level environment variables (`GOOGLE_CLIENT_ID`, etc.)
+- Configure BYOA credentials in Settings > OAuth App Credentials
+
+### "Needs Re-auth" status
+
+The refresh token has expired or been revoked. Click **Re-authorize** in Settings > Connected Accounts to re-establish the connection.
+
+### Redirect URI mismatch
+
+Ensure the redirect URI in your OAuth app matches exactly:
+- Google: `https://your-domain.com/api/v1/oauth/google/callback`
+- Microsoft: `https://your-domain.com/api/v1/oauth/microsoft/callback`
+
+If using `OAUTH_REDIRECT_BASE_URL`, the callback URL is `{OAUTH_REDIRECT_BASE_URL}/v1/oauth/{provider}/callback`.
+
+### Token refresh failures
+
+Check the server logs for refresh errors. Common causes:
+- Refresh token expired (Google refresh tokens expire after 6 months of inactivity)
+- OAuth app credentials rotated without updating the server
+- Provider API downtime

--- a/frontend/src/hooks/useDeleteOAuthProviderConfig.ts
+++ b/frontend/src/hooks/useDeleteOAuthProviderConfig.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+
+export function useDeleteOAuthProviderConfig() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (provider: string) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.DELETE(
+        "/v1/oauth/provider-configs/{provider}",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { provider } },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(
+            error,
+            "Failed to delete OAuth provider config",
+          ),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["oauth-provider-configs"] });
+      queryClient.invalidateQueries({ queryKey: ["oauth-providers"] });
+    },
+  });
+
+  return {
+    deleteConfig: (provider: string) => mutation.mutateAsync(provider),
+    isLoading: mutation.isPending,
+  };
+}

--- a/frontend/src/hooks/useDisconnectOAuth.ts
+++ b/frontend/src/hooks/useDisconnectOAuth.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+
+export function useDisconnectOAuth() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (provider: string) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.DELETE(
+        "/v1/oauth/connections/{provider}",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { provider } },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to disconnect provider"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["oauth-connections"] });
+    },
+  });
+
+  return {
+    disconnect: (provider: string) => mutation.mutateAsync(provider),
+    isLoading: mutation.isPending,
+  };
+}

--- a/frontend/src/hooks/useOAuthConnections.ts
+++ b/frontend/src/hooks/useOAuthConnections.ts
@@ -1,0 +1,41 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type OAuthConnection = components["schemas"]["OAuthConnection"];
+
+export function useOAuthConnections() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["oauth-connections", userId ?? ""],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/oauth/connections", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (error) throw new Error("Failed to load OAuth connections");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    connections: query.data?.connections ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load connected accounts. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useOAuthProviderConfigs.ts
+++ b/frontend/src/hooks/useOAuthProviderConfigs.ts
@@ -1,0 +1,44 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type OAuthProviderConfig =
+  components["schemas"]["OAuthProviderConfig"];
+
+export function useOAuthProviderConfigs() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["oauth-provider-configs"],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET(
+        "/v1/oauth/provider-configs",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+      if (error) throw new Error("Failed to load BYOA provider configs");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    configs: query.data?.configs ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load OAuth provider configurations. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useOAuthProviders.ts
+++ b/frontend/src/hooks/useOAuthProviders.ts
@@ -1,0 +1,40 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type OAuthProvider = components["schemas"]["OAuthProvider"];
+
+export function useOAuthProviders() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["oauth-providers"],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/oauth/providers", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (error) throw new Error("Failed to load OAuth providers");
+      return data;
+    },
+    enabled: !!accessToken,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    providers: query.data?.providers ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load OAuth providers. Please try again later."
+      : null,
+  };
+}

--- a/frontend/src/hooks/useSaveOAuthProviderConfig.ts
+++ b/frontend/src/hooks/useSaveOAuthProviderConfig.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+
+interface SaveProviderConfigParams {
+  provider: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export function useSaveOAuthProviderConfig() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      provider,
+      clientId,
+      clientSecret,
+    }: SaveProviderConfigParams) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST(
+        "/v1/oauth/provider-configs",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          body: {
+            provider,
+            client_id: clientId,
+            client_secret: clientSecret,
+          },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to save OAuth provider config"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["oauth-provider-configs"] });
+      queryClient.invalidateQueries({ queryKey: ["oauth-providers"] });
+    },
+  });
+
+  return {
+    save: (params: SaveProviderConfigParams) => mutation.mutateAsync(params),
+    isLoading: mutation.isPending,
+  };
+}

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -23,6 +23,7 @@ const mockActions: ConnectorAction[] = [
     name: "Create Issue",
     description: "Create a new issue in a repository",
     risk_level: "low",
+    requires_payment_method: false,
     parameters_schema: {
       type: "object",
       required: ["repo", "title"],
@@ -38,6 +39,7 @@ const mockActions: ConnectorAction[] = [
     name: "Merge Pull Request",
     description: "Merge an open pull request",
     risk_level: "high",
+    requires_payment_method: false,
     parameters_schema: {
       type: "object",
       required: ["repo", "pr"],

--- a/frontend/src/pages/settings/BYOAConfigDialog.tsx
+++ b/frontend/src/pages/settings/BYOAConfigDialog.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useSaveOAuthProviderConfig } from "@/hooks/useSaveOAuthProviderConfig";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface BYOAConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  provider: string;
+  providerLabel: string;
+}
+
+export function BYOAConfigDialog({
+  open,
+  onOpenChange,
+  provider,
+  providerLabel,
+}: BYOAConfigDialogProps) {
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const { save, isLoading } = useSaveOAuthProviderConfig();
+
+  function handleClose() {
+    setClientId("");
+    setClientSecret("");
+    onOpenChange(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const trimmedId = clientId.trim();
+    const trimmedSecret = clientSecret.trim();
+    if (!trimmedId || !trimmedSecret) {
+      toast.error("Both Client ID and Client Secret are required.");
+      return;
+    }
+
+    try {
+      await save({
+        provider,
+        clientId: trimmedId,
+        clientSecret: trimmedSecret,
+      });
+      toast.success(
+        `OAuth credentials saved for ${providerLabel}. You can now connect your account.`,
+      );
+      handleClose();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to save credentials.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>
+              Configure {providerLabel} OAuth App
+            </DialogTitle>
+            <DialogDescription>
+              Provide your own OAuth client credentials for{" "}
+              {providerLabel}. These are encrypted and stored securely in the
+              vault.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="byoa-client-id">Client ID</Label>
+              <Input
+                id="byoa-client-id"
+                placeholder="Your OAuth client ID"
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+                disabled={isLoading}
+                autoComplete="off"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="byoa-client-secret">Client Secret</Label>
+              <Input
+                id="byoa-client-secret"
+                type="password"
+                placeholder="Your OAuth client secret"
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
+                disabled={isLoading}
+                autoComplete="off"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save Credentials"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -1,0 +1,213 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  AlertTriangle,
+  Link2,
+  Loader2,
+  LogIn,
+  Unplug,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/auth/AuthContext";
+import { useOAuthConnections } from "@/hooks/useOAuthConnections";
+import { useOAuthProviders } from "@/hooks/useOAuthProviders";
+import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
+import { InlineConfirmButton } from "@/components/InlineConfirmButton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  google: "Google",
+  microsoft: "Microsoft",
+};
+
+function providerLabel(id: string): string {
+  return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+function statusBadge(status: string) {
+  switch (status) {
+    case "active":
+      return <Badge variant="secondary">Connected</Badge>;
+    case "needs_reauth":
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <AlertTriangle className="size-3" />
+          Needs Re-auth
+        </Badge>
+      );
+    default:
+      return <Badge variant="outline">{status}</Badge>;
+  }
+}
+
+export function ConnectedAccountsSection() {
+  const { session } = useAuth();
+  const { connections, isLoading, error, refetch } = useOAuthConnections();
+  const { providers } = useOAuthProviders();
+  const { disconnect, isLoading: isDisconnecting } = useDisconnectOAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Handle OAuth callback status from redirect
+  useEffect(() => {
+    const oauthStatus = searchParams.get("oauth_status");
+    const oauthProvider = searchParams.get("oauth_provider");
+    if (oauthStatus) {
+      if (oauthStatus === "success") {
+        toast.success(
+          `Successfully connected ${oauthProvider ? providerLabel(oauthProvider) : "account"}.`,
+        );
+        refetch();
+      } else {
+        toast.error(
+          `Failed to connect ${oauthProvider ? providerLabel(oauthProvider) : "account"}. Please try again.`,
+        );
+      }
+      // Remove query params without a full navigation
+      searchParams.delete("oauth_status");
+      searchParams.delete("oauth_provider");
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- run once on mount
+
+  async function handleDisconnect(provider: string) {
+    try {
+      await disconnect(provider);
+      toast.success(`${providerLabel(provider)} disconnected.`);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to disconnect.";
+      toast.error(message);
+    }
+  }
+
+  function handleConnect(providerId: string) {
+    if (!session?.access_token) return;
+    // Navigate to the OAuth authorize endpoint with the session token.
+    // The backend will redirect to the provider's consent screen.
+    const baseUrl =
+      import.meta.env.VITE_API_BASE_URL?.replace(/\/v1\/?$/, "") ?? "/api";
+    const url = `${baseUrl}/v1/oauth/${providerId}/authorize`;
+
+    // Open in same window — the callback redirects back to settings
+    window.location.href = `${url}?access_token=${encodeURIComponent(session.access_token)}`;
+  }
+
+  // Providers that are ready to connect but don't have an active connection
+  const connectedProviderIds = new Set(connections.map((c) => c.provider));
+  const availableProviders = providers.filter(
+    (p) => p.has_credentials && !connectedProviderIds.has(p.id),
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Link2 className="text-muted-foreground size-5" />
+          <CardTitle>Connected Accounts</CardTitle>
+          {connections.length > 0 && (
+            <Badge variant="outline" className="ml-1">
+              {connections.length}
+            </Badge>
+          )}
+        </div>
+        <CardDescription>
+          Connect your Google or Microsoft account to enable connectors that use
+          OAuth for authentication. Tokens are encrypted and automatically
+          refreshed.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div
+            className="flex items-center justify-center py-8"
+            role="status"
+            aria-label="Loading connected accounts"
+          >
+            <Loader2 className="text-muted-foreground size-5 animate-spin" />
+          </div>
+        ) : error ? (
+          <p className="text-destructive text-sm">{error}</p>
+        ) : (
+          <div className="space-y-3">
+            {connections.map((conn) => (
+              <div
+                key={conn.provider}
+                className="flex items-center justify-between rounded-lg border p-4"
+              >
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">
+                    {providerLabel(conn.provider)}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {conn.scopes.length} scope
+                    {conn.scopes.length !== 1 ? "s" : ""} granted &middot;
+                    Connected{" "}
+                    {new Date(conn.connected_at).toLocaleDateString()}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {statusBadge(conn.status)}
+                  {conn.status === "needs_reauth" ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleConnect(conn.provider)}
+                    >
+                      <LogIn className="size-4" />
+                      Re-authorize
+                    </Button>
+                  ) : (
+                    <InlineConfirmButton
+                      confirmLabel="Disconnect"
+                      isProcessing={isDisconnecting}
+                      onConfirm={() => handleDisconnect(conn.provider)}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Disconnect ${providerLabel(conn.provider)}`}
+                      >
+                        <Unplug className="text-muted-foreground size-4" />
+                      </Button>
+                    </InlineConfirmButton>
+                  )}
+                </div>
+              </div>
+            ))}
+
+            {availableProviders.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-2">
+                {availableProviders.map((provider) => (
+                  <Button
+                    key={provider.id}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleConnect(provider.id)}
+                  >
+                    <LogIn className="size-4" />
+                    Connect {providerLabel(provider.id)}
+                  </Button>
+                ))}
+              </div>
+            )}
+
+            {connections.length === 0 && availableProviders.length === 0 && (
+              <p className="text-muted-foreground py-4 text-center text-sm">
+                No OAuth providers are configured yet. Set up Google or
+                Microsoft client credentials to enable OAuth connections.
+              </p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/settings/OAuthProviderSection.tsx
+++ b/frontend/src/pages/settings/OAuthProviderSection.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react";
+import { KeyRound, Loader2, Settings2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { useOAuthProviders } from "@/hooks/useOAuthProviders";
+import { useOAuthProviderConfigs } from "@/hooks/useOAuthProviderConfigs";
+import { useDeleteOAuthProviderConfig } from "@/hooks/useDeleteOAuthProviderConfig";
+import { InlineConfirmButton } from "@/components/InlineConfirmButton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { BYOAConfigDialog } from "./BYOAConfigDialog";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  google: "Google",
+  microsoft: "Microsoft",
+};
+
+function providerLabel(id: string): string {
+  return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+export function OAuthProviderSection() {
+  const { providers, isLoading: providersLoading } = useOAuthProviders();
+  const { configs, isLoading: configsLoading } = useOAuthProviderConfigs();
+  const { deleteConfig, isLoading: isDeleting } =
+    useDeleteOAuthProviderConfig();
+  const [byoaDialog, setBYOADialog] = useState<{
+    provider: string;
+    label: string;
+  } | null>(null);
+
+  const isLoading = providersLoading || configsLoading;
+
+  // Providers that need BYOA setup: registered but lacking client credentials
+  const unconfiguredProviders = providers.filter((p) => !p.has_credentials);
+
+  // BYOA configs that have been saved
+  const configuredByoaProviders = configs;
+
+  async function handleDeleteConfig(provider: string) {
+    try {
+      await deleteConfig(provider);
+      toast.success(`OAuth credentials removed for ${providerLabel(provider)}.`);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to remove credentials.";
+      toast.error(message);
+    }
+  }
+
+  // Don't render this section if there are no BYOA configs and no unconfigured providers
+  if (
+    !isLoading &&
+    configuredByoaProviders.length === 0 &&
+    unconfiguredProviders.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Settings2 className="text-muted-foreground size-5" />
+            <CardTitle>OAuth App Credentials</CardTitle>
+          </div>
+          <CardDescription>
+            Configure your own OAuth client credentials for providers that
+            aren&apos;t pre-configured. Required for self-hosted deployments or
+            custom providers.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div
+              className="flex items-center justify-center py-8"
+              role="status"
+              aria-label="Loading OAuth provider configs"
+            >
+              <Loader2 className="text-muted-foreground size-5 animate-spin" />
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {configuredByoaProviders.map((config) => (
+                <div
+                  key={config.provider}
+                  className="flex items-center justify-between rounded-lg border p-4"
+                >
+                  <div className="space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <KeyRound className="text-muted-foreground size-4" />
+                      <p className="text-sm font-medium">
+                        {providerLabel(config.provider)}
+                      </p>
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      Custom credentials configured &middot; Added{" "}
+                      {new Date(config.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary">BYOA</Badge>
+                    <InlineConfirmButton
+                      confirmLabel="Remove"
+                      isProcessing={isDeleting}
+                      onConfirm={() => handleDeleteConfig(config.provider)}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Remove ${providerLabel(config.provider)} credentials`}
+                      >
+                        <Trash2 className="text-muted-foreground size-4" />
+                      </Button>
+                    </InlineConfirmButton>
+                  </div>
+                </div>
+              ))}
+
+              {unconfiguredProviders.map((provider) => (
+                <div
+                  key={provider.id}
+                  className="flex items-center justify-between rounded-lg border border-dashed p-4"
+                >
+                  <div className="space-y-0.5">
+                    <p className="text-sm font-medium">
+                      {providerLabel(provider.id)}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      Needs OAuth client credentials to enable connections
+                    </p>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setBYOADialog({
+                        provider: provider.id,
+                        label: providerLabel(provider.id),
+                      })
+                    }
+                  >
+                    Configure
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {byoaDialog && (
+        <BYOAConfigDialog
+          open
+          onOpenChange={() => setBYOADialog(null)}
+          provider={byoaDialog.provider}
+          providerLabel={byoaDialog.label}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -3,6 +3,8 @@ import { ArrowLeft } from "lucide-react";
 import { AccountSection } from "./AccountSection";
 import { NotificationSection } from "./NotificationSection";
 import { SecuritySection } from "./SecuritySection";
+import { ConnectedAccountsSection } from "./ConnectedAccountsSection";
+import { OAuthProviderSection } from "./OAuthProviderSection";
 import { CredentialSection } from "./CredentialSection";
 import { PaymentMethodSection } from "./PaymentMethodSection";
 import { DataRetentionSection } from "./DataRetentionSection";
@@ -25,6 +27,8 @@ export function SettingsPage() {
       <AccountSection />
       <SecuritySection />
       <NotificationSection />
+      <ConnectedAccountsSection />
+      <OAuthProviderSection />
       <CredentialSection />
       <PaymentMethodSection />
       <DataRetentionSection />

--- a/frontend/src/pages/settings/__tests__/ConnectedAccountsSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/ConnectedAccountsSection.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import {
+  mockGet,
+  mockDelete,
+  resetClientMocks,
+} from "../../../api/__mocks__/client";
+import { ConnectedAccountsSection } from "../ConnectedAccountsSection";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+function mockApiFetch(
+  connections: unknown[] = [],
+  providers: unknown[] = [],
+) {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/oauth/connections") {
+      return Promise.resolve({ data: { connections } });
+    }
+    if (url === "/v1/oauth/providers") {
+      return Promise.resolve({ data: { providers } });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
+
+describe("ConnectedAccountsSection", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper(["/settings"]);
+  });
+
+  it("renders the section title", async () => {
+    mockApiFetch();
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected Accounts")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state", () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockReturnValue(new Promise(() => {}));
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    expect(
+      screen.getByRole("status", { name: "Loading connected accounts" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no connections or providers", async () => {
+    mockApiFetch([], []);
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No OAuth providers are configured yet/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders connected accounts", async () => {
+    mockApiFetch(
+      [
+        {
+          provider: "google",
+          scopes: ["openid", "https://www.googleapis.com/auth/gmail.send"],
+          status: "active",
+          connected_at: "2026-03-05T10:00:00Z",
+        },
+      ],
+      [
+        { id: "google", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Google")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByText(/2 scopes granted/)).toBeInTheDocument();
+  });
+
+  it("shows needs re-auth badge and re-authorize button", async () => {
+    mockApiFetch(
+      [
+        {
+          provider: "microsoft",
+          scopes: ["openid"],
+          status: "needs_reauth",
+          connected_at: "2026-03-05T10:00:00Z",
+        },
+      ],
+      [
+        { id: "microsoft", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Needs Re-auth")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "Re-authorize" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows connect button for available providers", async () => {
+    mockApiFetch(
+      [],
+      [
+        { id: "google", scopes: ["openid"], source: "built_in", has_credentials: true },
+        { id: "microsoft", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect Google" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "Connect Microsoft" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show connect button for already-connected providers", async () => {
+    mockApiFetch(
+      [
+        {
+          provider: "google",
+          scopes: ["openid"],
+          status: "active",
+          connected_at: "2026-03-05T10:00:00Z",
+        },
+      ],
+      [
+        { id: "google", scopes: ["openid"], source: "built_in", has_credentials: true },
+        { id: "microsoft", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Google")).toBeInTheDocument();
+    });
+    // Google is already connected, should not show "Connect Google"
+    expect(
+      screen.queryByRole("button", { name: "Connect Google" }),
+    ).not.toBeInTheDocument();
+    // Microsoft is not connected, should show connect button
+    expect(
+      screen.getByRole("button", { name: "Connect Microsoft" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows disconnect confirmation", async () => {
+    mockApiFetch(
+      [
+        {
+          provider: "google",
+          scopes: ["openid"],
+          status: "active",
+          connected_at: "2026-03-05T10:00:00Z",
+        },
+      ],
+      [
+        { id: "google", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+    const user = userEvent.setup();
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Disconnect Google" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect Google" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Disconnect" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("calls DELETE endpoint after disconnect confirmation", async () => {
+    mockApiFetch(
+      [
+        {
+          provider: "google",
+          scopes: ["openid"],
+          status: "active",
+          connected_at: "2026-03-05T10:00:00Z",
+        },
+      ],
+      [
+        { id: "google", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+    mockDelete.mockResolvedValue({
+      data: { provider: "google", disconnected_at: "2026-03-05T15:00:00Z" },
+    });
+    const user = userEvent.setup();
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Disconnect Google" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Disconnect Google" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(
+        "/v1/oauth/connections/{provider}",
+        expect.objectContaining({
+          params: { path: { provider: "google" } },
+        }),
+      );
+    });
+  });
+
+  it("shows connection count badge", async () => {
+    mockApiFetch(
+      [
+        {
+          provider: "google",
+          scopes: ["openid"],
+          status: "active",
+          connected_at: "2026-03-05T10:00:00Z",
+        },
+        {
+          provider: "microsoft",
+          scopes: ["openid"],
+          status: "active",
+          connected_at: "2026-03-05T11:00:00Z",
+        },
+      ],
+      [
+        { id: "google", scopes: ["openid"], source: "built_in", has_credentials: true },
+        { id: "microsoft", scopes: ["openid"], source: "built_in", has_credentials: true },
+      ],
+    );
+
+    render(<ConnectedAccountsSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
@@ -48,13 +48,12 @@ describe("OAuthProviderSection", () => {
 
     const { container } = render(<OAuthProviderSection />, { wrapper });
 
-    // Wait for data to load, then verify section is not rendered
+    // Wait for queries to fire and component to settle (returns null when
+    // there are no unconfigured providers and no BYOA configs).
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalled();
+      expect(container.querySelector("[data-slot='card']")).not.toBeInTheDocument();
     });
-    // Give React time to settle after data loads
-    await new Promise((r) => setTimeout(r, 100));
-    expect(container.querySelector("[class*='card']")).not.toBeInTheDocument();
   });
 
   it("renders section with unconfigured providers", async () => {
@@ -68,9 +67,8 @@ describe("OAuthProviderSection", () => {
     render(<OAuthProviderSection />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText("OAuth App Credentials")).toBeInTheDocument();
+      expect(screen.getByText("Salesforce")).toBeInTheDocument();
     });
-    expect(screen.getByText("Salesforce")).toBeInTheDocument();
     expect(
       screen.getByText(/Needs OAuth client credentials/),
     ).toBeInTheDocument();

--- a/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
@@ -1,0 +1,263 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import {
+  mockGet,
+  mockPost,
+  mockDelete,
+  resetClientMocks,
+} from "../../../api/__mocks__/client";
+import { OAuthProviderSection } from "../OAuthProviderSection";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+function mockApiFetch(
+  providers: unknown[] = [],
+  configs: unknown[] = [],
+) {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/oauth/providers") {
+      return Promise.resolve({ data: { providers } });
+    }
+    if (url === "/v1/oauth/provider-configs") {
+      return Promise.resolve({ data: { configs } });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
+
+describe("OAuthProviderSection", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper(["/settings"]);
+  });
+
+  it("does not render when no BYOA configs or unconfigured providers", async () => {
+    // All providers have credentials, no BYOA configs
+    mockApiFetch(
+      [{ id: "google", scopes: ["openid"], source: "built_in", has_credentials: true }],
+      [],
+    );
+
+    const { container } = render(<OAuthProviderSection />, { wrapper });
+
+    // Wait for data to load, then verify section is not rendered
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled();
+    });
+    // Give React time to settle after data loads
+    await new Promise((r) => setTimeout(r, 100));
+    expect(container.querySelector("[class*='card']")).not.toBeInTheDocument();
+  });
+
+  it("renders section with unconfigured providers", async () => {
+    mockApiFetch(
+      [
+        { id: "salesforce", scopes: ["api"], source: "manifest", has_credentials: false },
+      ],
+      [],
+    );
+
+    render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("OAuth App Credentials")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Salesforce")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Needs OAuth client credentials/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Configure" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders BYOA configs", async () => {
+    mockApiFetch(
+      [
+        { id: "salesforce", scopes: ["api"], source: "byoa", has_credentials: true },
+      ],
+      [
+        {
+          provider: "salesforce",
+          created_at: "2026-03-05T12:00:00Z",
+          updated_at: "2026-03-05T12:00:00Z",
+        },
+      ],
+    );
+
+    render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Salesforce")).toBeInTheDocument();
+    });
+    expect(screen.getByText("BYOA")).toBeInTheDocument();
+    expect(screen.getByText(/Custom credentials configured/)).toBeInTheDocument();
+  });
+
+  it("opens BYOA config dialog when Configure is clicked", async () => {
+    mockApiFetch(
+      [
+        { id: "salesforce", scopes: ["api"], source: "manifest", has_credentials: false },
+      ],
+      [],
+    );
+    const user = userEvent.setup();
+
+    render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Configure" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Configure" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Configure Salesforce OAuth App"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Client ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Client Secret")).toBeInTheDocument();
+  });
+
+  it("submits BYOA credentials", async () => {
+    mockApiFetch(
+      [
+        { id: "salesforce", scopes: ["api"], source: "manifest", has_credentials: false },
+      ],
+      [],
+    );
+    mockPost.mockResolvedValue({
+      data: {
+        provider: "salesforce",
+        created_at: "2026-03-05T12:00:00Z",
+        updated_at: "2026-03-05T12:00:00Z",
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Configure" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Configure" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Client ID")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText("Client ID"), "my-client-id");
+    await user.type(
+      screen.getByLabelText("Client Secret"),
+      "my-client-secret",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Credentials" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/v1/oauth/provider-configs",
+        expect.objectContaining({
+          body: {
+            provider: "salesforce",
+            client_id: "my-client-id",
+            client_secret: "my-client-secret",
+          },
+        }),
+      );
+    });
+  });
+
+  it("shows delete confirmation for BYOA config", async () => {
+    mockApiFetch(
+      [
+        { id: "salesforce", scopes: ["api"], source: "byoa", has_credentials: true },
+      ],
+      [
+        {
+          provider: "salesforce",
+          created_at: "2026-03-05T12:00:00Z",
+          updated_at: "2026-03-05T12:00:00Z",
+        },
+      ],
+    );
+    const user = userEvent.setup();
+
+    render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "Remove Salesforce credentials",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove Salesforce credentials",
+      }),
+    );
+
+    expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("calls DELETE endpoint after removal confirmation", async () => {
+    mockApiFetch(
+      [
+        { id: "salesforce", scopes: ["api"], source: "byoa", has_credentials: true },
+      ],
+      [
+        {
+          provider: "salesforce",
+          created_at: "2026-03-05T12:00:00Z",
+          updated_at: "2026-03-05T12:00:00Z",
+        },
+      ],
+    );
+    mockDelete.mockResolvedValue({
+      data: { provider: "salesforce", deleted_at: "2026-03-05T15:00:00Z" },
+    });
+    const user = userEvent.setup();
+
+    render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "Remove Salesforce credentials",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove Salesforce credentials",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(
+        "/v1/oauth/provider-configs/{provider}",
+        expect.objectContaining({
+          params: { path: { provider: "salesforce" } },
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -41,6 +41,15 @@ function mockApiFetch() {
     if (url === "/v1/credentials") {
       return Promise.resolve({ data: { credentials: [] } });
     }
+    if (url === "/v1/oauth/connections") {
+      return Promise.resolve({ data: { connections: [] } });
+    }
+    if (url === "/v1/oauth/providers") {
+      return Promise.resolve({ data: { providers: [] } });
+    }
+    if (url === "/v1/oauth/provider-configs") {
+      return Promise.resolve({ data: { configs: [] } });
+    }
     if (url === "/v1/profile/data-retention") {
       return Promise.resolve({
         data: {
@@ -86,6 +95,7 @@ describe("SettingsPage", () => {
     });
     expect(screen.getByText("Security")).toBeInTheDocument();
     expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("Connected Accounts")).toBeInTheDocument();
     expect(screen.getByText("Credential Vault")).toBeInTheDocument();
     expect(screen.getByText("Data Retention")).toBeInTheDocument();
     expect(screen.getByText("Danger Zone")).toBeInTheDocument();

--- a/spec/openapi/components/schemas/config.yaml
+++ b/spec/openapi/components/schemas/config.yaml
@@ -6,6 +6,8 @@ ConfigResponse:
   required:
     - billing_enabled
     - stripe_test_mode
+    - google_oauth_configured
+    - microsoft_oauth_configured
   properties:
     billing_enabled:
       type: boolean
@@ -23,3 +25,19 @@ ConfigResponse:
         `VITE_STRIPE_PUBLISHABLE_KEY`. Only enabled when `STRIPE_TEST_MODE=true`
         and `BILLING_ENABLED=true` on the server.
       example: false
+    google_oauth_configured:
+      type: boolean
+      description: |
+        Whether Google OAuth client credentials are configured on the server.
+        When `true`, the built-in Google connector can initiate OAuth flows
+        without BYOA setup. When `false`, users must provide their own Google
+        OAuth app credentials via the BYOA configuration UI.
+      example: true
+    microsoft_oauth_configured:
+      type: boolean
+      description: |
+        Whether Microsoft OAuth client credentials are configured on the server.
+        When `true`, the built-in Microsoft connector can initiate OAuth flows
+        without BYOA setup. When `false`, users must provide their own Microsoft
+        OAuth app credentials via the BYOA configuration UI.
+      example: true

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -10471,6 +10471,8 @@ components:
       required:
         - billing_enabled
         - stripe_test_mode
+        - google_oauth_configured
+        - microsoft_oauth_configured
       properties:
         billing_enabled:
           type: boolean
@@ -10488,6 +10490,22 @@ components:
             `VITE_STRIPE_PUBLISHABLE_KEY`. Only enabled when `STRIPE_TEST_MODE=true`
             and `BILLING_ENABLED=true` on the server.
           example: false
+        google_oauth_configured:
+          type: boolean
+          description: |
+            Whether Google OAuth client credentials are configured on the server.
+            When `true`, the built-in Google connector can initiate OAuth flows
+            without BYOA setup. When `false`, users must provide their own Google
+            OAuth app credentials via the BYOA configuration UI.
+          example: true
+        microsoft_oauth_configured:
+          type: boolean
+          description: |
+            Whether Microsoft OAuth client credentials are configured on the server.
+            When `true`, the built-in Microsoft connector can initiate OAuth flows
+            without BYOA setup. When `false`, users must provide their own Microsoft
+            OAuth app credentials via the BYOA configuration UI.
+          example: true
     Action:
       type: object
       required:


### PR DESCRIPTION
## Summary

Completes the final two phases of the OAuth connector implementation (#80):

- **Phase 8 (Frontend)**: Connected Accounts section in Settings, BYOA credential management UI, 6 new API hooks, 17 new tests, OpenAPI spec updates with generated types
- **Phase 9 (Config + Docs)**: Config validation warnings for missing Google/Microsoft OAuth credentials, `google_oauth_configured`/`microsoft_oauth_configured` in config response, comprehensive OAuth setup guide (docs/oauth-setup.md)

Closes #80

## Test plan

- [ ] Verify Connected Accounts section shows in Settings page
- [ ] Test OAuth connect flow for Google and Microsoft
- [ ] Test disconnect flow with confirmation
- [ ] Test BYOA credential configuration for providers without platform config
- [ ] Verify config endpoint returns new OAuth fields
- [ ] All 90 frontend tests pass
- [ ] All Go config tests pass