### PR TITLE
Add SendGrid transactional email, create contact, bounces, and suppressions actions

### DIFF
--- a/connectors/sendgrid/README.md
+++ b/connectors/sendgrid/README.md
@@ -24,48 +24,91 @@ The API key needs these scopes depending on which actions you enable:
 
 | Scope | Actions |
 |-------|---------|
+| Mail Send | `send_transactional_email` |
 | Marketing > Single Sends | `send_campaign`, `schedule_campaign`, `get_campaign_stats` |
-| Marketing > Contacts | `add_to_list`, `remove_from_list`, `list_lists` |
+| Marketing > Contacts | `add_to_list`, `remove_from_list`, `create_contact`, `list_lists` |
 | Marketing > Segments | `list_segments` |
 | Templates | `create_template` |
 | Sender Verification | `list_senders` |
+| Suppressions > Bounces | `get_bounces` |
+| Suppressions > Unsubscribes | `get_suppressions` |
 
 ## Actions
+
+### Transactional Email
+
+| Action Type | Name | Risk | Description |
+|---|---|---|---|
+| `sendgrid.send_transactional_email` | Send Transactional Email | high | Send a single email via the Mail Send API (welcome, password reset, order confirmation). Supports dynamic templates with Handlebars substitution, CC/BCC, reply-to, and categories. Returns `message_id` from `X-Message-Id` for delivery tracking. |
+
+### Contact Management
+
+| Action Type | Name | Risk | Description |
+|---|---|---|---|
+| `sendgrid.create_contact` | Create Contact | medium | Upsert a contact in SendGrid globally (no list required). Supports name, phone, city, country. Returns a `job_id` — the operation is async. |
+| `sendgrid.add_to_list` | Add Subscriber to List | medium | Add a contact to a marketing contact list |
+| `sendgrid.remove_from_list` | Remove Subscriber from List | medium | Remove a contact from a contact list |
+
+### Deliverability & Suppressions
+
+| Action Type | Name | Risk | Description |
+|---|---|---|---|
+| `sendgrid.get_bounces` | Get Bounce List | low | Retrieve bounced addresses with reason, SMTP status, and ISO-8601 timestamp. Supports time range (RFC3339) and pagination. |
+| `sendgrid.get_suppressions` | Get Suppression List | low | Retrieve global unsubscribes with ISO-8601 timestamp. Supports pagination. |
+
+### Marketing Campaigns
 
 | Action Type | Name | Risk | Description |
 |---|---|---|---|
 | `sendgrid.send_campaign` | Send Email Campaign | high | Create and immediately send a single send email campaign |
 | `sendgrid.schedule_campaign` | Schedule Email Campaign | high | Create and schedule a single send campaign for future delivery |
-| `sendgrid.add_to_list` | Add Subscriber to List | medium | Add a contact to a marketing contact list |
-| `sendgrid.remove_from_list` | Remove Subscriber from List | medium | Remove a contact from a contact list |
-| `sendgrid.create_template` | Create Email Template | medium | Create a dynamic transactional email template |
 | `sendgrid.get_campaign_stats` | Get Campaign Stats | low | Get analytics for a campaign (opens, clicks, bounces) |
+
+### Discovery (Read-Only)
+
+| Action Type | Name | Risk | Description |
+|---|---|---|---|
+| `sendgrid.create_template` | Create Email Template | medium | Create a dynamic transactional email template |
 | `sendgrid.list_segments` | List Segments | low | List all contact segments in the account |
 | `sendgrid.list_senders` | List Verified Senders | low | List verified sender identities (find sender_id for campaigns) |
 | `sendgrid.list_lists` | List Contact Lists | low | List contact lists with subscriber counts (find list_id values) |
 
 ### Risk Levels
 
-- **High:** `send_campaign`, `schedule_campaign` — sends to potentially thousands of recipients. The blast radius of a bad email is large, so these always require approval.
-- **Medium:** `add_to_list`, `remove_from_list`, `create_template` — modifies audience data or content.
-- **Low:** `get_campaign_stats`, `list_segments`, `list_senders`, `list_lists` — read-only operations with no side effects.
+- **High:** `send_campaign`, `schedule_campaign`, `send_transactional_email` — sends emails to real recipients. The blast radius of a bad email is large, so these always require approval.
+- **Medium:** `add_to_list`, `remove_from_list`, `create_contact`, `create_template` — modifies audience data or content.
+- **Low:** `get_campaign_stats`, `get_bounces`, `get_suppressions`, `list_segments`, `list_senders`, `list_lists` — read-only operations with no side effects.
 
 ### Discovery Actions
 
-Before creating campaigns, agents typically need to discover available resources:
+Before creating campaigns or transactional emails, agents typically need to discover available resources:
 - **`list_senders`** — find `sender_id` values (required for campaigns)
 - **`list_lists`** — find `list_id` values (required for campaigns and subscriber management)
 - **`list_segments`** — find segments for targeted campaigns
 
 These are all low-risk, read-only actions that help agents work autonomously without requiring users to look up IDs manually.
 
-### Typical Agent Workflow
+### Typical Agent Workflows
+
+**Transactional Email (e.g. welcome email, password reset):**
+
+1. Call `send_transactional_email` with `to`, `from` (a verified sender), `subject`, and `html_content` or `template_id`
+2. Use the returned `message_id` for delivery tracking in the SendGrid Activity Feed
+3. Optionally, call `get_bounces` or `get_suppressions` to verify deliverability health
+
+**Marketing Campaign:**
 
 1. Call `list_senders` to find the verified sender identity to use
 2. Call `list_lists` to find the target audience list(s)
 3. Draft the campaign content (subject, HTML/plain text body)
 4. Call `send_campaign` or `schedule_campaign` (requires human approval due to high risk)
 5. After sending, call `get_campaign_stats` to monitor delivery and engagement
+
+**Deliverability Audit:**
+
+1. Call `get_bounces` with a time range to identify problematic addresses
+2. Call `get_suppressions` to review your global unsubscribe list
+3. Use this data to clean contact lists and improve sender reputation
 
 ### Campaign Sending
 
@@ -80,12 +123,26 @@ Both steps happen atomically within a single action execution.
 Some SendGrid operations are asynchronous:
 - **`add_to_list`** returns a `job_id` — the contact import runs in the background
 - **`remove_from_list`** returns a `job_id` — the removal runs in the background
+- **`create_contact`** returns a `job_id` — the upsert runs in the background
 
-Both operations return immediately with `"status": "accepted"`. The actual processing happens asynchronously on SendGrid's side.
+These operations return immediately with `"status": "accepted"`. The actual processing happens asynchronously on SendGrid's side.
+
+### Transactional Email Delivery
+
+`send_transactional_email` calls `POST /mail/send` which responds `202 Accepted` — the message is queued for delivery, **not** guaranteed delivered. The action returns `"status": "accepted"` to reflect this accurately. Use the `message_id` field in the result to look up delivery status in the [SendGrid Activity Feed](https://docs.sendgrid.com/ui/analytics-and-reporting/email-activity-feed).
+
+To debug delivery issues, check:
+- **`get_bounces`** — hard/soft bounces with SMTP reason codes
+- **`get_suppressions`** — global unsubscribes (address opted out of all email)
 
 ### Email Validation
 
-The `add_to_list` action validates email addresses with a basic pattern check (`user@domain.tld`) before making the API call. This catches obviously invalid addresses early.
+All actions that accept email addresses validate them with a basic pattern check (`user@domain.tld`) before making the API call. This catches obviously invalid addresses early and avoids a round trip to the SendGrid API.
+
+`send_transactional_email` applies additional bounds:
+- `subject`: max 998 characters (RFC 2822 §2.1.1 line length limit)
+- `cc` / `bcc`: max 100 addresses each (prevents bulk-sending abuse; SendGrid's limit is 1000 total recipients)
+- `categories`: max 10 items, each max 255 characters (SendGrid's documented limits)
 
 ## Templates
 
@@ -105,6 +162,10 @@ The locked-list templates are the recommended starting point — they let agents
 
 | Action | Method | Endpoint |
 |--------|--------|----------|
+| send_transactional_email | POST | `/mail/send` |
+| create_contact | PUT | `/marketing/contacts` |
+| get_bounces | GET | `/suppression/bounces` |
+| get_suppressions | GET | `/suppression/unsubscribes` |
 | send_campaign | POST + PUT | `/marketing/singlesends` then `/marketing/singlesends/{id}/schedule` |
 | schedule_campaign | POST + PUT | `/marketing/singlesends` then `/marketing/singlesends/{id}/schedule` |
 | add_to_list | PUT | `/marketing/contacts` |
@@ -143,30 +204,35 @@ All responses are capped at 1 MiB (`io.LimitReader`) to prevent memory exhaustio
 
 ```
 connectors/sendgrid/
-├── sendgrid.go              # SendGridConnector struct, New(), Actions(), ValidateCredentials(), doJSON()
-├── manifest.go              # Manifest() — action definitions, credentials, templates
-├── campaign.go              # Shared campaignFields validation + buildSingleSendBody()
-├── response.go              # checkResponse() — HTTP status → typed error mapping
-├── send_campaign.go         # sendgrid.send_campaign action
-├── schedule_campaign.go     # sendgrid.schedule_campaign action
-├── add_to_list.go           # sendgrid.add_to_list action
-├── remove_from_list.go      # sendgrid.remove_from_list action
-├── create_template.go       # sendgrid.create_template action
-├── get_campaign_stats.go    # sendgrid.get_campaign_stats action
-├── list_segments.go         # sendgrid.list_segments action
-├── list_senders.go          # sendgrid.list_senders action
-├── list_lists.go            # sendgrid.list_lists action
-├── *_test.go                # Tests for each action + connector + response
-├── helpers_test.go          # Shared test helpers (validCreds, testAPIKey)
-└── README.md                # This file
+├── sendgrid.go                    # Connector struct, New(), Actions(), ValidateCredentials(),
+│                                  # doRequest() (shared HTTP layer), doJSON(), doJSONCapturingHeader()
+├── manifest.go                    # Manifest() — action definitions, credentials, templates
+├── campaign.go                    # Shared campaignFields validation + buildSingleSendBody()
+├── response.go                    # checkResponse(), unixToISO(), validateEmailAddresses()
+├── send_transactional_email.go    # sendgrid.send_transactional_email action
+├── create_contact.go              # sendgrid.create_contact action
+├── get_bounces.go                 # sendgrid.get_bounces action
+├── get_suppressions.go            # sendgrid.get_suppressions action
+├── send_campaign.go               # sendgrid.send_campaign action
+├── schedule_campaign.go           # sendgrid.schedule_campaign action
+├── add_to_list.go                 # sendgrid.add_to_list action
+├── remove_from_list.go            # sendgrid.remove_from_list action
+├── create_template.go             # sendgrid.create_template action
+├── get_campaign_stats.go          # sendgrid.get_campaign_stats action
+├── list_segments.go               # sendgrid.list_segments action
+├── list_senders.go                # sendgrid.list_senders action
+├── list_lists.go                  # sendgrid.list_lists action
+├── *_test.go                      # Tests for each action + connector + response
+├── helpers_test.go                # Shared test helpers (validCreds, testAPIKey)
+└── README.md                      # This file
 ```
 
 ### Architecture
 
-- **`sendgrid.go`** — Connector setup, HTTP client, credential validation, and the shared `doJSON()` method
+- **`sendgrid.go`** — Connector setup, HTTP client, credential validation, and the shared HTTP dispatch layer. `doRequest()` is the single implementation of auth, request building, error classification, and response buffering — all other HTTP methods delegate here so that security and error-handling fixes propagate to every action automatically.
 - **`manifest.go`** — All action metadata, parameter schemas, credential requirements, and templates (separated for maintainability)
 - **`campaign.go`** — Shared `campaignFields` struct and validation used by both `send_campaign` and `schedule_campaign`, plus the `buildSingleSendBody()` helper
-- **`response.go`** — Centralized HTTP status code → typed error mapping
+- **`response.go`** — Centralized HTTP status code → typed error mapping (`checkResponse()`), plus shared package utilities: `unixToISO()` for consistent timestamp formatting and `validateEmailAddresses()` for reusable email list validation
 - **Action files** — One file per action, each containing the action struct, parameter validation, and Execute method
 
 ## Testing

--- a/connectors/sendgrid/add_to_list.go
+++ b/connectors/sendgrid/add_to_list.go
@@ -5,14 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
-
-// emailPattern is a basic email validation regex. It does not cover all
-// RFC 5322 edge cases but rejects obviously invalid addresses.
-var emailPattern = regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`)
 
 // addToListAction implements connectors.Action for sendgrid.add_to_list.
 // It adds a contact to a SendGrid marketing contact list using the

--- a/connectors/sendgrid/create_contact.go
+++ b/connectors/sendgrid/create_contact.go
@@ -1,0 +1,81 @@
+package sendgrid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createContactAction implements connectors.Action for sendgrid.create_contact.
+// It upserts a contact in SendGrid without requiring a list, using the
+// PUT /marketing/contacts endpoint with no list_ids.
+type createContactAction struct {
+	conn *SendGridConnector
+}
+
+type createContactParams struct {
+	Email     string `json:"email"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Phone     string `json:"phone_number"`
+	City      string `json:"city"`
+	Country   string `json:"country"`
+}
+
+func (p *createContactParams) validate() error {
+	if p.Email == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: email"}
+	}
+	if !emailPattern.MatchString(p.Email) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid email address: %q", p.Email)}
+	}
+	return nil
+}
+
+// Execute upserts a contact via PUT /marketing/contacts.
+func (a *createContactAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params createContactParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	contact := map[string]string{"email": params.Email}
+	if params.FirstName != "" {
+		contact["first_name"] = params.FirstName
+	}
+	if params.LastName != "" {
+		contact["last_name"] = params.LastName
+	}
+	if params.Phone != "" {
+		contact["phone_number"] = params.Phone
+	}
+	if params.City != "" {
+		contact["city"] = params.City
+	}
+	if params.Country != "" {
+		contact["country"] = params.Country
+	}
+
+	body := map[string]any{
+		"contacts": []map[string]string{contact},
+	}
+
+	var resp struct {
+		JobID string `json:"job_id"`
+	}
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPut, "/marketing/contacts", body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"job_id": resp.JobID,
+		"email":  params.Email,
+		"status": "accepted",
+	})
+}

--- a/connectors/sendgrid/create_contact_test.go
+++ b/connectors/sendgrid/create_contact_test.go
@@ -1,0 +1,96 @@
+package sendgrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateContact_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/marketing/contacts" {
+			t.Errorf("got %s %s, want PUT /marketing/contacts", r.Method, r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding body: %v", err)
+			return
+		}
+
+		// No list_ids — this is the key difference from add_to_list.
+		if _, hasListIDs := body["list_ids"]; hasListIDs {
+			t.Error("create_contact should not send list_ids")
+		}
+
+		contacts, ok := body["contacts"].([]any)
+		if !ok || len(contacts) != 1 {
+			t.Errorf("contacts = %v, want 1 contact", body["contacts"])
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]any{"job_id": "job_contact_123"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.create_contact"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.create_contact",
+		Parameters:  json.RawMessage(`{"email":"contact@example.com","first_name":"Jane","last_name":"Doe","city":"Portland","country":"US"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["job_id"] != "job_contact_123" {
+		t.Errorf("job_id = %v, want job_contact_123", data["job_id"])
+	}
+	if data["status"] != "accepted" {
+		t.Errorf("status = %v, want accepted", data["status"])
+	}
+}
+
+func TestCreateContact_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["sendgrid.create_contact"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{name: "missing email", params: `{"first_name":"Jane"}`},
+		{name: "invalid email", params: `{"email":"not-an-email"}`},
+		{name: "invalid JSON", params: `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "sendgrid.create_contact",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/sendgrid/get_bounces.go
+++ b/connectors/sendgrid/get_bounces.go
@@ -23,18 +23,27 @@ type getBouncesParams struct {
 	EndTime   string `json:"end_time"`
 	Limit     int    `json:"limit"`
 	Offset    int    `json:"offset"`
+
+	// parsedStart/parsedEnd hold the validated time.Time values so Execute
+	// doesn't need to re-parse (and cannot silently discard parse errors).
+	parsedStart time.Time
+	parsedEnd   time.Time
 }
 
 func (p *getBouncesParams) validate() error {
 	if p.StartTime != "" {
-		if _, err := time.Parse(time.RFC3339, p.StartTime); err != nil {
+		t, err := time.Parse(time.RFC3339, p.StartTime)
+		if err != nil {
 			return &connectors.ValidationError{Message: fmt.Sprintf("invalid start_time format (use RFC3339, e.g. 2026-01-01T00:00:00Z): %v", err)}
 		}
+		p.parsedStart = t
 	}
 	if p.EndTime != "" {
-		if _, err := time.Parse(time.RFC3339, p.EndTime); err != nil {
+		t, err := time.Parse(time.RFC3339, p.EndTime)
+		if err != nil {
 			return &connectors.ValidationError{Message: fmt.Sprintf("invalid end_time format (use RFC3339, e.g. 2026-01-31T23:59:59Z): %v", err)}
 		}
+		p.parsedEnd = t
 	}
 	if p.Limit < 0 {
 		return &connectors.ValidationError{Message: "limit must be non-negative"}
@@ -73,13 +82,11 @@ func (a *getBouncesAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	q := url.Values{}
-	if params.StartTime != "" {
-		t, _ := time.Parse(time.RFC3339, params.StartTime)
-		q.Set("start_time", strconv.FormatInt(t.Unix(), 10))
+	if !params.parsedStart.IsZero() {
+		q.Set("start_time", strconv.FormatInt(params.parsedStart.Unix(), 10))
 	}
-	if params.EndTime != "" {
-		t, _ := time.Parse(time.RFC3339, params.EndTime)
-		q.Set("end_time", strconv.FormatInt(t.Unix(), 10))
+	if !params.parsedEnd.IsZero() {
+		q.Set("end_time", strconv.FormatInt(params.parsedEnd.Unix(), 10))
 	}
 	if params.Limit > 0 {
 		q.Set("limit", strconv.Itoa(params.Limit))

--- a/connectors/sendgrid/get_bounces.go
+++ b/connectors/sendgrid/get_bounces.go
@@ -108,7 +108,7 @@ func (a *getBouncesAction) Execute(ctx context.Context, req connectors.ActionReq
 	results := make([]bounceResult, len(raw))
 	for i, b := range raw {
 		results[i] = bounceResult{
-			CreatedAt: time.Unix(b.Created, 0).UTC().Format(time.RFC3339),
+			CreatedAt: unixToISO(b.Created),
 			Email:     b.Email,
 			Reason:    b.Reason,
 			Status:    b.Status,

--- a/connectors/sendgrid/get_bounces.go
+++ b/connectors/sendgrid/get_bounces.go
@@ -45,11 +45,21 @@ func (p *getBouncesParams) validate() error {
 	return nil
 }
 
+// bounceEntry is the raw SendGrid API response shape for a bounce record.
+// created is a Unix timestamp; we convert it to ISO-8601 in the action result.
 type bounceEntry struct {
 	Created int64  `json:"created"`
 	Email   string `json:"email"`
 	Reason  string `json:"reason"`
 	Status  string `json:"status"`
+}
+
+// bounceResult is the human-friendly representation returned to callers.
+type bounceResult struct {
+	CreatedAt string `json:"created_at"` // ISO-8601, e.g. "2026-01-14T10:00:00Z"
+	Email     string `json:"email"`
+	Reason    string `json:"reason"`
+	Status    string `json:"status"`
 }
 
 // Execute retrieves bounces via GET /suppression/bounces.
@@ -83,13 +93,23 @@ func (a *getBouncesAction) Execute(ctx context.Context, req connectors.ActionReq
 		path += "?" + q.Encode()
 	}
 
-	var bounces []bounceEntry
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, path, nil, &bounces); err != nil {
+	var raw []bounceEntry
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, path, nil, &raw); err != nil {
 		return nil, err
 	}
 
+	results := make([]bounceResult, len(raw))
+	for i, b := range raw {
+		results[i] = bounceResult{
+			CreatedAt: time.Unix(b.Created, 0).UTC().Format(time.RFC3339),
+			Email:     b.Email,
+			Reason:    b.Reason,
+			Status:    b.Status,
+		}
+	}
+
 	return connectors.JSONResult(map[string]any{
-		"bounces": bounces,
-		"count":   len(bounces),
+		"bounces": results,
+		"count":   len(results),
 	})
 }

--- a/connectors/sendgrid/get_bounces.go
+++ b/connectors/sendgrid/get_bounces.go
@@ -1,0 +1,95 @@
+package sendgrid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getBouncesAction implements connectors.Action for sendgrid.get_bounces.
+// It retrieves the bounce list from the SendGrid v3 suppression/bounces endpoint.
+type getBouncesAction struct {
+	conn *SendGridConnector
+}
+
+type getBouncesParams struct {
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+	Limit     int    `json:"limit"`
+	Offset    int    `json:"offset"`
+}
+
+func (p *getBouncesParams) validate() error {
+	if p.StartTime != "" {
+		if _, err := time.Parse(time.RFC3339, p.StartTime); err != nil {
+			return &connectors.ValidationError{Message: fmt.Sprintf("invalid start_time format (use RFC3339, e.g. 2026-01-01T00:00:00Z): %v", err)}
+		}
+	}
+	if p.EndTime != "" {
+		if _, err := time.Parse(time.RFC3339, p.EndTime); err != nil {
+			return &connectors.ValidationError{Message: fmt.Sprintf("invalid end_time format (use RFC3339, e.g. 2026-01-31T23:59:59Z): %v", err)}
+		}
+	}
+	if p.Limit < 0 {
+		return &connectors.ValidationError{Message: "limit must be non-negative"}
+	}
+	if p.Offset < 0 {
+		return &connectors.ValidationError{Message: "offset must be non-negative"}
+	}
+	return nil
+}
+
+type bounceEntry struct {
+	Created int64  `json:"created"`
+	Email   string `json:"email"`
+	Reason  string `json:"reason"`
+	Status  string `json:"status"`
+}
+
+// Execute retrieves bounces via GET /suppression/bounces.
+func (a *getBouncesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getBouncesParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	if params.StartTime != "" {
+		t, _ := time.Parse(time.RFC3339, params.StartTime)
+		q.Set("start_time", strconv.FormatInt(t.Unix(), 10))
+	}
+	if params.EndTime != "" {
+		t, _ := time.Parse(time.RFC3339, params.EndTime)
+		q.Set("end_time", strconv.FormatInt(t.Unix(), 10))
+	}
+	if params.Limit > 0 {
+		q.Set("limit", strconv.Itoa(params.Limit))
+	}
+	if params.Offset > 0 {
+		q.Set("offset", strconv.Itoa(params.Offset))
+	}
+
+	path := "/suppression/bounces"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	var bounces []bounceEntry
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, path, nil, &bounces); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"bounces": bounces,
+		"count":   len(bounces),
+	})
+}

--- a/connectors/sendgrid/get_bounces_test.go
+++ b/connectors/sendgrid/get_bounces_test.go
@@ -44,6 +44,16 @@ func TestGetBounces_Success(t *testing.T) {
 	if data["count"] != float64(1) {
 		t.Errorf("count = %v, want 1", data["count"])
 	}
+
+	// Timestamps should be ISO-8601 strings, not raw unix integers.
+	bounces := data["bounces"].([]any)
+	first := bounces[0].(map[string]any)
+	if _, ok := first["created_at"].(string); !ok {
+		t.Errorf("bounces[0].created_at should be a string, got %T", first["created_at"])
+	}
+	if _, exists := first["created"]; exists {
+		t.Errorf("bounces[0] should not expose raw 'created' unix timestamp — use 'created_at'")
+	}
 }
 
 func TestGetBounces_WithTimeRange(t *testing.T) {

--- a/connectors/sendgrid/get_bounces_test.go
+++ b/connectors/sendgrid/get_bounces_test.go
@@ -1,0 +1,110 @@
+package sendgrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetBounces_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/suppression/bounces" {
+			t.Errorf("got %s %s, want GET /suppression/bounces", r.Method, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"email": "bounced@example.com", "reason": "550 No such user", "status": "5.1.1", "created": 1700000000},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.get_bounces"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.get_bounces",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["count"] != float64(1) {
+		t.Errorf("count = %v, want 1", data["count"])
+	}
+}
+
+func TestGetBounces_WithTimeRange(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("start_time") == "" {
+			t.Error("expected start_time query param")
+		}
+		if q.Get("end_time") == "" {
+			t.Error("expected end_time query param")
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.get_bounces"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.get_bounces",
+		Parameters:  json.RawMessage(`{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-31T23:59:59Z"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
+func TestGetBounces_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["sendgrid.get_bounces"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{name: "invalid start_time", params: `{"start_time":"not-a-date"}`},
+		{name: "invalid end_time", params: `{"end_time":"not-a-date"}`},
+		{name: "negative limit", params: `{"limit":-1}`},
+		{name: "negative offset", params: `{"offset":-1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "sendgrid.get_bounces",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/sendgrid/get_suppressions.go
+++ b/connectors/sendgrid/get_suppressions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -32,9 +33,17 @@ func (p *getSuppressionsParams) validate() error {
 	return nil
 }
 
+// suppressionEntry is the raw SendGrid API response shape for an unsubscribe record.
+// created is a Unix timestamp; we convert it to ISO-8601 in the action result.
 type suppressionEntry struct {
 	Created int64  `json:"created"`
 	Email   string `json:"email"`
+}
+
+// suppressionResult is the human-friendly representation returned to callers.
+type suppressionResult struct {
+	CreatedAt string `json:"created_at"` // ISO-8601, e.g. "2026-01-14T10:00:00Z"
+	Email     string `json:"email"`
 }
 
 // Execute retrieves global unsubscribes via GET /suppression/unsubscribes.
@@ -57,13 +66,21 @@ func (a *getSuppressionsAction) Execute(ctx context.Context, req connectors.Acti
 		path += sep + "offset=" + strconv.Itoa(params.Offset)
 	}
 
-	var suppressions []suppressionEntry
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, path, nil, &suppressions); err != nil {
+	var raw []suppressionEntry
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, path, nil, &raw); err != nil {
 		return nil, err
 	}
 
+	results := make([]suppressionResult, len(raw))
+	for i, s := range raw {
+		results[i] = suppressionResult{
+			CreatedAt: time.Unix(s.Created, 0).UTC().Format(time.RFC3339),
+			Email:     s.Email,
+		}
+	}
+
 	return connectors.JSONResult(map[string]any{
-		"suppressions": suppressions,
-		"count":        len(suppressions),
+		"suppressions": results,
+		"count":        len(results),
 	})
 }

--- a/connectors/sendgrid/get_suppressions.go
+++ b/connectors/sendgrid/get_suppressions.go
@@ -1,0 +1,69 @@
+package sendgrid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getSuppressionsAction implements connectors.Action for sendgrid.get_suppressions.
+// It retrieves global unsubscribes from the SendGrid v3
+// GET /suppression/unsubscribes endpoint.
+type getSuppressionsAction struct {
+	conn *SendGridConnector
+}
+
+type getSuppressionsParams struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+func (p *getSuppressionsParams) validate() error {
+	if p.Limit < 0 {
+		return &connectors.ValidationError{Message: "limit must be non-negative"}
+	}
+	if p.Offset < 0 {
+		return &connectors.ValidationError{Message: "offset must be non-negative"}
+	}
+	return nil
+}
+
+type suppressionEntry struct {
+	Created int64  `json:"created"`
+	Email   string `json:"email"`
+}
+
+// Execute retrieves global unsubscribes via GET /suppression/unsubscribes.
+func (a *getSuppressionsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getSuppressionsParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := "/suppression/unsubscribes"
+	sep := "?"
+	if params.Limit > 0 {
+		path += sep + "limit=" + strconv.Itoa(params.Limit)
+		sep = "&"
+	}
+	if params.Offset > 0 {
+		path += sep + "offset=" + strconv.Itoa(params.Offset)
+	}
+
+	var suppressions []suppressionEntry
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, path, nil, &suppressions); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"suppressions": suppressions,
+		"count":        len(suppressions),
+	})
+}

--- a/connectors/sendgrid/get_suppressions.go
+++ b/connectors/sendgrid/get_suppressions.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -74,7 +73,7 @@ func (a *getSuppressionsAction) Execute(ctx context.Context, req connectors.Acti
 	results := make([]suppressionResult, len(raw))
 	for i, s := range raw {
 		results[i] = suppressionResult{
-			CreatedAt: time.Unix(s.Created, 0).UTC().Format(time.RFC3339),
+			CreatedAt: unixToISO(s.Created),
 			Email:     s.Email,
 		}
 	}

--- a/connectors/sendgrid/get_suppressions_test.go
+++ b/connectors/sendgrid/get_suppressions_test.go
@@ -45,6 +45,16 @@ func TestGetSuppressions_Success(t *testing.T) {
 	if data["count"] != float64(2) {
 		t.Errorf("count = %v, want 2", data["count"])
 	}
+
+	// Timestamps should be ISO-8601 strings, not raw unix integers.
+	sups := data["suppressions"].([]any)
+	first := sups[0].(map[string]any)
+	if _, ok := first["created_at"].(string); !ok {
+		t.Errorf("suppressions[0].created_at should be a string, got %T", first["created_at"])
+	}
+	if _, exists := first["created"]; exists {
+		t.Errorf("suppressions[0] should not expose raw 'created' unix timestamp — use 'created_at'")
+	}
 }
 
 func TestGetSuppressions_WithPagination(t *testing.T) {

--- a/connectors/sendgrid/get_suppressions_test.go
+++ b/connectors/sendgrid/get_suppressions_test.go
@@ -1,0 +1,109 @@
+package sendgrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGetSuppressions_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/suppression/unsubscribes" {
+			t.Errorf("got %s %s, want GET /suppression/unsubscribes", r.Method, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"email": "unsub@example.com", "created": 1700000000},
+			{"email": "unsub2@example.com", "created": 1700001000},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.get_suppressions"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.get_suppressions",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["count"] != float64(2) {
+		t.Errorf("count = %v, want 2", data["count"])
+	}
+}
+
+func TestGetSuppressions_WithPagination(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("limit") != "10" {
+			t.Errorf("limit = %q, want 10", q.Get("limit"))
+		}
+		if q.Get("offset") != "20" {
+			t.Errorf("offset = %q, want 20", q.Get("offset"))
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.get_suppressions"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.get_suppressions",
+		Parameters:  json.RawMessage(`{"limit":10,"offset":20}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
+func TestGetSuppressions_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["sendgrid.get_suppressions"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{name: "negative limit", params: `{"limit":-1}`},
+		{name: "negative offset", params: `{"offset":-1}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "sendgrid.get_suppressions",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/sendgrid/manifest.go
+++ b/connectors/sendgrid/manifest.go
@@ -282,6 +282,22 @@ func (c *SendGridConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "string",
 							"format": "email",
 							"description": "Reply-to email address (optional)"
+						},
+						"cc": {
+							"type": "array",
+							"items": {"type": "string", "format": "email"},
+							"description": "CC recipients (optional). Useful for sending copies to account managers, team inboxes, etc."
+						},
+						"bcc": {
+							"type": "array",
+							"items": {"type": "string", "format": "email"},
+							"description": "BCC recipients (optional). Useful for silent compliance copies or audit trails."
+						},
+						"categories": {
+							"type": "array",
+							"items": {"type": "string"},
+							"maxItems": 10,
+							"description": "Labels for filtering and grouping in the SendGrid Activity Feed and stats (e.g. [\"welcome\", \"onboarding\"]). Maximum 10."
 						}
 					}
 				}`)),

--- a/connectors/sendgrid/manifest.go
+++ b/connectors/sendgrid/manifest.go
@@ -229,6 +229,152 @@ func (c *SendGridConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {}
 				}`)),
 			},
+			{
+				ActionType:  "sendgrid.send_transactional_email",
+				Name:        "Send Transactional Email",
+				Description: "Send a single transactional email (welcome, password reset, order confirmation, etc.) via the SendGrid v3 Mail Send API. Supports dynamic templates with Handlebars substitution.",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["to", "from"],
+					"properties": {
+						"to": {
+							"type": "string",
+							"format": "email",
+							"description": "Recipient email address"
+						},
+						"to_name": {
+							"type": "string",
+							"description": "Recipient display name (optional)"
+						},
+						"from": {
+							"type": "string",
+							"format": "email",
+							"description": "Sender email address — must be a verified sender in your SendGrid account"
+						},
+						"from_name": {
+							"type": "string",
+							"description": "Sender display name (optional)"
+						},
+						"subject": {
+							"type": "string",
+							"maxLength": 998,
+							"description": "Email subject line. Required when template_id is not provided."
+						},
+						"html_content": {
+							"type": "string",
+							"description": "HTML body. Required when template_id is not provided and plain_content is also absent."
+						},
+						"plain_content": {
+							"type": "string",
+							"description": "Plain-text body. Required when template_id is not provided and html_content is also absent."
+						},
+						"template_id": {
+							"type": "string",
+							"description": "SendGrid dynamic template ID (e.g. d-xxxx). When set, html_content/plain_content/subject can be omitted if defined in the template."
+						},
+						"dynamic_template_data": {
+							"type": "object",
+							"description": "Key/value pairs substituted into the dynamic template via Handlebars (e.g. {\"first_name\": \"Jane\"}). Only used when template_id is set.",
+							"additionalProperties": true
+						},
+						"reply_to": {
+							"type": "string",
+							"format": "email",
+							"description": "Reply-to email address (optional)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "sendgrid.create_contact",
+				Name:        "Create Contact",
+				Description: "Add or update a contact in SendGrid without assigning them to a specific list. Useful for building a global contact database.",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["email"],
+					"properties": {
+						"email": {
+							"type": "string",
+							"format": "email",
+							"description": "Contact email address"
+						},
+						"first_name": {
+							"type": "string",
+							"description": "Contact first name (optional)"
+						},
+						"last_name": {
+							"type": "string",
+							"description": "Contact last name (optional)"
+						},
+						"phone_number": {
+							"type": "string",
+							"description": "Contact phone number (optional)"
+						},
+						"city": {
+							"type": "string",
+							"description": "Contact city (optional)"
+						},
+						"country": {
+							"type": "string",
+							"description": "Contact country (optional)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "sendgrid.get_bounces",
+				Name:        "Get Bounce List",
+				Description: "Retrieve the list of email addresses that have bounced, with bounce reason and status. Useful for deliverability management.",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"start_time": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Filter bounces created after this time (ISO 8601, e.g. 2026-01-01T00:00:00Z)"
+						},
+						"end_time": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Filter bounces created before this time (ISO 8601, e.g. 2026-01-31T23:59:59Z)"
+						},
+						"limit": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Maximum number of results to return"
+						},
+						"offset": {
+							"type": "integer",
+							"minimum": 0,
+							"description": "Number of results to skip for pagination"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "sendgrid.get_suppressions",
+				Name:        "Get Suppression List",
+				Description: "Retrieve the global unsubscribe list — contacts who have opted out of all email. Useful for compliance and deliverability auditing.",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"limit": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Maximum number of results to return"
+						},
+						"offset": {
+							"type": "integer",
+							"minimum": 0,
+							"description": "Number of results to skip for pagination"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -324,6 +470,41 @@ func (c *SendGridConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "List contact lists",
 				Description: "Agent can list all contact lists to find list IDs.",
 				Parameters:  json.RawMessage(`{}`),
+			},
+			{
+				ID:          "tpl_sendgrid_send_transactional_email",
+				ActionType:  "sendgrid.send_transactional_email",
+				Name:        "Send transactional email",
+				Description: "Agent can send transactional emails (welcome, password reset, notifications) to any recipient from any verified sender.",
+				Parameters:  json.RawMessage(`{"to":"*","to_name":"*","from":"*","from_name":"*","subject":"*","html_content":"*","plain_content":"*","template_id":"*","dynamic_template_data":"*","reply_to":"*"}`),
+			},
+			{
+				ID:          "tpl_sendgrid_send_transactional_locked_sender",
+				ActionType:  "sendgrid.send_transactional_email",
+				Name:        "Send transactional email (locked sender)",
+				Description: "Locks the sender address — agent can only send from the specified verified sender. Safer than the unrestricted template.",
+				Parameters:  json.RawMessage(`{"to":"*","to_name":"*","from":"YOUR_VERIFIED_SENDER@example.com","from_name":"*","subject":"*","html_content":"*","plain_content":"*","template_id":"*","dynamic_template_data":"*"}`),
+			},
+			{
+				ID:          "tpl_sendgrid_create_contact",
+				ActionType:  "sendgrid.create_contact",
+				Name:        "Create contact",
+				Description: "Agent can add or update contacts in SendGrid without assigning them to a list.",
+				Parameters:  json.RawMessage(`{"email":"*","first_name":"*","last_name":"*","phone_number":"*","city":"*","country":"*"}`),
+			},
+			{
+				ID:          "tpl_sendgrid_get_bounces",
+				ActionType:  "sendgrid.get_bounces",
+				Name:        "View bounce list",
+				Description: "Agent can retrieve the bounce list for deliverability monitoring.",
+				Parameters:  json.RawMessage(`{"start_time":"*","end_time":"*","limit":"*","offset":"*"}`),
+			},
+			{
+				ID:          "tpl_sendgrid_get_suppressions",
+				ActionType:  "sendgrid.get_suppressions",
+				Name:        "View suppression/unsubscribe list",
+				Description: "Agent can retrieve the global unsubscribe list for compliance and deliverability auditing.",
+				Parameters:  json.RawMessage(`{"limit":"*","offset":"*"}`),
 			},
 		},
 	}

--- a/connectors/sendgrid/response.go
+++ b/connectors/sendgrid/response.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
-// unixToISO converts a Unix timestamp (seconds) to an ISO-8601 string in UTC.
-// Used by get_bounces and get_suppressions to return human-readable timestamps
-// instead of raw integers.
-func unixToISO(ts int64) string {
-	return time.Unix(ts, 0).UTC().Format(time.RFC3339)
-}
+// emailPattern is a basic email validation regex. It does not cover all
+// RFC 5322 edge cases but rejects obviously invalid addresses.
+// Defined here alongside validateEmailAddresses so that all email validation
+// logic lives in one place.
+var emailPattern = regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`)
 
 // validateEmailAddresses validates a slice of email addresses for a named field.
 // Returns a ValidationError if any address fails the email pattern check.
@@ -25,6 +25,13 @@ func validateEmailAddresses(field string, addrs []string) error {
 		}
 	}
 	return nil
+}
+
+// unixToISO converts a Unix timestamp (seconds) to an ISO-8601 string in UTC.
+// Used by get_bounces and get_suppressions to return human-readable timestamps
+// instead of raw integers.
+func unixToISO(ts int64) string {
+	return time.Unix(ts, 0).UTC().Format(time.RFC3339)
 }
 
 // checkResponse inspects the HTTP status code and returns an appropriate

--- a/connectors/sendgrid/response.go
+++ b/connectors/sendgrid/response.go
@@ -4,9 +4,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
+
+// unixToISO converts a Unix timestamp (seconds) to an ISO-8601 string in UTC.
+// Used by get_bounces and get_suppressions to return human-readable timestamps
+// instead of raw integers.
+func unixToISO(ts int64) string {
+	return time.Unix(ts, 0).UTC().Format(time.RFC3339)
+}
+
+// validateEmailAddresses validates a slice of email addresses for a named field.
+// Returns a ValidationError if any address fails the email pattern check.
+func validateEmailAddresses(field string, addrs []string) error {
+	for _, addr := range addrs {
+		if !emailPattern.MatchString(addr) {
+			return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s email address: %q", field, addr)}
+		}
+	}
+	return nil
+}
 
 // checkResponse inspects the HTTP status code and returns an appropriate
 // typed error for non-success responses.

--- a/connectors/sendgrid/response_test.go
+++ b/connectors/sendgrid/response_test.go
@@ -7,6 +7,71 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
+func TestUnixToISO(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ts   int64
+		want string
+	}{
+		{ts: 0, want: "1970-01-01T00:00:00Z"},
+		{ts: 1700000000, want: "2023-11-14T22:13:20Z"},
+		{ts: 1800000000, want: "2027-01-15T08:00:00Z"},
+	}
+
+	for _, tt := range tests {
+		got := unixToISO(tt.ts)
+		if got != tt.want {
+			t.Errorf("unixToISO(%d) = %q, want %q", tt.ts, got, tt.want)
+		}
+	}
+}
+
+func TestValidateEmailAddresses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid addresses pass", func(t *testing.T) {
+		t.Parallel()
+		if err := validateEmailAddresses("cc", []string{"a@example.com", "b@example.org"}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty slice passes", func(t *testing.T) {
+		t.Parallel()
+		if err := validateEmailAddresses("cc", nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid address returns ValidationError", func(t *testing.T) {
+		t.Parallel()
+		err := validateEmailAddresses("bcc", []string{"valid@example.com", "not-an-email"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !connectors.IsValidationError(err) {
+			t.Errorf("expected ValidationError, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("field name is included in error message", func(t *testing.T) {
+		t.Parallel()
+		err := validateEmailAddresses("cc", []string{"bad"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		// Field name should appear so callers can identify which field failed.
+		verr, ok := err.(*connectors.ValidationError)
+		if !ok {
+			t.Fatalf("expected *connectors.ValidationError, got %T", err)
+		}
+		if verr.Message == "" {
+			t.Error("error message should not be empty")
+		}
+	})
+}
+
 func TestCheckResponse_Success(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/sendgrid/send_transactional_email.go
+++ b/connectors/sendgrid/send_transactional_email.go
@@ -59,6 +59,9 @@ func (p *sendTransactionalEmailParams) validate() error {
 	if p.ReplyTo != "" && !emailPattern.MatchString(p.ReplyTo) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid reply_to email: %q", p.ReplyTo)}
 	}
+	if len(p.DynamicTemplateData) > 0 && p.TemplateID == "" {
+		return &connectors.ValidationError{Message: "dynamic_template_data requires template_id to be set"}
+	}
 	for _, addr := range p.CC {
 		if !emailPattern.MatchString(addr) {
 			return &connectors.ValidationError{Message: fmt.Sprintf("invalid cc email address: %q", addr)}
@@ -161,8 +164,9 @@ func (a *sendTransactionalEmailAction) Execute(ctx context.Context, req connecto
 		return nil, err
 	}
 
+	// SendGrid responds 202 Accepted — the message is queued, not yet delivered.
 	result := map[string]any{
-		"status": "sent",
+		"status": "accepted",
 		"to":     params.To,
 	}
 	if messageID != "" {

--- a/connectors/sendgrid/send_transactional_email.go
+++ b/connectors/sendgrid/send_transactional_email.go
@@ -1,0 +1,124 @@
+package sendgrid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// sendTransactionalEmailAction implements connectors.Action for
+// sendgrid.send_transactional_email. It sends a single transactional email
+// via the SendGrid v3 POST /mail/send endpoint.
+type sendTransactionalEmailAction struct {
+	conn *SendGridConnector
+}
+
+type sendTransactionalEmailParams struct {
+	To          string `json:"to"`
+	ToName      string `json:"to_name"`
+	From        string `json:"from"`
+	FromName    string `json:"from_name"`
+	Subject     string `json:"subject"`
+	HTMLContent string `json:"html_content"`
+	PlainContent string `json:"plain_content"`
+	TemplateID  string `json:"template_id"`
+	// DynamicTemplateData is arbitrary key/value pairs passed to a dynamic template.
+	DynamicTemplateData map[string]any `json:"dynamic_template_data"`
+	ReplyTo             string         `json:"reply_to"`
+}
+
+func (p *sendTransactionalEmailParams) validate() error {
+	if p.To == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: to"}
+	}
+	if !emailPattern.MatchString(p.To) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid recipient email: %q", p.To)}
+	}
+	if p.From == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: from"}
+	}
+	if !emailPattern.MatchString(p.From) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid sender email: %q", p.From)}
+	}
+	if p.Subject == "" && p.TemplateID == "" {
+		return &connectors.ValidationError{Message: "subject is required when template_id is not provided"}
+	}
+	if p.HTMLContent == "" && p.PlainContent == "" && p.TemplateID == "" {
+		return &connectors.ValidationError{Message: "at least one of html_content, plain_content, or template_id is required"}
+	}
+	if p.ReplyTo != "" && !emailPattern.MatchString(p.ReplyTo) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid reply_to email: %q", p.ReplyTo)}
+	}
+	return nil
+}
+
+// Execute sends a transactional email via POST /mail/send.
+func (a *sendTransactionalEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params sendTransactionalEmailParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	toAddr := map[string]string{"email": params.To}
+	if params.ToName != "" {
+		toAddr["name"] = params.ToName
+	}
+
+	fromAddr := map[string]string{"email": params.From}
+	if params.FromName != "" {
+		fromAddr["name"] = params.FromName
+	}
+
+	body := map[string]any{
+		"personalizations": []map[string]any{
+			{"to": []map[string]string{toAddr}},
+		},
+		"from": fromAddr,
+	}
+
+	// Subject and content are optional when a dynamic template is used.
+	if params.Subject != "" {
+		body["subject"] = params.Subject
+	}
+
+	var content []map[string]string
+	if params.PlainContent != "" {
+		content = append(content, map[string]string{"type": "text/plain", "value": params.PlainContent})
+	}
+	if params.HTMLContent != "" {
+		content = append(content, map[string]string{"type": "text/html", "value": params.HTMLContent})
+	}
+	if len(content) > 0 {
+		body["content"] = content
+	}
+
+	if params.TemplateID != "" {
+		body["template_id"] = params.TemplateID
+		if len(params.DynamicTemplateData) > 0 {
+			// Inject dynamic data into the first personalization.
+			perz := body["personalizations"].([]map[string]any)
+			perz[0]["dynamic_template_data"] = params.DynamicTemplateData
+			body["personalizations"] = perz
+		}
+	}
+
+	if params.ReplyTo != "" {
+		body["reply_to"] = map[string]string{"email": params.ReplyTo}
+	}
+
+	// POST /mail/send returns 202 Accepted with an empty body on success.
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, "/mail/send", body, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"status": "sent",
+		"to":     params.To,
+	})
+}

--- a/connectors/sendgrid/send_transactional_email.go
+++ b/connectors/sendgrid/send_transactional_email.go
@@ -22,12 +22,19 @@ type sendTransactionalEmailParams struct {
 	From        string `json:"from"`
 	FromName    string `json:"from_name"`
 	Subject     string `json:"subject"`
-	HTMLContent string `json:"html_content"`
+	HTMLContent  string `json:"html_content"`
 	PlainContent string `json:"plain_content"`
 	TemplateID  string `json:"template_id"`
 	// DynamicTemplateData is arbitrary key/value pairs passed to a dynamic template.
 	DynamicTemplateData map[string]any `json:"dynamic_template_data"`
 	ReplyTo             string         `json:"reply_to"`
+	// CC and BCC support common transactional patterns (e.g. CC account managers,
+	// BCC compliance inboxes). Each is a comma-separated list of email addresses.
+	CC  []string `json:"cc"`
+	BCC []string `json:"bcc"`
+	// Categories are freeform labels that appear in SendGrid's activity/stats UI,
+	// useful for filtering and analytics (e.g. ["welcome", "onboarding"]).
+	Categories []string `json:"categories"`
 }
 
 func (p *sendTransactionalEmailParams) validate() error {
@@ -52,6 +59,19 @@ func (p *sendTransactionalEmailParams) validate() error {
 	if p.ReplyTo != "" && !emailPattern.MatchString(p.ReplyTo) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid reply_to email: %q", p.ReplyTo)}
 	}
+	for _, addr := range p.CC {
+		if !emailPattern.MatchString(addr) {
+			return &connectors.ValidationError{Message: fmt.Sprintf("invalid cc email address: %q", addr)}
+		}
+	}
+	for _, addr := range p.BCC {
+		if !emailPattern.MatchString(addr) {
+			return &connectors.ValidationError{Message: fmt.Sprintf("invalid bcc email address: %q", addr)}
+		}
+	}
+	if len(p.Categories) > 10 {
+		return &connectors.ValidationError{Message: "categories must have at most 10 items (SendGrid limit)"}
+	}
 	return nil
 }
 
@@ -70,16 +90,32 @@ func (a *sendTransactionalEmailAction) Execute(ctx context.Context, req connecto
 		toAddr["name"] = params.ToName
 	}
 
+	personalization := map[string]any{
+		"to": []map[string]string{toAddr},
+	}
+	if len(params.CC) > 0 {
+		ccList := make([]map[string]string, len(params.CC))
+		for i, addr := range params.CC {
+			ccList[i] = map[string]string{"email": addr}
+		}
+		personalization["cc"] = ccList
+	}
+	if len(params.BCC) > 0 {
+		bccList := make([]map[string]string, len(params.BCC))
+		for i, addr := range params.BCC {
+			bccList[i] = map[string]string{"email": addr}
+		}
+		personalization["bcc"] = bccList
+	}
+
 	fromAddr := map[string]string{"email": params.From}
 	if params.FromName != "" {
 		fromAddr["name"] = params.FromName
 	}
 
 	body := map[string]any{
-		"personalizations": []map[string]any{
-			{"to": []map[string]string{toAddr}},
-		},
-		"from": fromAddr,
+		"personalizations": []map[string]any{personalization},
+		"from":             fromAddr,
 	}
 
 	// Subject and content are optional when a dynamic template is used.
@@ -112,13 +148,26 @@ func (a *sendTransactionalEmailAction) Execute(ctx context.Context, req connecto
 		body["reply_to"] = map[string]string{"email": params.ReplyTo}
 	}
 
+	if len(params.Categories) > 0 {
+		body["categories"] = params.Categories
+	}
+
 	// POST /mail/send returns 202 Accepted with an empty body on success.
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, "/mail/send", body, nil); err != nil {
+	// We capture X-Message-Id from the response headers — this is SendGrid's
+	// per-message identifier, useful for delivery troubleshooting via the
+	// Activity Feed or email.
+	messageID, err := a.conn.doJSONCapturingHeader(ctx, req.Credentials, http.MethodPost, "/mail/send", body, nil, "X-Message-Id")
+	if err != nil {
 		return nil, err
 	}
 
-	return connectors.JSONResult(map[string]string{
+	result := map[string]any{
 		"status": "sent",
 		"to":     params.To,
-	})
+	}
+	if messageID != "" {
+		result["message_id"] = messageID
+	}
+
+	return connectors.JSONResult(result)
 }

--- a/connectors/sendgrid/send_transactional_email.go
+++ b/connectors/sendgrid/send_transactional_email.go
@@ -56,11 +56,24 @@ func (p *sendTransactionalEmailParams) validate() error {
 	if p.HTMLContent == "" && p.PlainContent == "" && p.TemplateID == "" {
 		return &connectors.ValidationError{Message: "at least one of html_content, plain_content, or template_id is required"}
 	}
+	// RFC 2822 §2.1.1 limits header lines to 998 characters.
+	if len(p.Subject) > 998 {
+		return &connectors.ValidationError{Message: "subject must be 998 characters or fewer (RFC 2822 limit)"}
+	}
 	if p.ReplyTo != "" && !emailPattern.MatchString(p.ReplyTo) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid reply_to email: %q", p.ReplyTo)}
 	}
 	if len(p.DynamicTemplateData) > 0 && p.TemplateID == "" {
 		return &connectors.ValidationError{Message: "dynamic_template_data requires template_id to be set"}
+	}
+	// SendGrid limits total recipients (to + cc + bcc) to 1000 per send.
+	// We cap CC and BCC independently to prevent bulk-sending abuse through
+	// the connector.
+	if len(p.CC) > 100 {
+		return &connectors.ValidationError{Message: "cc must contain at most 100 addresses"}
+	}
+	if len(p.BCC) > 100 {
+		return &connectors.ValidationError{Message: "bcc must contain at most 100 addresses"}
 	}
 	for _, addr := range p.CC {
 		if !emailPattern.MatchString(addr) {
@@ -74,6 +87,11 @@ func (p *sendTransactionalEmailParams) validate() error {
 	}
 	if len(p.Categories) > 10 {
 		return &connectors.ValidationError{Message: "categories must have at most 10 items (SendGrid limit)"}
+	}
+	for _, cat := range p.Categories {
+		if len(cat) > 255 {
+			return &connectors.ValidationError{Message: fmt.Sprintf("category name %q exceeds 255 character limit", cat[:40]+"...")}
+		}
 	}
 	return nil
 }

--- a/connectors/sendgrid/send_transactional_email.go
+++ b/connectors/sendgrid/send_transactional_email.go
@@ -75,15 +75,11 @@ func (p *sendTransactionalEmailParams) validate() error {
 	if len(p.BCC) > 100 {
 		return &connectors.ValidationError{Message: "bcc must contain at most 100 addresses"}
 	}
-	for _, addr := range p.CC {
-		if !emailPattern.MatchString(addr) {
-			return &connectors.ValidationError{Message: fmt.Sprintf("invalid cc email address: %q", addr)}
-		}
+	if err := validateEmailAddresses("cc", p.CC); err != nil {
+		return err
 	}
-	for _, addr := range p.BCC {
-		if !emailPattern.MatchString(addr) {
-			return &connectors.ValidationError{Message: fmt.Sprintf("invalid bcc email address: %q", addr)}
-		}
+	if err := validateEmailAddresses("bcc", p.BCC); err != nil {
+		return err
 	}
 	if len(p.Categories) > 10 {
 		return &connectors.ValidationError{Message: "categories must have at most 10 items (SendGrid limit)"}

--- a/connectors/sendgrid/send_transactional_email_test.go
+++ b/connectors/sendgrid/send_transactional_email_test.go
@@ -60,8 +60,8 @@ func TestSendTransactionalEmail_Success(t *testing.T) {
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("unmarshaling result: %v", err)
 	}
-	if data["status"] != "sent" {
-		t.Errorf("status = %v, want sent", data["status"])
+	if data["status"] != "accepted" {
+		t.Errorf("status = %v, want accepted", data["status"])
 	}
 	if data["to"] != "user@example.com" {
 		t.Errorf("to = %v, want user@example.com", data["to"])
@@ -193,6 +193,7 @@ func TestSendTransactionalEmail_ValidationErrors(t *testing.T) {
 		{name: "invalid cc email", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","cc":["not-an-email"]}`},
 		{name: "invalid bcc email", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","bcc":["bad"]}`},
 		{name: "too many categories", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","categories":["a","b","c","d","e","f","g","h","i","j","k"]}`},
+		{name: "dynamic_template_data without template_id", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","dynamic_template_data":{"key":"value"}}`},
 		{name: "invalid JSON", params: `{invalid}`},
 	}
 

--- a/connectors/sendgrid/send_transactional_email_test.go
+++ b/connectors/sendgrid/send_transactional_email_test.go
@@ -3,6 +3,7 @@ package sendgrid
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"net/http/httptest"
 	"testing"
 
@@ -194,7 +195,7 @@ func TestSendTransactionalEmail_ValidationErrors(t *testing.T) {
 		{name: "invalid bcc email", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","bcc":["bad"]}`},
 		{name: "too many categories", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","categories":["a","b","c","d","e","f","g","h","i","j","k"]}`},
 		{name: "dynamic_template_data without template_id", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","dynamic_template_data":{"key":"value"}}`},
-		{name: "subject too long", params: `{"to":"user@example.com","from":"sender@example.com","subject":"` + string(make([]byte, 999)) + `","html_content":"<p>Hi</p>"}`},
+		{name: "subject too long", params: `{"to":"user@example.com","from":"sender@example.com","subject":"` + strings.Repeat("x", 999) + `","html_content":"<p>Hi</p>"}`},
 		{name: "invalid JSON", params: `{invalid}`},
 	}
 

--- a/connectors/sendgrid/send_transactional_email_test.go
+++ b/connectors/sendgrid/send_transactional_email_test.go
@@ -1,0 +1,145 @@
+package sendgrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestSendTransactionalEmail_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/mail/send" {
+			t.Errorf("got %s %s, want POST /mail/send", r.Method, r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding body: %v", err)
+			return
+		}
+
+		from, ok := body["from"].(map[string]any)
+		if !ok || from["email"] != "sender@example.com" {
+			t.Errorf("from.email = %v, want sender@example.com", body["from"])
+		}
+
+		perz, ok := body["personalizations"].([]any)
+		if !ok || len(perz) == 0 {
+			t.Errorf("personalizations missing or empty")
+		}
+
+		if body["subject"] != "Hello" {
+			t.Errorf("subject = %v, want Hello", body["subject"])
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.send_transactional_email"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.send_transactional_email",
+		Parameters:  json.RawMessage(`{"to":"user@example.com","from":"sender@example.com","subject":"Hello","html_content":"<p>Hi</p>"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["status"] != "sent" {
+		t.Errorf("status = %v, want sent", data["status"])
+	}
+	if data["to"] != "user@example.com" {
+		t.Errorf("to = %v, want user@example.com", data["to"])
+	}
+}
+
+func TestSendTransactionalEmail_WithTemplate(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding body: %v", err)
+			return
+		}
+
+		if body["template_id"] != "d-abc123" {
+			t.Errorf("template_id = %v, want d-abc123", body["template_id"])
+		}
+
+		perz := body["personalizations"].([]any)
+		first := perz[0].(map[string]any)
+		dynData, ok := first["dynamic_template_data"].(map[string]any)
+		if !ok {
+			t.Errorf("dynamic_template_data missing from personalization")
+		} else if dynData["first_name"] != "Jane" {
+			t.Errorf("dynamic_template_data.first_name = %v, want Jane", dynData["first_name"])
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.send_transactional_email"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "sendgrid.send_transactional_email",
+		Parameters:  json.RawMessage(`{"to":"user@example.com","from":"sender@example.com","template_id":"d-abc123","dynamic_template_data":{"first_name":"Jane"}}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
+func TestSendTransactionalEmail_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["sendgrid.send_transactional_email"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{name: "missing to", params: `{"from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>"}`},
+		{name: "missing from", params: `{"to":"user@example.com","subject":"Hi","html_content":"<p>Hi</p>"}`},
+		{name: "invalid to email", params: `{"to":"not-an-email","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>"}`},
+		{name: "invalid from email", params: `{"to":"user@example.com","from":"not-an-email","subject":"Hi","html_content":"<p>Hi</p>"}`},
+		{name: "missing subject without template", params: `{"to":"user@example.com","from":"sender@example.com","html_content":"<p>Hi</p>"}`},
+		{name: "missing content without template", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi"}`},
+		{name: "invalid reply_to", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","reply_to":"bad"}`},
+		{name: "invalid JSON", params: `{invalid}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "sendgrid.send_transactional_email",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/connectors/sendgrid/send_transactional_email_test.go
+++ b/connectors/sendgrid/send_transactional_email_test.go
@@ -194,6 +194,7 @@ func TestSendTransactionalEmail_ValidationErrors(t *testing.T) {
 		{name: "invalid bcc email", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","bcc":["bad"]}`},
 		{name: "too many categories", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","categories":["a","b","c","d","e","f","g","h","i","j","k"]}`},
 		{name: "dynamic_template_data without template_id", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","dynamic_template_data":{"key":"value"}}`},
+		{name: "subject too long", params: `{"to":"user@example.com","from":"sender@example.com","subject":"` + string(make([]byte, 999)) + `","html_content":"<p>Hi</p>"}`},
 		{name: "invalid JSON", params: `{invalid}`},
 	}
 

--- a/connectors/sendgrid/send_transactional_email_test.go
+++ b/connectors/sendgrid/send_transactional_email_test.go
@@ -37,6 +37,8 @@ func TestSendTransactionalEmail_Success(t *testing.T) {
 			t.Errorf("subject = %v, want Hello", body["subject"])
 		}
 
+		// X-Message-Id is returned by SendGrid for delivery tracking.
+		w.Header().Set("X-Message-Id", "abc123xyz")
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer srv.Close()
@@ -63,6 +65,9 @@ func TestSendTransactionalEmail_Success(t *testing.T) {
 	}
 	if data["to"] != "user@example.com" {
 		t.Errorf("to = %v, want user@example.com", data["to"])
+	}
+	if data["message_id"] != "abc123xyz" {
+		t.Errorf("message_id = %v, want abc123xyz", data["message_id"])
 	}
 }
 
@@ -107,6 +112,67 @@ func TestSendTransactionalEmail_WithTemplate(t *testing.T) {
 	}
 }
 
+func TestSendTransactionalEmail_WithCCBCCAndCategories(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding body: %v", err)
+			return
+		}
+
+		perz := body["personalizations"].([]any)
+		first := perz[0].(map[string]any)
+
+		// Verify CC is present in personalization.
+		cc, ok := first["cc"].([]any)
+		if !ok || len(cc) != 1 {
+			t.Errorf("cc = %v, want 1 address", first["cc"])
+		} else if cc[0].(map[string]any)["email"] != "cc@example.com" {
+			t.Errorf("cc[0].email = %v, want cc@example.com", cc[0])
+		}
+
+		// Verify BCC is present in personalization.
+		bcc, ok := first["bcc"].([]any)
+		if !ok || len(bcc) != 1 {
+			t.Errorf("bcc = %v, want 1 address", first["bcc"])
+		} else if bcc[0].(map[string]any)["email"] != "bcc@example.com" {
+			t.Errorf("bcc[0].email = %v, want bcc@example.com", bcc[0])
+		}
+
+		// Verify categories are present at the top level.
+		cats, ok := body["categories"].([]any)
+		if !ok || len(cats) != 2 {
+			t.Errorf("categories = %v, want 2 items", body["categories"])
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["sendgrid.send_transactional_email"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "sendgrid.send_transactional_email",
+		Parameters: json.RawMessage(`{
+			"to":"user@example.com",
+			"from":"sender@example.com",
+			"subject":"Hi",
+			"html_content":"<p>Hi</p>",
+			"cc":["cc@example.com"],
+			"bcc":["bcc@example.com"],
+			"categories":["welcome","onboarding"]
+		}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
 func TestSendTransactionalEmail_ValidationErrors(t *testing.T) {
 	t.Parallel()
 
@@ -124,6 +190,9 @@ func TestSendTransactionalEmail_ValidationErrors(t *testing.T) {
 		{name: "missing subject without template", params: `{"to":"user@example.com","from":"sender@example.com","html_content":"<p>Hi</p>"}`},
 		{name: "missing content without template", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi"}`},
 		{name: "invalid reply_to", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","reply_to":"bad"}`},
+		{name: "invalid cc email", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","cc":["not-an-email"]}`},
+		{name: "invalid bcc email", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","bcc":["bad"]}`},
+		{name: "too many categories", params: `{"to":"user@example.com","from":"sender@example.com","subject":"Hi","html_content":"<p>Hi</p>","categories":["a","b","c","d","e","f","g","h","i","j","k"]}`},
 		{name: "invalid JSON", params: `{invalid}`},
 	}
 

--- a/connectors/sendgrid/sendgrid.go
+++ b/connectors/sendgrid/sendgrid.go
@@ -73,7 +73,11 @@ func (c *SendGridConnector) Actions() map[string]connectors.Action {
 		"sendgrid.get_campaign_stats": &getCampaignStatsAction{conn: c},
 		"sendgrid.list_segments":      &listSegmentsAction{conn: c},
 		"sendgrid.list_senders":       &listSendersAction{conn: c},
-		"sendgrid.list_lists":         &listListsAction{conn: c},
+		"sendgrid.list_lists":               &listListsAction{conn: c},
+		"sendgrid.send_transactional_email": &sendTransactionalEmailAction{conn: c},
+		"sendgrid.create_contact":           &createContactAction{conn: c},
+		"sendgrid.get_bounces":              &getBouncesAction{conn: c},
+		"sendgrid.get_suppressions":         &getSuppressionsAction{conn: c},
 	}
 }
 

--- a/connectors/sendgrid/sendgrid.go
+++ b/connectors/sendgrid/sendgrid.go
@@ -158,3 +158,66 @@ func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credent
 	}
 	return nil
 }
+
+// doJSONCapturingHeader is like doJSON but also returns the value of a single
+// named response header. Useful for endpoints like POST /mail/send that return
+// an empty body with useful metadata only in headers (e.g. X-Message-Id).
+func (c *SendGridConnector) doJSONCapturingHeader(ctx context.Context, creds connectors.Credentials, method, path string, body any, respBody any, headerName string) (string, error) {
+	token, _ := creds.Get(credKeyAccessToken)
+	if token == "" {
+		token, _ = creds.Get(credKeyAPIKey)
+	}
+	if token == "" {
+		return "", &connectors.ValidationError{Message: "missing required credential: api_key or access_token (OAuth)"}
+	}
+
+	reqURL := c.baseURL + path
+
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return "", &connectors.ExternalError{Message: fmt.Sprintf("marshaling request body: %v", err)}
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
+	if err != nil {
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return "", &connectors.TimeoutError{Message: fmt.Sprintf("SendGrid API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return "", &connectors.TimeoutError{Message: "SendGrid API request canceled"}
+		}
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("SendGrid API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	headerValue := resp.Header.Get(headerName)
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
+		return "", err
+	}
+
+	if respBody != nil && len(respBytes) > 0 {
+		if err := json.Unmarshal(respBytes, respBody); err != nil {
+			return "", &connectors.ExternalError{Message: fmt.Sprintf("parsing SendGrid response: %v", err)}
+		}
+	}
+	return headerValue, nil
+}

--- a/connectors/sendgrid/sendgrid.go
+++ b/connectors/sendgrid/sendgrid.go
@@ -98,16 +98,19 @@ func (c *SendGridConnector) ValidateCredentials(_ context.Context, creds connect
 	return nil
 }
 
-// doJSON sends a JSON-encoded request to the SendGrid API and decodes
-// the response. SendGrid's v3 API uses application/json throughout.
-// It accepts either an OAuth2 access_token or an api_key as the Bearer token.
-func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credentials, method, path string, body any, respBody any) error {
+// doRequest is the shared HTTP dispatch layer for all SendGrid API calls.
+// It handles authentication, request building, error classification, and
+// response body buffering. The response body is fully consumed and closed
+// before return. Both doJSON and doJSONCapturingHeader delegate here so that
+// auth logic and error handling have a single implementation — security fixes
+// and error handling improvements propagate to all callers automatically.
+func (c *SendGridConnector) doRequest(ctx context.Context, creds connectors.Credentials, method, path string, body any) (http.Header, []byte, error) {
 	token, _ := creds.Get(credKeyAccessToken)
 	if token == "" {
 		token, _ = creds.Get(credKeyAPIKey)
 	}
 	if token == "" {
-		return &connectors.ValidationError{Message: "missing required credential: api_key or access_token (OAuth)"}
+		return nil, nil, &connectors.ValidationError{Message: "missing required credential: api_key or access_token (OAuth)"}
 	}
 
 	reqURL := c.baseURL + path
@@ -116,14 +119,14 @@ func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credent
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
-			return &connectors.ExternalError{Message: fmt.Sprintf("marshaling request body: %v", err)}
+			return nil, nil, &connectors.ExternalError{Message: fmt.Sprintf("marshaling request body: %v", err)}
 		}
 		reqBody = bytes.NewReader(data)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
 	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
+		return nil, nil, &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	if body != nil {
@@ -133,24 +136,37 @@ func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credent
 	resp, err := c.client.Do(req)
 	if err != nil {
 		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("SendGrid API request timed out: %v", err)}
+			return nil, nil, &connectors.TimeoutError{Message: fmt.Sprintf("SendGrid API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "SendGrid API request canceled"}
+			return nil, nil, &connectors.TimeoutError{Message: "SendGrid API request canceled"}
 		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("SendGrid API request failed: %v", err)}
+		return nil, nil, &connectors.ExternalError{Message: fmt.Sprintf("SendGrid API request failed: %v", err)}
 	}
 	defer resp.Body.Close()
 
+	respHeaders := resp.Header
+
 	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
 	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+		return nil, nil, &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
 	}
 
 	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
-		return err
+		return nil, nil, err
 	}
 
+	return respHeaders, respBytes, nil
+}
+
+// doJSON sends a JSON-encoded request to the SendGrid API and decodes
+// the response. SendGrid's v3 API uses application/json throughout.
+// It accepts either an OAuth2 access_token or an api_key as the Bearer token.
+func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credentials, method, path string, body any, respBody any) error {
+	_, respBytes, err := c.doRequest(ctx, creds, method, path, body)
+	if err != nil {
+		return err
+	}
 	if respBody != nil && len(respBytes) > 0 {
 		if err := json.Unmarshal(respBytes, respBody); err != nil {
 			return &connectors.ExternalError{Message: fmt.Sprintf("parsing SendGrid response: %v", err)}
@@ -163,61 +179,14 @@ func (c *SendGridConnector) doJSON(ctx context.Context, creds connectors.Credent
 // named response header. Useful for endpoints like POST /mail/send that return
 // an empty body with useful metadata only in headers (e.g. X-Message-Id).
 func (c *SendGridConnector) doJSONCapturingHeader(ctx context.Context, creds connectors.Credentials, method, path string, body any, respBody any, headerName string) (string, error) {
-	token, _ := creds.Get(credKeyAccessToken)
-	if token == "" {
-		token, _ = creds.Get(credKeyAPIKey)
-	}
-	if token == "" {
-		return "", &connectors.ValidationError{Message: "missing required credential: api_key or access_token (OAuth)"}
-	}
-
-	reqURL := c.baseURL + path
-
-	var reqBody io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return "", &connectors.ExternalError{Message: fmt.Sprintf("marshaling request body: %v", err)}
-		}
-		reqBody = bytes.NewReader(data)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
+	respHeaders, respBytes, err := c.doRequest(ctx, creds, method, path, body)
 	if err != nil {
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("creating request: %v", err)}
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		if connectors.IsTimeout(err) {
-			return "", &connectors.TimeoutError{Message: fmt.Sprintf("SendGrid API request timed out: %v", err)}
-		}
-		if errors.Is(err, context.Canceled) {
-			return "", &connectors.TimeoutError{Message: "SendGrid API request canceled"}
-		}
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("SendGrid API request failed: %v", err)}
-	}
-	defer resp.Body.Close()
-
-	headerValue := resp.Header.Get(headerName)
-
-	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
-	if err != nil {
-		return "", &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
-	}
-
-	if err := checkResponse(resp.StatusCode, resp.Header, respBytes); err != nil {
 		return "", err
 	}
-
 	if respBody != nil && len(respBytes) > 0 {
 		if err := json.Unmarshal(respBytes, respBody); err != nil {
 			return "", &connectors.ExternalError{Message: fmt.Sprintf("parsing SendGrid response: %v", err)}
 		}
 	}
-	return headerValue, nil
+	return respHeaders.Get(headerName), nil
 }

--- a/connectors/sendgrid/sendgrid_test.go
+++ b/connectors/sendgrid/sendgrid_test.go
@@ -29,6 +29,10 @@ func TestSendGridConnector_Actions(t *testing.T) {
 		"sendgrid.list_segments",
 		"sendgrid.list_senders",
 		"sendgrid.list_lists",
+		"sendgrid.send_transactional_email",
+		"sendgrid.create_contact",
+		"sendgrid.get_bounces",
+		"sendgrid.get_suppressions",
 	}
 	for _, at := range want {
 		if _, ok := actions[at]; !ok {
@@ -111,8 +115,8 @@ func TestSendGridConnector_Manifest(t *testing.T) {
 	if m.Name != "SendGrid" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "SendGrid")
 	}
-	if len(m.Actions) != 9 {
-		t.Fatalf("Manifest().Actions has %d items, want 9", len(m.Actions))
+	if len(m.Actions) != 13 {
+		t.Fatalf("Manifest().Actions has %d items, want 13", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -128,6 +132,10 @@ func TestSendGridConnector_Manifest(t *testing.T) {
 		"sendgrid.list_segments",
 		"sendgrid.list_senders",
 		"sendgrid.list_lists",
+		"sendgrid.send_transactional_email",
+		"sendgrid.create_contact",
+		"sendgrid.get_bounces",
+		"sendgrid.get_suppressions",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)


### PR DESCRIPTION
## Summary

Adds four new SendGrid connector actions that address the most common API use cases missing from the existing marketing-focused connector (issue #403):

- `sendgrid.send_transactional_email` — Send a single email via POST `/mail/send`; supports plain/HTML content, dynamic templates (Handlebars), reply-to, and a locked-sender template variant
- `sendgrid.create_contact` — Upsert a contact globally via PUT `/marketing/contacts` (no list required); supports name, phone, city, country fields  
- `sendgrid.get_bounces` — Retrieve bounce list from GET `/suppression/bounces` with optional RFC3339 time range and pagination
- `sendgrid.get_suppressions` — Retrieve global unsubscribes from GET `/suppression/unsubscribes` with optional pagination

Each action includes a handler, manifest entry with JSON Schema, pre-built templates, and full test coverage. Existing `TestSendGridConnector_Actions` and `TestSendGridConnector_Manifest` tests updated to reflect the new action count.

Closes #403

### Claude Code
- [x] Tests written and passing
- [x] Build verified (`make build`)

### OpenClaw
- [ ] Verify SendGrid API scopes are sufficient for `/mail/send` with both API key and OAuth paths
- [ ] Review `send_transactional_email` risk level (currently `high`) — same as campaigns
- [ ] Confirm `dynamic_template_data` schema (`additionalProperties: true`) is acceptable for the permissions UI
