### PR TITLE
Fix profile re-link failing in production due to auth.users INSERT permission

### DIFF
--- a/db/profile_relink.go
+++ b/db/profile_relink.go
@@ -62,12 +62,27 @@ func RelinkProfile(ctx context.Context, db DBTX, oldID, newID string) error {
 	// Ensure the new auth.users entry exists (Supabase manages this in prod;
 	// in local dev we create a minimal row ourselves). We omit the email
 	// to avoid colliding with the old user's unique email constraint.
+	//
+	// In production the app_backend role only has SELECT on auth.users
+	// (INSERT is intentionally omitted because Supabase creates the row
+	// during OTP login). The INSERT is therefore always a no-op in prod,
+	// but PostgreSQL still checks INSERT privilege before evaluating
+	// ON CONFLICT DO NOTHING — resulting in a 42501 (insufficient_privilege)
+	// error. We treat this specific error as success: if we lack INSERT
+	// permission, the row must already exist (managed by Supabase).
 	_, err := db.Exec(ctx,
 		`INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING`,
 		newID,
 	)
 	if err != nil {
-		return err
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42501" {
+			// insufficient_privilege — expected in production where
+			// app_backend lacks INSERT on auth.users. Safe to ignore
+			// because Supabase already created the row during login.
+		} else {
+			return err
+		}
 	}
 
 	// Update the profile PK — ON UPDATE CASCADE propagates to all child tables.


### PR DESCRIPTION
## Problem

The profile re-link mechanism added in #445 fails silently in production. When a returning user logs in and Supabase assigns a new UUID for their email, the re-link flow is supposed to transparently update their profile's primary key. Instead, it fails because:

`RelinkProfile` executes:
```sql
INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING
```

The `app_backend` role only has `SELECT` on `auth.users` (INSERT was intentionally omitted in the migration since Supabase creates the row during OTP login). However, **PostgreSQL checks INSERT privilege BEFORE evaluating ON CONFLICT DO NOTHING**, so even a no-op INSERT fails with error `42501` (insufficient_privilege).

## Symptoms

1. User clicks magic link → blank loading page (briefly)
2. After auth completes → sees the 'create username' onboarding page (as if new user)
3. Enters their existing username → 'Username is already taken' or 'Failed to create profile'

## Root Cause

The error cascade:
1. `RequireProfile` → profile not found by new user ID → email fallback finds old profile
2. `RelinkProfile` → `INSERT INTO auth.users` → **42501 insufficient_privilege** → re-link aborts
3. Profile remains nil → 404 → frontend shows onboarding page
4. Onboarding handler → `CreateProfile` fails (username taken) → re-link attempt → same INSERT error

## Fix

Catch PostgreSQL error code `42501` (insufficient_privilege) on the auth.users INSERT and treat it as success. If we lack INSERT permission, the row must already exist because Supabase manages auth.users rows during the OTP login flow.

This is a 1-line logic fix (plus comments) in `db/profile_relink.go`. No migration changes needed — the existing migration's SELECT-only grant is correct for production security.

## Testing

- All existing relink tests pass (`TestRelinkProfile`, `TestRelinkProfile_CascadesToChildTables`, etc.)
- All onboarding API tests pass
- The 42501 scenario only occurs in production (tests run as superuser), but the fix is narrowly scoped to a single well-documented error code