### PR TITLE
Upgrade Go from 1.24.0 to 1.26.1 to fix 24 stdlib vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN npm run build
 # ── Stage 2: Build Go binary ────────────────────────────────────────────────
 # Pin to the exact patch version from go.mod's toolchain directive to avoid
 # automatic toolchain downloads during build (which can fail in restricted envs).
-FROM golang:1.24.13-alpine AS backend
+FROM golang:1.26.1-alpine AS backend
 
 RUN apk add --no-cache git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip-web
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Upgrades Go from 1.24.0 to 1.26.1 (released 2026-03-05) to resolve all 24 standard library vulnerabilities flagged by `govulncheck` in CI.

## Changes
- `go.mod`: `go 1.24.0` → `go 1.26.1`
- `Dockerfile`: `golang:1.24.13-alpine` → `golang:1.26.1-alpine`

## Vulnerabilities fixed
GO-2026-4602, GO-2026-4601, GO-2026-4600, GO-2026-4599, GO-2026-4341, GO-2026-4340, GO-2026-4337, GO-2025-4175, GO-2025-4155, GO-2025-4015, GO-2025-4013, GO-2025-4012, GO-2025-4011, GO-2025-4010, GO-2025-4009, GO-2025-4008, GO-2025-4007, GO-2025-4006, GO-2025-3956, GO-2025-3849, GO-2025-3751, GO-2025-3750, GO-2025-3749, GO-2025-3563