### PR TITLE
Add GitHub connector actions: create_pr, add_reviewer, create_release, close_issue, add_label, add_comment, create_branch

### DIFF
--- a/connectors/github/README.md
+++ b/connectors/github/README.md
@@ -47,6 +47,130 @@ Creates a new issue in a GitHub repository.
 
 ---
 
+### `github.close_issue`
+
+Closes an issue, optionally posting a comment before closing.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `owner` | string | Yes | — | Repository owner (user or organization) |
+| `repo` | string | Yes | — | Repository name |
+| `issue_number` | integer | Yes | — | Issue number to close |
+| `state_reason` | string | No | `"completed"` | One of `completed` or `not_planned` |
+| `comment` | string | No | — | Comment to post before closing |
+
+**Response:**
+
+```json
+{
+  "number": 10,
+  "url": "https://api.github.com/repos/octocat/hello-world/issues/10",
+  "html_url": "https://github.com/octocat/hello-world/issues/10",
+  "state": "closed"
+}
+```
+
+**GitHub API:** `PATCH /repos/{owner}/{repo}/issues/{issue_number}` ([docs](https://docs.github.com/en/rest/issues/issues#update-an-issue))
+
+**Required token scopes:** `repo` (classic) or Issues write permission (fine-grained)
+
+---
+
+### `github.add_label`
+
+Adds labels to an issue or pull request.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | string | Yes | Repository owner (user or organization) |
+| `repo` | string | Yes | Repository name |
+| `issue_number` | integer | Yes | Issue or pull request number |
+| `labels` | array of strings | Yes | Labels to add |
+
+**Response:** Array of label objects with `id` and `name`.
+
+**GitHub API:** `POST /repos/{owner}/{repo}/issues/{issue_number}/labels` ([docs](https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue))
+
+**Required token scopes:** `repo` (classic) or Issues write permission (fine-grained)
+
+---
+
+### `github.add_comment`
+
+Adds a comment to an issue or pull request.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | string | Yes | Repository owner (user or organization) |
+| `repo` | string | Yes | Repository name |
+| `issue_number` | integer | Yes | Issue or pull request number |
+| `body` | string | Yes | Comment body (Markdown supported) |
+
+**Response:**
+
+```json
+{
+  "id": 123,
+  "url": "https://api.github.com/repos/octocat/hello-world/issues/comments/123",
+  "html_url": "https://github.com/octocat/hello-world/issues/7#issuecomment-123",
+  "body": "Looks good!"
+}
+```
+
+**GitHub API:** `POST /repos/{owner}/{repo}/issues/{issue_number}/comments` ([docs](https://docs.github.com/en/rest/issues/comments#create-an-issue-comment))
+
+**Required token scopes:** `repo` (classic) or Issues write permission (fine-grained)
+
+---
+
+### `github.create_pr`
+
+Creates a pull request from a branch.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `owner` | string | Yes | — | Repository owner (user or organization) |
+| `repo` | string | Yes | — | Repository name |
+| `title` | string | Yes | — | Pull request title |
+| `body` | string | No | — | Pull request body (Markdown supported) |
+| `head` | string | Yes | — | Branch containing the changes |
+| `base` | string | Yes | — | Branch to merge into |
+| `draft` | boolean | No | `false` | Whether to create the PR as a draft |
+
+**Response:**
+
+```json
+{
+  "number": 99,
+  "url": "https://api.github.com/repos/octocat/hello-world/pulls/99",
+  "html_url": "https://github.com/octocat/hello-world/pull/99",
+  "state": "open",
+  "draft": false
+}
+```
+
+**GitHub API:** `POST /repos/{owner}/{repo}/pulls` ([docs](https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request))
+
+**Required token scopes:** `repo` (classic) or Pull Requests write permission (fine-grained)
+
+---
+
 ### `github.merge_pr`
 
 Merges an open pull request.
@@ -76,6 +200,109 @@ Merges an open pull request.
 
 **Required token scopes:** `repo` (classic) or Pull Requests write permission (fine-grained)
 
+---
+
+### `github.add_reviewer`
+
+Requests reviews on a pull request.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | string | Yes | Repository owner (user or organization) |
+| `repo` | string | Yes | Repository name |
+| `pull_number` | integer | Yes | Pull request number |
+| `reviewers` | array of strings | Yes | GitHub usernames to request reviews from |
+
+**Response:**
+
+```json
+{
+  "number": 42,
+  "url": "https://api.github.com/repos/octocat/hello-world/pulls/42",
+  "html_url": "https://github.com/octocat/hello-world/pull/42"
+}
+```
+
+**GitHub API:** `POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers` ([docs](https://docs.github.com/en/rest/pulls/review-requests#request-reviewers-for-a-pull-request))
+
+**Required token scopes:** `repo` (classic) or Pull Requests write permission (fine-grained)
+
+---
+
+### `github.create_release`
+
+Creates a tagged release in a repository.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `owner` | string | Yes | — | Repository owner (user or organization) |
+| `repo` | string | Yes | — | Repository name |
+| `tag_name` | string | Yes | — | The name of the tag for this release |
+| `name` | string | No | — | The name of the release |
+| `body` | string | No | — | Release notes (Markdown supported) |
+| `draft` | boolean | No | `false` | Whether to create as a draft release |
+| `prerelease` | boolean | No | `false` | Whether to mark as a pre-release |
+
+**Response:**
+
+```json
+{
+  "id": 1,
+  "url": "https://api.github.com/repos/octocat/hello-world/releases/1",
+  "html_url": "https://github.com/octocat/hello-world/releases/tag/v1.0.0",
+  "tag_name": "v1.0.0",
+  "name": "Release 1.0",
+  "draft": false
+}
+```
+
+**GitHub API:** `POST /repos/{owner}/{repo}/releases` ([docs](https://docs.github.com/en/rest/releases/releases#create-a-release))
+
+**Required token scopes:** `repo` (classic) or Contents write permission (fine-grained)
+
+---
+
+### `github.create_branch`
+
+Creates a new branch from an existing branch or tag.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | string | Yes | Repository owner (user or organization) |
+| `repo` | string | Yes | Repository name |
+| `branch_name` | string | Yes | Name for the new branch |
+| `from_ref` | string | Yes | Branch or ref to create from (e.g. `"main"`, `"develop"`, or `"tags/v1.0"`) |
+
+Bare branch names (e.g. `"main"`) are automatically expanded to `"heads/main"`. To branch from a tag, use the full ref path (e.g. `"tags/v1.0"`).
+
+**Response:**
+
+```json
+{
+  "ref": "refs/heads/feature-branch",
+  "url": "https://api.github.com/repos/octocat/hello-world/git/refs/heads/feature-branch",
+  "object": {
+    "sha": "abc123def456"
+  }
+}
+```
+
+**GitHub API:** `GET /repos/{owner}/{repo}/git/ref/{ref}` + `POST /repos/{owner}/{repo}/git/refs` ([docs](https://docs.github.com/en/rest/git/refs#create-a-reference))
+
+**Required token scopes:** `repo` (classic) or Contents write permission (fine-grained)
+
 ## Error Handling
 
 The connector maps GitHub API responses to typed connector errors:
@@ -91,14 +318,15 @@ The connector maps GitHub API responses to typed connector errors:
 
 ## Adding a New Action
 
-Each action lives in its own file. To add one (e.g., `github.close_issue`):
+Each action lives in its own file. To add one:
 
-1. Create `connectors/github/close_issue.go` with a params struct, `validate()`, and an `Execute` method.
+1. Create `connectors/github/<action>.go` with a params struct, `validate()`, and an `Execute` method.
 2. Use `a.conn.do(ctx, creds, method, path, reqBody, &respBody)` for the HTTP lifecycle — it handles JSON marshaling, auth headers, response checking, and error mapping.
 3. Return `connectors.JSONResult(respBody)` to wrap the response struct into an `ActionResult`.
 4. Register the action in `Actions()` inside `github.go`.
 5. Add the action to the `Manifest()` return value inside `github.go` — include a `ParametersSchema` (see below).
-6. Add tests in `close_issue_test.go` using `httptest.NewServer` and `newForTest()`.
+6. Add one or more `ManifestTemplate` entries for common permission presets.
+7. Add tests in `<action>_test.go` using `httptest.NewServer` and `newForTest()`.
 
 The `do` method means each action file only contains what's unique: parameter parsing, validation, request body shape, and response shape. All shared HTTP concerns (auth, Content-Type, error mapping) are handled once.
 
@@ -151,15 +379,29 @@ When adding a new action, add it to the `Manifest()` return value with a `Parame
 
 ```
 connectors/github/
-├── github.go             # GitHubConnector struct, New(), Manifest(), do(), ValidateCredentials()
-├── create_issue.go       # github.create_issue action
-├── merge_pr.go           # github.merge_pr action
-├── response.go           # Shared HTTP response → typed error mapping
-├── github_test.go        # Connector-level tests
-├── helpers_test.go       # Shared test helpers (validCreds)
-├── create_issue_test.go  # Create issue action tests
-├── merge_pr_test.go      # Merge PR action tests
-└── README.md             # This file
+├── github.go               # GitHubConnector struct, New(), Manifest(), do(), ValidateCredentials()
+├── create_issue.go          # github.create_issue action
+├── close_issue.go           # github.close_issue action
+├── add_label.go             # github.add_label action
+├── add_comment.go           # github.add_comment action
+├── create_pr.go             # github.create_pr action
+├── merge_pr.go              # github.merge_pr action
+├── add_reviewer.go          # github.add_reviewer action
+├── create_release.go        # github.create_release action
+├── create_branch.go         # github.create_branch action
+├── response.go              # Shared HTTP response → typed error mapping
+├── github_test.go           # Connector-level tests
+├── helpers_test.go          # Shared test helpers (validCreds)
+├── create_issue_test.go     # Tests for github.create_issue
+├── close_issue_test.go      # Tests for github.close_issue
+├── add_label_test.go        # Tests for github.add_label
+├── add_comment_test.go      # Tests for github.add_comment
+├── create_pr_test.go        # Tests for github.create_pr
+├── merge_pr_test.go         # Tests for github.merge_pr
+├── add_reviewer_test.go     # Tests for github.add_reviewer
+├── create_release_test.go   # Tests for github.create_release
+├── create_branch_test.go    # Tests for github.create_branch
+└── README.md                # This file
 ```
 
 ## Testing

--- a/connectors/github/README.md
+++ b/connectors/github/README.md
@@ -389,6 +389,7 @@ connectors/github/
 ├── add_reviewer.go          # github.add_reviewer action
 ├── create_release.go        # github.create_release action
 ├── create_branch.go         # github.create_branch action
+├── validation.go            # Shared validation helpers (parseAndValidate, requireOwnerRepo, etc.)
 ├── response.go              # Shared HTTP response → typed error mapping
 ├── github_test.go           # Connector-level tests
 ├── helpers_test.go          # Shared test helpers (validCreds)

--- a/connectors/github/add_comment.go
+++ b/connectors/github/add_comment.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// addCommentAction implements connectors.Action for github.add_comment.
+// It adds a comment to an issue or PR via POST /repos/{owner}/{repo}/issues/{issue_number}/comments.
+type addCommentAction struct {
+	conn *GitHubConnector
+}
+
+type addCommentParams struct {
+	Owner       string `json:"owner"`
+	Repo        string `json:"repo"`
+	IssueNumber int    `json:"issue_number"`
+	Body        string `json:"body"`
+}
+
+func (p *addCommentParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.IssueNumber <= 0 {
+		return &connectors.ValidationError{Message: "missing or invalid required parameter: issue_number"}
+	}
+	if p.Body == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: body"}
+	}
+	return nil
+}
+
+// Execute adds a comment to a GitHub issue or pull request.
+func (a *addCommentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params addCommentParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	ghBody := map[string]string{
+		"body": params.Body,
+	}
+
+	var ghResp struct {
+		ID      int    `json:"id"`
+		URL     string `json:"url"`
+		HTMLURL string `json:"html_url"`
+		Body    string `json:"body"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments",
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.IssueNumber)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/add_comment.go
+++ b/connectors/github/add_comment.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -24,14 +23,11 @@ type addCommentParams struct {
 }
 
 func (p *addCommentParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
-	}
-	if p.IssueNumber <= 0 {
-		return &connectors.ValidationError{Message: "missing or invalid required parameter: issue_number"}
+	if err := requirePositiveInt(p.IssueNumber, "issue_number"); err != nil {
+		return err
 	}
 	if p.Body == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: body"}
@@ -41,11 +37,8 @@ func (p *addCommentParams) validate() error {
 
 // Execute adds a comment to a GitHub issue or pull request.
 func (a *addCommentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params addCommentParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[addCommentParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/add_comment_test.go
+++ b/connectors/github/add_comment_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestAddComment_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/issues/7/comments" {
+			t.Errorf("path = %s, want /repos/octocat/hello-world/issues/7/comments", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]string
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if reqBody["body"] != "Looks good!" {
+			t.Errorf("body = %q, want %q", reqBody["body"], "Looks good!")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":       123,
+			"url":      "https://api.github.com/repos/octocat/hello-world/issues/comments/123",
+			"html_url": "https://github.com/octocat/hello-world/issues/7#issuecomment-123",
+			"body":     "Looks good!",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.add_comment"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.add_comment",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","issue_number":7,"body":"Looks good!"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["id"] != float64(123) {
+		t.Errorf("id = %v, want 123", data["id"])
+	}
+	if data["body"] != "Looks good!" {
+		t.Errorf("body = %v, want Looks good!", data["body"])
+	}
+}
+
+func TestAddComment_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.add_comment"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","issue_number":1,"body":"hi"}`},
+		{"missing repo", `{"owner":"o","issue_number":1,"body":"hi"}`},
+		{"missing issue_number", `{"owner":"o","repo":"r","body":"hi"}`},
+		{"missing body", `{"owner":"o","repo":"r","issue_number":1}`},
+		{"empty body", `{"owner":"o","repo":"r","issue_number":1,"body":""}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.add_comment",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/github/add_label.go
+++ b/connectors/github/add_label.go
@@ -36,6 +36,11 @@ func (p *addLabelParams) validate() error {
 	if len(p.Labels) == 0 {
 		return &connectors.ValidationError{Message: "missing required parameter: labels"}
 	}
+	for _, l := range p.Labels {
+		if l == "" {
+			return &connectors.ValidationError{Message: "labels must not contain empty strings"}
+		}
+	}
 	return nil
 }
 

--- a/connectors/github/add_label.go
+++ b/connectors/github/add_label.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -24,33 +23,19 @@ type addLabelParams struct {
 }
 
 func (p *addLabelParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	if err := requirePositiveInt(p.IssueNumber, "issue_number"); err != nil {
+		return err
 	}
-	if p.IssueNumber <= 0 {
-		return &connectors.ValidationError{Message: "missing or invalid required parameter: issue_number"}
-	}
-	if len(p.Labels) == 0 {
-		return &connectors.ValidationError{Message: "missing required parameter: labels"}
-	}
-	for _, l := range p.Labels {
-		if l == "" {
-			return &connectors.ValidationError{Message: "labels must not contain empty strings"}
-		}
-	}
-	return nil
+	return requireNonEmptyStrings(p.Labels, "labels")
 }
 
 // Execute adds labels to a GitHub issue or pull request.
 func (a *addLabelAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params addLabelParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[addLabelParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/add_label.go
+++ b/connectors/github/add_label.go
@@ -1,0 +1,68 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// addLabelAction implements connectors.Action for github.add_label.
+// It adds labels to an issue or PR via POST /repos/{owner}/{repo}/issues/{issue_number}/labels.
+type addLabelAction struct {
+	conn *GitHubConnector
+}
+
+type addLabelParams struct {
+	Owner       string   `json:"owner"`
+	Repo        string   `json:"repo"`
+	IssueNumber int      `json:"issue_number"`
+	Labels      []string `json:"labels"`
+}
+
+func (p *addLabelParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.IssueNumber <= 0 {
+		return &connectors.ValidationError{Message: "missing or invalid required parameter: issue_number"}
+	}
+	if len(p.Labels) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: labels"}
+	}
+	return nil
+}
+
+// Execute adds labels to a GitHub issue or pull request.
+func (a *addLabelAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params addLabelParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	ghBody := map[string]any{
+		"labels": params.Labels,
+	}
+
+	var ghResp []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels",
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.IssueNumber)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/add_label_test.go
+++ b/connectors/github/add_label_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestAddLabel_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/issues/5/labels" {
+			t.Errorf("path = %s, want /repos/octocat/hello-world/issues/5/labels", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		labels, ok := reqBody["labels"].([]any)
+		if !ok || len(labels) != 2 {
+			t.Errorf("labels = %v, want [\"bug\",\"urgent\"]", reqBody["labels"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 1, "name": "bug"},
+			{"id": 2, "name": "urgent"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.add_label"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.add_label",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","issue_number":5,"labels":["bug","urgent"]}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data []map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if len(data) != 2 {
+		t.Errorf("got %d labels, want 2", len(data))
+	}
+}
+
+func TestAddLabel_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.add_label"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","issue_number":1,"labels":["bug"]}`},
+		{"missing repo", `{"owner":"o","issue_number":1,"labels":["bug"]}`},
+		{"missing issue_number", `{"owner":"o","repo":"r","labels":["bug"]}`},
+		{"missing labels", `{"owner":"o","repo":"r","issue_number":1}`},
+		{"empty labels", `{"owner":"o","repo":"r","issue_number":1,"labels":[]}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.add_label",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/github/add_label_test.go
+++ b/connectors/github/add_label_test.go
@@ -76,6 +76,7 @@ func TestAddLabel_MissingParams(t *testing.T) {
 		{"missing issue_number", `{"owner":"o","repo":"r","labels":["bug"]}`},
 		{"missing labels", `{"owner":"o","repo":"r","issue_number":1}`},
 		{"empty labels", `{"owner":"o","repo":"r","issue_number":1,"labels":[]}`},
+		{"empty string in labels", `{"owner":"o","repo":"r","issue_number":1,"labels":[""]}`},
 		{"invalid JSON", `{invalid}`},
 	}
 

--- a/connectors/github/add_reviewer.go
+++ b/connectors/github/add_reviewer.go
@@ -36,6 +36,11 @@ func (p *addReviewerParams) validate() error {
 	if len(p.Reviewers) == 0 {
 		return &connectors.ValidationError{Message: "missing required parameter: reviewers"}
 	}
+	for _, r := range p.Reviewers {
+		if r == "" {
+			return &connectors.ValidationError{Message: "reviewers must not contain empty strings"}
+		}
+	}
 	return nil
 }
 

--- a/connectors/github/add_reviewer.go
+++ b/connectors/github/add_reviewer.go
@@ -1,0 +1,69 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// addReviewerAction implements connectors.Action for github.add_reviewer.
+// It requests reviews on a PR via POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers.
+type addReviewerAction struct {
+	conn *GitHubConnector
+}
+
+type addReviewerParams struct {
+	Owner      string   `json:"owner"`
+	Repo       string   `json:"repo"`
+	PullNumber int      `json:"pull_number"`
+	Reviewers  []string `json:"reviewers"`
+}
+
+func (p *addReviewerParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.PullNumber <= 0 {
+		return &connectors.ValidationError{Message: "missing or invalid required parameter: pull_number"}
+	}
+	if len(p.Reviewers) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: reviewers"}
+	}
+	return nil
+}
+
+// Execute requests reviews on a pull request and returns the updated PR data.
+func (a *addReviewerAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params addReviewerParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	ghBody := map[string]any{
+		"reviewers": params.Reviewers,
+	}
+
+	var ghResp struct {
+		Number  int    `json:"number"`
+		URL     string `json:"url"`
+		HTMLURL string `json:"html_url"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers",
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.PullNumber)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/add_reviewer.go
+++ b/connectors/github/add_reviewer.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -24,33 +23,19 @@ type addReviewerParams struct {
 }
 
 func (p *addReviewerParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	if err := requirePositiveInt(p.PullNumber, "pull_number"); err != nil {
+		return err
 	}
-	if p.PullNumber <= 0 {
-		return &connectors.ValidationError{Message: "missing or invalid required parameter: pull_number"}
-	}
-	if len(p.Reviewers) == 0 {
-		return &connectors.ValidationError{Message: "missing required parameter: reviewers"}
-	}
-	for _, r := range p.Reviewers {
-		if r == "" {
-			return &connectors.ValidationError{Message: "reviewers must not contain empty strings"}
-		}
-	}
-	return nil
+	return requireNonEmptyStrings(p.Reviewers, "reviewers")
 }
 
 // Execute requests reviews on a pull request and returns the updated PR data.
 func (a *addReviewerAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params addReviewerParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[addReviewerParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/add_reviewer_test.go
+++ b/connectors/github/add_reviewer_test.go
@@ -77,6 +77,7 @@ func TestAddReviewer_MissingParams(t *testing.T) {
 		{"missing pull_number", `{"owner":"o","repo":"r","reviewers":["alice"]}`},
 		{"missing reviewers", `{"owner":"o","repo":"r","pull_number":1}`},
 		{"empty reviewers", `{"owner":"o","repo":"r","pull_number":1,"reviewers":[]}`},
+		{"empty string in reviewers", `{"owner":"o","repo":"r","pull_number":1,"reviewers":[""]}`},
 		{"invalid JSON", `{invalid}`},
 	}
 

--- a/connectors/github/add_reviewer_test.go
+++ b/connectors/github/add_reviewer_test.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestAddReviewer_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/pulls/42/requested_reviewers" {
+			t.Errorf("path = %s, want /repos/octocat/hello-world/pulls/42/requested_reviewers", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		reviewers, ok := reqBody["reviewers"].([]any)
+		if !ok || len(reviewers) != 2 {
+			t.Errorf("reviewers = %v, want [\"alice\",\"bob\"]", reqBody["reviewers"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"number":   42,
+			"url":      "https://api.github.com/repos/octocat/hello-world/pulls/42",
+			"html_url": "https://github.com/octocat/hello-world/pull/42",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.add_reviewer"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.add_reviewer",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","pull_number":42,"reviewers":["alice","bob"]}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["number"] != float64(42) {
+		t.Errorf("number = %v, want 42", data["number"])
+	}
+}
+
+func TestAddReviewer_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.add_reviewer"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","pull_number":1,"reviewers":["alice"]}`},
+		{"missing repo", `{"owner":"o","pull_number":1,"reviewers":["alice"]}`},
+		{"missing pull_number", `{"owner":"o","repo":"r","reviewers":["alice"]}`},
+		{"missing reviewers", `{"owner":"o","repo":"r","pull_number":1}`},
+		{"empty reviewers", `{"owner":"o","repo":"r","pull_number":1,"reviewers":[]}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.add_reviewer",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/github/close_issue.go
+++ b/connectors/github/close_issue.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -31,14 +30,11 @@ var validStateReasons = map[string]bool{
 }
 
 func (p *closeIssueParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
-	}
-	if p.IssueNumber <= 0 {
-		return &connectors.ValidationError{Message: "missing or invalid required parameter: issue_number"}
+	if err := requirePositiveInt(p.IssueNumber, "issue_number"); err != nil {
+		return err
 	}
 	if p.StateReason == "" {
 		p.StateReason = "completed"
@@ -51,11 +47,8 @@ func (p *closeIssueParams) validate() error {
 
 // Execute closes a GitHub issue, optionally posting a comment first.
 func (a *closeIssueAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params closeIssueParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[closeIssueParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/close_issue.go
+++ b/connectors/github/close_issue.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// closeIssueAction implements connectors.Action for github.close_issue.
+// It closes an issue via PATCH /repos/{owner}/{repo}/issues/{issue_number},
+// optionally adding a comment first.
+type closeIssueAction struct {
+	conn *GitHubConnector
+}
+
+type closeIssueParams struct {
+	Owner       string `json:"owner"`
+	Repo        string `json:"repo"`
+	IssueNumber int    `json:"issue_number"`
+	StateReason string `json:"state_reason"`
+	Comment     string `json:"comment"`
+}
+
+var validStateReasons = map[string]bool{
+	"completed":   true,
+	"not_planned": true,
+}
+
+func (p *closeIssueParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.IssueNumber <= 0 {
+		return &connectors.ValidationError{Message: "missing or invalid required parameter: issue_number"}
+	}
+	if p.StateReason == "" {
+		p.StateReason = "completed"
+	}
+	if !validStateReasons[p.StateReason] {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid state_reason %q: must be completed or not_planned", p.StateReason)}
+	}
+	return nil
+}
+
+// Execute closes a GitHub issue, optionally posting a comment first.
+func (a *closeIssueAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params closeIssueParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// If a comment is provided, post it before closing.
+	if params.Comment != "" {
+		commentPath := fmt.Sprintf("/repos/%s/%s/issues/%d/comments",
+			url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.IssueNumber)
+		if err := a.conn.do(ctx, req.Credentials, http.MethodPost, commentPath,
+			map[string]string{"body": params.Comment}, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	// Close the issue.
+	ghBody := map[string]string{
+		"state":        "closed",
+		"state_reason": params.StateReason,
+	}
+
+	var ghResp struct {
+		Number  int    `json:"number"`
+		URL     string `json:"url"`
+		HTMLURL string `json:"html_url"`
+		State   string `json:"state"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d",
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.IssueNumber)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPatch, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/close_issue_test.go
+++ b/connectors/github/close_issue_test.go
@@ -1,0 +1,179 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCloseIssue_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/issues/10" {
+			t.Errorf("path = %s, want /repos/octocat/hello-world/issues/10", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]string
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if reqBody["state"] != "closed" {
+			t.Errorf("state = %q, want %q", reqBody["state"], "closed")
+		}
+		if reqBody["state_reason"] != "completed" {
+			t.Errorf("state_reason = %q, want %q", reqBody["state_reason"], "completed")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"number":   10,
+			"url":      "https://api.github.com/repos/octocat/hello-world/issues/10",
+			"html_url": "https://github.com/octocat/hello-world/issues/10",
+			"state":    "closed",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.close_issue"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.close_issue",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","issue_number":10}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["state"] != "closed" {
+		t.Errorf("state = %v, want closed", data["state"])
+	}
+}
+
+func TestCloseIssue_WithComment(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+
+		if n == 1 {
+			// First call: comment
+			if r.Method != http.MethodPost {
+				t.Errorf("comment method = %s, want POST", r.Method)
+			}
+			if r.URL.Path != "/repos/octocat/hello-world/issues/10/comments" {
+				t.Errorf("comment path = %s, want /repos/octocat/hello-world/issues/10/comments", r.URL.Path)
+			}
+			body, _ := io.ReadAll(r.Body)
+			var reqBody map[string]string
+			if err := json.Unmarshal(body, &reqBody); err != nil {
+				t.Fatalf("unmarshaling comment body: %v", err)
+			}
+			if reqBody["body"] != "Closing this as done." {
+				t.Errorf("comment body = %q, want %q", reqBody["body"], "Closing this as done.")
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": 1})
+			return
+		}
+
+		// Second call: close
+		if r.Method != http.MethodPatch {
+			t.Errorf("close method = %s, want PATCH", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{
+			"number": 10,
+			"state":  "closed",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.close_issue"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.close_issue",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","issue_number":10,"comment":"Closing this as done."}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 API calls (comment + close), got %d", callCount.Load())
+	}
+}
+
+func TestCloseIssue_InvalidStateReason(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.close_issue"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.close_issue",
+		Parameters:  json.RawMessage(`{"owner":"o","repo":"r","issue_number":1,"state_reason":"invalid"}`),
+		Credentials: validCreds(),
+	})
+
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloseIssue_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.close_issue"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","issue_number":1}`},
+		{"missing repo", `{"owner":"o","issue_number":1}`},
+		{"missing issue_number", `{"owner":"o","repo":"r"}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.close_issue",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/github/create_branch.go
+++ b/connectors/github/create_branch.go
@@ -25,6 +25,35 @@ type createBranchParams struct {
 	FromRef    string `json:"from_ref"`
 }
 
+// invalidRefChars contains characters forbidden in git ref names.
+// See: https://git-scm.com/docs/git-check-ref-format
+var invalidRefChars = strings.NewReplacer(
+	"..", "",
+	"~", "",
+	"^", "",
+	":", "",
+	"?", "",
+	"*", "",
+	"[", "",
+	"\\", "",
+)
+
+func validateRefName(name, field string) error {
+	if name == "" {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
+	}
+	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, ".") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not start with '/' or '.'", field)}
+	}
+	if strings.HasSuffix(name, ".lock") || strings.HasSuffix(name, ".") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not end with '.lock' or '.'", field)}
+	}
+	if invalidRefChars.Replace(name) != name {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: contains forbidden characters (.. ~ ^ : ? * [ \\)", field)}
+	}
+	return nil
+}
+
 func (p *createBranchParams) validate() error {
 	if p.Owner == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: owner"}
@@ -32,11 +61,11 @@ func (p *createBranchParams) validate() error {
 	if p.Repo == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: repo"}
 	}
-	if p.BranchName == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: branch_name"}
+	if err := validateRefName(p.BranchName, "branch_name"); err != nil {
+		return err
 	}
-	if p.FromRef == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: from_ref"}
+	if err := validateRefName(p.FromRef, "from_ref"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/connectors/github/create_branch.go
+++ b/connectors/github/create_branch.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,41 +24,9 @@ type createBranchParams struct {
 	FromRef    string `json:"from_ref"`
 }
 
-// invalidRefChars contains characters forbidden in git ref names.
-// See: https://git-scm.com/docs/git-check-ref-format
-var invalidRefChars = strings.NewReplacer(
-	"..", "",
-	"~", "",
-	"^", "",
-	":", "",
-	"?", "",
-	"*", "",
-	"[", "",
-	"\\", "",
-)
-
-func validateRefName(name, field string) error {
-	if name == "" {
-		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
-	}
-	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, ".") {
-		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not start with '/' or '.'", field)}
-	}
-	if strings.HasSuffix(name, ".lock") || strings.HasSuffix(name, ".") {
-		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not end with '.lock' or '.'", field)}
-	}
-	if invalidRefChars.Replace(name) != name {
-		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: contains forbidden characters (.. ~ ^ : ? * [ \\)", field)}
-	}
-	return nil
-}
-
 func (p *createBranchParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
-	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
 	if err := validateRefName(p.BranchName, "branch_name"); err != nil {
 		return err
@@ -72,11 +39,8 @@ func (p *createBranchParams) validate() error {
 
 // Execute creates a new branch in a GitHub repository.
 func (a *createBranchAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params createBranchParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[createBranchParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/create_branch.go
+++ b/connectors/github/create_branch.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createBranchAction implements connectors.Action for github.create_branch.
+// It creates a branch by first resolving a ref to a SHA, then creating
+// a new git ref via POST /repos/{owner}/{repo}/git/refs.
+type createBranchAction struct {
+	conn *GitHubConnector
+}
+
+type createBranchParams struct {
+	Owner      string `json:"owner"`
+	Repo       string `json:"repo"`
+	BranchName string `json:"branch_name"`
+	FromRef    string `json:"from_ref"`
+}
+
+func (p *createBranchParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.BranchName == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: branch_name"}
+	}
+	if p.FromRef == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: from_ref"}
+	}
+	return nil
+}
+
+// Execute creates a new branch in a GitHub repository.
+func (a *createBranchAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createBranchParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	// Resolve the source ref to a SHA.
+	var refResp struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+
+	refPath := fmt.Sprintf("/repos/%s/%s/git/ref/%s",
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.FromRef)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodGet, refPath, nil, &refResp); err != nil {
+		return nil, err
+	}
+
+	// Create the new branch ref.
+	ghBody := map[string]string{
+		"ref": "refs/heads/" + params.BranchName,
+		"sha": refResp.Object.SHA,
+	}
+
+	var ghResp struct {
+		Ref    string `json:"ref"`
+		URL    string `json:"url"`
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", url.PathEscape(params.Owner), url.PathEscape(params.Repo))
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/create_branch.go
+++ b/connectors/github/create_branch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -50,6 +51,14 @@ func (a *createBranchAction) Execute(ctx context.Context, req connectors.ActionR
 		return nil, err
 	}
 
+	// Normalize from_ref: accept bare branch names like "main" and
+	// expand to "heads/main" for the Git refs API. Tags can be specified
+	// as "tags/v1.0". Full refs like "heads/main" pass through unchanged.
+	fromRef := params.FromRef
+	if !strings.Contains(fromRef, "/") {
+		fromRef = "heads/" + fromRef
+	}
+
 	// Resolve the source ref to a SHA.
 	var refResp struct {
 		Object struct {
@@ -58,7 +67,7 @@ func (a *createBranchAction) Execute(ctx context.Context, req connectors.ActionR
 	}
 
 	refPath := fmt.Sprintf("/repos/%s/%s/git/ref/%s",
-		url.PathEscape(params.Owner), url.PathEscape(params.Repo), params.FromRef)
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), fromRef)
 	if err := a.conn.do(ctx, req.Credentials, http.MethodGet, refPath, nil, &refResp); err != nil {
 		return nil, err
 	}

--- a/connectors/github/create_branch.go
+++ b/connectors/github/create_branch.go
@@ -59,6 +59,15 @@ func (a *createBranchAction) Execute(ctx context.Context, req connectors.ActionR
 		fromRef = "heads/" + fromRef
 	}
 
+	// Escape each segment of the ref path to prevent URL injection.
+	// Refs like "heads/main" become "heads/main" (no-op for safe chars),
+	// but malicious values like "../foo" are safely encoded per-segment.
+	segments := strings.Split(fromRef, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	escapedRef := strings.Join(segments, "/")
+
 	// Resolve the source ref to a SHA.
 	var refResp struct {
 		Object struct {
@@ -67,7 +76,7 @@ func (a *createBranchAction) Execute(ctx context.Context, req connectors.ActionR
 	}
 
 	refPath := fmt.Sprintf("/repos/%s/%s/git/ref/%s",
-		url.PathEscape(params.Owner), url.PathEscape(params.Repo), fromRef)
+		url.PathEscape(params.Owner), url.PathEscape(params.Repo), escapedRef)
 	if err := a.conn.do(ctx, req.Credentials, http.MethodGet, refPath, nil, &refResp); err != nil {
 		return nil, err
 	}

--- a/connectors/github/create_branch_test.go
+++ b/connectors/github/create_branch_test.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateBranch_Success(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+
+		if n == 1 {
+			// First call: resolve ref
+			if r.Method != http.MethodGet {
+				t.Errorf("ref resolve method = %s, want GET", r.Method)
+			}
+			if r.URL.Path != "/repos/octocat/hello-world/git/ref/heads/main" {
+				t.Errorf("ref path = %s, want /repos/octocat/hello-world/git/ref/heads/main", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"ref": "refs/heads/main",
+				"object": map[string]string{
+					"sha": "abc123def456",
+				},
+			})
+			return
+		}
+
+		// Second call: create ref
+		if r.Method != http.MethodPost {
+			t.Errorf("create ref method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/git/refs" {
+			t.Errorf("create ref path = %s, want /repos/octocat/hello-world/git/refs", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]string
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if reqBody["ref"] != "refs/heads/feature-branch" {
+			t.Errorf("ref = %q, want %q", reqBody["ref"], "refs/heads/feature-branch")
+		}
+		if reqBody["sha"] != "abc123def456" {
+			t.Errorf("sha = %q, want %q", reqBody["sha"], "abc123def456")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"ref": "refs/heads/feature-branch",
+			"url": "https://api.github.com/repos/octocat/hello-world/git/refs/heads/feature-branch",
+			"object": map[string]string{
+				"sha": "abc123def456",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_branch"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_branch",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","branch_name":"feature-branch","from_ref":"heads/main"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["ref"] != "refs/heads/feature-branch" {
+		t.Errorf("ref = %v, want refs/heads/feature-branch", data["ref"])
+	}
+
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 API calls (resolve ref + create ref), got %d", callCount.Load())
+	}
+}
+
+func TestCreateBranch_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.create_branch"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","branch_name":"b","from_ref":"heads/main"}`},
+		{"missing repo", `{"owner":"o","branch_name":"b","from_ref":"heads/main"}`},
+		{"missing branch_name", `{"owner":"o","repo":"r","from_ref":"heads/main"}`},
+		{"missing from_ref", `{"owner":"o","repo":"r","branch_name":"b"}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.create_branch",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/github/create_branch_test.go
+++ b/connectors/github/create_branch_test.go
@@ -73,7 +73,7 @@ func TestCreateBranch_Success(t *testing.T) {
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "github.create_branch",
-		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","branch_name":"feature-branch","from_ref":"heads/main"}`),
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","branch_name":"feature-branch","from_ref":"main"}`),
 		Credentials: validCreds(),
 	})
 
@@ -94,6 +94,49 @@ func TestCreateBranch_Success(t *testing.T) {
 	}
 }
 
+func TestCreateBranch_FromTag(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+
+		if n == 1 {
+			// Verify full ref path is used as-is (not prefixed with heads/)
+			if r.URL.Path != "/repos/octocat/hello-world/git/ref/tags/v1.0" {
+				t.Errorf("ref path = %s, want /repos/octocat/hello-world/git/ref/tags/v1.0", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"ref":    "refs/tags/v1.0",
+				"object": map[string]string{"sha": "abc123"},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"ref":    "refs/heads/hotfix",
+			"object": map[string]string{"sha": "abc123"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_branch"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_branch",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","branch_name":"hotfix","from_ref":"tags/v1.0"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
 func TestCreateBranch_MissingParams(t *testing.T) {
 	t.Parallel()
 
@@ -104,9 +147,9 @@ func TestCreateBranch_MissingParams(t *testing.T) {
 		name   string
 		params string
 	}{
-		{"missing owner", `{"repo":"r","branch_name":"b","from_ref":"heads/main"}`},
-		{"missing repo", `{"owner":"o","branch_name":"b","from_ref":"heads/main"}`},
-		{"missing branch_name", `{"owner":"o","repo":"r","from_ref":"heads/main"}`},
+		{"missing owner", `{"repo":"r","branch_name":"b","from_ref":"main"}`},
+		{"missing repo", `{"owner":"o","branch_name":"b","from_ref":"main"}`},
+		{"missing branch_name", `{"owner":"o","repo":"r","from_ref":"main"}`},
 		{"missing from_ref", `{"owner":"o","repo":"r","branch_name":"b"}`},
 		{"invalid JSON", `{invalid}`},
 	}

--- a/connectors/github/create_branch_test.go
+++ b/connectors/github/create_branch_test.go
@@ -151,6 +151,10 @@ func TestCreateBranch_MissingParams(t *testing.T) {
 		{"missing repo", `{"owner":"o","branch_name":"b","from_ref":"main"}`},
 		{"missing branch_name", `{"owner":"o","repo":"r","from_ref":"main"}`},
 		{"missing from_ref", `{"owner":"o","repo":"r","branch_name":"b"}`},
+		{"branch_name with path traversal", `{"owner":"o","repo":"r","branch_name":"../../main","from_ref":"main"}`},
+		{"branch_name starts with dot", `{"owner":"o","repo":"r","branch_name":".hidden","from_ref":"main"}`},
+		{"branch_name with tilde", `{"owner":"o","repo":"r","branch_name":"foo~1","from_ref":"main"}`},
+		{"from_ref with path traversal", `{"owner":"o","repo":"r","branch_name":"b","from_ref":"heads/../main"}`},
 		{"invalid JSON", `{invalid}`},
 	}
 

--- a/connectors/github/create_issue.go
+++ b/connectors/github/create_issue.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,11 +24,8 @@ type createIssueParams struct {
 }
 
 func (p *createIssueParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
-	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
 	if p.Title == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: title"}
@@ -39,11 +35,8 @@ func (p *createIssueParams) validate() error {
 
 // Execute creates a GitHub issue and returns the created issue data.
 func (a *createIssueAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params createIssueParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[createIssueParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/create_pr.go
+++ b/connectors/github/create_pr.go
@@ -1,0 +1,84 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createPRAction implements connectors.Action for github.create_pr.
+// It creates a pull request via POST /repos/{owner}/{repo}/pulls.
+type createPRAction struct {
+	conn *GitHubConnector
+}
+
+type createPRParams struct {
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Draft bool   `json:"draft"`
+}
+
+func (p *createPRParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.Title == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: title"}
+	}
+	if p.Head == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: head"}
+	}
+	if p.Base == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: base"}
+	}
+	return nil
+}
+
+// Execute creates a GitHub pull request and returns the created PR data.
+func (a *createPRAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createPRParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	ghBody := map[string]any{
+		"title": params.Title,
+		"head":  params.Head,
+		"base":  params.Base,
+	}
+	if params.Body != "" {
+		ghBody["body"] = params.Body
+	}
+	if params.Draft {
+		ghBody["draft"] = true
+	}
+
+	var ghResp struct {
+		Number  int    `json:"number"`
+		URL     string `json:"url"`
+		HTMLURL string `json:"html_url"`
+		State   string `json:"state"`
+		Draft   bool   `json:"draft"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/pulls", url.PathEscape(params.Owner), url.PathEscape(params.Repo))
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/create_pr.go
+++ b/connectors/github/create_pr.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -27,11 +26,8 @@ type createPRParams struct {
 }
 
 func (p *createPRParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
-	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
 	if p.Title == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: title"}
@@ -47,11 +43,8 @@ func (p *createPRParams) validate() error {
 
 // Execute creates a GitHub pull request and returns the created PR data.
 func (a *createPRAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params createPRParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[createPRParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/create_pr_test.go
+++ b/connectors/github/create_pr_test.go
@@ -1,0 +1,152 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreatePR_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/pulls" {
+			t.Errorf("path = %s, want /repos/octocat/hello-world/pulls", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if reqBody["title"] != "Add feature" {
+			t.Errorf("title = %q, want %q", reqBody["title"], "Add feature")
+		}
+		if reqBody["head"] != "feature-branch" {
+			t.Errorf("head = %q, want %q", reqBody["head"], "feature-branch")
+		}
+		if reqBody["base"] != "main" {
+			t.Errorf("base = %q, want %q", reqBody["base"], "main")
+		}
+		if reqBody["draft"] != true {
+			t.Errorf("draft = %v, want true", reqBody["draft"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"number":   99,
+			"url":      "https://api.github.com/repos/octocat/hello-world/pulls/99",
+			"html_url": "https://github.com/octocat/hello-world/pull/99",
+			"state":    "open",
+			"draft":    true,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_pr"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_pr",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","title":"Add feature","head":"feature-branch","base":"main","draft":true}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["number"] != float64(99) {
+		t.Errorf("number = %v, want 99", data["number"])
+	}
+	if data["html_url"] != "https://github.com/octocat/hello-world/pull/99" {
+		t.Errorf("html_url = %v, want https://github.com/octocat/hello-world/pull/99", data["html_url"])
+	}
+}
+
+func TestCreatePR_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.create_pr"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","title":"t","head":"h","base":"b"}`},
+		{"missing repo", `{"owner":"o","title":"t","head":"h","base":"b"}`},
+		{"missing title", `{"owner":"o","repo":"r","head":"h","base":"b"}`},
+		{"missing head", `{"owner":"o","repo":"r","title":"t","base":"b"}`},
+		{"missing base", `{"owner":"o","repo":"r","title":"t","head":"h"}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.create_pr",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestCreatePR_BodyOptional(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if _, ok := reqBody["body"]; ok {
+			t.Error("body field should not be present when empty")
+		}
+		if _, ok := reqBody["draft"]; ok {
+			t.Error("draft field should not be present when false")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"number":   1,
+			"url":      "https://api.github.com/repos/o/r/pulls/1",
+			"html_url": "https://github.com/o/r/pull/1",
+			"state":    "open",
+			"draft":    false,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_pr"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_pr",
+		Parameters:  json.RawMessage(`{"owner":"o","repo":"r","title":"t","head":"h","base":"b"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}

--- a/connectors/github/create_release.go
+++ b/connectors/github/create_release.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -27,11 +26,8 @@ type createReleaseParams struct {
 }
 
 func (p *createReleaseParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
-	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
 	if p.TagName == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: tag_name"}
@@ -41,11 +37,8 @@ func (p *createReleaseParams) validate() error {
 
 // Execute creates a GitHub release and returns the created release data.
 func (a *createReleaseAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params createReleaseParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[createReleaseParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/create_release.go
+++ b/connectors/github/create_release.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createReleaseAction implements connectors.Action for github.create_release.
+// It creates a release via POST /repos/{owner}/{repo}/releases.
+type createReleaseAction struct {
+	conn *GitHubConnector
+}
+
+type createReleaseParams struct {
+	Owner      string `json:"owner"`
+	Repo       string `json:"repo"`
+	TagName    string `json:"tag_name"`
+	Name       string `json:"name"`
+	Body       string `json:"body"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+func (p *createReleaseParams) validate() error {
+	if p.Owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if p.Repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	if p.TagName == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: tag_name"}
+	}
+	return nil
+}
+
+// Execute creates a GitHub release and returns the created release data.
+func (a *createReleaseAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createReleaseParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	ghBody := map[string]any{
+		"tag_name": params.TagName,
+	}
+	if params.Name != "" {
+		ghBody["name"] = params.Name
+	}
+	if params.Body != "" {
+		ghBody["body"] = params.Body
+	}
+	if params.Draft {
+		ghBody["draft"] = true
+	}
+	if params.Prerelease {
+		ghBody["prerelease"] = true
+	}
+
+	var ghResp struct {
+		ID      int    `json:"id"`
+		URL     string `json:"url"`
+		HTMLURL string `json:"html_url"`
+		TagName string `json:"tag_name"`
+		Name    string `json:"name"`
+		Draft   bool   `json:"draft"`
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/releases", url.PathEscape(params.Owner), url.PathEscape(params.Repo))
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/create_release_test.go
+++ b/connectors/github/create_release_test.go
@@ -1,0 +1,150 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateRelease_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/octocat/hello-world/releases" {
+			t.Errorf("path = %s, want /repos/octocat/hello-world/releases", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if reqBody["tag_name"] != "v1.0.0" {
+			t.Errorf("tag_name = %q, want %q", reqBody["tag_name"], "v1.0.0")
+		}
+		if reqBody["name"] != "Release 1.0" {
+			t.Errorf("name = %q, want %q", reqBody["name"], "Release 1.0")
+		}
+		if reqBody["prerelease"] != true {
+			t.Errorf("prerelease = %v, want true", reqBody["prerelease"])
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":       1,
+			"url":      "https://api.github.com/repos/octocat/hello-world/releases/1",
+			"html_url": "https://github.com/octocat/hello-world/releases/tag/v1.0.0",
+			"tag_name": "v1.0.0",
+			"name":     "Release 1.0",
+			"draft":    false,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_release"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_release",
+		Parameters:  json.RawMessage(`{"owner":"octocat","repo":"hello-world","tag_name":"v1.0.0","name":"Release 1.0","body":"Notes","prerelease":true}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["tag_name"] != "v1.0.0" {
+		t.Errorf("tag_name = %v, want v1.0.0", data["tag_name"])
+	}
+}
+
+func TestCreateRelease_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.create_release"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"missing owner", `{"repo":"r","tag_name":"v1.0.0"}`},
+		{"missing repo", `{"owner":"o","tag_name":"v1.0.0"}`},
+		{"missing tag_name", `{"owner":"o","repo":"r"}`},
+		{"invalid JSON", `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.create_release",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestCreateRelease_OptionalFields(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if _, ok := reqBody["name"]; ok {
+			t.Error("name field should not be present when empty")
+		}
+		if _, ok := reqBody["body"]; ok {
+			t.Error("body field should not be present when empty")
+		}
+		if _, ok := reqBody["draft"]; ok {
+			t.Error("draft field should not be present when false")
+		}
+		if _, ok := reqBody["prerelease"]; ok {
+			t.Error("prerelease field should not be present when false")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":       1,
+			"url":      "https://api.github.com/repos/o/r/releases/1",
+			"html_url": "https://github.com/o/r/releases/tag/v1.0.0",
+			"tag_name": "v1.0.0",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_release"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_release",
+		Parameters:  json.RawMessage(`{"owner":"o","repo":"r","tag_name":"v1.0.0"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}

--- a/connectors/github/github.go
+++ b/connectors/github/github.go
@@ -114,6 +114,237 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "github.create_pr",
+				Name:        "Create Pull Request",
+				Description: "Create a pull request from a branch",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "title", "head", "base"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"title": {
+							"type": "string",
+							"description": "Pull request title"
+						},
+						"body": {
+							"type": "string",
+							"description": "Pull request body (Markdown supported)"
+						},
+						"head": {
+							"type": "string",
+							"description": "Branch containing the changes"
+						},
+						"base": {
+							"type": "string",
+							"description": "Branch to merge into"
+						},
+						"draft": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to create the PR as a draft"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "github.add_reviewer",
+				Name:        "Add Reviewer",
+				Description: "Request reviews on a pull request",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "pull_number", "reviewers"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"pull_number": {
+							"type": "integer",
+							"description": "Pull request number"
+						},
+						"reviewers": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "GitHub usernames to request reviews from"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "github.create_release",
+				Name:        "Create Release",
+				Description: "Create a tagged release in a repository",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "tag_name"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"tag_name": {
+							"type": "string",
+							"description": "The name of the tag for this release"
+						},
+						"name": {
+							"type": "string",
+							"description": "The name of the release"
+						},
+						"body": {
+							"type": "string",
+							"description": "Release notes (Markdown supported)"
+						},
+						"draft": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to create as a draft release"
+						},
+						"prerelease": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to mark as a pre-release"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "github.close_issue",
+				Name:        "Close Issue",
+				Description: "Close an issue with an optional comment",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "issue_number"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"issue_number": {
+							"type": "integer",
+							"description": "Issue number to close"
+						},
+						"state_reason": {
+							"type": "string",
+							"enum": ["completed", "not_planned"],
+							"default": "completed",
+							"description": "Reason for closing the issue"
+						},
+						"comment": {
+							"type": "string",
+							"description": "Optional comment to add before closing"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "github.add_label",
+				Name:        "Add Label",
+				Description: "Add labels to an issue or pull request",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "issue_number", "labels"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"issue_number": {
+							"type": "integer",
+							"description": "Issue or pull request number"
+						},
+						"labels": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Labels to add"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "github.add_comment",
+				Name:        "Add Comment",
+				Description: "Add a comment to an issue or pull request",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "issue_number", "body"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"issue_number": {
+							"type": "integer",
+							"description": "Issue or pull request number"
+						},
+						"body": {
+							"type": "string",
+							"description": "Comment body (Markdown supported)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "github.create_branch",
+				Name:        "Create Branch",
+				Description: "Create a new branch from a ref",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["owner", "repo", "branch_name", "from_ref"],
+					"properties": {
+						"owner": {
+							"type": "string",
+							"description": "Repository owner (user or organization)"
+						},
+						"repo": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"branch_name": {
+							"type": "string",
+							"description": "Name for the new branch"
+						},
+						"from_ref": {
+							"type": "string",
+							"description": "Source ref to branch from (e.g. heads/main)"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{Service: "github", AuthType: "api_key", InstructionsURL: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"},
@@ -140,6 +371,55 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can merge any PR. Owner, repo, and PR number are agent-controlled.",
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","pull_number":"*","merge_method":"squash"}`),
 			},
+			{
+				ID:          "tpl_github_create_pr",
+				ActionType:  "github.create_pr",
+				Name:        "Create pull requests",
+				Description: "Agent can create PRs in any repo.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","title":"*","body":"*","head":"*","base":"*","draft":"*"}`),
+			},
+			{
+				ID:          "tpl_github_add_reviewer",
+				ActionType:  "github.add_reviewer",
+				Name:        "Add reviewers to PRs",
+				Description: "Agent can request reviewers on any PR.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","pull_number":"*","reviewers":"*"}`),
+			},
+			{
+				ID:          "tpl_github_create_release",
+				ActionType:  "github.create_release",
+				Name:        "Create releases",
+				Description: "Agent can create releases in any repo.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","tag_name":"*","name":"*","body":"*","draft":"*","prerelease":"*"}`),
+			},
+			{
+				ID:          "tpl_github_close_issue",
+				ActionType:  "github.close_issue",
+				Name:        "Close issues",
+				Description: "Agent can close issues in any repo with an optional comment.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","issue_number":"*","state_reason":"*","comment":"*"}`),
+			},
+			{
+				ID:          "tpl_github_add_label",
+				ActionType:  "github.add_label",
+				Name:        "Add labels",
+				Description: "Agent can add labels to any issue or PR.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","issue_number":"*","labels":"*"}`),
+			},
+			{
+				ID:          "tpl_github_add_comment",
+				ActionType:  "github.add_comment",
+				Name:        "Add comments",
+				Description: "Agent can comment on any issue or PR.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","issue_number":"*","body":"*"}`),
+			},
+			{
+				ID:          "tpl_github_create_branch",
+				ActionType:  "github.create_branch",
+				Name:        "Create branches",
+				Description: "Agent can create branches in any repo.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","branch_name":"*","from_ref":"*"}`),
+			},
 		},
 	}
 }
@@ -147,8 +427,15 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 // Actions returns the registered action handlers keyed by action_type.
 func (c *GitHubConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
-		"github.create_issue": &createIssueAction{conn: c},
-		"github.merge_pr":     &mergePRAction{conn: c},
+		"github.create_issue":   &createIssueAction{conn: c},
+		"github.merge_pr":       &mergePRAction{conn: c},
+		"github.create_pr":      &createPRAction{conn: c},
+		"github.add_reviewer":   &addReviewerAction{conn: c},
+		"github.create_release": &createReleaseAction{conn: c},
+		"github.close_issue":    &closeIssueAction{conn: c},
+		"github.add_label":      &addLabelAction{conn: c},
+		"github.add_comment":    &addCommentAction{conn: c},
+		"github.create_branch":  &createBranchAction{conn: c},
 	}
 }
 

--- a/connectors/github/github.go
+++ b/connectors/github/github.go
@@ -340,7 +340,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"from_ref": {
 							"type": "string",
-							"description": "Source ref to branch from (e.g. heads/main)"
+							"description": "Branch or ref to create from (e.g. \"main\", \"develop\", or \"tags/v1.0\")"
 						}
 					}
 				}`)),
@@ -371,6 +371,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can merge any PR. Owner, repo, and PR number are agent-controlled.",
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","pull_number":"*","merge_method":"squash"}`),
 			},
+			// --- PR lifecycle templates ---
 			{
 				ID:          "tpl_github_create_pr",
 				ActionType:  "github.create_pr",
@@ -379,12 +380,20 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","title":"*","body":"*","head":"*","base":"*","draft":"*"}`),
 			},
 			{
+				ID:          "tpl_github_create_pr_org",
+				ActionType:  "github.create_pr",
+				Name:        "Create PRs in your org",
+				Description: "Agent can create PRs only in repos owned by your organization.",
+				Parameters:  json.RawMessage(`{"owner":{"$pattern":"your-org-*"},"repo":"*","title":"*","body":"*","head":"*","base":"*","draft":"*"}`),
+			},
+			{
 				ID:          "tpl_github_add_reviewer",
 				ActionType:  "github.add_reviewer",
 				Name:        "Add reviewers to PRs",
 				Description: "Agent can request reviewers on any PR.",
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","pull_number":"*","reviewers":"*"}`),
 			},
+			// --- Release management templates ---
 			{
 				ID:          "tpl_github_create_release",
 				ActionType:  "github.create_release",
@@ -393,11 +402,26 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","tag_name":"*","name":"*","body":"*","draft":"*","prerelease":"*"}`),
 			},
 			{
+				ID:          "tpl_github_create_release_draft",
+				ActionType:  "github.create_release",
+				Name:        "Create draft releases only",
+				Description: "Agent can create draft releases — they won't be published until manually reviewed.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","tag_name":"*","name":"*","body":"*","draft":true,"prerelease":"*"}`),
+			},
+			// --- Issue lifecycle templates ---
+			{
 				ID:          "tpl_github_close_issue",
 				ActionType:  "github.close_issue",
 				Name:        "Close issues",
 				Description: "Agent can close issues in any repo with an optional comment.",
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","issue_number":"*","state_reason":"*","comment":"*"}`),
+			},
+			{
+				ID:          "tpl_github_close_issue_completed",
+				ActionType:  "github.close_issue",
+				Name:        "Close issues as completed",
+				Description: "Agent can close issues as completed (not as not_planned). Useful for bots that resolve issues.",
+				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","issue_number":"*","state_reason":"completed","comment":"*"}`),
 			},
 			{
 				ID:          "tpl_github_add_label",
@@ -413,6 +437,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Agent can comment on any issue or PR.",
 				Parameters:  json.RawMessage(`{"owner":"*","repo":"*","issue_number":"*","body":"*"}`),
 			},
+			// --- Branch management templates ---
 			{
 				ID:          "tpl_github_create_branch",
 				ActionType:  "github.create_branch",

--- a/connectors/github/github_test.go
+++ b/connectors/github/github_test.go
@@ -19,7 +19,17 @@ func TestGitHubConnector_Actions(t *testing.T) {
 	c := New()
 	actions := c.Actions()
 
-	want := []string{"github.create_issue", "github.merge_pr"}
+	want := []string{
+		"github.create_issue",
+		"github.merge_pr",
+		"github.create_pr",
+		"github.add_reviewer",
+		"github.create_release",
+		"github.close_issue",
+		"github.add_label",
+		"github.add_comment",
+		"github.create_branch",
+	}
 	for _, at := range want {
 		if _, ok := actions[at]; !ok {
 			t.Errorf("Actions() missing %q", at)
@@ -90,14 +100,18 @@ func TestGitHubConnector_Manifest(t *testing.T) {
 	if m.Name != "GitHub" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "GitHub")
 	}
-	if len(m.Actions) != 2 {
-		t.Fatalf("Manifest().Actions has %d items, want 2", len(m.Actions))
+	if len(m.Actions) != 9 {
+		t.Fatalf("Manifest().Actions has %d items, want 9", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
 		actionTypes[a.ActionType] = true
 	}
-	for _, want := range []string{"github.create_issue", "github.merge_pr"} {
+	for _, want := range []string{
+		"github.create_issue", "github.merge_pr", "github.create_pr",
+		"github.add_reviewer", "github.create_release", "github.close_issue",
+		"github.add_label", "github.add_comment", "github.create_branch",
+	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)
 		}

--- a/connectors/github/merge_pr.go
+++ b/connectors/github/merge_pr.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -31,14 +30,11 @@ var validMergeMethods = map[string]bool{
 }
 
 func (p *mergePRParams) validate() error {
-	if p.Owner == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return err
 	}
-	if p.Repo == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: repo"}
-	}
-	if p.PullNumber <= 0 {
-		return &connectors.ValidationError{Message: "missing or invalid required parameter: pull_number"}
+	if err := requirePositiveInt(p.PullNumber, "pull_number"); err != nil {
+		return err
 	}
 	if p.MergeMethod == "" {
 		p.MergeMethod = "merge"
@@ -51,11 +47,8 @@ func (p *mergePRParams) validate() error {
 
 // Execute merges a GitHub pull request and returns the merge result.
 func (a *mergePRAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params mergePRParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
+	params, err := parseAndValidate[mergePRParams](req.Parameters)
+	if err != nil {
 		return nil, err
 	}
 

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -8,22 +8,26 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
-// validatable is implemented by all action parameter structs.
-type validatable interface {
+// ptrValidatable constrains PT to be a pointer to T that implements validate().
+// This allows parseAndValidate to work with pointer-receiver validate() methods.
+type ptrValidatable[T any] interface {
+	*T
 	validate() error
 }
 
 // parseAndValidate unmarshals req.Parameters into T and calls validate().
 // This eliminates the repeated unmarshal→validate boilerplate in every action.
-func parseAndValidate[T validatable](raw json.RawMessage) (*T, error) {
-	var params T
-	if err := json.Unmarshal(raw, &params); err != nil {
+// Usage: parseAndValidate[createIssueParams](req.Parameters)
+// Go infers the pointer type automatically from the constraint.
+func parseAndValidate[T any, PT ptrValidatable[T]](raw json.RawMessage) (PT, error) {
+	params := PT(new(T))
+	if err := json.Unmarshal(raw, params); err != nil {
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
 	}
 	if err := params.validate(); err != nil {
 		return nil, err
 	}
-	return &params, nil
+	return params, nil
 }
 
 // requireOwnerRepo validates the common owner+repo pair present in every action.

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -1,0 +1,90 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// validatable is implemented by all action parameter structs.
+type validatable interface {
+	validate() error
+}
+
+// parseAndValidate unmarshals req.Parameters into T and calls validate().
+// This eliminates the repeated unmarshal→validate boilerplate in every action.
+func parseAndValidate[T validatable](raw json.RawMessage) (*T, error) {
+	var params T
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	return &params, nil
+}
+
+// requireOwnerRepo validates the common owner+repo pair present in every action.
+func requireOwnerRepo(owner, repo string) error {
+	if owner == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: owner"}
+	}
+	if repo == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: repo"}
+	}
+	return nil
+}
+
+// requirePositiveInt validates that an integer field is > 0.
+func requirePositiveInt(val int, field string) error {
+	if val <= 0 {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing or invalid required parameter: %s", field)}
+	}
+	return nil
+}
+
+// requireNonEmptyStrings validates a string slice has at least one element
+// and no element is empty.
+func requireNonEmptyStrings(vals []string, field string) error {
+	if len(vals) == 0 {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
+	}
+	for _, v := range vals {
+		if v == "" {
+			return &connectors.ValidationError{Message: fmt.Sprintf("%s must not contain empty strings", field)}
+		}
+	}
+	return nil
+}
+
+// invalidRefChars contains characters forbidden in git ref names.
+// See: https://git-scm.com/docs/git-check-ref-format
+var invalidRefChars = strings.NewReplacer(
+	"..", "",
+	"~", "",
+	"^", "",
+	":", "",
+	"?", "",
+	"*", "",
+	"[", "",
+	"\\", "",
+)
+
+// validateRefName checks that a git ref name conforms to git-check-ref-format rules.
+func validateRefName(name, field string) error {
+	if name == "" {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
+	}
+	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, ".") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not start with '/' or '.'", field)}
+	}
+	if strings.HasSuffix(name, ".lock") || strings.HasSuffix(name, ".") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: must not end with '.lock' or '.'", field)}
+	}
+	if invalidRefChars.Replace(name) != name {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: contains forbidden characters (.. ~ ^ : ? * [ \\)", field)}
+	}
+	return nil
+}

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -18,7 +18,14 @@ ConnectorListResponse:
         description: "GitHub integration for repository management"
         actions:
           - "github.create_issue"
+          - "github.close_issue"
+          - "github.add_label"
+          - "github.add_comment"
+          - "github.create_pr"
           - "github.merge_pr"
+          - "github.add_reviewer"
+          - "github.create_release"
+          - "github.create_branch"
         required_credentials:
           - "github"
 
@@ -61,7 +68,14 @@ ConnectorSummary:
         List of action types supported by this connector.
       example:
         - "github.create_issue"
+        - "github.close_issue"
+        - "github.add_label"
+        - "github.add_comment"
+        - "github.create_pr"
         - "github.merge_pr"
+        - "github.add_reviewer"
+        - "github.create_release"
+        - "github.create_branch"
 
     required_credentials:
       type: array
@@ -81,7 +95,14 @@ ConnectorSummary:
     description: "GitHub integration for repository management"
     actions:
       - "github.create_issue"
+      - "github.close_issue"
+      - "github.add_label"
+      - "github.add_comment"
+      - "github.create_pr"
       - "github.merge_pr"
+      - "github.add_reviewer"
+      - "github.create_release"
+      - "github.create_branch"
     required_credentials:
       - "github"
 

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7227,7 +7227,14 @@ components:
             description: GitHub integration for repository management
             actions:
               - github.create_issue
+              - github.close_issue
+              - github.add_label
+              - github.add_comment
+              - github.create_pr
               - github.merge_pr
+              - github.add_reviewer
+              - github.create_release
+              - github.create_branch
             required_credentials:
               - github
     ConnectorSummary:
@@ -7266,7 +7273,14 @@ components:
             List of action types supported by this connector.
           example:
             - github.create_issue
+            - github.close_issue
+            - github.add_label
+            - github.add_comment
+            - github.create_pr
             - github.merge_pr
+            - github.add_reviewer
+            - github.create_release
+            - github.create_branch
         required_credentials:
           type: array
           items:
@@ -7284,7 +7298,14 @@ components:
         description: GitHub integration for repository management
         actions:
           - github.create_issue
+          - github.close_issue
+          - github.add_label
+          - github.add_comment
+          - github.create_pr
           - github.merge_pr
+          - github.add_reviewer
+          - github.create_release
+          - github.create_branch
         required_credentials:
           - github
     ConnectorDetailResponse:


### PR DESCRIPTION
## Summary

- Add 7 new GitHub connector actions: `create_pr`, `add_reviewer`, `create_release`, `close_issue`, `add_label`, `add_comment`, `create_branch`
- Register all actions in `Actions()` map, `Manifest()` with JSON schemas, and permission `Templates`
- Add comprehensive tests for each action (success, validation, optional fields, multi-step flows)

## Test plan

- [ ] CI passes `go test ./connectors/github/...`
- [ ] CI passes `make build`
- [ ] Verify manifest validation passes (existing `TestGitHubConnector_Manifest` and `TestGitHubConnector_ActionsMatchManifest`)
- [ ] Verify each action's success and error test cases pass

Closes #272
