### PR TITLE
refactor: self-registering route groups in api/router.go

### DIFF
--- a/api/action_config_templates.go
+++ b/api/action_config_templates.go
@@ -28,6 +28,10 @@ type actionConfigTemplateListResponse struct {
 // --- Routes ---
 
 // RegisterActionConfigTemplateRoutes adds action configuration template endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterActionConfigTemplateRoutes)
+}
+
 func RegisterActionConfigTemplateRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /action-config-templates", requireProfile(handleListActionConfigTemplates(deps)))

--- a/api/action_config_templates.go
+++ b/api/action_config_templates.go
@@ -27,11 +27,11 @@ type actionConfigTemplateListResponse struct {
 
 // --- Routes ---
 
-// RegisterActionConfigTemplateRoutes adds action configuration template endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterActionConfigTemplateRoutes)
 }
 
+// RegisterActionConfigTemplateRoutes adds action configuration template endpoints to the mux.
 func RegisterActionConfigTemplateRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /action-config-templates", requireProfile(handleListActionConfigTemplates(deps)))

--- a/api/action_configurations.go
+++ b/api/action_configurations.go
@@ -57,11 +57,11 @@ type deleteActionConfigResponse struct {
 
 // --- Routes ---
 
-// RegisterActionConfigRoutes adds action configuration endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterActionConfigRoutes)
 }
 
+// RegisterActionConfigRoutes adds action configuration endpoints to the mux.
 func RegisterActionConfigRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("POST /action-configurations", requireProfile(handleCreateActionConfig(deps)))

--- a/api/action_configurations.go
+++ b/api/action_configurations.go
@@ -58,6 +58,10 @@ type deleteActionConfigResponse struct {
 // --- Routes ---
 
 // RegisterActionConfigRoutes adds action configuration endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterActionConfigRoutes)
+}
+
 func RegisterActionConfigRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("POST /action-configurations", requireProfile(handleCreateActionConfig(deps)))

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -36,11 +36,11 @@ type executeActionStandingResponse struct {
 
 // ── Route registration ─────────────────────────────────────────────────────
 
-// RegisterActionExecuteRoutes adds the action execution endpoint to the mux.
 func init() {
 	RegisterRouteGroup(RegisterActionExecuteRoutes)
 }
 
+// RegisterActionExecuteRoutes adds the action execution endpoint to the mux.
 func RegisterActionExecuteRoutes(mux *http.ServeMux, deps *Deps) {
 	requireAgent := RequireAgentSignature(deps)
 	mux.Handle("POST /actions/execute", requireAgent(handleExecuteAction(deps)))

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -37,6 +37,10 @@ type executeActionStandingResponse struct {
 // ── Route registration ─────────────────────────────────────────────────────
 
 // RegisterActionExecuteRoutes adds the action execution endpoint to the mux.
+func init() {
+	RegisterRouteGroup(RegisterActionExecuteRoutes)
+}
+
 func RegisterActionExecuteRoutes(mux *http.ServeMux, deps *Deps) {
 	requireAgent := RequireAgentSignature(deps)
 	mux.Handle("POST /actions/execute", requireAgent(handleExecuteAction(deps)))

--- a/api/admin_usage.go
+++ b/api/admin_usage.go
@@ -55,6 +55,10 @@ type agentUsageEntry struct {
 // connector aggregation) are intentionally omitted. They require an
 // admin role system that does not yet exist. Adding them behind
 // RequireProfile alone would create a cross-tenant data leak.
+func init() {
+	RegisterRouteGroup(RegisterAdminUsageRoutes)
+}
+
 func RegisterAdminUsageRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /admin/usage", requireProfile(handleAdminGetUsage(deps)))

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -45,6 +45,10 @@ type agentCancelApprovalResponse struct {
 // ── Route registration ─────────────────────────────────────────────────────
 
 // RegisterAgentApprovalRoutes adds agent-authenticated approval endpoints.
+func init() {
+	RegisterRouteGroup(RegisterAgentApprovalRoutes)
+}
+
 func RegisterAgentApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireAgent := RequireAgentSignature(deps)
 	mux.Handle("POST /approvals/request", requireAgent(handleAgentRequestApproval(deps)))

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -44,11 +44,11 @@ type agentCancelApprovalResponse struct {
 
 // ── Route registration ─────────────────────────────────────────────────────
 
-// RegisterAgentApprovalRoutes adds agent-authenticated approval endpoints.
 func init() {
 	RegisterRouteGroup(RegisterAgentApprovalRoutes)
 }
 
+// RegisterAgentApprovalRoutes adds agent-authenticated approval endpoints.
 func RegisterAgentApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireAgent := RequireAgentSignature(deps)
 	mux.Handle("POST /approvals/request", requireAgent(handleAgentRequestApproval(deps)))

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -34,6 +34,10 @@ type disableAgentConnectorResponse struct {
 }
 
 // RegisterAgentConnectorRoutes adds agent connector endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterAgentConnectorRoutes)
+}
+
 func RegisterAgentConnectorRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /agents/{agent_id}/connectors", requireProfile(handleListAgentConnectors(deps)))

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -33,11 +33,11 @@ type disableAgentConnectorResponse struct {
 	RevokedStandingApprovals int64     `json:"revoked_standing_approvals"`
 }
 
-// RegisterAgentConnectorRoutes adds agent connector endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterAgentConnectorRoutes)
 }
 
+// RegisterAgentConnectorRoutes adds agent connector endpoints to the mux.
 func RegisterAgentConnectorRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /agents/{agent_id}/connectors", requireProfile(handleListAgentConnectors(deps)))

--- a/api/agent_standing_approvals.go
+++ b/api/agent_standing_approvals.go
@@ -21,6 +21,10 @@ type agentStandingApprovalListResponse struct {
 // ── Route registration ──────────────────────────────────────────────────────
 
 // RegisterAgentStandingApprovalRoutes adds agent-authenticated standing approval endpoints.
+func init() {
+	RegisterRouteGroup(RegisterAgentStandingApprovalRoutes)
+}
+
 func RegisterAgentStandingApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.HandleFunc("GET /agents/{agent_id}/standing-approvals", handleAgentListStandingApprovals(deps))
 }

--- a/api/agent_standing_approvals.go
+++ b/api/agent_standing_approvals.go
@@ -20,11 +20,11 @@ type agentStandingApprovalListResponse struct {
 
 // ── Route registration ──────────────────────────────────────────────────────
 
-// RegisterAgentStandingApprovalRoutes adds agent-authenticated standing approval endpoints.
 func init() {
 	RegisterRouteGroup(RegisterAgentStandingApprovalRoutes)
 }
 
+// RegisterAgentStandingApprovalRoutes adds agent-authenticated standing approval endpoints.
 func RegisterAgentStandingApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.HandleFunc("GET /agents/{agent_id}/standing-approvals", handleAgentListStandingApprovals(deps))
 }

--- a/api/agents.go
+++ b/api/agents.go
@@ -32,11 +32,11 @@ type agentListResponse struct {
 	NextCursor *string         `json:"next_cursor,omitempty"`
 }
 
-// RegisterAgentRoutes adds agent-related endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterAgentRoutes)
 }
 
+// RegisterAgentRoutes adds agent-related endpoints to the mux.
 func RegisterAgentRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /agents", requireProfile(handleListAgents(deps)))

--- a/api/agents.go
+++ b/api/agents.go
@@ -33,6 +33,10 @@ type agentListResponse struct {
 }
 
 // RegisterAgentRoutes adds agent-related endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterAgentRoutes)
+}
+
 func RegisterAgentRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /agents", requireProfile(handleListAgents(deps)))

--- a/api/approval_events.go
+++ b/api/approval_events.go
@@ -127,6 +127,10 @@ func (b *ApprovalEventBroker) NotifyAll(event string) {
 // client passes the Supabase session token as a `?token=` query parameter.
 // This middleware copies it into the Authorization header before the standard
 // RequireProfile middleware runs, keeping auth logic in one place.
+func init() {
+	RegisterRouteGroup(RegisterApprovalEventRoutes)
+}
+
 func RegisterApprovalEventRoutes(mux *http.ServeMux, deps *Deps) {
 	if deps.ApprovalEvents == nil {
 		return

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -51,6 +51,10 @@ type denyResponse struct {
 }
 
 // RegisterApprovalRoutes adds approval-related endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterApprovalRoutes)
+}
+
 func RegisterApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /approvals", requireProfile(handleListApprovals(deps)))

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -50,11 +50,11 @@ type denyResponse struct {
 	DeniedAt   time.Time `json:"denied_at"`
 }
 
-// RegisterApprovalRoutes adds approval-related endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterApprovalRoutes)
 }
 
+// RegisterApprovalRoutes adds approval-related endpoints to the mux.
 func RegisterApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /approvals", requireProfile(handleListApprovals(deps)))

--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -82,11 +82,11 @@ type auditLogExportResponse struct {
 	EffectiveSince *time.Time                    `json:"effective_since,omitempty"`
 }
 
-// RegisterAuditEventRoutes adds audit event endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterAuditEventRoutes)
 }
 
+// RegisterAuditEventRoutes adds audit event endpoints to the mux.
 func RegisterAuditEventRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /audit-events", requireProfile(handleListAuditEvents(deps)))

--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -83,6 +83,10 @@ type auditLogExportResponse struct {
 }
 
 // RegisterAuditEventRoutes adds audit event endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterAuditEventRoutes)
+}
+
 func RegisterAuditEventRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /audit-events", requireProfile(handleListAuditEvents(deps)))

--- a/api/billing.go
+++ b/api/billing.go
@@ -157,6 +157,10 @@ const maxInvoiceResults = 24
 
 // RegisterBillingRoutes adds billing endpoints to the mux.
 // These are only registered when billing is enabled.
+func init() {
+	RegisterRouteGroup(RegisterBillingRoutes)
+}
+
 func RegisterBillingRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /billing/plan", requireProfile(handleGetBillingPlan(deps)))

--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -57,6 +57,10 @@ type standingApprovalCapability struct {
 // ── Route registration ──────────────────────────────────────────────────────
 
 // RegisterCapabilityRoutes adds the agent capabilities endpoint to the mux.
+func init() {
+	RegisterRouteGroup(RegisterCapabilityRoutes)
+}
+
 func RegisterCapabilityRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.HandleFunc("GET /agents/{agent_id}/capabilities", handleGetCapabilities(deps))
 }

--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -56,11 +56,11 @@ type standingApprovalCapability struct {
 
 // ── Route registration ──────────────────────────────────────────────────────
 
-// RegisterCapabilityRoutes adds the agent capabilities endpoint to the mux.
 func init() {
 	RegisterRouteGroup(RegisterCapabilityRoutes)
 }
 
+// RegisterCapabilityRoutes adds the agent capabilities endpoint to the mux.
 func RegisterCapabilityRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.HandleFunc("GET /agents/{agent_id}/capabilities", handleGetCapabilities(deps))
 }

--- a/api/config.go
+++ b/api/config.go
@@ -12,6 +12,10 @@ type configResponse struct {
 }
 
 // RegisterConfigRoutes adds server configuration endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterConfigRoutes)
+}
+
 func RegisterConfigRoutes(mux *http.ServeMux, deps *Deps) {
 	requireSession := RequireSession(deps)
 	mux.Handle("GET /v1/config", requireSession(handleGetConfig(deps)))

--- a/api/config.go
+++ b/api/config.go
@@ -11,11 +11,11 @@ type configResponse struct {
 	MicrosoftOAuthConfigured bool `json:"microsoft_oauth_configured"`
 }
 
-// RegisterConfigRoutes adds server configuration endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterConfigRoutes)
 }
 
+// RegisterConfigRoutes adds server configuration endpoints to the mux.
 func RegisterConfigRoutes(mux *http.ServeMux, deps *Deps) {
 	requireSession := RequireSession(deps)
 	mux.Handle("GET /v1/config", requireSession(handleGetConfig(deps)))

--- a/api/connectors.go
+++ b/api/connectors.go
@@ -52,6 +52,10 @@ type connectorDetailResponse struct {
 
 // RegisterConnectorRoutes adds connector-related endpoints to the mux.
 // These are public endpoints (no auth required).
+func init() {
+	RegisterRouteGroup(RegisterConnectorRoutes)
+}
+
 func RegisterConnectorRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.Handle("GET /connectors", handleListConnectors(deps))
 	mux.Handle("GET /connectors/{connector_id}", handleGetConnector(deps))

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -42,11 +42,11 @@ var servicePattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]*$`)
 
 // --- Routes ---
 
-// RegisterCredentialRoutes adds credential-related endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterCredentialRoutes)
 }
 
+// RegisterCredentialRoutes adds credential-related endpoints to the mux.
 func RegisterCredentialRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /credentials", requireProfile(handleListCredentials(deps)))

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -43,6 +43,10 @@ var servicePattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]*$`)
 // --- Routes ---
 
 // RegisterCredentialRoutes adds credential-related endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterCredentialRoutes)
+}
+
 func RegisterCredentialRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /credentials", requireProfile(handleListCredentials(deps)))

--- a/api/expo_push_tokens.go
+++ b/api/expo_push_tokens.go
@@ -36,11 +36,11 @@ type deleteExpoPushTokenResponse struct {
 
 // --- Routes ---
 
-// RegisterExpoPushTokenRoutes adds Expo push token endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterExpoPushTokenRoutes)
 }
 
+// RegisterExpoPushTokenRoutes adds Expo push token endpoints to the mux.
 func RegisterExpoPushTokenRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /expo-push-tokens", requireProfile(handleListExpoPushTokens(deps)))

--- a/api/expo_push_tokens.go
+++ b/api/expo_push_tokens.go
@@ -37,6 +37,10 @@ type deleteExpoPushTokenResponse struct {
 // --- Routes ---
 
 // RegisterExpoPushTokenRoutes adds Expo push token endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterExpoPushTokenRoutes)
+}
+
 func RegisterExpoPushTokenRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /expo-push-tokens", requireProfile(handleListExpoPushTokens(deps)))

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -98,6 +98,10 @@ type oauthDisconnectResponse struct {
 // --- Routes ---
 
 // RegisterOAuthRoutes adds OAuth-related endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterOAuthRoutes)
+}
+
 func RegisterOAuthRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	requireSession := RequireSession(deps)

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -97,11 +97,11 @@ type oauthDisconnectResponse struct {
 
 // --- Routes ---
 
-// RegisterOAuthRoutes adds OAuth-related endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterOAuthRoutes)
 }
 
+// RegisterOAuthRoutes adds OAuth-related endpoints to the mux.
 func RegisterOAuthRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	requireSession := RequireSession(deps)

--- a/api/oauth_byoa.go
+++ b/api/oauth_byoa.go
@@ -66,11 +66,11 @@ type oauthProviderConfigDeleteResponse struct {
 
 // --- Routes ---
 
-// RegisterOAuthBYOARoutes adds BYOA provider management endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterOAuthBYOARoutes)
 }
 
+// RegisterOAuthBYOARoutes adds BYOA provider management endpoints to the mux.
 func RegisterOAuthBYOARoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 

--- a/api/oauth_byoa.go
+++ b/api/oauth_byoa.go
@@ -67,6 +67,10 @@ type oauthProviderConfigDeleteResponse struct {
 // --- Routes ---
 
 // RegisterOAuthBYOARoutes adds BYOA provider management endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterOAuthBYOARoutes)
+}
+
 func RegisterOAuthBYOARoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 

--- a/api/onboarding.go
+++ b/api/onboarding.go
@@ -25,6 +25,10 @@ type onboardingResponse struct {
 
 // RegisterOnboardingRoutes adds onboarding endpoints to the mux.
 // RequireSession is used (not RequireProfile) because the user has no profile yet.
+func init() {
+	RegisterRouteGroup(RegisterOnboardingRoutes)
+}
+
 func RegisterOnboardingRoutes(mux *http.ServeMux, deps *Deps) {
 	requireSession := RequireSession(deps)
 	mux.Handle("POST /onboarding", requireSession(handleOnboarding(deps)))

--- a/api/payment_methods.go
+++ b/api/payment_methods.go
@@ -78,6 +78,10 @@ func toPaymentMethodResponse(pm *db.PaymentMethod) paymentMethodResponse {
 // ── Route registration ──────────────────────────────────────────────────────
 
 // RegisterPaymentMethodRoutes adds payment method endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterPaymentMethodRoutes)
+}
+
 func RegisterPaymentMethodRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /payment-methods", requireProfile(handleListPaymentMethods(deps)))

--- a/api/payment_methods.go
+++ b/api/payment_methods.go
@@ -77,11 +77,11 @@ func toPaymentMethodResponse(pm *db.PaymentMethod) paymentMethodResponse {
 
 // ── Route registration ──────────────────────────────────────────────────────
 
-// RegisterPaymentMethodRoutes adds payment method endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterPaymentMethodRoutes)
 }
 
+// RegisterPaymentMethodRoutes adds payment method endpoints to the mux.
 func RegisterPaymentMethodRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /payment-methods", requireProfile(handleListPaymentMethods(deps)))

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -43,6 +43,10 @@ type updateProfileRaw struct {
 }
 
 // RegisterProfileRoutes adds profile-related endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterProfileRoutes)
+}
+
 func RegisterProfileRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -42,11 +42,11 @@ type updateProfileRaw struct {
 	MarketingOptIn json.RawMessage `json:"marketing_opt_in"`
 }
 
-// RegisterProfileRoutes adds profile-related endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterProfileRoutes)
 }
 
+// RegisterProfileRoutes adds profile-related endpoints to the mux.
 func RegisterProfileRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 

--- a/api/push_subscriptions.go
+++ b/api/push_subscriptions.go
@@ -66,6 +66,10 @@ type vapidPublicKeyResponse struct {
 // --- Routes ---
 
 // RegisterPushSubscriptionRoutes adds push subscription endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterPushSubscriptionRoutes)
+}
+
 func RegisterPushSubscriptionRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /push-subscriptions", requireProfile(handleListPushSubscriptions(deps)))

--- a/api/push_subscriptions.go
+++ b/api/push_subscriptions.go
@@ -65,11 +65,11 @@ type vapidPublicKeyResponse struct {
 
 // --- Routes ---
 
-// RegisterPushSubscriptionRoutes adds push subscription endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterPushSubscriptionRoutes)
 }
 
+// RegisterPushSubscriptionRoutes adds push subscription endpoints to the mux.
 func RegisterPushSubscriptionRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /push-subscriptions", requireProfile(handleListPushSubscriptions(deps)))

--- a/api/registration.go
+++ b/api/registration.go
@@ -64,6 +64,10 @@ type verifyRegistrationResponse struct {
 // RegisterRegistrationRoutes adds the versioned agent registration endpoints
 // to the mux (mounted under /api/v1/). The invite endpoint is intentionally
 // excluded — it lives at the top level (/invite/{code}) via InviteHandler.
+func init() {
+	RegisterRouteGroup(RegisterRegistrationRoutes)
+}
+
 func RegisterRegistrationRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.HandleFunc("POST /agents/{agent_id}/verify", handleVerifyRegistration(deps))
 }

--- a/api/registration_invites.go
+++ b/api/registration_invites.go
@@ -36,6 +36,10 @@ type createInviteResponse struct {
 }
 
 // RegisterRegistrationInviteRoutes adds registration-invite endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterRegistrationInviteRoutes)
+}
+
 func RegisterRegistrationInviteRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("POST /registration-invites", requireProfile(handleCreateRegistrationInvite(deps)))

--- a/api/registration_invites.go
+++ b/api/registration_invites.go
@@ -35,11 +35,11 @@ type createInviteResponse struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
-// RegisterRegistrationInviteRoutes adds registration-invite endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterRegistrationInviteRoutes)
 }
 
+// RegisterRegistrationInviteRoutes adds registration-invite endpoints to the mux.
 func RegisterRegistrationInviteRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("POST /registration-invites", requireProfile(handleCreateRegistrationInvite(deps)))

--- a/api/router.go
+++ b/api/router.go
@@ -56,36 +56,11 @@ type Deps struct {
 func NewRouter(deps *Deps) http.Handler {
 	mux := http.NewServeMux()
 
-	RegisterActionConfigRoutes(mux, deps)
-	RegisterActionConfigTemplateRoutes(mux, deps)
-	RegisterConfigRoutes(mux, deps)
-	RegisterActionExecuteRoutes(mux, deps)
-	RegisterAgentApprovalRoutes(mux, deps)
-	RegisterAgentRoutes(mux, deps)
-	RegisterAgentConnectorRoutes(mux, deps)
-	RegisterAgentStandingApprovalRoutes(mux, deps)
-	RegisterApprovalRoutes(mux, deps)
-	RegisterCapabilityRoutes(mux, deps)
-	RegisterAuditEventRoutes(mux, deps)
-	RegisterConnectorRoutes(mux, deps)
-	RegisterCredentialRoutes(mux, deps)
-	RegisterOnboardingRoutes(mux, deps)
-	RegisterProfileRoutes(mux, deps)
-	RegisterRegistrationInviteRoutes(mux, deps)
-	RegisterRegistrationRoutes(mux, deps)
-	RegisterPushSubscriptionRoutes(mux, deps)
-	RegisterExpoPushTokenRoutes(mux, deps)
-	RegisterStandingApprovalRoutes(mux, deps)
-	RegisterApprovalEventRoutes(mux, deps)
-	RegisterOAuthRoutes(mux, deps)
-	RegisterOAuthBYOARoutes(mux, deps)
-
-	RegisterPaymentMethodRoutes(mux, deps)
-
-	// Billing routes are always registered (handlers check deps.BillingEnabled
-	// and deps.Stripe internally) so the OpenAPI spec can document them.
-	RegisterBillingRoutes(mux, deps)
-	RegisterAdminUsageRoutes(mux, deps)
+	// Each domain file self-registers via init() + RegisterRouteGroup().
+	// See router_registry.go for the registry.
+	for _, register := range routeGroups {
+		register(mux, deps)
+	}
 	// NOTE: Billing webhook routes are registered on the top-level mux in
 	// main.go, NOT here. They must bypass auth and rate-limiting middleware
 	// because Stripe verifies requests via signature, not Bearer tokens.

--- a/api/router_registry.go
+++ b/api/router_registry.go
@@ -1,0 +1,15 @@
+package api
+
+import "net/http"
+
+// RouteRegistrar is a function that registers HTTP routes on a mux.
+// Each API domain file provides one and self-registers it via init().
+type RouteRegistrar func(mux *http.ServeMux, deps *Deps)
+
+var routeGroups []RouteRegistrar
+
+// RegisterRouteGroup appends a route registrar to the global registry.
+// Call this from an init() function in each domain file.
+func RegisterRouteGroup(fn RouteRegistrar) {
+	routeGroups = append(routeGroups, fn)
+}

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -75,11 +75,11 @@ var validStandingApprovalStatusFilters = map[string]bool{
 
 var actionVersionPattern = regexp.MustCompile(`^\d+$`)
 
-// RegisterStandingApprovalRoutes adds standing-approval-related endpoints to the mux.
 func init() {
 	RegisterRouteGroup(RegisterStandingApprovalRoutes)
 }
 
+// RegisterStandingApprovalRoutes adds standing-approval-related endpoints to the mux.
 func RegisterStandingApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /standing-approvals", requireProfile(handleListStandingApprovals(deps)))

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -76,6 +76,10 @@ var validStandingApprovalStatusFilters = map[string]bool{
 var actionVersionPattern = regexp.MustCompile(`^\d+$`)
 
 // RegisterStandingApprovalRoutes adds standing-approval-related endpoints to the mux.
+func init() {
+	RegisterRouteGroup(RegisterStandingApprovalRoutes)
+}
+
 func RegisterStandingApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /standing-approvals", requireProfile(handleListStandingApprovals(deps)))


### PR DESCRIPTION
## Summary
- Each API domain file now self-registers its routes via `init()` + `RegisterRouteGroup()`, eliminating 26 explicit calls from `NewRouter()` in `router.go`
- New API domains only need a new file with an `init()` function — no edits to `router.go` required
- Follows the same pattern established in #386 for connectors

## Route registration order
Go's `http.ServeMux` is pattern-based (longest match wins), not order-based, so `init()` execution order doesn't affect routing behavior.

## Files changed
- **New:** `api/router_registry.go` — registry type, slice, and `RegisterRouteGroup()` 
- **Modified:** 26 domain files — added `init()` calling `RegisterRouteGroup`
- **Modified:** `api/router.go` — replaced 26 explicit calls with registry loop

## Test plan

### Claude Code
- [x] `go vet ./api/...` passes
- [x] `go test ./api/...` passes
- [x] Run `make build` in CI (sandbox can't download `klauspost/compress`)

### OpenClaw
- [ ] Verify no route regressions in staging (spot-check a few endpoints)
- [ ] Confirm billing webhook routes still work (registered separately in `main.go`)

Closes #387