### PR TITLE
Add OAuth2 support for Calendly connector

### DIFF
--- a/connectors/calendly/calendly.go
+++ b/connectors/calendly/calendly.go
@@ -1,6 +1,6 @@
 // Package calendly implements the Calendly connector for the Permission Slip
-// connector execution layer. It uses the Calendly REST API v2 with personal
-// access tokens (API key auth).
+// connector execution layer. It uses the Calendly REST API v2 with either
+// OAuth2 access tokens (preferred) or personal access tokens (API key).
 package calendly
 
 import (
@@ -20,7 +20,13 @@ import (
 const (
 	defaultBaseURL = "https://api.calendly.com"
 	defaultTimeout = 30 * time.Second
-	credKeyAPIKey  = "api_key"
+
+	// credKeyAPIKey is the credential key for Calendly personal access tokens.
+	credKeyAPIKey = "api_key"
+
+	// credKeyAccessToken is the credential key for OAuth2 access tokens,
+	// set by the OAuth credential resolution path.
+	credKeyAccessToken = "access_token"
 
 	// defaultRetryAfter is used when Calendly returns a 429 without a
 	// Retry-After header (or an unparseable one).
@@ -69,25 +75,33 @@ func (c *CalendlyConnector) Actions() map[string]connectors.Action {
 	}
 }
 
-// ValidateCredentials checks that the provided credentials contain a non-empty
-// api_key and tests it against GET /users/me.
+// ValidateCredentials checks that the provided credentials contain either a
+// non-empty access_token (OAuth2) or api_key (personal access token), and
+// tests them against GET /users/me.
 func (c *CalendlyConnector) ValidateCredentials(ctx context.Context, creds connectors.Credentials) error {
-	key, ok := creds.Get(credKeyAPIKey)
-	if !ok || key == "" {
-		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+	if token, ok := creds.Get(credKeyAccessToken); ok && token != "" {
+		// OAuth path — test against /users/me.
+		var resp usersmeResponse
+		if err := c.doJSON(ctx, creds, http.MethodGet, c.baseURL+"/users/me", nil, &resp); err != nil {
+			return err
+		}
+		if resp.Resource.URI == "" {
+			return &connectors.ValidationError{Message: "Calendly API returned empty user URI"}
+		}
+		return nil
 	}
-
-	// Test the key against /users/me to verify it's valid.
-	var resp usersmeResponse
-	if err := c.doJSON(ctx, creds, http.MethodGet, c.baseURL+"/users/me", nil, &resp); err != nil {
-		return err
+	if key, ok := creds.Get(credKeyAPIKey); ok && key != "" {
+		// API key path — test against /users/me.
+		var resp usersmeResponse
+		if err := c.doJSON(ctx, creds, http.MethodGet, c.baseURL+"/users/me", nil, &resp); err != nil {
+			return err
+		}
+		if resp.Resource.URI == "" {
+			return &connectors.ValidationError{Message: "Calendly API returned empty user URI"}
+		}
+		return nil
 	}
-
-	if resp.Resource.URI == "" {
-		return &connectors.ValidationError{Message: "Calendly API returned empty user URI"}
-	}
-
-	return nil
+	return &connectors.ValidationError{Message: "missing required credential: access_token (OAuth) or api_key"}
 }
 
 // usersmeResponse is the Calendly API response from GET /users/me.
@@ -116,9 +130,13 @@ func (c *CalendlyConnector) getUserURI(ctx context.Context, creds connectors.Cre
 // token auth, handles rate limiting and timeouts, and unmarshals the
 // response into respBody.
 func (c *CalendlyConnector) doJSON(ctx context.Context, creds connectors.Credentials, method, url string, reqBody, respBody any) error {
-	token, ok := creds.Get(credKeyAPIKey)
-	if !ok || token == "" {
-		return &connectors.ValidationError{Message: "api_key credential is missing or empty"}
+	// Prefer OAuth access_token; fall back to personal access token (api_key).
+	token, _ := creds.Get(credKeyAccessToken)
+	if token == "" {
+		token, _ = creds.Get(credKeyAPIKey)
+	}
+	if token == "" {
+		return &connectors.ValidationError{Message: "access_token (OAuth) or api_key credential is missing or empty"}
 	}
 
 	var body io.Reader

--- a/connectors/calendly/calendly_test.go
+++ b/connectors/calendly/calendly_test.go
@@ -65,6 +65,32 @@ func TestCalendlyConnector_ValidateCredentials(t *testing.T) {
 	}
 }
 
+func TestCalendlyConnector_ValidateCredentials_OAuth(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer oauth-access-token" {
+			t.Errorf("unexpected Authorization header: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(usersmeResponse{
+			Resource: struct {
+				URI  string `json:"uri"`
+				Name string `json:"name"`
+			}{URI: "https://api.calendly.com/users/abc123", Name: "Test User"},
+		})
+	}))
+	defer srv.Close()
+
+	c := newForTest(srv.Client(), srv.URL)
+	oauthCreds := connectors.NewCredentials(map[string]string{"access_token": "oauth-access-token"})
+
+	err := c.ValidateCredentials(t.Context(), oauthCreds)
+	if err != nil {
+		t.Errorf("ValidateCredentials() with OAuth token returned error: %v", err)
+	}
+}
+
 func TestCalendlyConnector_ValidateCredentials_MissingKey(t *testing.T) {
 	t.Parallel()
 	c := New()
@@ -142,15 +168,27 @@ func TestCalendlyConnector_Manifest(t *testing.T) {
 		}
 	}
 
-	if len(m.RequiredCredentials) != 1 {
-		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
+	if len(m.RequiredCredentials) != 2 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 2", len(m.RequiredCredentials))
 	}
-	cred := m.RequiredCredentials[0]
-	if cred.Service != "calendly" {
-		t.Errorf("credential service = %q, want %q", cred.Service, "calendly")
+	// OAuth2 credential should be listed first (default/recommended).
+	oauthCred := m.RequiredCredentials[0]
+	if oauthCred.Service != "calendly_oauth" {
+		t.Errorf("oauth credential service = %q, want %q", oauthCred.Service, "calendly_oauth")
 	}
-	if cred.AuthType != "api_key" {
-		t.Errorf("credential auth_type = %q, want %q", cred.AuthType, "api_key")
+	if oauthCred.AuthType != "oauth2" {
+		t.Errorf("oauth credential auth_type = %q, want %q", oauthCred.AuthType, "oauth2")
+	}
+	if oauthCred.OAuthProvider != "calendly" {
+		t.Errorf("oauth credential oauth_provider = %q, want %q", oauthCred.OAuthProvider, "calendly")
+	}
+	// API key credential is kept as an alternative.
+	apiKeyCred := m.RequiredCredentials[1]
+	if apiKeyCred.Service != "calendly" {
+		t.Errorf("api key credential service = %q, want %q", apiKeyCred.Service, "calendly")
+	}
+	if apiKeyCred.AuthType != "api_key" {
+		t.Errorf("api key credential auth_type = %q, want %q", apiKeyCred.AuthType, "api_key")
 	}
 
 	if err := m.Validate(); err != nil {
@@ -242,6 +280,31 @@ func TestDoJSON_PostWithBody(t *testing.T) {
 	}
 	if resp.Resource.BookingURL != "https://calendly.com/d/abc" {
 		t.Errorf("resp.Resource.BookingURL = %q, want %q", resp.Resource.BookingURL, "https://calendly.com/d/abc")
+	}
+}
+
+func TestDoJSON_OAuthTokenPreferredOverAPIKey(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should use OAuth access_token, not api_key.
+		if r.Header.Get("Authorization") != "Bearer oauth-token" {
+			t.Errorf("expected OAuth token in Authorization header, got: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"resource":{"uri":"https://api.calendly.com/users/abc123","name":"Test User"}}`)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	// Both tokens present — access_token should win.
+	bothCreds := connectors.NewCredentials(map[string]string{
+		"access_token": "oauth-token",
+		"api_key":      "should-not-be-used",
+	})
+	var resp usersmeResponse
+	err := conn.doJSON(t.Context(), bothCreds, http.MethodGet, srv.URL+"/users/me", nil, &resp)
+	if err != nil {
+		t.Fatalf("doJSON() returned error: %v", err)
 	}
 }
 

--- a/connectors/calendly/manifest.go
+++ b/connectors/calendly/manifest.go
@@ -164,6 +164,11 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
+				Service:       "calendly_oauth",
+				AuthType:      "oauth2",
+				OAuthProvider: "calendly",
+			},
+			{
 				Service:         "calendly",
 				AuthType:        "api_key",
 				InstructionsURL: "https://developer.calendly.com/how-to-authenticate-with-personal-access-tokens",

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -112,6 +112,7 @@ var BuiltInOAuthProviders = map[string]bool{
 	"stripe":     true,
 	"zoom":       true,
 	"pagerduty":  true,
+	"calendly":   true,
 }
 
 // ReservedAuthorizeParams lists OAuth 2.0 parameters that must not appear in

--- a/oauth/builtin.go
+++ b/oauth/builtin.go
@@ -259,6 +259,15 @@ func BuiltInProviders() []Provider {
 			ClientSecret: os.Getenv("STRIPE_CLIENT_SECRET"),
 			Source:       SourceBuiltIn,
 		},
+		{
+			ID:           "calendly",
+			AuthorizeURL: "https://auth.calendly.com/oauth/authorize",
+			TokenURL:     "https://auth.calendly.com/oauth/token",
+			Scopes:       []string{},
+			ClientID:     os.Getenv("CALENDLY_CLIENT_ID"),
+			ClientSecret: os.Getenv("CALENDLY_CLIENT_SECRET"),
+			Source:       SourceBuiltIn,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Registers Calendly as a built-in OAuth2 provider (<auth.calendly.com>) alongside the existing API key auth
- OAuth is now the default/recommended option in the connector credentials UI (listed first)
- API key support is preserved as an alternative — no breaking changes
- Both auth paths use Bearer tokens against the Calendly API; connector logic prefers `access_token` (OAuth) over `api_key` when both are present

## Test plan
- [ ] Verify Calendly connector config page shows OAuth as the primary option with "Recommended" badge, API key as "Alternative"
- [ ] Connect via OAuth (requires `CALENDLY_CLIENT_ID` / `CALENDLY_CLIENT_SECRET` env vars in prod)
- [ ] Verify existing API key credentials continue to work without re-configuration
- [ ] Confirm `Connect Calendly` button is disabled when OAuth credentials are not configured (existing behavior for unconfigured providers)

Closes #344
