### PR TITLE
fix: Kroger TestCheckResponse_TruncatesLargeBody and go.mod version

### DIFF
--- a/connectors/kroger/response_test.go
+++ b/connectors/kroger/response_test.go
@@ -47,7 +47,9 @@ func TestCheckResponse_TruncatesLargeBody(t *testing.T) {
 	t.Parallel()
 
 	// Create a body larger than 512 chars that doesn't parse as JSON.
-	largeBody := []byte(strings.Repeat("x", 1000))
+	// Use "z" instead of "x" because "x" appears in the error wrapper
+	// ("external service error..."), which inflates the count.
+	largeBody := []byte(strings.Repeat("z", 1000))
 	err := checkResponse(http.StatusInternalServerError, http.Header{}, largeBody)
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -57,7 +59,7 @@ func TestCheckResponse_TruncatesLargeBody(t *testing.T) {
 		t.Errorf("large error body should be truncated, got length %d", len(msg))
 	}
 	// The raw body portion should be at most 512 chars + truncation suffix.
-	if strings.Count(msg, "x") > 512 {
+	if strings.Count(msg, "z") > 512 {
 		t.Error("truncated body should contain at most 512 chars of raw content")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip-web
 
-go 1.26.1
+go 1.24.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
…wrapper

The test used strings.Repeat("x", 1000) then asserted strings.Count(msg, "x") <= 512. But ExternalError.Error() wraps the message with "external service error..." which contains an "x", making the count 513 and failing the assertion.

Switch to "z" which doesn't appear in the error wrapper.

Also revert go.mod from 1.26.1 back to 1.24.0 — Go 1.26.1 is not available in the build environment, preventing all backend tests from compiling.

https://claude.ai/code/session_01VBdc2hVen8srt3Xh7nfWX6