### PR TITLE
Add OAuth support for GitHub connector

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -291,6 +291,36 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, userID, act
 // resolveStaticCredentialsByService fetches and decrypts static credentials for
 // a specific service. Used when falling back from OAuth to API key.
 func resolveStaticCredentialsByService(ctx context.Context, deps *Deps, userID, service string) (connectors.Credentials, error) {
+	return decryptServiceCredentials(ctx, deps, userID, service)
+}
+
+// resolveStaticCredentials fetches and decrypts static credentials (api_key, basic, custom)
+// for the given action type.
+func resolveStaticCredentials(ctx context.Context, deps *Deps, userID, actionType string) (connectors.Credentials, error) {
+	services, err := db.GetRequiredServicesByActionType(ctx, deps.DB, actionType)
+	if err != nil {
+		return connectors.Credentials{}, fmt.Errorf("look up required services: %w", err)
+	}
+
+	credMap := make(map[string]string, len(services))
+	for _, service := range services {
+		creds, err := decryptServiceCredentials(ctx, deps, userID, service)
+		if err != nil {
+			return connectors.Credentials{}, err
+		}
+		// Merge into the combined map (multi-service connectors need all credentials).
+		for k, v := range creds.ToMap() {
+			credMap[k] = v
+		}
+	}
+
+	return connectors.NewCredentials(credMap), nil
+}
+
+// decryptServiceCredentials fetches and decrypts credentials for a single
+// service from the vault. Shared by resolveStaticCredentials (multi-service)
+// and resolveStaticCredentialsByService (single-service fallback).
+func decryptServiceCredentials(ctx context.Context, deps *Deps, userID, service string) (connectors.Credentials, error) {
 	var zero connectors.Credentials
 	if deps.Vault == nil {
 		return zero, fmt.Errorf("credential vault is not configured but connector requires service %q", service)
@@ -318,48 +348,6 @@ func resolveStaticCredentialsByService(ctx context.Context, deps *Deps, userID, 
 			credMap[k] = string(b)
 		}
 	}
-	return connectors.NewCredentials(credMap), nil
-}
-
-// resolveStaticCredentials fetches and decrypts static credentials (api_key, basic, custom)
-// for the given action type.
-func resolveStaticCredentials(ctx context.Context, deps *Deps, userID, actionType string) (connectors.Credentials, error) {
-	services, err := db.GetRequiredServicesByActionType(ctx, deps.DB, actionType)
-	if err != nil {
-		return connectors.Credentials{}, fmt.Errorf("look up required services: %w", err)
-	}
-
-	var zero connectors.Credentials
-	credMap := make(map[string]string, len(services))
-	for _, service := range services {
-		if deps.Vault == nil {
-			return zero, fmt.Errorf("credential vault is not configured but connector requires service %q", service)
-		}
-		decrypted, err := db.GetDecryptedCredentials(ctx, deps.DB, deps.Vault.ReadSecret, userID, service, nil)
-		if err != nil {
-			var credErr *db.CredentialError
-			if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
-				return zero, &connectors.ValidationError{
-					Message: fmt.Sprintf("no credentials stored for service %q", service),
-				}
-			}
-			return zero, fmt.Errorf("decrypt credentials for service %q: %w", service, err)
-		}
-		// Flatten decrypted JSON map into string values for the Credentials type.
-		for k, v := range decrypted {
-			switch vv := v.(type) {
-			case string:
-				credMap[k] = vv
-			default:
-				b, err := json.Marshal(v)
-				if err != nil {
-					return zero, fmt.Errorf("marshal credential %q for service %q: %w", k, service, err)
-				}
-				credMap[k] = string(b)
-			}
-		}
-	}
-
 	return connectors.NewCredentials(credMap), nil
 }
 

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -41,25 +41,18 @@ func executeConnectorAction(ctx context.Context, deps *Deps, userID, actionType 
 		return nil, nil
 	}
 
-	// Check auth_type for this connector's required credentials.
-	reqCred, err := db.GetRequiredCredentialByActionType(ctx, deps.DB, actionType)
+	// Look up all required credentials for this action's connector.
+	// Connectors may support multiple auth methods (e.g. OAuth + API key).
+	// We try OAuth first, falling back to static credentials.
+	reqCreds, err := db.GetRequiredCredentialsByActionType(ctx, deps.DB, actionType)
 	if err != nil {
-		return nil, fmt.Errorf("look up required credential: %w", err)
+		return nil, fmt.Errorf("look up required credentials: %w", err)
 	}
 
 	var creds connectors.Credentials
-	if reqCred != nil && reqCred.AuthType == "oauth2" {
-		// OAuth2 path: resolve access token from oauth_connections.
-		creds, err = resolveOAuthCredentials(ctx, deps, userID, reqCred)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// Static credential path (api_key, basic, custom): existing behavior.
-		creds, err = resolveStaticCredentials(ctx, deps, userID, actionType)
-		if err != nil {
-			return nil, err
-		}
+	creds, err = resolveCredentialsWithFallback(ctx, deps, userID, actionType, reqCreds)
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate credentials before executing the action.
@@ -223,6 +216,87 @@ func validatePaymentMethod(ctx context.Context, deps *Deps, userID string, pp *p
 		last4:                 pm.Last4,
 		amount:                amount,
 	}, nil
+}
+
+// resolveCredentialsWithFallback tries to resolve credentials in priority order.
+// For connectors supporting multiple auth methods (e.g. OAuth + API key), it
+// tries OAuth first, then falls back to static credentials if the user hasn't
+// connected their OAuth account.
+func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, userID, actionType string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
+	if len(reqCreds) == 0 {
+		return connectors.NewCredentials(nil), nil
+	}
+
+	// Single credential type: use the existing path directly.
+	if len(reqCreds) == 1 {
+		rc := reqCreds[0]
+		if rc.AuthType == "oauth2" {
+			return resolveOAuthCredentials(ctx, deps, userID, &rc)
+		}
+		return resolveStaticCredentials(ctx, deps, userID, actionType)
+	}
+
+	// Multiple credential types: try OAuth first, fall back to static.
+	for _, rc := range reqCreds {
+		if rc.AuthType == "oauth2" {
+			creds, err := resolveOAuthCredentials(ctx, deps, userID, &rc)
+			if err == nil {
+				return creds, nil
+			}
+			// If the error is because the user hasn't connected OAuth,
+			// continue to the next credential type (fallback).
+			if connectors.IsOAuthRefreshError(err) {
+				continue
+			}
+			// For other errors (vault misconfigured, etc.), fail immediately.
+			return connectors.Credentials{}, err
+		}
+	}
+
+	// No OAuth connection available — try static credentials.
+	// Find the first non-OAuth credential for service-based resolution.
+	for _, rc := range reqCreds {
+		if rc.AuthType != "oauth2" {
+			return resolveStaticCredentialsByService(ctx, deps, userID, rc.Service)
+		}
+	}
+
+	return connectors.Credentials{}, &connectors.ValidationError{
+		Message: "no credentials available — connect via OAuth or provide an API key",
+	}
+}
+
+// resolveStaticCredentialsByService fetches and decrypts static credentials for
+// a specific service. Used when falling back from OAuth to API key.
+func resolveStaticCredentialsByService(ctx context.Context, deps *Deps, userID, service string) (connectors.Credentials, error) {
+	var zero connectors.Credentials
+	if deps.Vault == nil {
+		return zero, fmt.Errorf("credential vault is not configured but connector requires service %q", service)
+	}
+	decrypted, err := db.GetDecryptedCredentials(ctx, deps.DB, deps.Vault.ReadSecret, userID, service, nil)
+	if err != nil {
+		var credErr *db.CredentialError
+		if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
+			return zero, &connectors.ValidationError{
+				Message: fmt.Sprintf("no credentials stored for service %q", service),
+			}
+		}
+		return zero, fmt.Errorf("decrypt credentials for service %q: %w", service, err)
+	}
+	credMap := make(map[string]string, len(decrypted))
+	for k, v := range decrypted {
+		switch vv := v.(type) {
+		case string:
+			credMap[k] = vv
+		default:
+			b, jsonErr := json.Marshal(v)
+			if jsonErr != nil {
+				return zero, fmt.Errorf("marshal credential %q for service %q: %w", k, service, jsonErr)
+			}
+			credMap[k] = string(b)
+		}
+	}
+	return connectors.NewCredentials(credMap), nil
 }
 
 // resolveStaticCredentials fetches and decrypts static credentials (api_key, basic, custom)

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -253,16 +253,38 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, userID, act
 		}
 	}
 
-	// No OAuth connection available — try static credentials.
-	// Find the first non-OAuth credential for service-based resolution.
+	// No OAuth connection available — fall back to static credentials.
 	for _, rc := range reqCreds {
 		if rc.AuthType != "oauth2" {
-			return resolveStaticCredentialsByService(ctx, deps, userID, rc.Service)
+			creds, err := resolveStaticCredentialsByService(ctx, deps, userID, rc.Service)
+			if err == nil {
+				return creds, nil
+			}
+			// If the specific static credential isn't found either, continue
+			// to try others or fall through to the final error.
+			var valErr *connectors.ValidationError
+			if errors.As(err, &valErr) {
+				continue
+			}
+			return connectors.Credentials{}, err
 		}
 	}
 
+	// Build a helpful message listing which credential options are available.
+	var methods []string
+	for _, rc := range reqCreds {
+		if rc.AuthType == "oauth2" {
+			provider := "OAuth"
+			if rc.OAuthProvider != nil {
+				provider = *rc.OAuthProvider + " OAuth"
+			}
+			methods = append(methods, provider+" (Settings → Connected Accounts)")
+		} else {
+			methods = append(methods, rc.Service+" "+rc.AuthType)
+		}
+	}
 	return connectors.Credentials{}, &connectors.ValidationError{
-		Message: "no credentials available — connect via OAuth or provide an API key",
+		Message: fmt.Sprintf("no credentials available — configure one of: %s", strings.Join(methods, ", ")),
 	}
 }
 

--- a/connectors/github/github.go
+++ b/connectors/github/github.go
@@ -347,7 +347,17 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
-			{Service: "github", AuthType: "api_key", InstructionsURL: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"},
+			{
+				Service:       "github",
+				AuthType:      "oauth2",
+				OAuthProvider: "github",
+				OAuthScopes:   []string{"repo"},
+			},
+			{
+				Service:         "github_pat",
+				AuthType:        "api_key",
+				InstructionsURL: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+			},
 		},
 		Templates: []connectors.ManifestTemplate{
 			{
@@ -464,14 +474,17 @@ func (c *GitHubConnector) Actions() map[string]connectors.Action {
 	}
 }
 
-// ValidateCredentials checks that the provided credentials contain a
-// non-empty api_key, which is required for all GitHub API calls.
+// ValidateCredentials checks that the provided credentials contain either a
+// non-empty access_token (from OAuth) or a non-empty api_key (PAT). OAuth
+// tokens take precedence when both are present.
 func (c *GitHubConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
-	key, ok := creds.Get("api_key")
-	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+	if token, ok := creds.Get("access_token"); ok && token != "" {
+		return nil
 	}
-	return nil
+	if key, ok := creds.Get("api_key"); ok && key != "" {
+		return nil
+	}
+	return &connectors.ValidationError{Message: "missing required credential: access_token or api_key"}
 }
 
 // do is the shared request lifecycle for all GitHub actions. It marshals
@@ -498,11 +511,16 @@ func (c *GitHubConnector) do(ctx context.Context, creds connectors.Credentials, 
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	key, ok := creds.Get("api_key")
-	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+	token := ""
+	if t, ok := creds.Get("access_token"); ok && t != "" {
+		token = t
+	} else if k, ok := creds.Get("api_key"); ok && k != "" {
+		token = k
 	}
-	req.Header.Set("Authorization", "Bearer "+key)
+	if token == "" {
+		return &connectors.ValidationError{Message: "access_token or api_key credential is missing or empty"}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/connectors/github/github_test.go
+++ b/connectors/github/github_test.go
@@ -55,13 +55,28 @@ func TestGitHubConnector_ValidateCredentials(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "missing api_key",
+			name:    "valid access_token (OAuth)",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": "gho_test123"}),
+			wantErr: false,
+		},
+		{
+			name:    "both present prefers access_token",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": "gho_test", "api_key": "ghp_test"}),
+			wantErr: false,
+		},
+		{
+			name:    "missing all credentials",
 			creds:   connectors.NewCredentials(map[string]string{}),
 			wantErr: true,
 		},
 		{
-			name:    "empty api_key",
+			name:    "empty api_key and no access_token",
 			creds:   connectors.NewCredentials(map[string]string{"api_key": ""}),
+			wantErr: true,
+		},
+		{
+			name:    "empty access_token and no api_key",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": ""}),
 			wantErr: true,
 		},
 		{
@@ -116,18 +131,33 @@ func TestGitHubConnector_Manifest(t *testing.T) {
 			t.Errorf("Manifest().Actions missing %q", want)
 		}
 	}
-	if len(m.RequiredCredentials) != 1 {
-		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	if len(m.RequiredCredentials) != 2 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 2", len(m.RequiredCredentials))
 	}
-	cred := m.RequiredCredentials[0]
-	if cred.Service != "github" {
-		t.Errorf("credential service = %q, want %q", cred.Service, "github")
+	// First credential should be OAuth (primary).
+	oauthCred := m.RequiredCredentials[0]
+	if oauthCred.Service != "github" {
+		t.Errorf("oauth credential service = %q, want %q", oauthCred.Service, "github")
 	}
-	if cred.AuthType != "api_key" {
-		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "api_key")
+	if oauthCred.AuthType != "oauth2" {
+		t.Errorf("oauth credential auth_type = %q, want %q", oauthCred.AuthType, "oauth2")
 	}
-	if cred.InstructionsURL == "" {
-		t.Error("credential instructions_url is empty, want a URL")
+	if oauthCred.OAuthProvider != "github" {
+		t.Errorf("oauth credential oauth_provider = %q, want %q", oauthCred.OAuthProvider, "github")
+	}
+	if len(oauthCred.OAuthScopes) == 0 {
+		t.Error("oauth credential oauth_scopes is empty, want at least one scope")
+	}
+	// Second credential should be API key (alternative).
+	patCred := m.RequiredCredentials[1]
+	if patCred.Service != "github_pat" {
+		t.Errorf("pat credential service = %q, want %q", patCred.Service, "github_pat")
+	}
+	if patCred.AuthType != "api_key" {
+		t.Errorf("pat credential auth_type = %q, want %q", patCred.AuthType, "api_key")
+	}
+	if patCred.InstructionsURL == "" {
+		t.Error("pat credential instructions_url is empty, want a URL")
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -92,6 +92,7 @@ var validAuthTypes = map[string]bool{
 // natively. Connectors referencing these providers don't need to declare them
 // in their oauth_providers section. Add new built-in providers here.
 var BuiltInOAuthProviders = map[string]bool{
+	"github":     true,
 	"google":     true,
 	"kroger":     true,
 	"linkedin":   true,

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -265,6 +265,9 @@ func ListExpiringOAuthConnections(ctx context.Context, db DBTX, horizon time.Dur
 
 // GetRequiredCredentialByActionType returns the required credential for the connector
 // that owns the given action type. Used to determine auth_type at execution time.
+// When a connector has multiple credential types (e.g. oauth2 + api_key), this
+// returns the OAuth credential first so the caller can attempt OAuth before
+// falling back to static credentials.
 func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType string) (*RequiredCredential, error) {
 	var rc RequiredCredential
 	err := db.QueryRow(ctx, `
@@ -272,6 +275,7 @@ func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType 
 		FROM connector_actions ca
 		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
 		WHERE ca.action_type = $1
+		ORDER BY CASE WHEN crc.auth_type = 'oauth2' THEN 0 ELSE 1 END
 		LIMIT 1`,
 		actionType,
 	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes)
@@ -282,4 +286,33 @@ func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType 
 		return nil, err
 	}
 	return &rc, nil
+}
+
+// GetRequiredCredentialsByActionType returns all required credentials for the
+// connector that owns the given action type, ordered with OAuth credentials
+// first. Used by connectors that support multiple auth methods (e.g. GitHub
+// supports both OAuth and API key).
+func GetRequiredCredentialsByActionType(ctx context.Context, db DBTX, actionType string) ([]RequiredCredential, error) {
+	rows, err := db.Query(ctx, `
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		FROM connector_actions ca
+		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
+		WHERE ca.action_type = $1
+		ORDER BY CASE WHEN crc.auth_type = 'oauth2' THEN 0 ELSE 1 END`,
+		actionType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var creds []RequiredCredential
+	for rows.Next() {
+		var rc RequiredCredential
+		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
+			return nil, err
+		}
+		creds = append(creds, rc)
+	}
+	return creds, rows.Err()
 }

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -347,7 +347,7 @@ Use `connectors.TrimIndent()` to keep inline JSON readable while stripping the s
 
 **Auth types:** `api_key`, `basic`, `custom`, `oauth2`
 
-When using `oauth2`, the credential entry must include `oauth_provider` (e.g., `"google"`, `"microsoft"`, `"zoom"`) and optionally `oauth_scopes`. Built-in providers (`google`, `kroger`, `microsoft`, `zoom`) are supported out of the box. External connectors can declare custom providers in the manifest's `oauth_providers` section (see below).
+When using `oauth2`, the credential entry must include `oauth_provider` (e.g., `"github"`, `"google"`, `"microsoft"`, `"zoom"`) and optionally `oauth_scopes`. Built-in providers (`github`, `google`, `kroger`, `microsoft`, `zoom`) are supported out of the box. External connectors can declare custom providers in the manifest's `oauth_providers` section (see below).
 
 ```go
 // Example: OAuth2 credential in a manifest
@@ -363,7 +363,7 @@ RequiredCredentials: []connectors.ManifestCredential{
 
 #### Declaring custom OAuth providers
 
-External connectors that use OAuth providers not built into the platform (anything other than `google`, `kroger`, `microsoft`, or `zoom`) must declare them in the manifest's `oauth_providers` section. The platform uses these URLs to drive the OAuth authorization flow.
+External connectors that use OAuth providers not built into the platform (anything other than `github`, `google`, `kroger`, `microsoft`, or `zoom`) must declare them in the manifest's `oauth_providers` section. The platform uses these URLs to drive the OAuth authorization flow.
 
 ```go
 OAuthProviders: []connectors.ManifestOAuthProvider{

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -1,6 +1,6 @@
 # OAuth Setup Guide
 
-Permission Slip uses OAuth 2.0 to connect with Google, Microsoft, Meta (Facebook/Instagram), and X (Twitter) services. This guide covers how to configure OAuth for both hosted and self-hosted deployments.
+Permission Slip uses OAuth 2.0 to connect with GitHub, Google, Microsoft, Meta (Facebook/Instagram), and X (Twitter) services. This guide covers how to configure OAuth for both hosted and self-hosted deployments.
 
 ## Overview
 
@@ -10,6 +10,13 @@ Permission Slip supports two modes for OAuth provider credentials:
 2. **BYOA (Bring Your Own App)**: Users provide their own OAuth client credentials through the Settings UI. Required for self-hosted deployments or custom providers.
 
 ## Environment Variables
+
+### GitHub OAuth
+
+| Variable | Description |
+|---|---|
+| `GITHUB_CLIENT_ID` | OAuth App Client ID from GitHub Developer Settings |
+| `GITHUB_CLIENT_SECRET` | OAuth App Client Secret from GitHub Developer Settings |
 
 ### Google OAuth
 
@@ -39,6 +46,33 @@ Permission Slip supports two modes for OAuth provider credentials:
 | `OAUTH_REDIRECT_BASE_URL` | Base URL for OAuth callbacks (e.g., `https://app.example.com/api`) | Falls back to `BASE_URL` |
 | `OAUTH_STATE_SECRET` | HMAC secret for signing OAuth CSRF state tokens | Falls back to `SUPABASE_JWT_SECRET` |
 | `OAUTH_REFRESH_INTERVAL` | Interval for background token refresh job | `10m` |
+
+## GitHub OAuth Setup
+
+### 1. Create a GitHub OAuth App
+
+1. Go to [GitHub Developer Settings > OAuth Apps](https://github.com/settings/developers)
+2. Click **New OAuth App**
+3. Fill in the required fields:
+   - Application name: Your deployment name (e.g., "Permission Slip")
+   - Homepage URL: Your deployment URL
+   - Authorization callback URL:
+     ```
+     https://your-domain.com/api/v1/oauth/github/callback
+     ```
+
+### 2. Configure Environment
+
+```bash
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+```
+
+### Scopes
+
+The GitHub connector requests the `repo` scope, which provides full access to private and public repositories. This enables all GitHub connector actions (create issues, merge PRs, create releases, manage branches, etc.).
+
+> **Note:** The GitHub connector supports both OAuth and Personal Access Tokens (PATs). OAuth is recommended for end users; PATs can be used as an alternative by configuring a `github_pat` credential with an `api_key` auth type.
 
 ## Google OAuth Setup
 
@@ -248,6 +282,7 @@ The refresh token has expired or been revoked. Click **Re-authorize** in Setting
 ### Redirect URI mismatch
 
 Ensure the redirect URI in your OAuth app matches exactly:
+- GitHub: `https://your-domain.com/api/v1/oauth/github/callback`
 - Google: `https://your-domain.com/api/v1/oauth/google/callback`
 - Microsoft: `https://your-domain.com/api/v1/oauth/microsoft/callback`
 - Meta: `https://your-domain.com/api/v1/oauth/meta/callback`

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -1,0 +1,49 @@
+/**
+ * Human-readable display labels for OAuth providers and credential services.
+ * Shared across Settings and Connector configuration pages.
+ */
+
+const PROVIDER_LABELS: Record<string, string> = {
+  github: "GitHub",
+  google: "Google",
+  microsoft: "Microsoft",
+  meta: "Meta",
+  linkedin: "LinkedIn",
+  salesforce: "Salesforce",
+  zoom: "Zoom",
+  kroger: "Kroger",
+};
+
+/**
+ * Returns a human-readable label for an OAuth provider ID.
+ * Falls back to title-casing the ID if no explicit label is defined.
+ */
+export function providerLabel(id: string): string {
+  return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+const SERVICE_LABELS: Record<string, string> = {
+  github_pat: "GitHub Personal Access Token",
+};
+
+/**
+ * Returns a human-readable label for a credential service identifier.
+ * Falls back to the raw service ID if no explicit label is defined.
+ */
+export function serviceLabel(service: string): string {
+  return SERVICE_LABELS[service] ?? service;
+}
+
+const AUTH_TYPE_LABELS: Record<string, string> = {
+  api_key: "API Key",
+  oauth2: "OAuth",
+  basic: "Username & Password",
+  custom: "Custom",
+};
+
+/**
+ * Returns a human-readable label for an auth_type value.
+ */
+export function authTypeLabel(authType: string): string {
+  return AUTH_TYPE_LABELS[authType] ?? authType;
+}

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -27,6 +27,7 @@ import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
 import { InlineConfirmButton } from "@/components/InlineConfirmButton";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import { providerLabel, serviceLabel, authTypeLabel } from "@/lib/labels";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 
@@ -271,7 +272,7 @@ function StaticCredentialRow({
             <div>
               <div className="flex items-center gap-2">
                 <p className="text-sm font-medium">
-                  {requiredCredential.service}
+                  {serviceLabel(requiredCredential.service)}
                 </p>
                 {isAlternative && (
                   <Badge variant="outline" className="text-xs">
@@ -280,7 +281,7 @@ function StaticCredentialRow({
                 )}
               </div>
               <p className="text-muted-foreground text-xs">
-                Auth type: {requiredCredential.auth_type}
+                {authTypeLabel(requiredCredential.auth_type)}
               </p>
               {requiredCredential.instructions_url && (
                 <a
@@ -369,15 +370,3 @@ function StaticCredentialRow({
   );
 }
 
-function providerLabel(id: string): string {
-  const labels: Record<string, string> = {
-    github: "GitHub",
-    google: "Google",
-    microsoft: "Microsoft",
-    meta: "Meta",
-    linkedin: "LinkedIn",
-    salesforce: "Salesforce",
-    zoom: "Zoom",
-  };
-  return labels[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
-}

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -1,21 +1,31 @@
 import { useState } from "react";
 import {
+  AlertTriangle,
   CheckCircle2,
   Circle,
   ExternalLink,
   Loader2,
+  LogIn,
   Plus,
   Trash2,
+  Unplug,
 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardHeader,
   CardTitle,
+  CardDescription,
   CardContent,
 } from "@/components/ui/card";
+import { useAuth } from "@/auth/AuthContext";
 import { useCredentials } from "@/hooks/useCredentials";
 import type { CredentialSummary } from "@/hooks/useCredentials";
+import { useOAuthConnections } from "@/hooks/useOAuthConnections";
+import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
+import { InlineConfirmButton } from "@/components/InlineConfirmButton";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
@@ -28,9 +38,12 @@ export function ConnectorCredentialsSection({
   requiredCredentials,
 }: ConnectorCredentialsSectionProps) {
   const hasRequiredCredentials = requiredCredentials.length > 0;
+  const hasOAuth = requiredCredentials.some((c) => c.auth_type === "oauth2");
+  const hasStatic = requiredCredentials.some((c) => c.auth_type !== "oauth2");
   const { credentials, isLoading, error } = useCredentials({
-    enabled: hasRequiredCredentials,
+    enabled: hasStatic,
   });
+  const { connections, isLoading: oauthLoading } = useOAuthConnections();
 
   const storedByService = new Map<string, CredentialSummary[]>();
   for (const cred of credentials) {
@@ -39,17 +52,45 @@ export function ConnectorCredentialsSection({
     storedByService.set(cred.service, list);
   }
 
+  // Sort: OAuth first, then static credentials
+  const sorted = [...requiredCredentials].sort((a, b) => {
+    if (a.auth_type === "oauth2" && b.auth_type !== "oauth2") return -1;
+    if (a.auth_type !== "oauth2" && b.auth_type === "oauth2") return 1;
+    return 0;
+  });
+
+  const anyLoading = (hasOAuth && oauthLoading) || (hasStatic && isLoading);
+
+  // Check if OAuth is connected (for display purposes)
+  const oauthCred = requiredCredentials.find((c) => c.auth_type === "oauth2");
+  const oauthConnection = oauthCred?.oauth_provider
+    ? connections.find((c) => c.provider === oauthCred.oauth_provider)
+    : undefined;
+  const hasAnyAuth =
+    (oauthConnection && oauthConnection.status === "active") ||
+    requiredCredentials.some(
+      (c) =>
+        c.auth_type !== "oauth2" &&
+        (storedByService.get(c.service)?.length ?? 0) > 0,
+    );
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Credentials</CardTitle>
+        {hasOAuth && hasStatic && (
+          <CardDescription>
+            Connect via OAuth (recommended) or use an API key as an
+            alternative.
+          </CardDescription>
+        )}
       </CardHeader>
       <CardContent>
         {!hasRequiredCredentials ? (
           <p className="text-muted-foreground py-4 text-center text-sm">
             This connector does not require any credentials.
           </p>
-        ) : isLoading ? (
+        ) : anyLoading ? (
           <div className="flex items-center justify-center py-4">
             <Loader2
               className="text-muted-foreground size-5 animate-spin"
@@ -60,13 +101,23 @@ export function ConnectorCredentialsSection({
           <p className="text-destructive text-sm">{error}</p>
         ) : (
           <div className="space-y-3">
-            {requiredCredentials.map((cred) => (
-              <CredentialRow
-                key={cred.service}
-                requiredCredential={cred}
-                storedCredentials={storedByService.get(cred.service) ?? []}
-              />
-            ))}
+            {sorted.map((cred) =>
+              cred.auth_type === "oauth2" ? (
+                <OAuthCredentialRow
+                  key={cred.service}
+                  requiredCredential={cred}
+                  connections={connections}
+                />
+              ) : (
+                <StaticCredentialRow
+                  key={cred.service}
+                  requiredCredential={cred}
+                  storedCredentials={storedByService.get(cred.service) ?? []}
+                  isAlternative={hasOAuth}
+                  oauthConnected={hasAnyAuth && !!oauthConnection}
+                />
+              ),
+            )}
           </div>
         )}
       </CardContent>
@@ -74,12 +125,131 @@ export function ConnectorCredentialsSection({
   );
 }
 
-function CredentialRow({
+function OAuthCredentialRow({
+  requiredCredential,
+  connections,
+}: {
+  requiredCredential: RequiredCredential;
+  connections: Array<{
+    provider: string;
+    status: string;
+    scopes: string[];
+    connected_at: string;
+  }>;
+}) {
+  const { session } = useAuth();
+  const { disconnect, isLoading: isDisconnecting } = useDisconnectOAuth();
+  const providerId = requiredCredential.oauth_provider ?? "";
+  const connection = connections.find((c) => c.provider === providerId);
+  const isConnected = connection?.status === "active";
+  const needsReauth = connection?.status === "needs_reauth";
+
+  function handleConnect() {
+    if (!session?.access_token) return;
+    const baseUrl =
+      import.meta.env.VITE_API_BASE_URL?.replace(/\/v1\/?$/, "") ?? "/api";
+    const url = `${baseUrl}/v1/oauth/${providerId}/authorize`;
+    window.location.href = `${url}?access_token=${encodeURIComponent(session.access_token)}`;
+  }
+
+  async function handleDisconnect() {
+    try {
+      await disconnect(providerId);
+      toast.success(`${providerLabel(providerId)} disconnected.`);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to disconnect.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {isConnected ? (
+            <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
+          ) : needsReauth ? (
+            <AlertTriangle className="text-destructive size-5 shrink-0" />
+          ) : (
+            <Circle className="text-muted-foreground size-5 shrink-0" />
+          )}
+          <div>
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium">
+                {providerLabel(providerId)}
+              </p>
+              <Badge variant="secondary" className="text-xs">
+                OAuth
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                Recommended
+              </Badge>
+            </div>
+            <p className="text-muted-foreground text-xs">
+              Connect your {providerLabel(providerId)} account for automatic
+              token management
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {isConnected ? (
+            <>
+              <span className="text-xs font-medium text-green-600 dark:text-green-400">
+                Connected
+              </span>
+              <InlineConfirmButton
+                confirmLabel="Disconnect"
+                isProcessing={isDisconnecting}
+                onConfirm={handleDisconnect}
+              >
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Disconnect ${providerLabel(providerId)}`}
+                >
+                  <Unplug className="text-muted-foreground size-4" />
+                </Button>
+              </InlineConfirmButton>
+            </>
+          ) : needsReauth ? (
+            <>
+              <Badge variant="destructive" className="gap-1">
+                <AlertTriangle className="size-3" />
+                Needs Re-auth
+              </Badge>
+              <Button variant="outline" size="sm" onClick={handleConnect}>
+                <LogIn className="size-3" />
+                Re-authorize
+              </Button>
+            </>
+          ) : (
+            <>
+              <span className="text-muted-foreground text-xs font-medium">
+                Not connected
+              </span>
+              <Button variant="default" size="sm" onClick={handleConnect}>
+                <LogIn className="size-3" />
+                Connect {providerLabel(providerId)}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StaticCredentialRow({
   requiredCredential,
   storedCredentials,
+  isAlternative,
+  oauthConnected,
 }: {
   requiredCredential: RequiredCredential;
   storedCredentials: CredentialSummary[];
+  isAlternative: boolean;
+  oauthConnected: boolean;
 }) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(
@@ -99,7 +269,16 @@ function CredentialRow({
               <Circle className="text-muted-foreground size-5 shrink-0" />
             )}
             <div>
-              <p className="text-sm font-medium">{requiredCredential.service}</p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium">
+                  {requiredCredential.service}
+                </p>
+                {isAlternative && (
+                  <Badge variant="outline" className="text-xs">
+                    Alternative
+                  </Badge>
+                )}
+              </div>
               <p className="text-muted-foreground text-xs">
                 Auth type: {requiredCredential.auth_type}
               </p>
@@ -124,7 +303,11 @@ function CredentialRow({
                   : "text-muted-foreground"
               }`}
             >
-              {isConnected ? "Connected" : "Not configured"}
+              {isConnected
+                ? "Connected"
+                : oauthConnected
+                  ? "Optional"
+                  : "Not configured"}
             </span>
             <Button
               variant="outline"
@@ -149,8 +332,7 @@ function CredentialRow({
                     {cred.label ?? cred.service}
                   </p>
                   <p className="text-muted-foreground text-xs">
-                    Added{" "}
-                    {new Date(cred.created_at).toLocaleDateString()}
+                    Added {new Date(cred.created_at).toLocaleDateString()}
                   </p>
                 </div>
                 <Button
@@ -185,4 +367,17 @@ function CredentialRow({
       )}
     </>
   );
+}
+
+function providerLabel(id: string): string {
+  const labels: Record<string, string> = {
+    github: "GitHub",
+    google: "Google",
+    microsoft: "Microsoft",
+    meta: "Meta",
+    linkedin: "LinkedIn",
+    salesforce: "Salesforce",
+    zoom: "Zoom",
+  };
+  return labels[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
 }

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -146,7 +146,7 @@ function OAuthCredentialRow({
   const needsReauth = connection?.status === "needs_reauth";
 
   function handleConnect() {
-    if (!session?.access_token) return;
+    if (!session?.access_token || !providerId) return;
     const baseUrl =
       import.meta.env.VITE_API_BASE_URL?.replace(/\/v1\/?$/, "") ?? "/api";
     const url = `${baseUrl}/v1/oauth/${providerId}/authorize`;

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
@@ -14,15 +14,39 @@ import { ConnectorCredentialsSection } from "../ConnectorCredentialsSection";
 vi.mock("../../../../lib/supabaseClient");
 vi.mock("../../../../api/client");
 
-const requiredCredentials = [
-  { service: "github", auth_type: "api_key" as const },
+const apiKeyCredentials = [
+  { service: "github_pat", auth_type: "api_key" as const },
+];
+
+const oauthCredentials = [
+  {
+    service: "github",
+    auth_type: "oauth2" as const,
+    oauth_provider: "github",
+    oauth_scopes: ["repo"],
+  },
+];
+
+const mixedCredentials = [
+  {
+    service: "github",
+    auth_type: "oauth2" as const,
+    oauth_provider: "github",
+    oauth_scopes: ["repo"],
+  },
+  {
+    service: "github_pat",
+    auth_type: "api_key" as const,
+    instructions_url:
+      "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+  },
 ];
 
 const storedCredentials = {
   credentials: [
     {
       id: "cred_123",
-      service: "github",
+      service: "github_pat",
       label: "Personal Access Token",
       created_at: "2026-02-11T10:00:00Z",
     },
@@ -49,7 +73,7 @@ describe("ConnectorCredentialsSection", () => {
     mockGet.mockReturnValue(new Promise(() => {}));
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
     expect(screen.getByText("Credentials")).toBeInTheDocument();
@@ -60,7 +84,7 @@ describe("ConnectorCredentialsSection", () => {
 
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
 
@@ -76,7 +100,7 @@ describe("ConnectorCredentialsSection", () => {
 
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
 
@@ -92,7 +116,7 @@ describe("ConnectorCredentialsSection", () => {
 
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
 
@@ -112,14 +136,14 @@ describe("ConnectorCredentialsSection", () => {
     mockPost.mockResolvedValue({
       data: {
         id: "cred_new",
-        service: "github",
+        service: "github_pat",
         created_at: "2026-02-20T10:00:00Z",
       },
     });
 
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
 
@@ -135,7 +159,7 @@ describe("ConnectorCredentialsSection", () => {
       expect(mockPost).toHaveBeenCalledWith("/v1/credentials", {
         headers: { Authorization: "Bearer token" },
         body: {
-          service: "github",
+          service: "github_pat",
           credentials: { api_key: "ghp_test_key" },
         },
       });
@@ -148,7 +172,7 @@ describe("ConnectorCredentialsSection", () => {
 
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
 
@@ -175,7 +199,7 @@ describe("ConnectorCredentialsSection", () => {
 
     renderWithProviders(
       <ConnectorCredentialsSection
-        requiredCredentials={requiredCredentials}
+        requiredCredentials={apiKeyCredentials}
       />,
     );
 
@@ -219,5 +243,38 @@ describe("ConnectorCredentialsSection", () => {
 
     expect(screen.getByLabelText("Username")).toBeInTheDocument();
     expect(screen.getByLabelText("Password / API Token")).toBeInTheDocument();
+  });
+
+  it("shows OAuth connect button for oauth2 credential", async () => {
+    // Mock both endpoints: OAuth connections (no connections) and credentials
+    mockGet.mockResolvedValue({ data: { connections: [], credentials: [] } });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        requiredCredentials={oauthCredentials}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
+    });
+    expect(screen.getByText("OAuth")).toBeInTheDocument();
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+  });
+
+  it("shows both OAuth and API key options for mixed credentials", async () => {
+    mockGet.mockResolvedValue({ data: { connections: [], credentials: [] } });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        requiredCredentials={mixedCredentials}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
+    });
+    expect(screen.getByText("OAuth")).toBeInTheDocument();
+    expect(screen.getByText("Alternative")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
@@ -276,5 +276,9 @@ describe("ConnectorCredentialsSection", () => {
     });
     expect(screen.getByText("OAuth")).toBeInTheDocument();
     expect(screen.getByText("Alternative")).toBeInTheDocument();
+    // Service name should be human-readable, not raw ID
+    expect(
+      screen.getByText("GitHub Personal Access Token"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/card";
 
 const PROVIDER_LABELS: Record<string, string> = {
+  github: "GitHub",
   google: "Google",
   microsoft: "Microsoft",
 };
@@ -119,9 +120,9 @@ export function ConnectedAccountsSection() {
           )}
         </div>
         <CardDescription>
-          Connect your Google or Microsoft account to enable connectors that use
-          OAuth for authentication. Tokens are encrypted and automatically
-          refreshed.
+          Connect your GitHub, Google, or Microsoft account to enable connectors
+          that use OAuth for authentication. Tokens are encrypted and
+          automatically refreshed.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -201,7 +202,7 @@ export function ConnectedAccountsSection() {
 
             {connections.length === 0 && availableProviders.length === 0 && (
               <p className="text-muted-foreground py-4 text-center text-sm">
-                No OAuth providers are configured yet. Set up Google or
+                No OAuth providers are configured yet. Set up GitHub, Google, or
                 Microsoft client credentials to enable OAuth connections.
               </p>
             )}

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "@/auth/AuthContext";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
 import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
+import { providerLabel } from "@/lib/labels";
 import { InlineConfirmButton } from "@/components/InlineConfirmButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -22,16 +23,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-
-const PROVIDER_LABELS: Record<string, string> = {
-  github: "GitHub",
-  google: "Google",
-  microsoft: "Microsoft",
-};
-
-function providerLabel(id: string): string {
-  return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
-}
 
 function statusBadge(status: string) {
   switch (status) {

--- a/frontend/src/pages/settings/OAuthProviderSection.tsx
+++ b/frontend/src/pages/settings/OAuthProviderSection.tsx
@@ -14,16 +14,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { providerLabel } from "@/lib/labels";
 import { BYOAConfigDialog } from "./BYOAConfigDialog";
-
-const PROVIDER_LABELS: Record<string, string> = {
-  google: "Google",
-  microsoft: "Microsoft",
-};
-
-function providerLabel(id: string): string {
-  return PROVIDER_LABELS[id] ?? id.charAt(0).toUpperCase() + id.slice(1);
-}
 
 export function OAuthProviderSection() {
   const { providers, isLoading: providersLoading } = useOAuthProviders();

--- a/oauth/builtin.go
+++ b/oauth/builtin.go
@@ -94,6 +94,17 @@ func BuiltInProviders() []Provider {
 			Source:       SourceBuiltIn,
 		},
 		{
+			ID:           "github",
+			AuthorizeURL: "https://github.com/login/oauth/authorize",
+			TokenURL:     "https://github.com/login/oauth/access_token",
+			Scopes: []string{
+				"repo",
+			},
+			ClientID:     os.Getenv("GITHUB_CLIENT_ID"),
+			ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
+			Source:       SourceBuiltIn,
+		},
+		{
 			ID:           "kroger",
 			AuthorizeURL: "https://api.kroger.com/v1/connect/oauth2/authorize",
 			TokenURL:     "https://api.kroger.com/v1/connect/oauth2/token",

--- a/oauth/builtin_test.go
+++ b/oauth/builtin_test.go
@@ -36,6 +36,25 @@ func TestBuiltInProviders(t *testing.T) {
 		}
 	})
 
+	t.Run("github", func(t *testing.T) {
+		gh, ok := byID["github"]
+		if !ok {
+			t.Fatal("github provider not found")
+		}
+		if gh.AuthorizeURL != "https://github.com/login/oauth/authorize" {
+			t.Errorf("AuthorizeURL = %q", gh.AuthorizeURL)
+		}
+		if gh.TokenURL != "https://github.com/login/oauth/access_token" {
+			t.Errorf("TokenURL = %q", gh.TokenURL)
+		}
+		if gh.Source != SourceBuiltIn {
+			t.Errorf("Source = %q, want %q", gh.Source, SourceBuiltIn)
+		}
+		if len(gh.Scopes) == 0 {
+			t.Error("expected default scopes")
+		}
+	})
+
 	t.Run("kroger", func(t *testing.T) {
 		k, ok := byID["kroger"]
 		if !ok {
@@ -83,6 +102,9 @@ func TestNewRegistryWithBuiltIns(t *testing.T) {
 		t.Fatalf("expected at least 2 providers, got %d", len(ids))
 	}
 
+	if _, ok := r.Get("github"); !ok {
+		t.Error("github not found in registry")
+	}
 	if _, ok := r.Get("google"); !ok {
 		t.Error("google not found in registry")
 	}

--- a/spec/openapi/components/paths/connectors.yaml
+++ b/spec/openapi/components/paths/connectors.yaml
@@ -137,7 +137,13 @@ connectorById:
                         description: "Pull request number"
               required_credentials:
                 - service: "github"
+                  auth_type: "oauth2"
+                  oauth_provider: "github"
+                  oauth_scopes:
+                    - "repo"
+                - service: "github_pat"
                   auth_type: "api_key"
+                  instructions_url: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
       
       '404':
         description: Connector not found

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -193,6 +193,11 @@ ConnectorDetailResponse:
               description: "Pull request number"
     required_credentials:
       - service: "github"
+        auth_type: "oauth2"
+        oauth_provider: "github"
+        oauth_scopes:
+          - "repo"
+      - service: "github_pat"
         auth_type: "api_key"
         instructions_url: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
 

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -245,7 +245,7 @@ paths:
                       - repo
                   - service: github_pat
                     auth_type: api_key
-                    instructions_url: 'https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens'
+                    instructions_url: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
         '404':
           description: Connector not found
           content:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7390,6 +7390,11 @@ components:
                   description: Pull request number
         required_credentials:
           - service: github
+            auth_type: oauth2
+            oauth_provider: github
+            oauth_scopes:
+              - repo
+          - service: github_pat
             auth_type: api_key
             instructions_url: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
     ConnectorAction:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -239,7 +239,13 @@ paths:
                           description: Pull request number
                 required_credentials:
                   - service: github
+                    auth_type: oauth2
+                    oauth_provider: github
+                    oauth_scopes:
+                      - repo
+                  - service: github_pat
                     auth_type: api_key
+                    instructions_url: 'https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens'
         '404':
           description: Connector not found
           content:


### PR DESCRIPTION
## Summary
- Add GitHub as a built-in OAuth provider alongside the existing API key/PAT support
- OAuth is presented as the recommended auth method in the UI, with API key as an alternative
- The execution layer tries OAuth credentials first and falls back to static credentials automatically
- Updated connector manifest, credential resolution, frontend UI, tests, and OpenAPI spec

## Test plan
- [ ] Verify GitHub OAuth flow: Settings → Connected Accounts → Connect GitHub
- [ ] Verify GitHub connector detail page shows both OAuth and API key options
- [ ] Verify action execution works with OAuth token
- [ ] Verify action execution falls back to API key when no OAuth connection exists
- [ ] Verify disconnect OAuth and re-auth flows work correctly
- [ ] Run `make test-backend` and `make test-frontend` — all tests pass

Closes #331
