### PR TITLE
Add Twilio SMS notification on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,28 @@ jobs:
 
       - name: Build
         run: make build
+
+  notify-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [backend, frontend, mobile, build]
+    if: ${{ failure() && github.event_name == 'push' }}
+    steps:
+      - name: Send Twilio SMS
+        env:
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_PHONE_FROM: ${{ secrets.TWILIO_PHONE_FROM }}
+          TWILIO_PHONE_TO: ${{ secrets.TWILIO_PHONE_TO }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BRANCH="${{ github.ref_name }}"
+          TITLE="${{ github.workflow }}"
+          MESSAGE="permission-slip CI failed: ${TITLE} on ${BRANCH} — ${RUN_URL}"
+
+          curl -s -f -X POST \
+            "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json" \
+            -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+            --data-urlencode "To=${TWILIO_PHONE_TO}" \
+            --data-urlencode "From=${TWILIO_PHONE_FROM}" \
+            --data-urlencode "Body=${MESSAGE}"


### PR DESCRIPTION
Adds a notify-failure job that sends an SMS via Twilio when any CI job fails on main. Includes the workflow name, branch, and a link to the failed run. Skips notification for manual workflow_dispatch runs.

https://claude.ai/code/session_01Awpo4sGybVhT7Nss5eniBG