### PR TITLE
Add dynamic go.mod patching for sandbox environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,11 @@ At the start of each session, set this so Go uses the locally installed toolchai
 
 ```bash
 export GOTOOLCHAIN=local
+
+# Patch go.mod to match the local Go version (sandbox can't download toolchains)
+GO_VERSION=$(go env GOVERSION | sed 's/^go//')
+sed -i "s/^go .*/go ${GO_VERSION}/" go.mod
+git update-index --assume-unchanged go.mod go.sum
 ```
 
 ## PostgreSQL Setup


### PR DESCRIPTION
Detects the installed Go version and patches go.mod to match at session start, then hides the change from git with --assume-unchanged. This prevents toolchain download errors in sandboxed Claude environments.

https://claude.ai/code/session_01Fpuc5iVpeP5emQJt5WBY1o