### PR TITLE
Fix login/profile creation: add per-table RLS policies for app_backend

### DIFF
--- a/db/migrations/20260310111634_grant_bypassrls_to_app_backend.sql
+++ b/db/migrations/20260310111634_grant_bypassrls_to_app_backend.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- The app_backend role needs BYPASSRLS because RLS is enabled on all
+-- application tables with no permissive policies (RLS is intended to
+-- block PostgREST/anon access only). Without BYPASSRLS, every query
+-- from the Go backend returns zero rows.
+ALTER ROLE app_backend BYPASSRLS;
+
+-- +goose Down
+ALTER ROLE app_backend NOBYPASSRLS;

--- a/db/migrations/20260310111634_grant_bypassrls_to_app_backend.sql
+++ b/db/migrations/20260310111634_grant_bypassrls_to_app_backend.sql
@@ -16,7 +16,6 @@ CREATE POLICY app_backend_all ON registration_invites FOR ALL TO app_backend USI
 CREATE POLICY app_backend_all ON agents FOR ALL TO app_backend USING (true) WITH CHECK (true);
 CREATE POLICY app_backend_all ON approvals FOR ALL TO app_backend USING (true) WITH CHECK (true);
 CREATE POLICY app_backend_all ON request_ids FOR ALL TO app_backend USING (true) WITH CHECK (true);
-CREATE POLICY app_backend_all ON consumed_tokens FOR ALL TO app_backend USING (true) WITH CHECK (true);
 CREATE POLICY app_backend_all ON credentials FOR ALL TO app_backend USING (true) WITH CHECK (true);
 CREATE POLICY app_backend_all ON agent_connectors FOR ALL TO app_backend USING (true) WITH CHECK (true);
 CREATE POLICY app_backend_all ON action_configurations FOR ALL TO app_backend USING (true) WITH CHECK (true);
@@ -52,7 +51,6 @@ DROP POLICY IF EXISTS app_backend_all ON registration_invites;
 DROP POLICY IF EXISTS app_backend_all ON agents;
 DROP POLICY IF EXISTS app_backend_all ON approvals;
 DROP POLICY IF EXISTS app_backend_all ON request_ids;
-DROP POLICY IF EXISTS app_backend_all ON consumed_tokens;
 DROP POLICY IF EXISTS app_backend_all ON credentials;
 DROP POLICY IF EXISTS app_backend_all ON agent_connectors;
 DROP POLICY IF EXISTS app_backend_all ON action_configurations;

--- a/db/migrations/20260310111634_grant_bypassrls_to_app_backend.sql
+++ b/db/migrations/20260310111634_grant_bypassrls_to_app_backend.sql
@@ -1,9 +1,74 @@
 -- +goose Up
--- The app_backend role needs BYPASSRLS because RLS is enabled on all
--- application tables with no permissive policies (RLS is intended to
--- block PostgREST/anon access only). Without BYPASSRLS, every query
--- from the Go backend returns zero rows.
-ALTER ROLE app_backend BYPASSRLS;
+-- RLS is enabled on all tables with no permissive policies to block
+-- PostgREST/anon access. The app_backend role (non-superuser) needs
+-- explicit allow-all policies so it can read/write rows at runtime.
+--
+-- We use per-table policies instead of BYPASSRLS so the role stays
+-- least-privilege — if scoped policies are added later, just drop
+-- these blanket policies and replace them.
+
+-- Tables from 20260303220625_enable_rls_all_tables
+CREATE POLICY app_backend_all ON profiles FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON connectors FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON connector_actions FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON connector_required_credentials FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON registration_invites FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON agents FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON approvals FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON request_ids FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON consumed_tokens FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON credentials FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON agent_connectors FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON action_configurations FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON action_config_templates FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON standing_approvals FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON standing_approval_executions FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON audit_events FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON plans FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON subscriptions FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON usage_periods FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON stripe_webhook_events FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON push_subscriptions FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON notification_preferences FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON server_config FOR ALL TO app_backend USING (true) WITH CHECK (true);
+
+-- Tables from 20260304041308_add_expo_push_tokens
+CREATE POLICY app_backend_all ON expo_push_tokens FOR ALL TO app_backend USING (true) WITH CHECK (true);
+
+-- Tables from 20260305045137_enable_rls_oauth_tables
+CREATE POLICY app_backend_all ON oauth_connections FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON oauth_provider_configs FOR ALL TO app_backend USING (true) WITH CHECK (true);
+
+-- Tables from 20260306021221_add_payment_methods
+CREATE POLICY app_backend_all ON payment_methods FOR ALL TO app_backend USING (true) WITH CHECK (true);
+CREATE POLICY app_backend_all ON payment_method_transactions FOR ALL TO app_backend USING (true) WITH CHECK (true);
 
 -- +goose Down
-ALTER ROLE app_backend NOBYPASSRLS;
+DROP POLICY IF EXISTS app_backend_all ON profiles;
+DROP POLICY IF EXISTS app_backend_all ON connectors;
+DROP POLICY IF EXISTS app_backend_all ON connector_actions;
+DROP POLICY IF EXISTS app_backend_all ON connector_required_credentials;
+DROP POLICY IF EXISTS app_backend_all ON registration_invites;
+DROP POLICY IF EXISTS app_backend_all ON agents;
+DROP POLICY IF EXISTS app_backend_all ON approvals;
+DROP POLICY IF EXISTS app_backend_all ON request_ids;
+DROP POLICY IF EXISTS app_backend_all ON consumed_tokens;
+DROP POLICY IF EXISTS app_backend_all ON credentials;
+DROP POLICY IF EXISTS app_backend_all ON agent_connectors;
+DROP POLICY IF EXISTS app_backend_all ON action_configurations;
+DROP POLICY IF EXISTS app_backend_all ON action_config_templates;
+DROP POLICY IF EXISTS app_backend_all ON standing_approvals;
+DROP POLICY IF EXISTS app_backend_all ON standing_approval_executions;
+DROP POLICY IF EXISTS app_backend_all ON audit_events;
+DROP POLICY IF EXISTS app_backend_all ON plans;
+DROP POLICY IF EXISTS app_backend_all ON subscriptions;
+DROP POLICY IF EXISTS app_backend_all ON usage_periods;
+DROP POLICY IF EXISTS app_backend_all ON stripe_webhook_events;
+DROP POLICY IF EXISTS app_backend_all ON push_subscriptions;
+DROP POLICY IF EXISTS app_backend_all ON notification_preferences;
+DROP POLICY IF EXISTS app_backend_all ON server_config;
+DROP POLICY IF EXISTS app_backend_all ON expo_push_tokens;
+DROP POLICY IF EXISTS app_backend_all ON oauth_connections;
+DROP POLICY IF EXISTS app_backend_all ON oauth_provider_configs;
+DROP POLICY IF EXISTS app_backend_all ON payment_methods;
+DROP POLICY IF EXISTS app_backend_all ON payment_method_transactions;

--- a/db/rls_test.go
+++ b/db/rls_test.go
@@ -46,3 +46,42 @@ func TestRLSEnabledOnAllTables(t *testing.T) {
 		t.Fatal("no tables found in public schema — migrations may not have run")
 	}
 }
+
+// TestAppBackendHasPoliciesOnAllRLSTables verifies that every RLS-enabled table
+// has an allow-all policy for the app_backend role. Without this, queries from
+// the Go backend silently return zero rows — a subtle bug that's hard to debug.
+func TestAppBackendHasPoliciesOnAllRLSTables(t *testing.T) {
+	t.Parallel()
+	pool := testhelper.SetupTestDB(t)
+
+	// Find all RLS-enabled tables that lack an app_backend policy.
+	rows, err := pool.Query(context.Background(), `
+		SELECT t.tablename
+		FROM pg_tables t
+		WHERE t.schemaname = 'public'
+		  AND t.tablename != 'goose_db_version'
+		  AND t.rowsecurity = true
+		  AND NOT EXISTS (
+		    SELECT 1 FROM pg_policies p
+		    WHERE p.schemaname = 'public'
+		      AND p.tablename = t.tablename
+		      AND 'app_backend' = ANY(p.roles)
+		  )
+		ORDER BY t.tablename
+	`)
+	if err != nil {
+		t.Fatalf("failed to query for missing policies: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tablename string
+		if err := rows.Scan(&tablename); err != nil {
+			t.Fatalf("failed to scan row: %v", err)
+		}
+		t.Errorf("table %q has RLS enabled but no policy for app_backend — the Go backend will get zero rows", tablename)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration error: %v", err)
+	}
+}

--- a/db/rls_test.go
+++ b/db/rls_test.go
@@ -55,6 +55,8 @@ func TestAppBackendHasPoliciesOnAllRLSTables(t *testing.T) {
 	pool := testhelper.SetupTestDB(t)
 
 	// Find all RLS-enabled tables that lack an app_backend policy.
+	// A TO PUBLIC policy (stored as '{=}' in pg_policies.roles) also covers
+	// app_backend, so we accept that as well.
 	rows, err := pool.Query(context.Background(), `
 		SELECT t.tablename
 		FROM pg_tables t
@@ -65,7 +67,7 @@ func TestAppBackendHasPoliciesOnAllRLSTables(t *testing.T) {
 		    SELECT 1 FROM pg_policies p
 		    WHERE p.schemaname = 'public'
 		      AND p.tablename = t.tablename
-		      AND 'app_backend' = ANY(p.roles)
+		      AND ('app_backend' = ANY(p.roles) OR p.roles = '{=}')
 		  )
 		ORDER BY t.tablename
 	`)
@@ -74,14 +76,35 @@ func TestAppBackendHasPoliciesOnAllRLSTables(t *testing.T) {
 	}
 	defer rows.Close()
 
+	var checked int
 	for rows.Next() {
 		var tablename string
 		if err := rows.Scan(&tablename); err != nil {
 			t.Fatalf("failed to scan row: %v", err)
 		}
+		checked++
 		t.Errorf("table %q has RLS enabled but no policy for app_backend — the Go backend will get zero rows", tablename)
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatalf("row iteration error: %v", err)
+	}
+
+	// Guard against vacuous pass when migrations didn't run.
+	if checked == 0 {
+		// Verify there actually are RLS-enabled tables — if there aren't,
+		// something is wrong with the test setup.
+		var rlsCount int
+		err := pool.QueryRow(context.Background(), `
+			SELECT count(*) FROM pg_tables
+			WHERE schemaname = 'public'
+			  AND tablename != 'goose_db_version'
+			  AND rowsecurity = true
+		`).Scan(&rlsCount)
+		if err != nil {
+			t.Fatalf("failed to count RLS tables: %v", err)
+		}
+		if rlsCount == 0 {
+			t.Fatal("no RLS-enabled tables found — migrations may not have run")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Login was broken because the `app_backend` role (used by the Go backend at runtime) had no RLS policies, so queries against RLS-enabled tables silently returned zero rows
- Added explicit `USING (true) WITH CHECK (true)` policies on all 27 RLS-enabled tables for the `app_backend` role — this is least-privilege compared to `BYPASSRLS` and can be swapped for scoped policies later
- Removed stale `consumed_tokens` reference (table was dropped in an earlier migration)
- Added `TestAppBackendHasPoliciesOnAllRLSTables` to catch missing policies in CI before they hit production
- Test handles `TO PUBLIC` policies and guards against vacuous passes

## Test plan

- [x] `go test ./db/...` passes (migration applies cleanly, both RLS tests pass)
- [x] `go build ./...` succeeds
- [ ] Verify login flow works end-to-end in staging

https://claude.ai/code/session_01Ge2rFsKyh2G2Yhmy8SYnuJ