### PR TITLE
feat: add Discord connector for community management

### DIFF
--- a/connectors/discord/README.md
+++ b/connectors/discord/README.md
@@ -1,0 +1,172 @@
+# Discord Connector
+
+Discord integration for community management and messaging. Uses the
+[Discord REST API v10](https://discord.com/developers/docs/reference)
+with a plain `net/http` client (no third-party SDK).
+
+## Credentials
+
+| Key         | Description                          |
+|-------------|--------------------------------------|
+| `bot_token` | Discord bot token (from the [Developer Portal](https://discord.com/developers/applications)) |
+
+### Setup steps
+
+1. Go to <https://discord.com/developers/applications> and create a new application.
+2. Navigate to **Bot** in the sidebar.
+3. Click **Reset Token** (or **Copy** if shown) to get the bot token.
+4. Under **Privileged Gateway Intents**, enable **Server Members Intent** if you plan to use `list_members`.
+5. Go to **OAuth2 > URL Generator**, select the `bot` scope, choose the permissions your actions require (see table below), then use the generated URL to invite the bot to your server.
+6. Paste the bot token into Permission Slip as the `bot_token` credential.
+
+## Actions
+
+| Action | Risk | Description | Required Bot Permission |
+|--------|------|-------------|------------------------|
+| `discord.send_message` | low | Send a message to a channel | Send Messages |
+| `discord.create_channel` | medium | Create a text, voice, or category channel | Manage Channels |
+| `discord.manage_roles` | medium | Assign or remove a role from a member | Manage Roles |
+| `discord.create_event` | medium | Create a scheduled guild event | Manage Events |
+| `discord.ban_user` | high | Ban a user from a guild | Ban Members |
+| `discord.kick_user` | high | Kick a user from a guild | Kick Members |
+| `discord.pin_message` | medium | Pin a message in a channel | Manage Messages |
+| `discord.unpin_message` | medium | Unpin a message in a channel | Manage Messages |
+| `discord.list_channels` | low | List channels in a guild | View Channels |
+| `discord.list_members` | low | List members of a guild | Server Members Intent |
+| `discord.create_thread` | low | Create a thread in a channel | Create Public Threads |
+| `discord.list_roles` | low | List roles in a guild | (none) |
+
+## Parameter constraints
+
+All ID parameters (channel, guild, user, role, message) are **snowflakes** --
+numeric strings, typically 17-20 digits (e.g. `1234567890123456789`). The
+connector validates that IDs contain only digits.
+
+| Parameter | Constraint |
+|-----------|-----------|
+| Message `content` | 1-2000 characters |
+| Channel `name` | 2-100 characters, lowercase, no spaces (`^[a-z0-9_-]+$`) |
+| Channel `topic` | Up to 1024 characters |
+| Event `name` | 1-100 characters |
+| Event `description` | Up to 1000 characters |
+| Thread `name` | 1-100 characters |
+| Thread `auto_archive_duration` | One of: 60, 1440, 4320, 10080 (minutes) |
+| `entity_type` | 1 (stage), 2 (voice), or 3 (external) |
+| Ban `delete_message_seconds` | 0 - 604800 (0 = none, 604800 = 7 days) |
+| List `limit` | 1 - 1000 (default 100) |
+
+## Error handling
+
+The connector maps Discord API error codes to actionable messages:
+
+| Discord Code | Meaning | Connector Error |
+|-------------|---------|-----------------|
+| 10003 | Unknown Channel | ExternalError -- "channel not found, verify the ID" |
+| 10004 | Unknown Guild | ExternalError -- "guild not found, verify the ID" |
+| 10007 | Unknown Member | ExternalError -- "member not found in guild" |
+| 10008 | Unknown Message | ExternalError -- "message not found in channel" |
+| 10011 | Unknown Role | ExternalError -- "role not found, use list_roles" |
+| 30003 | Max pins | ExternalError -- "50 pinned messages limit reached" |
+| 40001 | Unauthorized | AuthError -- "verify bot token" |
+| 50001 | Missing Access | AuthError -- "bot missing guild/channel access" |
+| 50013 | Missing Permissions | AuthError -- "check bot role permissions" |
+| 50028 | Invalid Role | ExternalError -- "role hierarchy issue" |
+| 50035 | Invalid Form Body | ValidationError -- parameter format issue |
+| HTTP 401 | Invalid token | AuthError -- "regenerate token" |
+| HTTP 403 | Forbidden | AuthError -- "check bot permissions" |
+| HTTP 429 | Rate limited | RateLimitError with Retry-After |
+
+## Response examples
+
+### send_message
+```json
+{"id": "1234567890", "channel_id": "9876543210"}
+```
+
+### create_channel
+```json
+{"id": "1234567890", "name": "new-channel", "type": 0}
+```
+
+### manage_roles
+```json
+{"status": "success", "action": "assign", "user_id": "111", "role_id": "222"}
+```
+
+### create_event
+```json
+{"id": "1234567890", "name": "Team Standup"}
+```
+
+### ban_user / kick_user
+```json
+{"status": "banned", "user_id": "111"}
+```
+
+### pin_message / unpin_message
+```json
+{"status": "pinned", "message_id": "111", "channel_id": "222"}
+```
+
+### list_channels
+```json
+{
+  "channels": [
+    {"id": "100", "name": "general", "type": 0, "position": 0}
+  ]
+}
+```
+
+### list_members
+```json
+{
+  "members": [
+    {"user_id": "100", "username": "alice", "nick": "Alice", "roles": ["200"], "joined_at": "2025-01-01T00:00:00Z"}
+  ]
+}
+```
+
+### list_roles
+```json
+{
+  "roles": [
+    {"id": "100", "name": "@everyone", "color": 0, "position": 0, "managed": false, "mentionable": false},
+    {"id": "200", "name": "Moderator", "color": 3447003, "position": 1, "managed": false, "mentionable": true}
+  ]
+}
+```
+
+### create_thread
+```json
+{"id": "1234567890", "name": "Discussion Thread"}
+```
+
+## File structure
+
+```
+connectors/discord/
+  discord.go              Main connector: manifest, HTTP client, error mapping
+  send_message.go         discord.send_message action
+  create_channel.go       discord.create_channel action
+  manage_roles.go         discord.manage_roles action
+  create_event.go         discord.create_event action
+  ban_user.go             discord.ban_user action
+  kick_user.go            discord.kick_user action
+  pin_message.go          discord.pin_message / discord.unpin_message actions
+  list_channels.go        discord.list_channels action
+  list_members.go         discord.list_members action
+  create_thread.go        discord.create_thread action
+  list_roles.go           discord.list_roles action
+  helpers_test.go         Shared test helpers (validCreds)
+  *_test.go               Tests for each action
+  README.md               This file
+```
+
+## Testing
+
+```bash
+go test ./connectors/discord/... -v
+```
+
+All tests use `httptest.NewServer` to mock the Discord API -- no real
+Discord credentials or network access required.

--- a/connectors/discord/README.md
+++ b/connectors/discord/README.md
@@ -50,7 +50,7 @@ connector validates that IDs contain only digits.
 | Event `name` | 1-100 characters |
 | Event `description` | Up to 1000 characters |
 | Thread `name` | 1-100 characters |
-| Thread `auto_archive_duration` | One of: 60, 1440, 4320, 10080 (minutes) |
+| Thread `auto_archive_duration` | One of: 0 (server default), 60, 1440, 4320, 10080 (minutes) |
 | `entity_type` | 1 (stage), 2 (voice), or 3 (external) |
 | Ban `delete_message_seconds` | 0 - 604800 (0 = none, 604800 = 7 days) |
 | List `limit` | 1 - 1000 (default 100) |

--- a/connectors/discord/ban_kick_test.go
+++ b/connectors/discord/ban_kick_test.go
@@ -1,0 +1,133 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestBanUser_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/bans/222" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &banUserAction{conn: conn}
+
+	params, _ := json.Marshal(banUserParams{
+		GuildID: "111",
+		UserID:  "222",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.ban_user",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["status"] != "banned" {
+		t.Errorf("expected status 'banned', got %q", data["status"])
+	}
+}
+
+func TestBanUser_InvalidDeleteMessageSeconds(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &banUserAction{conn: conn}
+
+	params, _ := json.Marshal(banUserParams{
+		GuildID:              "111",
+		UserID:               "222",
+		DeleteMessageSeconds: 700000,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.ban_user",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid delete_message_seconds")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestKickUser_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/members/222" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &kickUserAction{conn: conn}
+
+	params, _ := json.Marshal(kickUserParams{
+		GuildID: "111",
+		UserID:  "222",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.kick_user",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["status"] != "kicked" {
+		t.Errorf("expected status 'kicked', got %q", data["status"])
+	}
+}
+
+func TestKickUser_MissingUserID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &kickUserAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"guild_id": "111"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.kick_user",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing user_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/ban_kick_test.go
+++ b/connectors/discord/ban_kick_test.go
@@ -3,7 +3,6 @@ package discord
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -12,24 +11,11 @@ import (
 func TestBanUser_Success(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Errorf("expected PUT, got %s", r.Method)
-		}
-		if r.URL.Path != "/guilds/111/bans/222" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
+	conn, cleanup := mockServer(t, http.MethodPut, "/guilds/111/bans/222", http.StatusNoContent, nil)
+	defer cleanup()
 
-	conn := newForTest(srv.Client(), srv.URL)
 	action := &banUserAction{conn: conn}
-
-	params, _ := json.Marshal(banUserParams{
-		GuildID: "111",
-		UserID:  "222",
-	})
+	params, _ := json.Marshal(banUserParams{GuildID: "111", UserID: "222"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "discord.ban_user",
@@ -76,24 +62,11 @@ func TestBanUser_InvalidDeleteMessageSeconds(t *testing.T) {
 func TestKickUser_Success(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("expected DELETE, got %s", r.Method)
-		}
-		if r.URL.Path != "/guilds/111/members/222" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
+	conn, cleanup := mockServer(t, http.MethodDelete, "/guilds/111/members/222", http.StatusNoContent, nil)
+	defer cleanup()
 
-	conn := newForTest(srv.Client(), srv.URL)
 	action := &kickUserAction{conn: conn}
-
-	params, _ := json.Marshal(kickUserParams{
-		GuildID: "111",
-		UserID:  "222",
-	})
+	params, _ := json.Marshal(kickUserParams{GuildID: "111", UserID: "222"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "discord.kick_user",

--- a/connectors/discord/ban_user.go
+++ b/connectors/discord/ban_user.go
@@ -1,0 +1,60 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// banUserAction implements connectors.Action for discord.ban_user.
+type banUserAction struct {
+	conn *DiscordConnector
+}
+
+type banUserParams struct {
+	GuildID              string `json:"guild_id"`
+	UserID               string `json:"user_id"`
+	DeleteMessageSeconds int    `json:"delete_message_seconds,omitempty"`
+}
+
+func (p *banUserParams) validate() error {
+	if err := validateSnowflake(p.GuildID, "guild_id"); err != nil {
+		return err
+	}
+	if err := validateSnowflake(p.UserID, "user_id"); err != nil {
+		return err
+	}
+	if p.DeleteMessageSeconds < 0 || p.DeleteMessageSeconds > 604800 {
+		return &connectors.ValidationError{Message: "delete_message_seconds must be between 0 and 604800"}
+	}
+	return nil
+}
+
+type banUserRequest struct {
+	DeleteMessageSeconds int `json:"delete_message_seconds,omitempty"`
+}
+
+func (a *banUserAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params banUserParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/guilds/%s/bans/%s", params.GuildID, params.UserID)
+	body := banUserRequest{DeleteMessageSeconds: params.DeleteMessageSeconds}
+
+	// PUT /guilds/{guild.id}/bans/{user.id} returns 204 No Content.
+	if err := a.conn.doRequest(ctx, "PUT", path, req.Credentials, body, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status":  "banned",
+		"user_id": params.UserID,
+	})
+}

--- a/connectors/discord/ban_user.go
+++ b/connectors/discord/ban_user.go
@@ -9,6 +9,8 @@ import (
 )
 
 // banUserAction implements connectors.Action for discord.ban_user.
+// Discord API: PUT /guilds/{guild.id}/bans/{user.id}
+// See: https://discord.com/developers/docs/resources/guild#create-guild-ban
 type banUserAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/create_channel.go
+++ b/connectors/discord/create_channel.go
@@ -12,6 +12,8 @@ import (
 var channelNameRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 // createChannelAction implements connectors.Action for discord.create_channel.
+// Discord API: POST /guilds/{guild.id}/channels
+// See: https://discord.com/developers/docs/resources/guild#create-guild-channel
 type createChannelAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/create_channel.go
+++ b/connectors/discord/create_channel.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
+
+var channelNameRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 // createChannelAction implements connectors.Action for discord.create_channel.
 type createChannelAction struct {
@@ -30,6 +33,17 @@ func (p *createChannelParams) validate() error {
 	}
 	if len(p.Name) < 2 || len(p.Name) > 100 {
 		return &connectors.ValidationError{Message: "name must be between 2 and 100 characters"}
+	}
+	if !channelNameRe.MatchString(p.Name) {
+		return &connectors.ValidationError{Message: "name must be lowercase alphanumeric with hyphens or underscores only (no spaces)"}
+	}
+	if p.ParentID != "" {
+		if err := validateSnowflake(p.ParentID, "parent_id"); err != nil {
+			return err
+		}
+	}
+	if len(p.Topic) > 1024 {
+		return &connectors.ValidationError{Message: "topic must be 1024 characters or fewer"}
 	}
 	return nil
 }

--- a/connectors/discord/create_channel.go
+++ b/connectors/discord/create_channel.go
@@ -1,0 +1,76 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createChannelAction implements connectors.Action for discord.create_channel.
+type createChannelAction struct {
+	conn *DiscordConnector
+}
+
+type createChannelParams struct {
+	GuildID  string `json:"guild_id"`
+	Name     string `json:"name"`
+	Type     int    `json:"type,omitempty"`
+	ParentID string `json:"parent_id,omitempty"`
+	Topic    string `json:"topic,omitempty"`
+}
+
+func (p *createChannelParams) validate() error {
+	if err := validateSnowflake(p.GuildID, "guild_id"); err != nil {
+		return err
+	}
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	if len(p.Name) < 2 || len(p.Name) > 100 {
+		return &connectors.ValidationError{Message: "name must be between 2 and 100 characters"}
+	}
+	return nil
+}
+
+type createChannelRequest struct {
+	Name     string `json:"name"`
+	Type     int    `json:"type"`
+	ParentID string `json:"parent_id,omitempty"`
+	Topic    string `json:"topic,omitempty"`
+}
+
+type createChannelResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type int    `json:"type"`
+}
+
+func (a *createChannelAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createChannelParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := createChannelRequest{
+		Name:     params.Name,
+		Type:     params.Type,
+		ParentID: params.ParentID,
+		Topic:    params.Topic,
+	}
+
+	var resp createChannelResponse
+	if err := a.conn.doRequest(ctx, "POST", "/guilds/"+params.GuildID+"/channels", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"id":   resp.ID,
+		"name": resp.Name,
+		"type": resp.Type,
+	})
+}

--- a/connectors/discord/create_channel_test.go
+++ b/connectors/discord/create_channel_test.go
@@ -82,6 +82,91 @@ func TestCreateChannel_MissingName(t *testing.T) {
 	}
 }
 
+func TestCreateChannel_NameInvalidFormat(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createChannelAction{conn: conn}
+
+	tests := []struct {
+		name string
+		val  string
+	}{
+		{"uppercase", "General"},
+		{"spaces", "my channel"},
+		{"special chars", "hello!world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params, _ := json.Marshal(createChannelParams{
+				GuildID: "999888777666555444",
+				Name:    tt.val,
+			})
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "discord.create_channel",
+				Parameters:  params,
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatalf("expected error for name %q", tt.val)
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError for name %q, got: %T", tt.val, err)
+			}
+		})
+	}
+}
+
+func TestCreateChannel_TopicTooLong(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createChannelAction{conn: conn}
+
+	longTopic := make([]byte, 1025)
+	for i := range longTopic {
+		longTopic[i] = 'a'
+	}
+	params, _ := json.Marshal(createChannelParams{
+		GuildID: "999888777666555444",
+		Name:    "general",
+		Topic:   string(longTopic),
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_channel",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for topic too long")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateChannel_InvalidParentID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createChannelAction{conn: conn}
+
+	params, _ := json.Marshal(createChannelParams{
+		GuildID:  "999888777666555444",
+		Name:     "general",
+		ParentID: "not-a-snowflake",
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_channel",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid parent_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestCreateChannel_NameTooShort(t *testing.T) {
 	t.Parallel()
 	conn := New()

--- a/connectors/discord/create_channel_test.go
+++ b/connectors/discord/create_channel_test.go
@@ -1,0 +1,105 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateChannel_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/999888777666555444/channels" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body createChannelRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Name != "announcements" {
+			t.Errorf("expected name 'announcements', got %q", body.Name)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "111222333444555666",
+			"name": "announcements",
+			"type": 0,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createChannelAction{conn: conn}
+
+	params, _ := json.Marshal(createChannelParams{
+		GuildID: "999888777666555444",
+		Name:    "announcements",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_channel",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "111222333444555666" {
+		t.Errorf("expected id '111222333444555666', got %v", data["id"])
+	}
+}
+
+func TestCreateChannel_MissingName(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createChannelAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"guild_id": "999888777666555444"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_channel",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateChannel_NameTooShort(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createChannelAction{conn: conn}
+
+	params, _ := json.Marshal(createChannelParams{
+		GuildID: "999888777666555444",
+		Name:    "a",
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_channel",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for name too short")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/create_event.go
+++ b/connectors/discord/create_event.go
@@ -38,6 +38,11 @@ func (p *createEventParams) validate() error {
 	if p.EntityType < 1 || p.EntityType > 3 {
 		return &connectors.ValidationError{Message: "entity_type must be 1 (stage), 2 (voice), or 3 (external)"}
 	}
+	if p.ChannelID != "" {
+		if err := validateSnowflake(p.ChannelID, "channel_id"); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/connectors/discord/create_event.go
+++ b/connectors/discord/create_event.go
@@ -9,6 +9,8 @@ import (
 )
 
 // createEventAction implements connectors.Action for discord.create_event.
+// Discord API: POST /guilds/{guild.id}/scheduled-events
+// See: https://discord.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event
 type createEventAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/create_event.go
+++ b/connectors/discord/create_event.go
@@ -1,0 +1,94 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createEventAction implements connectors.Action for discord.create_event.
+type createEventAction struct {
+	conn *DiscordConnector
+}
+
+type createEventParams struct {
+	GuildID            string          `json:"guild_id"`
+	Name               string          `json:"name"`
+	Description        string          `json:"description,omitempty"`
+	ScheduledStartTime string          `json:"scheduled_start_time"`
+	ScheduledEndTime   string          `json:"scheduled_end_time,omitempty"`
+	PrivacyLevel       int             `json:"privacy_level,omitempty"`
+	EntityType         int             `json:"entity_type"`
+	ChannelID          string          `json:"channel_id,omitempty"`
+	EntityMetadata     json.RawMessage `json:"entity_metadata,omitempty"`
+}
+
+func (p *createEventParams) validate() error {
+	if err := validateSnowflake(p.GuildID, "guild_id"); err != nil {
+		return err
+	}
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	if p.ScheduledStartTime == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: scheduled_start_time"}
+	}
+	if p.EntityType < 1 || p.EntityType > 3 {
+		return &connectors.ValidationError{Message: "entity_type must be 1 (stage), 2 (voice), or 3 (external)"}
+	}
+	return nil
+}
+
+type createEventRequest struct {
+	Name               string          `json:"name"`
+	Description        string          `json:"description,omitempty"`
+	ScheduledStartTime string          `json:"scheduled_start_time"`
+	ScheduledEndTime   string          `json:"scheduled_end_time,omitempty"`
+	PrivacyLevel       int             `json:"privacy_level"`
+	EntityType         int             `json:"entity_type"`
+	ChannelID          string          `json:"channel_id,omitempty"`
+	EntityMetadata     json.RawMessage `json:"entity_metadata,omitempty"`
+}
+
+type createEventResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (a *createEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createEventParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	privacyLevel := params.PrivacyLevel
+	if privacyLevel == 0 {
+		privacyLevel = 2 // guild only
+	}
+
+	body := createEventRequest{
+		Name:               params.Name,
+		Description:        params.Description,
+		ScheduledStartTime: params.ScheduledStartTime,
+		ScheduledEndTime:   params.ScheduledEndTime,
+		PrivacyLevel:       privacyLevel,
+		EntityType:         params.EntityType,
+		ChannelID:          params.ChannelID,
+		EntityMetadata:     params.EntityMetadata,
+	}
+
+	var resp createEventResponse
+	if err := a.conn.doRequest(ctx, "POST", "/guilds/"+params.GuildID+"/scheduled-events", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":   resp.ID,
+		"name": resp.Name,
+	})
+}

--- a/connectors/discord/create_event_test.go
+++ b/connectors/discord/create_event_test.go
@@ -1,0 +1,116 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateEvent_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/scheduled-events" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body createEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body.Name != "Game Night" {
+			t.Errorf("expected name 'Game Night', got %q", body.Name)
+		}
+		if body.PrivacyLevel != 2 {
+			t.Errorf("expected privacy level 2, got %d", body.PrivacyLevel)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "555",
+			"name": "Game Night",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createEventAction{conn: conn}
+
+	params, _ := json.Marshal(createEventParams{
+		GuildID:            "111",
+		Name:               "Game Night",
+		ScheduledStartTime: "2026-04-01T20:00:00Z",
+		EntityType:         2,
+		ChannelID:          "222",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["id"] != "555" {
+		t.Errorf("expected id '555', got %q", data["id"])
+	}
+}
+
+func TestCreateEvent_MissingName(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createEventAction{conn: conn}
+
+	params, _ := json.Marshal(createEventParams{
+		GuildID:            "111",
+		ScheduledStartTime: "2026-04-01T20:00:00Z",
+		EntityType:         2,
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateEvent_InvalidEntityType(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createEventAction{conn: conn}
+
+	params, _ := json.Marshal(createEventParams{
+		GuildID:            "111",
+		Name:               "Test",
+		ScheduledStartTime: "2026-04-01T20:00:00Z",
+		EntityType:         5,
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid entity_type")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/create_thread.go
+++ b/connectors/discord/create_thread.go
@@ -9,6 +9,8 @@ import (
 )
 
 // createThreadAction implements connectors.Action for discord.create_thread.
+// Discord API: POST /channels/{channel.id}/threads (or /channels/{channel.id}/messages/{message.id}/threads)
+// See: https://discord.com/developers/docs/resources/channel#start-thread-without-message
 type createThreadAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/create_thread.go
+++ b/connectors/discord/create_thread.go
@@ -30,9 +30,14 @@ func (p *createThreadParams) validate() error {
 	if len(p.Name) > 100 {
 		return &connectors.ValidationError{Message: "name must be 100 characters or fewer"}
 	}
+	if p.MessageID != "" {
+		if err := validateSnowflake(p.MessageID, "message_id"); err != nil {
+			return err
+		}
+	}
 	validDurations := map[int]bool{0: true, 60: true, 1440: true, 4320: true, 10080: true}
 	if !validDurations[p.AutoArchiveDuration] {
-		return &connectors.ValidationError{Message: "auto_archive_duration must be 60, 1440, 4320, or 10080"}
+		return &connectors.ValidationError{Message: "auto_archive_duration must be one of 0 (use default), 60, 1440, 4320, or 10080"}
 	}
 	return nil
 }

--- a/connectors/discord/create_thread.go
+++ b/connectors/discord/create_thread.go
@@ -1,0 +1,94 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createThreadAction implements connectors.Action for discord.create_thread.
+type createThreadAction struct {
+	conn *DiscordConnector
+}
+
+type createThreadParams struct {
+	ChannelID           string `json:"channel_id"`
+	Name                string `json:"name"`
+	MessageID           string `json:"message_id,omitempty"`
+	AutoArchiveDuration int    `json:"auto_archive_duration,omitempty"`
+}
+
+func (p *createThreadParams) validate() error {
+	if err := validateSnowflake(p.ChannelID, "channel_id"); err != nil {
+		return err
+	}
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	if len(p.Name) > 100 {
+		return &connectors.ValidationError{Message: "name must be 100 characters or fewer"}
+	}
+	validDurations := map[int]bool{0: true, 60: true, 1440: true, 4320: true, 10080: true}
+	if !validDurations[p.AutoArchiveDuration] {
+		return &connectors.ValidationError{Message: "auto_archive_duration must be 60, 1440, 4320, or 10080"}
+	}
+	return nil
+}
+
+type createThreadRequest struct {
+	Name                string `json:"name"`
+	AutoArchiveDuration int    `json:"auto_archive_duration,omitempty"`
+	Type                int    `json:"type,omitempty"` // 11 = public thread, 12 = private thread
+}
+
+type createThreadResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (a *createThreadAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createThreadParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	archiveDuration := params.AutoArchiveDuration
+	if archiveDuration == 0 {
+		archiveDuration = 1440 // 24 hours
+	}
+
+	var path string
+	var body any
+
+	if params.MessageID != "" {
+		// Start thread from an existing message.
+		path = fmt.Sprintf("/channels/%s/messages/%s/threads", params.ChannelID, params.MessageID)
+		body = createThreadRequest{
+			Name:                params.Name,
+			AutoArchiveDuration: archiveDuration,
+		}
+	} else {
+		// Start thread without a message (forum-style).
+		path = fmt.Sprintf("/channels/%s/threads", params.ChannelID)
+		body = createThreadRequest{
+			Name:                params.Name,
+			AutoArchiveDuration: archiveDuration,
+			Type:                11, // public thread
+		}
+	}
+
+	var resp createThreadResponse
+	if err := a.conn.doRequest(ctx, "POST", path, req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":   resp.ID,
+		"name": resp.Name,
+	})
+}

--- a/connectors/discord/create_thread_test.go
+++ b/connectors/discord/create_thread_test.go
@@ -1,0 +1,143 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateThread_WithMessage(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/channels/111/messages/222/threads" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "333",
+			"name": "discussion",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createThreadAction{conn: conn}
+
+	params, _ := json.Marshal(createThreadParams{
+		ChannelID: "111",
+		Name:      "discussion",
+		MessageID: "222",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_thread",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["id"] != "333" {
+		t.Errorf("expected id '333', got %q", data["id"])
+	}
+	if data["name"] != "discussion" {
+		t.Errorf("expected name 'discussion', got %q", data["name"])
+	}
+}
+
+func TestCreateThread_WithoutMessage(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/channels/111/threads" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body createThreadRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body.Type != 11 {
+			t.Errorf("expected type 11 for standalone thread, got %d", body.Type)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "444",
+			"name": "standalone",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createThreadAction{conn: conn}
+
+	params, _ := json.Marshal(createThreadParams{
+		ChannelID: "111",
+		Name:      "standalone",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_thread",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateThread_MissingName(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createThreadAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"channel_id": "111"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_thread",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateThread_InvalidArchiveDuration(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &createThreadAction{conn: conn}
+
+	params, _ := json.Marshal(createThreadParams{
+		ChannelID:           "111",
+		Name:                "test",
+		AutoArchiveDuration: 999,
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.create_thread",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid archive duration")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/discord.go
+++ b/connectors/discord/discord.go
@@ -389,9 +389,9 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"auto_archive_duration": {
 							"type": "integer",
-							"enum": [60, 1440, 4320, 10080],
+							"enum": [0, 60, 1440, 4320, 10080],
 							"default": 1440,
-							"description": "Minutes of inactivity before auto-archive (60 = 1h, 1440 = 24h, 4320 = 3d, 10080 = 7d)"
+							"description": "Minutes of inactivity before auto-archive: 0 = server default, 60 = 1h, 1440 = 24h, 4320 = 3d, 10080 = 7d"
 						}
 					}
 				}`)),

--- a/connectors/discord/discord.go
+++ b/connectors/discord/discord.go
@@ -1,0 +1,587 @@
+// Package discord implements the Discord connector for the Permission Slip
+// connector execution layer. It uses the Discord REST API v10 with plain
+// net/http (no third-party SDK) to keep the dependency footprint minimal.
+package discord
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+const (
+	defaultBaseURL = "https://discord.com/api/v10"
+	defaultTimeout = 30 * time.Second
+	credKeyToken   = "bot_token"
+
+	// defaultRetryAfter is used when Discord returns a rate limit response
+	// without a Retry-After header (or an unparseable one).
+	defaultRetryAfter = 5 * time.Second
+
+	// maxResponseBytes caps the Discord API response body at 10 MB.
+	maxResponseBytes = 10 << 20 // 10 MB
+)
+
+// DiscordConnector owns the shared HTTP client and base URL used by all
+// Discord actions. Actions hold a pointer back to the connector to access
+// these shared resources.
+type DiscordConnector struct {
+	client  *http.Client
+	baseURL string
+}
+
+// New creates a DiscordConnector with sensible defaults.
+func New() *DiscordConnector {
+	return &DiscordConnector{
+		client:  &http.Client{Timeout: defaultTimeout},
+		baseURL: defaultBaseURL,
+	}
+}
+
+// newForTest creates a DiscordConnector that points at a test server.
+func newForTest(client *http.Client, baseURL string) *DiscordConnector {
+	return &DiscordConnector{
+		client:  client,
+		baseURL: baseURL,
+	}
+}
+
+// ID returns "discord", matching the connectors.id in the database.
+func (c *DiscordConnector) ID() string { return "discord" }
+
+// Manifest returns the connector's metadata manifest.
+func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "discord",
+		Name:        "Discord",
+		Description: "Discord integration for community management and messaging",
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "discord.send_message",
+				Name:        "Send Message",
+				Description: "Send a message to a Discord channel",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel_id", "content"],
+					"properties": {
+						"channel_id": {
+							"type": "string",
+							"description": "Discord channel ID (snowflake)"
+						},
+						"content": {
+							"type": "string",
+							"description": "Message content (up to 2000 characters)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.create_channel",
+				Name:        "Create Channel",
+				Description: "Create a new channel in a Discord guild",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id", "name"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						},
+						"name": {
+							"type": "string",
+							"description": "Channel name (2-100 characters, lowercase, no spaces)"
+						},
+						"type": {
+							"type": "integer",
+							"default": 0,
+							"description": "Channel type: 0 = text, 2 = voice, 4 = category"
+						},
+						"parent_id": {
+							"type": "string",
+							"description": "Parent category channel ID"
+						},
+						"topic": {
+							"type": "string",
+							"description": "Channel topic (up to 1024 characters, text channels only)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.manage_roles",
+				Name:        "Manage Roles",
+				Description: "Assign or remove a role from a guild member",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id", "user_id", "role_id", "action"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						},
+						"user_id": {
+							"type": "string",
+							"description": "Discord user ID"
+						},
+						"role_id": {
+							"type": "string",
+							"description": "Discord role ID"
+						},
+						"action": {
+							"type": "string",
+							"enum": ["assign", "remove"],
+							"description": "Whether to assign or remove the role"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.create_event",
+				Name:        "Create Event",
+				Description: "Create a scheduled event in a Discord guild",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id", "name", "scheduled_start_time", "privacy_level", "entity_type"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						},
+						"name": {
+							"type": "string",
+							"description": "Event name (1-100 characters)"
+						},
+						"description": {
+							"type": "string",
+							"description": "Event description (up to 1000 characters)"
+						},
+						"scheduled_start_time": {
+							"type": "string",
+							"description": "ISO 8601 timestamp for event start"
+						},
+						"scheduled_end_time": {
+							"type": "string",
+							"description": "ISO 8601 timestamp for event end (required for external events)"
+						},
+						"privacy_level": {
+							"type": "integer",
+							"default": 2,
+							"description": "Privacy level: 2 = guild only"
+						},
+						"entity_type": {
+							"type": "integer",
+							"description": "Entity type: 1 = stage, 2 = voice, 3 = external"
+						},
+						"channel_id": {
+							"type": "string",
+							"description": "Channel ID for stage/voice events"
+						},
+						"entity_metadata": {
+							"type": "object",
+							"properties": {
+								"location": {
+									"type": "string",
+									"description": "Location for external events"
+								}
+							}
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.ban_user",
+				Name:        "Ban User",
+				Description: "Ban a user from a Discord guild",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id", "user_id"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						},
+						"user_id": {
+							"type": "string",
+							"description": "Discord user ID to ban"
+						},
+						"delete_message_seconds": {
+							"type": "integer",
+							"default": 0,
+							"description": "Seconds of message history to delete (0-604800)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.kick_user",
+				Name:        "Kick User",
+				Description: "Kick a user from a Discord guild",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id", "user_id"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						},
+						"user_id": {
+							"type": "string",
+							"description": "Discord user ID to kick"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.pin_message",
+				Name:        "Pin Message",
+				Description: "Pin a message in a Discord channel",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel_id", "message_id"],
+					"properties": {
+						"channel_id": {
+							"type": "string",
+							"description": "Discord channel ID"
+						},
+						"message_id": {
+							"type": "string",
+							"description": "Discord message ID to pin"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.unpin_message",
+				Name:        "Unpin Message",
+				Description: "Unpin a message in a Discord channel",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel_id", "message_id"],
+					"properties": {
+						"channel_id": {
+							"type": "string",
+							"description": "Discord channel ID"
+						},
+						"message_id": {
+							"type": "string",
+							"description": "Discord message ID to unpin"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.list_channels",
+				Name:        "List Channels",
+				Description: "List channels in a Discord guild",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.list_members",
+				Name:        "List Members",
+				Description: "List members of a Discord guild",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"description": "Discord guild (server) ID"
+						},
+						"limit": {
+							"type": "integer",
+							"default": 100,
+							"description": "Max members to return (1-1000)"
+						},
+						"after": {
+							"type": "string",
+							"description": "User ID to paginate after"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.create_thread",
+				Name:        "Create Thread",
+				Description: "Create a thread in a Discord channel",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel_id", "name"],
+					"properties": {
+						"channel_id": {
+							"type": "string",
+							"description": "Discord channel ID to create the thread in"
+						},
+						"name": {
+							"type": "string",
+							"description": "Thread name (1-100 characters)"
+						},
+						"message_id": {
+							"type": "string",
+							"description": "Message ID to start the thread from (omit for a thread without a starter message)"
+						},
+						"auto_archive_duration": {
+							"type": "integer",
+							"default": 1440,
+							"description": "Minutes of inactivity before auto-archive: 60, 1440, 4320, or 10080"
+						}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{Service: "discord", AuthType: "custom", InstructionsURL: "https://discord.com/developers/docs/getting-started"},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_discord_send_message",
+				ActionType:  "discord.send_message",
+				Name:        "Send messages freely",
+				Description: "Agent can send messages to any channel.",
+				Parameters:  json.RawMessage(`{"channel_id":"*","content":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_create_channel",
+				ActionType:  "discord.create_channel",
+				Name:        "Create channels",
+				Description: "Agent can create channels in any guild.",
+				Parameters:  json.RawMessage(`{"guild_id":"*","name":"*","type":"*","parent_id":"*","topic":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_manage_roles",
+				ActionType:  "discord.manage_roles",
+				Name:        "Manage roles",
+				Description: "Agent can assign or remove roles from members.",
+				Parameters:  json.RawMessage(`{"guild_id":"*","user_id":"*","role_id":"*","action":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_create_event",
+				ActionType:  "discord.create_event",
+				Name:        "Create events",
+				Description: "Agent can create scheduled events in any guild.",
+				Parameters:  json.RawMessage(`{"guild_id":"*","name":"*","description":"*","scheduled_start_time":"*","scheduled_end_time":"*","privacy_level":"*","entity_type":"*","channel_id":"*","entity_metadata":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_ban_user",
+				ActionType:  "discord.ban_user",
+				Name:        "Ban users",
+				Description: "Agent can ban users from guilds.",
+				Parameters:  json.RawMessage(`{"guild_id":"*","user_id":"*","delete_message_seconds":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_kick_user",
+				ActionType:  "discord.kick_user",
+				Name:        "Kick users",
+				Description: "Agent can kick users from guilds.",
+				Parameters:  json.RawMessage(`{"guild_id":"*","user_id":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_pin_message",
+				ActionType:  "discord.pin_message",
+				Name:        "Pin messages",
+				Description: "Agent can pin messages in any channel.",
+				Parameters:  json.RawMessage(`{"channel_id":"*","message_id":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_unpin_message",
+				ActionType:  "discord.unpin_message",
+				Name:        "Unpin messages",
+				Description: "Agent can unpin messages in any channel.",
+				Parameters:  json.RawMessage(`{"channel_id":"*","message_id":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_list_channels",
+				ActionType:  "discord.list_channels",
+				Name:        "List channels",
+				Description: "Agent can list channels in any guild.",
+				Parameters:  json.RawMessage(`{"guild_id":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_list_members",
+				ActionType:  "discord.list_members",
+				Name:        "List members",
+				Description: "Agent can list members of any guild.",
+				Parameters:  json.RawMessage(`{"guild_id":"*","limit":"*","after":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_create_thread",
+				ActionType:  "discord.create_thread",
+				Name:        "Create threads",
+				Description: "Agent can create threads in any channel.",
+				Parameters:  json.RawMessage(`{"channel_id":"*","name":"*","message_id":"*","auto_archive_duration":"*"}`),
+			},
+		},
+	}
+}
+
+// Actions returns the registered action handlers keyed by action_type.
+func (c *DiscordConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"discord.send_message":   &sendMessageAction{conn: c},
+		"discord.create_channel": &createChannelAction{conn: c},
+		"discord.manage_roles":   &manageRolesAction{conn: c},
+		"discord.create_event":   &createEventAction{conn: c},
+		"discord.ban_user":       &banUserAction{conn: c},
+		"discord.kick_user":      &kickUserAction{conn: c},
+		"discord.pin_message":    &pinMessageAction{conn: c},
+		"discord.unpin_message":  &unpinMessageAction{conn: c},
+		"discord.list_channels":  &listChannelsAction{conn: c},
+		"discord.list_members":   &listMembersAction{conn: c},
+		"discord.create_thread":  &createThreadAction{conn: c},
+	}
+}
+
+// ValidateCredentials checks that the provided credentials contain a
+// non-empty bot_token.
+func (c *DiscordConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "missing required credential: bot_token"}
+	}
+	return nil
+}
+
+// discordErrorResponse is the standard Discord API error envelope.
+type discordErrorResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// doRequest is the shared request lifecycle for Discord API calls. It sends
+// the request with Bot auth, handles rate limiting and timeouts, and
+// unmarshals the response into dest (if non-nil, for 2xx with body).
+// For endpoints that return 204 No Content, pass nil for dest.
+func (c *DiscordConnector) doRequest(ctx context.Context, method, path string, creds connectors.Credentials, body any, dest any) error {
+	token, ok := creds.Get(credKeyToken)
+	if !ok || token == "" {
+		return &connectors.ValidationError{Message: "bot_token credential is missing or empty"}
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshaling request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Discord API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Discord API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Discord API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	// Discord returns 429 for rate limiting with a Retry-After header.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    "Discord API rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	// 204 No Content — success with no body.
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	// Auth errors.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		var errResp discordErrorResponse
+		_ = json.Unmarshal(respBody, &errResp)
+		msg := errResp.Message
+		if msg == "" {
+			msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		return &connectors.AuthError{Message: fmt.Sprintf("Discord auth error: %s", msg)}
+	}
+
+	// Other error status codes.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errResp discordErrorResponse
+		_ = json.Unmarshal(respBody, &errResp)
+		msg := errResp.Message
+		if msg == "" {
+			msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		return &connectors.ExternalError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("Discord API error: %s", msg),
+		}
+	}
+
+	// Success with body — unmarshal if dest is provided.
+	if dest != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, dest); err != nil {
+			return &connectors.ExternalError{
+				StatusCode: resp.StatusCode,
+				Message:    "failed to decode Discord API response",
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateSnowflake checks that a string looks like a valid Discord snowflake ID.
+func validateSnowflake(value, paramName string) error {
+	if value == "" {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", paramName)}
+	}
+	// Snowflakes are numeric strings, typically 17-20 digits.
+	for _, ch := range value {
+		if ch < '0' || ch > '9' {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("invalid %s %q: must be a numeric Discord snowflake ID", paramName, value),
+			}
+		}
+	}
+	return nil
+}

--- a/connectors/discord/discord.go
+++ b/connectors/discord/discord.go
@@ -74,10 +74,13 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel_id": {
 							"type": "string",
-							"description": "Discord channel ID (snowflake)"
+							"pattern": "^[0-9]+$",
+							"description": "Discord channel ID — a numeric snowflake (e.g. 1234567890123456789)"
 						},
 						"content": {
 							"type": "string",
+							"minLength": 1,
+							"maxLength": 2000,
 							"description": "Message content (up to 2000 characters)"
 						}
 					}
@@ -94,23 +97,30 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID — a numeric snowflake (e.g. 1234567890123456789)"
 						},
 						"name": {
 							"type": "string",
-							"description": "Channel name (2-100 characters, lowercase, no spaces)"
+							"minLength": 2,
+							"maxLength": 100,
+							"pattern": "^[a-z0-9_-]+$",
+							"description": "Channel name (2-100 characters, lowercase, no spaces — e.g. general-chat)"
 						},
 						"type": {
 							"type": "integer",
+							"enum": [0, 2, 4],
 							"default": 0,
 							"description": "Channel type: 0 = text, 2 = voice, 4 = category"
 						},
 						"parent_id": {
 							"type": "string",
-							"description": "Parent category channel ID"
+							"pattern": "^[0-9]+$",
+							"description": "Parent category channel ID (snowflake)"
 						},
 						"topic": {
 							"type": "string",
+							"maxLength": 1024,
 							"description": "Channel topic (up to 1024 characters, text channels only)"
 						}
 					}
@@ -127,15 +137,18 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						},
 						"user_id": {
 							"type": "string",
-							"description": "Discord user ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord user ID (snowflake)"
 						},
 						"role_id": {
 							"type": "string",
-							"description": "Discord role ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord role ID (snowflake) — use discord.list_roles to discover valid IDs"
 						},
 						"action": {
 							"type": "string",
@@ -156,43 +169,52 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						},
 						"name": {
 							"type": "string",
+							"minLength": 1,
+							"maxLength": 100,
 							"description": "Event name (1-100 characters)"
 						},
 						"description": {
 							"type": "string",
+							"maxLength": 1000,
 							"description": "Event description (up to 1000 characters)"
 						},
 						"scheduled_start_time": {
 							"type": "string",
-							"description": "ISO 8601 timestamp for event start"
+							"format": "date-time",
+							"description": "ISO 8601 timestamp for event start (e.g. 2026-04-01T18:00:00Z)"
 						},
 						"scheduled_end_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "ISO 8601 timestamp for event end (required for external events)"
 						},
 						"privacy_level": {
 							"type": "integer",
+							"enum": [2],
 							"default": 2,
-							"description": "Privacy level: 2 = guild only"
+							"description": "Privacy level: 2 = guild only (currently the only supported value)"
 						},
 						"entity_type": {
 							"type": "integer",
-							"description": "Entity type: 1 = stage, 2 = voice, 3 = external"
+							"enum": [1, 2, 3],
+							"description": "Entity type: 1 = stage instance, 2 = voice channel, 3 = external location"
 						},
 						"channel_id": {
 							"type": "string",
-							"description": "Channel ID for stage/voice events"
+							"pattern": "^[0-9]+$",
+							"description": "Channel ID for stage/voice events (required when entity_type is 1 or 2)"
 						},
 						"entity_metadata": {
 							"type": "object",
 							"properties": {
 								"location": {
 									"type": "string",
-									"description": "Location for external events"
+									"description": "Location for external events (required when entity_type is 3)"
 								}
 							}
 						}
@@ -210,16 +232,20 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						},
 						"user_id": {
 							"type": "string",
-							"description": "Discord user ID to ban"
+							"pattern": "^[0-9]+$",
+							"description": "Discord user ID to ban (snowflake)"
 						},
 						"delete_message_seconds": {
 							"type": "integer",
+							"minimum": 0,
+							"maximum": 604800,
 							"default": 0,
-							"description": "Seconds of message history to delete (0-604800)"
+							"description": "Seconds of message history to delete (0 = none, 604800 = 7 days)"
 						}
 					}
 				}`)),
@@ -235,11 +261,13 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						},
 						"user_id": {
 							"type": "string",
-							"description": "Discord user ID to kick"
+							"pattern": "^[0-9]+$",
+							"description": "Discord user ID to kick (snowflake)"
 						}
 					}
 				}`)),
@@ -255,11 +283,13 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel_id": {
 							"type": "string",
-							"description": "Discord channel ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord channel ID (snowflake)"
 						},
 						"message_id": {
 							"type": "string",
-							"description": "Discord message ID to pin"
+							"pattern": "^[0-9]+$",
+							"description": "Discord message ID to pin (snowflake)"
 						}
 					}
 				}`)),
@@ -275,11 +305,13 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel_id": {
 							"type": "string",
-							"description": "Discord channel ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord channel ID (snowflake)"
 						},
 						"message_id": {
 							"type": "string",
-							"description": "Discord message ID to unpin"
+							"pattern": "^[0-9]+$",
+							"description": "Discord message ID to unpin (snowflake)"
 						}
 					}
 				}`)),
@@ -295,7 +327,8 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						}
 					}
 				}`)),
@@ -311,16 +344,20 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"guild_id": {
 							"type": "string",
-							"description": "Discord guild (server) ID"
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						},
 						"limit": {
 							"type": "integer",
+							"minimum": 1,
+							"maximum": 1000,
 							"default": 100,
 							"description": "Max members to return (1-1000)"
 						},
 						"after": {
 							"type": "string",
-							"description": "User ID to paginate after"
+							"pattern": "^[0-9]+$",
+							"description": "User ID to paginate after (snowflake)"
 						}
 					}
 				}`)),
@@ -336,105 +373,134 @@ func (c *DiscordConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel_id": {
 							"type": "string",
-							"description": "Discord channel ID to create the thread in"
+							"pattern": "^[0-9]+$",
+							"description": "Discord channel ID to create the thread in (snowflake)"
 						},
 						"name": {
 							"type": "string",
+							"minLength": 1,
+							"maxLength": 100,
 							"description": "Thread name (1-100 characters)"
 						},
 						"message_id": {
 							"type": "string",
+							"pattern": "^[0-9]+$",
 							"description": "Message ID to start the thread from (omit for a thread without a starter message)"
 						},
 						"auto_archive_duration": {
 							"type": "integer",
+							"enum": [60, 1440, 4320, 10080],
 							"default": 1440,
-							"description": "Minutes of inactivity before auto-archive: 60, 1440, 4320, or 10080"
+							"description": "Minutes of inactivity before auto-archive (60 = 1h, 1440 = 24h, 4320 = 3d, 10080 = 7d)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "discord.list_roles",
+				Name:        "List Roles",
+				Description: "List roles in a Discord guild",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["guild_id"],
+					"properties": {
+						"guild_id": {
+							"type": "string",
+							"pattern": "^[0-9]+$",
+							"description": "Discord guild (server) ID (snowflake)"
 						}
 					}
 				}`)),
 			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
-			{Service: "discord", AuthType: "custom", InstructionsURL: "https://discord.com/developers/docs/getting-started"},
+			{Service: "discord", AuthType: "custom", InstructionsURL: "https://discord.com/developers/applications"},
 		},
 		Templates: []connectors.ManifestTemplate{
 			{
 				ID:          "tpl_discord_send_message",
 				ActionType:  "discord.send_message",
 				Name:        "Send messages freely",
-				Description: "Agent can send messages to any channel.",
+				Description: "Agent can send messages to any channel the bot has access to.",
 				Parameters:  json.RawMessage(`{"channel_id":"*","content":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_create_channel",
 				ActionType:  "discord.create_channel",
 				Name:        "Create channels",
-				Description: "Agent can create channels in any guild.",
+				Description: "Agent can create text, voice, or category channels in any guild. Requires Manage Channels permission on the bot.",
 				Parameters:  json.RawMessage(`{"guild_id":"*","name":"*","type":"*","parent_id":"*","topic":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_manage_roles",
 				ActionType:  "discord.manage_roles",
 				Name:        "Manage roles",
-				Description: "Agent can assign or remove roles from members.",
+				Description: "Agent can assign or remove roles from members. The bot's highest role must be above the target role.",
 				Parameters:  json.RawMessage(`{"guild_id":"*","user_id":"*","role_id":"*","action":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_create_event",
 				ActionType:  "discord.create_event",
 				Name:        "Create events",
-				Description: "Agent can create scheduled events in any guild.",
+				Description: "Agent can create scheduled events (stage, voice, or external) in any guild. Requires Manage Events permission.",
 				Parameters:  json.RawMessage(`{"guild_id":"*","name":"*","description":"*","scheduled_start_time":"*","scheduled_end_time":"*","privacy_level":"*","entity_type":"*","channel_id":"*","entity_metadata":"*"}`),
 			},
 			{
-				ID:          "tpl_discord_ban_user",
+				ID:          "tpl_discord_moderate",
 				ActionType:  "discord.ban_user",
 				Name:        "Ban users",
-				Description: "Agent can ban users from guilds.",
+				Description: "Agent can ban users and optionally delete their recent messages. Requires Ban Members permission.",
 				Parameters:  json.RawMessage(`{"guild_id":"*","user_id":"*","delete_message_seconds":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_kick_user",
 				ActionType:  "discord.kick_user",
 				Name:        "Kick users",
-				Description: "Agent can kick users from guilds.",
+				Description: "Agent can kick users from guilds. Requires Kick Members permission.",
 				Parameters:  json.RawMessage(`{"guild_id":"*","user_id":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_pin_message",
 				ActionType:  "discord.pin_message",
 				Name:        "Pin messages",
-				Description: "Agent can pin messages in any channel.",
+				Description: "Agent can pin messages in any channel. Requires Manage Messages permission.",
 				Parameters:  json.RawMessage(`{"channel_id":"*","message_id":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_unpin_message",
 				ActionType:  "discord.unpin_message",
 				Name:        "Unpin messages",
-				Description: "Agent can unpin messages in any channel.",
+				Description: "Agent can unpin messages in any channel. Requires Manage Messages permission.",
 				Parameters:  json.RawMessage(`{"channel_id":"*","message_id":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_list_channels",
 				ActionType:  "discord.list_channels",
 				Name:        "List channels",
-				Description: "Agent can list channels in any guild.",
+				Description: "Agent can list channels in any guild (read-only).",
 				Parameters:  json.RawMessage(`{"guild_id":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_list_members",
 				ActionType:  "discord.list_members",
 				Name:        "List members",
-				Description: "Agent can list members of any guild.",
+				Description: "Agent can list members of any guild (read-only). Requires Server Members Intent enabled on the bot.",
 				Parameters:  json.RawMessage(`{"guild_id":"*","limit":"*","after":"*"}`),
 			},
 			{
 				ID:          "tpl_discord_create_thread",
 				ActionType:  "discord.create_thread",
 				Name:        "Create threads",
-				Description: "Agent can create threads in any channel.",
+				Description: "Agent can create threads in any channel. Requires Create Public Threads permission.",
 				Parameters:  json.RawMessage(`{"channel_id":"*","name":"*","message_id":"*","auto_archive_duration":"*"}`),
+			},
+			{
+				ID:          "tpl_discord_list_roles",
+				ActionType:  "discord.list_roles",
+				Name:        "List roles",
+				Description: "Agent can list roles in any guild (read-only). Useful for discovering role IDs before assigning them.",
+				Parameters:  json.RawMessage(`{"guild_id":"*"}`),
 			},
 		},
 	}
@@ -454,6 +520,7 @@ func (c *DiscordConnector) Actions() map[string]connectors.Action {
 		"discord.list_channels":  &listChannelsAction{conn: c},
 		"discord.list_members":   &listMembersAction{conn: c},
 		"discord.create_thread":  &createThreadAction{conn: c},
+		"discord.list_roles":     &listRolesAction{conn: c},
 	}
 }
 
@@ -471,6 +538,56 @@ func (c *DiscordConnector) ValidateCredentials(_ context.Context, creds connecto
 type discordErrorResponse struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+// mapDiscordError converts a Discord API error code and HTTP status to the
+// appropriate connector error type with user-friendly, actionable messages.
+func mapDiscordError(statusCode int, errResp discordErrorResponse) error {
+	// Map well-known Discord JSON error codes first.
+	switch errResp.Code {
+	case 10003: // Unknown Channel
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "Discord channel not found — verify the channel ID is correct and the bot has access"}
+	case 10004: // Unknown Guild
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "Discord guild not found — verify the guild (server) ID is correct and the bot is a member"}
+	case 10007: // Unknown Member
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "Discord member not found — verify the user is a member of the guild"}
+	case 10008: // Unknown Message
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "Discord message not found — verify the message ID exists in the specified channel"}
+	case 10011: // Unknown Role
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "Discord role not found — use discord.list_roles to find valid role IDs"}
+	case 10013: // Unknown User
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "Discord user not found — verify the user ID is correct"}
+	case 30003: // Max pins reached
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "this channel has reached the maximum of 50 pinned messages — unpin one first"}
+	case 40001: // Unauthorized
+		return &connectors.AuthError{Message: "Discord request unauthorized — verify the bot token is valid and has not been regenerated"}
+	case 50001: // Missing Access
+		return &connectors.AuthError{Message: "bot is missing access to this resource — check that the bot has been invited to the guild and has the required channel permissions"}
+	case 50013: // Missing Permissions
+		return &connectors.AuthError{Message: "bot is missing a required permission — check the bot's role permissions in Discord server settings"}
+	case 50028: // Invalid role
+		return &connectors.ExternalError{StatusCode: statusCode, Message: "invalid role — the bot's highest role must be above the target role in the role hierarchy"}
+	case 50035: // Invalid form body
+		return &connectors.ValidationError{Message: fmt.Sprintf("Discord rejected the request body: %s — check parameter formats and constraints", errResp.Message)}
+	}
+
+	// Fall back to HTTP status classification.
+	msg := errResp.Message
+	if msg == "" {
+		msg = fmt.Sprintf("HTTP %d", statusCode)
+	}
+
+	switch {
+	case statusCode == http.StatusUnauthorized:
+		return &connectors.AuthError{Message: "Discord auth error: invalid bot token — generate a new token at https://discord.com/developers/applications"}
+	case statusCode == http.StatusForbidden:
+		return &connectors.AuthError{Message: fmt.Sprintf("Discord auth error: %s — check the bot's permissions in server settings", msg)}
+	default:
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Discord API error: %s", msg),
+		}
+	}
 }
 
 // doRequest is the shared request lifecycle for Discord API calls. It sends
@@ -532,29 +649,11 @@ func (c *DiscordConnector) doRequest(ctx context.Context, method, path string, c
 		return nil
 	}
 
-	// Auth errors.
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		var errResp discordErrorResponse
-		_ = json.Unmarshal(respBody, &errResp)
-		msg := errResp.Message
-		if msg == "" {
-			msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
-		}
-		return &connectors.AuthError{Message: fmt.Sprintf("Discord auth error: %s", msg)}
-	}
-
-	// Other error status codes.
+	// Non-success status codes — use mapDiscordError for actionable messages.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var errResp discordErrorResponse
 		_ = json.Unmarshal(respBody, &errResp)
-		msg := errResp.Message
-		if msg == "" {
-			msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
-		}
-		return &connectors.ExternalError{
-			StatusCode: resp.StatusCode,
-			Message:    fmt.Sprintf("Discord API error: %s", msg),
-		}
+		return mapDiscordError(resp.StatusCode, errResp)
 	}
 
 	// Success with body — unmarshal if dest is provided.
@@ -579,7 +678,7 @@ func validateSnowflake(value, paramName string) error {
 	for _, ch := range value {
 		if ch < '0' || ch > '9' {
 			return &connectors.ValidationError{
-				Message: fmt.Sprintf("invalid %s %q: must be a numeric Discord snowflake ID", paramName, value),
+				Message: fmt.Sprintf("invalid %s %q: must be a numeric Discord snowflake ID (e.g. 1234567890123456789)", paramName, value),
 			}
 		}
 	}

--- a/connectors/discord/discord_test.go
+++ b/connectors/discord/discord_test.go
@@ -1,0 +1,148 @@
+package discord
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestDiscordConnector_ID(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.ID() != "discord" {
+		t.Errorf("expected ID 'discord', got %q", c.ID())
+	}
+}
+
+func TestDiscordConnector_Manifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+	if m == nil {
+		t.Fatal("expected non-nil manifest")
+	}
+	if m.ID != "discord" {
+		t.Errorf("expected manifest ID 'discord', got %q", m.ID)
+	}
+	if err := m.Validate(); err != nil {
+		t.Errorf("manifest validation failed: %v", err)
+	}
+}
+
+func TestDiscordConnector_Actions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	expectedActions := []string{
+		"discord.send_message",
+		"discord.create_channel",
+		"discord.manage_roles",
+		"discord.create_event",
+		"discord.ban_user",
+		"discord.kick_user",
+		"discord.pin_message",
+		"discord.unpin_message",
+		"discord.list_channels",
+		"discord.list_members",
+		"discord.create_thread",
+	}
+
+	for _, actionType := range expectedActions {
+		if _, ok := actions[actionType]; !ok {
+			t.Errorf("missing action: %s", actionType)
+		}
+	}
+
+	if len(actions) != len(expectedActions) {
+		t.Errorf("expected %d actions, got %d", len(expectedActions), len(actions))
+	}
+}
+
+func TestDiscordConnector_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	tests := []struct {
+		name    string
+		creds   connectors.Credentials
+		wantErr bool
+	}{
+		{
+			name:    "valid token",
+			creds:   connectors.NewCredentials(map[string]string{"bot_token": "test-token"}),
+			wantErr: false,
+		},
+		{
+			name:    "missing token",
+			creds:   connectors.NewCredentials(map[string]string{}),
+			wantErr: true,
+		},
+		{
+			name:    "empty token",
+			creds:   connectors.NewCredentials(map[string]string{"bot_token": ""}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := c.ValidateCredentials(t.Context(), tt.creds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSnowflake(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid", "123456789012345678", false},
+		{"empty", "", true},
+		{"non-numeric", "abc123", true},
+		{"has spaces", "123 456", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateSnowflake(tt.value, "test_id")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSnowflake(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestManifestToDBConversion(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+	dbManifest := m.ToDBManifest()
+	if dbManifest.ID != "discord" {
+		t.Errorf("expected DB manifest ID 'discord', got %q", dbManifest.ID)
+	}
+	if len(dbManifest.Actions) != 11 {
+		t.Errorf("expected 11 DB actions, got %d", len(dbManifest.Actions))
+	}
+}
+
+func TestManifestTemplateParametersAreValidJSON(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+	for _, tpl := range m.Templates {
+		var params map[string]json.RawMessage
+		if err := json.Unmarshal(tpl.Parameters, &params); err != nil {
+			t.Errorf("template %q has invalid parameters JSON: %v", tpl.ID, err)
+		}
+	}
+}

--- a/connectors/discord/discord_test.go
+++ b/connectors/discord/discord_test.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -218,24 +219,11 @@ func TestMapDiscordError(t *testing.T) {
 					t.Errorf("expected ValidationError, got %T: %v", err, err)
 				}
 			}
-			if got := err.Error(); !containsSubstring(got, tt.wantSubstr) {
+			if got := err.Error(); !strings.Contains(got, tt.wantSubstr) {
 				t.Errorf("error %q should contain %q", got, tt.wantSubstr)
 			}
 		})
 	}
-}
-
-func containsSubstring(s, sub string) bool {
-	return len(s) >= len(sub) && (sub == "" || contains(s, sub))
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }
 
 func TestManifestTemplateParametersAreValidJSON(t *testing.T) {

--- a/connectors/discord/discord_test.go
+++ b/connectors/discord/discord_test.go
@@ -47,6 +47,7 @@ func TestDiscordConnector_Actions(t *testing.T) {
 		"discord.list_channels",
 		"discord.list_members",
 		"discord.create_thread",
+		"discord.list_roles",
 	}
 
 	for _, actionType := range expectedActions {
@@ -130,9 +131,111 @@ func TestManifestToDBConversion(t *testing.T) {
 	if dbManifest.ID != "discord" {
 		t.Errorf("expected DB manifest ID 'discord', got %q", dbManifest.ID)
 	}
-	if len(dbManifest.Actions) != 11 {
-		t.Errorf("expected 11 DB actions, got %d", len(dbManifest.Actions))
+	if len(dbManifest.Actions) != 12 {
+		t.Errorf("expected 12 DB actions, got %d", len(dbManifest.Actions))
 	}
+}
+
+func TestMapDiscordError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		code       int
+		message    string
+		wantType   string
+		wantSubstr string
+	}{
+		{
+			name:       "unknown channel",
+			statusCode: 404,
+			code:       10003,
+			message:    "Unknown Channel",
+			wantType:   "external",
+			wantSubstr: "channel not found",
+		},
+		{
+			name:       "missing permissions",
+			statusCode: 403,
+			code:       50013,
+			message:    "Missing Permissions",
+			wantType:   "auth",
+			wantSubstr: "missing a required permission",
+		},
+		{
+			name:       "unknown role",
+			statusCode: 404,
+			code:       10011,
+			message:    "Unknown Role",
+			wantType:   "external",
+			wantSubstr: "list_roles",
+		},
+		{
+			name:       "max pins",
+			statusCode: 400,
+			code:       30003,
+			message:    "Maximum number of pins reached",
+			wantType:   "external",
+			wantSubstr: "50 pinned messages",
+		},
+		{
+			name:       "unauthorized fallback",
+			statusCode: 401,
+			code:       0,
+			message:    "",
+			wantType:   "auth",
+			wantSubstr: "invalid bot token",
+		},
+		{
+			name:       "generic error",
+			statusCode: 500,
+			code:       0,
+			message:    "Internal Server Error",
+			wantType:   "external",
+			wantSubstr: "Internal Server Error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := mapDiscordError(tt.statusCode, discordErrorResponse{Code: tt.code, Message: tt.message})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			switch tt.wantType {
+			case "auth":
+				if !connectors.IsAuthError(err) {
+					t.Errorf("expected AuthError, got %T: %v", err, err)
+				}
+			case "external":
+				if !connectors.IsExternalError(err) {
+					t.Errorf("expected ExternalError, got %T: %v", err, err)
+				}
+			case "validation":
+				if !connectors.IsValidationError(err) {
+					t.Errorf("expected ValidationError, got %T: %v", err, err)
+				}
+			}
+			if got := err.Error(); !containsSubstring(got, tt.wantSubstr) {
+				t.Errorf("error %q should contain %q", got, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (sub == "" || contains(s, sub))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }
 
 func TestManifestTemplateParametersAreValidJSON(t *testing.T) {

--- a/connectors/discord/helpers_test.go
+++ b/connectors/discord/helpers_test.go
@@ -1,0 +1,10 @@
+package discord
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+// validCreds returns a Credentials value with a valid bot token for tests.
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		"bot_token": "test-bot-token-123",
+	})
+}

--- a/connectors/discord/helpers_test.go
+++ b/connectors/discord/helpers_test.go
@@ -1,10 +1,49 @@
 package discord
 
-import "github.com/supersuit-tech/permission-slip-web/connectors"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
 
 // validCreds returns a Credentials value with a valid bot token for tests.
 func validCreds() connectors.Credentials {
 	return connectors.NewCredentials(map[string]string{
 		"bot_token": "test-bot-token-123",
 	})
+}
+
+// mockServer creates an httptest server that verifies the expected HTTP method
+// and path, then responds with the given status code and JSON body. It returns
+// a DiscordConnector wired to the mock server.
+//
+// For 204 No Content responses, pass nil for responseBody.
+func mockServer(t *testing.T, expectedMethod, expectedPath string, statusCode int, responseBody any) (*DiscordConnector, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != expectedMethod {
+			t.Errorf("expected %s, got %s", expectedMethod, r.Method)
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bot test-bot-token-123" {
+			t.Errorf("expected Bot token in Authorization header, got %q", got)
+		}
+
+		if statusCode == http.StatusNoContent || responseBody == nil {
+			w.WriteHeader(statusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		json.NewEncoder(w).Encode(responseBody)
+	}))
+
+	conn := newForTest(srv.Client(), srv.URL)
+	return conn, srv.Close
 }

--- a/connectors/discord/kick_user.go
+++ b/connectors/discord/kick_user.go
@@ -1,0 +1,51 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// kickUserAction implements connectors.Action for discord.kick_user.
+type kickUserAction struct {
+	conn *DiscordConnector
+}
+
+type kickUserParams struct {
+	GuildID string `json:"guild_id"`
+	UserID  string `json:"user_id"`
+}
+
+func (p *kickUserParams) validate() error {
+	if err := validateSnowflake(p.GuildID, "guild_id"); err != nil {
+		return err
+	}
+	if err := validateSnowflake(p.UserID, "user_id"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *kickUserAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params kickUserParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/guilds/%s/members/%s", params.GuildID, params.UserID)
+
+	// DELETE /guilds/{guild.id}/members/{user.id} returns 204 No Content.
+	if err := a.conn.doRequest(ctx, "DELETE", path, req.Credentials, nil, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status":  "kicked",
+		"user_id": params.UserID,
+	})
+}

--- a/connectors/discord/kick_user.go
+++ b/connectors/discord/kick_user.go
@@ -9,6 +9,8 @@ import (
 )
 
 // kickUserAction implements connectors.Action for discord.kick_user.
+// Discord API: DELETE /guilds/{guild.id}/members/{user.id}
+// See: https://discord.com/developers/docs/resources/guild#remove-guild-member
 type kickUserAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/list_channels.go
+++ b/connectors/discord/list_channels.go
@@ -9,6 +9,8 @@ import (
 )
 
 // listChannelsAction implements connectors.Action for discord.list_channels.
+// Discord API: GET /guilds/{guild.id}/channels
+// See: https://discord.com/developers/docs/resources/guild#get-guild-channels
 type listChannelsAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/list_channels.go
+++ b/connectors/discord/list_channels.go
@@ -1,0 +1,67 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listChannelsAction implements connectors.Action for discord.list_channels.
+type listChannelsAction struct {
+	conn *DiscordConnector
+}
+
+type listChannelsParams struct {
+	GuildID string `json:"guild_id"`
+}
+
+type discordChannel struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     int    `json:"type"`
+	Position int    `json:"position"`
+	ParentID string `json:"parent_id,omitempty"`
+	Topic    string `json:"topic,omitempty"`
+}
+
+type listChannelSummary struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     int    `json:"type"`
+	Position int    `json:"position"`
+	ParentID string `json:"parent_id,omitempty"`
+	Topic    string `json:"topic,omitempty"`
+}
+
+func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listChannelsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := validateSnowflake(params.GuildID, "guild_id"); err != nil {
+		return nil, err
+	}
+
+	var channels []discordChannel
+	if err := a.conn.doRequest(ctx, "GET", "/guilds/"+params.GuildID+"/channels", req.Credentials, nil, &channels); err != nil {
+		return nil, err
+	}
+
+	result := make([]listChannelSummary, 0, len(channels))
+	for _, ch := range channels {
+		result = append(result, listChannelSummary{
+			ID:       ch.ID,
+			Name:     ch.Name,
+			Type:     ch.Type,
+			Position: ch.Position,
+			ParentID: ch.ParentID,
+			Topic:    ch.Topic,
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"channels": result,
+	})
+}

--- a/connectors/discord/list_channels_test.go
+++ b/connectors/discord/list_channels_test.go
@@ -3,7 +3,6 @@ package discord
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -12,25 +11,13 @@ import (
 func TestListChannels_Success(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("expected GET, got %s", r.Method)
-		}
-		if r.URL.Path != "/guilds/111/channels" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
+	conn, cleanup := mockServer(t, http.MethodGet, "/guilds/111/channels", http.StatusOK, []map[string]any{
+		{"id": "100", "name": "general", "type": 0, "position": 0},
+		{"id": "200", "name": "voice", "type": 2, "position": 1},
+	})
+	defer cleanup()
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]map[string]any{
-			{"id": "100", "name": "general", "type": 0, "position": 0},
-			{"id": "200", "name": "voice", "type": 2, "position": 1},
-		})
-	}))
-	defer srv.Close()
-
-	conn := newForTest(srv.Client(), srv.URL)
 	action := &listChannelsAction{conn: conn}
-
 	params, _ := json.Marshal(listChannelsParams{GuildID: "111"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/discord/list_channels_test.go
+++ b/connectors/discord/list_channels_test.go
@@ -1,0 +1,76 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListChannels_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/channels" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "100", "name": "general", "type": 0, "position": 0},
+			{"id": "200", "name": "voice", "type": 2, "position": 1},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+
+	params, _ := json.Marshal(listChannelsParams{GuildID: "111"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Channels []listChannelSummary `json:"channels"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(data.Channels) != 2 {
+		t.Errorf("expected 2 channels, got %d", len(data.Channels))
+	}
+	if data.Channels[0].Name != "general" {
+		t.Errorf("expected first channel 'general', got %q", data.Channels[0].Name)
+	}
+}
+
+func TestListChannels_MissingGuildID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &listChannelsAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing guild_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/list_members.go
+++ b/connectors/discord/list_members.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -25,6 +27,11 @@ func (p *listMembersParams) validate() error {
 	}
 	if p.Limit != 0 && (p.Limit < 1 || p.Limit > 1000) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("limit must be between 1 and 1000, got %d", p.Limit)}
+	}
+	if p.After != "" {
+		if err := validateSnowflake(p.After, "after"); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -65,10 +72,12 @@ func (a *listMembersAction) Execute(ctx context.Context, req connectors.ActionRe
 		limit = 100
 	}
 
-	path := fmt.Sprintf("/guilds/%s/members?limit=%d", params.GuildID, limit)
+	qv := url.Values{}
+	qv.Set("limit", strconv.Itoa(limit))
 	if params.After != "" {
-		path += "&after=" + params.After
+		qv.Set("after", params.After)
 	}
+	path := fmt.Sprintf("/guilds/%s/members?%s", params.GuildID, qv.Encode())
 
 	var members []discordMember
 	if err := a.conn.doRequest(ctx, "GET", path, req.Credentials, nil, &members); err != nil {

--- a/connectors/discord/list_members.go
+++ b/connectors/discord/list_members.go
@@ -11,6 +11,9 @@ import (
 )
 
 // listMembersAction implements connectors.Action for discord.list_members.
+// Discord API: GET /guilds/{guild.id}/members
+// See: https://discord.com/developers/docs/resources/guild#list-guild-members
+// Note: Requires the Server Members Intent to be enabled on the bot.
 type listMembersAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/list_members.go
+++ b/connectors/discord/list_members.go
@@ -1,0 +1,95 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listMembersAction implements connectors.Action for discord.list_members.
+type listMembersAction struct {
+	conn *DiscordConnector
+}
+
+type listMembersParams struct {
+	GuildID string `json:"guild_id"`
+	Limit   int    `json:"limit,omitempty"`
+	After   string `json:"after,omitempty"`
+}
+
+func (p *listMembersParams) validate() error {
+	if err := validateSnowflake(p.GuildID, "guild_id"); err != nil {
+		return err
+	}
+	if p.Limit != 0 && (p.Limit < 1 || p.Limit > 1000) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("limit must be between 1 and 1000, got %d", p.Limit)}
+	}
+	return nil
+}
+
+type discordUser struct {
+	ID            string `json:"id"`
+	Username      string `json:"username"`
+	Discriminator string `json:"discriminator"`
+	GlobalName    string `json:"global_name,omitempty"`
+}
+
+type discordMember struct {
+	User   *discordUser `json:"user,omitempty"`
+	Nick   string       `json:"nick,omitempty"`
+	Roles  []string     `json:"roles"`
+	Joined string       `json:"joined_at"`
+}
+
+type memberSummary struct {
+	UserID   string   `json:"user_id"`
+	Username string   `json:"username"`
+	Nick     string   `json:"nick,omitempty"`
+	Roles    []string `json:"roles"`
+	JoinedAt string   `json:"joined_at"`
+}
+
+func (a *listMembersAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listMembersParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	limit := params.Limit
+	if limit == 0 {
+		limit = 100
+	}
+
+	path := fmt.Sprintf("/guilds/%s/members?limit=%d", params.GuildID, limit)
+	if params.After != "" {
+		path += "&after=" + params.After
+	}
+
+	var members []discordMember
+	if err := a.conn.doRequest(ctx, "GET", path, req.Credentials, nil, &members); err != nil {
+		return nil, err
+	}
+
+	result := make([]memberSummary, 0, len(members))
+	for _, m := range members {
+		s := memberSummary{
+			Nick:     m.Nick,
+			Roles:    m.Roles,
+			JoinedAt: m.Joined,
+		}
+		if m.User != nil {
+			s.UserID = m.User.ID
+			s.Username = m.User.Username
+		}
+		result = append(result, s)
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"members": result,
+	})
+}

--- a/connectors/discord/list_members_test.go
+++ b/connectors/discord/list_members_test.go
@@ -1,0 +1,86 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListMembers_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/members" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"user":      map[string]string{"id": "100", "username": "alice"},
+				"nick":      "Alice",
+				"roles":     []string{"555"},
+				"joined_at": "2024-01-01T00:00:00Z",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listMembersAction{conn: conn}
+
+	params, _ := json.Marshal(listMembersParams{GuildID: "111"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.list_members",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Members []memberSummary `json:"members"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(data.Members) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(data.Members))
+	}
+	if data.Members[0].Username != "alice" {
+		t.Errorf("expected username 'alice', got %q", data.Members[0].Username)
+	}
+	if data.Members[0].Nick != "Alice" {
+		t.Errorf("expected nick 'Alice', got %q", data.Members[0].Nick)
+	}
+}
+
+func TestListMembers_InvalidLimit(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &listMembersAction{conn: conn}
+
+	params, _ := json.Marshal(listMembersParams{
+		GuildID: "111",
+		Limit:   2000,
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.list_members",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid limit")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/list_roles.go
+++ b/connectors/discord/list_roles.go
@@ -9,6 +9,8 @@ import (
 )
 
 // listRolesAction implements connectors.Action for discord.list_roles.
+// Discord API: GET /guilds/{guild.id}/roles
+// See: https://discord.com/developers/docs/resources/guild#get-guild-roles
 type listRolesAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/list_roles.go
+++ b/connectors/discord/list_roles.go
@@ -1,0 +1,68 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listRolesAction implements connectors.Action for discord.list_roles.
+type listRolesAction struct {
+	conn *DiscordConnector
+}
+
+type listRolesParams struct {
+	GuildID string `json:"guild_id"`
+}
+
+type discordRole struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Color       int    `json:"color"`
+	Position    int    `json:"position"`
+	Permissions string `json:"permissions"`
+	Managed     bool   `json:"managed"`
+	Mentionable bool   `json:"mentionable"`
+}
+
+type roleSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Color       int    `json:"color"`
+	Position    int    `json:"position"`
+	Managed     bool   `json:"managed"`
+	Mentionable bool   `json:"mentionable"`
+}
+
+func (a *listRolesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listRolesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := validateSnowflake(params.GuildID, "guild_id"); err != nil {
+		return nil, err
+	}
+
+	var roles []discordRole
+	if err := a.conn.doRequest(ctx, "GET", "/guilds/"+params.GuildID+"/roles", req.Credentials, nil, &roles); err != nil {
+		return nil, err
+	}
+
+	result := make([]roleSummary, 0, len(roles))
+	for _, r := range roles {
+		result = append(result, roleSummary{
+			ID:          r.ID,
+			Name:        r.Name,
+			Color:       r.Color,
+			Position:    r.Position,
+			Managed:     r.Managed,
+			Mentionable: r.Mentionable,
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"roles": result,
+	})
+}

--- a/connectors/discord/list_roles_test.go
+++ b/connectors/discord/list_roles_test.go
@@ -3,7 +3,6 @@ package discord
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -12,26 +11,14 @@ import (
 func TestListRoles_Success(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("expected GET, got %s", r.Method)
-		}
-		if r.URL.Path != "/guilds/111/roles" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
+	conn, cleanup := mockServer(t, http.MethodGet, "/guilds/111/roles", http.StatusOK, []map[string]any{
+		{"id": "100", "name": "@everyone", "color": 0, "position": 0, "managed": false, "mentionable": false},
+		{"id": "200", "name": "Moderator", "color": 3447003, "position": 1, "managed": false, "mentionable": true},
+		{"id": "300", "name": "Bot Role", "color": 0, "position": 2, "managed": true, "mentionable": false},
+	})
+	defer cleanup()
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]map[string]any{
-			{"id": "100", "name": "@everyone", "color": 0, "position": 0, "managed": false, "mentionable": false},
-			{"id": "200", "name": "Moderator", "color": 3447003, "position": 1, "managed": false, "mentionable": true},
-			{"id": "300", "name": "Bot Role", "color": 0, "position": 2, "managed": true, "mentionable": false},
-		})
-	}))
-	defer srv.Close()
-
-	conn := newForTest(srv.Client(), srv.URL)
 	action := &listRolesAction{conn: conn}
-
 	params, _ := json.Marshal(listRolesParams{GuildID: "111"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/discord/list_roles_test.go
+++ b/connectors/discord/list_roles_test.go
@@ -1,0 +1,83 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListRoles_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/roles" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"id": "100", "name": "@everyone", "color": 0, "position": 0, "managed": false, "mentionable": false},
+			{"id": "200", "name": "Moderator", "color": 3447003, "position": 1, "managed": false, "mentionable": true},
+			{"id": "300", "name": "Bot Role", "color": 0, "position": 2, "managed": true, "mentionable": false},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listRolesAction{conn: conn}
+
+	params, _ := json.Marshal(listRolesParams{GuildID: "111"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.list_roles",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data struct {
+		Roles []roleSummary `json:"roles"`
+	}
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(data.Roles) != 3 {
+		t.Errorf("expected 3 roles, got %d", len(data.Roles))
+	}
+	if data.Roles[1].Name != "Moderator" {
+		t.Errorf("expected second role 'Moderator', got %q", data.Roles[1].Name)
+	}
+	if !data.Roles[1].Mentionable {
+		t.Error("expected Moderator role to be mentionable")
+	}
+	if !data.Roles[2].Managed {
+		t.Error("expected Bot Role to be managed")
+	}
+}
+
+func TestListRoles_MissingGuildID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &listRolesAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.list_roles",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing guild_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/manage_roles.go
+++ b/connectors/discord/manage_roles.go
@@ -10,6 +10,8 @@ import (
 )
 
 // manageRolesAction implements connectors.Action for discord.manage_roles.
+// Discord API: PUT/DELETE /guilds/{guild.id}/members/{user.id}/roles/{role.id}
+// See: https://discord.com/developers/docs/resources/guild#add-guild-member-role
 type manageRolesAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/manage_roles.go
+++ b/connectors/discord/manage_roles.go
@@ -1,0 +1,67 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// manageRolesAction implements connectors.Action for discord.manage_roles.
+type manageRolesAction struct {
+	conn *DiscordConnector
+}
+
+type manageRolesParams struct {
+	GuildID string `json:"guild_id"`
+	UserID  string `json:"user_id"`
+	RoleID  string `json:"role_id"`
+	Action  string `json:"action"` // "assign" or "remove"
+}
+
+func (p *manageRolesParams) validate() error {
+	if err := validateSnowflake(p.GuildID, "guild_id"); err != nil {
+		return err
+	}
+	if err := validateSnowflake(p.UserID, "user_id"); err != nil {
+		return err
+	}
+	if err := validateSnowflake(p.RoleID, "role_id"); err != nil {
+		return err
+	}
+	if p.Action != "assign" && p.Action != "remove" {
+		return &connectors.ValidationError{Message: "action must be \"assign\" or \"remove\""}
+	}
+	return nil
+}
+
+func (a *manageRolesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params manageRolesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/guilds/%s/members/%s/roles/%s", params.GuildID, params.UserID, params.RoleID)
+
+	method := http.MethodPut
+	if params.Action == "remove" {
+		method = http.MethodDelete
+	}
+
+	// These endpoints return 204 No Content on success.
+	if err := a.conn.doRequest(ctx, method, path, req.Credentials, nil, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status":  "success",
+		"action":  params.Action,
+		"user_id": params.UserID,
+		"role_id": params.RoleID,
+	})
+}

--- a/connectors/discord/manage_roles_test.go
+++ b/connectors/discord/manage_roles_test.go
@@ -1,0 +1,111 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestManageRoles_Assign(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT for assign, got %s", r.Method)
+		}
+		if r.URL.Path != "/guilds/111/members/222/roles/333" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &manageRolesAction{conn: conn}
+
+	params, _ := json.Marshal(manageRolesParams{
+		GuildID: "111",
+		UserID:  "222",
+		RoleID:  "333",
+		Action:  "assign",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.manage_roles",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["status"] != "success" {
+		t.Errorf("expected status 'success', got %q", data["status"])
+	}
+	if data["action"] != "assign" {
+		t.Errorf("expected action 'assign', got %q", data["action"])
+	}
+}
+
+func TestManageRoles_Remove(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE for remove, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &manageRolesAction{conn: conn}
+
+	params, _ := json.Marshal(manageRolesParams{
+		GuildID: "111",
+		UserID:  "222",
+		RoleID:  "333",
+		Action:  "remove",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.manage_roles",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManageRoles_InvalidAction(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &manageRolesAction{conn: conn}
+
+	params, _ := json.Marshal(manageRolesParams{
+		GuildID: "111",
+		UserID:  "222",
+		RoleID:  "333",
+		Action:  "invalid",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.manage_roles",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid action")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/pin_message.go
+++ b/connectors/discord/pin_message.go
@@ -1,0 +1,80 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// pinMessageAction implements connectors.Action for discord.pin_message.
+type pinMessageAction struct {
+	conn *DiscordConnector
+}
+
+// unpinMessageAction implements connectors.Action for discord.unpin_message.
+type unpinMessageAction struct {
+	conn *DiscordConnector
+}
+
+type pinMessageParams struct {
+	ChannelID string `json:"channel_id"`
+	MessageID string `json:"message_id"`
+}
+
+func (p *pinMessageParams) validate() error {
+	if err := validateSnowflake(p.ChannelID, "channel_id"); err != nil {
+		return err
+	}
+	if err := validateSnowflake(p.MessageID, "message_id"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *pinMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params pinMessageParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/channels/%s/pins/%s", params.ChannelID, params.MessageID)
+
+	// PUT /channels/{channel.id}/pins/{message.id} returns 204 No Content.
+	if err := a.conn.doRequest(ctx, "PUT", path, req.Credentials, nil, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status":     "pinned",
+		"message_id": params.MessageID,
+		"channel_id": params.ChannelID,
+	})
+}
+
+func (a *unpinMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params pinMessageParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/channels/%s/pins/%s", params.ChannelID, params.MessageID)
+
+	// DELETE /channels/{channel.id}/pins/{message.id} returns 204 No Content.
+	if err := a.conn.doRequest(ctx, "DELETE", path, req.Credentials, nil, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status":     "unpinned",
+		"message_id": params.MessageID,
+		"channel_id": params.ChannelID,
+	})
+}

--- a/connectors/discord/pin_message.go
+++ b/connectors/discord/pin_message.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -33,7 +34,8 @@ func (p *pinMessageParams) validate() error {
 	return nil
 }
 
-func (a *pinMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+// executePinUnpin is the shared implementation for pin and unpin actions.
+func executePinUnpin(ctx context.Context, conn *DiscordConnector, req connectors.ActionRequest, method, status string) (*connectors.ActionResult, error) {
 	var params pinMessageParams
 	if err := json.Unmarshal(req.Parameters, &params); err != nil {
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
@@ -44,37 +46,21 @@ func (a *pinMessageAction) Execute(ctx context.Context, req connectors.ActionReq
 
 	path := fmt.Sprintf("/channels/%s/pins/%s", params.ChannelID, params.MessageID)
 
-	// PUT /channels/{channel.id}/pins/{message.id} returns 204 No Content.
-	if err := a.conn.doRequest(ctx, "PUT", path, req.Credentials, nil, nil); err != nil {
+	if err := conn.doRequest(ctx, method, path, req.Credentials, nil, nil); err != nil {
 		return nil, err
 	}
 
 	return connectors.JSONResult(map[string]string{
-		"status":     "pinned",
+		"status":     status,
 		"message_id": params.MessageID,
 		"channel_id": params.ChannelID,
 	})
 }
 
+func (a *pinMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	return executePinUnpin(ctx, a.conn, req, http.MethodPut, "pinned")
+}
+
 func (a *unpinMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
-	var params pinMessageParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-	if err := params.validate(); err != nil {
-		return nil, err
-	}
-
-	path := fmt.Sprintf("/channels/%s/pins/%s", params.ChannelID, params.MessageID)
-
-	// DELETE /channels/{channel.id}/pins/{message.id} returns 204 No Content.
-	if err := a.conn.doRequest(ctx, "DELETE", path, req.Credentials, nil, nil); err != nil {
-		return nil, err
-	}
-
-	return connectors.JSONResult(map[string]string{
-		"status":     "unpinned",
-		"message_id": params.MessageID,
-		"channel_id": params.ChannelID,
-	})
+	return executePinUnpin(ctx, a.conn, req, http.MethodDelete, "unpinned")
 }

--- a/connectors/discord/pin_message.go
+++ b/connectors/discord/pin_message.go
@@ -10,11 +10,15 @@ import (
 )
 
 // pinMessageAction implements connectors.Action for discord.pin_message.
+// Discord API: PUT /channels/{channel.id}/pins/{message.id}
+// See: https://discord.com/developers/docs/resources/channel#pin-message
 type pinMessageAction struct {
 	conn *DiscordConnector
 }
 
 // unpinMessageAction implements connectors.Action for discord.unpin_message.
+// Discord API: DELETE /channels/{channel.id}/pins/{message.id}
+// See: https://discord.com/developers/docs/resources/channel#unpin-message
 type unpinMessageAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/pin_message_test.go
+++ b/connectors/discord/pin_message_test.go
@@ -1,0 +1,109 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestPinMessage_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/channels/111/pins/222" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &pinMessageAction{conn: conn}
+
+	params, _ := json.Marshal(pinMessageParams{
+		ChannelID: "111",
+		MessageID: "222",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.pin_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["status"] != "pinned" {
+		t.Errorf("expected status 'pinned', got %q", data["status"])
+	}
+}
+
+func TestUnpinMessage_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/channels/111/pins/222" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &unpinMessageAction{conn: conn}
+
+	params, _ := json.Marshal(pinMessageParams{
+		ChannelID: "111",
+		MessageID: "222",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.unpin_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if data["status"] != "unpinned" {
+		t.Errorf("expected status 'unpinned', got %q", data["status"])
+	}
+}
+
+func TestPinMessage_MissingMessageID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &pinMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"channel_id": "111"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.pin_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/discord/pin_message_test.go
+++ b/connectors/discord/pin_message_test.go
@@ -3,7 +3,6 @@ package discord
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -12,24 +11,11 @@ import (
 func TestPinMessage_Success(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Errorf("expected PUT, got %s", r.Method)
-		}
-		if r.URL.Path != "/channels/111/pins/222" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
+	conn, cleanup := mockServer(t, http.MethodPut, "/channels/111/pins/222", http.StatusNoContent, nil)
+	defer cleanup()
 
-	conn := newForTest(srv.Client(), srv.URL)
 	action := &pinMessageAction{conn: conn}
-
-	params, _ := json.Marshal(pinMessageParams{
-		ChannelID: "111",
-		MessageID: "222",
-	})
+	params, _ := json.Marshal(pinMessageParams{ChannelID: "111", MessageID: "222"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "discord.pin_message",
@@ -52,24 +38,11 @@ func TestPinMessage_Success(t *testing.T) {
 func TestUnpinMessage_Success(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("expected DELETE, got %s", r.Method)
-		}
-		if r.URL.Path != "/channels/111/pins/222" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
+	conn, cleanup := mockServer(t, http.MethodDelete, "/channels/111/pins/222", http.StatusNoContent, nil)
+	defer cleanup()
 
-	conn := newForTest(srv.Client(), srv.URL)
 	action := &unpinMessageAction{conn: conn}
-
-	params, _ := json.Marshal(pinMessageParams{
-		ChannelID: "111",
-		MessageID: "222",
-	})
+	params, _ := json.Marshal(pinMessageParams{ChannelID: "111", MessageID: "222"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "discord.unpin_message",

--- a/connectors/discord/send_message.go
+++ b/connectors/discord/send_message.go
@@ -1,0 +1,62 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// sendMessageAction implements connectors.Action for discord.send_message.
+type sendMessageAction struct {
+	conn *DiscordConnector
+}
+
+type sendMessageParams struct {
+	ChannelID string `json:"channel_id"`
+	Content   string `json:"content"`
+}
+
+func (p *sendMessageParams) validate() error {
+	if err := validateSnowflake(p.ChannelID, "channel_id"); err != nil {
+		return err
+	}
+	if p.Content == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: content"}
+	}
+	if len(p.Content) > 2000 {
+		return &connectors.ValidationError{Message: "content must be 2000 characters or fewer"}
+	}
+	return nil
+}
+
+type sendMessageRequest struct {
+	Content string `json:"content"`
+}
+
+type sendMessageResponse struct {
+	ID        string `json:"id"`
+	ChannelID string `json:"channel_id"`
+}
+
+func (a *sendMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params sendMessageParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := sendMessageRequest{Content: params.Content}
+	var resp sendMessageResponse
+	if err := a.conn.doRequest(ctx, "POST", "/channels/"+params.ChannelID+"/messages", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"id":         resp.ID,
+		"channel_id": resp.ChannelID,
+	})
+}

--- a/connectors/discord/send_message.go
+++ b/connectors/discord/send_message.go
@@ -9,6 +9,8 @@ import (
 )
 
 // sendMessageAction implements connectors.Action for discord.send_message.
+// Discord API: POST /channels/{channel.id}/messages
+// See: https://discord.com/developers/docs/resources/message#create-message
 type sendMessageAction struct {
 	conn *DiscordConnector
 }

--- a/connectors/discord/send_message_test.go
+++ b/connectors/discord/send_message_test.go
@@ -1,0 +1,232 @@
+package discord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestSendMessage_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/channels/123456789012345678/messages" {
+			t.Errorf("expected path /channels/123456789012345678/messages, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bot test-bot-token-123" {
+			t.Errorf("expected Bot token in Authorization header, got %q", got)
+		}
+
+		var body sendMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Content != "Hello, Discord!" {
+			t.Errorf("expected content 'Hello, Discord!', got %q", body.Content)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "111222333444555666",
+			"channel_id": "123456789012345678",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(sendMessageParams{
+		ChannelID: "123456789012345678",
+		Content:   "Hello, Discord!",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "111222333444555666" {
+		t.Errorf("expected id '111222333444555666', got %q", data["id"])
+	}
+}
+
+func TestSendMessage_MissingChannelID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"content": "Hello"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing channel_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendMessage_MissingContent(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"channel_id": "123456789012345678"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendMessage_ContentTooLong(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &sendMessageAction{conn: conn}
+
+	longContent := make([]byte, 2001)
+	for i := range longContent {
+		longContent[i] = 'a'
+	}
+	params, _ := json.Marshal(sendMessageParams{
+		ChannelID: "123456789012345678",
+		Content:   string(longContent),
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for content too long")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendMessage_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"code":    0,
+			"message": "401: Unauthorized",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(sendMessageParams{
+		ChannelID: "123456789012345678",
+		Content:   "Hello",
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestSendMessage_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(sendMessageParams{
+		ChannelID: "123456789012345678",
+		Content:   "Hello",
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}
+
+func TestSendMessage_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &sendMessageAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendMessage_InvalidSnowflake(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(sendMessageParams{
+		ChannelID: "not-a-snowflake",
+		Content:   "Hello",
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "discord.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid snowflake")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/api"
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/connectors/amadeus"
+	"github.com/supersuit-tech/permission-slip-web/connectors/discord"
 	"github.com/supersuit-tech/permission-slip-web/connectors/doordash"
 	"github.com/supersuit-tech/permission-slip-web/connectors/expedia"
 	ghconnector "github.com/supersuit-tech/permission-slip-web/connectors/github"
@@ -356,6 +357,7 @@ func main() {
 	registry.Register(xconnector.New())
 	registry.Register(krogerconnector.New())
 	registry.Register(amadeus.New())
+	registry.Register(discord.New())
 	registry.Register(doordash.New())
 	registry.Register(expedia.New())
 	registry.Register(zoom.New())


### PR DESCRIPTION
Implements the Discord connector with 11 actions covering community management and messaging: send_message, create_channel, manage_roles, create_event, ban_user, kick_user, pin_message, unpin_message, list_channels, list_members, and create_thread.

Uses Discord REST API v10 with Bot token auth and proper rate limit handling via Retry-After headers. All parameters use Discord snowflake IDs with validation.

Risk levels follow the issue spec:
- low: list_channels, list_members, send_message, create_thread
- medium: create_channel, manage_roles, create_event, pin/unpin_message
- high: ban_user, kick_user

Closes #266

https://claude.ai/code/session_01MVirsgt6rrub9LfFhz9MVm