### PR TITLE
Replace webhook notification with Twilio SMS

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -11,37 +11,49 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Call webhook
+      - name: Send Twilio SMS
         env:
           PR_URL: ${{ inputs.pr_url }}
-          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-          WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_PHONE_FROM: ${{ secrets.TWILIO_PHONE_FROM }}
+          TWILIO_PHONE_TO: ${{ secrets.TWILIO_PHONE_TO }}
         run: |
-          if [ -z "$WEBHOOK_URL" ]; then
-            echo "::error::WEBHOOK_URL secret is not set"
+          if [ -z "$TWILIO_ACCOUNT_SID" ]; then
+            echo "::error::TWILIO_ACCOUNT_SID secret is not set"
             exit 1
           fi
-          if [ -z "$WEBHOOK_TOKEN" ]; then
-            echo "::error::WEBHOOK_TOKEN secret is not set"
+          if [ -z "$TWILIO_AUTH_TOKEN" ]; then
+            echo "::error::TWILIO_AUTH_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "$TWILIO_PHONE_FROM" ]; then
+            echo "::error::TWILIO_PHONE_FROM secret is not set"
+            exit 1
+          fi
+          if [ -z "$TWILIO_PHONE_TO" ]; then
+            echo "::error::TWILIO_PHONE_TO secret is not set"
             exit 1
           fi
 
           if [ -n "$PR_URL" ]; then
-            PAYLOAD=$(jq -n --arg pr_url "$PR_URL" '{pr_url: $pr_url}')
+            MESSAGE="permission-slip: PR needs attention — ${PR_URL}"
           else
-            PAYLOAD='{}'
+            MESSAGE="permission-slip: Claude Code needs your attention"
           fi
 
-          RESPONSE=$(echo "$PAYLOAD" | curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
-            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-binary @-)
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
+            "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json" \
+            -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+            --data-urlencode "To=${TWILIO_PHONE_TO}" \
+            --data-urlencode "From=${TWILIO_PHONE_FROM}" \
+            --data-urlencode "Body=${MESSAGE}")
 
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "::notice::status=$HTTP_STATUS body=$BODY"
 
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "::error::Webhook call failed with status $HTTP_STATUS"
+            echo "::error::Twilio SMS failed with status $HTTP_STATUS"
             exit 1
           fi

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -6,6 +6,10 @@ on:
         description: "PR URL (optional — omitted for non-PR notifications)"
         required: false
         default: ""
+      pr_title:
+        description: "PR title (optional — included in SMS when provided)"
+        required: false
+        default: ""
 
 jobs:
   notify:
@@ -14,6 +18,7 @@ jobs:
       - name: Send Twilio SMS
         env:
           PR_URL: ${{ inputs.pr_url }}
+          PR_TITLE: ${{ inputs.pr_title }}
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
           TWILIO_PHONE_FROM: ${{ secrets.TWILIO_PHONE_FROM }}
@@ -36,7 +41,9 @@ jobs:
             exit 1
           fi
 
-          if [ -n "$PR_URL" ]; then
+          if [ -n "$PR_URL" ] && [ -n "$PR_TITLE" ]; then
+            MESSAGE="permission-slip: ${PR_TITLE} — ${PR_URL}"
+          elif [ -n "$PR_URL" ]; then
             MESSAGE="permission-slip: PR needs attention — ${PR_URL}"
           else
             MESSAGE="permission-slip: Claude Code needs your attention"


### PR DESCRIPTION
## Summary
- Replaced the generic webhook POST in `trigger-webhook.yml` with a Twilio SMS call
- Notifications now arrive as text messages instead of hitting an arbitrary webhook endpoint
- PR URL is included in the SMS body when provided, otherwise a generic "attention needed" message is sent

## Secrets required
Remove: `WEBHOOK_URL`, `WEBHOOK_TOKEN`
Add: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_FROM`, `TWILIO_PHONE_TO`

## Test plan
- [ ] Add Twilio secrets to the repo
- [ ] Trigger workflow manually with no PR URL — verify SMS received
- [ ] Trigger workflow with a PR URL — verify SMS includes the link
- [ ] Remove old `WEBHOOK_URL` and `WEBHOOK_TOKEN` secrets
