### PR TITLE
Disable auto-stop machines to prevent server downtime

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,9 +21,9 @@ kill_timeout = '30s'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [http_service.concurrency]
     type = 'requests'


### PR DESCRIPTION
The Fly.io machine was being stopped multiple times a day due to
auto_stop_machines being set to 'stop' with min_machines_running at 0.
Set auto_stop_machines to false and min_machines_running to 1 to keep
the server always available.

https://claude.ai/code/session_01499RfpBkTHte17ivb4w6YW