### PR TITLE
Fix login failure: missing auth schema USAGE grant for app_backend

### DIFF
--- a/db/migrations/20260310102034_grant_auth_schema_usage_to_app_backend.sql
+++ b/db/migrations/20260310102034_grant_auth_schema_usage_to_app_backend.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- The app_backend role was granted SELECT on auth.users (in the cascade
+-- migration) but was never granted USAGE on the auth schema. In PostgreSQL,
+-- both USAGE on the schema and the table-level privilege are required.
+-- Without schema USAGE, every query touching auth.users (FindProfileByAuthEmail,
+-- RelinkProfile, CreateProfile) fails with 42501 insufficient_privilege —
+-- making profile re-linking and new-user onboarding silently fail in
+-- production.
+GRANT USAGE ON SCHEMA auth TO app_backend;
+
+-- +goose Down
+REVOKE USAGE ON SCHEMA auth FROM app_backend;

--- a/db/onboarding.go
+++ b/db/onboarding.go
@@ -34,12 +34,26 @@ func CreateProfile(ctx context.Context, db DBTX, userID, username string, market
 	// In production (Supabase), auth.users is managed by Supabase and this
 	// row already exists by the time the user reaches onboarding.
 	// In local dev (standalone Postgres), we insert it ourselves.
+	//
+	// In production the app_backend role only has SELECT on auth.users
+	// (INSERT is intentionally omitted because Supabase creates the row
+	// during OTP login). PostgreSQL checks INSERT privilege before evaluating
+	// ON CONFLICT DO NOTHING, so the no-op INSERT raises 42501
+	// (insufficient_privilege). We treat this as success: if we lack INSERT
+	// permission, the row must already exist (managed by Supabase).
 	_, err := db.Exec(ctx,
 		`INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT (id) DO NOTHING`,
 		userID,
 	)
 	if err != nil {
-		return nil, err
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42501" {
+			// insufficient_privilege — expected in production where
+			// app_backend lacks INSERT on auth.users. Safe to ignore
+			// because Supabase already created the row during login.
+		} else {
+			return nil, err
+		}
 	}
 
 	var p Profile


### PR DESCRIPTION
## Summary
- Add `GRANT USAGE ON SCHEMA auth TO app_backend` — the root cause of login failures. The role had `SELECT ON auth.users` but lacked schema-level USAGE, so **all** queries touching `auth.users` silently failed with `42501` in production. This broke both profile re-linking (PR #445) and new-user onboarding.
- Add `42501` handling to `CreateProfile`'s `auth.users` INSERT, mirroring the fix from PR #450 in `RelinkProfile`, as a defense-in-depth measure.

## Why PR #450 didn't fix the issue

PR #450 correctly handled the `42501` from `RelinkProfile`'s INSERT into `auth.users`. But the re-link path was **never reached** because `FindProfileByAuthEmail` — which JOINs `auth.users` — also failed with `42501` due to the missing schema USAGE. The error cascade:

1. `RequireProfile` → `GetProfileByUserID(newUUID)` → not found
2. `FindProfileByAuthEmail(email)` → `JOIN auth.users` → **42501** (no schema USAGE) → returns nil
3. Re-link skipped (no old profile found) → user sees onboarding
4. `CreateProfile` → `INSERT INTO auth.users` → **42501** (same issue, plus no INSERT handler) → "Failed to create profile"

## Test plan

### Claude Code
- [x] All DB tests pass (`go test ./db/... -v`)
- [x] All API tests pass (`go test ./api/... -v -run "Onboarding|Relink|Profile|Session"`)
- [x] Migration integrity test passes (unique timestamps, sorted order)
- [x] All 664 frontend tests pass
- [x] `go build ./...` succeeds
- [x] `go vet` passes

### OpenClaw
- [ ] Deploy to production and verify chiedo@chiedo.com can login
- [ ] Verify the migration applies cleanly on the production database
- [ ] Monitor logs — `FindProfileByAuthEmail` should no longer log 42501 errors
- [ ] Consider enabling `enable_manual_linking` in Supabase to prevent duplicate UUID creation at the source (TODO from PR #445)

https://claude.ai/code/session_01VsnZf6Pewz353BZoFKK9Za