### PR TITLE
Improve login rate limit UX: better error message and resend cooldown

### DIFF
--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -18,7 +18,11 @@ export default function LoginPage() {
         onBack={() => setStep("email")}
         onResend={async () => {
           const result = await sendOtp(email);
-          if (!result.error) cooldown.start();
+          // Start cooldown on success or rate-limit error so the button
+          // stays disabled even when the server rejects the request.
+          if (!result.error || result.error.code === "over_email_send_rate_limit") {
+            cooldown.start();
+          }
           return result;
         }}
         resendCooldownSeconds={cooldown.secondsLeft}

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useAuth } from "./AuthContext";
+import { useCooldown } from "./useCooldown";
 import EmailStep from "./EmailStep";
 import OtpStep from "./OtpStep";
 
@@ -7,6 +8,7 @@ export default function LoginPage() {
   const { sendOtp, verifyOtp } = useAuth();
   const [step, setStep] = useState<"email" | "otp">("email");
   const [email, setEmail] = useState("");
+  const cooldown = useCooldown();
 
   if (step === "otp") {
     return (
@@ -14,6 +16,12 @@ export default function LoginPage() {
         email={email}
         onVerify={(code) => verifyOtp(email, code)}
         onBack={() => setStep("email")}
+        onResend={async () => {
+          const result = await sendOtp(email);
+          if (!result.error) cooldown.start();
+          return result;
+        }}
+        resendCooldownSeconds={cooldown.secondsLeft}
       />
     );
   }
@@ -25,6 +33,7 @@ export default function LoginPage() {
         if (!result.error) {
           setEmail(inputEmail);
           setStep("otp");
+          cooldown.start();
         }
         return result;
       }}

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -11,11 +11,32 @@ interface OtpStepProps {
   email: string;
   onVerify: (code: string) => Promise<{ error: AuthError | null }>;
   onBack: () => void;
+  onResend: () => Promise<{ error: AuthError | null }>;
+  resendCooldownSeconds: number;
 }
 
-export default function OtpStep({ email, onVerify, onBack }: OtpStepProps) {
+export default function OtpStep({
+  email,
+  onVerify,
+  onBack,
+  onResend,
+  resendCooldownSeconds,
+}: OtpStepProps) {
   const [otpCode, setOtpCode] = useState("");
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
+  const [resendError, setResendError] = useState<string | null>(null);
+  const [resendSuccess, setResendSuccess] = useState(false);
+
+  const handleResend = async () => {
+    setResendError(null);
+    setResendSuccess(false);
+    const { error } = await onResend();
+    if (error) {
+      setResendError("Could not resend — please wait a moment and try again.");
+    } else {
+      setResendSuccess(true);
+    }
+  };
 
   const handleAutoFill = async () => {
     // Dynamic import keeps dev-only Mailpit code out of the production bundle
@@ -57,13 +78,33 @@ export default function OtpStep({ email, onVerify, onBack }: OtpStepProps) {
           </Button>
         </div>
       </form>
+      <div className="mt-3 flex flex-col items-start gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleResend}
+          disabled={resendCooldownSeconds > 0}
+          className="opacity-70"
+        >
+          {resendCooldownSeconds > 0
+            ? `Resend in ${resendCooldownSeconds}s`
+            : "Resend code"}
+        </Button>
+        {resendError && (
+          <p className="text-xs text-destructive">{resendError}</p>
+        )}
+        {resendSuccess && (
+          <p className="text-xs text-muted-foreground">Code resent.</p>
+        )}
+      </div>
       <DevOnly>
         <Button
           type="button"
           variant="ghost"
           size="sm"
           onClick={handleAutoFill}
-          className="mt-3 opacity-70"
+          className="mt-1 opacity-70"
         >
           Dev: Auto-fill code from Mailpit
         </Button>

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { AuthError } from "@supabase/supabase-js";
 import { useFormSubmit } from "./useFormSubmit";
+import { safeErrorMessage } from "./errors";
 import AuthLayout from "./AuthLayout";
 import DevOnly from "../components/DevOnly";
 import { Button } from "@/components/ui/button";
@@ -26,15 +27,23 @@ export default function OtpStep({
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
   const [resendError, setResendError] = useState<string | null>(null);
   const [resendSuccess, setResendSuccess] = useState(false);
+  const [isResending, setIsResending] = useState(false);
 
   const handleResend = async () => {
     setResendError(null);
     setResendSuccess(false);
-    const { error } = await onResend();
-    if (error) {
-      setResendError("Could not resend — please wait a moment and try again.");
-    } else {
-      setResendSuccess(true);
+    setIsResending(true);
+    try {
+      const { error } = await onResend();
+      if (error) {
+        setResendError(safeErrorMessage(error));
+      } else {
+        setResendSuccess(true);
+      }
+    } catch {
+      setResendError("Something went wrong. Please try again.");
+    } finally {
+      setIsResending(false);
     }
   };
 
@@ -84,12 +93,14 @@ export default function OtpStep({
           variant="ghost"
           size="sm"
           onClick={handleResend}
-          disabled={resendCooldownSeconds > 0}
+          disabled={resendCooldownSeconds > 0 || isResending}
           className="opacity-70"
         >
           {resendCooldownSeconds > 0
             ? `Resend in ${resendCooldownSeconds}s`
-            : "Resend code"}
+            : isResending
+              ? "Resending…"
+              : "Resend code"}
         </Button>
         {resendError && (
           <p className="text-xs text-destructive">{resendError}</p>

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -103,13 +103,24 @@ export default function OtpStep({
           size="sm"
           onClick={handleResend}
           disabled={resendCooldownSeconds > 0 || isResending}
+          aria-label={
+            resendCooldownSeconds > 0
+              ? "Resend code (on cooldown)"
+              : isResending
+                ? "Resending code"
+                : "Resend code"
+          }
           className="opacity-70"
         >
-          {resendCooldownSeconds > 0
-            ? `Resend in ${resendCooldownSeconds}s`
-            : isResending
-              ? "Resending…"
-              : "Resend code"}
+          {resendCooldownSeconds > 0 ? (
+            <>
+              Resend in <span aria-hidden="true">{resendCooldownSeconds}s</span>
+            </>
+          ) : isResending ? (
+            "Resending…"
+          ) : (
+            "Resend code"
+          )}
         </Button>
         {resendError && (
           <p className="text-xs text-destructive">{resendError}</p>

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { AuthError } from "@supabase/supabase-js";
 import { useFormSubmit } from "./useFormSubmit";
 import { safeErrorMessage } from "./errors";
@@ -28,6 +28,12 @@ export default function OtpStep({
   const [resendError, setResendError] = useState<string | null>(null);
   const [resendSuccess, setResendSuccess] = useState(false);
   const [isResending, setIsResending] = useState(false);
+
+  // Clear the success banner when the cooldown expires so it doesn't
+  // linger indefinitely alongside an active "Resend code" button.
+  useEffect(() => {
+    if (resendCooldownSeconds === 0) setResendSuccess(false);
+  }, [resendCooldownSeconds]);
 
   const handleResend = async () => {
     setResendError(null);

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -107,7 +107,7 @@ export default function OtpStep({
             resendCooldownSeconds > 0
               ? "Resend code (on cooldown)"
               : isResending
-                ? "Resending code"
+                ? "Resending…"
                 : "Resend code"
           }
           className="opacity-70"

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -43,10 +43,10 @@ export default function OtpStep({
     setResendSuccess(false);
     setIsResending(true);
     try {
-      const { error } = await onResend();
-      if (error) {
+      const { error: resendResultError } = await onResend();
+      if (resendResultError) {
         setResendError(
-          safeErrorMessage(error, {
+          safeErrorMessage(resendResultError, {
             over_email_send_rate_limit:
               "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
           })

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -45,7 +45,12 @@ export default function OtpStep({
     try {
       const { error } = await onResend();
       if (error) {
-        setResendError(safeErrorMessage(error));
+        setResendError(
+          safeErrorMessage(error, {
+            over_email_send_rate_limit:
+              "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
+          })
+        );
       } else {
         setResendSuccess(true);
       }

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -123,10 +123,10 @@ export default function OtpStep({
           )}
         </Button>
         {resendError && (
-          <p className="text-xs text-destructive">{resendError}</p>
+          <p role="alert" className="text-xs text-destructive">{resendError}</p>
         )}
         {resendSuccess && (
-          <p className="text-xs text-muted-foreground">Code resent.</p>
+          <p role="status" className="text-xs text-muted-foreground">Code resent.</p>
         )}
       </div>
       <DevOnly>

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -110,7 +110,7 @@ export default function OtpStep({
           disabled={resendCooldownSeconds > 0 || isResending}
           aria-label={
             resendCooldownSeconds > 0
-              ? "Resend code (on cooldown)"
+              ? `Resend code in ${resendCooldownSeconds}s (on cooldown)`
               : isResending
                 ? "Resending…"
                 : "Resend code"

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -32,7 +32,10 @@ export default function OtpStep({
   // Clear the success banner when the cooldown expires so it doesn't
   // linger indefinitely alongside an active "Resend code" button.
   useEffect(() => {
-    if (resendCooldownSeconds === 0) setResendSuccess(false);
+    if (resendCooldownSeconds === 0) {
+      setResendSuccess(false);
+      setResendError(null);
+    }
   }, [resendCooldownSeconds]);
 
   const handleResend = async () => {

--- a/frontend/src/auth/__tests__/EmailStep.test.tsx
+++ b/frontend/src/auth/__tests__/EmailStep.test.tsx
@@ -51,7 +51,7 @@ describe("EmailStep", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "Too many login emails sent.",
+          "Too many login emails sent. Please wait",
           { exact: false }
         )
       ).toBeInTheDocument();

--- a/frontend/src/auth/__tests__/EmailStep.test.tsx
+++ b/frontend/src/auth/__tests__/EmailStep.test.tsx
@@ -51,7 +51,7 @@ describe("EmailStep", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "Too many requests. Please wait a moment and try again.",
+          "Too many login emails sent.",
           { exact: false }
         )
       ).toBeInTheDocument();

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -84,7 +84,7 @@ describe("OtpStep", () => {
 
   it("disables resend button and shows countdown during cooldown", () => {
     renderOtpStep({ ...defaultProps, resendCooldownSeconds: 42 });
-    const btn = screen.getByRole("button", { name: "Resend code (on cooldown)" });
+    const btn = screen.getByRole("button", { name: "Resend code in 42s (on cooldown)" });
     expect(btn).toBeInTheDocument();
     expect(btn).toBeDisabled();
     expect(screen.getByText("42s")).toBeInTheDocument();

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -14,6 +14,8 @@ const defaultProps = {
   email: "test@example.com",
   onVerify: vi.fn().mockResolvedValue({ error: null }),
   onBack: vi.fn(),
+  onResend: vi.fn().mockResolvedValue({ error: null }),
+  resendCooldownSeconds: 0,
 };
 
 function renderOtpStep(props = defaultProps) {

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -87,7 +87,7 @@ describe("OtpStep", () => {
     const btn = screen.getByRole("button", { name: "Resend code in 42s (on cooldown)" });
     expect(btn).toBeInTheDocument();
     expect(btn).toBeDisabled();
-    expect(screen.getByText("42s")).toBeInTheDocument();
+    expect(btn).toHaveTextContent("42s");
   });
 
   it("calls onResend when resend button is clicked", async () => {

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -74,4 +74,52 @@ describe("OtpStep", () => {
 
     expect(onBack).toHaveBeenCalled();
   });
+
+  it("shows resend button when cooldown is 0", () => {
+    renderOtpStep({ ...defaultProps, resendCooldownSeconds: 0 });
+    expect(screen.getByText("Resend code")).toBeInTheDocument();
+    expect(screen.getByText("Resend code")).not.toBeDisabled();
+  });
+
+  it("disables resend button and shows countdown during cooldown", () => {
+    renderOtpStep({ ...defaultProps, resendCooldownSeconds: 42 });
+    const btn = screen.getByText("Resend in 42s");
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeDisabled();
+  });
+
+  it("calls onResend when resend button is clicked", async () => {
+    const onResend = vi.fn().mockResolvedValue({ error: null });
+    renderOtpStep({ ...defaultProps, onResend });
+
+    await userEvent.click(screen.getByText("Resend code"));
+
+    expect(onResend).toHaveBeenCalled();
+  });
+
+  it("shows success message after resend", async () => {
+    const onResend = vi.fn().mockResolvedValue({ error: null });
+    renderOtpStep({ ...defaultProps, onResend });
+
+    await userEvent.click(screen.getByText("Resend code"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Code resent.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows safe error message when resend fails", async () => {
+    const onResend = vi.fn().mockResolvedValue({
+      error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
+    });
+    renderOtpStep({ ...defaultProps, onResend });
+
+    await userEvent.click(screen.getByText("Resend code"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Too many login emails sent.", { exact: false })
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -77,22 +77,24 @@ describe("OtpStep", () => {
 
   it("shows resend button when cooldown is 0", () => {
     renderOtpStep({ ...defaultProps, resendCooldownSeconds: 0 });
-    expect(screen.getByText("Resend code")).toBeInTheDocument();
-    expect(screen.getByText("Resend code")).not.toBeDisabled();
+    const btn = screen.getByRole("button", { name: "Resend code" });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
   });
 
   it("disables resend button and shows countdown during cooldown", () => {
     renderOtpStep({ ...defaultProps, resendCooldownSeconds: 42 });
-    const btn = screen.getByText("Resend in 42s");
+    const btn = screen.getByRole("button", { name: "Resend code (on cooldown)" });
     expect(btn).toBeInTheDocument();
     expect(btn).toBeDisabled();
+    expect(screen.getByText("42s")).toBeInTheDocument();
   });
 
   it("calls onResend when resend button is clicked", async () => {
     const onResend = vi.fn().mockResolvedValue({ error: null });
     renderOtpStep({ ...defaultProps, onResend });
 
-    await userEvent.click(screen.getByText("Resend code"));
+    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 
     expect(onResend).toHaveBeenCalled();
   });
@@ -101,7 +103,7 @@ describe("OtpStep", () => {
     const onResend = vi.fn().mockResolvedValue({ error: null });
     renderOtpStep({ ...defaultProps, onResend });
 
-    await userEvent.click(screen.getByText("Resend code"));
+    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 
     await waitFor(() => {
       expect(screen.getByText("Code resent.")).toBeInTheDocument();
@@ -114,12 +116,43 @@ describe("OtpStep", () => {
     });
     renderOtpStep({ ...defaultProps, onResend });
 
-    await userEvent.click(screen.getByText("Resend code"));
+    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 
     await waitFor(() => {
       expect(
         screen.getByText("Too many login emails sent.", { exact: false })
       ).toBeInTheDocument();
+    });
+  });
+
+  it("clears success banner when cooldown expires", async () => {
+    const onResend = vi.fn().mockResolvedValue({ error: null });
+    const { rerender } = renderOtpStep({ ...defaultProps, onResend, resendCooldownSeconds: 0 });
+
+    // Click resend — success message appears
+    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
+    await waitFor(() => {
+      expect(screen.getByText("Code resent.")).toBeInTheDocument();
+    });
+
+    // Simulate cooldown starting then expiring back to 0
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <OtpStep {...defaultProps} onResend={onResend} resendCooldownSeconds={5} />
+        </CookieConsentProvider>
+      </MemoryRouter>
+    );
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <OtpStep {...defaultProps} onResend={onResend} resendCooldownSeconds={0} />
+        </CookieConsentProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Code resent.")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/auth/__tests__/errors.test.ts
+++ b/frontend/src/auth/__tests__/errors.test.ts
@@ -17,7 +17,7 @@ describe("safeErrorMessage", () => {
       "over_email_send_rate_limit"
     );
     expect(safeErrorMessage(error)).toBe(
-      "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again."
+      "Too many login emails sent. Please wait a few minutes and try again."
     );
   });
 

--- a/frontend/src/auth/__tests__/errors.test.ts
+++ b/frontend/src/auth/__tests__/errors.test.ts
@@ -17,7 +17,7 @@ describe("safeErrorMessage", () => {
       "over_email_send_rate_limit"
     );
     expect(safeErrorMessage(error)).toBe(
-      "Too many requests. Please wait a moment and try again."
+      "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again."
     );
   });
 

--- a/frontend/src/auth/__tests__/useCooldown.test.ts
+++ b/frontend/src/auth/__tests__/useCooldown.test.ts
@@ -84,6 +84,17 @@ describe("useCooldown", () => {
     expect(result.current.isActive).toBe(false);
   });
 
+  it("uses DEFAULT_SECONDS (60) when start() is called with no arguments", () => {
+    const { result } = renderHook(() => useCooldown());
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.secondsLeft).toBe(60);
+    expect(result.current.isActive).toBe(true);
+  });
+
   it("does nothing when start(0) is called", () => {
     const { result } = renderHook(() => useCooldown());
 

--- a/frontend/src/auth/__tests__/useCooldown.test.ts
+++ b/frontend/src/auth/__tests__/useCooldown.test.ts
@@ -1,0 +1,107 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCooldown } from "../useCooldown";
+
+describe("useCooldown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts inactive with secondsLeft at 0", () => {
+    const { result } = renderHook(() => useCooldown());
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("becomes active and counts down after start()", () => {
+    const { result } = renderHook(() => useCooldown());
+
+    act(() => {
+      result.current.start(3);
+    });
+
+    expect(result.current.secondsLeft).toBe(3);
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.secondsLeft).toBe(1);
+  });
+
+  it("reaches 0 and becomes inactive after full countdown", () => {
+    const { result } = renderHook(() => useCooldown());
+
+    act(() => {
+      result.current.start(2);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("resets correctly when start() is called while already running", () => {
+    const { result } = renderHook(() => useCooldown());
+
+    act(() => {
+      result.current.start(10);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.secondsLeft).toBe(7);
+
+    // Restart with a fresh 5-second countdown
+    act(() => {
+      result.current.start(5);
+    });
+
+    expect(result.current.secondsLeft).toBe(5);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("does nothing when start(0) is called", () => {
+    const { result } = renderHook(() => useCooldown());
+
+    act(() => {
+      result.current.start(0);
+    });
+
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("cleans up interval on unmount mid-countdown", () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const { result, unmount } = renderHook(() => useCooldown());
+
+    act(() => {
+      result.current.start(10);
+    });
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/frontend/src/auth/__tests__/useCooldown.test.ts
+++ b/frontend/src/auth/__tests__/useCooldown.test.ts
@@ -2,6 +2,8 @@ import { renderHook, act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCooldown } from "../useCooldown";
 
+let clearIntervalSpy: ReturnType<typeof vi.spyOn> | null = null;
+
 describe("useCooldown", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -9,6 +11,8 @@ describe("useCooldown", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    clearIntervalSpy?.mockRestore();
+    clearIntervalSpy = null;
   });
 
   it("starts inactive with secondsLeft at 0", () => {
@@ -92,7 +96,7 @@ describe("useCooldown", () => {
   });
 
   it("cleans up interval on unmount mid-countdown", () => {
-    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
     const { result, unmount } = renderHook(() => useCooldown());
 
     act(() => {
@@ -102,6 +106,5 @@ describe("useCooldown", () => {
     unmount();
 
     expect(clearIntervalSpy).toHaveBeenCalled();
-    clearIntervalSpy.mockRestore();
   });
 });

--- a/frontend/src/auth/errors.ts
+++ b/frontend/src/auth/errors.ts
@@ -10,7 +10,7 @@ const SAFE_ERROR_MESSAGES: Record<string, string> = {
   over_request_rate_limit:
     "Too many attempts. Please wait a moment and try again.",
   over_email_send_rate_limit:
-    "Too many requests. Please wait a moment and try again.",
+    "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
   mfa_factor_not_found: "No authenticator found. Please re-enroll.",
   mfa_verification_failed:
     "Invalid code. Please check your authenticator app and try again.",

--- a/frontend/src/auth/errors.ts
+++ b/frontend/src/auth/errors.ts
@@ -10,7 +10,7 @@ const SAFE_ERROR_MESSAGES: Record<string, string> = {
   over_request_rate_limit:
     "Too many attempts. Please wait a moment and try again.",
   over_email_send_rate_limit:
-    "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
+    "Too many login emails sent. Please wait a few minutes and try again.",
   mfa_factor_not_found: "No authenticator found. Please re-enroll.",
   mfa_verification_failed:
     "Invalid code. Please check your authenticator app and try again.",
@@ -20,9 +20,17 @@ const SAFE_ERROR_MESSAGES: Record<string, string> = {
 };
 
 /** Returns a user-safe message for a Supabase AuthError by matching its code
- *  against a known allowlist. Unknown codes get a generic fallback. */
-export function safeErrorMessage(error: AuthError): string {
+ *  against a known allowlist. Unknown codes get a generic fallback.
+ *
+ *  Pass `overrides` to substitute a context-specific message for a given code
+ *  while still falling back to the allowlist for everything else. */
+export function safeErrorMessage(
+  error: AuthError,
+  overrides?: Partial<Record<string, string>>
+): string {
   if (error.code) {
+    const override = overrides?.[error.code];
+    if (override) return override;
     const message = SAFE_ERROR_MESSAGES[error.code];
     if (message) return message;
   }

--- a/frontend/src/auth/errors.ts
+++ b/frontend/src/auth/errors.ts
@@ -30,7 +30,7 @@ export function safeErrorMessage(
 ): string {
   if (error.code) {
     const override = overrides?.[error.code];
-    if (override) return override;
+    if (override !== undefined) return override;
     const message = SAFE_ERROR_MESSAGES[error.code];
     if (message) return message;
   }

--- a/frontend/src/auth/useCooldown.ts
+++ b/frontend/src/auth/useCooldown.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useRef } from "react";
+
+interface UseCooldownResult {
+  secondsLeft: number;
+  isActive: boolean;
+  start: (seconds?: number) => void;
+}
+
+const DEFAULT_SECONDS = 60;
+
+/** Tracks a countdown timer (e.g. for rate-limit cooldowns). Call start() to
+ *  begin a countdown; secondsLeft counts down to 0, then isActive becomes false. */
+export function useCooldown(): UseCooldownResult {
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const start = (seconds = DEFAULT_SECONDS) => {
+    if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    setSecondsLeft(seconds);
+    intervalRef.current = setInterval(() => {
+      setSecondsLeft((prev) => {
+        if (prev <= 1) {
+          if (intervalRef.current !== null) clearInterval(intervalRef.current);
+          intervalRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  return { secondsLeft, isActive: secondsLeft > 0, start };
+}

--- a/frontend/src/auth/useCooldown.ts
+++ b/frontend/src/auth/useCooldown.ts
@@ -20,19 +20,21 @@ export function useCooldown(): UseCooldownResult {
     };
   }, []);
 
+  // Clear the interval once the counter reaches zero, keeping the
+  // state updater above pure (no side effects inside the updater).
+  useEffect(() => {
+    if (secondsLeft === 0 && intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, [secondsLeft]);
+
   const start = useCallback((seconds = DEFAULT_SECONDS) => {
     if (seconds <= 0) return;
     if (intervalRef.current !== null) clearInterval(intervalRef.current);
     setSecondsLeft(seconds);
     intervalRef.current = setInterval(() => {
-      setSecondsLeft((prev) => {
-        if (prev <= 1) {
-          if (intervalRef.current !== null) clearInterval(intervalRef.current);
-          intervalRef.current = null;
-          return 0;
-        }
-        return prev - 1;
-      });
+      setSecondsLeft((prev) => (prev <= 1 ? 0 : prev - 1));
     }, 1000);
   }, []);
 

--- a/frontend/src/auth/useCooldown.ts
+++ b/frontend/src/auth/useCooldown.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 
 interface UseCooldownResult {
   secondsLeft: number;
@@ -20,7 +20,8 @@ export function useCooldown(): UseCooldownResult {
     };
   }, []);
 
-  const start = (seconds = DEFAULT_SECONDS) => {
+  const start = useCallback((seconds = DEFAULT_SECONDS) => {
+    if (seconds <= 0) return;
     if (intervalRef.current !== null) clearInterval(intervalRef.current);
     setSecondsLeft(seconds);
     intervalRef.current = setInterval(() => {
@@ -33,7 +34,7 @@ export function useCooldown(): UseCooldownResult {
         return prev - 1;
       });
     }, 1000);
-  };
+  }, []);
 
   return { secondsLeft, isActive: secondsLeft > 0, start };
 }


### PR DESCRIPTION
- Clarify `over_email_send_rate_limit` message to tell users their
  existing OTP code is still valid if they already received one
- Add `useCooldown` hook for a 60-second countdown timer
- Show "Resend code" button on OTP step with live countdown (e.g.
  "Resend in 42s") to prevent users from hammering send and burning
  through the project-level email rate limit
- Update tests to match new message and new OtpStep props

https://claude.ai/code/session_01LrnH4zb3ErewEDcaWojVB5