### PR TITLE
Lower go.mod minimum version to fix sandbox toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip-web
 
-go 1.25.8
+go 1.24.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
The go directive was pinned to 1.25.8, which caused failures in sandbox environments with older Go versions (e.g. 1.25.1) since GOTOOLCHAIN=local prevents downloading. Lowering to 1.24.0 ensures any recent Go installation satisfies the requirement.

https://claude.ai/code/session_01WNFkQhtNRfvFS5yvj3WjG6