### PR TITLE
Upgrade Go to 1.26.1 to fix 24 stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip-web
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
All vulnerabilities (GO-2025-3563 through GO-2026-4602) are in the Go standard library and are fixed by upgrading to go1.26.1. The Dockerfile already uses golang:1.26.1-alpine, so this aligns go.mod with production.

https://claude.ai/code/session_018SCfqqXCvQ9fLgDtUy8ERj