### PR TITLE
Remove pull_request trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
CI now only runs on pushes to main and manual workflow_dispatch,
not on every PR targeting main.

https://claude.ai/code/session_01PQsffsHxqS7nAzHaB96hGU