### PR TITLE
refactor: route config array in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,16 +8,11 @@ import LoginPage from "./auth/LoginPage";
 import MfaChallengePage from "./auth/MfaChallengePage";
 import OnboardingPage from "./auth/OnboardingPage";
 import { AppLayout } from "./components/AppLayout";
-import { Dashboard } from "./pages/dashboard/Dashboard";
-import { AgentConfigPage } from "./pages/agents/AgentConfigPage";
-import { ConnectorConfigPage } from "./pages/agents/connectors/ConnectorConfigPage";
-import { ActivityPage } from "./pages/activity/ActivityPage";
-import { SettingsPage } from "./pages/settings/SettingsPage";
-import { BillingPage } from "./pages/billing/BillingPage";
 import { PrivacyPolicyPage } from "./pages/policy/PrivacyPolicyPage";
 import { TermsOfServicePage } from "./pages/policy/TermsOfServicePage";
 import { CookiePolicyPage } from "./pages/policy/CookiePolicyPage";
 import { useProfile } from "./hooks/useProfile";
+import { appRoutes } from "./routes";
 
 const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
 
@@ -102,12 +97,13 @@ function App() {
     <Sentry.ErrorBoundary fallback={<AppCrashFallback />} showDialog>
       <AppLayout>
         <SentryRoutes>
-          <Route path="/" element={<RouteWithBoundary><Dashboard /></RouteWithBoundary>} />
-          <Route path="/agents/:agentId" element={<RouteWithBoundary><AgentConfigPage /></RouteWithBoundary>} />
-          <Route path="/agents/:agentId/connectors/:connectorId" element={<RouteWithBoundary><ConnectorConfigPage /></RouteWithBoundary>} />
-          <Route path="/activity" element={<RouteWithBoundary><ActivityPage /></RouteWithBoundary>} />
-          <Route path="/settings" element={<RouteWithBoundary><SettingsPage /></RouteWithBoundary>} />
-          <Route path="/billing" element={<RouteWithBoundary><BillingPage /></RouteWithBoundary>} />
+          {appRoutes.map(({ path, element: Element }) => (
+            <Route
+              key={path}
+              path={path}
+              element={<RouteWithBoundary><Element /></RouteWithBoundary>}
+            />
+          ))}
           <Route path="*" element={<Navigate to="/" replace />} />
         </SentryRoutes>
       </AppLayout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,11 +97,11 @@ function App() {
     <Sentry.ErrorBoundary fallback={<AppCrashFallback />} showDialog>
       <AppLayout>
         <SentryRoutes>
-          {appRoutes.map(({ path, element: Element }) => (
+          {appRoutes.map(({ path, Component }) => (
             <Route
               key={path}
               path={path}
-              element={<RouteWithBoundary><Element /></RouteWithBoundary>}
+              element={<RouteWithBoundary><Component /></RouteWithBoundary>}
             />
           ))}
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -1,0 +1,27 @@
+import { type ComponentType } from "react";
+import { Dashboard } from "./pages/dashboard/Dashboard";
+import { AgentConfigPage } from "./pages/agents/AgentConfigPage";
+import { ConnectorConfigPage } from "./pages/agents/connectors/ConnectorConfigPage";
+import { ActivityPage } from "./pages/activity/ActivityPage";
+import { SettingsPage } from "./pages/settings/SettingsPage";
+import { BillingPage } from "./pages/billing/BillingPage";
+
+export interface RouteConfig {
+  path: string;
+  element: ComponentType;
+}
+
+/**
+ * Authenticated app routes. Each entry maps a URL path to a page component.
+ * Add new pages here — no need to touch App.tsx.
+ *
+ * Append new routes at the end to minimize merge conflicts.
+ */
+export const appRoutes: RouteConfig[] = [
+  { path: "/", element: Dashboard },
+  { path: "/agents/:agentId", element: AgentConfigPage },
+  { path: "/agents/:agentId/connectors/:connectorId", element: ConnectorConfigPage },
+  { path: "/activity", element: ActivityPage },
+  { path: "/settings", element: SettingsPage },
+  { path: "/billing", element: BillingPage },
+];

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -8,7 +8,8 @@ import { BillingPage } from "./pages/billing/BillingPage";
 
 export interface RouteConfig {
   path: string;
-  element: ComponentType;
+  /** The page component type (not a React element). Used as `<Component />` in App.tsx. */
+  Component: ComponentType;
 }
 
 /**
@@ -18,10 +19,10 @@ export interface RouteConfig {
  * Append new routes at the end to minimize merge conflicts.
  */
 export const appRoutes: RouteConfig[] = [
-  { path: "/", element: Dashboard },
-  { path: "/agents/:agentId", element: AgentConfigPage },
-  { path: "/agents/:agentId/connectors/:connectorId", element: ConnectorConfigPage },
-  { path: "/activity", element: ActivityPage },
-  { path: "/settings", element: SettingsPage },
-  { path: "/billing", element: BillingPage },
+  { path: "/", Component: Dashboard },
+  { path: "/agents/:agentId", Component: AgentConfigPage },
+  { path: "/agents/:agentId/connectors/:connectorId", Component: ConnectorConfigPage },
+  { path: "/activity", Component: ActivityPage },
+  { path: "/settings", Component: SettingsPage },
+  { path: "/billing", Component: BillingPage },
 ];


### PR DESCRIPTION
Moves the authenticated route definitions from App.tsx into a new `frontend/src/routes.ts` config array. App.tsx now maps over the array to render Route elements, so adding a new page only requires one entry in routes.ts rather than an import + Route in App.tsx.

Closes #389