### PR TITLE
Update login UI to communicate magic link sign-in

### DIFF
--- a/frontend/src/auth/EmailStep.tsx
+++ b/frontend/src/auth/EmailStep.tsx
@@ -18,7 +18,7 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
   return (
     <AuthLayout>
       <p className="text-sm text-muted-foreground">
-        Enter your email to sign in or create an account.
+        Enter your email and we'll send you a sign-in link.
       </p>
       <form
         onSubmit={(e) => handleSubmit(e, () => onSubmit(email.trim()))}

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -48,7 +48,7 @@ export default function OtpStep({
         setResendError(
           safeErrorMessage(resendResultError, {
             over_email_send_rate_limit:
-              "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
+              "Too many login emails sent. Check your inbox for an existing link, or wait a few minutes and try again.",
           })
         );
       } else {
@@ -73,7 +73,8 @@ export default function OtpStep({
   return (
     <AuthLayout>
       <p className="text-sm text-muted-foreground">
-        Enter the code sent to <strong>{email}</strong>
+        We sent a sign-in link to <strong>{email}</strong>.
+        Click the link in your email, or enter the code below.
       </p>
       <form
         onSubmit={(e) => handleSubmit(e, () => onVerify(otpCode))}
@@ -110,10 +111,10 @@ export default function OtpStep({
           disabled={resendCooldownSeconds > 0 || isResending}
           aria-label={
             resendCooldownSeconds > 0
-              ? `Resend code in ${resendCooldownSeconds}s (on cooldown)`
+              ? `Resend email in ${resendCooldownSeconds}s (on cooldown)`
               : isResending
                 ? "Resending…"
-                : "Resend code"
+                : "Resend email"
           }
           className="opacity-70"
         >
@@ -124,14 +125,14 @@ export default function OtpStep({
           ) : isResending ? (
             "Resending…"
           ) : (
-            "Resend code"
+            "Resend email"
           )}
         </Button>
         {resendError && (
           <p role="alert" className="text-xs text-destructive">{resendError}</p>
         )}
         {resendSuccess && (
-          <p role="status" className="text-xs text-muted-foreground">Code resent.</p>
+          <p role="status" className="text-xs text-muted-foreground">Email resent.</p>
         )}
       </div>
       <DevOnly>

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -59,7 +59,7 @@ describe("OtpStep", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "Your code has expired. Please request a new one.",
+          "Your sign-in link has expired. Please request a new one.",
           { exact: false }
         )
       ).toBeInTheDocument();
@@ -77,14 +77,14 @@ describe("OtpStep", () => {
 
   it("shows resend button when cooldown is 0", () => {
     renderOtpStep({ ...defaultProps, resendCooldownSeconds: 0 });
-    const btn = screen.getByRole("button", { name: "Resend code" });
+    const btn = screen.getByRole("button", { name: "Resend email" });
     expect(btn).toBeInTheDocument();
     expect(btn).not.toBeDisabled();
   });
 
   it("disables resend button and shows countdown during cooldown", () => {
     renderOtpStep({ ...defaultProps, resendCooldownSeconds: 42 });
-    const btn = screen.getByRole("button", { name: "Resend code in 42s (on cooldown)" });
+    const btn = screen.getByRole("button", { name: "Resend email in 42s (on cooldown)" });
     expect(btn).toBeInTheDocument();
     expect(btn).toBeDisabled();
     expect(btn).toHaveTextContent("42s");
@@ -94,7 +94,7 @@ describe("OtpStep", () => {
     const onResend = vi.fn().mockResolvedValue({ error: null });
     renderOtpStep({ ...defaultProps, onResend });
 
-    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
 
     expect(onResend).toHaveBeenCalled();
   });
@@ -103,10 +103,10 @@ describe("OtpStep", () => {
     const onResend = vi.fn().mockResolvedValue({ error: null });
     renderOtpStep({ ...defaultProps, onResend });
 
-    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Code resent.")).toBeInTheDocument();
+      expect(screen.getByText("Email resent.")).toBeInTheDocument();
     });
   });
 
@@ -116,7 +116,7 @@ describe("OtpStep", () => {
     });
     renderOtpStep({ ...defaultProps, onResend });
 
-    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
 
     await waitFor(() => {
       expect(
@@ -130,9 +130,9 @@ describe("OtpStep", () => {
     const { rerender } = renderOtpStep({ ...defaultProps, onResend, resendCooldownSeconds: 0 });
 
     // Click resend — success message appears
-    await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
     await waitFor(() => {
-      expect(screen.getByText("Code resent.")).toBeInTheDocument();
+      expect(screen.getByText("Email resent.")).toBeInTheDocument();
     });
 
     // Simulate cooldown starting then expiring back to 0
@@ -152,7 +152,7 @@ describe("OtpStep", () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText("Code resent.")).not.toBeInTheDocument();
+      expect(screen.queryByText("Email resent.")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/auth/__tests__/errors.test.ts
+++ b/frontend/src/auth/__tests__/errors.test.ts
@@ -6,7 +6,7 @@ describe("safeErrorMessage", () => {
   it("maps otp_expired code", () => {
     const error = new AuthError("Token expired", 401, "otp_expired");
     expect(safeErrorMessage(error)).toBe(
-      "Your code has expired. Please request a new one."
+      "Your sign-in link has expired. Please request a new one."
     );
   });
 

--- a/frontend/src/auth/errors.ts
+++ b/frontend/src/auth/errors.ts
@@ -5,7 +5,7 @@ import type { AuthError } from "@supabase/supabase-js";
 // we only surface messages from this allowlist and fall back to a generic
 // message for anything unexpected.
 const SAFE_ERROR_MESSAGES: Record<string, string> = {
-  otp_expired: "Your code has expired. Please request a new one.",
+  otp_expired: "Your sign-in link has expired. Please request a new one.",
   otp_disabled: "Something went wrong. Please try again.",
   over_request_rate_limit:
     "Too many attempts. Please wait a moment and try again.",

--- a/mobile/src/auth/EmailStep.tsx
+++ b/mobile/src/auth/EmailStep.tsx
@@ -44,7 +44,7 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
       <Pressable style={authStyles.content} onPress={Keyboard.dismiss}>
         <Text style={authStyles.title}>Permission Slip</Text>
         <Text style={authStyles.subtitle}>
-          Enter your email to sign in or create an account.
+          Enter your email and we'll send you a sign-in link.
         </Text>
 
         <View style={authStyles.field}>
@@ -76,7 +76,7 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
 
         <TouchableOpacity
           testID="email-submit"
-          accessibilityLabel={isSubmitting ? "Sending code" : "Continue"}
+          accessibilityLabel={isSubmitting ? "Sending link" : "Continue"}
           accessibilityRole="button"
           style={[
             authStyles.button,

--- a/mobile/src/auth/OtpStep.tsx
+++ b/mobile/src/auth/OtpStep.tsx
@@ -99,8 +99,9 @@ export default function OtpStep({
       <Pressable style={authStyles.content} onPress={Keyboard.dismiss}>
         <Text style={authStyles.title}>Check your email</Text>
         <Text style={authStyles.subtitle}>
-          Enter the code sent to{" "}
-          <Text style={localStyles.bold}>{email}</Text>
+          We sent a sign-in link to{" "}
+          <Text style={localStyles.bold}>{email}</Text>. Tap the link in the
+          email, or enter the code below.
         </Text>
 
         <View style={authStyles.field}>
@@ -164,7 +165,7 @@ export default function OtpStep({
         <View style={localStyles.resendRow}>
           <TouchableOpacity
             testID="otp-resend"
-            accessibilityLabel="Resend verification code"
+            accessibilityLabel="Resend sign-in email"
             accessibilityRole="button"
             onPress={handleResend}
             disabled={resendCooldown > 0 || isSubmitting}
@@ -177,8 +178,8 @@ export default function OtpStep({
               ]}
             >
               {resendCooldown > 0
-                ? `Resend code (${resendCooldown}s)`
-                : "Resend code"}
+                ? `Resend email (${resendCooldown}s)`
+                : "Resend email"}
             </Text>
           </TouchableOpacity>
           {resendStatus !== "idle" ? (
@@ -190,7 +191,7 @@ export default function OtpStep({
               ]}
             >
               {resendStatus === "sent"
-                ? "Code sent!"
+                ? "Email sent!"
                 : "Failed to resend. Please try again."}
             </Text>
           ) : null}

--- a/mobile/src/auth/__tests__/errors.test.ts
+++ b/mobile/src/auth/__tests__/errors.test.ts
@@ -13,7 +13,7 @@ function mockAuthError(code: string): AuthError {
 describe("safeErrorMessage", () => {
   it("returns a safe message for known error codes", () => {
     expect(safeErrorMessage(mockAuthError("otp_expired"))).toBe(
-      "Your code has expired. Please request a new one."
+      "Your sign-in link has expired. Please request a new one."
     );
     expect(safeErrorMessage(mockAuthError("over_request_rate_limit"))).toBe(
       "Too many attempts. Please wait a moment and try again."

--- a/mobile/src/auth/errors.ts
+++ b/mobile/src/auth/errors.ts
@@ -5,7 +5,7 @@ import type { AuthError } from "@supabase/supabase-js";
 // we only surface messages from this allowlist and fall back to a generic
 // message for anything unexpected.
 const SAFE_ERROR_MESSAGES: Record<string, string> = {
-  otp_expired: "Your code has expired. Please request a new one.",
+  otp_expired: "Your sign-in link has expired. Please request a new one.",
   otp_disabled: "Something went wrong. Please try again.",
   over_request_rate_limit:
     "Too many attempts. Please wait a moment and try again.",


### PR DESCRIPTION
## Summary

- Updated login flow copy (web + mobile) to tell users they can **click the sign-in link** in their email OR enter the 6-digit code
- Changed "Resend code" to "Resend email" and "Code resent" to "Email resent"
- Updated `otp_expired` error message to reference "sign-in link" instead of "code"
- Updated subtitle on email entry step: "Enter your email and we'll send you a sign-in link"

## Context

Supabase sends both a magic link and a 6-digit OTP code in the sign-in email. The UI previously only mentioned entering a code, which confused users who saw the magic link prominently in their email.

## Test plan

### Claude Code
- [x] Frontend tests pass (`make test-frontend` — 664/664)
- [x] Mobile tests pass (`make mobile-test` — 181/181)
- [x] TypeScript compiles cleanly (both `frontend` and `mobile`)

### OpenClaw
- [ ] Verify production email template — confirm both magic link and code are visible
- [ ] Manual test: sign in via magic link on web
- [ ] Manual test: sign in via OTP code on web
- [ ] Manual test: sign in on mobile (both methods)
- [ ] Review copy for tone/clarity

https://claude.ai/code/session_019iy3rqR8A2he5265ounQYD