### PR TITLE
Add Shopify actions: fulfill_order, cancel_order, update_product, create_collection, get_analytics

### DIFF
--- a/connectors/shopify/cancel_order.go
+++ b/connectors/shopify/cancel_order.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -40,10 +42,22 @@ func (p *cancelOrderParams) validate() error {
 	}
 	if p.Reason != "" && !validCancelReasons[p.Reason] {
 		return &connectors.ValidationError{
-			Message: fmt.Sprintf("invalid reason %q: must be customer, fraud, inventory, declined, or other", p.Reason),
+			Message: fmt.Sprintf("invalid reason %q: must be one of %s", p.Reason, sortedKeys(validCancelReasons)),
 		}
 	}
 	return nil
+}
+
+// sortedKeys returns the keys of a map[string]bool as a sorted,
+// comma-separated string. Used in validation error messages so they
+// stay in sync with the allowed-values maps automatically.
+func sortedKeys(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
 }
 
 // Execute cancels a Shopify order. This action is irreversible.

--- a/connectors/shopify/cancel_order.go
+++ b/connectors/shopify/cancel_order.go
@@ -1,0 +1,79 @@
+package shopify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// cancelOrderAction implements connectors.Action for shopify.cancel_order.
+// It cancels an order via POST /admin/api/2024-10/orders/{order_id}/cancel.json.
+// This is an irreversible, high-risk action.
+type cancelOrderAction struct {
+	conn *ShopifyConnector
+}
+
+// cancelOrderParams maps the JSON parameters for the cancel_order action.
+type cancelOrderParams struct {
+	OrderID int64  `json:"order_id"`
+	Reason  string `json:"reason,omitempty"`
+	Restock *bool  `json:"restock,omitempty"`
+	Email   *bool  `json:"email,omitempty"`
+}
+
+// validCancelReasons are the cancellation reasons accepted by the Shopify Orders API.
+// See: https://shopify.dev/docs/api/admin-rest/2024-10/resources/order#post-orders-order-id-cancel
+var validCancelReasons = map[string]bool{
+	"customer":  true,
+	"fraud":     true,
+	"inventory": true,
+	"declined":  true,
+	"other":     true,
+}
+
+func (p *cancelOrderParams) validate() error {
+	if p.OrderID <= 0 {
+		return &connectors.ValidationError{Message: "order_id must be a positive integer"}
+	}
+	if p.Reason != "" && !validCancelReasons[p.Reason] {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid reason %q: must be customer, fraud, inventory, declined, or other", p.Reason),
+		}
+	}
+	return nil
+}
+
+// Execute cancels a Shopify order. This action is irreversible.
+func (a *cancelOrderAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params cancelOrderParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	reqBody := map[string]interface{}{}
+	if params.Reason != "" {
+		reqBody["reason"] = params.Reason
+	}
+	if params.Restock != nil {
+		reqBody["restock"] = *params.Restock
+	}
+	if params.Email != nil {
+		reqBody["email"] = *params.Email
+	}
+
+	var resp struct {
+		Order json.RawMessage `json:"order"`
+	}
+	path := fmt.Sprintf("/orders/%d/cancel.json", params.OrderID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/shopify/cancel_order.go
+++ b/connectors/shopify/cancel_order.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -46,18 +44,6 @@ func (p *cancelOrderParams) validate() error {
 		}
 	}
 	return nil
-}
-
-// sortedKeys returns the keys of a map[string]bool as a sorted,
-// comma-separated string. Used in validation error messages so they
-// stay in sync with the allowed-values maps automatically.
-func sortedKeys(m map[string]bool) string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return strings.Join(keys, ", ")
 }
 
 // Execute cancels a Shopify order. This action is irreversible.

--- a/connectors/shopify/cancel_order_test.go
+++ b/connectors/shopify/cancel_order_test.go
@@ -1,0 +1,200 @@
+package shopify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCancelOrder_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/orders/2001/cancel.json" {
+			t.Errorf("path = %s, want /orders/2001/cancel.json", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		if reqBody["reason"] != "customer" {
+			t.Errorf("reason = %v, want customer", reqBody["reason"])
+		}
+		if reqBody["restock"] != true {
+			t.Errorf("restock = %v, want true", reqBody["restock"])
+		}
+		if reqBody["email"] != true {
+			t.Errorf("email = %v, want true", reqBody["email"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"order": map[string]any{
+				"id": 2001, "cancel_reason": "customer", "cancelled_at": "2024-06-15T10:00:00Z",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.cancel_order"]
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{"order_id":2001,"reason":"customer","restock":true,"email":true}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, ok := data["order"]; !ok {
+		t.Error("result missing 'order' key")
+	}
+}
+
+func TestCancelOrder_MinimalParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		if _, ok := reqBody["reason"]; ok {
+			t.Error("reason should not be present when not provided")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"order": map[string]any{"id": 2002, "cancelled_at": "2024-06-15T10:00:00Z"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.cancel_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{"order_id":2002}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestCancelOrder_InvalidOrderID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.cancel_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{"order_id":-1}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCancelOrder_InvalidReason(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.cancel_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{"order_id":2001,"reason":"invalid_reason"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCancelOrder_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.cancel_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{invalid}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCancelOrder_APINotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"errors":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.cancel_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{"order_id":9999}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 404, got %T: %v", err, err)
+	}
+}
+
+func TestCancelOrder_APIServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"errors":"Internal Server Error"}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.cancel_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.cancel_order",
+		Parameters:  json.RawMessage(`{"order_id":2001}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError for 500, got %T: %v", err, err)
+	}
+}

--- a/connectors/shopify/create_collection.go
+++ b/connectors/shopify/create_collection.go
@@ -1,0 +1,90 @@
+package shopify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createCollectionAction implements connectors.Action for shopify.create_collection.
+// It creates a custom collection via POST /admin/api/2024-10/custom_collections.json.
+type createCollectionAction struct {
+	conn *ShopifyConnector
+}
+
+// createCollectionParams maps the JSON parameters for the create_collection action.
+type createCollectionParams struct {
+	Title     string                 `json:"title"`
+	BodyHTML  string                 `json:"body_html,omitempty"`
+	Published *bool                  `json:"published,omitempty"`
+	SortOrder string                 `json:"sort_order,omitempty"`
+	Image     map[string]interface{} `json:"image,omitempty"`
+}
+
+// validSortOrders are the sort orders accepted by the Shopify Custom Collections API.
+// See: https://shopify.dev/docs/api/admin-rest/2024-10/resources/custom-collection
+var validSortOrders = map[string]bool{
+	"alpha-asc":       true,
+	"alpha-desc":      true,
+	"best-selling":    true,
+	"created":         true,
+	"created-desc":    true,
+	"manual":          true,
+	"price-asc":       true,
+	"price-desc":      true,
+}
+
+func (p *createCollectionParams) validate() error {
+	if p.Title == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: title"}
+	}
+	if p.SortOrder != "" && !validSortOrders[p.SortOrder] {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid sort_order %q: must be one of alpha-asc, alpha-desc, best-selling, created, created-desc, manual, price-asc, price-desc", p.SortOrder),
+		}
+	}
+	return nil
+}
+
+// Execute creates a custom collection in the Shopify store.
+func (a *createCollectionAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createCollectionParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	collection := map[string]interface{}{
+		"title": params.Title,
+	}
+	if params.BodyHTML != "" {
+		collection["body_html"] = params.BodyHTML
+	}
+	if params.Published != nil {
+		collection["published"] = *params.Published
+	}
+	if params.SortOrder != "" {
+		collection["sort_order"] = params.SortOrder
+	}
+	if params.Image != nil {
+		collection["image"] = params.Image
+	}
+
+	reqBody := map[string]interface{}{
+		"custom_collection": collection,
+	}
+
+	var resp struct {
+		CustomCollection json.RawMessage `json:"custom_collection"`
+	}
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/custom_collections.json", reqBody, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/shopify/create_collection.go
+++ b/connectors/shopify/create_collection.go
@@ -43,7 +43,7 @@ func (p *createCollectionParams) validate() error {
 	}
 	if p.SortOrder != "" && !validSortOrders[p.SortOrder] {
 		return &connectors.ValidationError{
-			Message: fmt.Sprintf("invalid sort_order %q: must be one of alpha-asc, alpha-desc, best-selling, created, created-desc, manual, price-asc, price-desc", p.SortOrder),
+			Message: fmt.Sprintf("invalid sort_order %q: must be one of %s", p.SortOrder, sortedKeys(validSortOrders)),
 		}
 	}
 	return nil

--- a/connectors/shopify/create_collection_test.go
+++ b/connectors/shopify/create_collection_test.go
@@ -1,0 +1,218 @@
+package shopify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateCollection_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/custom_collections.json" {
+			t.Errorf("path = %s, want /custom_collections.json", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		collection := reqBody["custom_collection"]
+		if collection["title"] != "Summer Sale" {
+			t.Errorf("title = %v, want %q", collection["title"], "Summer Sale")
+		}
+		if collection["sort_order"] != "best-selling" {
+			t.Errorf("sort_order = %v, want %q", collection["sort_order"], "best-selling")
+		}
+		if collection["published"] != true {
+			t.Errorf("published = %v, want true", collection["published"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"custom_collection": map[string]any{
+				"id": 6001, "title": "Summer Sale", "sort_order": "best-selling",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.create_collection"]
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{"title":"Summer Sale","sort_order":"best-selling","published":true}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, ok := data["custom_collection"]; !ok {
+		t.Error("result missing 'custom_collection' key")
+	}
+}
+
+func TestCreateCollection_TitleOnly(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		collection := reqBody["custom_collection"]
+		if _, ok := collection["sort_order"]; ok {
+			t.Error("sort_order should not be present when not provided")
+		}
+		if _, ok := collection["published"]; ok {
+			t.Error("published should not be present when not provided")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"custom_collection": map[string]any{"id": 6002, "title": "Basics"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.create_collection"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{"title":"Basics"}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestCreateCollection_WithImage(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		collection := reqBody["custom_collection"]
+		image, ok := collection["image"].(map[string]interface{})
+		if !ok {
+			t.Fatal("image not present or wrong type")
+		}
+		if image["src"] != "https://example.com/banner.jpg" {
+			t.Errorf("image src = %v, want https://example.com/banner.jpg", image["src"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"custom_collection": map[string]any{"id": 6003},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.create_collection"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{"title":"With Image","image":{"src":"https://example.com/banner.jpg","alt":"Banner"}}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestCreateCollection_MissingTitle(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.create_collection"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{"sort_order":"manual"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCreateCollection_InvalidSortOrder(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.create_collection"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{"title":"Test","sort_order":"random"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCreateCollection_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.create_collection"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{invalid}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCreateCollection_APIValidationError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":{"title":["has already been taken"]}}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.create_collection"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.create_collection",
+		Parameters:  json.RawMessage(`{"title":"Duplicate"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 422, got %T: %v", err, err)
+	}
+}

--- a/connectors/shopify/create_product.go
+++ b/connectors/shopify/create_product.go
@@ -38,7 +38,7 @@ func (p *createProductParams) validate() error {
 		return &connectors.ValidationError{Message: "missing required parameter: title"}
 	}
 	if p.Status != "" && !validProductStatuses[p.Status] {
-		return &connectors.ValidationError{Message: fmt.Sprintf("invalid status %q: must be active, draft, or archived", p.Status)}
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid status %q: must be one of %s", p.Status, sortedKeys(validProductStatuses))}
 	}
 	return nil
 }

--- a/connectors/shopify/fulfill_order.go
+++ b/connectors/shopify/fulfill_order.go
@@ -1,0 +1,76 @@
+package shopify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// fulfillOrderAction implements connectors.Action for shopify.fulfill_order.
+// It creates a fulfillment for an order via POST /admin/api/2024-10/orders/{order_id}/fulfillments.json.
+type fulfillOrderAction struct {
+	conn *ShopifyConnector
+}
+
+// fulfillOrderParams maps the JSON parameters for the fulfill_order action.
+type fulfillOrderParams struct {
+	OrderID         int64  `json:"order_id"`
+	TrackingNumber  string `json:"tracking_number,omitempty"`
+	TrackingCompany string `json:"tracking_company,omitempty"`
+	TrackingURL     string `json:"tracking_url,omitempty"`
+	NotifyCustomer  *bool  `json:"notify_customer,omitempty"`
+}
+
+func (p *fulfillOrderParams) validate() error {
+	if p.OrderID <= 0 {
+		return &connectors.ValidationError{Message: "order_id must be a positive integer"}
+	}
+	return nil
+}
+
+// Execute creates a fulfillment for a Shopify order with optional tracking info.
+func (a *fulfillOrderAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params fulfillOrderParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	trackingInfo := map[string]interface{}{}
+	if params.TrackingNumber != "" {
+		trackingInfo["number"] = params.TrackingNumber
+	}
+	if params.TrackingCompany != "" {
+		trackingInfo["company"] = params.TrackingCompany
+	}
+	if params.TrackingURL != "" {
+		trackingInfo["url"] = params.TrackingURL
+	}
+
+	fulfillment := map[string]interface{}{}
+	if len(trackingInfo) > 0 {
+		fulfillment["tracking_info"] = trackingInfo
+	}
+	if params.NotifyCustomer != nil {
+		fulfillment["notify_customer"] = *params.NotifyCustomer
+	}
+
+	reqBody := map[string]interface{}{
+		"fulfillment": fulfillment,
+	}
+
+	var resp struct {
+		Fulfillment json.RawMessage `json:"fulfillment"`
+	}
+	path := fmt.Sprintf("/orders/%d/fulfillments.json", params.OrderID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/shopify/fulfill_order.go
+++ b/connectors/shopify/fulfill_order.go
@@ -28,6 +28,11 @@ func (p *fulfillOrderParams) validate() error {
 	if p.OrderID <= 0 {
 		return &connectors.ValidationError{Message: "order_id must be a positive integer"}
 	}
+	// Warn if tracking URL is provided without a tracking number — the URL
+	// alone isn't very useful for customers.
+	if p.TrackingURL != "" && p.TrackingNumber == "" {
+		return &connectors.ValidationError{Message: "tracking_url requires tracking_number to be set"}
+	}
 	return nil
 }
 

--- a/connectors/shopify/fulfill_order_test.go
+++ b/connectors/shopify/fulfill_order_test.go
@@ -1,0 +1,192 @@
+package shopify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestFulfillOrder_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/orders/1001/fulfillments.json" {
+			t.Errorf("path = %s, want /orders/1001/fulfillments.json", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		fulfillment, ok := reqBody["fulfillment"].(map[string]interface{})
+		if !ok {
+			t.Fatal("missing fulfillment key in request body")
+		}
+		trackingInfo, ok := fulfillment["tracking_info"].(map[string]interface{})
+		if !ok {
+			t.Fatal("missing tracking_info in fulfillment")
+		}
+		if trackingInfo["number"] != "1Z999AA10123456784" {
+			t.Errorf("tracking number = %v, want 1Z999AA10123456784", trackingInfo["number"])
+		}
+		if trackingInfo["company"] != "UPS" {
+			t.Errorf("tracking company = %v, want UPS", trackingInfo["company"])
+		}
+		if fulfillment["notify_customer"] != true {
+			t.Errorf("notify_customer = %v, want true", fulfillment["notify_customer"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"fulfillment": map[string]any{
+				"id": 3001, "order_id": 1001, "status": "success",
+				"tracking_number": "1Z999AA10123456784", "tracking_company": "UPS",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.fulfill_order"]
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{"order_id":1001,"tracking_number":"1Z999AA10123456784","tracking_company":"UPS","notify_customer":true}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, ok := data["fulfillment"]; !ok {
+		t.Error("result missing 'fulfillment' key")
+	}
+}
+
+func TestFulfillOrder_MinimalParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		fulfillment := reqBody["fulfillment"].(map[string]interface{})
+		if _, ok := fulfillment["tracking_info"]; ok {
+			t.Error("tracking_info should not be present when no tracking params provided")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"fulfillment": map[string]any{"id": 3002, "order_id": 1002},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.fulfill_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{"order_id":1002}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestFulfillOrder_InvalidOrderID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.fulfill_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{"order_id":0}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestFulfillOrder_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.fulfill_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{invalid}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestFulfillOrder_APINotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"errors":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.fulfill_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{"order_id":9999}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 404, got %T: %v", err, err)
+	}
+}
+
+func TestFulfillOrder_APIValidationError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":{"order":["is already fulfilled"]}}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.fulfill_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{"order_id":1001}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 422, got %T: %v", err, err)
+	}
+}

--- a/connectors/shopify/fulfill_order_test.go
+++ b/connectors/shopify/fulfill_order_test.go
@@ -125,6 +125,24 @@ func TestFulfillOrder_InvalidOrderID(t *testing.T) {
 	}
 }
 
+func TestFulfillOrder_TrackingURLWithoutNumber(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.fulfill_order"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.fulfill_order",
+		Parameters:  json.RawMessage(`{"order_id":1001,"tracking_url":"https://track.example.com/123"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestFulfillOrder_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/shopify/get_analytics.go
+++ b/connectors/shopify/get_analytics.go
@@ -1,0 +1,66 @@
+package shopify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getAnalyticsAction implements connectors.Action for shopify.get_analytics.
+// It retrieves shop reports via GET /admin/api/2024-10/reports.json.
+// Note: Analytics API access varies by Shopify plan — not all plans support it.
+type getAnalyticsAction struct {
+	conn *ShopifyConnector
+}
+
+// getAnalyticsParams maps the JSON parameters for the get_analytics action.
+type getAnalyticsParams struct {
+	Since  string `json:"since,omitempty"`
+	Until  string `json:"until,omitempty"`
+	Fields string `json:"fields,omitempty"`
+}
+
+func (p *getAnalyticsParams) validate() error {
+	// All parameters are optional for this read-only action.
+	return nil
+}
+
+// Execute retrieves shop analytics reports from the Shopify API.
+func (a *getAnalyticsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getAnalyticsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	if params.Since != "" {
+		q.Set("since", params.Since)
+	}
+	if params.Until != "" {
+		q.Set("until", params.Until)
+	}
+	if params.Fields != "" {
+		q.Set("fields", params.Fields)
+	}
+
+	path := "/reports.json"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	var resp struct {
+		Reports json.RawMessage `json:"reports"`
+	}
+	if err := a.conn.do(ctx, req.Credentials, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/shopify/get_analytics_test.go
+++ b/connectors/shopify/get_analytics_test.go
@@ -1,0 +1,182 @@
+package shopify
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetAnalytics_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Path; got != "/reports.json" {
+			t.Errorf("path = %s, want /reports.json", got)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"reports": []any{
+				map[string]any{"id": 1, "name": "Orders over time", "shopify_ql": "SHOW orders"},
+				map[string]any{"id": 2, "name": "Sales over time", "shopify_ql": "SHOW sales"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.get_analytics"]
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.get_analytics",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, ok := data["reports"]; !ok {
+		t.Error("result missing 'reports' key")
+	}
+}
+
+func TestGetAnalytics_WithQueryParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		q := r.URL.Query()
+		if got := q.Get("since"); got != "2024-01-01T00:00:00Z" {
+			t.Errorf("since = %q, want 2024-01-01T00:00:00Z", got)
+		}
+		if got := q.Get("until"); got != "2024-06-30T23:59:59Z" {
+			t.Errorf("until = %q, want 2024-06-30T23:59:59Z", got)
+		}
+		if got := q.Get("fields"); got != "id,name" {
+			t.Errorf("fields = %q, want id,name", got)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"reports": []any{},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.get_analytics"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.get_analytics",
+		Parameters:  json.RawMessage(`{"since":"2024-01-01T00:00:00Z","until":"2024-06-30T23:59:59Z","fields":"id,name"}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestGetAnalytics_NoParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query params, got %q", r.URL.RawQuery)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"reports": []any{},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.get_analytics"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.get_analytics",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestGetAnalytics_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.get_analytics"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.get_analytics",
+		Parameters:  json.RawMessage(`{invalid}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestGetAnalytics_APIAuthError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"errors":"[API] This action requires merchant approval for read_reports scope."}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.get_analytics"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.get_analytics",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError for 403, got %T: %v", err, err)
+	}
+}
+
+func TestGetAnalytics_APIRateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"errors":"Exceeded 2 calls per second for api client."}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.get_analytics"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.get_analytics",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError for 429, got %T: %v", err, err)
+	}
+}

--- a/connectors/shopify/helpers.go
+++ b/connectors/shopify/helpers.go
@@ -1,0 +1,18 @@
+package shopify
+
+import (
+	"sort"
+	"strings"
+)
+
+// sortedKeys returns the keys of a map[string]bool as a sorted,
+// comma-separated string. Used in validation error messages so they
+// stay in sync with the allowed-values maps automatically.
+func sortedKeys(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}

--- a/connectors/shopify/manifest.go
+++ b/connectors/shopify/manifest.go
@@ -507,7 +507,14 @@ func (c *ShopifyConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "shopify.fulfill_order",
 				Name:        "Fulfill order with tracking",
 				Description: "Create a fulfillment with tracking info and notify the customer",
-				Parameters:  json.RawMessage(`{"order_id":0,"tracking_number":"","tracking_company":"","notify_customer":true}`),
+				Parameters:  json.RawMessage(`{"order_id":0,"tracking_number":"1Z999AA10123456784","tracking_company":"UPS","notify_customer":true}`),
+			},
+			{
+				ID:          "shopify-fulfill-order-silent",
+				ActionType:  "shopify.fulfill_order",
+				Name:        "Fulfill order (no notification)",
+				Description: "Create a fulfillment without sending a notification email to the customer",
+				Parameters:  json.RawMessage(`{"order_id":0,"notify_customer":false}`),
 			},
 			{
 				ID:          "shopify-cancel-order-customer-request",
@@ -517,11 +524,25 @@ func (c *ShopifyConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:  json.RawMessage(`{"order_id":0,"reason":"customer","restock":true,"email":true}`),
 			},
 			{
+				ID:          "shopify-cancel-order-fraud",
+				ActionType:  "shopify.cancel_order",
+				Name:        "Cancel order (fraud)",
+				Description: "Cancel a fraudulent order, restock items, and suppress notification to the customer",
+				Parameters:  json.RawMessage(`{"order_id":0,"reason":"fraud","restock":true,"email":false}`),
+			},
+			{
 				ID:          "shopify-update-product-status",
 				ActionType:  "shopify.update_product",
 				Name:        "Update product status",
 				Description: "Change a product's status (e.g. draft to active, or active to archived)",
 				Parameters:  json.RawMessage(`{"product_id":0,"status":"active"}`),
+			},
+			{
+				ID:          "shopify-update-product-details",
+				ActionType:  "shopify.update_product",
+				Name:        "Update product details",
+				Description: "Update a product's title, description, and tags",
+				Parameters:  json.RawMessage(`{"product_id":0,"title":"","body_html":"","tags":""}`),
 			},
 			{
 				ID:          "shopify-create-collection",

--- a/connectors/shopify/manifest.go
+++ b/connectors/shopify/manifest.go
@@ -259,6 +259,191 @@ func (c *ShopifyConnector) Manifest() *connectors.ConnectorManifest {
 					"additionalProperties": false
 				}`)),
 			},
+			{
+				ActionType:  "shopify.fulfill_order",
+				Name:        "Fulfill Order",
+				Description: "Create a fulfillment for an order with optional tracking information. When notify_customer is true, Shopify sends a shipment notification email.",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"order_id": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "The Shopify order ID to fulfill"
+						},
+						"tracking_number": {
+							"type": "string",
+							"description": "Shipment tracking number"
+						},
+						"tracking_company": {
+							"type": "string",
+							"description": "Shipping carrier name (e.g. UPS, FedEx, USPS)"
+						},
+						"tracking_url": {
+							"type": "string",
+							"format": "uri",
+							"description": "URL for tracking the shipment"
+						},
+						"notify_customer": {
+							"type": "boolean",
+							"description": "Whether to send a shipment notification email to the customer"
+						}
+					},
+					"required": ["order_id"],
+					"additionalProperties": false
+				}`)),
+			},
+			{
+				ActionType:  "shopify.cancel_order",
+				Name:        "Cancel Order",
+				Description: "Cancel an order. This action is irreversible and affects the customer experience. Use with caution.",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"order_id": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "The Shopify order ID to cancel"
+						},
+						"reason": {
+							"type": "string",
+							"enum": ["customer", "fraud", "inventory", "declined", "other"],
+							"description": "Reason for cancellation"
+						},
+						"restock": {
+							"type": "boolean",
+							"description": "Whether to restock the order's line items"
+						},
+						"email": {
+							"type": "boolean",
+							"description": "Whether to send a cancellation email to the customer"
+						}
+					},
+					"required": ["order_id"],
+					"additionalProperties": false
+				}`)),
+			},
+			{
+				ActionType:  "shopify.update_product",
+				Name:        "Update Product",
+				Description: "Update an existing product's attributes such as title, description, vendor, tags, status, or variants",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"product_id": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "The Shopify product ID to update"
+						},
+						"title": {
+							"type": "string",
+							"description": "Product title"
+						},
+						"body_html": {
+							"type": "string",
+							"description": "Product description in HTML"
+						},
+						"vendor": {
+							"type": "string",
+							"description": "Product vendor"
+						},
+						"tags": {
+							"type": "string",
+							"description": "Comma-separated list of tags"
+						},
+						"status": {
+							"type": "string",
+							"enum": ["active", "draft", "archived"],
+							"description": "Product status"
+						},
+						"variants": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"id": {"type": "integer", "description": "Variant ID (required for updating existing variants)"},
+									"price": {"type": "string", "description": "Variant price as decimal string"},
+									"sku": {"type": "string", "description": "Unique SKU code"},
+									"inventory_quantity": {"type": "integer", "description": "Inventory count"},
+									"option1": {"type": "string", "description": "First option value"},
+									"option2": {"type": "string", "description": "Second option value"},
+									"option3": {"type": "string", "description": "Third option value"}
+								}
+							},
+							"description": "Product variants to update or add"
+						}
+					},
+					"required": ["product_id"],
+					"additionalProperties": false
+				}`)),
+			},
+			{
+				ActionType:  "shopify.create_collection",
+				Name:        "Create Collection",
+				Description: "Create a custom product collection for organizing products in the storefront",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string",
+							"description": "Collection title"
+						},
+						"body_html": {
+							"type": "string",
+							"description": "Collection description in HTML"
+						},
+						"published": {
+							"type": "boolean",
+							"description": "Whether the collection is published to the storefront"
+						},
+						"sort_order": {
+							"type": "string",
+							"enum": ["alpha-asc", "alpha-desc", "best-selling", "created", "created-desc", "manual", "price-asc", "price-desc"],
+							"description": "Default sort order for products in the collection"
+						},
+						"image": {
+							"type": "object",
+							"properties": {
+								"src": {"type": "string", "format": "uri", "description": "Image URL"},
+								"alt": {"type": "string", "description": "Image alt text"}
+							},
+							"description": "Collection image"
+						}
+					},
+					"required": ["title"],
+					"additionalProperties": false
+				}`)),
+			},
+			{
+				ActionType:  "shopify.get_analytics",
+				Name:        "Get Analytics",
+				Description: "Retrieve shop analytics reports. Note: Analytics API access varies by Shopify plan — not all plans support it.",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"since": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Show reports created at or after this date (ISO 8601)"
+						},
+						"until": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Show reports created at or before this date (ISO 8601)"
+						},
+						"fields": {
+							"type": "string",
+							"description": "Comma-separated list of fields to return (e.g. id,name,shopify_ql)"
+						}
+					},
+					"additionalProperties": false
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -316,6 +501,41 @@ func (c *ShopifyConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Create $5 off discount code",
 				Description: "Create a fixed-amount discount code",
 				Parameters:  json.RawMessage(`{"code":"SAVE5","value_type":"fixed_amount","value":"-5.00","starts_at":"2024-01-01T00:00:00Z"}`),
+			},
+			{
+				ID:          "shopify-fulfill-order-with-tracking",
+				ActionType:  "shopify.fulfill_order",
+				Name:        "Fulfill order with tracking",
+				Description: "Create a fulfillment with tracking info and notify the customer",
+				Parameters:  json.RawMessage(`{"order_id":0,"tracking_number":"","tracking_company":"","notify_customer":true}`),
+			},
+			{
+				ID:          "shopify-cancel-order-customer-request",
+				ActionType:  "shopify.cancel_order",
+				Name:        "Cancel order (customer request)",
+				Description: "Cancel an order due to customer request, restock items, and notify the customer",
+				Parameters:  json.RawMessage(`{"order_id":0,"reason":"customer","restock":true,"email":true}`),
+			},
+			{
+				ID:          "shopify-update-product-status",
+				ActionType:  "shopify.update_product",
+				Name:        "Update product status",
+				Description: "Change a product's status (e.g. draft to active, or active to archived)",
+				Parameters:  json.RawMessage(`{"product_id":0,"status":"active"}`),
+			},
+			{
+				ID:          "shopify-create-collection",
+				ActionType:  "shopify.create_collection",
+				Name:        "Create product collection",
+				Description: "Create a new published collection with alphabetical sorting",
+				Parameters:  json.RawMessage(`{"title":"New Collection","published":true,"sort_order":"alpha-asc"}`),
+			},
+			{
+				ID:          "shopify-get-analytics",
+				ActionType:  "shopify.get_analytics",
+				Name:        "Get shop reports",
+				Description: "Retrieve all available analytics reports",
+				Parameters:  json.RawMessage(`{}`),
 			},
 		},
 	}

--- a/connectors/shopify/shopify.go
+++ b/connectors/shopify/shopify.go
@@ -118,12 +118,17 @@ func (c *ShopifyConnector) ID() string { return "shopify" }
 // Actions returns the registered action handlers keyed by action_type.
 func (c *ShopifyConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
-		"shopify.get_orders":      &getOrdersAction{conn: c},
-		"shopify.get_order":       &getOrderAction{conn: c},
-		"shopify.update_order":    &updateOrderAction{conn: c},
-		"shopify.create_product":  &createProductAction{conn: c},
-		"shopify.update_inventory": &updateInventoryAction{conn: c},
-		"shopify.create_discount": &createDiscountAction{conn: c},
+		"shopify.get_orders":         &getOrdersAction{conn: c},
+		"shopify.get_order":          &getOrderAction{conn: c},
+		"shopify.update_order":       &updateOrderAction{conn: c},
+		"shopify.fulfill_order":      &fulfillOrderAction{conn: c},
+		"shopify.cancel_order":       &cancelOrderAction{conn: c},
+		"shopify.create_product":     &createProductAction{conn: c},
+		"shopify.update_product":     &updateProductAction{conn: c},
+		"shopify.update_inventory":   &updateInventoryAction{conn: c},
+		"shopify.create_discount":    &createDiscountAction{conn: c},
+		"shopify.create_collection":  &createCollectionAction{conn: c},
+		"shopify.get_analytics":      &getAnalyticsAction{conn: c},
 	}
 }
 

--- a/connectors/shopify/shopify_test.go
+++ b/connectors/shopify/shopify_test.go
@@ -30,6 +30,11 @@ func TestShopifyConnector_Actions(t *testing.T) {
 		"shopify.create_product",
 		"shopify.update_inventory",
 		"shopify.create_discount",
+		"shopify.fulfill_order",
+		"shopify.cancel_order",
+		"shopify.update_product",
+		"shopify.create_collection",
+		"shopify.get_analytics",
 	}
 
 	if len(actions) != len(wantActions) {
@@ -136,8 +141,8 @@ func TestShopifyConnector_Manifest(t *testing.T) {
 		t.Error("credential instructions_url is empty, want a URL")
 	}
 
-	if len(m.Actions) != 6 {
-		t.Errorf("Manifest().Actions has %d items, want 6", len(m.Actions))
+	if len(m.Actions) != 11 {
+		t.Errorf("Manifest().Actions has %d items, want 11", len(m.Actions))
 	}
 	if err := m.Validate(); err != nil {
 		t.Errorf("Manifest().Validate() = %v, want nil", err)

--- a/connectors/shopify/update_product.go
+++ b/connectors/shopify/update_product.go
@@ -39,11 +39,13 @@ func (p *updateProductParams) validate() error {
 	}
 	if p.Status != nil {
 		if *p.Status == "" {
-			return &connectors.ValidationError{Message: "status cannot be empty: must be active, draft, or archived"}
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("status cannot be empty: must be one of %s", sortedKeys(validProductStatuses)),
+			}
 		}
 		if !validProductStatuses[*p.Status] {
 			return &connectors.ValidationError{
-				Message: fmt.Sprintf("invalid status %q: must be active, draft, or archived", *p.Status),
+				Message: fmt.Sprintf("invalid status %q: must be one of %s", *p.Status, sortedKeys(validProductStatuses)),
 			}
 		}
 	}

--- a/connectors/shopify/update_product.go
+++ b/connectors/shopify/update_product.go
@@ -1,0 +1,89 @@
+package shopify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// updateProductAction implements connectors.Action for shopify.update_product.
+// It updates an existing product via PUT /admin/api/2024-10/products/{product_id}.json.
+type updateProductAction struct {
+	conn *ShopifyConnector
+}
+
+// updateProductParams maps the JSON parameters for the update_product action.
+// Pointer fields distinguish between "not provided" (nil) and "set to empty string".
+type updateProductParams struct {
+	ProductID int64                    `json:"product_id"`
+	Title     *string                  `json:"title,omitempty"`
+	BodyHTML  *string                  `json:"body_html,omitempty"`
+	Vendor    *string                  `json:"vendor,omitempty"`
+	Tags      *string                  `json:"tags,omitempty"`
+	Status    *string                  `json:"status,omitempty"`
+	Variants  []map[string]interface{} `json:"variants,omitempty"`
+}
+
+func (p *updateProductParams) validate() error {
+	if p.ProductID <= 0 {
+		return &connectors.ValidationError{Message: "product_id must be a positive integer"}
+	}
+	if p.Title == nil && p.BodyHTML == nil && p.Vendor == nil && p.Tags == nil && p.Status == nil && p.Variants == nil {
+		return &connectors.ValidationError{Message: "at least one field to update must be provided"}
+	}
+	if p.Status != nil && *p.Status != "" && !validProductStatuses[*p.Status] {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid status %q: must be active, draft, or archived", *p.Status),
+		}
+	}
+	return nil
+}
+
+// Execute updates an existing product in the Shopify store.
+// Only provided fields are included in the request body.
+func (a *updateProductAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params updateProductParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	product := map[string]interface{}{}
+	if params.Title != nil {
+		product["title"] = *params.Title
+	}
+	if params.BodyHTML != nil {
+		product["body_html"] = *params.BodyHTML
+	}
+	if params.Vendor != nil {
+		product["vendor"] = *params.Vendor
+	}
+	if params.Tags != nil {
+		product["tags"] = *params.Tags
+	}
+	if params.Status != nil {
+		product["status"] = *params.Status
+	}
+	if len(params.Variants) > 0 {
+		product["variants"] = params.Variants
+	}
+
+	reqBody := map[string]interface{}{
+		"product": product,
+	}
+
+	var resp struct {
+		Product json.RawMessage `json:"product"`
+	}
+	path := fmt.Sprintf("/products/%d.json", params.ProductID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPut, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/shopify/update_product.go
+++ b/connectors/shopify/update_product.go
@@ -31,12 +31,20 @@ func (p *updateProductParams) validate() error {
 	if p.ProductID <= 0 {
 		return &connectors.ValidationError{Message: "product_id must be a positive integer"}
 	}
-	if p.Title == nil && p.BodyHTML == nil && p.Vendor == nil && p.Tags == nil && p.Status == nil && p.Variants == nil {
+	// Treat an empty variants slice the same as not provided — sending an
+	// empty array to Shopify is almost certainly unintended.
+	hasVariants := len(p.Variants) > 0
+	if p.Title == nil && p.BodyHTML == nil && p.Vendor == nil && p.Tags == nil && p.Status == nil && !hasVariants {
 		return &connectors.ValidationError{Message: "at least one field to update must be provided"}
 	}
-	if p.Status != nil && *p.Status != "" && !validProductStatuses[*p.Status] {
-		return &connectors.ValidationError{
-			Message: fmt.Sprintf("invalid status %q: must be active, draft, or archived", *p.Status),
+	if p.Status != nil {
+		if *p.Status == "" {
+			return &connectors.ValidationError{Message: "status cannot be empty: must be active, draft, or archived"}
+		}
+		if !validProductStatuses[*p.Status] {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("invalid status %q: must be active, draft, or archived", *p.Status),
+			}
 		}
 	}
 	return nil

--- a/connectors/shopify/update_product_test.go
+++ b/connectors/shopify/update_product_test.go
@@ -172,6 +172,42 @@ func TestUpdateProduct_NoFieldsProvided(t *testing.T) {
 	}
 }
 
+func TestUpdateProduct_EmptyVariantsArray(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001,"variants":[]}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for empty variants array, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUpdateProduct_EmptyStatus(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001,"status":""}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for empty status, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestUpdateProduct_InvalidStatus(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/shopify/update_product_test.go
+++ b/connectors/shopify/update_product_test.go
@@ -1,0 +1,233 @@
+package shopify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUpdateProduct_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if got := r.URL.Path; got != "/products/5001.json" {
+			t.Errorf("path = %s, want /products/5001.json", got)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		product := reqBody["product"]
+		if product["title"] != "Updated Widget" {
+			t.Errorf("title = %v, want %q", product["title"], "Updated Widget")
+		}
+		if product["status"] != "active" {
+			t.Errorf("status = %v, want %q", product["status"], "active")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"product": map[string]any{
+				"id": 5001, "title": "Updated Widget", "status": "active",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.update_product"]
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001,"title":"Updated Widget","status":"active"}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, ok := data["product"]; !ok {
+		t.Error("result missing 'product' key")
+	}
+}
+
+func TestUpdateProduct_OnlyTagsProvided(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		product := reqBody["product"]
+		if _, ok := product["title"]; ok {
+			t.Error("title should not be present when not provided")
+		}
+		if product["tags"] != "sale,featured" {
+			t.Errorf("tags = %v, want %q", product["tags"], "sale,featured")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"product": map[string]any{"id": 5001, "tags": "sale,featured"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001,"tags":"sale,featured"}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestUpdateProduct_WithVariants(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
+		product := reqBody["product"]
+		variants, ok := product["variants"].([]interface{})
+		if !ok {
+			t.Fatal("variants not present or wrong type")
+		}
+		if len(variants) != 1 {
+			t.Errorf("len(variants) = %d, want 1", len(variants))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"product": map[string]any{"id": 5001},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001,"variants":[{"id":1,"price":"29.99"}]}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestUpdateProduct_InvalidProductID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":0,"title":"Test"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUpdateProduct_NoFieldsProvided(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUpdateProduct_InvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":5001,"status":"deleted"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUpdateProduct_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{invalid}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUpdateProduct_APINotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"errors":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["shopify.update_product"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "shopify.update_product",
+		Parameters:  json.RawMessage(`{"product_id":9999,"title":"Test"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for 404, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds 5 new Shopify connector actions: `fulfill_order`, `cancel_order`, `update_product`, `create_collection`, `get_analytics`
- Each action includes parameter validation, manifest schema, templates, and comprehensive httptest-based tests
- `cancel_order` is high risk (irreversible); `fulfill_order` and `update_product` are medium risk; `create_collection` and `get_analytics` are low risk
- Completes the merchant workflow for order management, product catalog admin, and read-only analytics

Closes #275

## Test plan
- [ ] CI passes `go test ./connectors/shopify/...`
- [ ] CI passes `make build`
- [ ] Verify manifest validation passes on server startup (no duplicate action types or template IDs)
- [ ] Manually test each action against a Shopify dev store

<https://claude.ai/code/session_01GscXLg1oQR7K6vKMxguRrJ>
