### PR TITLE
fix: ignore Stripe API version mismatch in webhook verification

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7522,24 +7522,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",

--- a/stripe/webhook.go
+++ b/stripe/webhook.go
@@ -33,7 +33,8 @@ func VerifyWebhook(r *http.Request, webhookSecret string, maxBodyBytes int64) (*
 		return nil, fmt.Errorf("stripe webhook: missing Stripe-Signature header")
 	}
 
-	event, err := webhook.ConstructEvent(body, sig, webhookSecret)
+	event, err := webhook.ConstructEventWithOptions(body, sig, webhookSecret,
+		webhook.ConstructEventOptions{IgnoreAPIVersionMismatch: true})
 	if err != nil {
 		return nil, fmt.Errorf("stripe webhook: verify signature: %w", err)
 	}


### PR DESCRIPTION
## Problem

After a user completes the Stripe Checkout payment flow, their plan stays on "free" instead of upgrading.

**Root cause:** `webhook.ConstructEvent()` in stripe-go v82 strictly validates that the incoming event's API version matches the SDK's expected version (`2025-08-27.basil`). Our Stripe account is set to API version `2022-11-15`, so every webhook arrives with that version and gets rejected with a 400 error.

This means no webhook events have ever been successfully processed — the subscription upgrade never gets written to the database.

## Fix

Use `webhook.ConstructEventWithOptions` with `IgnoreAPIVersionMismatch: true` so webhooks are verified and processed regardless of API version differences.

## Testing

- Complete the Stripe Checkout flow with test card `4242 4242 4242 4242`
- Confirm backend log shows `StripeWebhook: received event` (not a 400 error)
- Confirm plan updates from free → paid in the UI after webhook is processed