### PR TITLE
Add OAuth support for Intercom connector

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -42,24 +42,17 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 	}
 
 	// Check auth_type for this connector's required credentials.
-	reqCred, err := db.GetRequiredCredentialByActionType(ctx, deps.DB, actionType)
+	// A connector may support multiple auth methods (e.g. both oauth2 and api_key).
+	// We try OAuth first; if the user has no OAuth connection, fall back to static credentials.
+	reqCreds, err := db.GetRequiredCredentialsByActionType(ctx, deps.DB, actionType)
 	if err != nil {
-		return nil, fmt.Errorf("look up required credential: %w", err)
+		return nil, fmt.Errorf("look up required credentials: %w", err)
 	}
 
 	var creds connectors.Credentials
-	if reqCred != nil && reqCred.AuthType == "oauth2" {
-		// OAuth2 path: resolve access token from oauth_connections.
-		creds, err = resolveOAuthCredentials(ctx, deps, userID, reqCred)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// Static credential path (api_key, basic, custom): existing behavior.
-		creds, err = resolveStaticCredentials(ctx, deps, userID, actionType)
-		if err != nil {
-			return nil, err
-		}
+	creds, err = resolveCredentialsWithFallback(ctx, deps, userID, actionType, reqCreds)
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate credentials before executing the action.
@@ -444,4 +437,39 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 	conn.AccessTokenVaultID = newAccessVaultID
 
 	return nil
+}
+
+// resolveCredentialsWithFallback tries to resolve credentials using the preferred
+// auth method (OAuth first), falling back to static credentials if OAuth is
+// unavailable. This supports connectors that offer multiple auth methods (e.g.
+// Intercom supports both OAuth and API key).
+func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, userID, actionType string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
+	var zero connectors.Credentials
+
+	// Partition credentials by auth type.
+	var oauthCred *db.RequiredCredential
+	var hasStaticCred bool
+	for i := range reqCreds {
+		if reqCreds[i].AuthType == "oauth2" && oauthCred == nil {
+			oauthCred = &reqCreds[i]
+		} else if reqCreds[i].AuthType != "oauth2" {
+			hasStaticCred = true
+		}
+	}
+
+	// If the connector has an OAuth credential, try it first.
+	if oauthCred != nil {
+		creds, err := resolveOAuthCredentials(ctx, deps, userID, oauthCred)
+		if err == nil {
+			return creds, nil
+		}
+		// If there's a static fallback, swallow the OAuth error and try that.
+		// Otherwise, return the OAuth error as-is.
+		if !hasStaticCred {
+			return zero, err
+		}
+	}
+
+	// Fall back to static credentials (api_key, basic, custom).
+	return resolveStaticCredentials(ctx, deps, userID, actionType)
 }

--- a/connectors/intercom/intercom_test.go
+++ b/connectors/intercom/intercom_test.go
@@ -103,18 +103,40 @@ func TestIntercomConnector_Manifest(t *testing.T) {
 	if m.Name != "Intercom" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Intercom")
 	}
-	if len(m.RequiredCredentials) != 1 {
-		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	if len(m.RequiredCredentials) != 2 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 2", len(m.RequiredCredentials))
 	}
-	cred := m.RequiredCredentials[0]
-	if cred.Service != "intercom" {
-		t.Errorf("credential service = %q, want %q", cred.Service, "intercom")
+
+	// First credential: OAuth (preferred auth method).
+	oauthCred := m.RequiredCredentials[0]
+	if oauthCred.Service != "intercom_oauth" {
+		t.Errorf("oauth credential service = %q, want %q", oauthCred.Service, "intercom_oauth")
 	}
-	if cred.AuthType != "api_key" {
-		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "api_key")
+	if oauthCred.AuthType != "oauth2" {
+		t.Errorf("oauth credential auth_type = %q, want %q", oauthCred.AuthType, "oauth2")
 	}
-	if cred.InstructionsURL == "" {
-		t.Error("credential instructions_url is empty, want a URL")
+	if oauthCred.OAuthProvider != "intercom" {
+		t.Errorf("oauth credential oauth_provider = %q, want %q", oauthCred.OAuthProvider, "intercom")
+	}
+
+	// Second credential: API key (fallback).
+	apiKeyCred := m.RequiredCredentials[1]
+	if apiKeyCred.Service != "intercom" {
+		t.Errorf("api_key credential service = %q, want %q", apiKeyCred.Service, "intercom")
+	}
+	if apiKeyCred.AuthType != "api_key" {
+		t.Errorf("api_key credential auth_type = %q, want %q", apiKeyCred.AuthType, "api_key")
+	}
+	if apiKeyCred.InstructionsURL == "" {
+		t.Error("api_key credential instructions_url is empty, want a URL")
+	}
+
+	// OAuth provider should be declared.
+	if len(m.OAuthProviders) != 1 {
+		t.Fatalf("Manifest().OAuthProviders has %d items, want 1", len(m.OAuthProviders))
+	}
+	if m.OAuthProviders[0].ID != "intercom" {
+		t.Errorf("oauth provider ID = %q, want %q", m.OAuthProviders[0].ID, "intercom")
 	}
 
 	if len(m.Actions) != 7 {

--- a/connectors/intercom/manifest.go
+++ b/connectors/intercom/manifest.go
@@ -199,9 +199,23 @@ func (c *IntercomConnector) Manifest() *connectors.ConnectorManifest {
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
+				Service:       "intercom_oauth",
+				AuthType:      "oauth2",
+				OAuthProvider: "intercom",
+				OAuthScopes:   []string{},
+			},
+			{
 				Service:         "intercom",
 				AuthType:        "api_key",
 				InstructionsURL: "https://developers.intercom.com/docs/build-an-integration/learn-more/authentication/",
+			},
+		},
+		OAuthProviders: []connectors.ManifestOAuthProvider{
+			{
+				ID:           "intercom",
+				AuthorizeURL: "https://app.intercom.com/oauth",
+				TokenURL:     "https://api.intercom.io/auth/eagle/token",
+				Scopes:       []string{},
 			},
 		},
 		Templates: []connectors.ManifestTemplate{

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -265,6 +265,8 @@ func ListExpiringOAuthConnections(ctx context.Context, db DBTX, horizon time.Dur
 
 // GetRequiredCredentialByActionType returns the required credential for the connector
 // that owns the given action type. Used to determine auth_type at execution time.
+// When a connector has multiple credentials (e.g. both oauth2 and api_key),
+// this returns the oauth2 credential preferentially.
 func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType string) (*RequiredCredential, error) {
 	var rc RequiredCredential
 	err := db.QueryRow(ctx, `
@@ -272,6 +274,7 @@ func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType 
 		FROM connector_actions ca
 		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
 		WHERE ca.action_type = $1
+		ORDER BY CASE WHEN crc.auth_type = 'oauth2' THEN 0 ELSE 1 END
 		LIMIT 1`,
 		actionType,
 	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes)
@@ -282,4 +285,33 @@ func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType 
 		return nil, err
 	}
 	return &rc, nil
+}
+
+// GetRequiredCredentialsByActionType returns all required credentials for the
+// connector that owns the given action type. Used when a connector supports
+// multiple auth methods (e.g. both oauth2 and api_key) and the execution layer
+// needs to try OAuth first then fall back to static credentials.
+func GetRequiredCredentialsByActionType(ctx context.Context, db DBTX, actionType string) ([]RequiredCredential, error) {
+	rows, err := db.Query(ctx, `
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		FROM connector_actions ca
+		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
+		WHERE ca.action_type = $1
+		ORDER BY CASE WHEN crc.auth_type = 'oauth2' THEN 0 ELSE 1 END`,
+		actionType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var creds []RequiredCredential
+	for rows.Next() {
+		var rc RequiredCredential
+		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
+			return nil, err
+		}
+		creds = append(creds, rc)
+	}
+	return creds, rows.Err()
 }

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -25,6 +25,7 @@ import {
 
 const PROVIDER_LABELS: Record<string, string> = {
   google: "Google",
+  intercom: "Intercom",
   microsoft: "Microsoft",
 };
 
@@ -119,9 +120,8 @@ export function ConnectedAccountsSection() {
           )}
         </div>
         <CardDescription>
-          Connect your Google or Microsoft account to enable connectors that use
-          OAuth for authentication. Tokens are encrypted and automatically
-          refreshed.
+          Connect your accounts to enable connectors that use OAuth for
+          authentication. Tokens are encrypted and automatically refreshed.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -201,8 +201,8 @@ export function ConnectedAccountsSection() {
 
             {connections.length === 0 && availableProviders.length === 0 && (
               <p className="text-muted-foreground py-4 text-center text-sm">
-                No OAuth providers are configured yet. Set up Google or
-                Microsoft client credentials to enable OAuth connections.
+                No OAuth providers are configured yet. Set up client credentials
+                to enable OAuth connections.
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Add OAuth2 as the preferred auth method for Intercom, with API key as fallback
- Add multi-auth credential resolution: execution layer tries OAuth first, falls back to static credentials
- Add `GetRequiredCredentialsByActionType` DB function for multi-credential lookup
- Update frontend Connected Accounts to show Intercom as a connectable provider

## Test plan

- [ ] Verify existing Intercom API key auth continues to work (no OAuth connection → falls back to API key)
- [ ] Connect an Intercom OAuth app via Settings → Connected Accounts → verify OAuth token is used
- [ ] Disconnect Intercom OAuth → verify it falls back to API key
- [ ] Verify other connectors (Google, QuickBooks, Slack) still work as expected
- [ ] Run `make test-backend` and `make test-frontend` (frontend passes ✅, backend blocked by sandbox network — tests are structurally sound)

Closes #337

<https://claude.ai/code/session_01CRucFot4pwt5bQ8GyiVNup>
