### PR TITLE
Add Slack DM, message editing, user lookup, and search actions

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -478,7 +478,7 @@ Lists workspace users visible to the bot, with cursor-based pagination.
 
 **Slack API:** `POST /users.list` ([docs](https://api.slack.com/methods/users.list))
 
-**Required bot token scopes:** `users:read`
+**Required bot token scopes:** `users:read` (add `users:read.email` for email addresses)
 
 ---
 

--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -359,9 +359,184 @@ Adds an emoji reaction to a Slack message.
 
 ---
 
+### `slack.send_dm`
+
+Sends a direct message to a Slack user. Opens (or reuses) a DM channel with the user, then posts the message.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `user_id` | string | Yes | Slack user ID (e.g., `U01234567`) — must start with `U` or `W` |
+| `message` | string | Yes | Message text (supports Slack mrkdwn formatting) |
+
+**Response:**
+
+```json
+{
+  "ts": "1234567890.123456",
+  "channel": "D09876543"
+}
+```
+
+**Slack API:** `POST /conversations.open` + `POST /chat.postMessage` ([docs](https://api.slack.com/methods/conversations.open))
+
+**Required bot token scopes:** `im:write`, `chat:write`
+
+---
+
+### `slack.update_message`
+
+Edits an existing message in a Slack channel. Bots can only edit their own messages.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `channel` | string | Yes | Channel ID (e.g., `C01234567`) |
+| `ts` | string | Yes | Timestamp of the message to update (e.g., `1234567890.123456`) |
+| `message` | string | Yes | New message text (supports Slack mrkdwn formatting) |
+
+**Response:**
+
+```json
+{
+  "ts": "1234567890.123456",
+  "channel": "C01234567"
+}
+```
+
+**Slack API:** `POST /chat.update` ([docs](https://api.slack.com/methods/chat.update))
+
+**Required bot token scopes:** `chat:write`
+
+---
+
+### `slack.delete_message`
+
+Deletes a message from a Slack channel. Bots can only delete their own messages.
+
+**Risk level:** high
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `channel` | string | Yes | Channel ID (e.g., `C01234567`) |
+| `ts` | string | Yes | Timestamp of the message to delete (e.g., `1234567890.123456`) |
+
+**Response:**
+
+```json
+{
+  "ts": "1234567890.123456",
+  "channel": "C01234567"
+}
+```
+
+**Slack API:** `POST /chat.delete` ([docs](https://api.slack.com/methods/chat.delete))
+
+**Required bot token scopes:** `chat:write`
+
+---
+
+### `slack.list_users`
+
+Lists workspace users visible to the bot, with cursor-based pagination.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `limit` | integer | No | `100` | Max users to return (1–1000) |
+| `cursor` | string | No | — | Pagination cursor from a previous response |
+
+**Response:**
+
+```json
+{
+  "users": [
+    {
+      "id": "U001",
+      "name": "jdoe",
+      "real_name": "John Doe",
+      "display_name": "John",
+      "email": "john@example.com",
+      "is_bot": false,
+      "is_admin": false
+    }
+  ],
+  "next_cursor": "dGVhbTpDMDI="
+}
+```
+
+**Slack API:** `POST /users.list` ([docs](https://api.slack.com/methods/users.list))
+
+**Required bot token scopes:** `users:read`
+
+---
+
+### `slack.search_messages`
+
+Searches messages across Slack channels. **Requires a user token** (`xoxp-`) with the `search:read` scope — bot tokens (`xoxb-`) do not support this endpoint.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `query` | string | Yes | — | Search query (supports Slack modifiers like `in:#channel`, `from:@user`) |
+| `count` | integer | No | `20` | Max results per page (1–100) |
+| `page` | integer | No | `1` | Page number for pagination (1-indexed) |
+| `sort` | string | No | `score` | Sort order: `score` (relevance) or `timestamp` |
+
+**Response:**
+
+```json
+{
+  "matches": [
+    {
+      "channel_id": "C001",
+      "channel_name": "engineering",
+      "user": "U001",
+      "username": "jdoe",
+      "text": "Deploying v2.0 now",
+      "ts": "1234567890.123456",
+      "permalink": "https://team.slack.com/archives/C001/p1234567890123456"
+    }
+  ],
+  "total": 42,
+  "page": 1,
+  "pages": 3
+}
+```
+
+**Slack API:** `POST /search.messages` ([docs](https://api.slack.com/methods/search.messages))
+
+**Required scopes:** `search:read` (user token only)
+
+> **Note:** This action will return a `missing_scope` error when invoked with a bot token. To use it, the OAuth flow must persist the user's access token (the `authed_user.access_token` field from Slack's OAuth v2 response).
+
+---
+
 ### Channel ID Validation
 
 The `channel` parameter on `read_channel_messages` and `read_thread` must be a Slack channel ID — not a channel name. Valid IDs start with `C` (public channels), `G` (private channels / group DMs), or `D` (direct messages). Passing a name like `#general` or `general` returns a `ValidationError` with a helpful hint before hitting the Slack API.
+
+### User ID Validation
+
+The `user_id` parameter on `send_dm` must be a Slack user ID starting with `U` or `W`. Passing a username or email returns a `ValidationError` with a helpful hint.
+
+### Message Timestamp Validation
+
+The `ts` / `timestamp` parameters on `update_message`, `delete_message`, and `add_reaction` must be a valid Slack timestamp in `<seconds>.<microseconds>` format (e.g., `1234567890.123456`). Non-numeric values or missing dot separators are rejected with a `ValidationError`.
 
 ### Pagination Limits
 
@@ -377,6 +552,7 @@ The Slack API returns HTTP 200 for most errors, with success/failure indicated b
 | `missing_scope` | `AuthError` (with link to Slack app settings) | 502 Bad Gateway |
 | `ratelimited` (or HTTP 429) | `RateLimitError` | 429 Too Many Requests |
 | `channel_not_found`, `not_in_channel`, `is_archived` | `ExternalError` (user-friendly message) | 502 Bad Gateway |
+| `message_not_found`, `cant_update_message`, `cant_delete_message`, `edit_window_closed` | `ExternalError` (user-friendly message) | 502 Bad Gateway |
 | `already_reacted`, `already_in_channel`, `user_not_found`, etc. | `ExternalError` (user-friendly message) | 502 Bad Gateway |
 | All other Slack errors | `ExternalError` | 502 Bad Gateway |
 | Client timeout / context deadline / cancellation | `TimeoutError` | 504 Gateway Timeout |
@@ -456,18 +632,14 @@ connectors/slack/
 ├── invite_to_channel.go            # slack.invite_to_channel action
 ├── upload_file.go                  # slack.upload_file action (v2 upload flow)
 ├── add_reaction.go                 # slack.add_reaction action
-├── slack_test.go                   # Connector-level tests
+├── send_dm.go                      # slack.send_dm action (conversations.open + chat.postMessage)
+├── update_message.go               # slack.update_message action
+├── delete_message.go               # slack.delete_message action
+├── list_users.go                   # slack.list_users action
+├── search_messages.go              # slack.search_messages action (requires user token)
+├── slack_test.go                   # Connector-level tests + validator tests
 ├── helpers_test.go                 # Shared test helpers (validCreds)
-├── send_message_test.go            # Send message action tests
-├── create_channel_test.go          # Create channel action tests
-├── list_channels_test.go           # List channels action tests
-├── read_channel_messages_test.go   # Read channel messages action tests
-├── read_thread_test.go             # Read thread action tests
-├── schedule_message_test.go        # Schedule message action tests
-├── set_topic_test.go               # Set topic action tests
-├── invite_to_channel_test.go       # Invite to channel action tests
-├── upload_file_test.go             # Upload file action tests
-├── add_reaction_test.go            # Add reaction action tests
+├── *_test.go                       # Per-action test files (one per action)
 └── README.md                       # This file
 ```
 

--- a/connectors/slack/add_reaction.go
+++ b/connectors/slack/add_reaction.go
@@ -24,8 +24,8 @@ func (p *addReactionParams) validate() error {
 	if err := validateChannelID(p.Channel); err != nil {
 		return err
 	}
-	if p.Timestamp == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: timestamp"}
+	if err := validateMessageTS(p.Timestamp); err != nil {
+		return err
 	}
 	if p.Name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}

--- a/connectors/slack/delete_message.go
+++ b/connectors/slack/delete_message.go
@@ -1,0 +1,68 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// deleteMessageAction implements connectors.Action for slack.delete_message.
+// It deletes a message from a channel via POST /chat.delete.
+type deleteMessageAction struct {
+	conn *SlackConnector
+}
+
+// deleteMessageParams is the user-facing parameter schema.
+type deleteMessageParams struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+}
+
+func (p *deleteMessageParams) validate() error {
+	if err := validateChannelID(p.Channel); err != nil {
+		return err
+	}
+	if p.TS == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: ts"}
+	}
+	return nil
+}
+
+// deleteMessageRequest is the Slack API request body for chat.delete.
+type deleteMessageRequest struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+}
+
+type deleteMessageResponse struct {
+	slackResponse
+	TS      string `json:"ts,omitempty"`
+	Channel string `json:"channel,omitempty"`
+}
+
+// Execute deletes a message from a Slack channel.
+func (a *deleteMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params deleteMessageParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	body := deleteMessageRequest{
+		Channel: params.Channel,
+		TS:      params.TS,
+	}
+
+	var resp deleteMessageResponse
+	if err := a.conn.doPost(ctx, "chat.delete", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, mapSlackError(resp.Error)
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"ts":      resp.TS,
+		"channel": resp.Channel,
+	})
+}

--- a/connectors/slack/delete_message.go
+++ b/connectors/slack/delete_message.go
@@ -22,8 +22,8 @@ func (p *deleteMessageParams) validate() error {
 	if err := validateChannelID(p.Channel); err != nil {
 		return err
 	}
-	if p.TS == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: ts"}
+	if err := validateMessageTS(p.TS); err != nil {
+		return err
 	}
 	return nil
 }

--- a/connectors/slack/delete_message_test.go
+++ b/connectors/slack/delete_message_test.go
@@ -148,6 +148,30 @@ func TestDeleteMessage_SlackAPIError(t *testing.T) {
 	}
 }
 
+func TestDeleteMessage_InvalidTSFormat(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C01234567",
+		"ts":      "abc123",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.delete_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid ts format")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestDeleteMessage_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/delete_message_test.go
+++ b/connectors/slack/delete_message_test.go
@@ -1,0 +1,168 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestDeleteMessage_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/chat.delete" {
+			t.Errorf("expected path /chat.delete, got %s", r.URL.Path)
+		}
+
+		var body deleteMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Channel != "C01234567" {
+			t.Errorf("expected channel 'C01234567', got %q", body.Channel)
+		}
+		if body.TS != "1234567890.123456" {
+			t.Errorf("expected ts '1234567890.123456', got %q", body.TS)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"ts":      "1234567890.123456",
+			"channel": "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &deleteMessageAction{conn: conn}
+
+	params, _ := json.Marshal(deleteMessageParams{
+		Channel: "C01234567",
+		TS:      "1234567890.123456",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.delete_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["ts"] != "1234567890.123456" {
+		t.Errorf("expected ts '1234567890.123456', got %q", data["ts"])
+	}
+	if data["channel"] != "C01234567" {
+		t.Errorf("expected channel 'C01234567', got %q", data["channel"])
+	}
+}
+
+func TestDeleteMessage_MissingChannel(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"ts": "1234567890.123456",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.delete_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing channel")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDeleteMessage_MissingTS(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C01234567",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.delete_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing ts")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDeleteMessage_SlackAPIError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "cant_delete_message",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &deleteMessageAction{conn: conn}
+
+	params, _ := json.Marshal(deleteMessageParams{
+		Channel: "C01234567",
+		TS:      "1234567890.123456",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.delete_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for cant_delete_message")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got: %T", err)
+	}
+}
+
+func TestDeleteMessage_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &deleteMessageAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.delete_message",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/slack/list_users.go
+++ b/connectors/slack/list_users.go
@@ -62,6 +62,7 @@ type listUserSummary struct {
 	DisplayName string `json:"display_name,omitempty"`
 	Email       string `json:"email,omitempty"`
 	IsBot       bool   `json:"is_bot"`
+	IsAdmin     bool   `json:"is_admin"`
 	Deleted     bool   `json:"deleted"`
 }
 
@@ -100,6 +101,7 @@ func (a *listUsersAction) Execute(ctx context.Context, req connectors.ActionRequ
 			DisplayName: u.Profile.DisplayName,
 			Email:       u.Profile.Email,
 			IsBot:       u.IsBot,
+			IsAdmin:     u.IsAdmin,
 			Deleted:     u.Deleted,
 		})
 	}

--- a/connectors/slack/list_users.go
+++ b/connectors/slack/list_users.go
@@ -1,0 +1,111 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listUsersAction implements connectors.Action for slack.list_users.
+// It lists workspace users via POST /users.list.
+type listUsersAction struct {
+	conn *SlackConnector
+}
+
+// listUsersParams defines the user-facing parameter schema.
+type listUsersParams struct {
+	Limit  int    `json:"limit,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+func (p *listUsersParams) validate() error {
+	return validateLimit(p.Limit)
+}
+
+// listUsersRequest is the Slack API request body for users.list.
+type listUsersRequest struct {
+	Limit  int    `json:"limit,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+type listUsersResponse struct {
+	slackResponse
+	Members []listUserEntry `json:"members,omitempty"`
+	Meta    *paginationMeta `json:"response_metadata,omitempty"`
+}
+
+type listUserEntry struct {
+	ID       string          `json:"id"`
+	Name     string          `json:"name"`
+	RealName string          `json:"real_name"`
+	Deleted  bool            `json:"deleted"`
+	IsBot    bool            `json:"is_bot"`
+	IsAdmin  bool            `json:"is_admin"`
+	Profile  listUserProfile `json:"profile"`
+}
+
+type listUserProfile struct {
+	DisplayName string `json:"display_name"`
+	Email       string `json:"email"`
+}
+
+// listUsersResult is the action output.
+type listUsersResult struct {
+	Users      []listUserSummary `json:"users"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type listUserSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	RealName    string `json:"real_name,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Email       string `json:"email,omitempty"`
+	IsBot       bool   `json:"is_bot"`
+	Deleted     bool   `json:"deleted"`
+}
+
+// Execute lists workspace users visible to the bot.
+func (a *listUsersAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listUsersParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	body := listUsersRequest{
+		Limit:  params.Limit,
+		Cursor: params.Cursor,
+	}
+	if body.Limit == 0 {
+		body.Limit = 100
+	}
+
+	var resp listUsersResponse
+	if err := a.conn.doPost(ctx, "users.list", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, mapSlackError(resp.Error)
+	}
+
+	result := listUsersResult{
+		Users: make([]listUserSummary, 0, len(resp.Members)),
+	}
+	for _, u := range resp.Members {
+		result.Users = append(result.Users, listUserSummary{
+			ID:          u.ID,
+			Name:        u.Name,
+			RealName:    u.RealName,
+			DisplayName: u.Profile.DisplayName,
+			Email:       u.Profile.Email,
+			IsBot:       u.IsBot,
+			Deleted:     u.Deleted,
+		})
+	}
+	if resp.Meta != nil {
+		result.NextCursor = resp.Meta.NextCursor
+	}
+
+	return connectors.JSONResult(result)
+}

--- a/connectors/slack/list_users_test.go
+++ b/connectors/slack/list_users_test.go
@@ -1,0 +1,225 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListUsers_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/users.list" {
+			t.Errorf("expected path /users.list, got %s", r.URL.Path)
+		}
+
+		var body listUsersRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Limit != 100 {
+			t.Errorf("expected limit 100, got %d", body.Limit)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"members": []map[string]any{
+				{
+					"id":        "U001",
+					"name":      "jdoe",
+					"real_name": "Jane Doe",
+					"deleted":   false,
+					"is_bot":    false,
+					"is_admin":  true,
+					"profile": map[string]string{
+						"display_name": "Jane",
+						"email":        "jane@example.com",
+					},
+				},
+				{
+					"id":        "U002",
+					"name":      "bot_user",
+					"real_name": "Bot",
+					"deleted":   false,
+					"is_bot":    true,
+					"is_admin":  false,
+					"profile": map[string]string{
+						"display_name": "Helper Bot",
+						"email":        "",
+					},
+				},
+			},
+			"response_metadata": map[string]string{
+				"next_cursor": "dXNlcjpVMDAy",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUsersAction{conn: conn}
+
+	params, _ := json.Marshal(listUsersParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_users",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listUsersResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(data.Users))
+	}
+	if data.Users[0].ID != "U001" {
+		t.Errorf("expected first user ID 'U001', got %q", data.Users[0].ID)
+	}
+	if data.Users[0].Name != "jdoe" {
+		t.Errorf("expected first user name 'jdoe', got %q", data.Users[0].Name)
+	}
+	if data.Users[0].Email != "jane@example.com" {
+		t.Errorf("expected email 'jane@example.com', got %q", data.Users[0].Email)
+	}
+	if data.Users[1].IsBot != true {
+		t.Error("expected second user to be a bot")
+	}
+	if data.NextCursor != "dXNlcjpVMDAy" {
+		t.Errorf("expected next_cursor 'dXNlcjpVMDAy', got %q", data.NextCursor)
+	}
+}
+
+func TestListUsers_WithPagination(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body listUsersRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Cursor != "dXNlcjpVMDAy" {
+			t.Errorf("expected cursor 'dXNlcjpVMDAy', got %q", body.Cursor)
+		}
+		if body.Limit != 50 {
+			t.Errorf("expected limit 50, got %d", body.Limit)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"members": []map[string]any{},
+			"response_metadata": map[string]string{
+				"next_cursor": "",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUsersAction{conn: conn}
+
+	params, _ := json.Marshal(listUsersParams{
+		Limit:  50,
+		Cursor: "dXNlcjpVMDAy",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_users",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listUsersResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(data.Users))
+	}
+}
+
+func TestListUsers_SlackAPIError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "invalid_auth",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUsersAction{conn: conn}
+
+	params, _ := json.Marshal(listUsersParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_users",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestListUsers_LimitOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listUsersAction{conn: conn}
+
+	params, _ := json.Marshal(listUsersParams{Limit: 2000})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_users",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for limit out of range")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestListUsers_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &listUsersAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_users",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -355,7 +355,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.search_messages",
 				Name:        "Search Messages",
-				Description: "Search messages across Slack channels",
+				Description: "Search messages across Slack channels (requires a user token with search:read scope; bot tokens are not supported by Slack for this endpoint)",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -268,6 +268,120 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "slack.send_dm",
+				Name:        "Send Direct Message",
+				Description: "Send a direct message to a Slack user",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["user_id", "message"],
+					"properties": {
+						"user_id": {
+							"type": "string",
+							"description": "User ID to send the DM to (e.g. U01234567)"
+						},
+						"message": {
+							"type": "string",
+							"description": "Message text (supports Slack mrkdwn formatting)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "slack.update_message",
+				Name:        "Update Message",
+				Description: "Edit an existing message in a Slack channel",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel", "ts", "message"],
+					"properties": {
+						"channel": {
+							"type": "string",
+							"description": "Channel ID containing the message (e.g. C01234567)"
+						},
+						"ts": {
+							"type": "string",
+							"description": "Timestamp of the message to update (e.g. 1234567890.123456)"
+						},
+						"message": {
+							"type": "string",
+							"description": "New message text (supports Slack mrkdwn formatting)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "slack.delete_message",
+				Name:        "Delete Message",
+				Description: "Delete a message from a Slack channel",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel", "ts"],
+					"properties": {
+						"channel": {
+							"type": "string",
+							"description": "Channel ID containing the message (e.g. C01234567)"
+						},
+						"ts": {
+							"type": "string",
+							"description": "Timestamp of the message to delete (e.g. 1234567890.123456)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "slack.list_users",
+				Name:        "List Users",
+				Description: "List workspace users visible to the bot",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"limit": {
+							"type": "integer",
+							"default": 100,
+							"description": "Max users to return (1-1000)"
+						},
+						"cursor": {
+							"type": "string",
+							"description": "Pagination cursor from a previous response"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "slack.search_messages",
+				Name:        "Search Messages",
+				Description: "Search messages across Slack channels",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["query"],
+					"properties": {
+						"query": {
+							"type": "string",
+							"description": "Search query (supports Slack search modifiers like in:#channel, from:@user)"
+						},
+						"count": {
+							"type": "integer",
+							"default": 20,
+							"description": "Max results per page (1-100)"
+						},
+						"page": {
+							"type": "integer",
+							"default": 1,
+							"description": "Page number for pagination"
+						},
+						"sort": {
+							"type": "string",
+							"description": "Sort order: score (relevance) or timestamp"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -355,6 +469,41 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Add reactions",
 				Description: "Agent can add emoji reactions to messages.",
 				Parameters:  json.RawMessage(`{"channel":"*","timestamp":"*","name":"*"}`),
+			},
+			{
+				ID:          "tpl_slack_send_dm",
+				ActionType:  "slack.send_dm",
+				Name:        "Send direct messages",
+				Description: "Agent can send direct messages to any user.",
+				Parameters:  json.RawMessage(`{"user_id":"*","message":"*"}`),
+			},
+			{
+				ID:          "tpl_slack_update_message",
+				ActionType:  "slack.update_message",
+				Name:        "Update messages",
+				Description: "Agent can edit messages in any channel.",
+				Parameters:  json.RawMessage(`{"channel":"*","ts":"*","message":"*"}`),
+			},
+			{
+				ID:          "tpl_slack_delete_message",
+				ActionType:  "slack.delete_message",
+				Name:        "Delete messages",
+				Description: "Agent can delete messages from any channel.",
+				Parameters:  json.RawMessage(`{"channel":"*","ts":"*"}`),
+			},
+			{
+				ID:          "tpl_slack_list_users",
+				ActionType:  "slack.list_users",
+				Name:        "List users",
+				Description: "Agent can list workspace users.",
+				Parameters:  json.RawMessage(`{"limit":"*","cursor":"*"}`),
+			},
+			{
+				ID:          "tpl_slack_search_messages",
+				ActionType:  "slack.search_messages",
+				Name:        "Search messages",
+				Description: "Agent can search messages across channels.",
+				Parameters:  json.RawMessage(`{"query":"*","count":"*","page":"*","sort":"*"}`),
 			},
 		},
 	}

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -8,8 +8,15 @@ import (
 
 // searchMessagesAction implements connectors.Action for slack.search_messages.
 // It searches messages across channels via POST /search.messages.
-// NOTE: This endpoint requires a user token (not a bot token) with the
-// search:read scope.
+//
+// IMPORTANT: This Slack endpoint requires a user token (xoxp-) with the
+// search:read scope. Bot tokens (xoxb-) do NOT support search.messages.
+// For this action to work, the OAuth flow must persist the authed_user
+// access_token (returned alongside the bot token in Slack's OAuth v2
+// response) into the connector's credentials. Until user-token credential
+// support is added, this action will return a missing_scope / not_allowed
+// error when invoked with a bot token. See the manifest description for
+// user-facing guidance.
 type searchMessagesAction struct {
 	conn *SlackConnector
 }
@@ -30,7 +37,10 @@ func (p *searchMessagesParams) validate() error {
 		return &connectors.ValidationError{Message: "count must be between 1 and 100"}
 	}
 	if p.Page < 0 {
-		return &connectors.ValidationError{Message: "page must be non-negative"}
+		return &connectors.ValidationError{Message: "page must be at least 1"}
+	}
+	if p.Page == 0 {
+		p.Page = 1
 	}
 	if p.Sort != "" && p.Sort != "score" && p.Sort != "timestamp" {
 		return &connectors.ValidationError{Message: "sort must be \"score\" (relevance) or \"timestamp\""}

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -39,9 +39,6 @@ func (p *searchMessagesParams) validate() error {
 	if p.Page < 0 {
 		return &connectors.ValidationError{Message: "page must be at least 1"}
 	}
-	if p.Page == 0 {
-		p.Page = 1
-	}
 	if p.Sort != "" && p.Sort != "score" && p.Sort != "timestamp" {
 		return &connectors.ValidationError{Message: "sort must be \"score\" (relevance) or \"timestamp\""}
 	}
@@ -116,6 +113,9 @@ func (a *searchMessagesAction) Execute(ctx context.Context, req connectors.Actio
 	}
 	if body.Count == 0 {
 		body.Count = 20
+	}
+	if body.Page == 0 {
+		body.Page = 1
 	}
 
 	var resp searchMessagesResponse

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -32,6 +32,9 @@ func (p *searchMessagesParams) validate() error {
 	if p.Page < 0 {
 		return &connectors.ValidationError{Message: "page must be non-negative"}
 	}
+	if p.Sort != "" && p.Sort != "score" && p.Sort != "timestamp" {
+		return &connectors.ValidationError{Message: "sort must be \"score\" (relevance) or \"timestamp\""}
+	}
 	return nil
 }
 

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -1,0 +1,136 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// searchMessagesAction implements connectors.Action for slack.search_messages.
+// It searches messages across channels via POST /search.messages.
+// NOTE: This endpoint requires a user token (not a bot token) with the
+// search:read scope.
+type searchMessagesAction struct {
+	conn *SlackConnector
+}
+
+// searchMessagesParams is the user-facing parameter schema.
+type searchMessagesParams struct {
+	Query string `json:"query"`
+	Count int    `json:"count,omitempty"`
+	Page  int    `json:"page,omitempty"`
+	Sort  string `json:"sort,omitempty"`
+}
+
+func (p *searchMessagesParams) validate() error {
+	if p.Query == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: query"}
+	}
+	if p.Count != 0 && (p.Count < 1 || p.Count > 100) {
+		return &connectors.ValidationError{Message: "count must be between 1 and 100"}
+	}
+	if p.Page < 0 {
+		return &connectors.ValidationError{Message: "page must be non-negative"}
+	}
+	return nil
+}
+
+// searchMessagesRequest is the Slack API request body for search.messages.
+type searchMessagesRequest struct {
+	Query string `json:"query"`
+	Count int    `json:"count,omitempty"`
+	Page  int    `json:"page,omitempty"`
+	Sort  string `json:"sort,omitempty"`
+}
+
+type searchMessagesResponse struct {
+	slackResponse
+	Messages struct {
+		Matches []searchMatch       `json:"matches,omitempty"`
+		Paging  searchMessagePaging `json:"paging"`
+	} `json:"messages"`
+}
+
+type searchMatch struct {
+	Channel struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"channel"`
+	User      string `json:"user"`
+	Username  string `json:"username"`
+	Text      string `json:"text"`
+	TS        string `json:"ts"`
+	Permalink string `json:"permalink"`
+}
+
+type searchMessagePaging struct {
+	Count int `json:"count"`
+	Total int `json:"total"`
+	Page  int `json:"page"`
+	Pages int `json:"pages"`
+}
+
+// searchMessagesResult is the action output.
+type searchMessagesResult struct {
+	Matches []searchMatchSummary `json:"matches"`
+	Total   int                  `json:"total"`
+	Page    int                  `json:"page"`
+	Pages   int                  `json:"pages"`
+}
+
+type searchMatchSummary struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelName string `json:"channel_name"`
+	User        string `json:"user"`
+	Username    string `json:"username,omitempty"`
+	Text        string `json:"text"`
+	TS          string `json:"ts"`
+	Permalink   string `json:"permalink,omitempty"`
+}
+
+// Execute searches messages across Slack channels.
+func (a *searchMessagesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params searchMessagesParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	body := searchMessagesRequest{
+		Query: params.Query,
+		Count: params.Count,
+		Page:  params.Page,
+		Sort:  params.Sort,
+	}
+	if body.Count == 0 {
+		body.Count = 20
+	}
+
+	var resp searchMessagesResponse
+	if err := a.conn.doPost(ctx, "search.messages", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, mapSlackError(resp.Error)
+	}
+
+	result := searchMessagesResult{
+		Matches: make([]searchMatchSummary, 0, len(resp.Messages.Matches)),
+		Total:   resp.Messages.Paging.Total,
+		Page:    resp.Messages.Paging.Page,
+		Pages:   resp.Messages.Paging.Pages,
+	}
+	for _, m := range resp.Messages.Matches {
+		result.Matches = append(result.Matches, searchMatchSummary{
+			ChannelID:   m.Channel.ID,
+			ChannelName: m.Channel.Name,
+			User:        m.User,
+			Username:    m.Username,
+			Text:        m.Text,
+			TS:          m.TS,
+			Permalink:   m.Permalink,
+		})
+	}
+
+	return connectors.JSONResult(result)
+}

--- a/connectors/slack/search_messages_test.go
+++ b/connectors/slack/search_messages_test.go
@@ -180,6 +180,30 @@ func TestSearchMessages_SlackAPIError(t *testing.T) {
 	}
 }
 
+func TestSearchMessages_InvalidSort(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &searchMessagesAction{conn: conn}
+
+	params, _ := json.Marshal(searchMessagesParams{
+		Query: "test",
+		Sort:  "invalid_sort",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid sort value")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestSearchMessages_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/search_messages_test.go
+++ b/connectors/slack/search_messages_test.go
@@ -1,0 +1,200 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestSearchMessages_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/search.messages" {
+			t.Errorf("expected path /search.messages, got %s", r.URL.Path)
+		}
+
+		var body searchMessagesRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Query != "deploy in:#engineering" {
+			t.Errorf("expected query 'deploy in:#engineering', got %q", body.Query)
+		}
+		if body.Count != 20 {
+			t.Errorf("expected count 20, got %d", body.Count)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"messages": map[string]any{
+				"matches": []map[string]any{
+					{
+						"channel":   map[string]string{"id": "C001", "name": "engineering"},
+						"user":      "U001",
+						"username":  "jdoe",
+						"text":      "Deploying v2.0 now",
+						"ts":        "1234567890.123456",
+						"permalink": "https://team.slack.com/archives/C001/p1234567890123456",
+					},
+					{
+						"channel":  map[string]string{"id": "C001", "name": "engineering"},
+						"user":     "U002",
+						"username": "asmith",
+						"text":     "Deploy complete",
+						"ts":       "1234567891.123456",
+					},
+				},
+				"paging": map[string]int{
+					"count": 20,
+					"total": 2,
+					"page":  1,
+					"pages": 1,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &searchMessagesAction{conn: conn}
+
+	params, _ := json.Marshal(searchMessagesParams{
+		Query: "deploy in:#engineering",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data searchMessagesResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(data.Matches))
+	}
+	if data.Matches[0].ChannelID != "C001" {
+		t.Errorf("expected channel_id 'C001', got %q", data.Matches[0].ChannelID)
+	}
+	if data.Matches[0].Text != "Deploying v2.0 now" {
+		t.Errorf("expected text 'Deploying v2.0 now', got %q", data.Matches[0].Text)
+	}
+	if data.Matches[0].Permalink != "https://team.slack.com/archives/C001/p1234567890123456" {
+		t.Errorf("unexpected permalink: %q", data.Matches[0].Permalink)
+	}
+	if data.Total != 2 {
+		t.Errorf("expected total 2, got %d", data.Total)
+	}
+	if data.Pages != 1 {
+		t.Errorf("expected pages 1, got %d", data.Pages)
+	}
+}
+
+func TestSearchMessages_MissingQuery(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &searchMessagesAction{conn: conn}
+
+	params, _ := json.Marshal(searchMessagesParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSearchMessages_CountOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &searchMessagesAction{conn: conn}
+
+	params, _ := json.Marshal(searchMessagesParams{
+		Query: "test",
+		Count: 200,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for count out of range")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSearchMessages_SlackAPIError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "missing_scope",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &searchMessagesAction{conn: conn}
+
+	params, _ := json.Marshal(searchMessagesParams{
+		Query: "test",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing_scope")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestSearchMessages_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &searchMessagesAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/slack/send_dm.go
+++ b/connectors/slack/send_dm.go
@@ -1,0 +1,80 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// sendDMAction implements connectors.Action for slack.send_dm.
+// It opens (or reuses) a DM channel with a user and sends a message
+// via conversations.open + chat.postMessage.
+type sendDMAction struct {
+	conn *SlackConnector
+}
+
+// sendDMParams is the user-facing parameter schema.
+type sendDMParams struct {
+	UserID  string `json:"user_id"`
+	Message string `json:"message"`
+}
+
+func (p *sendDMParams) validate() error {
+	if p.UserID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: user_id"}
+	}
+	if p.Message == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: message"}
+	}
+	return nil
+}
+
+// conversationsOpenRequest is the Slack API request body for conversations.open.
+type conversationsOpenRequest struct {
+	Users string `json:"users"`
+}
+
+type conversationsOpenResponse struct {
+	slackResponse
+	Channel struct {
+		ID string `json:"id"`
+	} `json:"channel"`
+}
+
+// Execute opens a DM channel with the user and sends a message.
+func (a *sendDMAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params sendDMParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	// Step 1: Open (or reuse) a DM channel with the user.
+	openBody := conversationsOpenRequest{Users: params.UserID}
+	var openResp conversationsOpenResponse
+	if err := a.conn.doPost(ctx, "conversations.open", req.Credentials, openBody, &openResp); err != nil {
+		return nil, err
+	}
+	if !openResp.OK {
+		return nil, mapSlackError(openResp.Error)
+	}
+
+	dmChannelID := openResp.Channel.ID
+
+	// Step 2: Post the message to the DM channel.
+	msgBody := sendMessageRequest{
+		Channel: dmChannelID,
+		Text:    params.Message,
+	}
+	var msgResp sendMessageResponse
+	if err := a.conn.doPost(ctx, "chat.postMessage", req.Credentials, msgBody, &msgResp); err != nil {
+		return nil, err
+	}
+	if !msgResp.OK {
+		return nil, mapSlackError(msgResp.Error)
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"ts":      msgResp.TS,
+		"channel": msgResp.Channel,
+	})
+}

--- a/connectors/slack/send_dm.go
+++ b/connectors/slack/send_dm.go
@@ -20,8 +20,8 @@ type sendDMParams struct {
 }
 
 func (p *sendDMParams) validate() error {
-	if p.UserID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: user_id"}
+	if err := validateUserID(p.UserID); err != nil {
+		return err
 	}
 	if p.Message == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: message"}

--- a/connectors/slack/send_dm_test.go
+++ b/connectors/slack/send_dm_test.go
@@ -171,6 +171,30 @@ func TestSendDM_ConversationsOpenError(t *testing.T) {
 	}
 }
 
+func TestSendDM_InvalidUserIDFormat(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendDMAction{conn: conn}
+
+	params, _ := json.Marshal(sendDMParams{
+		UserID:  "john.doe",
+		Message: "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid user_id format")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestSendDM_InvalidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/send_dm_test.go
+++ b/connectors/slack/send_dm_test.go
@@ -1,0 +1,191 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestSendDM_Success(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/conversations.open":
+			callCount++
+			var body conversationsOpenRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode conversations.open body: %v", err)
+			}
+			if body.Users != "U01234567" {
+				t.Errorf("expected users 'U01234567', got %q", body.Users)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"channel": map[string]string{"id": "D09876543"},
+			})
+
+		case "/chat.postMessage":
+			callCount++
+			var body sendMessageRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode chat.postMessage body: %v", err)
+			}
+			if body.Channel != "D09876543" {
+				t.Errorf("expected channel 'D09876543', got %q", body.Channel)
+			}
+			if body.Text != "Hello via DM!" {
+				t.Errorf("expected text 'Hello via DM!', got %q", body.Text)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"ts":      "1234567890.123456",
+				"channel": "D09876543",
+			})
+
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendDMAction{conn: conn}
+
+	params, _ := json.Marshal(sendDMParams{
+		UserID:  "U01234567",
+		Message: "Hello via DM!",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["ts"] != "1234567890.123456" {
+		t.Errorf("expected ts '1234567890.123456', got %q", data["ts"])
+	}
+	if data["channel"] != "D09876543" {
+		t.Errorf("expected channel 'D09876543', got %q", data["channel"])
+	}
+}
+
+func TestSendDM_MissingUserID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendDMAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"message": "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing user_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendDM_MissingMessage(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendDMAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"user_id": "U01234567",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendDM_ConversationsOpenError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "user_not_found",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendDMAction{conn: conn}
+
+	params, _ := json.Marshal(sendDMParams{
+		UserID:  "U_INVALID",
+		Message: "Hello",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for user_not_found")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got: %T", err)
+	}
+}
+
+func TestSendDM_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &sendDMAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/slack/send_dm_test.go
+++ b/connectors/slack/send_dm_test.go
@@ -141,7 +141,9 @@ func TestSendDM_MissingMessage(t *testing.T) {
 func TestSendDM_ConversationsOpenError(t *testing.T) {
 	t.Parallel()
 
+	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"ok":    false,
@@ -168,6 +170,9 @@ func TestSendDM_ConversationsOpenError(t *testing.T) {
 	}
 	if !connectors.IsExternalError(err) {
 		t.Errorf("expected ExternalError, got: %T", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 API call (conversations.open only), got %d", callCount)
 	}
 }
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -47,8 +47,10 @@ var OAuthScopes = []string{
 	"groups:history",
 	"groups:read",
 	"im:history",
+	"im:write",
 	"mpim:history",
 	"reactions:write",
+	"search:read",
 	"users:read",
 }
 
@@ -93,6 +95,11 @@ func (c *SlackConnector) Actions() map[string]connectors.Action {
 		"slack.invite_to_channel":     &inviteToChannelAction{conn: c},
 		"slack.upload_file":           &uploadFileAction{conn: c},
 		"slack.add_reaction":          &addReactionAction{conn: c},
+		"slack.send_dm":               &sendDMAction{conn: c},
+		"slack.update_message":        &updateMessageAction{conn: c},
+		"slack.delete_message":        &deleteMessageAction{conn: c},
+		"slack.list_users":            &listUsersAction{conn: c},
+		"slack.search_messages":       &searchMessagesAction{conn: c},
 	}
 }
 
@@ -281,6 +288,16 @@ func mapSlackError(slackErr string) error {
 		return &connectors.ExternalError{StatusCode: 200, Message: "the bot cannot invite itself to a channel"}
 	case "user_not_found":
 		return &connectors.ExternalError{StatusCode: 200, Message: "one or more user IDs were not found — verify the user IDs are correct"}
+
+	// Message edit/delete errors
+	case "message_not_found":
+		return &connectors.ExternalError{StatusCode: 200, Message: "message not found — verify the channel ID and message timestamp are correct"}
+	case "cant_delete_message":
+		return &connectors.ExternalError{StatusCode: 200, Message: "cannot delete this message — bots can only delete their own messages"}
+	case "edit_window_closed":
+		return &connectors.ExternalError{StatusCode: 200, Message: "the message editing window has closed — messages can only be edited within a limited time"}
+	case "cant_update_message":
+		return &connectors.ExternalError{StatusCode: 200, Message: "cannot update this message — bots can only edit their own messages"}
 
 	// Message errors
 	case "time_in_past":

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -171,6 +171,53 @@ func validateChannelID(channel string) error {
 	}
 }
 
+// validateUserID checks that a user_id parameter looks like a valid Slack user
+// ID (starts with U or W). This catches common mistakes like passing a username
+// or email instead of an ID before hitting the Slack API.
+func validateUserID(userID string) error {
+	if userID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: user_id"}
+	}
+	if len(userID) < 2 {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid user ID %q: expected a Slack user ID starting with U or W (e.g. U01234567)", userID),
+		}
+	}
+	switch userID[0] {
+	case 'U', 'W':
+		return nil
+	default:
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid user ID %q: expected a Slack user ID starting with U or W — did you pass a username instead?", userID),
+		}
+	}
+}
+
+// validateMessageTS checks that a message timestamp parameter is non-empty and
+// looks like a valid Slack TS value (contains a dot, e.g. "1234567890.123456").
+// This catches typos and wrong-format values before they reach the Slack API.
+func validateMessageTS(ts string) error {
+	if ts == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: ts (message timestamp)"}
+	}
+	dotFound := false
+	for _, c := range ts {
+		if c == '.' {
+			dotFound = true
+		} else if c < '0' || c > '9' {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("invalid message timestamp %q: expected a numeric Slack timestamp like 1234567890.123456", ts),
+			}
+		}
+	}
+	if !dotFound {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid message timestamp %q: expected a Slack timestamp with a dot separator (e.g. 1234567890.123456)", ts),
+		}
+	}
+	return nil
+}
+
 // validateLimit checks that a pagination limit is within the Slack API range (1-1000).
 // A zero value means "use default" and is always valid.
 func validateLimit(limit int) error {

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -47,11 +47,11 @@ var OAuthScopes = []string{
 	"groups:history",
 	"groups:read",
 	"im:history",
-	"im:write",
 	"mpim:history",
 	"reactions:write",
-	"search:read",
 	"users:read",
+	"im:write",
+	"search:read",
 }
 
 // SlackConnector owns the shared HTTP client and base URL used by all

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -194,25 +195,26 @@ func validateUserID(userID string) error {
 }
 
 // validateMessageTS checks that a message timestamp parameter is non-empty and
-// looks like a valid Slack TS value (contains a dot, e.g. "1234567890.123456").
-// This catches typos and wrong-format values before they reach the Slack API.
+// looks like a valid Slack TS value (exactly two numeric parts separated by a
+// dot, e.g. "1234567890.123456"). This catches typos and wrong-format values
+// before they reach the Slack API.
 func validateMessageTS(ts string) error {
 	if ts == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: ts (message timestamp)"}
 	}
-	dotFound := false
-	for _, c := range ts {
-		if c == '.' {
-			dotFound = true
-		} else if c < '0' || c > '9' {
-			return &connectors.ValidationError{
-				Message: fmt.Sprintf("invalid message timestamp %q: expected a numeric Slack timestamp like 1234567890.123456", ts),
-			}
+	parts := strings.SplitN(ts, ".", 3)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid message timestamp %q: expected format like 1234567890.123456", ts),
 		}
 	}
-	if !dotFound {
-		return &connectors.ValidationError{
-			Message: fmt.Sprintf("invalid message timestamp %q: expected a Slack timestamp with a dot separator (e.g. 1234567890.123456)", ts),
+	for _, part := range parts {
+		for _, c := range part {
+			if c < '0' || c > '9' {
+				return &connectors.ValidationError{
+					Message: fmt.Sprintf("invalid message timestamp %q: expected a numeric Slack timestamp like 1234567890.123456", ts),
+				}
+			}
 		}
 	}
 	return nil

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -221,3 +221,55 @@ func TestSlackConnector_ImplementsInterface(t *testing.T) {
 	var _ connectors.Connector = (*SlackConnector)(nil)
 	var _ connectors.ManifestProvider = (*SlackConnector)(nil)
 }
+
+func TestValidateUserID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		userID  string
+		wantErr bool
+	}{
+		{name: "valid U prefix", userID: "U01234567", wantErr: false},
+		{name: "valid W prefix", userID: "W01234567", wantErr: false},
+		{name: "empty", userID: "", wantErr: true},
+		{name: "single char", userID: "U", wantErr: true},
+		{name: "username instead of ID", userID: "john.doe", wantErr: true},
+		{name: "email instead of ID", userID: "john@example.com", wantErr: true},
+		{name: "channel ID", userID: "C01234567", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateUserID(tt.userID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateUserID(%q) error = %v, wantErr %v", tt.userID, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateMessageTS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ts      string
+		wantErr bool
+	}{
+		{name: "valid ts", ts: "1234567890.123456", wantErr: false},
+		{name: "empty", ts: "", wantErr: true},
+		{name: "no dot", ts: "1234567890123456", wantErr: true},
+		{name: "letters", ts: "not-a-timestamp", wantErr: true},
+		{name: "mixed", ts: "123abc.456", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateMessageTS(tt.ts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMessageTS(%q) error = %v, wantErr %v", tt.ts, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -30,6 +30,11 @@ func TestSlackConnector_Actions(t *testing.T) {
 		"slack.invite_to_channel",
 		"slack.upload_file",
 		"slack.add_reaction",
+		"slack.send_dm",
+		"slack.update_message",
+		"slack.delete_message",
+		"slack.list_users",
+		"slack.search_messages",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -132,8 +137,8 @@ func TestSlackConnector_Manifest(t *testing.T) {
 	if m.Name != "Slack" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Slack")
 	}
-	if len(m.Actions) != 10 {
-		t.Fatalf("Manifest().Actions has %d items, want 10", len(m.Actions))
+	if len(m.Actions) != 15 {
+		t.Fatalf("Manifest().Actions has %d items, want 15", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -144,6 +149,8 @@ func TestSlackConnector_Manifest(t *testing.T) {
 		"slack.read_channel_messages", "slack.read_thread",
 		"slack.schedule_message", "slack.set_topic", "slack.invite_to_channel",
 		"slack.upload_file", "slack.add_reaction",
+		"slack.send_dm", "slack.update_message", "slack.delete_message",
+		"slack.list_users", "slack.search_messages",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -262,6 +262,9 @@ func TestValidateMessageTS(t *testing.T) {
 		{name: "no dot", ts: "1234567890123456", wantErr: true},
 		{name: "letters", ts: "not-a-timestamp", wantErr: true},
 		{name: "mixed", ts: "123abc.456", wantErr: true},
+		{name: "multiple dots", ts: "1.2.3", wantErr: true},
+		{name: "leading dot", ts: ".123456", wantErr: true},
+		{name: "trailing dot", ts: "123456.", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/connectors/slack/update_message.go
+++ b/connectors/slack/update_message.go
@@ -23,8 +23,8 @@ func (p *updateMessageParams) validate() error {
 	if err := validateChannelID(p.Channel); err != nil {
 		return err
 	}
-	if p.TS == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: ts"}
+	if err := validateMessageTS(p.TS); err != nil {
+		return err
 	}
 	if p.Message == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: message"}

--- a/connectors/slack/update_message.go
+++ b/connectors/slack/update_message.go
@@ -1,0 +1,74 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// updateMessageAction implements connectors.Action for slack.update_message.
+// It edits an existing message via POST /chat.update.
+type updateMessageAction struct {
+	conn *SlackConnector
+}
+
+// updateMessageParams is the user-facing parameter schema.
+type updateMessageParams struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+	Message string `json:"message"`
+}
+
+func (p *updateMessageParams) validate() error {
+	if err := validateChannelID(p.Channel); err != nil {
+		return err
+	}
+	if p.TS == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: ts"}
+	}
+	if p.Message == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: message"}
+	}
+	return nil
+}
+
+// updateMessageRequest is the Slack API request body for chat.update.
+type updateMessageRequest struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+	Text    string `json:"text"`
+}
+
+type updateMessageResponse struct {
+	slackResponse
+	TS      string `json:"ts,omitempty"`
+	Channel string `json:"channel,omitempty"`
+}
+
+// Execute updates an existing Slack message and returns the updated metadata.
+func (a *updateMessageAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params updateMessageParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	body := updateMessageRequest{
+		Channel: params.Channel,
+		TS:      params.TS,
+		Text:    params.Message,
+	}
+
+	var resp updateMessageResponse
+	if err := a.conn.doPost(ctx, "chat.update", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, mapSlackError(resp.Error)
+	}
+
+	return connectors.JSONResult(map[string]string{
+		"ts":      resp.TS,
+		"channel": resp.Channel,
+	})
+}

--- a/connectors/slack/update_message_test.go
+++ b/connectors/slack/update_message_test.go
@@ -1,0 +1,224 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestUpdateMessage_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/chat.update" {
+			t.Errorf("expected path /chat.update, got %s", r.URL.Path)
+		}
+
+		var body updateMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Channel != "C01234567" {
+			t.Errorf("expected channel 'C01234567', got %q", body.Channel)
+		}
+		if body.TS != "1234567890.123456" {
+			t.Errorf("expected ts '1234567890.123456', got %q", body.TS)
+		}
+		if body.Text != "Updated message" {
+			t.Errorf("expected text 'Updated message', got %q", body.Text)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"ts":      "1234567890.123456",
+			"channel": "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(updateMessageParams{
+		Channel: "C01234567",
+		TS:      "1234567890.123456",
+		Message: "Updated message",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["ts"] != "1234567890.123456" {
+		t.Errorf("expected ts '1234567890.123456', got %q", data["ts"])
+	}
+	if data["channel"] != "C01234567" {
+		t.Errorf("expected channel 'C01234567', got %q", data["channel"])
+	}
+}
+
+func TestUpdateMessage_MissingChannel(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"ts":      "1234567890.123456",
+		"message": "Updated",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing channel")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateMessage_MissingTS(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C01234567",
+		"message": "Updated",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing ts")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateMessage_MissingMessage(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C01234567",
+		"ts":      "1234567890.123456",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateMessage_SlackAPIError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "message_not_found",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(updateMessageParams{
+		Channel: "C01234567",
+		TS:      "1234567890.123456",
+		Message: "Updated",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for message_not_found")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got: %T", err)
+	}
+}
+
+func TestUpdateMessage_InvalidChannelID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "general",
+		"ts":      "1234567890.123456",
+		"message": "Updated",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid channel ID")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestUpdateMessage_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateMessageAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}

--- a/connectors/slack/update_message_test.go
+++ b/connectors/slack/update_message_test.go
@@ -204,6 +204,31 @@ func TestUpdateMessage_InvalidChannelID(t *testing.T) {
 	}
 }
 
+func TestUpdateMessage_InvalidTSFormat(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &updateMessageAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C01234567",
+		"ts":      "not-a-timestamp",
+		"message": "Updated",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.update_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid ts format")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestUpdateMessage_InvalidJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add `slack.send_dm` action — opens a DM channel with a user and sends a message (two-step: `conversations.open` + `chat.postMessage`)
- Add `slack.update_message` action — edits an existing message via `chat.update`
- Add `slack.delete_message` action — deletes a message via `chat.delete`
- Add `slack.list_users` action — lists workspace users with cursor-based pagination via `users.list`
- Add `slack.search_messages` action — searches messages across channels via `search.messages`

Each action includes manifest entry (JSON Schema), handler file, permission template, and comprehensive tests. Adds `im:write` and `search:read` OAuth scopes, plus error mappings for message edit/delete failures.

Closes #402

## Test plan

### Claude Code
- [x] All 100 Slack connector tests pass (33 new)
- [x] `go vet` passes with no issues
- [x] `go build ./connectors/slack/` succeeds
- [x] Verify CI passes end-to-end

### OpenClaw
- [ ] Test `send_dm` with a real Slack workspace — confirm DM arrives
- [ ] Test `update_message` / `delete_message` — verify bots can edit/delete their own messages
- [ ] Test `list_users` pagination with a large workspace
- [ ] Test `search_messages` with a user token (bot tokens don't support search)
- [ ] Verify new OAuth scopes (`im:write`, `search:read`) are prompted during app installation

<https://claude.ai/code/session_015jFmzLjDqUpgiuU5uPZxsD>