### PR TITLE
Add HubSpot email campaigns, workflows, deal pipeline, and analytics actions

### DIFF
--- a/connectors/hubspot/README.md
+++ b/connectors/hubspot/README.md
@@ -26,6 +26,11 @@ The credential `auth_type` in the database is `api_key`. Tokens are stored encry
 | `hubspot.create_ticket` | low | Create a support ticket in a pipeline |
 | `hubspot.add_note` | low | Add an engagement note to a contact, deal, or ticket (two-step: create + associate) |
 | `hubspot.search` | low | Search contacts, deals, tickets, or companies with property filters |
+| `hubspot.list_deals` | low | Search and list deals with filtering, sorting, and property selection |
+| `hubspot.update_deal_stage` | medium | Move a deal to a different pipeline stage |
+| `hubspot.enroll_in_workflow` | medium | Enroll a contact in an automation workflow |
+| `hubspot.create_email_campaign` | high | Create and optionally send a marketing email campaign |
+| `hubspot.get_analytics` | low | Get marketing and sales analytics reports |
 
 ### `hubspot.create_contact`
 
@@ -72,6 +77,43 @@ Searches CRM objects with filters. Supports contacts, deals, tickets, and compan
 **Supported operators:** `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `CONTAINS_TOKEN`, `NOT_CONTAINS_TOKEN`, `HAS_PROPERTY`, `NOT_HAS_PROPERTY`, `BETWEEN`
 
 **Limit:** Defaults to 10, capped at HubSpot's API maximum of 200.
+
+### `hubspot.list_deals`
+
+Searches and lists deals in the sales pipeline. Supports filtering, sorting, and property selection. Returns default properties (dealname, amount, dealstage, pipeline, closedate, createdate, hs_lastmodifieddate) when none are specified.
+
+**HubSpot API:** `POST /crm/v3/objects/deals/search`
+**Required scopes:** `crm.objects.deals.read`
+
+**Supported operators:** `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`, `CONTAINS_TOKEN`, `NOT_CONTAINS_TOKEN` (a subset of HubSpot's full operator set — `BETWEEN`, `HAS_PROPERTY`, and `NOT_HAS_PROPERTY` are not supported by this action's single-value filter model; use `hubspot.search` for those).
+
+### `hubspot.update_deal_stage`
+
+Moves a deal to a different pipeline stage, with an optional close date update.
+
+**HubSpot API:** `PATCH /crm/v3/objects/deals/{deal_id}`
+**Required scopes:** `crm.objects.deals.write`
+
+### `hubspot.enroll_in_workflow`
+
+Enrolls a contact in an automation workflow. Workflows may trigger emails, delays, and branching logic — verify the workflow ID before enrolling.
+
+**HubSpot API:** `POST /automation/v4/flows/{flow_id}/enrollments`
+**Required scopes:** `automation`
+
+### `hubspot.create_email_campaign`
+
+Creates a marketing email campaign and optionally sends it immediately. When `send_now` is true, the email is sent to all contacts in the specified lists — `list_ids` is required in that case. When `send_now` is false (or omitted), a draft is created.
+
+**HubSpot API:** `POST /marketing/v3/emails`
+**Required scopes:** `content`
+
+### `hubspot.get_analytics`
+
+Fetches marketing and sales analytics reports with configurable time period granularity. Optional date range filtering via `start` and `end` parameters.
+
+**HubSpot API:** `GET /analytics/v2/reports/{object_type}/{time_period}`
+**Required scopes:** `analytics.read`
 
 ### Key patterns
 
@@ -150,6 +192,11 @@ connectors/hubspot/
 ├── create_ticket.go        # hubspot.create_ticket
 ├── add_note.go             # hubspot.add_note (two-step create + associate)
 ├── search.go               # hubspot.search
+├── list_deals.go           # hubspot.list_deals
+├── update_deal_stage.go    # hubspot.update_deal_stage
+├── enroll_in_workflow.go   # hubspot.enroll_in_workflow
+├── create_email_campaign.go # hubspot.create_email_campaign
+├── get_analytics.go        # hubspot.get_analytics
 ├── hubspot_test.go         # Connector-level tests
 ├── response_test.go        # Error mapping tests
 ├── helpers_test.go         # Shared test helpers (validCreds)

--- a/connectors/hubspot/create_email_campaign.go
+++ b/connectors/hubspot/create_email_campaign.go
@@ -1,0 +1,84 @@
+package hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createEmailCampaignAction implements connectors.Action for hubspot.create_email_campaign.
+// It creates a marketing email via POST /marketing/v3/emails, and optionally sends it.
+type createEmailCampaignAction struct {
+	conn *HubSpotConnector
+}
+
+type createEmailCampaignParams struct {
+	Name    string   `json:"name"`
+	Subject string   `json:"subject"`
+	Content string   `json:"content"`
+	ListIDs []string `json:"list_ids"`
+	SendNow bool     `json:"send_now"`
+}
+
+func (p *createEmailCampaignParams) validate() error {
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	if p.Subject == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: subject"}
+	}
+	if p.Content == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: content"}
+	}
+	for i, id := range p.ListIDs {
+		if !isValidHubSpotID(id) {
+			return &connectors.ValidationError{Message: fmt.Sprintf("list_ids[%d]: must be a numeric HubSpot ID", i)}
+		}
+	}
+	return nil
+}
+
+// emailCampaignRequest is the request body for the marketing email API.
+type emailCampaignRequest struct {
+	Name    string   `json:"name"`
+	Subject string   `json:"subject"`
+	Content string   `json:"content"`
+	ListIDs []string `json:"listIds,omitempty"`
+	SendNow bool     `json:"sendNow"`
+}
+
+// emailCampaignResponse captures the response from the marketing email API.
+type emailCampaignResponse struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Subject string `json:"subject"`
+	State   string `json:"state"`
+}
+
+func (a *createEmailCampaignAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createEmailCampaignParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := emailCampaignRequest{
+		Name:    params.Name,
+		Subject: params.Subject,
+		Content: params.Content,
+		ListIDs: params.ListIDs,
+		SendNow: params.SendNow,
+	}
+
+	var resp emailCampaignResponse
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/marketing/v3/emails", body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/hubspot/create_email_campaign.go
+++ b/connectors/hubspot/create_email_campaign.go
@@ -33,6 +33,9 @@ func (p *createEmailCampaignParams) validate() error {
 	if p.Content == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: content"}
 	}
+	if p.SendNow && len(p.ListIDs) == 0 {
+		return &connectors.ValidationError{Message: "list_ids is required when send_now is true — specify at least one contact list to send to"}
+	}
 	for i, id := range p.ListIDs {
 		if !isValidHubSpotID(id) {
 			return &connectors.ValidationError{Message: fmt.Sprintf("list_ids[%d]: must be a numeric HubSpot ID", i)}

--- a/connectors/hubspot/create_email_campaign_test.go
+++ b/connectors/hubspot/create_email_campaign_test.go
@@ -104,6 +104,7 @@ func TestCreateEmailCampaign_SendNow(t *testing.T) {
 		Name:    "Urgent Update",
 		Subject: "Action Required",
 		Content: "<p>Please read</p>",
+		ListIDs: []string{"10"},
 		SendNow: true,
 	})
 
@@ -153,6 +154,32 @@ func TestCreateEmailCampaign_MissingSubject(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing subject")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateEmailCampaign_SendNowWithoutListIDs(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(createEmailCampaignParams{
+		Name:    "Test",
+		Subject: "Hi",
+		Content: "Hello",
+		SendNow: true,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error when send_now is true without list_ids")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)

--- a/connectors/hubspot/create_email_campaign_test.go
+++ b/connectors/hubspot/create_email_campaign_test.go
@@ -1,0 +1,207 @@
+package hubspot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateEmailCampaign_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/marketing/v3/emails" {
+			t.Errorf("expected path /marketing/v3/emails, got %s", r.URL.Path)
+		}
+
+		var body emailCampaignRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Name != "March Newsletter" {
+			t.Errorf("expected name March Newsletter, got %q", body.Name)
+		}
+		if body.Subject != "Big News" {
+			t.Errorf("expected subject Big News, got %q", body.Subject)
+		}
+		if body.SendNow {
+			t.Error("expected sendNow to be false")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(emailCampaignResponse{
+			ID:      "email-1",
+			Name:    body.Name,
+			Subject: body.Subject,
+			State:   "DRAFT",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(createEmailCampaignParams{
+		Name:    "March Newsletter",
+		Subject: "Big News",
+		Content: "<h1>Hello</h1>",
+		ListIDs: []string{"10", "20"},
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data emailCampaignResponse
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.ID != "email-1" {
+		t.Errorf("expected id email-1, got %q", data.ID)
+	}
+	if data.State != "DRAFT" {
+		t.Errorf("expected state DRAFT, got %q", data.State)
+	}
+}
+
+func TestCreateEmailCampaign_SendNow(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body emailCampaignRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode: %v", err)
+		}
+		if !body.SendNow {
+			t.Error("expected sendNow to be true")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(emailCampaignResponse{
+			ID:    "email-2",
+			State: "SENT",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(createEmailCampaignParams{
+		Name:    "Urgent Update",
+		Subject: "Action Required",
+		Content: "<p>Please read</p>",
+		SendNow: true,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateEmailCampaign_MissingName(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"subject": "Hi", "content": "Hello"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateEmailCampaign_MissingSubject(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"name": "Test", "content": "Hello"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing subject")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateEmailCampaign_MissingContent(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"name": "Test", "subject": "Hi"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestCreateEmailCampaign_InvalidListID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &createEmailCampaignAction{conn: conn}
+
+	params, _ := json.Marshal(createEmailCampaignParams{
+		Name:    "Test",
+		Subject: "Hi",
+		Content: "Hello",
+		ListIDs: []string{"10", "not-a-number"},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.create_email_campaign",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid list ID")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/hubspot/enroll_in_workflow.go
+++ b/connectors/hubspot/enroll_in_workflow.go
@@ -1,0 +1,74 @@
+package hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// enrollInWorkflowAction implements connectors.Action for hubspot.enroll_in_workflow.
+// It enrolls a contact in an automation workflow via POST /automation/v4/flows/{flowId}/enrollments.
+type enrollInWorkflowAction struct {
+	conn *HubSpotConnector
+}
+
+type enrollInWorkflowParams struct {
+	FlowID    string `json:"flow_id"`
+	ContactID string `json:"contact_id"`
+}
+
+func (p *enrollInWorkflowParams) validate() error {
+	if p.FlowID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: flow_id"}
+	}
+	if !isValidHubSpotID(p.FlowID) {
+		return &connectors.ValidationError{Message: "flow_id must be a numeric HubSpot ID"}
+	}
+	if p.ContactID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: contact_id"}
+	}
+	if !isValidHubSpotID(p.ContactID) {
+		return &connectors.ValidationError{Message: "contact_id must be a numeric HubSpot ID"}
+	}
+	return nil
+}
+
+// enrollmentRequest is the request body for the workflow enrollment API.
+type enrollmentRequest struct {
+	ObjectID   string `json:"objectId"`
+	ObjectType string `json:"objectType"`
+}
+
+// enrollmentResponse captures the response from the enrollment API.
+type enrollmentResponse struct {
+	ID         string `json:"id,omitempty"`
+	Status     string `json:"status,omitempty"`
+	ObjectID   string `json:"objectId,omitempty"`
+	ObjectType string `json:"objectType,omitempty"`
+}
+
+func (a *enrollInWorkflowAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params enrollInWorkflowParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	body := enrollmentRequest{
+		ObjectID:   params.ContactID,
+		ObjectType: "CONTACT",
+	}
+
+	var resp enrollmentResponse
+	path := fmt.Sprintf("/automation/v4/flows/%s/enrollments", params.FlowID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/hubspot/enroll_in_workflow_test.go
+++ b/connectors/hubspot/enroll_in_workflow_test.go
@@ -1,0 +1,158 @@
+package hubspot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestEnrollInWorkflow_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/automation/v4/flows/100/enrollments" {
+			t.Errorf("expected path /automation/v4/flows/100/enrollments, got %s", r.URL.Path)
+		}
+
+		var body enrollmentRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.ObjectID != "501" {
+			t.Errorf("expected objectId 501, got %q", body.ObjectID)
+		}
+		if body.ObjectType != "CONTACT" {
+			t.Errorf("expected objectType CONTACT, got %q", body.ObjectType)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(enrollmentResponse{
+			ID:         "enroll-1",
+			Status:     "ENROLLED",
+			ObjectID:   "501",
+			ObjectType: "CONTACT",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &enrollInWorkflowAction{conn: conn}
+
+	params, _ := json.Marshal(enrollInWorkflowParams{
+		FlowID:    "100",
+		ContactID: "501",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.enroll_in_workflow",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data enrollmentResponse
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Status != "ENROLLED" {
+		t.Errorf("expected status ENROLLED, got %q", data.Status)
+	}
+}
+
+func TestEnrollInWorkflow_MissingFlowID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &enrollInWorkflowAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"contact_id": "501"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.enroll_in_workflow",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing flow_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestEnrollInWorkflow_MissingContactID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &enrollInWorkflowAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"flow_id": "100"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.enroll_in_workflow",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing contact_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestEnrollInWorkflow_NonNumericFlowID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &enrollInWorkflowAction{conn: conn}
+
+	params, _ := json.Marshal(enrollInWorkflowParams{
+		FlowID:    "../../admin",
+		ContactID: "501",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.enroll_in_workflow",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-numeric flow_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestEnrollInWorkflow_NonNumericContactID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &enrollInWorkflowAction{conn: conn}
+
+	params, _ := json.Marshal(enrollInWorkflowParams{
+		FlowID:    "100",
+		ContactID: "abc",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.enroll_in_workflow",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-numeric contact_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/hubspot/get_analytics.go
+++ b/connectors/hubspot/get_analytics.go
@@ -1,0 +1,94 @@
+package hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getAnalyticsAction implements connectors.Action for hubspot.get_analytics.
+// It fetches analytics data via GET /analytics/v2/reports/{object_type}/{time_period}.
+type getAnalyticsAction struct {
+	conn *HubSpotConnector
+}
+
+type getAnalyticsParams struct {
+	ObjectType string `json:"object_type"`
+	TimePeriod string `json:"time_period"`
+	Start      string `json:"start"`
+	End        string `json:"end"`
+}
+
+var validAnalyticsObjectTypes = map[string]bool{
+	"contacts":  true,
+	"deals":     true,
+	"companies": true,
+	"tickets":   true,
+}
+
+var validAnalyticsTimePeriods = map[string]bool{
+	"total":   true,
+	"daily":   true,
+	"weekly":  true,
+	"monthly": true,
+}
+
+func (p *getAnalyticsParams) validate() error {
+	if p.ObjectType == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: object_type"}
+	}
+	if !validAnalyticsObjectTypes[p.ObjectType] {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid object_type %q: must be contacts, deals, companies, or tickets", p.ObjectType)}
+	}
+	if p.TimePeriod == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: time_period"}
+	}
+	if !validAnalyticsTimePeriods[p.TimePeriod] {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid time_period %q: must be total, daily, weekly, or monthly", p.TimePeriod)}
+	}
+	return nil
+}
+
+// analyticsResponse captures the response from the analytics API.
+type analyticsResponse struct {
+	Breakdowns []json.RawMessage `json:"breakdowns"`
+	Total      json.RawMessage   `json:"total,omitempty"`
+	Offset     json.RawMessage   `json:"offset,omitempty"`
+}
+
+func (a *getAnalyticsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getAnalyticsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/analytics/v2/reports/%s/%s",
+		url.PathEscape(params.ObjectType),
+		url.PathEscape(params.TimePeriod),
+	)
+
+	query := url.Values{}
+	if params.Start != "" {
+		query.Set("start", params.Start)
+	}
+	if params.End != "" {
+		query.Set("end", params.End)
+	}
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	var resp analyticsResponse
+	if err := a.conn.do(ctx, req.Credentials, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/hubspot/get_analytics_test.go
+++ b/connectors/hubspot/get_analytics_test.go
@@ -1,0 +1,187 @@
+package hubspot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetAnalytics_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/analytics/v2/reports/deals/monthly" {
+			t.Errorf("expected path /analytics/v2/reports/deals/monthly, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("start") != "2026-01-01" {
+			t.Errorf("expected start query param 2026-01-01, got %q", r.URL.Query().Get("start"))
+		}
+		if r.URL.Query().Get("end") != "2026-03-01" {
+			t.Errorf("expected end query param 2026-03-01, got %q", r.URL.Query().Get("end"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"breakdowns": []map[string]any{
+				{"month": "2026-01", "count": 42},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getAnalyticsAction{conn: conn}
+
+	params, _ := json.Marshal(getAnalyticsParams{
+		ObjectType: "deals",
+		TimePeriod: "monthly",
+		Start:      "2026-01-01",
+		End:        "2026-03-01",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.get_analytics",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data analyticsResponse
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Breakdowns) != 1 {
+		t.Errorf("expected 1 breakdown, got %d", len(data.Breakdowns))
+	}
+}
+
+func TestGetAnalytics_NoDateRange(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query params, got %q", r.URL.RawQuery)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"breakdowns": []map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &getAnalyticsAction{conn: conn}
+
+	params, _ := json.Marshal(getAnalyticsParams{
+		ObjectType: "contacts",
+		TimePeriod: "total",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.get_analytics",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAnalytics_MissingObjectType(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getAnalyticsAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"time_period": "daily"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.get_analytics",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing object_type")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetAnalytics_InvalidObjectType(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getAnalyticsAction{conn: conn}
+
+	params, _ := json.Marshal(getAnalyticsParams{
+		ObjectType: "widgets",
+		TimePeriod: "daily",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.get_analytics",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid object_type")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetAnalytics_MissingTimePeriod(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getAnalyticsAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"object_type": "deals"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.get_analytics",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing time_period")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestGetAnalytics_InvalidTimePeriod(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &getAnalyticsAction{conn: conn}
+
+	params, _ := json.Marshal(getAnalyticsParams{
+		ObjectType: "deals",
+		TimePeriod: "hourly",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.get_analytics",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid time_period")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/hubspot/hubspot.go
+++ b/connectors/hubspot/hubspot.go
@@ -68,12 +68,17 @@ func (c *HubSpotConnector) ID() string { return "hubspot" }
 // Actions returns the registered action handlers keyed by action_type.
 func (c *HubSpotConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
-		"hubspot.create_contact": &createContactAction{conn: c},
-		"hubspot.update_contact": &updateContactAction{conn: c},
-		"hubspot.create_deal":    &createDealAction{conn: c},
-		"hubspot.create_ticket":  &createTicketAction{conn: c},
-		"hubspot.add_note":       &addNoteAction{conn: c},
-		"hubspot.search":         &searchAction{conn: c},
+		"hubspot.create_contact":       &createContactAction{conn: c},
+		"hubspot.update_contact":       &updateContactAction{conn: c},
+		"hubspot.create_deal":          &createDealAction{conn: c},
+		"hubspot.create_ticket":        &createTicketAction{conn: c},
+		"hubspot.add_note":             &addNoteAction{conn: c},
+		"hubspot.search":               &searchAction{conn: c},
+		"hubspot.list_deals":           &listDealsAction{conn: c},
+		"hubspot.update_deal_stage":    &updateDealStageAction{conn: c},
+		"hubspot.enroll_in_workflow":   &enrollInWorkflowAction{conn: c},
+		"hubspot.create_email_campaign": &createEmailCampaignAction{conn: c},
+		"hubspot.get_analytics":        &getAnalyticsAction{conn: c},
 	}
 }
 

--- a/connectors/hubspot/hubspot_test.go
+++ b/connectors/hubspot/hubspot_test.go
@@ -30,6 +30,11 @@ func TestHubSpotConnector_Actions(t *testing.T) {
 		"hubspot.create_ticket",
 		"hubspot.add_note",
 		"hubspot.search",
+		"hubspot.list_deals",
+		"hubspot.update_deal_stage",
+		"hubspot.enroll_in_workflow",
+		"hubspot.create_email_campaign",
+		"hubspot.get_analytics",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -116,8 +121,8 @@ func TestHubSpotConnector_Manifest(t *testing.T) {
 		t.Error("credential instructions_url is empty, want a URL")
 	}
 
-	if len(m.Actions) != 6 {
-		t.Fatalf("Manifest().Actions has %d items, want 6", len(m.Actions))
+	if len(m.Actions) != 11 {
+		t.Fatalf("Manifest().Actions has %d items, want 11", len(m.Actions))
 	}
 	if err := m.Validate(); err != nil {
 		t.Errorf("Manifest().Validate() = %v", err)

--- a/connectors/hubspot/list_deals.go
+++ b/connectors/hubspot/list_deals.go
@@ -35,10 +35,8 @@ var defaultDealProperties = []string{
 	"closedate", "createdate", "hs_lastmodifieddate",
 }
 
-const (
-	defaultListDealsLimit = 10
-	maxListDealsLimit     = 200 // HubSpot API maximum
-)
+// list_deals reuses defaultSearchLimit and maxSearchLimit from search.go
+// since both hit the same HubSpot search API with identical limits.
 
 // validSingleValueOperators is the subset of HubSpot search operators that
 // work with a single "value" field. BETWEEN requires highValue (not supported
@@ -101,10 +99,10 @@ func (a *listDealsAction) Execute(ctx context.Context, req connectors.ActionRequ
 
 	limit := params.Limit
 	if limit <= 0 {
-		limit = defaultListDealsLimit
+		limit = defaultSearchLimit
 	}
-	if limit > maxListDealsLimit {
-		limit = maxListDealsLimit
+	if limit > maxSearchLimit {
+		limit = maxSearchLimit
 	}
 
 	props := params.Properties

--- a/connectors/hubspot/list_deals.go
+++ b/connectors/hubspot/list_deals.go
@@ -15,22 +15,24 @@ type listDealsAction struct {
 	conn *HubSpotConnector
 }
 
-type listDealsFilter struct {
-	PropertyName string `json:"propertyName"`
-	Operator     string `json:"operator"`
-	Value        string `json:"value"`
-}
-
 type listDealsSort struct {
 	PropertyName string `json:"propertyName"`
 	Direction    string `json:"direction"`
 }
 
 type listDealsParams struct {
-	Filters    []listDealsFilter `json:"filters"`
-	Sorts      []listDealsSort   `json:"sorts"`
-	Limit      int               `json:"limit"`
-	Properties []string          `json:"properties"`
+	Filters    []searchFilter  `json:"filters"`
+	Sorts      []listDealsSort `json:"sorts"`
+	Limit      int             `json:"limit"`
+	Properties []string        `json:"properties"`
+}
+
+// defaultDealProperties are returned when no properties are specified,
+// so callers always get a useful response without needing to know
+// HubSpot's internal property names.
+var defaultDealProperties = []string{
+	"dealname", "amount", "dealstage", "pipeline",
+	"closedate", "createdate", "hs_lastmodifieddate",
 }
 
 const (
@@ -52,7 +54,7 @@ func (p *listDealsParams) validate() error {
 			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: missing operator", i)}
 		}
 		if !validSearchOperators[f.Operator] {
-			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: unsupported operator %q", i, f.Operator)}
+			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: unsupported operator %q (supported: EQ, NEQ, LT, LTE, GT, GTE, BETWEEN, CONTAINS_TOKEN, NOT_CONTAINS_TOKEN, HAS_PROPERTY, NOT_HAS_PROPERTY)", i, f.Operator)}
 		}
 	}
 	for i, s := range p.Sorts {
@@ -90,22 +92,19 @@ func (a *listDealsAction) Execute(ctx context.Context, req connectors.ActionRequ
 		limit = maxListDealsLimit
 	}
 
+	props := params.Properties
+	if len(props) == 0 {
+		props = defaultDealProperties
+	}
+
 	body := listDealsRequest{
 		Limit:      limit,
 		Sorts:      params.Sorts,
-		Properties: params.Properties,
+		Properties: props,
 	}
 
 	if len(params.Filters) > 0 {
-		filters := make([]searchFilter, len(params.Filters))
-		for i, f := range params.Filters {
-			filters[i] = searchFilter{
-				PropertyName: f.PropertyName,
-				Operator:     f.Operator,
-				Value:        f.Value,
-			}
-		}
-		body.FilterGroups = []filterGroup{{Filters: filters}}
+		body.FilterGroups = []filterGroup{{Filters: params.Filters}}
 	}
 
 	var resp searchResponse

--- a/connectors/hubspot/list_deals.go
+++ b/connectors/hubspot/list_deals.go
@@ -40,6 +40,21 @@ const (
 	maxListDealsLimit     = 200 // HubSpot API maximum
 )
 
+// validSingleValueOperators is the subset of HubSpot search operators that
+// work with a single "value" field. BETWEEN requires highValue (not supported
+// by this filter shape), and HAS_PROPERTY/NOT_HAS_PROPERTY don't take a value.
+// The generic hubspot.search action supports the full operator set.
+var validSingleValueOperators = map[string]bool{
+	"EQ":                 true,
+	"NEQ":                true,
+	"LT":                 true,
+	"LTE":                true,
+	"GT":                 true,
+	"GTE":                true,
+	"CONTAINS_TOKEN":     true,
+	"NOT_CONTAINS_TOKEN": true,
+}
+
 var validSortDirections = map[string]bool{
 	"ASCENDING":  true,
 	"DESCENDING": true,
@@ -53,8 +68,8 @@ func (p *listDealsParams) validate() error {
 		if f.Operator == "" {
 			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: missing operator", i)}
 		}
-		if !validSearchOperators[f.Operator] {
-			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: unsupported operator %q (supported: EQ, NEQ, LT, LTE, GT, GTE, BETWEEN, CONTAINS_TOKEN, NOT_CONTAINS_TOKEN, HAS_PROPERTY, NOT_HAS_PROPERTY)", i, f.Operator)}
+		if !validSingleValueOperators[f.Operator] {
+			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: unsupported operator %q (supported: EQ, NEQ, LT, LTE, GT, GTE, CONTAINS_TOKEN, NOT_CONTAINS_TOKEN)", i, f.Operator)}
 		}
 	}
 	for i, s := range p.Sorts {

--- a/connectors/hubspot/list_deals.go
+++ b/connectors/hubspot/list_deals.go
@@ -1,0 +1,117 @@
+package hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listDealsAction implements connectors.Action for hubspot.list_deals.
+// It searches deals via POST /crm/v3/objects/deals/search.
+type listDealsAction struct {
+	conn *HubSpotConnector
+}
+
+type listDealsFilter struct {
+	PropertyName string `json:"propertyName"`
+	Operator     string `json:"operator"`
+	Value        string `json:"value"`
+}
+
+type listDealsSort struct {
+	PropertyName string `json:"propertyName"`
+	Direction    string `json:"direction"`
+}
+
+type listDealsParams struct {
+	Filters    []listDealsFilter `json:"filters"`
+	Sorts      []listDealsSort   `json:"sorts"`
+	Limit      int               `json:"limit"`
+	Properties []string          `json:"properties"`
+}
+
+const (
+	defaultListDealsLimit = 10
+	maxListDealsLimit     = 200 // HubSpot API maximum
+)
+
+var validSortDirections = map[string]bool{
+	"ASCENDING":  true,
+	"DESCENDING": true,
+}
+
+func (p *listDealsParams) validate() error {
+	for i, f := range p.Filters {
+		if f.PropertyName == "" {
+			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: missing propertyName", i)}
+		}
+		if f.Operator == "" {
+			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: missing operator", i)}
+		}
+		if !validSearchOperators[f.Operator] {
+			return &connectors.ValidationError{Message: fmt.Sprintf("filters[%d]: unsupported operator %q", i, f.Operator)}
+		}
+	}
+	for i, s := range p.Sorts {
+		if s.PropertyName == "" {
+			return &connectors.ValidationError{Message: fmt.Sprintf("sorts[%d]: missing propertyName", i)}
+		}
+		if s.Direction != "" && !validSortDirections[s.Direction] {
+			return &connectors.ValidationError{Message: fmt.Sprintf("sorts[%d]: invalid direction %q (must be ASCENDING or DESCENDING)", i, s.Direction)}
+		}
+	}
+	return nil
+}
+
+type listDealsRequest struct {
+	FilterGroups []filterGroup   `json:"filterGroups,omitempty"`
+	Sorts        []listDealsSort `json:"sorts,omitempty"`
+	Limit        int             `json:"limit"`
+	Properties   []string        `json:"properties,omitempty"`
+}
+
+func (a *listDealsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listDealsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	limit := params.Limit
+	if limit <= 0 {
+		limit = defaultListDealsLimit
+	}
+	if limit > maxListDealsLimit {
+		limit = maxListDealsLimit
+	}
+
+	body := listDealsRequest{
+		Limit:      limit,
+		Sorts:      params.Sorts,
+		Properties: params.Properties,
+	}
+
+	if len(params.Filters) > 0 {
+		filters := make([]searchFilter, len(params.Filters))
+		for i, f := range params.Filters {
+			filters[i] = searchFilter{
+				PropertyName: f.PropertyName,
+				Operator:     f.Operator,
+				Value:        f.Value,
+			}
+		}
+		body.FilterGroups = []filterGroup{{Filters: filters}}
+	}
+
+	var resp searchResponse
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/crm/v3/objects/deals/search", body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/hubspot/list_deals_test.go
+++ b/connectors/hubspot/list_deals_test.go
@@ -1,0 +1,192 @@
+package hubspot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListDeals_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/crm/v3/objects/deals/search" {
+			t.Errorf("expected path /crm/v3/objects/deals/search, got %s", r.URL.Path)
+		}
+
+		var body listDealsRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Limit != 5 {
+			t.Errorf("expected limit 5, got %d", body.Limit)
+		}
+		if len(body.FilterGroups) != 1 || len(body.FilterGroups[0].Filters) != 1 {
+			t.Fatalf("expected 1 filter group with 1 filter, got %d groups", len(body.FilterGroups))
+		}
+		if body.FilterGroups[0].Filters[0].PropertyName != "dealstage" {
+			t.Errorf("expected filter on dealstage, got %q", body.FilterGroups[0].Filters[0].PropertyName)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searchResponse{
+			Total: 1,
+			Results: []hubspotObjectResponse{
+				{ID: "101", Properties: map[string]string{"dealname": "Big Deal"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listDealsAction{conn: conn}
+
+	params, _ := json.Marshal(listDealsParams{
+		Filters: []listDealsFilter{{PropertyName: "dealstage", Operator: "EQ", Value: "closedwon"}},
+		Limit:   5,
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.list_deals",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data searchResponse
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Total != 1 {
+		t.Errorf("expected total 1, got %d", data.Total)
+	}
+	if data.Results[0].ID != "101" {
+		t.Errorf("expected id 101, got %q", data.Results[0].ID)
+	}
+}
+
+func TestListDeals_NoFilters(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body listDealsRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode: %v", err)
+		}
+		if len(body.FilterGroups) != 0 {
+			t.Errorf("expected no filter groups, got %d", len(body.FilterGroups))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searchResponse{Total: 0, Results: []hubspotObjectResponse{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listDealsAction{conn: conn}
+
+	params, _ := json.Marshal(listDealsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.list_deals",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data searchResponse
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.Total != 0 {
+		t.Errorf("expected total 0, got %d", data.Total)
+	}
+}
+
+func TestListDeals_InvalidFilterOperator(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDealsAction{conn: conn}
+
+	params, _ := json.Marshal(listDealsParams{
+		Filters: []listDealsFilter{{PropertyName: "dealstage", Operator: "INVALID", Value: "x"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.list_deals",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid operator")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListDeals_InvalidSortDirection(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDealsAction{conn: conn}
+
+	params, _ := json.Marshal(listDealsParams{
+		Sorts: []listDealsSort{{PropertyName: "createdate", Direction: "SIDEWAYS"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.list_deals",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid sort direction")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListDeals_LimitClamped(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body listDealsRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode: %v", err)
+		}
+		if body.Limit != maxListDealsLimit {
+			t.Errorf("expected limit clamped to %d, got %d", maxListDealsLimit, body.Limit)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searchResponse{Total: 0, Results: []hubspotObjectResponse{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listDealsAction{conn: conn}
+
+	params, _ := json.Marshal(listDealsParams{Limit: 9999})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.list_deals",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/connectors/hubspot/list_deals_test.go
+++ b/connectors/hubspot/list_deals_test.go
@@ -48,7 +48,7 @@ func TestListDeals_Success(t *testing.T) {
 	action := &listDealsAction{conn: conn}
 
 	params, _ := json.Marshal(listDealsParams{
-		Filters: []listDealsFilter{{PropertyName: "dealstage", Operator: "EQ", Value: "closedwon"}},
+		Filters: []searchFilter{{PropertyName: "dealstage", Operator: "EQ", Value: "closedwon"}},
 		Limit:   5,
 	})
 
@@ -83,6 +83,10 @@ func TestListDeals_NoFilters(t *testing.T) {
 		}
 		if len(body.FilterGroups) != 0 {
 			t.Errorf("expected no filter groups, got %d", len(body.FilterGroups))
+		}
+		// Should include default properties when none specified
+		if len(body.Properties) != len(defaultDealProperties) {
+			t.Errorf("expected %d default properties, got %d", len(defaultDealProperties), len(body.Properties))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -120,7 +124,7 @@ func TestListDeals_InvalidFilterOperator(t *testing.T) {
 	action := &listDealsAction{conn: conn}
 
 	params, _ := json.Marshal(listDealsParams{
-		Filters: []listDealsFilter{{PropertyName: "dealstage", Operator: "INVALID", Value: "x"}},
+		Filters: []searchFilter{{PropertyName: "dealstage", Operator: "INVALID", Value: "x"}},
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/hubspot/list_deals_test.go
+++ b/connectors/hubspot/list_deals_test.go
@@ -140,6 +140,29 @@ func TestListDeals_InvalidFilterOperator(t *testing.T) {
 	}
 }
 
+func TestListDeals_BetweenOperatorRejected(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listDealsAction{conn: conn}
+
+	params, _ := json.Marshal(listDealsParams{
+		Filters: []searchFilter{{PropertyName: "amount", Operator: "BETWEEN", Value: "100"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.list_deals",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for BETWEEN operator (requires highValue)")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestListDeals_InvalidSortDirection(t *testing.T) {
 	t.Parallel()
 
@@ -171,8 +194,8 @@ func TestListDeals_LimitClamped(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode: %v", err)
 		}
-		if body.Limit != maxListDealsLimit {
-			t.Errorf("expected limit clamped to %d, got %d", maxListDealsLimit, body.Limit)
+		if body.Limit != maxSearchLimit {
+			t.Errorf("expected limit clamped to %d, got %d", maxSearchLimit, body.Limit)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/connectors/hubspot/manifest.go
+++ b/connectors/hubspot/manifest.go
@@ -214,7 +214,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "hubspot.list_deals",
 				Name:        "List Deals",
-				Description: "List deals with optional filtering and sorting",
+				Description: "Search and list deals in the sales pipeline with optional filtering, sorting, and property selection. Returns dealname, amount, stage, and dates by default.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -252,7 +252,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 						"properties": {
 							"type": "array",
 							"items": {"type": "string"},
-							"description": "Deal properties to include in the response"
+							"description": "Deal properties to include in the response (defaults to dealname, amount, dealstage, pipeline, closedate, createdate, hs_lastmodifieddate)"
 						}
 					}
 				}`)),
@@ -260,7 +260,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "hubspot.update_deal_stage",
 				Name:        "Update Deal Stage",
-				Description: "Move a deal to a different pipeline stage",
+				Description: "Move a deal to a different pipeline stage. Use this to advance deals through the sales process (e.g., from qualified to closed-won).",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -284,7 +284,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "hubspot.enroll_in_workflow",
 				Name:        "Enroll in Workflow",
-				Description: "Enroll a contact in an automation workflow",
+				Description: "Enroll a contact in an automation workflow. Workflows may trigger emails, delays, and branching logic — verify the workflow ID before enrolling.",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -304,7 +304,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "hubspot.create_email_campaign",
 				Name:        "Create Email Campaign",
-				Description: "Create and optionally send a marketing email campaign",
+				Description: "Create a marketing email campaign and optionally send it immediately. When send_now is true, the email is sent to all contacts in the specified lists — use with caution.",
 				RiskLevel:   "high",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -338,7 +338,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "hubspot.get_analytics",
 				Name:        "Get Analytics",
-				Description: "Get marketing and sales analytics reports",
+				Description: "Get marketing and sales analytics reports with configurable time periods. Use for dashboards, reporting, and performance tracking.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",

--- a/connectors/hubspot/manifest.go
+++ b/connectors/hubspot/manifest.go
@@ -226,7 +226,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 								"required": ["propertyName", "operator", "value"],
 								"properties": {
 									"propertyName": {"type": "string", "description": "Property to filter on"},
-									"operator": {"type": "string", "description": "Filter operator (EQ, NEQ, LT, LTE, GT, GTE, CONTAINS_TOKEN, etc.)"},
+									"operator": {"type": "string", "enum": ["EQ", "NEQ", "LT", "LTE", "GT", "GTE", "CONTAINS_TOKEN", "NOT_CONTAINS_TOKEN"], "description": "Filter operator"},
 									"value": {"type": "string", "description": "Value to compare against"}
 								}
 							},
@@ -428,7 +428,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "hubspot.create_email_campaign",
 				Name:        "Create email drafts",
 				Description: "Allow the agent to create draft email campaigns (no sending).",
-				Parameters:  json.RawMessage(`{"name":"*","subject":"*","content":"*","list_ids":"*","send_now":"false"}`),
+				Parameters:  json.RawMessage(`{"name":"*","subject":"*","content":"*","list_ids":"*","send_now":false}`),
 			},
 			{
 				ID:          "tpl_hubspot_full_marketing",

--- a/connectors/hubspot/manifest.go
+++ b/connectors/hubspot/manifest.go
@@ -12,7 +12,7 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "hubspot",
 		Name:        "HubSpot",
-		Description: "HubSpot CRM integration for contacts, deals, tickets, and notes",
+		Description: "HubSpot CRM integration for contacts, deals, tickets, notes, marketing, and analytics",
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "hubspot.create_contact",
@@ -211,6 +211,160 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "hubspot.list_deals",
+				Name:        "List Deals",
+				Description: "List deals with optional filtering and sorting",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"filters": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"required": ["propertyName", "operator", "value"],
+								"properties": {
+									"propertyName": {"type": "string", "description": "Property to filter on"},
+									"operator": {"type": "string", "description": "Filter operator (EQ, NEQ, LT, LTE, GT, GTE, CONTAINS_TOKEN, etc.)"},
+									"value": {"type": "string", "description": "Value to compare against"}
+								}
+							},
+							"description": "Array of filter conditions"
+						},
+						"sorts": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"required": ["propertyName"],
+								"properties": {
+									"propertyName": {"type": "string", "description": "Property to sort by"},
+									"direction": {"type": "string", "enum": ["ASCENDING", "DESCENDING"], "description": "Sort direction (default ASCENDING)"}
+								}
+							},
+							"description": "Array of sort conditions"
+						},
+						"limit": {
+							"type": "integer",
+							"default": 10,
+							"description": "Maximum number of results (default 10, max 200)"
+						},
+						"properties": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Deal properties to include in the response"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "hubspot.update_deal_stage",
+				Name:        "Update Deal Stage",
+				Description: "Move a deal to a different pipeline stage",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["deal_id", "pipeline_stage"],
+					"properties": {
+						"deal_id": {
+							"type": "string",
+							"description": "HubSpot deal ID to update"
+						},
+						"pipeline_stage": {
+							"type": "string",
+							"description": "Target pipeline stage ID"
+						},
+						"close_date": {
+							"type": "string",
+							"description": "Updated expected close date (ISO 8601)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "hubspot.enroll_in_workflow",
+				Name:        "Enroll in Workflow",
+				Description: "Enroll a contact in an automation workflow",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["flow_id", "contact_id"],
+					"properties": {
+						"flow_id": {
+							"type": "string",
+							"description": "Workflow (flow) ID to enroll the contact in"
+						},
+						"contact_id": {
+							"type": "string",
+							"description": "Contact ID to enroll"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "hubspot.create_email_campaign",
+				Name:        "Create Email Campaign",
+				Description: "Create and optionally send a marketing email campaign",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["name", "subject", "content"],
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "Internal campaign name"
+						},
+						"subject": {
+							"type": "string",
+							"description": "Email subject line"
+						},
+						"content": {
+							"type": "string",
+							"description": "Email body content (HTML supported)"
+						},
+						"list_ids": {
+							"type": "array",
+							"items": {"type": "string"},
+							"description": "Contact list IDs to send to"
+						},
+						"send_now": {
+							"type": "boolean",
+							"default": false,
+							"description": "If true, send immediately; if false, create as draft"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "hubspot.get_analytics",
+				Name:        "Get Analytics",
+				Description: "Get marketing and sales analytics reports",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["object_type", "time_period"],
+					"properties": {
+						"object_type": {
+							"type": "string",
+							"enum": ["contacts", "deals", "companies", "tickets"],
+							"description": "Object type to get analytics for"
+						},
+						"time_period": {
+							"type": "string",
+							"enum": ["total", "daily", "weekly", "monthly"],
+							"description": "Time period granularity"
+						},
+						"start": {
+							"type": "string",
+							"description": "Start date/time (ISO 8601 or epoch milliseconds)"
+						},
+						"end": {
+							"type": "string",
+							"description": "End date/time (ISO 8601 or epoch milliseconds)"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -240,6 +394,48 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Log notes on any object",
 				Description: "Add engagement notes to contacts, deals, or tickets.",
 				Parameters:  json.RawMessage(`{"object_type":"*","object_id":"*","body":"*"}`),
+			},
+			{
+				ID:          "tpl_hubspot_sales_pipeline",
+				ActionType:  "hubspot.update_deal_stage",
+				Name:        "Sales pipeline management",
+				Description: "Allow the agent to move deals between pipeline stages.",
+				Parameters:  json.RawMessage(`{"deal_id":"*","pipeline_stage":"*"}`),
+			},
+			{
+				ID:          "tpl_hubspot_list_deals",
+				ActionType:  "hubspot.list_deals",
+				Name:        "List and filter deals",
+				Description: "Allow the agent to search and list deals with filters.",
+				Parameters:  json.RawMessage(`{"filters":"*","sorts":"*","limit":"*"}`),
+			},
+			{
+				ID:          "tpl_hubspot_marketing_readonly",
+				ActionType:  "hubspot.get_analytics",
+				Name:        "Marketing read-only",
+				Description: "Allow the agent to view marketing and sales analytics.",
+				Parameters:  json.RawMessage(`{"object_type":"*","time_period":"*","start":"*","end":"*"}`),
+			},
+			{
+				ID:          "tpl_hubspot_workflow_enrollment",
+				ActionType:  "hubspot.enroll_in_workflow",
+				Name:        "Workflow enrollment",
+				Description: "Allow the agent to enroll contacts in automation workflows.",
+				Parameters:  json.RawMessage(`{"flow_id":"*","contact_id":"*"}`),
+			},
+			{
+				ID:          "tpl_hubspot_email_drafts",
+				ActionType:  "hubspot.create_email_campaign",
+				Name:        "Create email drafts",
+				Description: "Allow the agent to create draft email campaigns (no sending).",
+				Parameters:  json.RawMessage(`{"name":"*","subject":"*","content":"*","list_ids":"*","send_now":"false"}`),
+			},
+			{
+				ID:          "tpl_hubspot_full_marketing",
+				ActionType:  "hubspot.create_email_campaign",
+				Name:        "Full marketing admin",
+				Description: "Allow the agent to create and send email campaigns.",
+				Parameters:  json.RawMessage(`{"name":"*","subject":"*","content":"*","list_ids":"*","send_now":"*"}`),
 			},
 		},
 	}

--- a/connectors/hubspot/update_deal_stage.go
+++ b/connectors/hubspot/update_deal_stage.go
@@ -1,0 +1,61 @@
+package hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// updateDealStageAction implements connectors.Action for hubspot.update_deal_stage.
+// It moves a deal to a different pipeline stage via PATCH /crm/v3/objects/deals/{dealId}.
+type updateDealStageAction struct {
+	conn *HubSpotConnector
+}
+
+type updateDealStageParams struct {
+	DealID        string `json:"deal_id"`
+	PipelineStage string `json:"pipeline_stage"`
+	CloseDate     string `json:"close_date"`
+}
+
+func (p *updateDealStageParams) validate() error {
+	if p.DealID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: deal_id"}
+	}
+	if !isValidHubSpotID(p.DealID) {
+		return &connectors.ValidationError{Message: "deal_id must be a numeric HubSpot ID"}
+	}
+	if p.PipelineStage == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: pipeline_stage"}
+	}
+	return nil
+}
+
+func (a *updateDealStageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params updateDealStageParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	props := map[string]string{
+		"dealstage": params.PipelineStage,
+	}
+	if params.CloseDate != "" {
+		props["closedate"] = params.CloseDate
+	}
+
+	body := hubspotObjectRequest{Properties: props}
+	var resp hubspotObjectResponse
+	path := fmt.Sprintf("/crm/v3/objects/deals/%s", params.DealID)
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPatch, path, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(resp)
+}

--- a/connectors/hubspot/update_deal_stage_test.go
+++ b/connectors/hubspot/update_deal_stage_test.go
@@ -1,0 +1,212 @@
+package hubspot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUpdateDealStage_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/crm/v3/objects/deals/201" {
+			t.Errorf("expected path /crm/v3/objects/deals/201, got %s", r.URL.Path)
+		}
+
+		var body hubspotObjectRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Properties["dealstage"] != "closedwon" {
+			t.Errorf("expected dealstage closedwon, got %q", body.Properties["dealstage"])
+		}
+		if body.Properties["closedate"] != "2026-03-15" {
+			t.Errorf("expected closedate 2026-03-15, got %q", body.Properties["closedate"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "201",
+			"properties": map[string]string{
+				"dealstage": "closedwon",
+				"closedate": "2026-03-15",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &updateDealStageAction{conn: conn}
+
+	params, _ := json.Marshal(updateDealStageParams{
+		DealID:        "201",
+		PipelineStage: "closedwon",
+		CloseDate:     "2026-03-15",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.update_deal_stage",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data hubspotObjectResponse
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data.ID != "201" {
+		t.Errorf("expected id 201, got %q", data.ID)
+	}
+	if data.Properties["dealstage"] != "closedwon" {
+		t.Errorf("expected dealstage closedwon, got %q", data.Properties["dealstage"])
+	}
+}
+
+func TestUpdateDealStage_WithoutCloseDate(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body hubspotObjectRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode: %v", err)
+		}
+		if _, ok := body.Properties["closedate"]; ok {
+			t.Error("expected closedate to be absent when not provided")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "201",
+			"properties": map[string]string{"dealstage": "qualifiedtobuy"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &updateDealStageAction{conn: conn}
+
+	params, _ := json.Marshal(updateDealStageParams{
+		DealID:        "201",
+		PipelineStage: "qualifiedtobuy",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.update_deal_stage",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateDealStage_MissingDealID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDealStageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"pipeline_stage": "closedwon"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.update_deal_stage",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing deal_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateDealStage_MissingPipelineStage(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDealStageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{"deal_id": "201"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.update_deal_stage",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing pipeline_stage")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateDealStage_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateDealStageAction{conn: conn}
+
+	params, _ := json.Marshal(updateDealStageParams{
+		DealID:        "../admin",
+		PipelineStage: "closedwon",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.update_deal_stage",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-numeric deal_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateDealStage_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":   "error",
+			"category": "OBJECT_NOT_FOUND",
+			"message":  "Deal not found",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &updateDealStageAction{conn: conn}
+
+	params, _ := json.Marshal(updateDealStageParams{
+		DealID:        "999",
+		PipelineStage: "closedwon",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "hubspot.update_deal_stage",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for not found deal")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError for OBJECT_NOT_FOUND, got: %T", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add 5 new HubSpot connector actions: `list_deals`, `update_deal_stage`, `enroll_in_workflow`, `create_email_campaign`, `get_analytics`
- Add 7 templates including draft-only email (enforces `send_now: false`) and marketing read-only
- Risk levels: high for email sending, medium for workflow enrollment and deal stage changes, low for read-only

## Test plan
- [x] All 80+ HubSpot connector tests pass (`go test ./connectors/hubspot/...`)
- [ ] Verify manifest auto-seeds correctly on startup
- [ ] Test email campaign creation via HubSpot sandbox API
- [ ] Test workflow enrollment with a test flow
- [ ] Verify analytics endpoint returns expected breakdowns

Closes #276
