### PR TITLE
Add OAuth support for SendGrid connector

### DIFF
--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -112,6 +112,7 @@ var BuiltInOAuthProviders = map[string]bool{
 	"stripe":     true,
 	"zoom":       true,
 	"pagerduty":  true,
+	"sendgrid":   true,
 }
 
 // ReservedAuthorizeParams lists OAuth 2.0 parameters that must not appear in

--- a/connectors/sendgrid/helpers_test.go
+++ b/connectors/sendgrid/helpers_test.go
@@ -2,11 +2,21 @@ package sendgrid
 
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
-const testAPIKey = "SG.test_api_key_for_unit_tests_1234567890"
+const (
+	testAPIKey      = "SG.test_api_key_for_unit_tests_1234567890"
+	testAccessToken = "test_oauth_access_token_for_unit_tests_1234567890"
+)
 
 // validCreds returns a Credentials value with a valid SendGrid API key for tests.
 func validCreds() connectors.Credentials {
 	return connectors.NewCredentials(map[string]string{
 		"api_key": testAPIKey,
+	})
+}
+
+// validOAuthCreds returns a Credentials value with a valid OAuth access token for tests.
+func validOAuthCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		"access_token": testAccessToken,
 	})
 }

--- a/connectors/sendgrid/manifest.go
+++ b/connectors/sendgrid/manifest.go
@@ -232,6 +232,16 @@ func (c *SendGridConnector) Manifest() *connectors.ConnectorManifest {
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
+				Service:       "sendgrid_oauth",
+				AuthType:      "oauth2",
+				OAuthProvider: "sendgrid",
+				OAuthScopes: []string{
+					"openid",
+					"profile",
+					"email",
+				},
+			},
+			{
 				Service:         "sendgrid",
 				AuthType:        "api_key",
 				InstructionsURL: "https://docs.sendgrid.com/ui/account-and-settings/api-keys",

--- a/connectors/sendgrid/sendgrid.go
+++ b/connectors/sendgrid/sendgrid.go
@@ -22,6 +22,10 @@ const (
 
 	credKeyAPIKey = "api_key"
 
+	// credKeyAccessToken is the credential key for OAuth2 access tokens,
+	// set by the OAuth credential resolution path.
+	credKeyAccessToken = "access_token"
+
 	// maxResponseBody is the maximum response body size we'll read from SendGrid.
 	maxResponseBody = 1 << 20 // 1 MiB
 
@@ -74,11 +78,15 @@ func (c *SendGridConnector) Actions() map[string]connectors.Action {
 }
 
 // ValidateCredentials checks that the provided credentials contain a
-// valid SendGrid API key.
+// non-empty access token. Accepts either an OAuth2 access_token or an
+// api_key — both are used as Bearer tokens against the SendGrid v3 API.
 func (c *SendGridConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+	if token, ok := creds.Get(credKeyAccessToken); ok && token != "" {
+		return nil
+	}
 	key, ok := creds.Get(credKeyAPIKey)
 	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+		return &connectors.ValidationError{Message: "missing required credential: api_key or access_token (OAuth)"}
 	}
 	if len(key) < minAPIKeyLen {
 		return &connectors.ValidationError{Message: fmt.Sprintf("api_key is too short (minimum %d characters)", minAPIKeyLen)}
@@ -88,8 +96,12 @@ func (c *SendGridConnector) ValidateCredentials(_ context.Context, creds connect
 
 // doJSON sends a JSON-encoded request to the SendGrid API and decodes
 // the response. SendGrid's v3 API uses application/json throughout.
+// It accepts either an OAuth2 access_token or an api_key as the Bearer token.
 func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credentials, method, path string, body any, respBody any) error {
-	apiKey, _ := creds.Get(credKeyAPIKey)
+	token, _ := creds.Get(credKeyAccessToken)
+	if token == "" {
+		token, _ = creds.Get(credKeyAPIKey)
+	}
 
 	reqURL := c.baseURL + path
 
@@ -106,7 +118,7 @@ func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credent
 	if err != nil {
 		return &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer "+token)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/connectors/sendgrid/sendgrid.go
+++ b/connectors/sendgrid/sendgrid.go
@@ -102,6 +102,9 @@ func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credent
 	if token == "" {
 		token, _ = creds.Get(credKeyAPIKey)
 	}
+	if token == "" {
+		return &connectors.ValidationError{Message: "missing required credential: api_key or access_token (OAuth)"}
+	}
 
 	reqURL := c.baseURL + path
 

--- a/connectors/sendgrid/sendgrid_test.go
+++ b/connectors/sendgrid/sendgrid_test.go
@@ -50,8 +50,13 @@ func TestSendGridConnector_ValidateCredentials(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid credentials",
+			name:    "valid api_key credentials",
 			creds:   validCreds(),
+			wantErr: false,
+		},
+		{
+			name:    "valid oauth access_token credentials",
+			creds:   validOAuthCreds(),
 			wantErr: false,
 		},
 		{
@@ -62,6 +67,11 @@ func TestSendGridConnector_ValidateCredentials(t *testing.T) {
 		{
 			name:    "empty api_key",
 			creds:   connectors.NewCredentials(map[string]string{"api_key": ""}),
+			wantErr: true,
+		},
+		{
+			name:    "empty access_token falls back to missing api_key",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": ""}),
 			wantErr: true,
 		},
 		{
@@ -123,18 +133,30 @@ func TestSendGridConnector_Manifest(t *testing.T) {
 			t.Errorf("Manifest().Actions missing %q", want)
 		}
 	}
-	if len(m.RequiredCredentials) != 1 {
-		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	if len(m.RequiredCredentials) != 2 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 2", len(m.RequiredCredentials))
 	}
-	cred := m.RequiredCredentials[0]
-	if cred.Service != "sendgrid" {
-		t.Errorf("credential service = %q, want %q", cred.Service, "sendgrid")
+	// OAuth credential should be first (default in UI).
+	oauthCred := m.RequiredCredentials[0]
+	if oauthCred.Service != "sendgrid_oauth" {
+		t.Errorf("first credential service = %q, want %q", oauthCred.Service, "sendgrid_oauth")
 	}
-	if cred.AuthType != "api_key" {
-		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "api_key")
+	if oauthCred.AuthType != "oauth2" {
+		t.Errorf("first credential auth_type = %q, want %q", oauthCred.AuthType, "oauth2")
 	}
-	if cred.InstructionsURL == "" {
-		t.Error("credential instructions_url is empty, want a URL")
+	if oauthCred.OAuthProvider != "sendgrid" {
+		t.Errorf("first credential oauth_provider = %q, want %q", oauthCred.OAuthProvider, "sendgrid")
+	}
+	// API key credential should be second.
+	apiKeyCred := m.RequiredCredentials[1]
+	if apiKeyCred.Service != "sendgrid" {
+		t.Errorf("second credential service = %q, want %q", apiKeyCred.Service, "sendgrid")
+	}
+	if apiKeyCred.AuthType != "api_key" {
+		t.Errorf("second credential auth_type = %q, want %q", apiKeyCred.AuthType, "api_key")
+	}
+	if apiKeyCred.InstructionsURL == "" {
+		t.Error("second credential instructions_url is empty, want a URL")
 	}
 
 	if err := m.Validate(); err != nil {

--- a/oauth/builtin.go
+++ b/oauth/builtin.go
@@ -259,6 +259,22 @@ func BuiltInProviders() []Provider {
 			ClientSecret: os.Getenv("STRIPE_CLIENT_SECRET"),
 			Source:       SourceBuiltIn,
 		},
+		{
+			// SendGrid is owned by Twilio and uses Twilio's OAuth 2.0
+			// authorization server. The resulting access token is used as a
+			// Bearer token on SendGrid v3 API requests, the same as an API key.
+			ID:           "sendgrid",
+			AuthorizeURL: "https://login.twilio.com/oauth2/authorize",
+			TokenURL:     "https://login.twilio.com/oauth2/token",
+			Scopes: []string{
+				"openid",
+				"profile",
+				"email",
+			},
+			ClientID:     os.Getenv("SENDGRID_CLIENT_ID"),
+			ClientSecret: os.Getenv("SENDGRID_CLIENT_SECRET"),
+			Source:       SourceBuiltIn,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Investigated SendGrid/Twilio OAuth2 support — SendGrid uses Twilio's OAuth authorization server at `<login.twilio.com>`. OAuth access tokens work as Bearer tokens on the SendGrid v3 API, identical to API keys.
- Added `sendgrid` as a built-in OAuth provider (Twilio's OAuth endpoints, `openid`/`profile`/`email` scopes, configured via `SENDGRID_CLIENT_ID`/`SENDGRID_CLIENT_SECRET` env vars)
- Added OAuth as the **default** credential option in the SendGrid connector manifest (API key preserved as second option)
- Updated the connector to accept either `access_token` (OAuth) or `api_key`, using the same dual-auth pattern as HubSpot and Intercom
- Updated tests to cover OAuth credential validation and new manifest shape

## Notes

- No changes needed to action implementations — OAuth tokens and API keys both go in the `Authorization: Bearer` header
- Operators need to register a Twilio OAuth app and set `SENDGRID_CLIENT_ID` / `SENDGRID_CLIENT_SECRET` to enable the OAuth flow

Closes #351
