### PR TITLE
Fix "Keep me in the loop" text color on onboarding page

### DIFF
--- a/frontend/src/auth/OnboardingPage.tsx
+++ b/frontend/src/auth/OnboardingPage.tsx
@@ -111,7 +111,7 @@ export default function OnboardingPage() {
           />
           <Label
             htmlFor="marketing-opt-in"
-            className="text-sm font-normal leading-snug text-muted-foreground"
+            className="text-sm font-normal leading-snug"
           >
             Keep me in the loop — Get occasional emails about new features,
             platform updates, and tips to get more out of Permission Slip.


### PR DESCRIPTION
Remove text-muted-foreground class from the marketing opt-in label
so it matches the color of surrounding text instead of appearing grey.

https://claude.ai/code/session_012fW1NEvALV35uCJ8VY4SZ9