### PR TITLE
Add least-privilege app_backend database role (tasks 1-3 of #182)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 # Test database — used by "go test" and CI (standalone Postgres, not Supabase)
 DATABASE_URL_TEST=postgres://localhost:5432/permission_slip_test?sslmode=disable
 
+# App backend database role — least-privilege runtime role (separate from superuser migrations)
+# Password 'app_backend_dev' matches what the migration sets for local dev.
+DATABASE_URL_APP=postgresql://app_backend:app_backend_dev@127.0.0.1:54322/postgres
+
 # API base URL — override the default "/api" prefix used by the frontend
 # VITE_API_BASE_URL=/api/v1
 

--- a/db/migrations/20260309003720_create_app_backend_role.sql
+++ b/db/migrations/20260309003720_create_app_backend_role.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+
+-- Create the role with a known local dev password.
+-- Production password is set separately via Supabase SQL Editor (see deployment docs).
+CREATE ROLE app_backend WITH LOGIN PASSWORD 'app_backend_dev';
+
+GRANT CONNECT ON DATABASE postgres TO app_backend;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+  action_config_templates,
+  action_configurations,
+  agent_connectors,
+  agents,
+  approvals,
+  audit_events,
+  connector_actions,
+  connector_required_credentials,
+  connectors,
+  credentials,
+  expo_push_tokens,
+  notification_preferences,
+  oauth_connections,
+  oauth_provider_configs,
+  payment_method_transactions,
+  payment_methods,
+  plans,
+  profiles,
+  push_subscriptions,
+  registration_invites,
+  request_ids,
+  server_config,
+  standing_approval_executions,
+  standing_approvals,
+  stripe_webhook_events,
+  subscriptions,
+  usage_periods
+TO app_backend;
+
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_backend;
+
+-- Future tables: default privileges so new migrations don't need manual grants
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_backend;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO app_backend;
+
+-- +goose Down
+
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM app_backend;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM app_backend;
+REVOKE CONNECT ON DATABASE postgres FROM app_backend;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM app_backend;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE USAGE, SELECT ON SEQUENCES FROM app_backend;
+DROP ROLE IF EXISTS app_backend;

--- a/main.go
+++ b/main.go
@@ -196,7 +196,14 @@ func main() {
 			log.Fatalf("Failed to run migrations: %v", err)
 		}
 
-		pool, err := db.Connect(ctx, dbURL)
+		// Use least-privilege app role for runtime queries, falling back to
+		// the superuser DATABASE_URL for backward compatibility.
+		appURL := os.Getenv("DATABASE_URL_APP")
+		if appURL == "" {
+			appURL = dbURL
+		}
+
+		pool, err := db.Connect(ctx, appURL)
 		if err != nil {
 			sentry.CaptureException(err)
 			sentry.Flush(2 * time.Second)


### PR DESCRIPTION
- Create migration to add app_backend role with only DML privileges on
  application tables (SELECT, INSERT, UPDATE, DELETE) plus sequence usage
- Add DATABASE_URL_APP to .env.example for local dev
- Update main.go to prefer DATABASE_URL_APP for runtime queries while
  keeping DATABASE_URL (superuser) for migrations

Note: consumed_tokens was removed from the grant list since it was
dropped in migration 20260304111830.

https://claude.ai/code/session_01Lq1Fceg6qgLgwfZ2mw4qnx