### PR TITLE
Add Trello connector with API key auth and 6 actions

### DIFF
--- a/connectors/trello/add_comment.go
+++ b/connectors/trello/add_comment.go
@@ -1,0 +1,62 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// addCommentAction implements connectors.Action for trello.add_comment.
+type addCommentAction struct {
+	conn *TrelloConnector
+}
+
+type addCommentParams struct {
+	CardID string `json:"card_id"`
+	Text   string `json:"text"`
+}
+
+func (p *addCommentParams) validate() error {
+	if p.CardID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	}
+	if p.Text == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: text"}
+	}
+	return nil
+}
+
+// Execute adds a comment to a Trello card via POST /1/cards/{card_id}/actions/comments.
+func (a *addCommentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params addCommentParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := map[string]string{
+		"text": params.Text,
+	}
+
+	var resp struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+		Data struct {
+			Text string `json:"text"`
+		} `json:"data"`
+	}
+	path := fmt.Sprintf("/cards/%s/actions/comments", params.CardID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":   resp.ID,
+		"text": resp.Data.Text,
+	})
+}

--- a/connectors/trello/add_comment.go
+++ b/connectors/trello/add_comment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -50,7 +51,7 @@ func (a *addCommentAction) Execute(ctx context.Context, req connectors.ActionReq
 			Text string `json:"text"`
 		} `json:"data"`
 	}
-	path := fmt.Sprintf("/cards/%s/actions/comments", params.CardID)
+	path := fmt.Sprintf("/cards/%s/actions/comments", url.PathEscape(params.CardID))
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, body, &resp); err != nil {
 		return nil, err
 	}

--- a/connectors/trello/add_comment.go
+++ b/connectors/trello/add_comment.go
@@ -20,8 +20,8 @@ type addCommentParams struct {
 }
 
 func (p *addCommentParams) validate() error {
-	if p.CardID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	if err := validateTrelloID(p.CardID, "card_id"); err != nil {
+		return err
 	}
 	if p.Text == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: text"}

--- a/connectors/trello/add_comment_test.go
+++ b/connectors/trello/add_comment_test.go
@@ -1,0 +1,126 @@
+package trello
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestAddComment_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/cards/card123/actions/comments" {
+			t.Errorf("expected path /cards/card123/actions/comments, got %s", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]string
+		json.Unmarshal(body, &reqBody)
+		if reqBody["text"] != "This is a comment" {
+			t.Errorf("expected text='This is a comment', got %q", reqBody["text"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "action123",
+			"type": "commentCard",
+			"data": map[string]string{"text": "This is a comment"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.add_comment"]
+
+	params, _ := json.Marshal(addCommentParams{
+		CardID: "card123",
+		Text:   "This is a comment",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.add_comment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	json.Unmarshal(result.Data, &data)
+	if data["id"] != "action123" {
+		t.Errorf("expected id=action123, got %q", data["id"])
+	}
+	if data["text"] != "This is a comment" {
+		t.Errorf("expected text='This is a comment', got %q", data["text"])
+	}
+}
+
+func TestAddComment_MissingCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.add_comment"]
+
+	params, _ := json.Marshal(map[string]string{"text": "comment"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.add_comment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing card_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestAddComment_MissingText(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.add_comment"]
+
+	params, _ := json.Marshal(map[string]string{"card_id": "card123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.add_comment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing text")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestAddComment_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.add_comment"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.add_comment",
+		Parameters:  []byte(`{bad`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/trello/add_comment_test.go
+++ b/connectors/trello/add_comment_test.go
@@ -17,8 +17,9 @@ func TestAddComment_Success(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/cards/card123/actions/comments" {
-			t.Errorf("expected path /cards/card123/actions/comments, got %s", r.URL.Path)
+		expectedPath := "/cards/" + testCardID + "/actions/comments"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
 		}
 
 		body, _ := io.ReadAll(r.Body)
@@ -41,7 +42,7 @@ func TestAddComment_Success(t *testing.T) {
 	action := conn.Actions()["trello.add_comment"]
 
 	params, _ := json.Marshal(addCommentParams{
-		CardID: "card123",
+		CardID: testCardID,
 		Text:   "This is a comment",
 	})
 
@@ -85,13 +86,34 @@ func TestAddComment_MissingCardID(t *testing.T) {
 	}
 }
 
+func TestAddComment_InvalidCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.add_comment"]
+
+	params, _ := json.Marshal(map[string]string{"card_id": "https://trello.com/c/abc", "text": "comment"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.add_comment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid card_id (URL instead of ID)")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestAddComment_MissingText(t *testing.T) {
 	t.Parallel()
 
 	conn := New()
 	action := conn.Actions()["trello.add_comment"]
 
-	params, _ := json.Marshal(map[string]string{"card_id": "card123"})
+	params, _ := json.Marshal(map[string]string{"card_id": testCardID})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.add_comment",

--- a/connectors/trello/create_card.go
+++ b/connectors/trello/create_card.go
@@ -1,0 +1,78 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createCardAction implements connectors.Action for trello.create_card.
+type createCardAction struct {
+	conn *TrelloConnector
+}
+
+type createCardParams struct {
+	ListID   string `json:"list_id"`
+	Name     string `json:"name"`
+	Desc     string `json:"desc"`
+	Pos      string `json:"pos"`
+	Due      string `json:"due"`
+	IDMembers string `json:"idMembers"`
+	IDLabels  string `json:"idLabels"`
+}
+
+func (p *createCardParams) validate() error {
+	if p.ListID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: list_id"}
+	}
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	return nil
+}
+
+// Execute creates a new card in a Trello list via POST /1/cards.
+func (a *createCardAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createCardParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"idList": params.ListID,
+		"name":   params.Name,
+	}
+	if params.Desc != "" {
+		body["desc"] = params.Desc
+	}
+	if params.Pos != "" {
+		body["pos"] = params.Pos
+	}
+	if params.Due != "" {
+		body["due"] = params.Due
+	}
+	if params.IDMembers != "" {
+		body["idMembers"] = params.IDMembers
+	}
+	if params.IDLabels != "" {
+		body["idLabels"] = params.IDLabels
+	}
+
+	var resp struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		ShortURL string `json:"shortUrl"`
+		URL      string `json:"url"`
+	}
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/cards", body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/trello/create_card.go
+++ b/connectors/trello/create_card.go
@@ -65,10 +65,15 @@ func (a *createCardAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	var resp struct {
-		ID       string `json:"id"`
-		Name     string `json:"name"`
-		ShortURL string `json:"shortUrl"`
-		URL      string `json:"url"`
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Desc        string `json:"desc"`
+		IDList      string `json:"idList"`
+		Due         string `json:"due"`
+		DueComplete bool   `json:"dueComplete"`
+		Closed      bool   `json:"closed"`
+		ShortURL    string `json:"shortUrl"`
+		URL         string `json:"url"`
 	}
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/cards", body, &resp); err != nil {
 		return nil, err

--- a/connectors/trello/create_card.go
+++ b/connectors/trello/create_card.go
@@ -25,8 +25,8 @@ type createCardParams struct {
 }
 
 func (p *createCardParams) validate() error {
-	if p.ListID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: list_id"}
+	if err := validateTrelloID(p.ListID, "list_id"); err != nil {
+		return err
 	}
 	if p.Name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}

--- a/connectors/trello/create_card_test.go
+++ b/connectors/trello/create_card_test.go
@@ -1,0 +1,250 @@
+package trello
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateCard_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/cards" {
+			t.Errorf("expected path /cards, got %s", r.URL.Path)
+		}
+		// Verify auth query params.
+		if r.URL.Query().Get("key") != "test-api-key-123" {
+			t.Errorf("expected key=test-api-key-123, got %q", r.URL.Query().Get("key"))
+		}
+		if r.URL.Query().Get("token") != "test-token-456" {
+			t.Errorf("expected token=test-token-456, got %q", r.URL.Query().Get("token"))
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("expected JSON content type, got %q", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if reqBody["idList"] != "list123" {
+			t.Errorf("expected idList=list123, got %v", reqBody["idList"])
+		}
+		if reqBody["name"] != "Test Card" {
+			t.Errorf("expected name=Test Card, got %v", reqBody["name"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":       "card123",
+			"name":     "Test Card",
+			"shortUrl": "https://trello.com/c/abc123",
+			"url":      "https://trello.com/c/abc123/1-test-card",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(createCardParams{
+		ListID: "list123",
+		Name:   "Test Card",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "card123" {
+		t.Errorf("expected id=card123, got %v", data["id"])
+	}
+	if data["shortUrl"] != "https://trello.com/c/abc123" {
+		t.Errorf("expected shortUrl, got %v", data["shortUrl"])
+	}
+}
+
+func TestCreateCard_WithOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+
+		if reqBody["desc"] != "A description" {
+			t.Errorf("expected desc, got %v", reqBody["desc"])
+		}
+		if reqBody["pos"] != "top" {
+			t.Errorf("expected pos=top, got %v", reqBody["pos"])
+		}
+		if reqBody["due"] != "2026-12-31T00:00:00.000Z" {
+			t.Errorf("expected due date, got %v", reqBody["due"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"id": "card456", "name": "Full Card", "shortUrl": "https://trello.com/c/xyz", "url": "https://trello.com/c/xyz/1"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(createCardParams{
+		ListID: "list123",
+		Name:   "Full Card",
+		Desc:   "A description",
+		Pos:    "top",
+		Due:    "2026-12-31T00:00:00.000Z",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateCard_MissingListID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(map[string]string{"name": "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing list_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCard_MissingName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(map[string]string{"list_id": "list123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCard_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.create_card"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateCard_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "10")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("Rate limit exceeded"))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(createCardParams{ListID: "list123", Name: "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+	var rlErr *connectors.RateLimitError
+	if connectors.AsRateLimitError(err, &rlErr) {
+		if rlErr.RetryAfter.Seconds() != 10 {
+			t.Errorf("expected RetryAfter 10s, got %v", rlErr.RetryAfter)
+		}
+	}
+}
+
+func TestCreateCard_AuthError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("unauthorized permission requested"))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(createCardParams{ListID: "list123", Name: "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}

--- a/connectors/trello/create_card_test.go
+++ b/connectors/trello/create_card_test.go
@@ -36,8 +36,8 @@ func TestCreateCard_Success(t *testing.T) {
 		if err := json.Unmarshal(body, &reqBody); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
-		if reqBody["idList"] != "list123" {
-			t.Errorf("expected idList=list123, got %v", reqBody["idList"])
+		if reqBody["idList"] != testListID {
+			t.Errorf("expected idList=%s, got %v", testListID, reqBody["idList"])
 		}
 		if reqBody["name"] != "Test Card" {
 			t.Errorf("expected name=Test Card, got %v", reqBody["name"])
@@ -46,7 +46,7 @@ func TestCreateCard_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]any{
-			"id":       "card123",
+			"id":       testCardID,
 			"name":     "Test Card",
 			"shortUrl": "https://trello.com/c/abc123",
 			"url":      "https://trello.com/c/abc123/1-test-card",
@@ -58,7 +58,7 @@ func TestCreateCard_Success(t *testing.T) {
 	action := conn.Actions()["trello.create_card"]
 
 	params, _ := json.Marshal(createCardParams{
-		ListID: "list123",
+		ListID: testListID,
 		Name:   "Test Card",
 	})
 
@@ -75,8 +75,8 @@ func TestCreateCard_Success(t *testing.T) {
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	if data["id"] != "card123" {
-		t.Errorf("expected id=card123, got %v", data["id"])
+	if data["id"] != testCardID {
+		t.Errorf("expected id=%s, got %v", testCardID, data["id"])
 	}
 	if data["shortUrl"] != "https://trello.com/c/abc123" {
 		t.Errorf("expected shortUrl, got %v", data["shortUrl"])
@@ -102,7 +102,7 @@ func TestCreateCard_WithOptionalFields(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"id": "card456", "name": "Full Card", "shortUrl": "https://trello.com/c/xyz", "url": "https://trello.com/c/xyz/1"})
+		json.NewEncoder(w).Encode(map[string]any{"id": testCardID, "name": "Full Card", "shortUrl": "https://trello.com/c/xyz", "url": "https://trello.com/c/xyz/1"})
 	}))
 	defer srv.Close()
 
@@ -110,7 +110,7 @@ func TestCreateCard_WithOptionalFields(t *testing.T) {
 	action := conn.Actions()["trello.create_card"]
 
 	params, _ := json.Marshal(createCardParams{
-		ListID: "list123",
+		ListID: testListID,
 		Name:   "Full Card",
 		Desc:   "A description",
 		Pos:    "top",
@@ -148,13 +148,34 @@ func TestCreateCard_MissingListID(t *testing.T) {
 	}
 }
 
+func TestCreateCard_InvalidListID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.create_card"]
+
+	params, _ := json.Marshal(map[string]string{"list_id": "not-a-valid-id", "name": "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid list_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestCreateCard_MissingName(t *testing.T) {
 	t.Parallel()
 
 	conn := New()
 	action := conn.Actions()["trello.create_card"]
 
-	params, _ := json.Marshal(map[string]string{"list_id": "list123"})
+	params, _ := json.Marshal(map[string]string{"list_id": testListID})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.create_card",
@@ -201,7 +222,7 @@ func TestCreateCard_RateLimit(t *testing.T) {
 	conn := newForTest(srv.Client(), srv.URL)
 	action := conn.Actions()["trello.create_card"]
 
-	params, _ := json.Marshal(createCardParams{ListID: "list123", Name: "Test"})
+	params, _ := json.Marshal(createCardParams{ListID: testListID, Name: "Test"})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.create_card",
@@ -234,7 +255,7 @@ func TestCreateCard_AuthError(t *testing.T) {
 	conn := newForTest(srv.Client(), srv.URL)
 	action := conn.Actions()["trello.create_card"]
 
-	params, _ := json.Marshal(createCardParams{ListID: "list123", Name: "Test"})
+	params, _ := json.Marshal(createCardParams{ListID: testListID, Name: "Test"})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.create_card",

--- a/connectors/trello/create_checklist.go
+++ b/connectors/trello/create_checklist.go
@@ -1,0 +1,83 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createChecklistAction implements connectors.Action for trello.create_checklist.
+type createChecklistAction struct {
+	conn *TrelloConnector
+}
+
+type createChecklistParams struct {
+	CardID string   `json:"card_id"`
+	Name   string   `json:"name"`
+	Items  []string `json:"items"`
+}
+
+func (p *createChecklistParams) validate() error {
+	if p.CardID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	}
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	return nil
+}
+
+// Execute creates a checklist on a card via POST /1/checklists, then adds
+// items via POST /1/checklists/{id}/checkItems for each item.
+func (a *createChecklistAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createChecklistParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// Create the checklist.
+	checklistBody := map[string]string{
+		"idCard": params.CardID,
+		"name":   params.Name,
+	}
+
+	var checklistResp struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/checklists", checklistBody, &checklistResp); err != nil {
+		return nil, err
+	}
+
+	// Add items to the checklist.
+	var addedItems []map[string]string
+	for _, item := range params.Items {
+		itemBody := map[string]string{
+			"name": item,
+		}
+		var itemResp struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		path := fmt.Sprintf("/checklists/%s/checkItems", checklistResp.ID)
+		if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, itemBody, &itemResp); err != nil {
+			return nil, err
+		}
+		addedItems = append(addedItems, map[string]string{
+			"id":   itemResp.ID,
+			"name": itemResp.Name,
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"id":    checklistResp.ID,
+		"name":  checklistResp.Name,
+		"items": addedItems,
+	})
+}

--- a/connectors/trello/create_checklist.go
+++ b/connectors/trello/create_checklist.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -55,8 +56,9 @@ func (a *createChecklistAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	// Add items to the checklist.
-	var addedItems []map[string]string
+	// Add items to the checklist. Initialize to empty slice so JSON
+	// serialization produces [] instead of null when no items are provided.
+	addedItems := make([]map[string]string, 0, len(params.Items))
 	for _, item := range params.Items {
 		itemBody := map[string]string{
 			"name": item,
@@ -65,7 +67,7 @@ func (a *createChecklistAction) Execute(ctx context.Context, req connectors.Acti
 			ID   string `json:"id"`
 			Name string `json:"name"`
 		}
-		path := fmt.Sprintf("/checklists/%s/checkItems", checklistResp.ID)
+		path := fmt.Sprintf("/checklists/%s/checkItems", url.PathEscape(checklistResp.ID))
 		if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, itemBody, &itemResp); err != nil {
 			return nil, err
 		}

--- a/connectors/trello/create_checklist.go
+++ b/connectors/trello/create_checklist.go
@@ -21,8 +21,8 @@ type createChecklistParams struct {
 }
 
 func (p *createChecklistParams) validate() error {
-	if p.CardID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	if err := validateTrelloID(p.CardID, "card_id"); err != nil {
+		return err
 	}
 	if p.Name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}

--- a/connectors/trello/create_checklist_test.go
+++ b/connectors/trello/create_checklist_test.go
@@ -30,18 +30,18 @@ func TestCreateChecklist_Success(t *testing.T) {
 			body, _ := io.ReadAll(r.Body)
 			var reqBody map[string]string
 			json.Unmarshal(body, &reqBody)
-			if reqBody["idCard"] != "card123" {
-				t.Errorf("expected idCard=card123, got %q", reqBody["idCard"])
+			if reqBody["idCard"] != testCardID {
+				t.Errorf("expected idCard=%s, got %q", testCardID, reqBody["idCard"])
 			}
 			if reqBody["name"] != "TODO" {
 				t.Errorf("expected name=TODO, got %q", reqBody["name"])
 			}
 			json.NewEncoder(w).Encode(map[string]any{
-				"id":   "checklist123",
+				"id":   testChecklistID,
 				"name": "TODO",
 			})
 
-		case n == 2 && r.URL.Path == "/checklists/checklist123/checkItems":
+		case n == 2 && r.URL.Path == "/checklists/"+testChecklistID+"/checkItems":
 			body, _ := io.ReadAll(r.Body)
 			var reqBody map[string]string
 			json.Unmarshal(body, &reqBody)
@@ -50,7 +50,7 @@ func TestCreateChecklist_Success(t *testing.T) {
 				"name": reqBody["name"],
 			})
 
-		case n == 3 && r.URL.Path == "/checklists/checklist123/checkItems":
+		case n == 3 && r.URL.Path == "/checklists/"+testChecklistID+"/checkItems":
 			body, _ := io.ReadAll(r.Body)
 			var reqBody map[string]string
 			json.Unmarshal(body, &reqBody)
@@ -70,7 +70,7 @@ func TestCreateChecklist_Success(t *testing.T) {
 	action := conn.Actions()["trello.create_checklist"]
 
 	params, _ := json.Marshal(createChecklistParams{
-		CardID: "card123",
+		CardID: testCardID,
 		Name:   "TODO",
 		Items:  []string{"Buy milk", "Walk dog"},
 	})
@@ -86,8 +86,8 @@ func TestCreateChecklist_Success(t *testing.T) {
 
 	var data map[string]any
 	json.Unmarshal(result.Data, &data)
-	if data["id"] != "checklist123" {
-		t.Errorf("expected id=checklist123, got %v", data["id"])
+	if data["id"] != testChecklistID {
+		t.Errorf("expected id=%s, got %v", testChecklistID, data["id"])
 	}
 	items, ok := data["items"].([]any)
 	if !ok {
@@ -107,7 +107,7 @@ func TestCreateChecklist_NoItems(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"id":   "checklist456",
+			"id":   testChecklistID,
 			"name": "Empty List",
 		})
 	}))
@@ -117,7 +117,7 @@ func TestCreateChecklist_NoItems(t *testing.T) {
 	action := conn.Actions()["trello.create_checklist"]
 
 	params, _ := json.Marshal(createChecklistParams{
-		CardID: "card123",
+		CardID: testCardID,
 		Name:   "Empty List",
 	})
 
@@ -132,8 +132,8 @@ func TestCreateChecklist_NoItems(t *testing.T) {
 
 	var data map[string]any
 	json.Unmarshal(result.Data, &data)
-	if data["id"] != "checklist456" {
-		t.Errorf("expected id=checklist456, got %v", data["id"])
+	if data["id"] != testChecklistID {
+		t.Errorf("expected id=%s, got %v", testChecklistID, data["id"])
 	}
 }
 
@@ -164,7 +164,7 @@ func TestCreateChecklist_MissingName(t *testing.T) {
 	conn := New()
 	action := conn.Actions()["trello.create_checklist"]
 
-	params, _ := json.Marshal(map[string]string{"card_id": "card123"})
+	params, _ := json.Marshal(map[string]string{"card_id": testCardID})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.create_checklist",

--- a/connectors/trello/create_checklist_test.go
+++ b/connectors/trello/create_checklist_test.go
@@ -1,0 +1,180 @@
+package trello
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateChecklist_Success(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		n := callCount.Add(1)
+		switch {
+		case n == 1 && r.URL.Path == "/checklists":
+			// Create checklist request.
+			body, _ := io.ReadAll(r.Body)
+			var reqBody map[string]string
+			json.Unmarshal(body, &reqBody)
+			if reqBody["idCard"] != "card123" {
+				t.Errorf("expected idCard=card123, got %q", reqBody["idCard"])
+			}
+			if reqBody["name"] != "TODO" {
+				t.Errorf("expected name=TODO, got %q", reqBody["name"])
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":   "checklist123",
+				"name": "TODO",
+			})
+
+		case n == 2 && r.URL.Path == "/checklists/checklist123/checkItems":
+			body, _ := io.ReadAll(r.Body)
+			var reqBody map[string]string
+			json.Unmarshal(body, &reqBody)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":   "item1",
+				"name": reqBody["name"],
+			})
+
+		case n == 3 && r.URL.Path == "/checklists/checklist123/checkItems":
+			body, _ := io.ReadAll(r.Body)
+			var reqBody map[string]string
+			json.Unmarshal(body, &reqBody)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":   "item2",
+				"name": reqBody["name"],
+			})
+
+		default:
+			t.Errorf("unexpected request #%d: %s %s", n, r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.create_checklist"]
+
+	params, _ := json.Marshal(createChecklistParams{
+		CardID: "card123",
+		Name:   "TODO",
+		Items:  []string{"Buy milk", "Walk dog"},
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_checklist",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	json.Unmarshal(result.Data, &data)
+	if data["id"] != "checklist123" {
+		t.Errorf("expected id=checklist123, got %v", data["id"])
+	}
+	items, ok := data["items"].([]any)
+	if !ok {
+		t.Fatalf("expected items array, got %T", data["items"])
+	}
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestCreateChecklist_NoItems(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/checklists" {
+			t.Errorf("expected path /checklists, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "checklist456",
+			"name": "Empty List",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.create_checklist"]
+
+	params, _ := json.Marshal(createChecklistParams{
+		CardID: "card123",
+		Name:   "Empty List",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_checklist",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	json.Unmarshal(result.Data, &data)
+	if data["id"] != "checklist456" {
+		t.Errorf("expected id=checklist456, got %v", data["id"])
+	}
+}
+
+func TestCreateChecklist_MissingCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.create_checklist"]
+
+	params, _ := json.Marshal(map[string]string{"name": "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_checklist",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing card_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateChecklist_MissingName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.create_checklist"]
+
+	params, _ := json.Marshal(map[string]string{"card_id": "card123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.create_checklist",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/trello/helpers_test.go
+++ b/connectors/trello/helpers_test.go
@@ -1,0 +1,11 @@
+package trello
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+// validCreds returns a Credentials value with valid api_key and token for tests.
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		"api_key": "test-api-key-123",
+		"token":   "test-token-456",
+	})
+}

--- a/connectors/trello/helpers_test.go
+++ b/connectors/trello/helpers_test.go
@@ -2,6 +2,14 @@ package trello
 
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
+// Test IDs that pass Trello ID validation (24-char hex strings).
+const (
+	testCardID      = "507f1f77bcf86cd799439011"
+	testListID      = "507f1f77bcf86cd799439022"
+	testBoardID     = "507f1f77bcf86cd799439033"
+	testChecklistID = "507f1f77bcf86cd799439044"
+)
+
 // validCreds returns a Credentials value with valid api_key and token for tests.
 func validCreds() connectors.Credentials {
 	return connectors.NewCredentials(map[string]string{

--- a/connectors/trello/manifest.go
+++ b/connectors/trello/manifest.go
@@ -25,7 +25,7 @@ func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"list_id": {
 							"type": "string",
-							"description": "ID of the list to create the card in"
+							"description": "ID of the list to create the card in (24-character hex string, e.g. 507f1f77bcf86cd799439011)"
 						},
 						"name": {
 							"type": "string",
@@ -65,7 +65,7 @@ func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"card_id": {
 							"type": "string",
-							"description": "ID of the card to update"
+							"description": "ID of the card to update (24-character hex string)"
 						},
 						"name": {
 							"type": "string",
@@ -117,7 +117,7 @@ func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"card_id": {
 							"type": "string",
-							"description": "ID of the card to comment on"
+							"description": "ID of the card to comment on (24-character hex string)"
 						},
 						"text": {
 							"type": "string",
@@ -137,11 +137,11 @@ func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"card_id": {
 							"type": "string",
-							"description": "ID of the card to move"
+							"description": "ID of the card to move (24-character hex string)"
 						},
 						"list_id": {
 							"type": "string",
-							"description": "ID of the destination list"
+							"description": "ID of the destination list (24-character hex string)"
 						},
 						"pos": {
 							"type": "string",
@@ -161,7 +161,7 @@ func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"card_id": {
 							"type": "string",
-							"description": "ID of the card to add the checklist to"
+							"description": "ID of the card to add the checklist to (24-character hex string)"
 						},
 						"name": {
 							"type": "string",
@@ -188,23 +188,23 @@ func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"query": {
 							"type": "string",
-							"description": "Search query string"
+							"description": "Search query string (supports Trello search operators like @member, #label, is:open)"
 						},
 						"board_id": {
 							"type": "string",
-							"description": "Filter results to a specific board"
+							"description": "Filter results to a specific board (24-character hex string)"
 						},
 						"list_id": {
 							"type": "string",
-							"description": "Filter results to a specific list"
+							"description": "Filter results to a specific list name or ID (appended as list: modifier)"
 						},
 						"members": {
 							"type": "string",
-							"description": "Filter by member"
+							"description": "Filter by member username (appended as @member modifier)"
 						},
 						"due": {
 							"type": "string",
-							"description": "Filter by due date"
+							"description": "Filter by due date: \"day\", \"week\", \"month\", \"overdue\", \"notdue\", or \"incomplete\""
 						},
 						"limit": {
 							"type": "integer",

--- a/connectors/trello/manifest.go
+++ b/connectors/trello/manifest.go
@@ -1,0 +1,284 @@
+package trello
+
+import (
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// Manifest returns the connector's metadata manifest. Used by the server to
+// auto-seed DB rows on startup, replacing manual seed.go files.
+func (c *TrelloConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "trello",
+		Name:        "Trello",
+		Description: "Trello integration for project management and kanban boards",
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "trello.create_card",
+				Name:        "Create Card",
+				Description: "Create a new card in a Trello list",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["list_id", "name"],
+					"properties": {
+						"list_id": {
+							"type": "string",
+							"description": "ID of the list to create the card in"
+						},
+						"name": {
+							"type": "string",
+							"description": "Card title"
+						},
+						"desc": {
+							"type": "string",
+							"description": "Card description (supports Markdown)"
+						},
+						"pos": {
+							"type": "string",
+							"description": "Position of the card: \"top\", \"bottom\", or a positive number"
+						},
+						"due": {
+							"type": "string",
+							"description": "Due date in ISO 8601 format (e.g. 2026-12-31T00:00:00.000Z)"
+						},
+						"idMembers": {
+							"type": "string",
+							"description": "Comma-separated member IDs to assign"
+						},
+						"idLabels": {
+							"type": "string",
+							"description": "Comma-separated label IDs to apply"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "trello.update_card",
+				Name:        "Update Card",
+				Description: "Update fields on an existing Trello card",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["card_id"],
+					"properties": {
+						"card_id": {
+							"type": "string",
+							"description": "ID of the card to update"
+						},
+						"name": {
+							"type": "string",
+							"description": "New card title"
+						},
+						"desc": {
+							"type": "string",
+							"description": "New card description (supports Markdown)"
+						},
+						"due": {
+							"type": "string",
+							"description": "Due date in ISO 8601 format"
+						},
+						"dueComplete": {
+							"type": "boolean",
+							"description": "Whether the due date is complete"
+						},
+						"idList": {
+							"type": "string",
+							"description": "ID of the list to move the card to"
+						},
+						"pos": {
+							"type": "string",
+							"description": "Position: \"top\", \"bottom\", or a positive number"
+						},
+						"idMembers": {
+							"type": "string",
+							"description": "Comma-separated member IDs"
+						},
+						"idLabels": {
+							"type": "string",
+							"description": "Comma-separated label IDs"
+						},
+						"closed": {
+							"type": "boolean",
+							"description": "Whether to archive the card"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "trello.add_comment",
+				Name:        "Add Comment",
+				Description: "Add a comment to a Trello card",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["card_id", "text"],
+					"properties": {
+						"card_id": {
+							"type": "string",
+							"description": "ID of the card to comment on"
+						},
+						"text": {
+							"type": "string",
+							"description": "Comment text"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "trello.move_card",
+				Name:        "Move Card",
+				Description: "Move a card to a different list — separate action for permission gating since moving represents a workflow state change",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["card_id", "list_id"],
+					"properties": {
+						"card_id": {
+							"type": "string",
+							"description": "ID of the card to move"
+						},
+						"list_id": {
+							"type": "string",
+							"description": "ID of the destination list"
+						},
+						"pos": {
+							"type": "string",
+							"description": "Position in the destination list: \"top\", \"bottom\", or a positive number"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "trello.create_checklist",
+				Name:        "Create Checklist",
+				Description: "Create a checklist on a card with optional initial items",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["card_id", "name"],
+					"properties": {
+						"card_id": {
+							"type": "string",
+							"description": "ID of the card to add the checklist to"
+						},
+						"name": {
+							"type": "string",
+							"description": "Checklist name"
+						},
+						"items": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							},
+							"description": "List of checklist item names to add"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "trello.search_cards",
+				Name:        "Search Cards",
+				Description: "Search cards across Trello boards",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["query"],
+					"properties": {
+						"query": {
+							"type": "string",
+							"description": "Search query string"
+						},
+						"board_id": {
+							"type": "string",
+							"description": "Filter results to a specific board"
+						},
+						"list_id": {
+							"type": "string",
+							"description": "Filter results to a specific list"
+						},
+						"members": {
+							"type": "string",
+							"description": "Filter by member"
+						},
+						"due": {
+							"type": "string",
+							"description": "Filter by due date"
+						},
+						"limit": {
+							"type": "integer",
+							"default": 10,
+							"description": "Max cards to return (1-1000)"
+						}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{
+				Service:         "trello",
+				AuthType:        "api_key",
+				InstructionsURL: "https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/#authentication-and-authorization",
+			},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_trello_create_card",
+				ActionType:  "trello.create_card",
+				Name:        "Create cards in a list",
+				Description: "Locks the list and lets the agent choose card name and details.",
+				Parameters:  json.RawMessage(`{"list_id":"your-list-id","name":"*","desc":"*","pos":"*","due":"*","idMembers":"*","idLabels":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_create_card_any",
+				ActionType:  "trello.create_card",
+				Name:        "Create cards freely",
+				Description: "Agent can create cards in any list with any details.",
+				Parameters:  json.RawMessage(`{"list_id":"*","name":"*","desc":"*","pos":"*","due":"*","idMembers":"*","idLabels":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_update_card",
+				ActionType:  "trello.update_card",
+				Name:        "Update any card",
+				Description: "Agent can update any field on any card.",
+				Parameters:  json.RawMessage(`{"card_id":"*","name":"*","desc":"*","due":"*","dueComplete":"*","idList":"*","pos":"*","idMembers":"*","idLabels":"*","closed":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_add_comment",
+				ActionType:  "trello.add_comment",
+				Name:        "Comment on any card",
+				Description: "Agent can add comments to any card.",
+				Parameters:  json.RawMessage(`{"card_id":"*","text":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_move_card_to_list",
+				ActionType:  "trello.move_card",
+				Name:        "Move cards to a specific list",
+				Description: "Locks the destination list (e.g., Done). Agent picks the card.",
+				Parameters:  json.RawMessage(`{"card_id":"*","list_id":"your-done-list-id","pos":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_move_card_any",
+				ActionType:  "trello.move_card",
+				Name:        "Move cards freely",
+				Description: "Agent can move any card to any list.",
+				Parameters:  json.RawMessage(`{"card_id":"*","list_id":"*","pos":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_create_checklist",
+				ActionType:  "trello.create_checklist",
+				Name:        "Create checklists",
+				Description: "Agent can create checklists on any card.",
+				Parameters:  json.RawMessage(`{"card_id":"*","name":"*","items":"*"}`),
+			},
+			{
+				ID:          "tpl_trello_search_cards",
+				ActionType:  "trello.search_cards",
+				Name:        "Search cards",
+				Description: "Agent can search for cards across boards.",
+				Parameters:  json.RawMessage(`{"query":"*","board_id":"*","list_id":"*","members":"*","due":"*","limit":"*"}`),
+			},
+		},
+	}
+}

--- a/connectors/trello/move_card.go
+++ b/connectors/trello/move_card.go
@@ -24,11 +24,11 @@ type moveCardParams struct {
 }
 
 func (p *moveCardParams) validate() error {
-	if p.CardID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	if err := validateTrelloID(p.CardID, "card_id"); err != nil {
+		return err
 	}
-	if p.ListID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: list_id"}
+	if err := validateTrelloID(p.ListID, "list_id"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/connectors/trello/move_card.go
+++ b/connectors/trello/move_card.go
@@ -1,0 +1,66 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// moveCardAction implements connectors.Action for trello.move_card.
+// This is a thin wrapper over PUT /1/cards/{card_id} that exists as a
+// separate action for explicit permission gating, since moving a card
+// between lists represents a workflow state change.
+type moveCardAction struct {
+	conn *TrelloConnector
+}
+
+type moveCardParams struct {
+	CardID string `json:"card_id"`
+	ListID string `json:"list_id"`
+	Pos    string `json:"pos"`
+}
+
+func (p *moveCardParams) validate() error {
+	if p.CardID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	}
+	if p.ListID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: list_id"}
+	}
+	return nil
+}
+
+// Execute moves a card to a different list via PUT /1/cards/{card_id}.
+func (a *moveCardAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params moveCardParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"idList": params.ListID,
+	}
+	if params.Pos != "" {
+		body["pos"] = params.Pos
+	}
+
+	var resp struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		IDList   string `json:"idList"`
+		ShortURL string `json:"shortUrl"`
+		URL      string `json:"url"`
+	}
+	path := fmt.Sprintf("/cards/%s", params.CardID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPut, path, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/trello/move_card.go
+++ b/connectors/trello/move_card.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -57,7 +58,7 @@ func (a *moveCardAction) Execute(ctx context.Context, req connectors.ActionReque
 		ShortURL string `json:"shortUrl"`
 		URL      string `json:"url"`
 	}
-	path := fmt.Sprintf("/cards/%s", params.CardID)
+	path := fmt.Sprintf("/cards/%s", url.PathEscape(params.CardID))
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPut, path, body, &resp); err != nil {
 		return nil, err
 	}

--- a/connectors/trello/move_card_test.go
+++ b/connectors/trello/move_card_test.go
@@ -17,22 +17,23 @@ func TestMoveCard_Success(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/cards/card123" {
-			t.Errorf("expected path /cards/card123, got %s", r.URL.Path)
+		expectedPath := "/cards/" + testCardID
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
 		}
 
 		body, _ := io.ReadAll(r.Body)
 		var reqBody map[string]any
 		json.Unmarshal(body, &reqBody)
-		if reqBody["idList"] != "done-list" {
-			t.Errorf("expected idList=done-list, got %v", reqBody["idList"])
+		if reqBody["idList"] != testListID {
+			t.Errorf("expected idList=%s, got %v", testListID, reqBody["idList"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"id":       "card123",
+			"id":       testCardID,
 			"name":     "Card",
-			"idList":   "done-list",
+			"idList":   testListID,
 			"shortUrl": "https://trello.com/c/abc123",
 			"url":      "https://trello.com/c/abc123/1-card",
 		})
@@ -43,8 +44,8 @@ func TestMoveCard_Success(t *testing.T) {
 	action := conn.Actions()["trello.move_card"]
 
 	params, _ := json.Marshal(moveCardParams{
-		CardID: "card123",
-		ListID: "done-list",
+		CardID: testCardID,
+		ListID: testListID,
 	})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -58,8 +59,8 @@ func TestMoveCard_Success(t *testing.T) {
 
 	var data map[string]any
 	json.Unmarshal(result.Data, &data)
-	if data["idList"] != "done-list" {
-		t.Errorf("expected idList=done-list, got %v", data["idList"])
+	if data["idList"] != testListID {
+		t.Errorf("expected idList=%s, got %v", testListID, data["idList"])
 	}
 }
 
@@ -75,7 +76,7 @@ func TestMoveCard_WithPosition(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"id": "card123", "name": "Card", "idList": "list456", "shortUrl": "https://trello.com/c/abc", "url": "https://trello.com/c/abc/1"})
+		json.NewEncoder(w).Encode(map[string]any{"id": testCardID, "name": "Card", "idList": testListID, "shortUrl": "https://trello.com/c/abc", "url": "https://trello.com/c/abc/1"})
 	}))
 	defer srv.Close()
 
@@ -83,8 +84,8 @@ func TestMoveCard_WithPosition(t *testing.T) {
 	action := conn.Actions()["trello.move_card"]
 
 	params, _ := json.Marshal(moveCardParams{
-		CardID: "card123",
-		ListID: "list456",
+		CardID: testCardID,
+		ListID: testListID,
 		Pos:    "top",
 	})
 
@@ -104,7 +105,7 @@ func TestMoveCard_MissingCardID(t *testing.T) {
 	conn := New()
 	action := conn.Actions()["trello.move_card"]
 
-	params, _ := json.Marshal(map[string]string{"list_id": "list123"})
+	params, _ := json.Marshal(map[string]string{"list_id": testListID})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.move_card",
@@ -125,7 +126,7 @@ func TestMoveCard_MissingListID(t *testing.T) {
 	conn := New()
 	action := conn.Actions()["trello.move_card"]
 
-	params, _ := json.Marshal(map[string]string{"card_id": "card123"})
+	params, _ := json.Marshal(map[string]string{"card_id": testCardID})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "trello.move_card",
@@ -134,6 +135,27 @@ func TestMoveCard_MissingListID(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing list_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestMoveCard_InvalidCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.move_card"]
+
+	params, _ := json.Marshal(map[string]string{"card_id": "bad-id", "list_id": testListID})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.move_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid card_id")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)

--- a/connectors/trello/move_card_test.go
+++ b/connectors/trello/move_card_test.go
@@ -1,0 +1,141 @@
+package trello
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestMoveCard_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/cards/card123" {
+			t.Errorf("expected path /cards/card123, got %s", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		if reqBody["idList"] != "done-list" {
+			t.Errorf("expected idList=done-list, got %v", reqBody["idList"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":       "card123",
+			"name":     "Card",
+			"idList":   "done-list",
+			"shortUrl": "https://trello.com/c/abc123",
+			"url":      "https://trello.com/c/abc123/1-card",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.move_card"]
+
+	params, _ := json.Marshal(moveCardParams{
+		CardID: "card123",
+		ListID: "done-list",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.move_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	json.Unmarshal(result.Data, &data)
+	if data["idList"] != "done-list" {
+		t.Errorf("expected idList=done-list, got %v", data["idList"])
+	}
+}
+
+func TestMoveCard_WithPosition(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		if reqBody["pos"] != "top" {
+			t.Errorf("expected pos=top, got %v", reqBody["pos"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"id": "card123", "name": "Card", "idList": "list456", "shortUrl": "https://trello.com/c/abc", "url": "https://trello.com/c/abc/1"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.move_card"]
+
+	params, _ := json.Marshal(moveCardParams{
+		CardID: "card123",
+		ListID: "list456",
+		Pos:    "top",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.move_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMoveCard_MissingCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.move_card"]
+
+	params, _ := json.Marshal(map[string]string{"list_id": "list123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.move_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing card_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestMoveCard_MissingListID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.move_card"]
+
+	params, _ := json.Marshal(map[string]string{"card_id": "card123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.move_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing list_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/trello/response.go
+++ b/connectors/trello/response.go
@@ -1,0 +1,58 @@
+package trello
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// maxErrorMessageLen caps the length of error messages included from Trello
+// API responses. Trello returns plain text errors that are usually short,
+// but we truncate to prevent unexpectedly large error payloads from
+// propagating through the system.
+const maxErrorMessageLen = 512
+
+// checkResponse maps Trello HTTP status codes to connector error types.
+// Trello returns plain text error messages in the response body.
+func checkResponse(statusCode int, header http.Header, body []byte) error {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+
+	msg := truncateErrorMessage(string(body))
+	if msg == "" {
+		msg = http.StatusText(statusCode)
+	}
+
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    fmt.Sprintf("Trello API rate limit exceeded: %s", msg),
+			RetryAfter: retryAfter,
+		}
+	case statusCode == http.StatusUnauthorized:
+		return &connectors.AuthError{Message: fmt.Sprintf("Trello API auth error: %s", msg)}
+	case statusCode == http.StatusForbidden:
+		return &connectors.AuthError{Message: fmt.Sprintf("Trello API forbidden: %s", msg)}
+	case statusCode == http.StatusBadRequest:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Trello API validation error: %s", msg)}
+	case statusCode == http.StatusNotFound:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Trello API resource not found: %s", msg)}
+	default:
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Trello API error: %s", msg),
+		}
+	}
+}
+
+// truncateErrorMessage caps error message length to prevent unexpectedly
+// large Trello responses from bloating error payloads.
+func truncateErrorMessage(msg string) string {
+	if len(msg) <= maxErrorMessageLen {
+		return msg
+	}
+	return msg[:maxErrorMessageLen] + "... (truncated)"
+}

--- a/connectors/trello/response_test.go
+++ b/connectors/trello/response_test.go
@@ -1,0 +1,74 @@
+package trello
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestTruncateErrorMessage_Short(t *testing.T) {
+	t.Parallel()
+	msg := "short error"
+	result := truncateErrorMessage(msg)
+	if result != msg {
+		t.Errorf("expected unchanged message, got %q", result)
+	}
+}
+
+func TestTruncateErrorMessage_ExactLimit(t *testing.T) {
+	t.Parallel()
+	msg := strings.Repeat("x", maxErrorMessageLen)
+	result := truncateErrorMessage(msg)
+	if result != msg {
+		t.Error("expected unchanged message at exact limit")
+	}
+}
+
+func TestTruncateErrorMessage_Long(t *testing.T) {
+	t.Parallel()
+	msg := strings.Repeat("x", maxErrorMessageLen+100)
+	result := truncateErrorMessage(msg)
+	if !strings.HasSuffix(result, "... (truncated)") {
+		t.Errorf("expected truncated suffix, got %q", result[len(result)-20:])
+	}
+	if len(result) != maxErrorMessageLen+len("... (truncated)") {
+		t.Errorf("expected length %d, got %d", maxErrorMessageLen+len("... (truncated)"), len(result))
+	}
+}
+
+func TestTruncateErrorMessage_Empty(t *testing.T) {
+	t.Parallel()
+	result := truncateErrorMessage("")
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestCheckResponse_EmptyBody(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(500, http.Header{}, []byte(""))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	// Should use http.StatusText as fallback.
+	if !strings.Contains(err.Error(), "Internal Server Error") {
+		t.Errorf("expected StatusText fallback, got %q", err.Error())
+	}
+}
+
+func TestCheckResponse_LongBody(t *testing.T) {
+	t.Parallel()
+	longBody := []byte(strings.Repeat("a", 2000))
+	err := checkResponse(400, http.Header{}, longBody)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("expected truncated message, got %q", err.Error())
+	}
+}

--- a/connectors/trello/search_cards.go
+++ b/connectors/trello/search_cards.go
@@ -1,0 +1,72 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// searchCardsAction implements connectors.Action for trello.search_cards.
+type searchCardsAction struct {
+	conn *TrelloConnector
+}
+
+type searchCardsParams struct {
+	Query   string `json:"query"`
+	BoardID string `json:"board_id"`
+	ListID  string `json:"list_id"`
+	Members string `json:"members"`
+	Due     string `json:"due"`
+	Limit   int    `json:"limit"`
+}
+
+func (p *searchCardsParams) validate() error {
+	if p.Query == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: query"}
+	}
+	if p.Limit < 0 || p.Limit > 1000 {
+		return &connectors.ValidationError{Message: "limit must be between 0 and 1000"}
+	}
+	return nil
+}
+
+// Execute searches for cards across boards via GET /1/search.
+func (a *searchCardsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params searchCardsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	qp := map[string]string{
+		"query":      params.Query,
+		"modelTypes": "cards",
+	}
+
+	limit := params.Limit
+	if limit == 0 {
+		limit = 10
+	}
+	qp["cards_limit"] = strconv.Itoa(limit)
+
+	if params.BoardID != "" {
+		qp["idBoards"] = params.BoardID
+	}
+
+	var resp struct {
+		Cards []json.RawMessage `json:"cards"`
+	}
+	if err := a.conn.doGet(ctx, req.Credentials, "/search", qp, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"cards": resp.Cards,
+		"count": len(resp.Cards),
+	})
+}

--- a/connectors/trello/search_cards.go
+++ b/connectors/trello/search_cards.go
@@ -43,9 +43,24 @@ func (a *searchCardsAction) Execute(ctx context.Context, req connectors.ActionRe
 		return nil, err
 	}
 
+	// Build the search query string. Trello's search supports inline
+	// modifiers like @member, list:name, and due:day — we append these
+	// to the user's query so they compose naturally.
+	query := params.Query
+	if params.Members != "" {
+		query += " @" + params.Members
+	}
+	if params.ListID != "" {
+		query += " list:" + params.ListID
+	}
+	if params.Due != "" {
+		query += " due:" + params.Due
+	}
+
 	qp := map[string]string{
-		"query":      params.Query,
+		"query":      query,
 		"modelTypes": "cards",
+		"card_fields": "id,name,desc,idList,shortUrl,url,due,dueComplete,labels,idMembers,closed",
 	}
 
 	limit := params.Limit

--- a/connectors/trello/search_cards_test.go
+++ b/connectors/trello/search_cards_test.go
@@ -1,0 +1,198 @@
+package trello
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestSearchCards_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/search" {
+			t.Errorf("expected path /search, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "bug fix" {
+			t.Errorf("expected query='bug fix', got %q", r.URL.Query().Get("query"))
+		}
+		if r.URL.Query().Get("modelTypes") != "cards" {
+			t.Errorf("expected modelTypes=cards, got %q", r.URL.Query().Get("modelTypes"))
+		}
+		if r.URL.Query().Get("cards_limit") != "10" {
+			t.Errorf("expected cards_limit=10, got %q", r.URL.Query().Get("cards_limit"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"cards": []map[string]any{
+				{"id": "card1", "name": "Fix bug #1"},
+				{"id": "card2", "name": "Fix bug #2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(searchCardsParams{
+		Query: "bug fix",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	json.Unmarshal(result.Data, &data)
+	if data["count"] != float64(2) {
+		t.Errorf("expected count=2, got %v", data["count"])
+	}
+	cards, ok := data["cards"].([]any)
+	if !ok {
+		t.Fatalf("expected cards array, got %T", data["cards"])
+	}
+	if len(cards) != 2 {
+		t.Errorf("expected 2 cards, got %d", len(cards))
+	}
+}
+
+func TestSearchCards_WithBoardFilter(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("idBoards") != "board123" {
+			t.Errorf("expected idBoards=board123, got %q", r.URL.Query().Get("idBoards"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"cards": []map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(searchCardsParams{
+		Query:   "test",
+		BoardID: "board123",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchCards_CustomLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("cards_limit") != "50" {
+			t.Errorf("expected cards_limit=50, got %q", r.URL.Query().Get("cards_limit"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(searchCardsParams{
+		Query: "test",
+		Limit: 50,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchCards_MissingQuery(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(map[string]string{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSearchCards_InvalidLimit(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(searchCardsParams{
+		Query: "test",
+		Limit: 2000,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid limit")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSearchCards_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.search_cards"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  []byte(`{bad`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/trello/search_cards_test.go
+++ b/connectors/trello/search_cards_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -27,6 +28,10 @@ func TestSearchCards_Success(t *testing.T) {
 		}
 		if r.URL.Query().Get("cards_limit") != "10" {
 			t.Errorf("expected cards_limit=10, got %q", r.URL.Query().Get("cards_limit"))
+		}
+		// Verify card_fields is requested for richer responses.
+		if !strings.Contains(r.URL.Query().Get("card_fields"), "id") {
+			t.Errorf("expected card_fields to include 'id', got %q", r.URL.Query().Get("card_fields"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -73,8 +78,8 @@ func TestSearchCards_WithBoardFilter(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("idBoards") != "board123" {
-			t.Errorf("expected idBoards=board123, got %q", r.URL.Query().Get("idBoards"))
+		if r.URL.Query().Get("idBoards") != testBoardID {
+			t.Errorf("expected idBoards=%s, got %q", testBoardID, r.URL.Query().Get("idBoards"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -89,7 +94,72 @@ func TestSearchCards_WithBoardFilter(t *testing.T) {
 
 	params, _ := json.Marshal(searchCardsParams{
 		Query:   "test",
-		BoardID: "board123",
+		BoardID: testBoardID,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchCards_WithMemberFilter(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Members filter is appended to query as @member.
+		query := r.URL.Query().Get("query")
+		if !strings.Contains(query, "@johndoe") {
+			t.Errorf("expected query to contain '@johndoe', got %q", query)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(searchCardsParams{
+		Query:   "test",
+		Members: "johndoe",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.search_cards",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchCards_WithDueFilter(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		if !strings.Contains(query, "due:week") {
+			t.Errorf("expected query to contain 'due:week', got %q", query)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.search_cards"]
+
+	params, _ := json.Marshal(searchCardsParams{
+		Query: "test",
+		Due:   "week",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/trello/trello.go
+++ b/connectors/trello/trello.go
@@ -76,16 +76,49 @@ func (c *TrelloConnector) Actions() map[string]connectors.Action {
 }
 
 // ValidateCredentials checks that the provided credentials contain non-empty
-// api_key and token fields. Trello API keys are 32-character hex strings and
-// tokens are longer hex strings, but we only validate presence here.
-func (c *TrelloConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+// api_key and token fields, then verifies them against the Trello API by
+// calling GET /1/members/me. This catches invalid or revoked credentials
+// early instead of failing on the first action.
+func (c *TrelloConnector) ValidateCredentials(ctx context.Context, creds connectors.Credentials) error {
 	key, ok := creds.Get(credKeyAPIKey)
 	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+		return &connectors.ValidationError{Message: "missing required credential: api_key — get yours at https://trello.com/power-ups/admin"}
 	}
 	token, ok := creds.Get(credKeyToken)
 	if !ok || token == "" {
-		return &connectors.ValidationError{Message: "missing required credential: token"}
+		return &connectors.ValidationError{Message: "missing required credential: token — generate one at https://trello.com/1/authorize?expiration=never&scope=read,write&response_type=token&key=YOUR_API_KEY"}
+	}
+
+	// Verify credentials by hitting the members/me endpoint.
+	var me struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+	}
+	if err := c.doGet(ctx, creds, "/members/me", map[string]string{"fields": "id,username"}, &me); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateTrelloID checks that a string looks like a valid Trello ID
+// (24-character hexadecimal string). This catches common mistakes like
+// passing a card URL or name instead of an ID.
+func validateTrelloID(value, paramName string) error {
+	if value == "" {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", paramName)}
+	}
+	if len(value) != 24 {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid %s %q: expected a 24-character Trello ID (e.g. 507f1f77bcf86cd799439011)", paramName, value),
+		}
+	}
+	for _, c := range value {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("invalid %s %q: expected a 24-character hex string — did you pass a URL or name instead of an ID?", paramName, value),
+			}
+		}
 	}
 	return nil
 }

--- a/connectors/trello/trello.go
+++ b/connectors/trello/trello.go
@@ -44,12 +44,24 @@ type TrelloConnector struct {
 }
 
 // New creates a TrelloConnector with sensible defaults (30s timeout,
-// https://api.trello.com/1 base URL).
+// https://api.trello.com/1 base URL). The HTTP client disables automatic
+// redirect following to prevent leaking credential query parameters
+// (key/token) to redirect targets.
 func New() *TrelloConnector {
 	return &TrelloConnector{
-		client:  &http.Client{Timeout: defaultTimeout},
+		client: &http.Client{
+			Timeout:       defaultTimeout,
+			CheckRedirect: noRedirect,
+		},
 		baseURL: defaultBaseURL,
 	}
+}
+
+// noRedirect prevents the HTTP client from following redirects. Trello
+// credentials are passed as query parameters, and following a redirect
+// would forward them to the redirect target, potentially leaking them.
+func noRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
 }
 
 // newForTest creates a TrelloConnector that points at a test server.

--- a/connectors/trello/trello.go
+++ b/connectors/trello/trello.go
@@ -1,0 +1,263 @@
+// Package trello implements the Trello connector for the Permission Slip
+// connector execution layer. It uses the Trello REST API with plain net/http
+// (no third-party SDK) to keep the dependency footprint minimal.
+//
+// Trello uses query-parameter auth (key + token), not header-based auth.
+package trello
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+const (
+	defaultBaseURL = "https://api.trello.com/1"
+	defaultTimeout = 30 * time.Second
+
+	credKeyAPIKey = "api_key"
+	credKeyToken  = "token"
+
+	// defaultRetryAfter is used when Trello returns a rate limit response
+	// without a Retry-After header (or an unparseable one).
+	defaultRetryAfter = 10 * time.Second
+
+	// maxResponseBytes limits how much data we read from the Trello API
+	// to prevent OOM from unexpectedly large responses.
+	maxResponseBytes = 10 * 1024 * 1024 // 10 MB
+)
+
+// TrelloConnector owns the shared HTTP client and base URL used by all
+// Trello actions. Actions hold a pointer back to the connector to access
+// these shared resources.
+type TrelloConnector struct {
+	client  *http.Client
+	baseURL string
+}
+
+// New creates a TrelloConnector with sensible defaults (30s timeout,
+// https://api.trello.com/1 base URL).
+func New() *TrelloConnector {
+	return &TrelloConnector{
+		client:  &http.Client{Timeout: defaultTimeout},
+		baseURL: defaultBaseURL,
+	}
+}
+
+// newForTest creates a TrelloConnector that points at a test server.
+func newForTest(client *http.Client, baseURL string) *TrelloConnector {
+	return &TrelloConnector{
+		client:  client,
+		baseURL: baseURL,
+	}
+}
+
+// ID returns "trello", matching the connectors.id in the database.
+func (c *TrelloConnector) ID() string { return "trello" }
+
+// Actions returns the registered action handlers keyed by action_type.
+func (c *TrelloConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"trello.create_card":      &createCardAction{conn: c},
+		"trello.update_card":      &updateCardAction{conn: c},
+		"trello.add_comment":      &addCommentAction{conn: c},
+		"trello.move_card":        &moveCardAction{conn: c},
+		"trello.create_checklist": &createChecklistAction{conn: c},
+		"trello.search_cards":     &searchCardsAction{conn: c},
+	}
+}
+
+// ValidateCredentials checks that the provided credentials contain non-empty
+// api_key and token fields. Trello API keys are 32-character hex strings and
+// tokens are longer hex strings, but we only validate presence here.
+func (c *TrelloConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+	key, ok := creds.Get(credKeyAPIKey)
+	if !ok || key == "" {
+		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+	}
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "missing required credential: token"}
+	}
+	return nil
+}
+
+// do is the shared request lifecycle for all Trello actions. It appends
+// key/token query parameters to all requests (Trello uses query-param auth,
+// not headers), marshals reqBody as JSON for POST/PUT, sends the request,
+// checks the response status, and unmarshals the response into respBody.
+func (c *TrelloConnector) do(ctx context.Context, creds connectors.Credentials, method, path string, reqBody, respBody any) error {
+	key, ok := creds.Get(credKeyAPIKey)
+	if !ok || key == "" {
+		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+	}
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "token credential is missing or empty"}
+	}
+
+	// Build the full URL with auth query params.
+	u, err := url.Parse(c.baseURL + path)
+	if err != nil {
+		return fmt.Errorf("parsing URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("key", key)
+	q.Set("token", token)
+	u.RawQuery = q.Encode()
+
+	var body io.Reader
+	if reqBody != nil {
+		payload, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("marshaling request body: %w", err)
+		}
+		body = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Trello API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Trello API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Trello API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return err
+	}
+
+	if respBody != nil {
+		if err := json.Unmarshal(respBytes, respBody); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    fmt.Sprintf("failed to decode Trello API response: %v", err),
+			}
+		}
+	}
+
+	return nil
+}
+
+// doGet is a convenience wrapper for GET requests. It builds query parameters
+// from the params map and appends them alongside the auth params.
+func (c *TrelloConnector) doGet(ctx context.Context, creds connectors.Credentials, path string, params map[string]string, respBody any) error {
+	key, ok := creds.Get(credKeyAPIKey)
+	if !ok || key == "" {
+		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+	}
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "token credential is missing or empty"}
+	}
+
+	u, err := url.Parse(c.baseURL + path)
+	if err != nil {
+		return fmt.Errorf("parsing URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("key", key)
+	q.Set("token", token)
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Trello API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Trello API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Trello API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return err
+	}
+
+	if respBody != nil {
+		if err := json.Unmarshal(respBytes, respBody); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    fmt.Sprintf("failed to decode Trello API response: %v", err),
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkResponse maps Trello HTTP status codes to connector error types.
+// Trello returns plain text error messages in the response body.
+func checkResponse(statusCode int, header http.Header, body []byte) error {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+
+	// Trello error messages are typically plain text.
+	msg := string(body)
+	if msg == "" {
+		msg = http.StatusText(statusCode)
+	}
+
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    fmt.Sprintf("Trello API rate limit exceeded: %s", msg),
+			RetryAfter: retryAfter,
+		}
+	case statusCode == http.StatusUnauthorized:
+		return &connectors.AuthError{Message: fmt.Sprintf("Trello API auth error: %s", msg)}
+	case statusCode == http.StatusForbidden:
+		return &connectors.AuthError{Message: fmt.Sprintf("Trello API forbidden: %s", msg)}
+	case statusCode == http.StatusBadRequest:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Trello API validation error: %s", msg)}
+	case statusCode == http.StatusNotFound:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Trello API resource not found: %s", msg)}
+	default:
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Trello API error: %s", msg),
+		}
+	}
+}

--- a/connectors/trello/trello.go
+++ b/connectors/trello/trello.go
@@ -135,28 +135,74 @@ func validateTrelloID(value, paramName string) error {
 	return nil
 }
 
-// do is the shared request lifecycle for all Trello actions. It appends
-// key/token query parameters to all requests (Trello uses query-param auth,
-// not headers), marshals reqBody as JSON for POST/PUT, sends the request,
-// checks the response status, and unmarshals the response into respBody.
-func (c *TrelloConnector) do(ctx context.Context, creds connectors.Credentials, method, path string, reqBody, respBody any) error {
+// authQuery extracts api_key and token from credentials and returns them
+// as URL query parameters. This is the single point where credentials are
+// read, reducing duplication across do() and doGet().
+func authQuery(creds connectors.Credentials) (url.Values, error) {
 	key, ok := creds.Get(credKeyAPIKey)
 	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+		return nil, &connectors.ValidationError{Message: "api_key credential is missing or empty"}
 	}
 	token, ok := creds.Get(credKeyToken)
 	if !ok || token == "" {
-		return &connectors.ValidationError{Message: "token credential is missing or empty"}
+		return nil, &connectors.ValidationError{Message: "token credential is missing or empty"}
+	}
+	q := url.Values{}
+	q.Set("key", key)
+	q.Set("token", token)
+	return q, nil
+}
+
+// sendAndDecode executes an HTTP request, reads the response, checks for
+// errors, and unmarshals the result into respBody. Shared by do() and doGet()
+// to eliminate duplicated response-handling logic.
+func (c *TrelloConnector) sendAndDecode(req *http.Request, respBody any) error {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Trello API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Trello API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Trello API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
 	}
 
-	// Build the full URL with auth query params.
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return err
+	}
+
+	if respBody != nil {
+		if err := json.Unmarshal(respBytes, respBody); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    fmt.Sprintf("failed to decode Trello API response: %v", err),
+			}
+		}
+	}
+
+	return nil
+}
+
+// do is the shared request lifecycle for Trello write actions (POST/PUT).
+// It appends key/token query parameters, marshals reqBody as JSON, and
+// unmarshals the response into respBody.
+func (c *TrelloConnector) do(ctx context.Context, creds connectors.Credentials, method, path string, reqBody, respBody any) error {
+	q, err := authQuery(creds)
+	if err != nil {
+		return err
+	}
+
 	u, err := url.Parse(c.baseURL + path)
 	if err != nil {
 		return fmt.Errorf("parsing URL: %w", err)
 	}
-	q := u.Query()
-	q.Set("key", key)
-	q.Set("token", token)
 	u.RawQuery = q.Encode()
 
 	var body io.Reader
@@ -176,60 +222,23 @@ func (c *TrelloConnector) do(ctx context.Context, creds connectors.Credentials, 
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("Trello API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Trello API request canceled"}
-		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("Trello API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
-		return err
-	}
-
-	if respBody != nil {
-		if err := json.Unmarshal(respBytes, respBody); err != nil {
-			return &connectors.ExternalError{
-				StatusCode: resp.StatusCode,
-				Message:    fmt.Sprintf("failed to decode Trello API response: %v", err),
-			}
-		}
-	}
-
-	return nil
+	return c.sendAndDecode(req, respBody)
 }
 
 // doGet is a convenience wrapper for GET requests. It builds query parameters
 // from the params map and appends them alongside the auth params.
 func (c *TrelloConnector) doGet(ctx context.Context, creds connectors.Credentials, path string, params map[string]string, respBody any) error {
-	key, ok := creds.Get(credKeyAPIKey)
-	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+	q, err := authQuery(creds)
+	if err != nil {
+		return err
 	}
-	token, ok := creds.Get(credKeyToken)
-	if !ok || token == "" {
-		return &connectors.ValidationError{Message: "token credential is missing or empty"}
+	for k, v := range params {
+		q.Set(k, v)
 	}
 
 	u, err := url.Parse(c.baseURL + path)
 	if err != nil {
 		return fmt.Errorf("parsing URL: %w", err)
-	}
-	q := u.Query()
-	q.Set("key", key)
-	q.Set("token", token)
-	for k, v := range params {
-		q.Set(k, v)
 	}
 	u.RawQuery = q.Encode()
 
@@ -238,71 +247,5 @@ func (c *TrelloConnector) doGet(ctx context.Context, creds connectors.Credential
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("Trello API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Trello API request canceled"}
-		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("Trello API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
-		return err
-	}
-
-	if respBody != nil {
-		if err := json.Unmarshal(respBytes, respBody); err != nil {
-			return &connectors.ExternalError{
-				StatusCode: resp.StatusCode,
-				Message:    fmt.Sprintf("failed to decode Trello API response: %v", err),
-			}
-		}
-	}
-
-	return nil
-}
-
-// checkResponse maps Trello HTTP status codes to connector error types.
-// Trello returns plain text error messages in the response body.
-func checkResponse(statusCode int, header http.Header, body []byte) error {
-	if statusCode >= 200 && statusCode < 300 {
-		return nil
-	}
-
-	// Trello error messages are typically plain text.
-	msg := string(body)
-	if msg == "" {
-		msg = http.StatusText(statusCode)
-	}
-
-	switch {
-	case statusCode == http.StatusTooManyRequests:
-		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
-		return &connectors.RateLimitError{
-			Message:    fmt.Sprintf("Trello API rate limit exceeded: %s", msg),
-			RetryAfter: retryAfter,
-		}
-	case statusCode == http.StatusUnauthorized:
-		return &connectors.AuthError{Message: fmt.Sprintf("Trello API auth error: %s", msg)}
-	case statusCode == http.StatusForbidden:
-		return &connectors.AuthError{Message: fmt.Sprintf("Trello API forbidden: %s", msg)}
-	case statusCode == http.StatusBadRequest:
-		return &connectors.ValidationError{Message: fmt.Sprintf("Trello API validation error: %s", msg)}
-	case statusCode == http.StatusNotFound:
-		return &connectors.ValidationError{Message: fmt.Sprintf("Trello API resource not found: %s", msg)}
-	default:
-		return &connectors.ExternalError{
-			StatusCode: statusCode,
-			Message:    fmt.Sprintf("Trello API error: %s", msg),
-		}
-	}
+	return c.sendAndDecode(req, respBody)
 }

--- a/connectors/trello/trello_test.go
+++ b/connectors/trello/trello_test.go
@@ -1,0 +1,230 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestID(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.ID() != "trello" {
+		t.Errorf("expected ID 'trello', got %q", c.ID())
+	}
+}
+
+func TestActions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	expected := []string{
+		"trello.create_card",
+		"trello.update_card",
+		"trello.add_comment",
+		"trello.move_card",
+		"trello.create_checklist",
+		"trello.search_cards",
+	}
+
+	for _, name := range expected {
+		if _, ok := actions[name]; !ok {
+			t.Errorf("missing action %q", name)
+		}
+	}
+
+	if len(actions) != len(expected) {
+		t.Errorf("expected %d actions, got %d", len(expected), len(actions))
+	}
+}
+
+func TestValidateCredentials_Valid(t *testing.T) {
+	t.Parallel()
+	c := New()
+	err := c.ValidateCredentials(context.Background(), validCreds())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCredentials_MissingAPIKey(t *testing.T) {
+	t.Parallel()
+	c := New()
+	creds := connectors.NewCredentials(map[string]string{
+		"token": "test-token",
+	})
+	err := c.ValidateCredentials(context.Background(), creds)
+	if err == nil {
+		t.Fatal("expected error for missing api_key")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestValidateCredentials_MissingToken(t *testing.T) {
+	t.Parallel()
+	c := New()
+	creds := connectors.NewCredentials(map[string]string{
+		"api_key": "test-key",
+	})
+	err := c.ValidateCredentials(context.Background(), creds)
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestValidateCredentials_Empty(t *testing.T) {
+	t.Parallel()
+	c := New()
+	creds := connectors.NewCredentials(map[string]string{})
+	err := c.ValidateCredentials(context.Background(), creds)
+	if err == nil {
+		t.Fatal("expected error for empty credentials")
+	}
+}
+
+func TestManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+
+	if m.ID != "trello" {
+		t.Errorf("expected manifest ID 'trello', got %q", m.ID)
+	}
+	if m.Name != "Trello" {
+		t.Errorf("expected manifest name 'Trello', got %q", m.Name)
+	}
+	if len(m.Actions) != 6 {
+		t.Errorf("expected 6 actions in manifest, got %d", len(m.Actions))
+	}
+	if len(m.RequiredCredentials) != 1 {
+		t.Errorf("expected 1 required credential, got %d", len(m.RequiredCredentials))
+	}
+	if m.RequiredCredentials[0].AuthType != "api_key" {
+		t.Errorf("expected auth type 'api_key', got %q", m.RequiredCredentials[0].AuthType)
+	}
+
+	// Verify all action schemas parse as valid JSON.
+	for _, a := range m.Actions {
+		var schema map[string]any
+		if err := json.Unmarshal(a.ParametersSchema, &schema); err != nil {
+			t.Errorf("action %q has invalid JSON schema: %v", a.ActionType, err)
+		}
+	}
+}
+
+func TestCheckResponse_Success(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(200, http.Header{}, []byte("OK"))
+	if err != nil {
+		t.Errorf("expected nil error for 200, got: %v", err)
+	}
+}
+
+func TestCheckResponse_RateLimit(t *testing.T) {
+	t.Parallel()
+	h := http.Header{}
+	h.Set("Retry-After", "5")
+	err := checkResponse(429, h, []byte("Rate limit"))
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestCheckResponse_Unauthorized(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(401, http.Header{}, []byte("unauthorized"))
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestCheckResponse_Forbidden(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(403, http.Header{}, []byte("forbidden"))
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestCheckResponse_BadRequest(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(400, http.Header{}, []byte("invalid value"))
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCheckResponse_NotFound(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(404, http.Header{}, []byte("not found"))
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCheckResponse_ServerError(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(500, http.Header{}, []byte("server error"))
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got: %T", err)
+	}
+}
+
+func TestDo_QueryParamAuth(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth is in query params, NOT in headers.
+		if r.URL.Query().Get("key") != "test-api-key-123" {
+			t.Errorf("expected key in query params, got %q", r.URL.Query().Get("key"))
+		}
+		if r.URL.Query().Get("token") != "test-token-456" {
+			t.Errorf("expected token in query params, got %q", r.URL.Query().Get("token"))
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("expected no Authorization header, got %q", auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"id": "me123"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]string
+	err := conn.do(t.Context(), validCreds(), http.MethodGet, "/members/me", nil, &resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp["id"] != "me123" {
+		t.Errorf("expected id=me123, got %q", resp["id"])
+	}
+}

--- a/connectors/trello/trello_test.go
+++ b/connectors/trello/trello_test.go
@@ -45,10 +45,42 @@ func TestActions(t *testing.T) {
 
 func TestValidateCredentials_Valid(t *testing.T) {
 	t.Parallel()
-	c := New()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/members/me" {
+			t.Errorf("expected /members/me, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("key") == "" || r.URL.Query().Get("token") == "" {
+			t.Error("expected key and token in query params")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"id": "member123", "username": "testuser"})
+	}))
+	defer srv.Close()
+
+	c := newForTest(srv.Client(), srv.URL)
 	err := c.ValidateCredentials(context.Background(), validCreds())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCredentials_InvalidCreds(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("invalid key"))
+	}))
+	defer srv.Close()
+
+	c := newForTest(srv.Client(), srv.URL)
+	err := c.ValidateCredentials(context.Background(), validCreds())
+	if err == nil {
+		t.Fatal("expected error for invalid credentials")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
 	}
 }
 
@@ -119,6 +151,68 @@ func TestManifest(t *testing.T) {
 		if err := json.Unmarshal(a.ParametersSchema, &schema); err != nil {
 			t.Errorf("action %q has invalid JSON schema: %v", a.ActionType, err)
 		}
+	}
+
+	// Verify risk levels match the issue spec.
+	riskMap := map[string]string{}
+	for _, a := range m.Actions {
+		riskMap[a.ActionType] = a.RiskLevel
+	}
+	if riskMap["trello.move_card"] != "medium" {
+		t.Errorf("expected move_card risk=medium, got %q", riskMap["trello.move_card"])
+	}
+	for _, action := range []string{"trello.create_card", "trello.update_card", "trello.add_comment", "trello.create_checklist", "trello.search_cards"} {
+		if riskMap[action] != "low" {
+			t.Errorf("expected %s risk=low, got %q", action, riskMap[action])
+		}
+	}
+}
+
+func TestValidateTrelloID_Valid(t *testing.T) {
+	t.Parallel()
+	err := validateTrelloID("507f1f77bcf86cd799439011", "card_id")
+	if err != nil {
+		t.Errorf("expected nil for valid ID, got: %v", err)
+	}
+}
+
+func TestValidateTrelloID_Empty(t *testing.T) {
+	t.Parallel()
+	err := validateTrelloID("", "card_id")
+	if err == nil {
+		t.Fatal("expected error for empty ID")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestValidateTrelloID_TooShort(t *testing.T) {
+	t.Parallel()
+	err := validateTrelloID("abc123", "card_id")
+	if err == nil {
+		t.Fatal("expected error for short ID")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestValidateTrelloID_InvalidChars(t *testing.T) {
+	t.Parallel()
+	// 24 chars but contains uppercase and non-hex chars
+	err := validateTrelloID("507f1f77bcf86cd79943901X", "card_id")
+	if err == nil {
+		t.Fatal("expected error for non-hex chars")
+	}
+}
+
+func TestValidateTrelloID_URL(t *testing.T) {
+	t.Parallel()
+	// Common mistake: passing a Trello URL instead of an ID
+	err := validateTrelloID("https://trello.com/c/abc", "card_id")
+	if err == nil {
+		t.Fatal("expected error when passing URL")
 	}
 }
 

--- a/connectors/trello/update_card.go
+++ b/connectors/trello/update_card.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -79,7 +80,7 @@ func (a *updateCardAction) Execute(ctx context.Context, req connectors.ActionReq
 		ShortURL string `json:"shortUrl"`
 		URL      string `json:"url"`
 	}
-	path := fmt.Sprintf("/cards/%s", params.CardID)
+	path := fmt.Sprintf("/cards/%s", url.PathEscape(params.CardID))
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPut, path, body, &resp); err != nil {
 		return nil, err
 	}

--- a/connectors/trello/update_card.go
+++ b/connectors/trello/update_card.go
@@ -28,8 +28,8 @@ type updateCardParams struct {
 }
 
 func (p *updateCardParams) validate() error {
-	if p.CardID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	if err := validateTrelloID(p.CardID, "card_id"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/connectors/trello/update_card.go
+++ b/connectors/trello/update_card.go
@@ -75,10 +75,15 @@ func (a *updateCardAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	var resp struct {
-		ID       string `json:"id"`
-		Name     string `json:"name"`
-		ShortURL string `json:"shortUrl"`
-		URL      string `json:"url"`
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Desc        string `json:"desc"`
+		IDList      string `json:"idList"`
+		Due         string `json:"due"`
+		DueComplete bool   `json:"dueComplete"`
+		Closed      bool   `json:"closed"`
+		ShortURL    string `json:"shortUrl"`
+		URL         string `json:"url"`
 	}
 	path := fmt.Sprintf("/cards/%s", url.PathEscape(params.CardID))
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPut, path, body, &resp); err != nil {

--- a/connectors/trello/update_card.go
+++ b/connectors/trello/update_card.go
@@ -1,0 +1,88 @@
+package trello
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// updateCardAction implements connectors.Action for trello.update_card.
+type updateCardAction struct {
+	conn *TrelloConnector
+}
+
+type updateCardParams struct {
+	CardID      string `json:"card_id"`
+	Name        string `json:"name"`
+	Desc        string `json:"desc"`
+	Due         string `json:"due"`
+	DueComplete *bool  `json:"dueComplete"`
+	IDList      string `json:"idList"`
+	Pos         string `json:"pos"`
+	IDMembers   string `json:"idMembers"`
+	IDLabels    string `json:"idLabels"`
+	Closed      *bool  `json:"closed"`
+}
+
+func (p *updateCardParams) validate() error {
+	if p.CardID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: card_id"}
+	}
+	return nil
+}
+
+// Execute updates fields on an existing Trello card via PUT /1/cards/{card_id}.
+func (a *updateCardAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params updateCardParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{}
+	if params.Name != "" {
+		body["name"] = params.Name
+	}
+	if params.Desc != "" {
+		body["desc"] = params.Desc
+	}
+	if params.Due != "" {
+		body["due"] = params.Due
+	}
+	if params.DueComplete != nil {
+		body["dueComplete"] = *params.DueComplete
+	}
+	if params.IDList != "" {
+		body["idList"] = params.IDList
+	}
+	if params.Pos != "" {
+		body["pos"] = params.Pos
+	}
+	if params.IDMembers != "" {
+		body["idMembers"] = params.IDMembers
+	}
+	if params.IDLabels != "" {
+		body["idLabels"] = params.IDLabels
+	}
+	if params.Closed != nil {
+		body["closed"] = *params.Closed
+	}
+
+	var resp struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		ShortURL string `json:"shortUrl"`
+		URL      string `json:"url"`
+	}
+	path := fmt.Sprintf("/cards/%s", params.CardID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPut, path, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/trello/update_card_test.go
+++ b/connectors/trello/update_card_test.go
@@ -17,8 +17,9 @@ func TestUpdateCard_Success(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/cards/card123" {
-			t.Errorf("expected path /cards/card123, got %s", r.URL.Path)
+		expectedPath := "/cards/" + testCardID
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
 		}
 
 		body, _ := io.ReadAll(r.Body)
@@ -30,7 +31,7 @@ func TestUpdateCard_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"id":       "card123",
+			"id":       testCardID,
 			"name":     "Updated Name",
 			"shortUrl": "https://trello.com/c/abc123",
 			"url":      "https://trello.com/c/abc123/1-updated-name",
@@ -42,7 +43,7 @@ func TestUpdateCard_Success(t *testing.T) {
 	action := conn.Actions()["trello.update_card"]
 
 	params, _ := json.Marshal(map[string]any{
-		"card_id": "card123",
+		"card_id": testCardID,
 		"name":    "Updated Name",
 	})
 
@@ -57,8 +58,8 @@ func TestUpdateCard_Success(t *testing.T) {
 
 	var data map[string]any
 	json.Unmarshal(result.Data, &data)
-	if data["id"] != "card123" {
-		t.Errorf("expected id=card123, got %v", data["id"])
+	if data["id"] != testCardID {
+		t.Errorf("expected id=%s, got %v", testCardID, data["id"])
 	}
 }
 
@@ -78,7 +79,7 @@ func TestUpdateCard_BooleanFields(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"id": "card123", "name": "Card", "shortUrl": "https://trello.com/c/abc", "url": "https://trello.com/c/abc/1"})
+		json.NewEncoder(w).Encode(map[string]any{"id": testCardID, "name": "Card", "shortUrl": "https://trello.com/c/abc", "url": "https://trello.com/c/abc/1"})
 	}))
 	defer srv.Close()
 
@@ -87,7 +88,7 @@ func TestUpdateCard_BooleanFields(t *testing.T) {
 
 	bTrue := true
 	params, _ := json.Marshal(updateCardParams{
-		CardID:      "card123",
+		CardID:      testCardID,
 		DueComplete: &bTrue,
 		Closed:      &bTrue,
 	})
@@ -117,6 +118,27 @@ func TestUpdateCard_MissingCardID(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing card_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateCard_InvalidCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.update_card"]
+
+	params, _ := json.Marshal(map[string]string{"card_id": "short", "name": "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.update_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid card_id")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)

--- a/connectors/trello/update_card_test.go
+++ b/connectors/trello/update_card_test.go
@@ -1,0 +1,143 @@
+package trello
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUpdateCard_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/cards/card123" {
+			t.Errorf("expected path /cards/card123, got %s", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+		if reqBody["name"] != "Updated Name" {
+			t.Errorf("expected name=Updated Name, got %v", reqBody["name"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":       "card123",
+			"name":     "Updated Name",
+			"shortUrl": "https://trello.com/c/abc123",
+			"url":      "https://trello.com/c/abc123/1-updated-name",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.update_card"]
+
+	params, _ := json.Marshal(map[string]any{
+		"card_id": "card123",
+		"name":    "Updated Name",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.update_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	json.Unmarshal(result.Data, &data)
+	if data["id"] != "card123" {
+		t.Errorf("expected id=card123, got %v", data["id"])
+	}
+}
+
+func TestUpdateCard_BooleanFields(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		json.Unmarshal(body, &reqBody)
+
+		if reqBody["dueComplete"] != true {
+			t.Errorf("expected dueComplete=true, got %v", reqBody["dueComplete"])
+		}
+		if reqBody["closed"] != true {
+			t.Errorf("expected closed=true, got %v", reqBody["closed"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"id": "card123", "name": "Card", "shortUrl": "https://trello.com/c/abc", "url": "https://trello.com/c/abc/1"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["trello.update_card"]
+
+	bTrue := true
+	params, _ := json.Marshal(updateCardParams{
+		CardID:      "card123",
+		DueComplete: &bTrue,
+		Closed:      &bTrue,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.update_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateCard_MissingCardID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.update_card"]
+
+	params, _ := json.Marshal(map[string]string{"name": "Test"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.update_card",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing card_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateCard_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["trello.update_card"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "trello.update_card",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors/slack"
 	"github.com/supersuit-tech/permission-slip-web/connectors/square"
 	stripeconnector "github.com/supersuit-tech/permission-slip-web/connectors/stripe"
+	"github.com/supersuit-tech/permission-slip-web/connectors/trello"
 	"github.com/supersuit-tech/permission-slip-web/connectors/twilio"
 	"github.com/supersuit-tech/permission-slip-web/connectors/walmart"
 	xconnector "github.com/supersuit-tech/permission-slip-web/connectors/x"
@@ -351,6 +352,7 @@ func main() {
 	registry.Register(redisconnector.New())
 	registry.Register(square.New())
 	registry.Register(stripeconnector.New())
+	registry.Register(trello.New())
 	registry.Register(twilio.New())
 	registry.Register(walmart.New())
 	registry.Register(xconnector.New())


### PR DESCRIPTION
Implements the Trello connector using query-parameter auth (key + token) per the Trello REST API. Includes create_card, update_card, add_comment, move_card, create_checklist, and search_cards actions with full test coverage, manifest with JSON schemas, and configuration templates.

Closes #177

https://claude.ai/code/session_01XbCAJeUHgwN7sYX35aHFNZ