### PR TITLE
fix: scope agents query key to user ID to prevent stale cache across users

### DIFF
--- a/frontend/src/hooks/useAgents.ts
+++ b/frontend/src/hooks/useAgents.ts
@@ -11,9 +11,10 @@ const PENDING_POLL_INTERVAL = 5_000;
 export function useAgents() {
   const { session } = useAuth();
   const accessToken = session?.access_token;
+  const userId = session?.user?.id;
 
   const query = useQuery({
-    queryKey: ["agents"],
+    queryKey: ["agents", userId ?? ""],
     queryFn: async () => {
       if (!accessToken) throw new Error("Missing access token");
       const { data, error } = await client.GET("/v1/agents", {


### PR DESCRIPTION
## Problem

`useAgents` used `queryKey: ["agents"]` with no user ID. All other user-specific hooks (`useApprovals`, `useBillingPlan`, `usePushSubscriptions`, etc.) include `userId` in their query key.

This bug was latent since the initial commit but only became visible 7 days ago when the global `staleTime` was bumped from 30s → 5min (commit `4e41209`). With 30s staleTime, the cache expired before you'd switch users and navigate to the dashboard. With 5 minutes, React Query considers `["agents"]` still fresh and serves the previous user's cached data instead of fetching.

## Fix

Add `userId` to the query key: `["agents", userId ?? ""]`

This matches the pattern used by every other user-scoped hook in the codebase.

## Root cause discovery

Identified by comparing proxy logs across two login sessions:
- First user: `GET /api/v1/agents` fired ✅
- Second user (`has-everything`): all dashboard endpoints fired **except** `/api/v1/agents` — because React Query considered the `["agents"]` cache still fresh from the previous session.