### PR TITLE
Add Calendly connector with API key auth

### DIFF
--- a/connectors/calendly/README.md
+++ b/connectors/calendly/README.md
@@ -1,0 +1,31 @@
+# Calendly Connector
+
+Calendly integration for scheduling, event types, and availability using the [Calendly API v2](https://developer.calendly.com/api-docs).
+
+## Authentication
+
+**Auth type:** `api_key` (personal access token)
+
+Generate a personal access token at:
+https://developer.calendly.com/how-to-authenticate-with-personal-access-tokens
+
+The token is sent as a `Bearer` token in the `Authorization` header.
+
+## Actions
+
+| Action | Risk | Description |
+|--------|------|-------------|
+| `calendly.list_event_types` | low | List scheduling event types (e.g., "30 min meeting") |
+| `calendly.create_scheduling_link` | low | Generate a single-use or reusable scheduling link |
+| `calendly.list_scheduled_events` | low | List upcoming/past events with filters and guest info |
+| `calendly.cancel_event` | medium | Cancel a scheduled event (sends cancellation email) |
+| `calendly.get_event` | low | Get full event details including attendees and location |
+| `calendly.list_available_times` | low | Check available time slots for a date range |
+
+## User URI
+
+Most Calendly list endpoints require a `user_uri` parameter (a full URI like `https://api.calendly.com/users/abc123`). The connector automatically fetches this from `GET /users/me` when needed. To avoid the extra API call, you can pass `user_uri` directly to `list_event_types` and `list_scheduled_events`.
+
+## Rate Limits
+
+Calendly allows 140 requests per 60 seconds. The connector maps 429 responses to `RateLimitError` with the `Retry-After` header value.

--- a/connectors/calendly/calendly.go
+++ b/connectors/calendly/calendly.go
@@ -1,0 +1,220 @@
+// Package calendly implements the Calendly connector for the Permission Slip
+// connector execution layer. It uses the Calendly REST API v2 with personal
+// access tokens (API key auth).
+package calendly
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+const (
+	defaultBaseURL = "https://api.calendly.com"
+	defaultTimeout = 30 * time.Second
+	credKeyAPIKey  = "api_key"
+
+	// defaultRetryAfter is used when Calendly returns a 429 without a
+	// Retry-After header (or an unparseable one).
+	defaultRetryAfter = 60 * time.Second
+
+	// maxResponseBytes caps the response body we'll read from Calendly APIs.
+	maxResponseBytes = 10 * 1024 * 1024 // 10 MB
+)
+
+// CalendlyConnector owns the shared HTTP client and base URL used by all
+// Calendly actions. Actions hold a pointer back to the connector to access
+// these shared resources.
+type CalendlyConnector struct {
+	client  *http.Client
+	baseURL string
+}
+
+// New creates a CalendlyConnector with sensible defaults.
+func New() *CalendlyConnector {
+	return &CalendlyConnector{
+		client:  &http.Client{Timeout: defaultTimeout},
+		baseURL: defaultBaseURL,
+	}
+}
+
+// newForTest creates a CalendlyConnector that points at a test server.
+func newForTest(client *http.Client, baseURL string) *CalendlyConnector {
+	return &CalendlyConnector{
+		client:  client,
+		baseURL: baseURL,
+	}
+}
+
+// ID returns "calendly", matching the connectors.id in the database.
+func (c *CalendlyConnector) ID() string { return "calendly" }
+
+// Actions returns the registered action handlers keyed by action_type.
+func (c *CalendlyConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"calendly.list_event_types":      &listEventTypesAction{conn: c},
+		"calendly.create_scheduling_link": &createSchedulingLinkAction{conn: c},
+		"calendly.list_scheduled_events":  &listScheduledEventsAction{conn: c},
+		"calendly.cancel_event":           &cancelEventAction{conn: c},
+		"calendly.get_event":              &getEventAction{conn: c},
+		"calendly.list_available_times":   &listAvailableTimesAction{conn: c},
+	}
+}
+
+// ValidateCredentials checks that the provided credentials contain a non-empty
+// api_key and tests it against GET /users/me.
+func (c *CalendlyConnector) ValidateCredentials(ctx context.Context, creds connectors.Credentials) error {
+	key, ok := creds.Get(credKeyAPIKey)
+	if !ok || key == "" {
+		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+	}
+
+	// Test the key against /users/me to verify it's valid.
+	var resp usersmeResponse
+	if err := c.doJSON(ctx, creds, http.MethodGet, c.baseURL+"/users/me", nil, &resp); err != nil {
+		return err
+	}
+
+	if resp.Resource.URI == "" {
+		return &connectors.ValidationError{Message: "Calendly API returned empty user URI"}
+	}
+
+	return nil
+}
+
+// usersmeResponse is the Calendly API response from GET /users/me.
+type usersmeResponse struct {
+	Resource struct {
+		URI  string `json:"uri"`
+		Name string `json:"name"`
+	} `json:"resource"`
+}
+
+// getUserURI calls GET /users/me and returns the authenticated user's URI.
+// Most Calendly list endpoints require this URI as a filter parameter.
+func (c *CalendlyConnector) getUserURI(ctx context.Context, creds connectors.Credentials) (string, error) {
+	var resp usersmeResponse
+	if err := c.doJSON(ctx, creds, http.MethodGet, c.baseURL+"/users/me", nil, &resp); err != nil {
+		return "", err
+	}
+	if resp.Resource.URI == "" {
+		return "", &connectors.ExternalError{Message: "Calendly API returned empty user URI from /users/me"}
+	}
+	return resp.Resource.URI, nil
+}
+
+// doJSON is the shared request lifecycle for Calendly API calls that send and
+// receive JSON. It marshals reqBody as JSON, sends the request with Bearer
+// token auth, handles rate limiting and timeouts, and unmarshals the
+// response into respBody.
+func (c *CalendlyConnector) doJSON(ctx context.Context, creds connectors.Credentials, method, url string, reqBody, respBody any) error {
+	token, ok := creds.Get(credKeyAPIKey)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+	}
+
+	var body io.Reader
+	if reqBody != nil {
+		payload, err := json.Marshal(reqBody)
+		if err != nil {
+			return &connectors.ExternalError{Message: fmt.Sprintf("marshaling request body: %v", err)}
+		}
+		body = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Calendly API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Calendly API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Calendly API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return err
+	}
+
+	if respBody != nil && len(respBytes) > 0 {
+		if err := json.Unmarshal(respBytes, respBody); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    "failed to decode Calendly API response",
+			}
+		}
+	}
+
+	return nil
+}
+
+// calendlyAPIError represents the error response format from the Calendly API.
+// Calendly returns {"title": "<string>", "message": "<string>"} on errors.
+type calendlyAPIError struct {
+	Title   string `json:"title"`
+	Message string `json:"message"`
+}
+
+// checkResponse maps HTTP status codes to typed connector errors.
+func checkResponse(statusCode int, header http.Header, body []byte) error {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+
+	var apiErr calendlyAPIError
+	msg := "Calendly API error"
+	if err := json.Unmarshal(body, &apiErr); err == nil {
+		if apiErr.Message != "" {
+			msg = apiErr.Message
+		} else if apiErr.Title != "" {
+			msg = apiErr.Title
+		}
+	}
+
+	switch {
+	case statusCode == http.StatusUnauthorized:
+		return &connectors.AuthError{Message: fmt.Sprintf("Calendly auth error: %s", msg)}
+	case statusCode == http.StatusForbidden:
+		return &connectors.AuthError{Message: fmt.Sprintf("Calendly permission denied: %s", msg)}
+	case statusCode == http.StatusTooManyRequests:
+		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    fmt.Sprintf("Calendly API rate limit exceeded: %s", msg),
+			RetryAfter: retryAfter,
+		}
+	case statusCode == http.StatusBadRequest:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Calendly API bad request: %s", msg)}
+	case statusCode == http.StatusUnprocessableEntity:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Calendly API validation error: %s", msg)}
+	case statusCode == http.StatusNotFound:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Calendly API not found: %s", msg)}
+	case statusCode == http.StatusConflict:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Calendly API conflict: %s", msg)}
+	default:
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Calendly API error (HTTP %d): %s", statusCode, msg),
+		}
+	}
+}

--- a/connectors/calendly/calendly.go
+++ b/connectors/calendly/calendly.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -134,7 +135,9 @@ func (c *CalendlyConnector) doJSON(ctx context.Context, creds connectors.Credent
 		return &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -167,6 +170,32 @@ func (c *CalendlyConnector) doJSON(ctx context.Context, creds connectors.Credent
 	}
 
 	return nil
+}
+
+// uuidPattern validates that an event UUID contains only safe characters.
+// Calendly UUIDs are alphanumeric with hyphens (e.g., "abc-123-def-456").
+var uuidPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// validateUUID checks that the given string is a safe UUID for use in URL paths.
+// This prevents path traversal attacks (e.g., "../../other-endpoint").
+func validateUUID(uuid string) error {
+	if !uuidPattern.MatchString(uuid) {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid event_uuid format: must contain only alphanumeric characters, hyphens, and underscores; got %q", uuid),
+		}
+	}
+	return nil
+}
+
+// resolveUserURI returns the user URI to use for API calls. If userURI is
+// provided (non-empty), it is returned directly — this allows callers to
+// skip the extra GET /users/me round-trip when they already have the URI.
+// Otherwise, it fetches the URI from the API.
+func (c *CalendlyConnector) resolveUserURI(ctx context.Context, creds connectors.Credentials, userURI string) (string, error) {
+	if userURI != "" {
+		return userURI, nil
+	}
+	return c.getUserURI(ctx, creds)
 }
 
 // calendlyAPIError represents the error response format from the Calendly API.

--- a/connectors/calendly/calendly_test.go
+++ b/connectors/calendly/calendly_test.go
@@ -219,7 +219,8 @@ func TestDoJSON_PostWithBody(t *testing.T) {
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decoding request body: %v", err)
+			t.Errorf("decoding request body: %v", err)
+			return
 		}
 		if body["owner_type"] != "EventType" {
 			t.Errorf("body owner_type = %q, want %q", body["owner_type"], "EventType")

--- a/connectors/calendly/calendly_test.go
+++ b/connectors/calendly/calendly_test.go
@@ -1,0 +1,418 @@
+package calendly
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCalendlyConnector_ID(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.ID() != "calendly" {
+		t.Errorf("expected ID 'calendly', got %q", c.ID())
+	}
+}
+
+func TestCalendlyConnector_Actions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	expected := []string{
+		"calendly.list_event_types",
+		"calendly.create_scheduling_link",
+		"calendly.list_scheduled_events",
+		"calendly.cancel_event",
+		"calendly.get_event",
+		"calendly.list_available_times",
+	}
+	for _, name := range expected {
+		if _, ok := actions[name]; !ok {
+			t.Errorf("expected action %q to be registered", name)
+		}
+	}
+
+	if len(actions) != len(expected) {
+		t.Errorf("expected %d actions, got %d", len(expected), len(actions))
+	}
+}
+
+func TestCalendlyConnector_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(usersmeResponse{
+			Resource: struct {
+				URI  string `json:"uri"`
+				Name string `json:"name"`
+			}{URI: "https://api.calendly.com/users/abc123", Name: "Test User"},
+		})
+	}))
+	defer srv.Close()
+
+	c := newForTest(srv.Client(), srv.URL)
+
+	err := c.ValidateCredentials(t.Context(), validCreds())
+	if err != nil {
+		t.Errorf("ValidateCredentials() returned error: %v", err)
+	}
+}
+
+func TestCalendlyConnector_ValidateCredentials_MissingKey(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	tests := []struct {
+		name    string
+		creds   connectors.Credentials
+		wantErr bool
+	}{
+		{
+			name:    "missing api_key",
+			creds:   connectors.NewCredentials(map[string]string{}),
+			wantErr: true,
+		},
+		{
+			name:    "empty api_key",
+			creds:   connectors.NewCredentials(map[string]string{"api_key": ""}),
+			wantErr: true,
+		},
+		{
+			name:    "zero-value credentials",
+			creds:   connectors.Credentials{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.ValidateCredentials(t.Context(), tt.creds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("ValidateCredentials() returned %T, want *connectors.ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestCalendlyConnector_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+	var _ connectors.Connector = (*CalendlyConnector)(nil)
+	var _ connectors.ManifestProvider = (*CalendlyConnector)(nil)
+}
+
+func TestCalendlyConnector_Manifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+
+	if m.ID != "calendly" {
+		t.Errorf("Manifest().ID = %q, want %q", m.ID, "calendly")
+	}
+	if m.Name != "Calendly" {
+		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Calendly")
+	}
+	if len(m.Actions) != 6 {
+		t.Fatalf("Manifest().Actions has %d items, want 6", len(m.Actions))
+	}
+
+	actionTypes := make(map[string]bool)
+	for _, a := range m.Actions {
+		actionTypes[a.ActionType] = true
+	}
+	for _, want := range []string{
+		"calendly.list_event_types",
+		"calendly.create_scheduling_link",
+		"calendly.list_scheduled_events",
+		"calendly.cancel_event",
+		"calendly.get_event",
+		"calendly.list_available_times",
+	} {
+		if !actionTypes[want] {
+			t.Errorf("Manifest().Actions missing %q", want)
+		}
+	}
+
+	if len(m.RequiredCredentials) != 1 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	}
+	cred := m.RequiredCredentials[0]
+	if cred.Service != "calendly" {
+		t.Errorf("credential service = %q, want %q", cred.Service, "calendly")
+	}
+	if cred.AuthType != "api_key" {
+		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "api_key")
+	}
+
+	if err := m.Validate(); err != nil {
+		t.Errorf("Manifest().Validate() = %v", err)
+	}
+}
+
+func TestCalendlyConnector_ActionsMatchManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+	manifest := c.Manifest()
+
+	manifestTypes := make(map[string]bool, len(manifest.Actions))
+	for _, a := range manifest.Actions {
+		manifestTypes[a.ActionType] = true
+	}
+
+	for actionType := range actions {
+		if !manifestTypes[actionType] {
+			t.Errorf("Actions() has %q but Manifest() does not", actionType)
+		}
+	}
+	for _, a := range manifest.Actions {
+		if _, ok := actions[a.ActionType]; !ok {
+			t.Errorf("Manifest() has %q but Actions() does not", a.ActionType)
+		}
+	}
+}
+
+func TestDoJSON_Success(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-calendly-api-key-123" {
+			t.Errorf("unexpected Authorization header: %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Path != "/users/me" {
+			t.Errorf("unexpected path: %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"resource":{"uri":"https://api.calendly.com/users/abc123","name":"Test User"}}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp usersmeResponse
+
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/users/me", nil, &resp)
+	if err != nil {
+		t.Fatalf("doJSON() returned error: %v", err)
+	}
+	if resp.Resource.URI != "https://api.calendly.com/users/abc123" {
+		t.Errorf("resp.Resource.URI = %q, want %q", resp.Resource.URI, "https://api.calendly.com/users/abc123")
+	}
+}
+
+func TestDoJSON_PostWithBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %q", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected Content-Type: %q", r.Header.Get("Content-Type"))
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if body["owner_type"] != "EventType" {
+			t.Errorf("body owner_type = %q, want %q", body["owner_type"], "EventType")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"resource":{"booking_url":"https://calendly.com/d/abc","owner":"evt","owner_type":"EventType"}}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	reqBody := map[string]any{"owner_type": "EventType", "max_event_count": 1}
+	var resp calendlySchedulingLinkResponse
+
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodPost, srv.URL+"/scheduling_links", reqBody, &resp)
+	if err != nil {
+		t.Fatalf("doJSON() returned error: %v", err)
+	}
+	if resp.Resource.BookingURL != "https://calendly.com/d/abc" {
+		t.Errorf("resp.Resource.BookingURL = %q, want %q", resp.Resource.BookingURL, "https://calendly.com/d/abc")
+	}
+}
+
+func TestDoJSON_MissingToken(t *testing.T) {
+	t.Parallel()
+	conn := newForTest(http.DefaultClient, "http://localhost")
+	err := conn.doJSON(t.Context(), connectors.NewCredentials(map[string]string{}), http.MethodGet, "http://localhost/test", nil, nil)
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_AuthError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"title":"Unauthenticated","message":"Invalid token."}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/users/me", nil, &resp)
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_Forbidden(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"title":"Forbidden","message":"Insufficient permissions."}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/users/me", nil, &resp)
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError for 403, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_RateLimit(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"title":"Rate Limit Exceeded","message":"Too many requests."}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/event_types", nil, &resp)
+	if !connectors.IsRateLimitError(err) {
+		t.Fatalf("expected RateLimitError, got %T: %v", err, err)
+	}
+	var rle *connectors.RateLimitError
+	if connectors.AsRateLimitError(err, &rle) {
+		if rle.RetryAfter != 30*time.Second {
+			t.Errorf("RetryAfter = %v, want 30s", rle.RetryAfter)
+		}
+	}
+}
+
+func TestCheckResponse_BadRequest(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"title":"Invalid Argument","message":"Invalid parameter: start_time"}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/test", nil, &resp)
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 400, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_UnprocessableEntity(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"title":"Validation Error","message":"event_type is invalid"}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodPost, srv.URL+"/scheduling_links", map[string]any{}, &resp)
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 422, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"title":"Resource Not Found","message":"The scheduled event does not exist."}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/scheduled_events/999", nil, &resp)
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 404, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"title":"Internal Server Error","message":"Something went wrong"}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/users/me", nil, &resp)
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError for 500, got %T: %v", err, err)
+	}
+}
+
+func TestCheckResponse_RateLimitNoRetryAfter(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"title":"Rate Limit Exceeded","message":"Too many requests."}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/users/me", nil, &resp)
+	if !connectors.IsRateLimitError(err) {
+		t.Fatalf("expected RateLimitError, got %T: %v", err, err)
+	}
+	var rle *connectors.RateLimitError
+	if connectors.AsRateLimitError(err, &rle) {
+		if rle.RetryAfter != defaultRetryAfter {
+			t.Errorf("RetryAfter = %v, want default %v", rle.RetryAfter, defaultRetryAfter)
+		}
+	}
+}
+
+func TestCheckResponse_MalformedErrorBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `not json`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	var resp map[string]any
+	err := conn.doJSON(t.Context(), validCreds(), http.MethodGet, srv.URL+"/test", nil, &resp)
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 400 with malformed body, got %T: %v", err, err)
+	}
+}

--- a/connectors/calendly/cancel_event.go
+++ b/connectors/calendly/cancel_event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -55,7 +56,7 @@ func (a *cancelEventAction) Execute(ctx context.Context, req connectors.ActionRe
 	}
 
 	var resp calendlyCancelResponse
-	reqURL := fmt.Sprintf("%s/scheduled_events/%s/cancellation", a.conn.baseURL, params.EventUUID)
+	reqURL := a.conn.baseURL + "/scheduled_events/" + url.PathEscape(params.EventUUID) + "/cancellation"
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, reqURL, body, &resp); err != nil {
 		return nil, err
 	}

--- a/connectors/calendly/cancel_event.go
+++ b/connectors/calendly/cancel_event.go
@@ -24,6 +24,9 @@ func (p *cancelEventParams) validate() error {
 	if p.EventUUID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: event_uuid"}
 	}
+	if err := validateUUID(p.EventUUID); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/connectors/calendly/cancel_event.go
+++ b/connectors/calendly/cancel_event.go
@@ -1,0 +1,64 @@
+package calendly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// cancelEventAction implements connectors.Action for calendly.cancel_event.
+// It cancels an event via POST /scheduled_events/{uuid}/cancellation.
+type cancelEventAction struct {
+	conn *CalendlyConnector
+}
+
+type cancelEventParams struct {
+	EventUUID string `json:"event_uuid"`
+	Reason    string `json:"reason"`
+}
+
+func (p *cancelEventParams) validate() error {
+	if p.EventUUID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: event_uuid"}
+	}
+	return nil
+}
+
+type calendlyCancelRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+type calendlyCancelResponse struct {
+	Resource struct {
+		CanceledBy string `json:"canceled_by"`
+		Reason     string `json:"reason"`
+	} `json:"resource"`
+}
+
+func (a *cancelEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params cancelEventParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := calendlyCancelRequest{
+		Reason: params.Reason,
+	}
+
+	var resp calendlyCancelResponse
+	reqURL := fmt.Sprintf("%s/scheduled_events/%s/cancellation", a.conn.baseURL, params.EventUUID)
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, reqURL, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"canceled_by": resp.Resource.CanceledBy,
+		"reason":      resp.Resource.Reason,
+	})
+}

--- a/connectors/calendly/cancel_event_test.go
+++ b/connectors/calendly/cancel_event_test.go
@@ -1,0 +1,109 @@
+package calendly
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCancelEvent_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/scheduled_events/ev-uuid-123/cancellation" {
+			t.Errorf("expected path /scheduled_events/ev-uuid-123/cancellation, got %s", r.URL.Path)
+		}
+
+		var body calendlyCancelRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if body.Reason != "Meeting no longer needed" {
+			t.Errorf("expected reason 'Meeting no longer needed', got %q", body.Reason)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(calendlyCancelResponse{
+			Resource: struct {
+				CanceledBy string `json:"canceled_by"`
+				Reason     string `json:"reason"`
+			}{
+				CanceledBy: "https://api.calendly.com/users/abc123",
+				Reason:     "Meeting no longer needed",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &cancelEventAction{conn: conn}
+
+	params, _ := json.Marshal(cancelEventParams{
+		EventUUID: "ev-uuid-123",
+		Reason:    "Meeting no longer needed",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.cancel_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["reason"] != "Meeting no longer needed" {
+		t.Errorf("unexpected reason: %v", data["reason"])
+	}
+}
+
+func TestCancelEvent_MissingEventUUID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &cancelEventAction{conn: conn}
+
+	params, _ := json.Marshal(cancelEventParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.cancel_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing event_uuid")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCancelEvent_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &cancelEventAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.cancel_event",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/calendly/cancel_event_test.go
+++ b/connectors/calendly/cancel_event_test.go
@@ -89,6 +89,27 @@ func TestCancelEvent_MissingEventUUID(t *testing.T) {
 	}
 }
 
+func TestCancelEvent_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &cancelEventAction{conn: conn}
+
+	params, _ := json.Marshal(cancelEventParams{EventUUID: "../../users/me"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.cancel_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal UUID")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestCancelEvent_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/calendly/cancel_event_test.go
+++ b/connectors/calendly/cancel_event_test.go
@@ -22,7 +22,8 @@ func TestCancelEvent_Success(t *testing.T) {
 
 		var body calendlyCancelRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decoding request body: %v", err)
+			t.Errorf("decoding request body: %v", err)
+			return
 		}
 		if body.Reason != "Meeting no longer needed" {
 			t.Errorf("expected reason 'Meeting no longer needed', got %q", body.Reason)

--- a/connectors/calendly/create_scheduling_link.go
+++ b/connectors/calendly/create_scheduling_link.go
@@ -1,0 +1,81 @@
+package calendly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createSchedulingLinkAction implements connectors.Action for calendly.create_scheduling_link.
+// It creates a scheduling link via POST /scheduling_links.
+type createSchedulingLinkAction struct {
+	conn *CalendlyConnector
+}
+
+type createSchedulingLinkParams struct {
+	EventTypeURI  string `json:"event_type_uri"`
+	MaxEventCount int    `json:"max_event_count"`
+	OwnerType     string `json:"owner_type"`
+}
+
+func (p *createSchedulingLinkParams) validate() error {
+	if p.EventTypeURI == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: event_type_uri"}
+	}
+	return nil
+}
+
+func (p *createSchedulingLinkParams) normalize() {
+	if p.MaxEventCount <= 0 {
+		p.MaxEventCount = 1
+	}
+	if p.OwnerType == "" {
+		p.OwnerType = "EventType"
+	}
+}
+
+type calendlySchedulingLinkRequest struct {
+	MaxEventCount int    `json:"max_event_count"`
+	Owner         string `json:"owner"`
+	OwnerType     string `json:"owner_type"`
+}
+
+type calendlySchedulingLinkResponse struct {
+	Resource struct {
+		BookingURL    string `json:"booking_url"`
+		Owner         string `json:"owner"`
+		OwnerType     string `json:"owner_type"`
+	} `json:"resource"`
+}
+
+func (a *createSchedulingLinkAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createSchedulingLinkParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.normalize()
+
+	body := calendlySchedulingLinkRequest{
+		MaxEventCount: params.MaxEventCount,
+		Owner:         params.EventTypeURI,
+		OwnerType:     params.OwnerType,
+	}
+
+	var resp calendlySchedulingLinkResponse
+	reqURL := a.conn.baseURL + "/scheduling_links"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, reqURL, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"booking_url": resp.Resource.BookingURL,
+		"owner":       resp.Resource.Owner,
+		"owner_type":  resp.Resource.OwnerType,
+	})
+}

--- a/connectors/calendly/create_scheduling_link_test.go
+++ b/connectors/calendly/create_scheduling_link_test.go
@@ -1,0 +1,116 @@
+package calendly
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateSchedulingLink_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/scheduling_links" {
+			t.Errorf("expected path /scheduling_links, got %s", r.URL.Path)
+		}
+
+		var body calendlySchedulingLinkRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if body.Owner != "https://api.calendly.com/event_types/et1" {
+			t.Errorf("expected owner to be event type URI, got %q", body.Owner)
+		}
+		if body.OwnerType != "EventType" {
+			t.Errorf("expected owner_type 'EventType', got %q", body.OwnerType)
+		}
+		if body.MaxEventCount != 1 {
+			t.Errorf("expected max_event_count 1, got %d", body.MaxEventCount)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(calendlySchedulingLinkResponse{
+			Resource: struct {
+				BookingURL string `json:"booking_url"`
+				Owner      string `json:"owner"`
+				OwnerType  string `json:"owner_type"`
+			}{
+				BookingURL: "https://calendly.com/d/abc-123-xyz/30min",
+				Owner:      "https://api.calendly.com/event_types/et1",
+				OwnerType:  "EventType",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createSchedulingLinkAction{conn: conn}
+
+	params, _ := json.Marshal(createSchedulingLinkParams{
+		EventTypeURI: "https://api.calendly.com/event_types/et1",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.create_scheduling_link",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["booking_url"] != "https://calendly.com/d/abc-123-xyz/30min" {
+		t.Errorf("unexpected booking_url: %v", data["booking_url"])
+	}
+}
+
+func TestCreateSchedulingLink_MissingEventTypeURI(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createSchedulingLinkAction{conn: conn}
+
+	params, _ := json.Marshal(createSchedulingLinkParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.create_scheduling_link",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing event_type_uri")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateSchedulingLink_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createSchedulingLinkAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.create_scheduling_link",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/calendly/create_scheduling_link_test.go
+++ b/connectors/calendly/create_scheduling_link_test.go
@@ -22,7 +22,8 @@ func TestCreateSchedulingLink_Success(t *testing.T) {
 
 		var body calendlySchedulingLinkRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decoding request body: %v", err)
+			t.Errorf("decoding request body: %v", err)
+			return
 		}
 		if body.Owner != "https://api.calendly.com/event_types/et1" {
 			t.Errorf("expected owner to be event type URI, got %q", body.Owner)

--- a/connectors/calendly/get_event.go
+++ b/connectors/calendly/get_event.go
@@ -23,6 +23,9 @@ func (p *getEventParams) validate() error {
 	if p.EventUUID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: event_uuid"}
 	}
+	if err := validateUUID(p.EventUUID); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -70,6 +73,9 @@ func (a *getEventAction) Execute(ctx context.Context, req connectors.ActionReque
 		"event_type": resp.Resource.EventType,
 		"created_at": resp.Resource.CreatedAt,
 		"updated_at": resp.Resource.UpdatedAt,
+	}
+	if resp.Resource.Location.Type != "" {
+		result["location_type"] = resp.Resource.Location.Type
 	}
 	if resp.Resource.Location.Location != "" {
 		result["location"] = resp.Resource.Location.Location

--- a/connectors/calendly/get_event.go
+++ b/connectors/calendly/get_event.go
@@ -32,21 +32,17 @@ func (p *getEventParams) validate() error {
 
 type calendlyGetEventResponse struct {
 	Resource struct {
-		URI       string `json:"uri"`
-		Name      string `json:"name"`
-		Status    string `json:"status"`
-		StartTime string `json:"start_time"`
-		EndTime   string `json:"end_time"`
-		EventType string `json:"event_type"`
-		Location  struct {
-			Type     string `json:"type"`
-			Location string `json:"location"`
-			JoinURL  string `json:"join_url"`
-		} `json:"location"`
-		CreatedAt        string                   `json:"created_at"`
-		UpdatedAt        string                   `json:"updated_at"`
-		EventMemberships []map[string]any         `json:"event_memberships"`
-		EventGuests      []calendlyScheduledGuest `json:"event_guests"`
+		URI              string           `json:"uri"`
+		Name             string           `json:"name"`
+		Status           string           `json:"status"`
+		StartTime        string           `json:"start_time"`
+		EndTime          string           `json:"end_time"`
+		EventType        string           `json:"event_type"`
+		Location         calendlyLocation `json:"location"`
+		CreatedAt        string           `json:"created_at"`
+		UpdatedAt        string           `json:"updated_at"`
+		EventMemberships []map[string]any `json:"event_memberships"`
+		EventGuests      []calendlyGuest  `json:"event_guests"`
 	} `json:"resource"`
 }
 

--- a/connectors/calendly/get_event.go
+++ b/connectors/calendly/get_event.go
@@ -1,0 +1,91 @@
+package calendly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getEventAction implements connectors.Action for calendly.get_event.
+// It gets event details via GET /scheduled_events/{uuid}.
+type getEventAction struct {
+	conn *CalendlyConnector
+}
+
+type getEventParams struct {
+	EventUUID string `json:"event_uuid"`
+}
+
+func (p *getEventParams) validate() error {
+	if p.EventUUID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: event_uuid"}
+	}
+	return nil
+}
+
+type calendlyGetEventResponse struct {
+	Resource struct {
+		URI       string `json:"uri"`
+		Name      string `json:"name"`
+		Status    string `json:"status"`
+		StartTime string `json:"start_time"`
+		EndTime   string `json:"end_time"`
+		EventType string `json:"event_type"`
+		Location  struct {
+			Type     string `json:"type"`
+			Location string `json:"location"`
+			JoinURL  string `json:"join_url"`
+		} `json:"location"`
+		CreatedAt        string                   `json:"created_at"`
+		UpdatedAt        string                   `json:"updated_at"`
+		EventMemberships []map[string]any         `json:"event_memberships"`
+		EventGuests      []calendlyScheduledGuest `json:"event_guests"`
+	} `json:"resource"`
+}
+
+func (a *getEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getEventParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	var resp calendlyGetEventResponse
+	reqURL := fmt.Sprintf("%s/scheduled_events/%s", a.conn.baseURL, params.EventUUID)
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, reqURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	result := map[string]any{
+		"uri":        resp.Resource.URI,
+		"name":       resp.Resource.Name,
+		"status":     resp.Resource.Status,
+		"start_time": resp.Resource.StartTime,
+		"end_time":   resp.Resource.EndTime,
+		"event_type": resp.Resource.EventType,
+		"created_at": resp.Resource.CreatedAt,
+		"updated_at": resp.Resource.UpdatedAt,
+	}
+	if resp.Resource.Location.Location != "" {
+		result["location"] = resp.Resource.Location.Location
+	}
+	if resp.Resource.Location.JoinURL != "" {
+		result["join_url"] = resp.Resource.Location.JoinURL
+	}
+	if len(resp.Resource.EventGuests) > 0 {
+		guests := make([]map[string]string, 0, len(resp.Resource.EventGuests))
+		for _, g := range resp.Resource.EventGuests {
+			guests = append(guests, map[string]string{
+				"email": g.Email,
+			})
+		}
+		result["guests"] = guests
+	}
+
+	return connectors.JSONResult(result)
+}

--- a/connectors/calendly/get_event.go
+++ b/connectors/calendly/get_event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -59,7 +60,7 @@ func (a *getEventAction) Execute(ctx context.Context, req connectors.ActionReque
 	}
 
 	var resp calendlyGetEventResponse
-	reqURL := fmt.Sprintf("%s/scheduled_events/%s", a.conn.baseURL, params.EventUUID)
+	reqURL := a.conn.baseURL + "/scheduled_events/" + url.PathEscape(params.EventUUID)
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, reqURL, nil, &resp); err != nil {
 		return nil, err
 	}

--- a/connectors/calendly/get_event_test.go
+++ b/connectors/calendly/get_event_test.go
@@ -1,0 +1,131 @@
+package calendly
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetEvent_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/scheduled_events/ev-uuid-123" {
+			t.Errorf("expected path /scheduled_events/ev-uuid-123, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := `{
+			"resource": {
+				"uri": "https://api.calendly.com/scheduled_events/ev-uuid-123",
+				"name": "30 Minute Meeting",
+				"status": "active",
+				"start_time": "2024-01-15T09:00:00.000000Z",
+				"end_time": "2024-01-15T09:30:00.000000Z",
+				"event_type": "https://api.calendly.com/event_types/et1",
+				"location": {
+					"type": "zoom",
+					"location": "https://zoom.us/j/123",
+					"join_url": "https://zoom.us/j/123"
+				},
+				"created_at": "2024-01-10T10:00:00.000000Z",
+				"updated_at": "2024-01-10T10:00:00.000000Z",
+				"event_guests": [
+					{"email": "guest@example.com", "created_at": "2024-01-10T10:00:00.000000Z", "updated_at": "2024-01-10T10:00:00.000000Z"}
+				]
+			}
+		}`
+		w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getEventAction{conn: conn}
+
+	params, _ := json.Marshal(getEventParams{EventUUID: "ev-uuid-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.get_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["name"] != "30 Minute Meeting" {
+		t.Errorf("unexpected name: %v", data["name"])
+	}
+	if data["status"] != "active" {
+		t.Errorf("unexpected status: %v", data["status"])
+	}
+	if data["join_url"] != "https://zoom.us/j/123" {
+		t.Errorf("unexpected join_url: %v", data["join_url"])
+	}
+
+	guests, ok := data["guests"].([]any)
+	if !ok {
+		t.Fatalf("expected guests to be array, got %T", data["guests"])
+	}
+	if len(guests) != 1 {
+		t.Fatalf("expected 1 guest, got %d", len(guests))
+	}
+}
+
+func TestGetEvent_MissingEventUUID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getEventAction{conn: conn}
+
+	params, _ := json.Marshal(getEventParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.get_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing event_uuid")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetEvent_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(calendlyAPIError{Title: "Resource Not Found", Message: "The event does not exist."})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getEventAction{conn: conn}
+
+	params, _ := json.Marshal(getEventParams{EventUUID: "nonexistent"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.get_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 404, got: %T", err)
+	}
+}

--- a/connectors/calendly/get_event_test.go
+++ b/connectors/calendly/get_event_test.go
@@ -72,6 +72,9 @@ func TestGetEvent_Success(t *testing.T) {
 	if data["join_url"] != "https://zoom.us/j/123" {
 		t.Errorf("unexpected join_url: %v", data["join_url"])
 	}
+	if data["location_type"] != "zoom" {
+		t.Errorf("unexpected location_type: %v", data["location_type"])
+	}
 
 	guests, ok := data["guests"].([]any)
 	if !ok {
@@ -97,6 +100,27 @@ func TestGetEvent_MissingEventUUID(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing event_uuid")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetEvent_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getEventAction{conn: conn}
+
+	params, _ := json.Marshal(getEventParams{EventUUID: "../../../users/me"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.get_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for path traversal UUID")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)

--- a/connectors/calendly/helpers_test.go
+++ b/connectors/calendly/helpers_test.go
@@ -1,0 +1,10 @@
+package calendly
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+// validCreds returns a Credentials value with a valid API key for tests.
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		"api_key": "test-calendly-api-key-123",
+	})
+}

--- a/connectors/calendly/list_available_times.go
+++ b/connectors/calendly/list_available_times.go
@@ -46,13 +46,6 @@ type calendlyAvailableTime struct {
 	SchedulingURL string `json:"scheduling_url"`
 }
 
-type availableTimeItem struct {
-	Status            string `json:"status"`
-	InviteesRemaining int    `json:"invitees_remaining"`
-	StartTime         string `json:"start_time"`
-	SchedulingURL     string `json:"scheduling_url"`
-}
-
 func (a *listAvailableTimesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params listAvailableTimesParams
 	if err := json.Unmarshal(req.Parameters, &params); err != nil {
@@ -73,18 +66,8 @@ func (a *listAvailableTimesAction) Execute(ctx context.Context, req connectors.A
 		return nil, err
 	}
 
-	items := make([]availableTimeItem, 0, len(resp.Collection))
-	for _, at := range resp.Collection {
-		items = append(items, availableTimeItem{
-			Status:            at.Status,
-			InviteesRemaining: at.InviteesRemaining,
-			StartTime:         at.StartTime,
-			SchedulingURL:     at.SchedulingURL,
-		})
-	}
-
 	return connectors.JSONResult(map[string]any{
-		"total_available_times": len(items),
-		"available_times":       items,
+		"total_available_times": len(resp.Collection),
+		"available_times":       resp.Collection,
 	})
 }

--- a/connectors/calendly/list_available_times.go
+++ b/connectors/calendly/list_available_times.go
@@ -1,0 +1,90 @@
+package calendly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listAvailableTimesAction implements connectors.Action for calendly.list_available_times.
+// It lists available time slots via GET /event_type_available_times.
+type listAvailableTimesAction struct {
+	conn *CalendlyConnector
+}
+
+type listAvailableTimesParams struct {
+	EventTypeURI string `json:"event_type_uri"`
+	StartTime    string `json:"start_time"`
+	EndTime      string `json:"end_time"`
+}
+
+func (p *listAvailableTimesParams) validate() error {
+	if p.EventTypeURI == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: event_type_uri"}
+	}
+	if p.StartTime == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: start_time"}
+	}
+	if p.EndTime == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: end_time"}
+	}
+	return nil
+}
+
+type calendlyAvailableTimesResponse struct {
+	Collection []calendlyAvailableTime `json:"collection"`
+}
+
+type calendlyAvailableTime struct {
+	Status        string `json:"status"`
+	InviteesRemaining int    `json:"invitees_remaining"`
+	StartTime     string `json:"start_time"`
+	SchedulingURL string `json:"scheduling_url"`
+}
+
+type availableTimeItem struct {
+	Status            string `json:"status"`
+	InviteesRemaining int    `json:"invitees_remaining"`
+	StartTime         string `json:"start_time"`
+	SchedulingURL     string `json:"scheduling_url"`
+}
+
+func (a *listAvailableTimesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listAvailableTimesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("event_type", params.EventTypeURI)
+	q.Set("start_time", params.StartTime)
+	q.Set("end_time", params.EndTime)
+
+	var resp calendlyAvailableTimesResponse
+	reqURL := a.conn.baseURL + "/event_type_available_times?" + q.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, reqURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	items := make([]availableTimeItem, 0, len(resp.Collection))
+	for _, at := range resp.Collection {
+		items = append(items, availableTimeItem{
+			Status:            at.Status,
+			InviteesRemaining: at.InviteesRemaining,
+			StartTime:         at.StartTime,
+			SchedulingURL:     at.SchedulingURL,
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"total_available_times": len(items),
+		"available_times":       items,
+	})
+}

--- a/connectors/calendly/list_available_times_test.go
+++ b/connectors/calendly/list_available_times_test.go
@@ -1,0 +1,139 @@
+package calendly
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListAvailableTimes_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/event_type_available_times" {
+			t.Errorf("expected path /event_type_available_times, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("event_type") == "" {
+			t.Error("expected event_type query param")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendlyAvailableTimesResponse{
+			Collection: []calendlyAvailableTime{
+				{
+					Status:            "available",
+					InviteesRemaining: 1,
+					StartTime:         "2024-01-15T09:00:00.000000Z",
+					SchedulingURL:     "https://calendly.com/testuser/30min?month=2024-01&date=2024-01-15",
+				},
+				{
+					Status:            "available",
+					InviteesRemaining: 1,
+					StartTime:         "2024-01-15T10:00:00.000000Z",
+					SchedulingURL:     "https://calendly.com/testuser/30min?month=2024-01&date=2024-01-15",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listAvailableTimesAction{conn: conn}
+
+	params, _ := json.Marshal(listAvailableTimesParams{
+		EventTypeURI: "https://api.calendly.com/event_types/et1",
+		StartTime:    "2024-01-15T00:00:00Z",
+		EndTime:      "2024-01-16T00:00:00Z",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_available_times",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		TotalAvailableTimes int                 `json:"total_available_times"`
+		AvailableTimes      []availableTimeItem `json:"available_times"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.AvailableTimes) != 2 {
+		t.Fatalf("expected 2 available times, got %d", len(data.AvailableTimes))
+	}
+	if data.AvailableTimes[0].Status != "available" {
+		t.Errorf("expected status 'available', got %q", data.AvailableTimes[0].Status)
+	}
+}
+
+func TestListAvailableTimes_MissingRequiredParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params listAvailableTimesParams
+	}{
+		{
+			name:   "missing event_type_uri",
+			params: listAvailableTimesParams{StartTime: "2024-01-15T00:00:00Z", EndTime: "2024-01-16T00:00:00Z"},
+		},
+		{
+			name:   "missing start_time",
+			params: listAvailableTimesParams{EventTypeURI: "https://api.calendly.com/event_types/et1", EndTime: "2024-01-16T00:00:00Z"},
+		},
+		{
+			name:   "missing end_time",
+			params: listAvailableTimesParams{EventTypeURI: "https://api.calendly.com/event_types/et1", StartTime: "2024-01-15T00:00:00Z"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := New()
+			action := &listAvailableTimesAction{conn: conn}
+
+			params, _ := json.Marshal(tt.params)
+
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "calendly.list_available_times",
+				Parameters:  params,
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("expected error for missing required param")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got: %T", err)
+			}
+		})
+	}
+}
+
+func TestListAvailableTimes_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listAvailableTimesAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_available_times",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/calendly/list_available_times_test.go
+++ b/connectors/calendly/list_available_times_test.go
@@ -63,7 +63,7 @@ func TestListAvailableTimes_Success(t *testing.T) {
 
 	var data struct {
 		TotalAvailableTimes int                 `json:"total_available_times"`
-		AvailableTimes      []availableTimeItem `json:"available_times"`
+		AvailableTimes      []calendlyAvailableTime `json:"available_times"`
 	}
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)

--- a/connectors/calendly/list_event_types.go
+++ b/connectors/calendly/list_event_types.go
@@ -1,0 +1,100 @@
+package calendly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listEventTypesAction implements connectors.Action for calendly.list_event_types.
+// It lists event types via GET /event_types?user={user_uri}.
+type listEventTypesAction struct {
+	conn *CalendlyConnector
+}
+
+type listEventTypesParams struct {
+	Active *bool `json:"active,omitempty"`
+}
+
+// calendlyEventTypesResponse is the Calendly API response from GET /event_types.
+type calendlyEventTypesResponse struct {
+	Collection []calendlyEventType `json:"collection"`
+}
+
+type calendlyEventType struct {
+	URI                string `json:"uri"`
+	Name               string `json:"name"`
+	Active             bool   `json:"active"`
+	Slug               string `json:"slug"`
+	SchedulingURL      string `json:"scheduling_url"`
+	Duration           int    `json:"duration"`
+	Kind               string `json:"kind"`
+	Type               string `json:"type"`
+	Color              string `json:"color"`
+	DescriptionPlain   string `json:"description_plain"`
+	InternalNote       string `json:"internal_note"`
+	PoolingType        string `json:"pooling_type"`
+	SecretEvent        bool   `json:"secret"`
+}
+
+type eventTypeItem struct {
+	URI           string `json:"uri"`
+	Name          string `json:"name"`
+	Active        bool   `json:"active"`
+	Slug          string `json:"slug"`
+	SchedulingURL string `json:"scheduling_url"`
+	Duration      int    `json:"duration"`
+	Kind          string `json:"kind"`
+	Description   string `json:"description,omitempty"`
+}
+
+func (a *listEventTypesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listEventTypesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+
+	userURI, err := a.conn.getUserURI(ctx, req.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("user", userURI)
+	if params.Active != nil {
+		if *params.Active {
+			q.Set("active", "true")
+		} else {
+			q.Set("active", "false")
+		}
+	}
+
+	var resp calendlyEventTypesResponse
+	reqURL := a.conn.baseURL + "/event_types?" + q.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, reqURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	items := make([]eventTypeItem, 0, len(resp.Collection))
+	for _, et := range resp.Collection {
+		items = append(items, eventTypeItem{
+			URI:           et.URI,
+			Name:          et.Name,
+			Active:        et.Active,
+			Slug:          et.Slug,
+			SchedulingURL: et.SchedulingURL,
+			Duration:      et.Duration,
+			Kind:          et.Kind,
+			Description:   et.DescriptionPlain,
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"total_event_types": len(items),
+		"event_types":       items,
+	})
+}

--- a/connectors/calendly/list_event_types.go
+++ b/connectors/calendly/list_event_types.go
@@ -17,7 +17,8 @@ type listEventTypesAction struct {
 }
 
 type listEventTypesParams struct {
-	Active *bool `json:"active,omitempty"`
+	UserURI string `json:"user_uri,omitempty"`
+	Active  *bool  `json:"active,omitempty"`
 }
 
 // calendlyEventTypesResponse is the Calendly API response from GET /event_types.
@@ -58,7 +59,7 @@ func (a *listEventTypesAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
 	}
 
-	userURI, err := a.conn.getUserURI(ctx, req.Credentials)
+	userURI, err := a.conn.resolveUserURI(ctx, req.Credentials, params.UserURI)
 	if err != nil {
 		return nil, err
 	}

--- a/connectors/calendly/list_event_types.go
+++ b/connectors/calendly/list_event_types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -67,11 +68,7 @@ func (a *listEventTypesAction) Execute(ctx context.Context, req connectors.Actio
 	q := url.Values{}
 	q.Set("user", userURI)
 	if params.Active != nil {
-		if *params.Active {
-			q.Set("active", "true")
-		} else {
-			q.Set("active", "false")
-		}
+		q.Set("active", strconv.FormatBool(*params.Active))
 	}
 
 	var resp calendlyEventTypesResponse

--- a/connectors/calendly/list_event_types_test.go
+++ b/connectors/calendly/list_event_types_test.go
@@ -1,0 +1,184 @@
+package calendly
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListEventTypes_Success(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// First call is /users/me
+			if r.URL.Path != "/users/me" {
+				t.Errorf("expected path /users/me, got %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(usersmeResponse{
+				Resource: struct {
+					URI  string `json:"uri"`
+					Name string `json:"name"`
+				}{URI: "https://api.calendly.com/users/abc123", Name: "Test User"},
+			})
+			return
+		}
+		// Second call is /event_types
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/event_types" {
+			t.Errorf("expected path /event_types, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("user") != "https://api.calendly.com/users/abc123" {
+			t.Errorf("expected user query param, got %s", r.URL.Query().Get("user"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendlyEventTypesResponse{
+			Collection: []calendlyEventType{
+				{
+					URI:              "https://api.calendly.com/event_types/et1",
+					Name:             "30 Minute Meeting",
+					Active:           true,
+					Slug:             "30min",
+					SchedulingURL:    "https://calendly.com/testuser/30min",
+					Duration:         30,
+					Kind:             "solo",
+					DescriptionPlain: "A quick 30 minute chat",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listEventTypesAction{conn: conn}
+
+	params, _ := json.Marshal(listEventTypesParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_event_types",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		TotalEventTypes int             `json:"total_event_types"`
+		EventTypes      []eventTypeItem `json:"event_types"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.EventTypes) != 1 {
+		t.Fatalf("expected 1 event type, got %d", len(data.EventTypes))
+	}
+	if data.EventTypes[0].Name != "30 Minute Meeting" {
+		t.Errorf("expected name '30 Minute Meeting', got %q", data.EventTypes[0].Name)
+	}
+	if data.EventTypes[0].Duration != 30 {
+		t.Errorf("expected duration 30, got %d", data.EventTypes[0].Duration)
+	}
+}
+
+func TestListEventTypes_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(usersmeResponse{
+				Resource: struct {
+					URI  string `json:"uri"`
+					Name string `json:"name"`
+				}{URI: "https://api.calendly.com/users/abc123", Name: "Test User"},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendlyEventTypesResponse{Collection: nil})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listEventTypesAction{conn: conn}
+
+	params, _ := json.Marshal(listEventTypesParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_event_types",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		TotalEventTypes int             `json:"total_event_types"`
+		EventTypes      []eventTypeItem `json:"event_types"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.EventTypes) != 0 {
+		t.Errorf("expected 0 event types, got %d", len(data.EventTypes))
+	}
+}
+
+func TestListEventTypes_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(calendlyAPIError{Title: "Unauthenticated", Message: "Invalid token."})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listEventTypesAction{conn: conn}
+
+	params, _ := json.Marshal(listEventTypesParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_event_types",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestListEventTypes_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listEventTypesAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_event_types",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/calendly/list_event_types_test.go
+++ b/connectors/calendly/list_event_types_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -12,10 +13,10 @@ import (
 func TestListEventTypes_Success(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
+	callCount := int32(0)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if callCount == 1 {
+		c := atomic.AddInt32(&callCount, 1)
+		if c == 1 {
 			// First call is /users/me
 			if r.URL.Path != "/users/me" {
 				t.Errorf("expected path /users/me, got %s", r.URL.Path)
@@ -93,10 +94,10 @@ func TestListEventTypes_Success(t *testing.T) {
 func TestListEventTypes_EmptyResult(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
+	callCount := int32(0)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if callCount == 1 {
+		c := atomic.AddInt32(&callCount, 1)
+		if c == 1 {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(usersmeResponse{
 				Resource: struct {

--- a/connectors/calendly/list_scheduled_events.go
+++ b/connectors/calendly/list_scheduled_events.go
@@ -52,26 +52,17 @@ type calendlyScheduledEventsResponse struct {
 }
 
 type calendlyScheduledEvent struct {
-	URI       string `json:"uri"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
-	StartTime string `json:"start_time"`
-	EndTime   string `json:"end_time"`
-	EventType string `json:"event_type"`
-	Location  struct {
-		Type     string `json:"type"`
-		Location string `json:"location"`
-	} `json:"location"`
-	CreatedAt        string                   `json:"created_at"`
-	UpdatedAt        string                   `json:"updated_at"`
-	EventMemberships []map[string]any         `json:"event_memberships"`
-	EventGuests      []calendlyScheduledGuest `json:"event_guests"`
-}
-
-type calendlyScheduledGuest struct {
-	Email     string `json:"email"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	URI              string           `json:"uri"`
+	Name             string           `json:"name"`
+	Status           string           `json:"status"`
+	StartTime        string           `json:"start_time"`
+	EndTime          string           `json:"end_time"`
+	EventType        string           `json:"event_type"`
+	Location         calendlyLocation `json:"location"`
+	CreatedAt        string           `json:"created_at"`
+	UpdatedAt        string           `json:"updated_at"`
+	EventMemberships []map[string]any `json:"event_memberships"`
+	EventGuests      []calendlyGuest  `json:"event_guests"`
 }
 
 type scheduledEventItem struct {

--- a/connectors/calendly/list_scheduled_events.go
+++ b/connectors/calendly/list_scheduled_events.go
@@ -18,6 +18,7 @@ type listScheduledEventsAction struct {
 }
 
 type listScheduledEventsParams struct {
+	UserURI      string `json:"user_uri,omitempty"`
 	MinStartTime string `json:"min_start_time"`
 	MaxStartTime string `json:"max_start_time"`
 	Status       string `json:"status"`
@@ -74,13 +75,15 @@ type calendlyScheduledGuest struct {
 }
 
 type scheduledEventItem struct {
-	URI       string `json:"uri"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
-	StartTime string `json:"start_time"`
-	EndTime   string `json:"end_time"`
-	EventType string `json:"event_type"`
-	Location  string `json:"location,omitempty"`
+	URI        string   `json:"uri"`
+	Name       string   `json:"name"`
+	Status     string   `json:"status"`
+	StartTime  string   `json:"start_time"`
+	EndTime    string   `json:"end_time"`
+	EventType  string   `json:"event_type"`
+	Location   string   `json:"location,omitempty"`
+	GuestCount int      `json:"guest_count"`
+	Guests     []string `json:"guests,omitempty"`
 }
 
 func (a *listScheduledEventsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
@@ -93,7 +96,7 @@ func (a *listScheduledEventsAction) Execute(ctx context.Context, req connectors.
 	}
 	params.normalize()
 
-	userURI, err := a.conn.getUserURI(ctx, req.Credentials)
+	userURI, err := a.conn.resolveUserURI(ctx, req.Credentials, params.UserURI)
 	if err != nil {
 		return nil, err
 	}
@@ -120,13 +123,17 @@ func (a *listScheduledEventsAction) Execute(ctx context.Context, req connectors.
 	items := make([]scheduledEventItem, 0, len(resp.Collection))
 	for _, ev := range resp.Collection {
 		item := scheduledEventItem{
-			URI:       ev.URI,
-			Name:      ev.Name,
-			Status:    ev.Status,
-			StartTime: ev.StartTime,
-			EndTime:   ev.EndTime,
-			EventType: ev.EventType,
-			Location:  ev.Location.Location,
+			URI:        ev.URI,
+			Name:       ev.Name,
+			Status:     ev.Status,
+			StartTime:  ev.StartTime,
+			EndTime:    ev.EndTime,
+			EventType:  ev.EventType,
+			Location:   ev.Location.Location,
+			GuestCount: len(ev.EventGuests),
+		}
+		for _, g := range ev.EventGuests {
+			item.Guests = append(item.Guests, g.Email)
 		}
 		items = append(items, item)
 	}

--- a/connectors/calendly/list_scheduled_events.go
+++ b/connectors/calendly/list_scheduled_events.go
@@ -1,0 +1,138 @@
+package calendly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listScheduledEventsAction implements connectors.Action for calendly.list_scheduled_events.
+// It lists scheduled events via GET /scheduled_events?user={user_uri}.
+type listScheduledEventsAction struct {
+	conn *CalendlyConnector
+}
+
+type listScheduledEventsParams struct {
+	MinStartTime string `json:"min_start_time"`
+	MaxStartTime string `json:"max_start_time"`
+	Status       string `json:"status"`
+	Count        int    `json:"count"`
+}
+
+var validEventStatuses = map[string]bool{
+	"active":   true,
+	"canceled": true,
+}
+
+func (p *listScheduledEventsParams) validate() error {
+	if p.Status != "" && !validEventStatuses[p.Status] {
+		return &connectors.ValidationError{Message: fmt.Sprintf("status must be one of: active, canceled; got %q", p.Status)}
+	}
+	return nil
+}
+
+func (p *listScheduledEventsParams) normalize() {
+	if p.Count <= 0 {
+		p.Count = 20
+	}
+	if p.Count > 100 {
+		p.Count = 100
+	}
+}
+
+// calendlyScheduledEventsResponse is the Calendly API response from GET /scheduled_events.
+type calendlyScheduledEventsResponse struct {
+	Collection []calendlyScheduledEvent `json:"collection"`
+}
+
+type calendlyScheduledEvent struct {
+	URI       string `json:"uri"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+	EventType string `json:"event_type"`
+	Location  struct {
+		Type     string `json:"type"`
+		Location string `json:"location"`
+	} `json:"location"`
+	CreatedAt        string                   `json:"created_at"`
+	UpdatedAt        string                   `json:"updated_at"`
+	EventMemberships []map[string]any         `json:"event_memberships"`
+	EventGuests      []calendlyScheduledGuest `json:"event_guests"`
+}
+
+type calendlyScheduledGuest struct {
+	Email     string `json:"email"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type scheduledEventItem struct {
+	URI       string `json:"uri"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+	EventType string `json:"event_type"`
+	Location  string `json:"location,omitempty"`
+}
+
+func (a *listScheduledEventsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listScheduledEventsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	params.normalize()
+
+	userURI, err := a.conn.getUserURI(ctx, req.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("user", userURI)
+	q.Set("count", strconv.Itoa(params.Count))
+	if params.MinStartTime != "" {
+		q.Set("min_start_time", params.MinStartTime)
+	}
+	if params.MaxStartTime != "" {
+		q.Set("max_start_time", params.MaxStartTime)
+	}
+	if params.Status != "" {
+		q.Set("status", params.Status)
+	}
+
+	var resp calendlyScheduledEventsResponse
+	reqURL := a.conn.baseURL + "/scheduled_events?" + q.Encode()
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, reqURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	items := make([]scheduledEventItem, 0, len(resp.Collection))
+	for _, ev := range resp.Collection {
+		item := scheduledEventItem{
+			URI:       ev.URI,
+			Name:      ev.Name,
+			Status:    ev.Status,
+			StartTime: ev.StartTime,
+			EndTime:   ev.EndTime,
+			EventType: ev.EventType,
+			Location:  ev.Location.Location,
+		}
+		items = append(items, item)
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"total_events": len(items),
+		"events":       items,
+	})
+}

--- a/connectors/calendly/list_scheduled_events_test.go
+++ b/connectors/calendly/list_scheduled_events_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -12,10 +13,10 @@ import (
 func TestListScheduledEvents_Success(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
+	callCount := int32(0)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if callCount == 1 {
+		c := atomic.AddInt32(&callCount, 1)
+		if c == 1 {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(usersmeResponse{
 				Resource: struct {
@@ -46,7 +47,7 @@ func TestListScheduledEvents_Success(t *testing.T) {
 					StartTime: "2024-01-15T09:00:00.000000Z",
 					EndTime:   "2024-01-15T09:30:00.000000Z",
 					EventType: "https://api.calendly.com/event_types/et1",
-					EventGuests: []calendlyScheduledGuest{
+					EventGuests: []calendlyGuest{
 						{Email: "guest@example.com"},
 					},
 				},

--- a/connectors/calendly/list_scheduled_events_test.go
+++ b/connectors/calendly/list_scheduled_events_test.go
@@ -1,0 +1,125 @@
+package calendly
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListScheduledEvents_Success(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(usersmeResponse{
+				Resource: struct {
+					URI  string `json:"uri"`
+					Name string `json:"name"`
+				}{URI: "https://api.calendly.com/users/abc123", Name: "Test User"},
+			})
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/scheduled_events" {
+			t.Errorf("expected path /scheduled_events, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("status") != "active" {
+			t.Errorf("expected status=active, got %s", r.URL.Query().Get("status"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(calendlyScheduledEventsResponse{
+			Collection: []calendlyScheduledEvent{
+				{
+					URI:       "https://api.calendly.com/scheduled_events/ev1",
+					Name:      "30 Minute Meeting",
+					Status:    "active",
+					StartTime: "2024-01-15T09:00:00.000000Z",
+					EndTime:   "2024-01-15T09:30:00.000000Z",
+					EventType: "https://api.calendly.com/event_types/et1",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listScheduledEventsAction{conn: conn}
+
+	params, _ := json.Marshal(listScheduledEventsParams{Status: "active"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_scheduled_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		TotalEvents int                  `json:"total_events"`
+		Events      []scheduledEventItem `json:"events"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(data.Events))
+	}
+	if data.Events[0].Name != "30 Minute Meeting" {
+		t.Errorf("expected name '30 Minute Meeting', got %q", data.Events[0].Name)
+	}
+	if data.Events[0].Status != "active" {
+		t.Errorf("expected status 'active', got %q", data.Events[0].Status)
+	}
+}
+
+func TestListScheduledEvents_InvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listScheduledEventsAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"status": "invalid"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_scheduled_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid status")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListScheduledEvents_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listScheduledEventsAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "calendly.list_scheduled_events",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/calendly/list_scheduled_events_test.go
+++ b/connectors/calendly/list_scheduled_events_test.go
@@ -46,6 +46,9 @@ func TestListScheduledEvents_Success(t *testing.T) {
 					StartTime: "2024-01-15T09:00:00.000000Z",
 					EndTime:   "2024-01-15T09:30:00.000000Z",
 					EventType: "https://api.calendly.com/event_types/et1",
+					EventGuests: []calendlyScheduledGuest{
+						{Email: "guest@example.com"},
+					},
 				},
 			},
 		})
@@ -81,6 +84,12 @@ func TestListScheduledEvents_Success(t *testing.T) {
 	}
 	if data.Events[0].Status != "active" {
 		t.Errorf("expected status 'active', got %q", data.Events[0].Status)
+	}
+	if data.Events[0].GuestCount != 1 {
+		t.Errorf("expected guest_count 1, got %d", data.Events[0].GuestCount)
+	}
+	if len(data.Events[0].Guests) != 1 || data.Events[0].Guests[0] != "guest@example.com" {
+		t.Errorf("expected guests [guest@example.com], got %v", data.Events[0].Guests)
 	}
 }
 

--- a/connectors/calendly/manifest.go
+++ b/connectors/calendly/manifest.go
@@ -1,0 +1,204 @@
+package calendly
+
+import (
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// Manifest returns the connector's metadata manifest. Used by the server to
+// auto-seed DB rows on startup.
+func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "calendly",
+		Name:        "Calendly",
+		Description: "Calendly integration for scheduling, event types, and availability",
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "calendly.list_event_types",
+				Name:        "List Event Types",
+				Description: "List available scheduling event types (e.g., \"30 min meeting\", \"1 hour consultation\")",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"active": {
+							"type": "boolean",
+							"description": "Filter by active status. If omitted, returns all event types."
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "calendly.create_scheduling_link",
+				Name:        "Create Scheduling Link",
+				Description: "Generate a single-use or reusable scheduling link for a specific event type",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["event_type_uri"],
+					"properties": {
+						"event_type_uri": {
+							"type": "string",
+							"description": "The URI of the event type to create a scheduling link for"
+						},
+						"max_event_count": {
+							"type": "integer",
+							"default": 1,
+							"minimum": 1,
+							"description": "Maximum number of events that can be scheduled using this link (default 1)"
+						},
+						"owner_type": {
+							"type": "string",
+							"enum": ["EventType"],
+							"default": "EventType",
+							"description": "The type of the owner of the scheduling link"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "calendly.list_scheduled_events",
+				Name:        "List Scheduled Events",
+				Description: "List upcoming/past scheduled events with attendee details",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"min_start_time": {
+							"type": "string",
+							"description": "Only return events starting at or after this time (ISO 8601 format)"
+						},
+						"max_start_time": {
+							"type": "string",
+							"description": "Only return events starting before this time (ISO 8601 format)"
+						},
+						"status": {
+							"type": "string",
+							"enum": ["active", "canceled"],
+							"description": "Filter by event status"
+						},
+						"count": {
+							"type": "integer",
+							"default": 20,
+							"minimum": 1,
+							"maximum": 100,
+							"description": "Number of events to return (1-100, default 20)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "calendly.cancel_event",
+				Name:        "Cancel Event",
+				Description: "Cancel a scheduled event — sends a cancellation email to all participants",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["event_uuid"],
+					"properties": {
+						"event_uuid": {
+							"type": "string",
+							"description": "The UUID of the scheduled event to cancel"
+						},
+						"reason": {
+							"type": "string",
+							"description": "Cancellation reason text (sent to participants)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "calendly.get_event",
+				Name:        "Get Event Details",
+				Description: "Get full details of a specific scheduled event including attendees, location, and start/end times",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["event_uuid"],
+					"properties": {
+						"event_uuid": {
+							"type": "string",
+							"description": "The UUID of the scheduled event to retrieve"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "calendly.list_available_times",
+				Name:        "List Available Times",
+				Description: "Check available time slots for a given event type and date range",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["event_type_uri", "start_time", "end_time"],
+					"properties": {
+						"event_type_uri": {
+							"type": "string",
+							"description": "The URI of the event type to check availability for"
+						},
+						"start_time": {
+							"type": "string",
+							"description": "Start of the time range to check (ISO 8601 format)"
+						},
+						"end_time": {
+							"type": "string",
+							"description": "End of the time range to check (ISO 8601 format)"
+						}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{
+				Service:         "calendly",
+				AuthType:        "api_key",
+				InstructionsURL: "https://developer.calendly.com/how-to-authenticate-with-personal-access-tokens",
+			},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_calendly_list_event_types",
+				ActionType:  "calendly.list_event_types",
+				Name:        "List active event types",
+				Description: "Agent can list active scheduling event types.",
+				Parameters:  json.RawMessage(`{"active":"*"}`),
+			},
+			{
+				ID:          "tpl_calendly_create_scheduling_link",
+				ActionType:  "calendly.create_scheduling_link",
+				Name:        "Share scheduling link for 30-min meeting",
+				Description: "Agent can generate a single-use scheduling link for any event type.",
+				Parameters:  json.RawMessage(`{"event_type_uri":"*","max_event_count":"*","owner_type":"*"}`),
+			},
+			{
+				ID:          "tpl_calendly_list_scheduled_events",
+				ActionType:  "calendly.list_scheduled_events",
+				Name:        "List upcoming events",
+				Description: "Agent can list upcoming scheduled events.",
+				Parameters:  json.RawMessage(`{"min_start_time":"*","max_start_time":"*","status":"*","count":"*"}`),
+			},
+			{
+				ID:          "tpl_calendly_cancel_event",
+				ActionType:  "calendly.cancel_event",
+				Name:        "Cancel a scheduled event",
+				Description: "Agent can cancel scheduled events with a reason.",
+				Parameters:  json.RawMessage(`{"event_uuid":"*","reason":"*"}`),
+			},
+			{
+				ID:          "tpl_calendly_get_event",
+				ActionType:  "calendly.get_event",
+				Name:        "View event details",
+				Description: "Agent can view details of any scheduled event.",
+				Parameters:  json.RawMessage(`{"event_uuid":"*"}`),
+			},
+			{
+				ID:          "tpl_calendly_list_available_times",
+				ActionType:  "calendly.list_available_times",
+				Name:        "Check my availability this week",
+				Description: "Agent can check available time slots for any event type.",
+				Parameters:  json.RawMessage(`{"event_type_uri":"*","start_time":"*","end_time":"*"}`),
+			},
+		},
+	}
+}

--- a/connectors/calendly/manifest.go
+++ b/connectors/calendly/manifest.go
@@ -22,6 +22,10 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
+						"user_uri": {
+							"type": "string",
+							"description": "The user URI to list event types for. If omitted, fetches automatically from /users/me. Pass this to avoid an extra API call if you already have the URI."
+						},
 						"active": {
 							"type": "boolean",
 							"description": "Filter by active status. If omitted, returns all event types."
@@ -65,6 +69,10 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
+						"user_uri": {
+							"type": "string",
+							"description": "The user URI to list events for. If omitted, fetches automatically from /users/me. Pass this to avoid an extra API call if you already have the URI."
+						},
 						"min_start_time": {
 							"type": "string",
 							"description": "Only return events starting at or after this time (ISO 8601 format)"
@@ -162,7 +170,7 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "calendly.list_event_types",
 				Name:        "List active event types",
 				Description: "Agent can list active scheduling event types.",
-				Parameters:  json.RawMessage(`{"active":"*"}`),
+				Parameters:  json.RawMessage(`{"user_uri":"*","active":"*"}`),
 			},
 			{
 				ID:          "tpl_calendly_create_scheduling_link",
@@ -176,7 +184,7 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "calendly.list_scheduled_events",
 				Name:        "List upcoming events",
 				Description: "Agent can list upcoming scheduled events.",
-				Parameters:  json.RawMessage(`{"min_start_time":"*","max_start_time":"*","status":"*","count":"*"}`),
+				Parameters:  json.RawMessage(`{"user_uri":"*","min_start_time":"*","max_start_time":"*","status":"*","count":"*"}`),
 			},
 			{
 				ID:          "tpl_calendly_cancel_event",

--- a/connectors/calendly/types.go
+++ b/connectors/calendly/types.go
@@ -1,0 +1,17 @@
+package calendly
+
+// Shared Calendly API response types used across multiple action files.
+
+// calendlyLocation represents the location object in Calendly event responses.
+type calendlyLocation struct {
+	Type     string `json:"type"`
+	Location string `json:"location"`
+	JoinURL  string `json:"join_url"`
+}
+
+// calendlyGuest represents an event guest/invitee in Calendly event responses.
+type calendlyGuest struct {
+	Email     string `json:"email"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/api"
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/connectors/amadeus"
+	"github.com/supersuit-tech/permission-slip-web/connectors/calendly"
 	"github.com/supersuit-tech/permission-slip-web/connectors/doordash"
 	"github.com/supersuit-tech/permission-slip-web/connectors/expedia"
 	ghconnector "github.com/supersuit-tech/permission-slip-web/connectors/github"
@@ -359,6 +360,7 @@ func main() {
 	registry.Register(doordash.New())
 	registry.Register(expedia.New())
 	registry.Register(zoom.New())
+	registry.Register(calendly.New())
 
 	// Auto-seed built-in connectors from their manifests.
 	if deps.DB != nil {


### PR DESCRIPTION
Implements the Calendly connector using the Calendly REST API v2 with personal access token authentication. Includes all 6 actions from #178:

- list_event_types: List scheduling event types
- create_scheduling_link: Generate single-use/reusable scheduling links
- list_scheduled_events: List upcoming/past events with filters
- cancel_event: Cancel a scheduled event (medium risk)
- get_event: Get full event details with attendees and location
- list_available_times: Check availability for a date range

Each action has comprehensive tests covering success, validation errors, auth failures, and edge cases. The connector uses Bearer token auth, maps Calendly's error format (title/message) to typed connector errors, and fetches the user URI from /users/me for list endpoints.

Closes #178

https://claude.ai/code/session_01YThcbLZUMiZnsF8kQMivpu