### PR TITLE
refactor: config-driven notification sender setup using factory registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -507,6 +507,56 @@ Connectors define what actions agents can perform. If you want to add support fo
 - See [Custom Connectors](docs/custom-connectors.md) for the external plugin system
 - Look at the existing [Slack](connectors/slack/) and [GitHub](connectors/github/) connectors as reference implementations
 
+## Adding Notification Channels
+
+Notification channels self-register via Go's `init()` mechanism — no changes to `main.go` or the approval handler are needed when adding a new channel.
+
+**Steps:**
+
+1. **Implement `notify.Sender`** in a new package, e.g. `notify/slack/`:
+
+   ```go
+   // notify/slack/sender.go
+   package slack
+
+   type Sender struct { /* ... */ }
+   func (s *Sender) Name() string { return "slack" }
+   func (s *Sender) Send(ctx context.Context, a notify.Approval, r notify.Recipient) error { /* ... */ }
+   ```
+
+2. **Add config fields** to `notify.Config` in `notify/config.go` and load them in `LoadConfig()`.
+
+3. **Create `notify/slack/register.go`** with the self-registration factory:
+
+   ```go
+   package slack
+
+   import "github.com/supersuit-tech/permission-slip-web/notify"
+
+   func init() {
+       notify.RegisterSenderFactory("slack", func(ctx context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
+           if bc.Config.SlackWebhookURL == "" {
+               return nil, nil // channel disabled; silently skipped
+           }
+           return []notify.Sender{New(bc.Config.SlackWebhookURL)}, nil
+       })
+   }
+   ```
+
+4. **Add a blank import** to `notify/all/all.go`:
+
+   ```go
+   import _ "github.com/supersuit-tech/permission-slip-web/notify/slack"
+   ```
+
+5. **Write tests** in `notify/slack/` and optionally add registry-level tests in `notify/registry_test.go`.
+
+**`SenderFactory` contract:**
+- Return `(senders, nil)` when the channel is configured and active.
+- Return `(nil, nil)` when the channel is disabled (e.g. env var missing) — silently skipped.
+- Return `(nil, err)` for unexpected setup failures — logged, then skipped.
+- Never call `log.Fatalf` or `os.Exit` inside a factory.
+
 ## Troubleshooting
 
 ### `make test-backend` fails with connection errors

--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ go run ./cmd/generate-vapid-keys --format=heroku
 
 **Mobile Push (Expo):** Mobile push notifications are always enabled when a database is configured — no additional keys required. The sender uses the [Expo Push Service](https://docs.expo.dev/push-notifications/overview/) to deliver notifications to registered devices. Set `EXPO_ACCESS_TOKEN` for authenticated mode (higher rate limits); without it, unauthenticated mode is used.
 
+**Adding a notification channel:** Channels self-register via Go's `init()` mechanism. To add a new channel:
+1. Implement `notify.Sender` in a new package (e.g. `notify/mynewchannel/`).
+2. Add any required env-var fields to `notify.Config` in `notify/config.go`.
+3. Create `notify/mynewchannel/register.go` with an `init()` that calls `notify.RegisterSenderFactory("my-channel", fn)`.
+4. Add a blank import to `notify/all/all.go`.
+
+No changes to `main.go` or the approval handler are needed. See the `notify` package doc comment for details.
+
 ## Mobile App
 
 The mobile approval app lives in `mobile/` (React Native / Expo). It's a thin client for approving and viewing requests from your phone — similar to the Microsoft Authenticator approval flow.

--- a/docs/spec/notifications.md
+++ b/docs/spec/notifications.md
@@ -17,6 +17,8 @@ This document specifies how Permission Slip notifies users when agents request a
 7. [Deep Linking](#deep-linking)
 8. [Security Considerations](#security-considerations)
 
+> **Note for developers:** For instructions on adding a new notification channel to the server, see the `notify` package documentation and the README's "Adding a notification channel" section.
+
 ---
 
 ## Overview
@@ -63,9 +65,9 @@ Approval requests have a limited lifetime to ensure security and timely resoluti
 
 ## Delivery Mechanisms
 
-Services MUST support webhook notifications. Services MAY additionally support mobile push notifications. This specification defines two delivery mechanisms with different requirements.
+Permission Slip supports four notification channels. Channels are active only when their required configuration is present; multiple channels may be active simultaneously and notifications are fanned out to all of them.
 
-### Primary: Webhook Notifications (Required)
+### Webhook Notifications (Required)
 
 **Webhooks** are HTTP POST requests sent from the service to a URL registered by the approver.
 
@@ -78,18 +80,37 @@ Services MUST support webhook notifications. Services MAY additionally support m
 
 **Requirement Level:** Services MUST support webhook notifications.
 
-### Secondary: Mobile Push Notifications (Optional)
+### Web Push Notifications (Optional)
 
-**Mobile push notifications** deliver alerts directly to iOS and Android devices via Apple Push Notification Service (APNs) and Firebase Cloud Messaging (FCM).
+**Web push** delivers browser notifications via the [Web Push Protocol](https://www.rfc-editor.org/rfc/rfc8030) using VAPID authentication. Subscriptions are stored per browser; the service sends encrypted payloads directly to the browser push service (FCM for Chrome, Mozilla for Firefox, etc.).
 
-**Characteristics:**
-- Native mobile device notifications
-- Instant delivery even when app is closed
-- Better user experience for mobile-first implementations
-- Requires integration with APNs (iOS) and FCM (Android)
-- More complex to implement
+**Configuration:** Set `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_SUBJECT`. Keys are auto-generated in development mode. See the README for key generation instructions.
 
-**Requirement Level:** Services MAY support mobile push notifications as an optional enhancement.
+**Requirement Level:** Services MAY support web push as an optional enhancement.
+
+### Mobile Push Notifications (Optional)
+
+**Mobile push notifications** deliver alerts to iOS and Android devices via the [Expo Push Service](https://docs.expo.dev/push-notifications/overview/), which routes to APNs (iOS) and FCM (Android). Device tokens are registered on login via the Permission Slip mobile app.
+
+**Configuration:** Always enabled when a database is available. Set `EXPO_ACCESS_TOKEN` for higher rate limits (authenticated mode); unauthenticated mode is used otherwise.
+
+**Requirement Level:** Services MAY support mobile push as an optional enhancement.
+
+### Email Notifications (Optional)
+
+**Email notifications** deliver approval requests to the approver's registered email address. Two providers are supported: SendGrid and SMTP.
+
+**Configuration:** Set `NOTIFICATION_EMAIL_PROVIDER` to `twilio-sendgrid` or `smtp`, plus the provider-specific credentials. See `.env.example` for all variables.
+
+**Requirement Level:** Services MAY support email as an optional enhancement.
+
+### SMS Notifications (Optional)
+
+**SMS notifications** deliver approval requests as text messages via Twilio. SMS delivery is gated behind paid subscription tiers when billing is enabled.
+
+**Configuration:** Set `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER`. All three are required; partial configuration disables the channel.
+
+**Requirement Level:** Services MAY support SMS as an optional enhancement.
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -24,8 +24,7 @@ import (
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/providers"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/notify"
-	"github.com/supersuit-tech/permission-slip-web/notify/mobilepush"
-	"github.com/supersuit-tech/permission-slip-web/notify/webpush"
+	_ "github.com/supersuit-tech/permission-slip-web/notify/all"
 	poauth "github.com/supersuit-tech/permission-slip-web/oauth"
 	_ "github.com/supersuit-tech/permission-slip-web/oauth/providers"
 	pstripe "github.com/supersuit-tech/permission-slip-web/stripe"
@@ -231,63 +230,18 @@ func main() {
 	}
 
 	// Initialize notification dispatcher.
-	// Channel senders are built from environment variables; each channel
-	// issue (#275 Email, #276 Web Push, #277 SMS) adds its own env vars
-	// and sender construction to notify.Config.BuildSenders().
+	// Each channel registers itself via init() in its own package (imported via
+	// notify/all). BuildSenders calls all registered factories with the runtime
+	// context so each channel can inspect its required config and dependencies.
 	notifyCfg := notify.LoadConfig()
-	senders := notifyCfg.BuildSenders()
-
-	// #17 — Gate SMS behind paid tier: wrap SMS senders with plan checking
-	// and usage tracking. When the DB is available, free-tier users are blocked
-	// and paid-tier SMS usage is recorded in usage_periods.
-	if deps.DB != nil {
-		smsGate := &notify.DBSMSGate{DB: deps.DB}
-		for i, s := range senders {
-			if s.Name() == "sms" {
-				senders[i] = notify.NewPlanGatedSender(s, smsGate)
-			}
-		}
-	}
-
-	// #276 — Web Push (VAPID): Initialize VAPID keys and register sender.
-	// VAPID keys require the database for auto-generation + persistence,
-	// so this is wired here rather than in BuildSenders().
-	if deps.DB != nil {
-		vapidCtx, vapidCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		vapidKeys, err := webpush.InitVAPIDKeys(vapidCtx, deps.DB, deps.DevMode)
-		vapidCancel()
-		if err != nil {
-			if deps.DevMode {
-				log.Printf("Warning: failed to initialize VAPID keys: %v", err)
-			} else {
-				log.Fatalf("Failed to initialize VAPID keys: %v", err)
-			}
-		} else if vapidKeys != nil {
-			deps.VAPIDPublicKey = vapidKeys.PublicKey
-			subject := strings.TrimSpace(notifyCfg.VAPIDSubject)
-			if subject == "" {
-				if deps.DevMode {
-					subject = "mailto:admin@example.com"
-					log.Println("Web Push: VAPID_SUBJECT not set, using default mailto:admin@example.com (development mode only)")
-				} else {
-					log.Fatalf("Web Push: VAPID_SUBJECT is required in production (e.g. mailto:admin@mycompany.com or https://example.com/contact)")
-				}
-			}
-			senders = append(senders, webpush.New(vapidKeys, subject, deps.DB))
-		}
-	}
-
-	// Mobile Push (Expo): Register sender when the database is available.
-	// The Expo access token is optional — unauthenticated requests work
-	// but have lower rate limits.
-	if deps.DB != nil {
-		if notifyCfg.ExpoAccessToken != "" {
-			log.Println("Mobile Push: Expo access token configured (authenticated mode)")
-		} else {
-			log.Println("Mobile Push: no EXPO_ACCESS_TOKEN set, using unauthenticated mode (lower rate limits)")
-		}
-		senders = append(senders, mobilepush.New(deps.DB, notifyCfg.ExpoAccessToken))
-	}
+	senders := notify.BuildSenders(context.Background(), notify.BuildContext{
+		DB:      deps.DB,
+		Config:  notifyCfg,
+		DevMode: deps.DevMode,
+		OnVAPIDPublicKey: func(key string) {
+			deps.VAPIDPublicKey = key
+		},
+	})
 
 	notify.LogChannelSummary(senders)
 	if deps.DB != nil && len(senders) > 0 {

--- a/notify/all/all.go
+++ b/notify/all/all.go
@@ -1,0 +1,18 @@
+// Package all blank-imports every built-in notification sender package so that
+// their init() functions run and self-register with the notify sender registry.
+//
+// Usage in main.go:
+//
+//	import _ "github.com/supersuit-tech/permission-slip-web/notify/all"
+//
+// To add a new sender, create notify/<channel>/register.go with an init() that
+// calls notify.RegisterSenderFactory(...), then add a blank import here.
+//
+// Note: email and SMS senders register themselves via init() in the notify
+// package itself, so no additional imports are needed for those channels.
+package all
+
+import (
+	_ "github.com/supersuit-tech/permission-slip-web/notify/mobilepush"
+	_ "github.com/supersuit-tech/permission-slip-web/notify/webpush"
+)

--- a/notify/config.go
+++ b/notify/config.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"context"
 	"log"
 	"os"
 	"strings"
@@ -57,36 +58,18 @@ func LoadConfig() Config {
 	}
 }
 
-// BuildSenders inspects the config and returns the set of Sender
-// implementations whose required env vars are present. Each channel issue
-// (#275, #276, #277) will add its sender construction here.
+// BuildSenders calls the globally registered sender factories and returns the
+// set of Sender implementations whose required config is present. Each channel
+// registers itself via init() in its own package.
+//
+// This method is provided for backward-compatibility and testing convenience.
+// Production code should prefer calling notify.BuildSenders(ctx, BuildContext{...})
+// with the full build context, including the database handle (required for web
+// push, mobile push, and SMS plan gating).
 //
 // Returns nil when no channels are configured.
 func (c Config) BuildSenders() []Sender {
-	var senders []Sender
-
-	// #275 — Email (SendGrid + SMTP)
-	if s := c.buildEmailSender(); s != nil {
-		senders = append(senders, s)
-	}
-
-	// Channel registrations for future issues:
-	//
-	// #276 — Web Push (VAPID):
-	//   if c.VAPIDPrivateKey != "" { senders = append(senders, webpush.New(...)) }
-
-	// #277 — SMS (Twilio)
-	if c.TwilioAccountSID != "" && c.TwilioAuthToken != "" && c.TwilioFromNumber != "" {
-		senders = append(senders, NewSMSSender(SMSConfig{
-			AccountSID: c.TwilioAccountSID,
-			AuthToken:  c.TwilioAuthToken,
-			FromNumber: c.TwilioFromNumber,
-		}))
-	} else if c.TwilioAccountSID != "" || c.TwilioAuthToken != "" || c.TwilioFromNumber != "" {
-		log.Println("notify: SMS (Twilio) partially configured — set all three: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER")
-	}
-
-	return senders
+	return BuildSenders(context.Background(), BuildContext{Config: c})
 }
 
 // buildEmailSender returns an email Sender based on the configured provider,

--- a/notify/email_register.go
+++ b/notify/email_register.go
@@ -3,7 +3,7 @@ package notify
 import "context"
 
 func init() {
-	RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
+	RegisterSenderFactory("email", func(_ context.Context, bc BuildContext) ([]Sender, error) {
 		s := bc.Config.buildEmailSender()
 		if s == nil {
 			return nil, nil

--- a/notify/email_register.go
+++ b/notify/email_register.go
@@ -1,0 +1,13 @@
+package notify
+
+import "context"
+
+func init() {
+	RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
+		s := bc.Config.buildEmailSender()
+		if s == nil {
+			return nil, nil
+		}
+		return []Sender{s}, nil
+	})
+}

--- a/notify/mobilepush/register.go
+++ b/notify/mobilepush/register.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	notify.RegisterSenderFactory(func(_ context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
+	notify.RegisterSenderFactory("mobile-push", func(_ context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
 		if bc.DB == nil {
 			return nil, nil
 		}

--- a/notify/mobilepush/register.go
+++ b/notify/mobilepush/register.go
@@ -1,0 +1,24 @@
+package mobilepush
+
+import (
+	"context"
+	"log"
+
+	"github.com/supersuit-tech/permission-slip-web/notify"
+)
+
+func init() {
+	notify.RegisterSenderFactory(func(_ context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
+		if bc.DB == nil {
+			return nil, nil
+		}
+
+		if bc.Config.ExpoAccessToken != "" {
+			log.Println("Mobile Push: Expo access token configured (authenticated mode)")
+		} else {
+			log.Println("Mobile Push: no EXPO_ACCESS_TOKEN set, using unauthenticated mode (lower rate limits)")
+		}
+
+		return []notify.Sender{New(bc.DB, bc.Config.ExpoAccessToken)}, nil
+	})
+}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -2,15 +2,15 @@
 // Permission Slip. It defines the Sender interface that individual channels
 // (email, web-push, SMS) implement, a Dispatcher that fans out to all
 // configured senders, and the shared types (Approval, Recipient) that
-// senders receive. Additional channels (for example, mobile push) can be
-// added by implementing the Sender interface.
+// senders receive.
 //
-// Adding a new channel requires three steps:
-//  1. Implement the Sender interface.
-//  2. Add env-var loading for the channel's config.
-//  3. Register the sender in main.go.
+// Adding a new notification channel requires three steps:
+//  1. Implement the Sender interface in a new package (e.g. notify/mynewchannel).
+//  2. Add any required env-var fields to Config in notify/config.go.
+//  3. Create notify/mynewchannel/register.go with an init() that calls
+//     notify.RegisterSenderFactory(...), then add a blank import to notify/all/all.go.
 //
-// No changes to the Dispatcher or approval handler are needed.
+// No changes to main.go, the Dispatcher, or the approval handler are needed.
 package notify
 
 import (

--- a/notify/registry.go
+++ b/notify/registry.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 
@@ -49,9 +50,18 @@ func RegisterSenderFactory(fn SenderFactory) {
 	senderFactories = append(senderFactories, fn)
 }
 
+// SenderFactoryCount returns the number of registered sender factories.
+// Useful for tests and diagnostics.
+func SenderFactoryCount() int {
+	senderMu.Lock()
+	defer senderMu.Unlock()
+	return len(senderFactories)
+}
+
 // BuildSenders calls all registered factories with bc and returns the combined
 // Sender slice. Errors from individual factories are logged but do not prevent
-// other factories from running.
+// other factories from running. Panics inside factories are caught and treated
+// as errors so a misbehaving factory cannot crash the server at startup.
 //
 // To ensure all built-in senders are registered, import the notify/all package
 // (or import sender packages individually) before calling BuildSenders.
@@ -62,13 +72,23 @@ func BuildSenders(ctx context.Context, bc BuildContext) []Sender {
 	senderMu.Unlock()
 
 	var senders []Sender
-	for _, factory := range factories {
-		ss, err := factory(ctx, bc)
+	for i, factory := range factories {
+		ss, err := runFactory(ctx, bc, factory)
 		if err != nil {
-			log.Printf("notify: failed to build sender: %v", err)
+			log.Printf("notify: factory[%d] failed: %v", i, err)
 			continue
 		}
 		senders = append(senders, ss...)
 	}
 	return senders
+}
+
+// runFactory calls a single SenderFactory and recovers from panics.
+func runFactory(ctx context.Context, bc BuildContext, fn SenderFactory) (ss []Sender, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return fn(ctx, bc)
 }

--- a/notify/registry.go
+++ b/notify/registry.go
@@ -44,7 +44,11 @@ var (
 // RegisterSenderFactory registers a SenderFactory to be called by BuildSenders.
 // Factories are called in registration order. Packages register themselves in
 // their init() function so registration happens automatically on import.
+// Panics if fn is nil so the mistake surfaces immediately at registration time.
 func RegisterSenderFactory(fn SenderFactory) {
+	if fn == nil {
+		panic("notify: RegisterSenderFactory called with nil factory")
+	}
 	senderMu.Lock()
 	defer senderMu.Unlock()
 	senderFactories = append(senderFactories, fn)

--- a/notify/registry.go
+++ b/notify/registry.go
@@ -11,29 +11,43 @@ import (
 
 // BuildContext holds the runtime dependencies available to sender factories
 // at startup. It is passed to each registered SenderFactory so factories can
-// inspect config, access the database, and communicate results back.
+// inspect config, access the database, and communicate results back to the
+// caller without requiring a global variable.
 type BuildContext struct {
-	// DB is the database handle. Nil when no database is configured.
+	// DB is the database handle. Nil when no database is configured (e.g.
+	// during unit tests or when DATABASE_URL is not set). Factories that
+	// require database access (web push, mobile push, SMS plan gating) should
+	// return nil, nil when DB is nil rather than failing.
 	DB db.DBTX
 
-	// Config holds the notification configuration loaded from environment variables.
+	// Config holds the notification configuration loaded from environment
+	// variables. Each channel reads its own fields from Config to decide
+	// whether it is configured.
 	Config Config
 
-	// DevMode is true when the server is running in development mode.
-	// Factories use this to relax requirements (e.g. auto-generate VAPID keys)
-	// or degrade gracefully instead of calling log.Fatalf.
+	// DevMode is true when the server is running in development mode
+	// (MODE=development). Factories use this to relax hard requirements —
+	// for example, the web push factory auto-generates VAPID keys in dev mode
+	// rather than failing, and uses a default VAPID_SUBJECT.
 	DevMode bool
 
-	// OnVAPIDPublicKey, when non-nil, is called by the web push factory once
-	// VAPID keys are available. The caller stores the key for serving to
-	// browser clients via the /push/vapid-public-key endpoint.
+	// OnVAPIDPublicKey, when non-nil, is called by the web push factory with
+	// the VAPID public key once VAPID keys are initialised. The caller stores
+	// the key for serving to browser clients via /push/vapid-public-key.
+	// This callback pattern avoids a global variable for the public key while
+	// keeping the factory self-contained.
 	OnVAPIDPublicKey func(publicKey string)
 }
 
-// SenderFactory constructs Senders from a BuildContext. It returns the senders
-// to register (nil or empty when the channel is not configured) and any error
-// encountered during construction. Errors are logged but do not prevent other
-// factories from running.
+// SenderFactory constructs Senders from a BuildContext.
+//
+// Return values:
+//   - (senders, nil) — channel is active; senders are appended to the result.
+//   - (nil, nil)     — channel is disabled (e.g. env vars not set); silently skipped.
+//   - (nil, err)     — unexpected failure; error is logged and the channel is skipped.
+//
+// Factories must not call log.Fatalf or os.Exit — return an error instead so
+// BuildSenders can log it and continue with other channels.
 type SenderFactory func(ctx context.Context, bc BuildContext) ([]Sender, error)
 
 // namedFactory pairs a human-readable channel name with its factory so that

--- a/notify/registry.go
+++ b/notify/registry.go
@@ -36,22 +36,31 @@ type BuildContext struct {
 // factories from running.
 type SenderFactory func(ctx context.Context, bc BuildContext) ([]Sender, error)
 
+// namedFactory pairs a human-readable channel name with its factory so that
+// error and panic log messages identify which channel failed.
+type namedFactory struct {
+	channel string
+	fn      SenderFactory
+}
+
 var (
 	senderMu        sync.Mutex
-	senderFactories []SenderFactory
+	senderFactories []namedFactory
 )
 
 // RegisterSenderFactory registers a SenderFactory to be called by BuildSenders.
-// Factories are called in registration order. Packages register themselves in
-// their init() function so registration happens automatically on import.
+// channel is a short human-readable name (e.g. "email", "sms") used in log
+// messages to identify which factory failed. Factories are called in
+// registration order. Packages register themselves in their init() function so
+// registration happens automatically on import.
 // Panics if fn is nil so the mistake surfaces immediately at registration time.
-func RegisterSenderFactory(fn SenderFactory) {
+func RegisterSenderFactory(channel string, fn SenderFactory) {
 	if fn == nil {
-		panic("notify: RegisterSenderFactory called with nil factory")
+		panic("notify: RegisterSenderFactory called with nil factory for channel " + channel)
 	}
 	senderMu.Lock()
 	defer senderMu.Unlock()
-	senderFactories = append(senderFactories, fn)
+	senderFactories = append(senderFactories, namedFactory{channel: channel, fn: fn})
 }
 
 // SenderFactoryCount returns the number of registered sender factories.
@@ -71,15 +80,15 @@ func SenderFactoryCount() int {
 // (or import sender packages individually) before calling BuildSenders.
 func BuildSenders(ctx context.Context, bc BuildContext) []Sender {
 	senderMu.Lock()
-	factories := make([]SenderFactory, len(senderFactories))
+	factories := make([]namedFactory, len(senderFactories))
 	copy(factories, senderFactories)
 	senderMu.Unlock()
 
 	var senders []Sender
-	for i, factory := range factories {
-		ss, err := runFactory(ctx, bc, factory)
+	for _, nf := range factories {
+		ss, err := runFactory(ctx, bc, nf.fn)
 		if err != nil {
-			log.Printf("notify: factory[%d] failed: %v", i, err)
+			log.Printf("notify: %s sender factory failed: %v", nf.channel, err)
 			continue
 		}
 		senders = append(senders, ss...)

--- a/notify/registry.go
+++ b/notify/registry.go
@@ -1,0 +1,74 @@
+package notify
+
+import (
+	"context"
+	"log"
+	"sync"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// BuildContext holds the runtime dependencies available to sender factories
+// at startup. It is passed to each registered SenderFactory so factories can
+// inspect config, access the database, and communicate results back.
+type BuildContext struct {
+	// DB is the database handle. Nil when no database is configured.
+	DB db.DBTX
+
+	// Config holds the notification configuration loaded from environment variables.
+	Config Config
+
+	// DevMode is true when the server is running in development mode.
+	// Factories use this to relax requirements (e.g. auto-generate VAPID keys)
+	// or degrade gracefully instead of calling log.Fatalf.
+	DevMode bool
+
+	// OnVAPIDPublicKey, when non-nil, is called by the web push factory once
+	// VAPID keys are available. The caller stores the key for serving to
+	// browser clients via the /push/vapid-public-key endpoint.
+	OnVAPIDPublicKey func(publicKey string)
+}
+
+// SenderFactory constructs Senders from a BuildContext. It returns the senders
+// to register (nil or empty when the channel is not configured) and any error
+// encountered during construction. Errors are logged but do not prevent other
+// factories from running.
+type SenderFactory func(ctx context.Context, bc BuildContext) ([]Sender, error)
+
+var (
+	senderMu        sync.Mutex
+	senderFactories []SenderFactory
+)
+
+// RegisterSenderFactory registers a SenderFactory to be called by BuildSenders.
+// Factories are called in registration order. Packages register themselves in
+// their init() function so registration happens automatically on import.
+func RegisterSenderFactory(fn SenderFactory) {
+	senderMu.Lock()
+	defer senderMu.Unlock()
+	senderFactories = append(senderFactories, fn)
+}
+
+// BuildSenders calls all registered factories with bc and returns the combined
+// Sender slice. Errors from individual factories are logged but do not prevent
+// other factories from running.
+//
+// To ensure all built-in senders are registered, import the notify/all package
+// (or import sender packages individually) before calling BuildSenders.
+func BuildSenders(ctx context.Context, bc BuildContext) []Sender {
+	senderMu.Lock()
+	factories := make([]SenderFactory, len(senderFactories))
+	copy(factories, senderFactories)
+	senderMu.Unlock()
+
+	var senders []Sender
+	for _, factory := range factories {
+		ss, err := factory(ctx, bc)
+		if err != nil {
+			log.Printf("notify: failed to build sender: %v", err)
+			continue
+		}
+		senders = append(senders, ss...)
+	}
+	return senders
+}

--- a/notify/registry_test.go
+++ b/notify/registry_test.go
@@ -168,3 +168,13 @@ func TestSenderFactoryCount(t *testing.T) {
 		}
 	})
 }
+
+func TestRegisterSenderFactory_NilPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("expected panic when registering nil factory, got none")
+		}
+	}()
+	RegisterSenderFactory(nil)
+}

--- a/notify/registry_test.go
+++ b/notify/registry_test.go
@@ -14,159 +14,152 @@ func (m *mockSender) Send(_ context.Context, _ Approval, _ Recipient) error {
 	return nil
 }
 
-// withCleanRegistry runs fn with a temporarily empty factory registry, then
-// restores the original state. Registry tests must NOT call t.Parallel()
-// because they temporarily modify global state shared with Config.BuildSenders.
-// Non-parallel tests run before the parallel pool starts, so there is no
-// interference with the config_test.go tests.
-func withCleanRegistry(fn func()) {
+// cleanRegistry clears the factory registry for the duration of a test and
+// restores the original state when the test ends via t.Cleanup.
+//
+// Registry tests must NOT call t.Parallel() because they temporarily modify
+// global state. Non-parallel tests run before the parallel pool starts,
+// preventing interference with config_test.go tests that call
+// Config.BuildSenders() (which reads the same global registry).
+func cleanRegistry(t *testing.T) {
+	t.Helper()
 	senderMu.Lock()
 	saved := senderFactories
 	senderFactories = nil
 	senderMu.Unlock()
 
-	defer func() {
+	t.Cleanup(func() {
 		senderMu.Lock()
 		senderFactories = saved
 		senderMu.Unlock()
-	}()
-
-	fn()
+	})
 }
 
 func TestBuildSenders_MockFactory(t *testing.T) {
-	withCleanRegistry(func() {
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-			return []Sender{&mockSender{name: "test-channel"}}, nil
-		})
-
-		senders := BuildSenders(context.Background(), BuildContext{})
-		if len(senders) != 1 {
-			t.Fatalf("expected 1 sender, got %d", len(senders))
-		}
-		if senders[0].Name() != "test-channel" {
-			t.Errorf("expected name=test-channel, got %q", senders[0].Name())
-		}
+	cleanRegistry(t)
+	RegisterSenderFactory("test", func(_ context.Context, _ BuildContext) ([]Sender, error) {
+		return []Sender{&mockSender{name: "test-channel"}}, nil
 	})
+
+	senders := BuildSenders(context.Background(), BuildContext{})
+	if len(senders) != 1 {
+		t.Fatalf("expected 1 sender, got %d", len(senders))
+	}
+	if senders[0].Name() != "test-channel" {
+		t.Errorf("expected name=test-channel, got %q", senders[0].Name())
+	}
 }
 
 func TestBuildSenders_MultipleFactories(t *testing.T) {
-	withCleanRegistry(func() {
-		for _, name := range []string{"alpha", "beta", "gamma"} {
-			n := name // capture loop variable
-			RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-				return []Sender{&mockSender{name: n}}, nil
-			})
-		}
+	cleanRegistry(t)
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		n := name // capture loop variable
+		RegisterSenderFactory(n, func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			return []Sender{&mockSender{name: n}}, nil
+		})
+	}
 
-		senders := BuildSenders(context.Background(), BuildContext{})
-		if len(senders) != 3 {
-			t.Fatalf("expected 3 senders, got %d", len(senders))
-		}
-		if senders[0].Name() != "alpha" || senders[1].Name() != "beta" || senders[2].Name() != "gamma" {
-			t.Errorf("unexpected sender order: %v", senders)
-		}
-	})
+	senders := BuildSenders(context.Background(), BuildContext{})
+	if len(senders) != 3 {
+		t.Fatalf("expected 3 senders, got %d", len(senders))
+	}
+	if senders[0].Name() != "alpha" || senders[1].Name() != "beta" || senders[2].Name() != "gamma" {
+		t.Errorf("unexpected sender order: %v", senders)
+	}
 }
 
 func TestBuildSenders_FactoryError_OthersStillRun(t *testing.T) {
-	withCleanRegistry(func() {
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-			return nil, errors.New("intentional factory error")
-		})
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-			return []Sender{&mockSender{name: "resilient"}}, nil
-		})
-
-		senders := BuildSenders(context.Background(), BuildContext{})
-		if len(senders) != 1 {
-			t.Fatalf("expected 1 sender (erroring factory skipped), got %d", len(senders))
-		}
-		if senders[0].Name() != "resilient" {
-			t.Errorf("expected name=resilient, got %q", senders[0].Name())
-		}
+	cleanRegistry(t)
+	RegisterSenderFactory("broken", func(_ context.Context, _ BuildContext) ([]Sender, error) {
+		return nil, errors.New("intentional factory error")
 	})
+	RegisterSenderFactory("resilient", func(_ context.Context, _ BuildContext) ([]Sender, error) {
+		return []Sender{&mockSender{name: "resilient"}}, nil
+	})
+
+	senders := BuildSenders(context.Background(), BuildContext{})
+	if len(senders) != 1 {
+		t.Fatalf("expected 1 sender (erroring factory skipped), got %d", len(senders))
+	}
+	if senders[0].Name() != "resilient" {
+		t.Errorf("expected name=resilient, got %q", senders[0].Name())
+	}
 }
 
 func TestBuildSenders_FactoryPanic_OthersStillRun(t *testing.T) {
-	withCleanRegistry(func() {
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-			panic("factory meltdown")
-		})
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-			return []Sender{&mockSender{name: "survived"}}, nil
-		})
-
-		senders := BuildSenders(context.Background(), BuildContext{})
-		if len(senders) != 1 {
-			t.Fatalf("expected 1 sender (panicking factory skipped), got %d", len(senders))
-		}
-		if senders[0].Name() != "survived" {
-			t.Errorf("expected name=survived, got %q", senders[0].Name())
-		}
+	cleanRegistry(t)
+	RegisterSenderFactory("panicky", func(_ context.Context, _ BuildContext) ([]Sender, error) {
+		panic("factory meltdown")
 	})
+	RegisterSenderFactory("survivor", func(_ context.Context, _ BuildContext) ([]Sender, error) {
+		return []Sender{&mockSender{name: "survived"}}, nil
+	})
+
+	senders := BuildSenders(context.Background(), BuildContext{})
+	if len(senders) != 1 {
+		t.Fatalf("expected 1 sender (panicking factory skipped), got %d", len(senders))
+	}
+	if senders[0].Name() != "survived" {
+		t.Errorf("expected name=survived, got %q", senders[0].Name())
+	}
 }
 
 func TestBuildSenders_FactoryDisabledChannel_ReturnsNil(t *testing.T) {
-	withCleanRegistry(func() {
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
-			// Simulates a channel whose required env vars are missing.
-			return nil, nil
-		})
-
-		senders := BuildSenders(context.Background(), BuildContext{})
-		if len(senders) != 0 {
-			t.Errorf("expected 0 senders when factory returns nil, got %d", len(senders))
-		}
+	cleanRegistry(t)
+	RegisterSenderFactory("disabled", func(_ context.Context, _ BuildContext) ([]Sender, error) {
+		// Simulates a channel whose required env vars are missing.
+		return nil, nil
 	})
+
+	senders := BuildSenders(context.Background(), BuildContext{})
+	if len(senders) != 0 {
+		t.Errorf("expected 0 senders when factory returns nil, got %d", len(senders))
+	}
 }
 
 func TestBuildSenders_BuildContextPassedToFactory(t *testing.T) {
-	withCleanRegistry(func() {
-		var gotDevMode bool
-		RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
-			gotDevMode = bc.DevMode
-			return nil, nil
-		})
-
-		BuildSenders(context.Background(), BuildContext{DevMode: true})
-		if !gotDevMode {
-			t.Error("expected DevMode=true to be passed to factory")
-		}
+	cleanRegistry(t)
+	var gotDevMode bool
+	RegisterSenderFactory("ctx-check", func(_ context.Context, bc BuildContext) ([]Sender, error) {
+		gotDevMode = bc.DevMode
+		return nil, nil
 	})
+
+	BuildSenders(context.Background(), BuildContext{DevMode: true})
+	if !gotDevMode {
+		t.Error("expected DevMode=true to be passed to factory")
+	}
 }
 
 func TestBuildSenders_OnVAPIDPublicKey_Callback(t *testing.T) {
-	withCleanRegistry(func() {
-		var captured string
-		RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
-			if bc.OnVAPIDPublicKey != nil {
-				bc.OnVAPIDPublicKey("test-vapid-key")
-			}
-			return []Sender{&mockSender{name: "web-push"}}, nil
-		})
-
-		BuildSenders(context.Background(), BuildContext{
-			OnVAPIDPublicKey: func(key string) { captured = key },
-		})
-
-		if captured != "test-vapid-key" {
-			t.Errorf("expected VAPID key to be captured, got %q", captured)
+	cleanRegistry(t)
+	var captured string
+	RegisterSenderFactory("web-push", func(_ context.Context, bc BuildContext) ([]Sender, error) {
+		if bc.OnVAPIDPublicKey != nil {
+			bc.OnVAPIDPublicKey("test-vapid-key")
 		}
+		return []Sender{&mockSender{name: "web-push"}}, nil
 	})
+
+	BuildSenders(context.Background(), BuildContext{
+		OnVAPIDPublicKey: func(key string) { captured = key },
+	})
+
+	if captured != "test-vapid-key" {
+		t.Errorf("expected VAPID key to be captured, got %q", captured)
+	}
 }
 
 func TestSenderFactoryCount(t *testing.T) {
-	withCleanRegistry(func() {
-		if SenderFactoryCount() != 0 {
-			t.Errorf("expected 0 factories in clean registry, got %d", SenderFactoryCount())
-		}
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) { return nil, nil })
-		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) { return nil, nil })
-		if SenderFactoryCount() != 2 {
-			t.Errorf("expected 2 factories, got %d", SenderFactoryCount())
-		}
-	})
+	cleanRegistry(t)
+	if SenderFactoryCount() != 0 {
+		t.Errorf("expected 0 factories in clean registry, got %d", SenderFactoryCount())
+	}
+	RegisterSenderFactory("a", func(_ context.Context, _ BuildContext) ([]Sender, error) { return nil, nil })
+	RegisterSenderFactory("b", func(_ context.Context, _ BuildContext) ([]Sender, error) { return nil, nil })
+	if SenderFactoryCount() != 2 {
+		t.Errorf("expected 2 factories, got %d", SenderFactoryCount())
+	}
 }
 
 func TestRegisterSenderFactory_NilPanics(t *testing.T) {
@@ -176,5 +169,5 @@ func TestRegisterSenderFactory_NilPanics(t *testing.T) {
 			t.Error("expected panic when registering nil factory, got none")
 		}
 	}()
-	RegisterSenderFactory(nil)
+	RegisterSenderFactory("bad", nil)
 }

--- a/notify/registry_test.go
+++ b/notify/registry_test.go
@@ -1,0 +1,170 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockSender is a minimal Sender for testing the registry.
+type mockSender struct{ name string }
+
+func (m *mockSender) Name() string { return m.name }
+func (m *mockSender) Send(_ context.Context, _ Approval, _ Recipient) error {
+	return nil
+}
+
+// withCleanRegistry runs fn with a temporarily empty factory registry, then
+// restores the original state. Registry tests must NOT call t.Parallel()
+// because they temporarily modify global state shared with Config.BuildSenders.
+// Non-parallel tests run before the parallel pool starts, so there is no
+// interference with the config_test.go tests.
+func withCleanRegistry(fn func()) {
+	senderMu.Lock()
+	saved := senderFactories
+	senderFactories = nil
+	senderMu.Unlock()
+
+	defer func() {
+		senderMu.Lock()
+		senderFactories = saved
+		senderMu.Unlock()
+	}()
+
+	fn()
+}
+
+func TestBuildSenders_MockFactory(t *testing.T) {
+	withCleanRegistry(func() {
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			return []Sender{&mockSender{name: "test-channel"}}, nil
+		})
+
+		senders := BuildSenders(context.Background(), BuildContext{})
+		if len(senders) != 1 {
+			t.Fatalf("expected 1 sender, got %d", len(senders))
+		}
+		if senders[0].Name() != "test-channel" {
+			t.Errorf("expected name=test-channel, got %q", senders[0].Name())
+		}
+	})
+}
+
+func TestBuildSenders_MultipleFactories(t *testing.T) {
+	withCleanRegistry(func() {
+		for _, name := range []string{"alpha", "beta", "gamma"} {
+			n := name // capture loop variable
+			RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+				return []Sender{&mockSender{name: n}}, nil
+			})
+		}
+
+		senders := BuildSenders(context.Background(), BuildContext{})
+		if len(senders) != 3 {
+			t.Fatalf("expected 3 senders, got %d", len(senders))
+		}
+		if senders[0].Name() != "alpha" || senders[1].Name() != "beta" || senders[2].Name() != "gamma" {
+			t.Errorf("unexpected sender order: %v", senders)
+		}
+	})
+}
+
+func TestBuildSenders_FactoryError_OthersStillRun(t *testing.T) {
+	withCleanRegistry(func() {
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			return nil, errors.New("intentional factory error")
+		})
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			return []Sender{&mockSender{name: "resilient"}}, nil
+		})
+
+		senders := BuildSenders(context.Background(), BuildContext{})
+		if len(senders) != 1 {
+			t.Fatalf("expected 1 sender (erroring factory skipped), got %d", len(senders))
+		}
+		if senders[0].Name() != "resilient" {
+			t.Errorf("expected name=resilient, got %q", senders[0].Name())
+		}
+	})
+}
+
+func TestBuildSenders_FactoryPanic_OthersStillRun(t *testing.T) {
+	withCleanRegistry(func() {
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			panic("factory meltdown")
+		})
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			return []Sender{&mockSender{name: "survived"}}, nil
+		})
+
+		senders := BuildSenders(context.Background(), BuildContext{})
+		if len(senders) != 1 {
+			t.Fatalf("expected 1 sender (panicking factory skipped), got %d", len(senders))
+		}
+		if senders[0].Name() != "survived" {
+			t.Errorf("expected name=survived, got %q", senders[0].Name())
+		}
+	})
+}
+
+func TestBuildSenders_FactoryDisabledChannel_ReturnsNil(t *testing.T) {
+	withCleanRegistry(func() {
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) {
+			// Simulates a channel whose required env vars are missing.
+			return nil, nil
+		})
+
+		senders := BuildSenders(context.Background(), BuildContext{})
+		if len(senders) != 0 {
+			t.Errorf("expected 0 senders when factory returns nil, got %d", len(senders))
+		}
+	})
+}
+
+func TestBuildSenders_BuildContextPassedToFactory(t *testing.T) {
+	withCleanRegistry(func() {
+		var gotDevMode bool
+		RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
+			gotDevMode = bc.DevMode
+			return nil, nil
+		})
+
+		BuildSenders(context.Background(), BuildContext{DevMode: true})
+		if !gotDevMode {
+			t.Error("expected DevMode=true to be passed to factory")
+		}
+	})
+}
+
+func TestBuildSenders_OnVAPIDPublicKey_Callback(t *testing.T) {
+	withCleanRegistry(func() {
+		var captured string
+		RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
+			if bc.OnVAPIDPublicKey != nil {
+				bc.OnVAPIDPublicKey("test-vapid-key")
+			}
+			return []Sender{&mockSender{name: "web-push"}}, nil
+		})
+
+		BuildSenders(context.Background(), BuildContext{
+			OnVAPIDPublicKey: func(key string) { captured = key },
+		})
+
+		if captured != "test-vapid-key" {
+			t.Errorf("expected VAPID key to be captured, got %q", captured)
+		}
+	})
+}
+
+func TestSenderFactoryCount(t *testing.T) {
+	withCleanRegistry(func() {
+		if SenderFactoryCount() != 0 {
+			t.Errorf("expected 0 factories in clean registry, got %d", SenderFactoryCount())
+		}
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) { return nil, nil })
+		RegisterSenderFactory(func(_ context.Context, _ BuildContext) ([]Sender, error) { return nil, nil })
+		if SenderFactoryCount() != 2 {
+			t.Errorf("expected 2 factories, got %d", SenderFactoryCount())
+		}
+	})
+}

--- a/notify/sms_register.go
+++ b/notify/sms_register.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
+	RegisterSenderFactory("sms", func(_ context.Context, bc BuildContext) ([]Sender, error) {
 		cfg := bc.Config
 		if cfg.TwilioAccountSID == "" || cfg.TwilioAuthToken == "" || cfg.TwilioFromNumber == "" {
 			if cfg.TwilioAccountSID != "" || cfg.TwilioAuthToken != "" || cfg.TwilioFromNumber != "" {

--- a/notify/sms_register.go
+++ b/notify/sms_register.go
@@ -21,8 +21,15 @@ func init() {
 		})
 		// Gate SMS behind paid tier when the database is available.
 		// Free-tier users are blocked; paid-tier usage is tracked in usage_periods.
+		//
+		// Security note: when bc.DB is nil (no database configured), plan gating
+		// is skipped and SMS is sent to all recipients without billing checks.
+		// This matches the behaviour of the previous inline main.go setup and only
+		// occurs in configurations that explicitly disable the database.
 		if bc.DB != nil {
 			s = NewPlanGatedSender(s, &DBSMSGate{DB: bc.DB})
+		} else {
+			log.Println("notify: SMS plan gating disabled — no database configured; all recipients will receive SMS regardless of subscription tier")
 		}
 		return []Sender{s}, nil
 	})

--- a/notify/sms_register.go
+++ b/notify/sms_register.go
@@ -1,0 +1,29 @@
+package notify
+
+import (
+	"context"
+	"log"
+)
+
+func init() {
+	RegisterSenderFactory(func(_ context.Context, bc BuildContext) ([]Sender, error) {
+		cfg := bc.Config
+		if cfg.TwilioAccountSID == "" || cfg.TwilioAuthToken == "" || cfg.TwilioFromNumber == "" {
+			if cfg.TwilioAccountSID != "" || cfg.TwilioAuthToken != "" || cfg.TwilioFromNumber != "" {
+				log.Println("notify: SMS (Twilio) partially configured — set all three: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER")
+			}
+			return nil, nil
+		}
+		var s Sender = NewSMSSender(SMSConfig{
+			AccountSID: cfg.TwilioAccountSID,
+			AuthToken:  cfg.TwilioAuthToken,
+			FromNumber: cfg.TwilioFromNumber,
+		})
+		// Gate SMS behind paid tier when the database is available.
+		// Free-tier users are blocked; paid-tier usage is tracked in usage_periods.
+		if bc.DB != nil {
+			s = NewPlanGatedSender(s, &DBSMSGate{DB: bc.DB})
+		}
+		return []Sender{s}, nil
+	})
+}

--- a/notify/webpush/register.go
+++ b/notify/webpush/register.go
@@ -1,0 +1,48 @@
+package webpush
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/notify"
+)
+
+func init() {
+	notify.RegisterSenderFactory(func(ctx context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
+		if bc.DB == nil {
+			return nil, nil
+		}
+
+		vapidCtx, vapidCancel := context.WithTimeout(ctx, 10*time.Second)
+		vapidKeys, err := InitVAPIDKeys(vapidCtx, bc.DB, bc.DevMode)
+		vapidCancel()
+		if err != nil {
+			if bc.DevMode {
+				log.Printf("Warning: failed to initialize VAPID keys: %v", err)
+				return nil, nil
+			}
+			log.Fatalf("Failed to initialize VAPID keys: %v", err)
+		}
+		if vapidKeys == nil {
+			return nil, nil
+		}
+
+		if bc.OnVAPIDPublicKey != nil {
+			bc.OnVAPIDPublicKey(vapidKeys.PublicKey)
+		}
+
+		subject := strings.TrimSpace(bc.Config.VAPIDSubject)
+		if subject == "" {
+			if bc.DevMode {
+				subject = "mailto:admin@example.com"
+				log.Println("Web Push: VAPID_SUBJECT not set, using default mailto:admin@example.com (development mode only)")
+			} else {
+				log.Fatalf("Web Push: VAPID_SUBJECT is required in production (e.g. mailto:admin@mycompany.com or https://example.com/contact)")
+			}
+		}
+
+		return []notify.Sender{New(vapidKeys, subject, bc.DB)}, nil
+	})
+}

--- a/notify/webpush/register.go
+++ b/notify/webpush/register.go
@@ -2,6 +2,7 @@ package webpush
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -23,7 +24,11 @@ func init() {
 				log.Printf("Warning: failed to initialize VAPID keys: %v", err)
 				return nil, nil
 			}
-			log.Fatalf("Failed to initialize VAPID keys: %v", err)
+			// Return an error so BuildSenders logs it and skips web push.
+			// In production the startup validator (validateConfig) already
+			// ensures VAPID env vars are present, so this path indicates an
+			// unexpected database failure rather than misconfiguration.
+			return nil, fmt.Errorf("initialize VAPID keys: %w", err)
 		}
 		if vapidKeys == nil {
 			return nil, nil
@@ -39,7 +44,11 @@ func init() {
 				subject = "mailto:admin@example.com"
 				log.Println("Web Push: VAPID_SUBJECT not set, using default mailto:admin@example.com (development mode only)")
 			} else {
-				log.Fatalf("Web Push: VAPID_SUBJECT is required in production (e.g. mailto:admin@mycompany.com or https://example.com/contact)")
+				// Return an error rather than calling log.Fatalf so that
+				// BuildSenders' error-handling contract is respected. In
+				// production validateConfig already catches a missing
+				// VAPID_SUBJECT before the server starts.
+				return nil, fmt.Errorf("VAPID_SUBJECT is required in production (e.g. mailto:admin@mycompany.com or https://example.com/contact)")
 			}
 		}
 

--- a/notify/webpush/register.go
+++ b/notify/webpush/register.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	notify.RegisterSenderFactory(func(ctx context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
+	notify.RegisterSenderFactory("web-push", func(ctx context.Context, bc notify.BuildContext) ([]notify.Sender, error) {
 		if bc.DB == nil {
 			return nil, nil
 		}


### PR DESCRIPTION
## Summary

- Replaces 60 lines of inline notification sender setup in `main.go` with a single `notify.BuildSenders()` call, following the same self-registration pattern used by connectors
- Introduces `notify/registry.go` with a `BuildContext` + `SenderFactory` pattern so each channel self-registers via `init()` in its own `register.go` file
- SMS plan gating (previously inline in main.go) moves into the SMS factory, applied automatically when a DB is available
- Web push VAPID init and mobile push setup each have their own factory; VAPID public key is communicated back via an `OnVAPIDPublicKey` callback on `BuildContext`
- Adds `notify/all/all.go` as the blank-import entry point (mirrors `connectors/all`)

## Work items

### Claude Code
- [x] Add a test for `notify.BuildSenders()` exercising the registry directly (with a mock factory)

### OpenClaw
- [ ] Verify that existing deployment configs still work end-to-end (notification channels fire correctly after deploy)
- [x] Review whether the `log.Fatalf` calls inside factories are acceptable, or should be surfaced as errors instead — fixed: factories now return errors instead of calling log.Fatalf (commit 512803a)