### PR TITLE
Refactor background jobs to self-registering pattern

### DIFF
--- a/background_card_expiry.go
+++ b/background_card_expiry.go
@@ -8,9 +8,26 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/supersuit-tech/permission-slip-web/api"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/notify"
 )
+
+func init() {
+	RegisterBackgroundJob(BackgroundJob{
+		Name: "card expiry check",
+		Start: func(ctx context.Context, deps *api.Deps, logger *slog.Logger) <-chan struct{} {
+			if deps.DB == nil || deps.Notifier == nil {
+				return nil
+			}
+			return startCardExpiryCheck(ctx, CardExpiryCheckDeps{
+				DB:       deps.DB,
+				Notifier: deps.Notifier,
+				BaseURL:  deps.BaseURL,
+			}, logger)
+		},
+	})
+}
 
 // CardExpiryCheckDeps holds the dependencies for the background card
 // expiration check job.

--- a/background_oauth.go
+++ b/background_oauth.go
@@ -8,10 +8,27 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/supersuit-tech/permission-slip-web/api"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/oauth"
 	"github.com/supersuit-tech/permission-slip-web/vault"
 )
+
+func init() {
+	RegisterBackgroundJob(BackgroundJob{
+		Name: "oauth refresh",
+		Start: func(ctx context.Context, deps *api.Deps, logger *slog.Logger) <-chan struct{} {
+			if deps.DB == nil || deps.Vault == nil || deps.OAuthProviders == nil {
+				return nil
+			}
+			return startOAuthRefresh(ctx, OAuthRefreshDeps{
+				DB:       deps.DB,
+				Vault:    deps.Vault,
+				Registry: deps.OAuthProviders,
+			}, logger)
+		},
+	})
+}
 
 // oauthRefreshHorizon is the time window before token expiry within which
 // the background job proactively refreshes tokens. This prevents execution-time

--- a/background_registry.go
+++ b/background_registry.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/supersuit-tech/permission-slip-web/api"
+)
+
+// BackgroundJob describes a self-registering background job.
+// Each job provides a Name for logging and a Start function that launches
+// the goroutine and returns a done channel (closed when the goroutine exits).
+// Start may return nil if required dependencies are absent — callers skip nil channels.
+type BackgroundJob struct {
+	Name  string
+	Start func(ctx context.Context, deps *api.Deps, logger *slog.Logger) <-chan struct{}
+}
+
+var backgroundJobs []BackgroundJob
+
+// RegisterBackgroundJob appends a job to the global registry.
+// Call this from an init() function in each job file.
+func RegisterBackgroundJob(job BackgroundJob) {
+	backgroundJobs = append(backgroundJobs, job)
+}

--- a/main.go
+++ b/main.go
@@ -179,8 +179,10 @@ func main() {
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	defer bgCancel()
 	var auditPurgeDone <-chan struct{}
-	var oauthRefreshDone <-chan struct{}
-	var cardExpiryCheckDone <-chan struct{}
+	var bgJobDone []struct {
+		name string
+		done <-chan struct{}
+	}
 
 	// Connect to Postgres if DATABASE_URL is set
 	if dbURL := os.Getenv("DATABASE_URL"); dbURL != "" {
@@ -348,22 +350,14 @@ func main() {
 		loadBYOAProviderConfigs(oauthRegistry, deps.DB, deps.Vault)
 	}
 
-	// Start background OAuth token refresh job (requires DB, vault, and OAuth registry).
-	if deps.DB != nil && deps.Vault != nil {
-		oauthRefreshDone = startOAuthRefresh(bgCtx, OAuthRefreshDeps{
-			DB:       deps.DB,
-			Vault:    deps.Vault,
-			Registry: oauthRegistry,
-		}, logger)
-	}
-
-	// Start background card expiration check (requires DB + notifier).
-	if deps.DB != nil && deps.Notifier != nil {
-		cardExpiryCheckDone = startCardExpiryCheck(bgCtx, CardExpiryCheckDeps{
-			DB:       deps.DB,
-			Notifier: deps.Notifier,
-			BaseURL:  deps.BaseURL,
-		}, logger)
+	// Start all registered background jobs.
+	for _, job := range backgroundJobs {
+		if done := job.Start(bgCtx, &deps, logger); done != nil {
+			bgJobDone = append(bgJobDone, struct {
+				name string
+				done <-chan struct{}
+			}{name: job.Name, done: done})
+		}
 	}
 
 	log.Printf("Connector registry: %d connector(s) registered", len(registry.IDs()))
@@ -504,18 +498,11 @@ func main() {
 			logger.Warn("audit purge goroutine did not exit in time")
 		}
 	}
-	if oauthRefreshDone != nil {
+	for _, j := range bgJobDone {
 		select {
-		case <-oauthRefreshDone:
+		case <-j.done:
 		case <-time.After(5 * time.Second):
-			logger.Warn("oauth refresh goroutine did not exit in time")
-		}
-	}
-	if cardExpiryCheckDone != nil {
-		select {
-		case <-cardExpiryCheckDone:
-		case <-time.After(5 * time.Second):
-			logger.Warn("card expiry check goroutine did not exit in time")
+			logger.Warn("background job did not exit in time", "job", j.name)
 		}
 	}
 


### PR DESCRIPTION
Each background job now registers itself via init() using RegisterBackgroundJob(),
following the same pattern as API route groups. main.go iterates over the registry
to start jobs and wait for shutdown, eliminating inline conditional logic that
grows with every new job added.

Closes #391

https://claude.ai/code/session_016f72KeaYwUgLRfEd3WjNjm