### PR TITLE
Fix URL encoding test expectation for Zoom meeting UUIDs

### DIFF
--- a/connectors/zoom/get_meeting_test.go
+++ b/connectors/zoom/get_meeting_test.go
@@ -82,7 +82,7 @@ func TestGetMeeting_URLEncodesSpecialChars(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The path should have the UUID properly escaped.
-		expectedPath := "/meetings/abc123%3D%3D%2F%2Fdef456"
+		expectedPath := "/meetings/abc123==%2F%2Fdef456"
 		if r.URL.RawPath != expectedPath {
 			t.Errorf("expected raw path %q, got %q", expectedPath, r.URL.RawPath)
 		}


### PR DESCRIPTION
## Summary
- Fixed `TestGetMeeting_URLEncodesSpecialChars` which expected `=` to be percent-encoded as `%3D`
- Go's `url.PathEscape` correctly leaves `=` unencoded per RFC 3986 (it's a valid sub-delimiter in paths)
- The important encoding (`/` → `%2F`) for Zoom double-encoded UUIDs was already working correctly

## Test plan
- [ ] `go test ./connectors/zoom/ -run TestGetMeeting_URLEncodesSpecialChars` passes
- [ ] `make test-backend` passes
