### PR TITLE
Fix invoice list response to match OpenAPI Invoice schema

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -77,7 +77,18 @@ type smsUsage struct {
 }
 
 type invoiceListResponse struct {
-	Invoices []pstripe.InvoiceSummary `json:"invoices"`
+	Invoices []apiInvoice `json:"invoices"`
+}
+
+// apiInvoice is the API representation of an invoice, matching the OpenAPI Invoice schema.
+type apiInvoice struct {
+	ID               string  `json:"id"`
+	Date             string  `json:"date"`
+	AmountCents      int64   `json:"amount_cents"`
+	Status           string  `json:"status"`
+	PeriodStart      *string `json:"period_start,omitempty"`
+	PeriodEnd        *string `json:"period_end,omitempty"`
+	StripeInvoiceURL *string `json:"stripe_invoice_url,omitempty"`
 }
 
 type billingPlanResponse struct {
@@ -606,19 +617,38 @@ func handleListInvoices(deps *Deps) http.HandlerFunc {
 		}
 		if sub == nil || sub.StripeCustomerID == nil {
 			// No Stripe customer → no invoices.
-			RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: []pstripe.InvoiceSummary{}})
+			RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: []apiInvoice{}})
 			return
 		}
 
-		invoices, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, maxInvoiceResults)
+		summaries, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, maxInvoiceResults)
 		if err != nil {
 			log.Printf("[%s] ListInvoices: Stripe list: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
 			RespondError(w, r, http.StatusBadGateway, upstreamError("Failed to fetch invoices"))
 			return
 		}
-		if invoices == nil {
-			invoices = []pstripe.InvoiceSummary{}
+
+		invoices := make([]apiInvoice, 0, len(summaries))
+		for _, s := range summaries {
+			inv := apiInvoice{
+				ID:          s.ID,
+				Date:        time.Unix(s.Created, 0).UTC().Format(time.RFC3339),
+				AmountCents: s.AmountPaid,
+				Status:      s.Status,
+			}
+			if s.PeriodStart > 0 {
+				ps := time.Unix(s.PeriodStart, 0).UTC().Format(time.RFC3339)
+				inv.PeriodStart = &ps
+			}
+			if s.PeriodEnd > 0 {
+				pe := time.Unix(s.PeriodEnd, 0).UTC().Format(time.RFC3339)
+				inv.PeriodEnd = &pe
+			}
+			if s.HostedURL != "" {
+				inv.StripeInvoiceURL = &s.HostedURL
+			}
+			invoices = append(invoices, inv)
 		}
 
 		RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: invoices})

--- a/api/billing.go
+++ b/api/billing.go
@@ -78,6 +78,7 @@ type smsUsage struct {
 
 type invoiceListResponse struct {
 	Invoices []apiInvoice `json:"invoices"`
+	HasMore  bool         `json:"has_more"`
 }
 
 // apiInvoice is the API representation of an invoice, matching the OpenAPI Invoice schema.
@@ -89,6 +90,29 @@ type apiInvoice struct {
 	PeriodStart      *string `json:"period_start,omitempty"`
 	PeriodEnd        *string `json:"period_end,omitempty"`
 	StripeInvoiceURL *string `json:"stripe_invoice_url,omitempty"`
+}
+
+// toAPIInvoice converts a Stripe InvoiceSummary to the API Invoice schema.
+func toAPIInvoice(s pstripe.InvoiceSummary) apiInvoice {
+	inv := apiInvoice{
+		ID:          s.ID,
+		Date:        time.Unix(s.Created, 0).UTC().Format(time.RFC3339),
+		AmountCents: s.AmountPaid,
+		Status:      s.Status,
+	}
+	if s.PeriodStart > 0 {
+		ps := time.Unix(s.PeriodStart, 0).UTC().Format(time.RFC3339)
+		inv.PeriodStart = &ps
+	}
+	if s.PeriodEnd > 0 {
+		pe := time.Unix(s.PeriodEnd, 0).UTC().Format(time.RFC3339)
+		inv.PeriodEnd = &pe
+	}
+	if s.HostedURL != "" {
+		hu := s.HostedURL
+		inv.StripeInvoiceURL = &hu
+	}
+	return inv
 }
 
 type billingPlanResponse struct {
@@ -621,7 +645,7 @@ func handleListInvoices(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		summaries, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, maxInvoiceResults)
+		summaries, hasMore, err := deps.Stripe.ListInvoices(r.Context(), *sub.StripeCustomerID, maxInvoiceResults)
 		if err != nil {
 			log.Printf("[%s] ListInvoices: Stripe list: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -631,27 +655,10 @@ func handleListInvoices(deps *Deps) http.HandlerFunc {
 
 		invoices := make([]apiInvoice, 0, len(summaries))
 		for _, s := range summaries {
-			inv := apiInvoice{
-				ID:          s.ID,
-				Date:        time.Unix(s.Created, 0).UTC().Format(time.RFC3339),
-				AmountCents: s.AmountPaid,
-				Status:      s.Status,
-			}
-			if s.PeriodStart > 0 {
-				ps := time.Unix(s.PeriodStart, 0).UTC().Format(time.RFC3339)
-				inv.PeriodStart = &ps
-			}
-			if s.PeriodEnd > 0 {
-				pe := time.Unix(s.PeriodEnd, 0).UTC().Format(time.RFC3339)
-				inv.PeriodEnd = &pe
-			}
-			if s.HostedURL != "" {
-				inv.StripeInvoiceURL = &s.HostedURL
-			}
-			invoices = append(invoices, inv)
+			invoices = append(invoices, toAPIInvoice(s))
 		}
 
-		RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: invoices})
+		RespondJSON(w, http.StatusOK, invoiceListResponse{Invoices: invoices, HasMore: hasMore})
 	}
 }
 

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -879,6 +879,85 @@ func TestListInvoices_NoStripeCustomer(t *testing.T) {
 	}
 }
 
+// ── toAPIInvoice mapping ────────────────────────────────────────────────────
+
+func TestToAPIInvoice_FullFields(t *testing.T) {
+	t.Parallel()
+	hostedURL := "https://invoice.stripe.com/i/acct_123/inv_456"
+	s := pstripe.InvoiceSummary{
+		ID:          "inv_456",
+		Status:      "paid",
+		AmountPaid:  1099,
+		Created:     1740787200, // 2025-03-01T00:00:00Z
+		PeriodStart: 1738368000, // 2025-02-01T00:00:00Z
+		PeriodEnd:   1740787200, // 2025-03-01T00:00:00Z
+		HostedURL:   hostedURL,
+	}
+
+	inv := toAPIInvoice(s)
+
+	if inv.ID != "inv_456" {
+		t.Errorf("ID: got %q, want %q", inv.ID, "inv_456")
+	}
+	if inv.AmountCents != 1099 {
+		t.Errorf("AmountCents: got %d, want 1099", inv.AmountCents)
+	}
+	if inv.Status != "paid" {
+		t.Errorf("Status: got %q, want %q", inv.Status, "paid")
+	}
+	wantDate := time.Unix(1740787200, 0).UTC().Format(time.RFC3339)
+	if inv.Date != wantDate {
+		t.Errorf("Date: got %q, want %q", inv.Date, wantDate)
+	}
+	if inv.PeriodStart == nil {
+		t.Fatal("PeriodStart: expected non-nil")
+	}
+	wantPS := time.Unix(1738368000, 0).UTC().Format(time.RFC3339)
+	if *inv.PeriodStart != wantPS {
+		t.Errorf("PeriodStart: got %q, want %q", *inv.PeriodStart, wantPS)
+	}
+	if inv.PeriodEnd == nil {
+		t.Fatal("PeriodEnd: expected non-nil")
+	}
+	wantPE := time.Unix(1740787200, 0).UTC().Format(time.RFC3339)
+	if *inv.PeriodEnd != wantPE {
+		t.Errorf("PeriodEnd: got %q, want %q", *inv.PeriodEnd, wantPE)
+	}
+	if inv.StripeInvoiceURL == nil {
+		t.Fatal("StripeInvoiceURL: expected non-nil")
+	}
+	if *inv.StripeInvoiceURL != hostedURL {
+		t.Errorf("StripeInvoiceURL: got %q, want %q", *inv.StripeInvoiceURL, hostedURL)
+	}
+	// Ensure pointer independence — mutating the original doesn't affect the copy.
+	s.HostedURL = "https://other.example.com"
+	if *inv.StripeInvoiceURL != hostedURL {
+		t.Error("StripeInvoiceURL pointer aliases original struct field")
+	}
+}
+
+func TestToAPIInvoice_OptionalFieldsAbsent(t *testing.T) {
+	t.Parallel()
+	s := pstripe.InvoiceSummary{
+		ID:      "inv_789",
+		Status:  "paid",
+		Created: 1740787200,
+		// PeriodStart, PeriodEnd, and HostedURL intentionally zero/empty
+	}
+
+	inv := toAPIInvoice(s)
+
+	if inv.PeriodStart != nil {
+		t.Errorf("PeriodStart: expected nil when zero, got %q", *inv.PeriodStart)
+	}
+	if inv.PeriodEnd != nil {
+		t.Errorf("PeriodEnd: expected nil when zero, got %q", *inv.PeriodEnd)
+	}
+	if inv.StripeInvoiceURL != nil {
+		t.Errorf("StripeInvoiceURL: expected nil when empty, got %q", *inv.StripeInvoiceURL)
+	}
+}
+
 func TestListInvoices_NoSubscription(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
@@ -906,3 +985,4 @@ func TestListInvoices_NoSubscription(t *testing.T) {
 		t.Errorf("expected empty invoices list, got %d", len(resp.Invoices))
 	}
 }
+

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -183,18 +183,22 @@ type InvoiceSummary struct {
 
 // ListInvoices returns up to `limit` invoices for the given Stripe customer,
 // filtered to only paid invoices. Returns an empty slice if the customer has
-// no invoices.
-func (c *Client) ListInvoices(ctx context.Context, stripeCustomerID string, limit int) ([]InvoiceSummary, error) {
+// no invoices. hasMore is true when additional invoices exist beyond the limit.
+func (c *Client) ListInvoices(ctx context.Context, stripeCustomerID string, limit int) (invoices []InvoiceSummary, hasMore bool, err error) {
 	params := &gostripe.InvoiceListParams{
 		Customer: gostripe.String(stripeCustomerID),
 		Status:   gostripe.String("paid"),
 	}
-	params.Limit = gostripe.Int64(int64(limit))
+	// Fetch one extra to detect whether more pages exist.
+	params.Limit = gostripe.Int64(int64(limit + 1))
 	params.Context = ctx
 
-	var invoices []InvoiceSummary
 	iter := invoice.List(params)
 	for iter.Next() {
+		if len(invoices) == limit {
+			hasMore = true
+			break
+		}
 		inv := iter.Invoice()
 		summary := InvoiceSummary{
 			ID:          inv.ID,
@@ -215,10 +219,10 @@ func (c *Client) ListInvoices(ctx context.Context, stripeCustomerID string, limi
 		}
 		invoices = append(invoices, summary)
 	}
-	if err := iter.Err(); err != nil {
-		return nil, fmt.Errorf("stripe: list invoices: %w", err)
+	if iterErr := iter.Err(); iterErr != nil {
+		return nil, false, fmt.Errorf("stripe: list invoices: %w", iterErr)
 	}
-	return invoices, nil
+	return invoices, hasMore, nil
 }
 
 // ── Payment Method operations ─────────────────────────────────────────────


### PR DESCRIPTION
The backend was returning InvoiceSummary objects (with `created`,
`amount_due`/`amount_paid`, `hosted_invoice_url`) but the frontend's
generated types expect Invoice objects (with `date`, `amount_cents`,
`stripe_invoice_url`). This caused `invoice.date` and
`invoice.amount_cents` to be undefined in the frontend, resulting in
"Invalid Date" and "$NaN" in the Recent Invoices section.

Now maps InvoiceSummary → apiInvoice, converting Unix timestamps to
RFC3339 strings and using `amount_paid` as `amount_cents`.

https://claude.ai/code/session_01K77eKU1oZQ18PDzoJbZDjS