### PR TITLE
Add persistent beta banner to all authenticated pages

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -6,6 +6,7 @@ import { useApprovals } from "@/hooks/useApprovals";
 import { Footer } from "./Footer";
 import { UserMenu } from "./UserMenu";
 import { PendingAgentBanners } from "./PendingAgentBanners";
+import { BetaBanner } from "./BetaBanner";
 
 interface NavItem {
   label: string;
@@ -33,7 +34,9 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const navItems = buildNavItems(pendingCount);
 
   return (
-    <div className="min-h-screen bg-background p-3 pb-20 md:p-5 md:pb-5">
+    <div className="min-h-screen bg-background">
+      <BetaBanner />
+      <div className="p-3 pb-20 md:p-5 md:pb-5">
       <nav className="mx-auto mb-6 flex max-w-[1200px] items-center rounded-xl border-b-2 bg-card px-4 py-3 shadow-sm md:mb-8 md:px-10 md:py-4">
         <Link to="/" className="flex items-center gap-2 text-base font-bold md:mr-10 md:gap-2.5 md:text-lg">
           <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-primary text-xs font-bold text-primary-foreground md:h-8 md:w-8 md:text-sm">
@@ -87,6 +90,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
       <Footer className="mx-auto mt-12 max-w-[1200px] border-t pt-4" />
 
+      </div>
       {/* Mobile bottom navigation */}
       <nav className="bg-card/95 fixed inset-x-0 bottom-0 z-40 border-t backdrop-blur-sm md:hidden">
         <div className="mx-auto flex max-w-md items-center justify-around px-4 py-2">

--- a/frontend/src/components/BetaBanner.tsx
+++ b/frontend/src/components/BetaBanner.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { GITHUB_REPO_URL } from "@/lib/links";
 
 /**
  * Persistent beta banner shown at the top of every authenticated page.
@@ -16,7 +17,7 @@ export function BetaBanner() {
       {" — "}
       This product is in early access. It is up to you to verify the code in our{" "}
       <a
-        href="https://github.com/supersuit-tech/permission-slip-web"
+        href={GITHUB_REPO_URL}
         target="_blank"
         rel="noopener noreferrer"
         className="underline underline-offset-2 hover:opacity-75"

--- a/frontend/src/components/BetaBanner.tsx
+++ b/frontend/src/components/BetaBanner.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+
+/**
+ * Persistent beta banner shown at the top of every authenticated page.
+ * Reminds users that the product is in early access and links to the
+ * open source repository and Terms of Service for verification.
+ */
+export function BetaBanner() {
+  return (
+    <div
+      role="banner"
+      aria-label="Beta notice"
+      className="w-full border-b border-secondary/20 bg-secondary/10 px-4 py-2 text-center text-xs text-secondary"
+    >
+      <span className="font-semibold">Beta</span>
+      {" — "}
+      This product is in early access. It is up to you to verify the code in our{" "}
+      <a
+        href="https://github.com/supersuit-tech/permission-slip-web"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2 hover:opacity-75"
+      >
+        open source repository
+      </a>{" "}
+      and{" "}
+      <Link
+        to="/policy/terms"
+        className="underline underline-offset-2 hover:opacity-75"
+      >
+        review our Terms of Service
+      </Link>{" "}
+      before use.
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/BetaBanner.test.tsx
+++ b/frontend/src/components/__tests__/BetaBanner.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { BetaBanner } from "../BetaBanner";
+import { GITHUB_REPO_URL } from "@/lib/links";
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <BetaBanner />
+    </MemoryRouter>,
+  );
+}
+
+describe("BetaBanner", () => {
+  it("renders the beta notice banner", () => {
+    renderBanner();
+    expect(screen.getByRole("banner", { name: /beta notice/i })).toBeInTheDocument();
+    expect(screen.getByText(/early access/i)).toBeInTheDocument();
+  });
+
+  it("links to the open source GitHub repository", () => {
+    renderBanner();
+    const link = screen.getByRole("link", { name: /open source repository/i });
+    expect(link).toHaveAttribute("href", GITHUB_REPO_URL);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("links to the Terms of Service page", () => {
+    renderBanner();
+    const link = screen.getByRole("link", { name: /terms of service/i });
+    expect(link).toHaveAttribute("href", "/policy/terms");
+  });
+});

--- a/frontend/src/lib/links.ts
+++ b/frontend/src/lib/links.ts
@@ -1,0 +1,2 @@
+/** URL of the Permission Slip open source repository. */
+export const GITHUB_REPO_URL = "https://github.com/supersuit-tech/permission-slip";

--- a/frontend/src/pages/policy/TermsOfServicePage.tsx
+++ b/frontend/src/pages/policy/TermsOfServicePage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { PolicyLayout } from "./PolicyLayout";
+import { GITHUB_REPO_URL } from "@/lib/links";
 
 export function TermsOfServicePage() {
   return (
@@ -196,11 +197,11 @@ export function TermsOfServicePage() {
         Permission Slip&apos;s source code is publicly available under the
         Apache 2.0 license at{" "}
         <a
-          href="https://github.com/supersuit-tech/permission-slip-web"
+          href={GITHUB_REPO_URL}
           target="_blank"
           rel="noopener noreferrer"
         >
-          github.com/supersuit-tech/permission-slip-web
+          github.com/supersuit-tech/permission-slip
         </a>
         .
       </p>


### PR DESCRIPTION
Shows a full-width notice at the top of every page reminding users
the product is in early access, linking to the open source repo
and Terms of Service for transparency.

https://claude.ai/code/session_01WoaWJPqsruKZUmS3VXw2CA