### PR TITLE
Hide OTP code input in production

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,21 +1,28 @@
 # Frontend Authentication
 
-The frontend uses [Supabase Auth](https://supabase.com/docs/guides/auth) with a **passwordless OTP (email code)** flow. No passwords are stored or managed by this application.
+The frontend uses [Supabase Auth](https://supabase.com/docs/guides/auth) with a **passwordless email** flow. No passwords are stored or managed by this application.
+
+The authentication method differs by environment:
+- **Development**: Supabase sends a **6-digit OTP code** (via local Mailpit). The user enters the code in the UI.
+- **Production**: Supabase sends a **magic link**. The user clicks the link in their email to authenticate — no code entry required.
 
 ## How it works
 
 1. User enters their email on the login page.
-2. Supabase sends a 6-digit one-time code to that email.
-3. User enters the code. Supabase verifies it and returns a session.
+2. Supabase sends either a 6-digit code (dev) or a magic link (production) to that email.
+3. **Development**: User enters the code → Supabase verifies it and returns a session.
+   **Production**: User clicks the magic link → Supabase authenticates via URL callback and returns a session.
 4. The session (JWT) is stored in the browser by the Supabase client library and refreshed automatically.
 
 ```
-EmailStep  ──sendOtp(email)──→  Supabase Auth
+                           Development                              Production
+                           ───────────                              ──────────
+EmailStep  ──sendOtp(email)──→  Supabase Auth  ←──sendOtp(email)──  EmailStep
                                      │
-                                sends email
+                      sends email (code or link)
                                      │
-OtpStep   ──verifyOtp(email, code)─→ Supabase Auth
-                                     │
+OtpStep   ──verifyOtp(email, code)─→ │ ←── user clicks link ──  CheckEmailStep
+                                     │         (no code input)
                               returns session
                                      │
 AuthContext  ←──onAuthStateChange────┘
@@ -31,9 +38,12 @@ All auth code lives in `frontend/src/auth/`:
 | `types.ts` | `AuthStatus` and `AuthState` type definitions |
 | `AuthContext.tsx` | React context provider + `useAuth` hook. Wraps the Supabase auth listener and exposes `sendOtp`, `verifyOtp`, `signOut`, and MFA functions (`verifyMfa`, `enrollMfa`, `confirmMfaEnrollment`, `unenrollMfa`, `listMfaFactors`). |
 | `MfaChallengePage.tsx` | Shown at login when the user has MFA enrolled but hasn't completed the second factor. Prompts for a TOTP code. |
-| `LoginPage.tsx` | Step router — switches between `EmailStep` and `OtpStep` based on local state |
-| `EmailStep.tsx` | Email input form. Calls `sendOtp` and advances to OTP step on success. |
-| `OtpStep.tsx` | 6-digit code input form. Calls `verifyOtp`. Shows a dev-only auto-fill button (see below). |
+| `LoginPage.tsx` | Step router — switches between `EmailStep`, `OtpStep` (dev), or `CheckEmailStep` (production) based on local state and `import.meta.env.DEV`. |
+| `EmailStep.tsx` | Email input form. Calls `sendOtp` and advances to the next step on success. |
+| `OtpStep.tsx` | 6-digit code input form (dev only). Calls `verifyOtp`. Shows a dev-only auto-fill button (see below). |
+| `CheckEmailStep.tsx` | "Check your email" screen (production only). Tells the user to click their magic link. No code input. |
+| `useResend.ts` | Shared hook for resend state machine — loading flag, success/error banners, cooldown-expiry cleanup. Used by both `OtpStep` and `CheckEmailStep`. |
+| `ResendButton.tsx` | Shared presentational component for the resend button with cooldown countdown, loading state, and error/success banners. |
 | `useFormSubmit.ts` | Shared hook for form submission — manages error state, loading state, and safe error message conversion. Used by both `EmailStep` and `OtpStep`. |
 | `AuthLayout.tsx` | Shared layout wrapper for auth pages (container + heading). |
 | `errors.ts` | Maps Supabase `AuthError` codes to safe, user-facing messages. Avoids leaking internal error details. |

--- a/frontend/src/auth/CheckEmailStep.tsx
+++ b/frontend/src/auth/CheckEmailStep.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import type { AuthError } from "@supabase/supabase-js";
 import { safeErrorMessage } from "./errors";
 import AuthLayout from "./AuthLayout";
+import { Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface CheckEmailStepProps {
@@ -35,7 +36,12 @@ export default function CheckEmailStep({
     try {
       const { error } = await onResend();
       if (error) {
-        setResendError(safeErrorMessage(error));
+        setResendError(
+          safeErrorMessage(error, {
+            over_email_send_rate_limit:
+              "Too many sign-in emails sent. If you already received a link, you can still use it — otherwise wait a few minutes and try again.",
+          })
+        );
       } else {
         setResendSuccess(true);
       }
@@ -49,10 +55,21 @@ export default function CheckEmailStep({
   return (
     <AuthLayout>
       <div className="space-y-4 text-center">
-        <p className="text-sm text-muted-foreground">
-          We sent a sign-in link to <strong>{email}</strong>. Click the link in
-          your email to continue.
-        </p>
+        <div className="flex justify-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Mail className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+          </div>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Check your email</p>
+          <p className="text-sm text-muted-foreground">
+            We sent a sign-in link to <strong>{email}</strong>.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Click the link in your email to continue. If you don&apos;t see it,
+            check your spam folder.
+          </p>
+        </div>
         <Button variant="outline" className="w-full" onClick={onBack}>
           Back
         </Button>

--- a/frontend/src/auth/CheckEmailStep.tsx
+++ b/frontend/src/auth/CheckEmailStep.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
 import type { AuthError } from "@supabase/supabase-js";
-import { safeErrorMessage } from "./errors";
+import { useResend } from "./useResend";
 import AuthLayout from "./AuthLayout";
+import { ResendButton } from "./ResendButton";
 import { Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -18,39 +18,12 @@ export default function CheckEmailStep({
   onResend,
   resendCooldownSeconds,
 }: CheckEmailStepProps) {
-  const [resendError, setResendError] = useState<string | null>(null);
-  const [resendSuccess, setResendSuccess] = useState(false);
-  const [isResending, setIsResending] = useState(false);
-
-  useEffect(() => {
-    if (resendCooldownSeconds === 0) {
-      setResendSuccess(false);
-      setResendError(null);
-    }
-  }, [resendCooldownSeconds]);
-
-  const handleResend = async () => {
-    setResendError(null);
-    setResendSuccess(false);
-    setIsResending(true);
-    try {
-      const { error } = await onResend();
-      if (error) {
-        setResendError(
-          safeErrorMessage(error, {
-            over_email_send_rate_limit:
-              "Too many sign-in emails sent. If you already received a link, you can still use it — otherwise wait a few minutes and try again.",
-          })
-        );
-      } else {
-        setResendSuccess(true);
-      }
-    } catch {
-      setResendError("Something went wrong. Please try again.");
-    } finally {
-      setIsResending(false);
-    }
-  };
+  const resend = useResend({
+    onResend,
+    cooldownSeconds: resendCooldownSeconds,
+    rateLimitMessage:
+      "Too many sign-in emails sent. If you already received a link, you can still use it — otherwise wait a few minutes and try again.",
+  });
 
   return (
     <AuthLayout>
@@ -74,39 +47,15 @@ export default function CheckEmailStep({
           Back
         </Button>
       </div>
-      <div className="mt-3 flex flex-col items-start gap-1">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={handleResend}
-          disabled={resendCooldownSeconds > 0 || isResending}
-          aria-label={
-            resendCooldownSeconds > 0
-              ? `Resend email in ${resendCooldownSeconds}s (on cooldown)`
-              : isResending
-                ? "Resending…"
-                : "Resend email"
-          }
-          className="opacity-70"
-        >
-          {resendCooldownSeconds > 0 ? (
-            <>
-              Resend in <span aria-hidden="true">{resendCooldownSeconds}s</span>
-            </>
-          ) : isResending ? (
-            "Resending…"
-          ) : (
-            "Resend email"
-          )}
-        </Button>
-        {resendError && (
-          <p role="alert" className="text-xs text-destructive">{resendError}</p>
-        )}
-        {resendSuccess && (
-          <p role="status" className="text-xs text-muted-foreground">Email resent.</p>
-        )}
-      </div>
+      <ResendButton
+        cooldownSeconds={resendCooldownSeconds}
+        isResending={resend.isResending}
+        error={resend.error}
+        success={resend.success}
+        onResend={resend.handleResend}
+        label="Resend email"
+        successMessage="Email resent."
+      />
     </AuthLayout>
   );
 }

--- a/frontend/src/auth/CheckEmailStep.tsx
+++ b/frontend/src/auth/CheckEmailStep.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect } from "react";
+import type { AuthError } from "@supabase/supabase-js";
+import { safeErrorMessage } from "./errors";
+import AuthLayout from "./AuthLayout";
+import { Button } from "@/components/ui/button";
+
+interface CheckEmailStepProps {
+  email: string;
+  onBack: () => void;
+  onResend: () => Promise<{ error: AuthError | null }>;
+  resendCooldownSeconds: number;
+}
+
+export default function CheckEmailStep({
+  email,
+  onBack,
+  onResend,
+  resendCooldownSeconds,
+}: CheckEmailStepProps) {
+  const [resendError, setResendError] = useState<string | null>(null);
+  const [resendSuccess, setResendSuccess] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+
+  useEffect(() => {
+    if (resendCooldownSeconds === 0) {
+      setResendSuccess(false);
+      setResendError(null);
+    }
+  }, [resendCooldownSeconds]);
+
+  const handleResend = async () => {
+    setResendError(null);
+    setResendSuccess(false);
+    setIsResending(true);
+    try {
+      const { error } = await onResend();
+      if (error) {
+        setResendError(safeErrorMessage(error));
+      } else {
+        setResendSuccess(true);
+      }
+    } catch {
+      setResendError("Something went wrong. Please try again.");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <div className="space-y-4 text-center">
+        <p className="text-sm text-muted-foreground">
+          We sent a sign-in link to <strong>{email}</strong>. Click the link in
+          your email to continue.
+        </p>
+        <Button variant="outline" className="w-full" onClick={onBack}>
+          Back
+        </Button>
+      </div>
+      <div className="mt-3 flex flex-col items-start gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleResend}
+          disabled={resendCooldownSeconds > 0 || isResending}
+          aria-label={
+            resendCooldownSeconds > 0
+              ? `Resend email in ${resendCooldownSeconds}s (on cooldown)`
+              : isResending
+                ? "Resending…"
+                : "Resend email"
+          }
+          className="opacity-70"
+        >
+          {resendCooldownSeconds > 0 ? (
+            <>
+              Resend in <span aria-hidden="true">{resendCooldownSeconds}s</span>
+            </>
+          ) : isResending ? (
+            "Resending…"
+          ) : (
+            "Resend email"
+          )}
+        </Button>
+        {resendError && (
+          <p role="alert" className="text-xs text-destructive">{resendError}</p>
+        )}
+        {resendSuccess && (
+          <p role="status" className="text-xs text-muted-foreground">Email resent.</p>
+        )}
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -1,9 +1,13 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, lazy, Suspense } from "react";
 import { useAuth } from "./AuthContext";
 import { useCooldown } from "./useCooldown";
 import EmailStep from "./EmailStep";
-import OtpStep from "./OtpStep";
 import CheckEmailStep from "./CheckEmailStep";
+
+// Lazy-load OtpStep so it (and its dev-only dependencies like OtpCodeInput,
+// DevOnly, Mailpit auto-fill) are tree-shaken from the production bundle.
+// In production, the "otp" step is never reached.
+const OtpStep = lazy(() => import("./OtpStep"));
 
 type Step = "email" | "otp" | "check-email";
 
@@ -29,13 +33,15 @@ export default function LoginPage() {
 
   if (step === "otp") {
     return (
-      <OtpStep
-        email={email}
-        onVerify={(code) => verifyOtp(email, code)}
-        onBack={() => setStep("email")}
-        onResend={handleResend}
-        resendCooldownSeconds={cooldown.secondsLeft}
-      />
+      <Suspense fallback={null}>
+        <OtpStep
+          email={email}
+          onVerify={(code) => verifyOtp(email, code)}
+          onBack={() => setStep("email")}
+          onResend={handleResend}
+          resendCooldownSeconds={cooldown.secondsLeft}
+        />
+      </Suspense>
     );
   }
 

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -3,12 +3,29 @@ import { useAuth } from "./AuthContext";
 import { useCooldown } from "./useCooldown";
 import EmailStep from "./EmailStep";
 import OtpStep from "./OtpStep";
+import CheckEmailStep from "./CheckEmailStep";
+
+type Step = "email" | "otp" | "check-email";
 
 export default function LoginPage() {
   const { sendOtp, verifyOtp } = useAuth();
-  const [step, setStep] = useState<"email" | "otp">("email");
+  const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
   const cooldown = useCooldown();
+
+  const handleSendSuccess = (inputEmail: string) => {
+    setEmail(inputEmail);
+    setStep(import.meta.env.DEV ? "otp" : "check-email");
+    cooldown.start();
+  };
+
+  const handleResend = async () => {
+    const result = await sendOtp(email);
+    if (!result.error || result.error.code === "over_email_send_rate_limit") {
+      cooldown.start();
+    }
+    return result;
+  };
 
   if (step === "otp") {
     return (
@@ -16,15 +33,18 @@ export default function LoginPage() {
         email={email}
         onVerify={(code) => verifyOtp(email, code)}
         onBack={() => setStep("email")}
-        onResend={async () => {
-          const result = await sendOtp(email);
-          // Start cooldown on success or rate-limit error so the button
-          // stays disabled even when the server rejects the request.
-          if (!result.error || result.error.code === "over_email_send_rate_limit") {
-            cooldown.start();
-          }
-          return result;
-        }}
+        onResend={handleResend}
+        resendCooldownSeconds={cooldown.secondsLeft}
+      />
+    );
+  }
+
+  if (step === "check-email") {
+    return (
+      <CheckEmailStep
+        email={email}
+        onBack={() => setStep("email")}
+        onResend={handleResend}
         resendCooldownSeconds={cooldown.secondsLeft}
       />
     );
@@ -35,9 +55,7 @@ export default function LoginPage() {
       onSubmit={async (inputEmail) => {
         const result = await sendOtp(inputEmail);
         if (!result.error) {
-          setEmail(inputEmail);
-          setStep("otp");
-          cooldown.start();
+          handleSendSuccess(inputEmail);
         }
         return result;
       }}

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "./AuthContext";
 import { useCooldown } from "./useCooldown";
 import EmailStep from "./EmailStep";
 import CheckEmailStep from "./CheckEmailStep";
+import AuthLayout from "./AuthLayout";
 
 // Lazy-load OtpStep so it (and its dev-only dependencies like OtpCodeInput,
 // DevOnly, Mailpit auto-fill) are tree-shaken from the production bundle.
@@ -33,7 +34,7 @@ export default function LoginPage() {
 
   if (step === "otp") {
     return (
-      <Suspense fallback={null}>
+      <Suspense fallback={<AuthLayout />}>
         <OtpStep
           email={email}
           onVerify={(code) => verifyOtp(email, code)}

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
 
   if (step === "otp") {
     return (
-      <Suspense fallback={<AuthLayout />}>
+      <Suspense fallback={<AuthLayout>{null}</AuthLayout>}>
         <OtpStep
           email={email}
           onVerify={(code) => verifyOtp(email, code)}

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useAuth } from "./AuthContext";
 import { useCooldown } from "./useCooldown";
 import EmailStep from "./EmailStep";
@@ -19,13 +19,13 @@ export default function LoginPage() {
     cooldown.start();
   };
 
-  const handleResend = async () => {
+  const handleResend = useCallback(async () => {
     const result = await sendOtp(email);
     if (!result.error || result.error.code === "over_email_send_rate_limit") {
       cooldown.start();
     }
     return result;
-  };
+  }, [sendOtp, email, cooldown.start]);
 
   if (step === "otp") {
     return (

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { AuthError } from "@supabase/supabase-js";
 import { useFormSubmit } from "./useFormSubmit";
-import { safeErrorMessage } from "./errors";
+import { useResend } from "./useResend";
 import AuthLayout from "./AuthLayout";
+import { ResendButton } from "./ResendButton";
 import DevOnly from "../components/DevOnly";
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/FormError";
@@ -25,41 +26,12 @@ export default function OtpStep({
 }: OtpStepProps) {
   const [otpCode, setOtpCode] = useState("");
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
-  const [resendError, setResendError] = useState<string | null>(null);
-  const [resendSuccess, setResendSuccess] = useState(false);
-  const [isResending, setIsResending] = useState(false);
-
-  // Clear the success banner when the cooldown expires so it doesn't
-  // linger indefinitely alongside an active "Resend code" button.
-  useEffect(() => {
-    if (resendCooldownSeconds === 0) {
-      setResendSuccess(false);
-      setResendError(null);
-    }
-  }, [resendCooldownSeconds]);
-
-  const handleResend = async () => {
-    setResendError(null);
-    setResendSuccess(false);
-    setIsResending(true);
-    try {
-      const { error: resendResultError } = await onResend();
-      if (resendResultError) {
-        setResendError(
-          safeErrorMessage(resendResultError, {
-            over_email_send_rate_limit:
-              "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
-          })
-        );
-      } else {
-        setResendSuccess(true);
-      }
-    } catch {
-      setResendError("Something went wrong. Please try again.");
-    } finally {
-      setIsResending(false);
-    }
-  };
+  const resend = useResend({
+    onResend,
+    cooldownSeconds: resendCooldownSeconds,
+    rateLimitMessage:
+      "Too many login emails sent. If you already received a code, you can still use it — otherwise wait a few minutes and try again.",
+  });
 
   const handleAutoFill = async () => {
     // Dynamic import keeps dev-only Mailpit code out of the production bundle
@@ -101,39 +73,15 @@ export default function OtpStep({
           </Button>
         </div>
       </form>
-      <div className="mt-3 flex flex-col items-start gap-1">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={handleResend}
-          disabled={resendCooldownSeconds > 0 || isResending}
-          aria-label={
-            resendCooldownSeconds > 0
-              ? `Resend code in ${resendCooldownSeconds}s (on cooldown)`
-              : isResending
-                ? "Resending…"
-                : "Resend code"
-          }
-          className="opacity-70"
-        >
-          {resendCooldownSeconds > 0 ? (
-            <>
-              Resend in <span aria-hidden="true">{resendCooldownSeconds}s</span>
-            </>
-          ) : isResending ? (
-            "Resending…"
-          ) : (
-            "Resend code"
-          )}
-        </Button>
-        {resendError && (
-          <p role="alert" className="text-xs text-destructive">{resendError}</p>
-        )}
-        {resendSuccess && (
-          <p role="status" className="text-xs text-muted-foreground">Code resent.</p>
-        )}
-      </div>
+      <ResendButton
+        cooldownSeconds={resendCooldownSeconds}
+        isResending={resend.isResending}
+        error={resend.error}
+        success={resend.success}
+        onResend={resend.handleResend}
+        label="Resend code"
+        successMessage="Code resent."
+      />
       <DevOnly>
         <Button
           type="button"

--- a/frontend/src/auth/ResendButton.tsx
+++ b/frontend/src/auth/ResendButton.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@/components/ui/button";
+
+interface ResendButtonProps {
+  cooldownSeconds: number;
+  isResending: boolean;
+  error: string | null;
+  success: boolean;
+  onResend: () => void;
+  /** Label used for the button text and aria-label (e.g. "Resend code", "Resend email"). */
+  label: string;
+  /** Success message shown after a successful resend (e.g. "Code resent.", "Email resent."). */
+  successMessage: string;
+}
+
+export function ResendButton({
+  cooldownSeconds,
+  isResending,
+  error,
+  success,
+  onResend,
+  label,
+  successMessage,
+}: ResendButtonProps) {
+  return (
+    <div className="mt-3 flex flex-col items-start gap-1">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onResend}
+        disabled={cooldownSeconds > 0 || isResending}
+        aria-label={
+          cooldownSeconds > 0
+            ? `${label} in ${cooldownSeconds}s (on cooldown)`
+            : isResending
+              ? "Resending…"
+              : label
+        }
+        className="opacity-70"
+      >
+        {cooldownSeconds > 0 ? (
+          <>
+            Resend in <span aria-hidden="true">{cooldownSeconds}s</span>
+          </>
+        ) : isResending ? (
+          "Resending…"
+        ) : (
+          label
+        )}
+      </Button>
+      {error && (
+        <p role="alert" className="text-xs text-destructive">{error}</p>
+      )}
+      {success && (
+        <p role="status" className="text-xs text-muted-foreground">{successMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/auth/__tests__/CheckEmailStep.test.tsx
+++ b/frontend/src/auth/__tests__/CheckEmailStep.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { AuthError } from "@supabase/supabase-js";
+import { MemoryRouter } from "react-router-dom";
+import { CookieConsentProvider } from "@/components/CookieConsentContext";
+import CheckEmailStep from "../CheckEmailStep";
+
+const defaultProps = {
+  email: "test@example.com",
+  onBack: vi.fn(),
+  onResend: vi.fn().mockResolvedValue({ error: null }),
+  resendCooldownSeconds: 0,
+};
+
+function renderCheckEmailStep(props = defaultProps) {
+  return render(
+    <MemoryRouter>
+      <CookieConsentProvider>
+        <CheckEmailStep {...props} />
+      </CookieConsentProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("CheckEmailStep", () => {
+  it("shows email and sign-in link message", () => {
+    renderCheckEmailStep();
+    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/sign-in link/)).toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeInTheDocument();
+  });
+
+  it("does not show a code input", () => {
+    renderCheckEmailStep();
+    expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
+  });
+
+  it("calls onBack when back button is clicked", async () => {
+    const onBack = vi.fn();
+    renderCheckEmailStep({ ...defaultProps, onBack });
+
+    await userEvent.click(screen.getByText("Back"));
+
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows resend email button when cooldown is 0", () => {
+    renderCheckEmailStep({ ...defaultProps, resendCooldownSeconds: 0 });
+    const btn = screen.getByRole("button", { name: "Resend email" });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("disables resend button and shows countdown during cooldown", () => {
+    renderCheckEmailStep({ ...defaultProps, resendCooldownSeconds: 30 });
+    const btn = screen.getByRole("button", { name: "Resend email in 30s (on cooldown)" });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("30s");
+  });
+
+  it("calls onResend when resend button is clicked", async () => {
+    const onResend = vi.fn().mockResolvedValue({ error: null });
+    renderCheckEmailStep({ ...defaultProps, onResend });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
+
+    expect(onResend).toHaveBeenCalled();
+  });
+
+  it("shows success message after resend", async () => {
+    const onResend = vi.fn().mockResolvedValue({ error: null });
+    renderCheckEmailStep({ ...defaultProps, onResend });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email resent.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when resend fails", async () => {
+    const onResend = vi.fn().mockResolvedValue({
+      error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
+    });
+    renderCheckEmailStep({ ...defaultProps, onResend });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Too many login emails sent.", { exact: false })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clears success banner when cooldown expires", async () => {
+    const onResend = vi.fn().mockResolvedValue({ error: null });
+    const { rerender } = renderCheckEmailStep({ ...defaultProps, onResend, resendCooldownSeconds: 0 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
+    await waitFor(() => {
+      expect(screen.getByText("Email resent.")).toBeInTheDocument();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <CheckEmailStep {...defaultProps} onResend={onResend} resendCooldownSeconds={5} />
+        </CookieConsentProvider>
+      </MemoryRouter>
+    );
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <CheckEmailStep {...defaultProps} onResend={onResend} resendCooldownSeconds={0} />
+        </CookieConsentProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Email resent.")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/auth/__tests__/CheckEmailStep.test.tsx
+++ b/frontend/src/auth/__tests__/CheckEmailStep.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AuthError } from "@supabase/supabase-js";
 import { MemoryRouter } from "react-router-dom";
 import { CookieConsentProvider } from "@/components/CookieConsentContext";
@@ -24,6 +24,11 @@ function renderCheckEmailStep(props = defaultProps) {
 }
 
 describe("CheckEmailStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultProps.onResend.mockResolvedValue({ error: null });
+  });
+
   it("shows email, sign-in link message, and spam hint", () => {
     renderCheckEmailStep();
     expect(screen.getByText("Check your email")).toBeInTheDocument();
@@ -97,6 +102,37 @@ describe("CheckEmailStep", () => {
       expect(
         screen.getByText("already received a link", { exact: false })
       ).toBeInTheDocument();
+    });
+  });
+
+  it("clears error banner when cooldown expires", async () => {
+    const onResend = vi.fn().mockResolvedValue({
+      error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
+    });
+    const { rerender } = renderCheckEmailStep({ ...defaultProps, onResend, resendCooldownSeconds: 0 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resend email" }));
+    await waitFor(() => {
+      expect(screen.getByText("Too many sign-in emails sent.", { exact: false })).toBeInTheDocument();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <CheckEmailStep {...defaultProps} onResend={onResend} resendCooldownSeconds={5} />
+        </CookieConsentProvider>
+      </MemoryRouter>
+    );
+    rerender(
+      <MemoryRouter>
+        <CookieConsentProvider>
+          <CheckEmailStep {...defaultProps} onResend={onResend} resendCooldownSeconds={0} />
+        </CookieConsentProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/auth/__tests__/CheckEmailStep.test.tsx
+++ b/frontend/src/auth/__tests__/CheckEmailStep.test.tsx
@@ -24,10 +24,12 @@ function renderCheckEmailStep(props = defaultProps) {
 }
 
 describe("CheckEmailStep", () => {
-  it("shows email and sign-in link message", () => {
+  it("shows email, sign-in link message, and spam hint", () => {
     renderCheckEmailStep();
+    expect(screen.getByText("Check your email")).toBeInTheDocument();
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
     expect(screen.getByText(/sign-in link/)).toBeInTheDocument();
+    expect(screen.getByText(/spam folder/)).toBeInTheDocument();
     expect(screen.getByText("Back")).toBeInTheDocument();
   });
 
@@ -80,7 +82,7 @@ describe("CheckEmailStep", () => {
     });
   });
 
-  it("shows error message when resend fails", async () => {
+  it("shows context-specific error when rate-limited", async () => {
     const onResend = vi.fn().mockResolvedValue({
       error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
     });
@@ -90,7 +92,10 @@ describe("CheckEmailStep", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Too many login emails sent.", { exact: false })
+        screen.getByText("Too many sign-in emails sent.", { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("already received a link", { exact: false })
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/auth/__tests__/LoginPage.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { AuthError } from "@supabase/supabase-js";
 import { renderWithProviders } from "../../test-helpers";
 import { mockAuth, mockUser, mockSession, setupAuthMocks } from "./fixtures";
@@ -16,6 +16,10 @@ describe("LoginPage", () => {
     setupAuthMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("shows email step initially", async () => {
     renderWithProviders(<LoginPage />);
     await waitFor(() => {
@@ -24,21 +28,122 @@ describe("LoginPage", () => {
     expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
   });
 
-  it("transitions to OTP step after successful code send", async () => {
-    mockAuth.signInWithOtp.mockResolvedValue({
-      data: { user: null, session: null },
-      error: null,
+  describe("development mode", () => {
+    // import.meta.env.DEV is true by default in vitest
+
+    it("transitions to OTP step after successful code send", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Code")).toBeInTheDocument();
+      });
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
     });
 
-    renderWithProviders(<LoginPage />);
+    it("returns to email step when back is clicked", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
 
-    await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
-    await userEvent.click(screen.getByText("Continue"));
+      renderWithProviders(<LoginPage />);
 
-    await waitFor(() => {
-      expect(screen.getByLabelText("Code")).toBeInTheDocument();
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Code")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByText("Back"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Email")).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
     });
-    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+
+    it("calls verifyOtp with correct email and code", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
+      mockAuth.verifyOtp.mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Code")).toBeInTheDocument();
+      });
+      await userEvent.type(screen.getByLabelText("Code"), "123456");
+      await userEvent.click(screen.getByText("Verify"));
+
+      expect(mockAuth.verifyOtp).toHaveBeenCalledWith({
+        email: "test@example.com",
+        token: "123456",
+        type: "email",
+      });
+    });
+  });
+
+  describe("production mode", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", false);
+    });
+
+    it("shows check-email step instead of OTP after successful send", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/sign-in link/)).toBeInTheDocument();
+      });
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
+    });
+
+    it("returns to email step when back is clicked from check-email", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/sign-in link/)).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByText("Back"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Email")).toBeInTheDocument();
+      });
+    });
   });
 
   it("stays on email step when send fails", async () => {
@@ -56,56 +161,5 @@ describe("LoginPage", () => {
       expect(screen.getByLabelText("Email")).toBeInTheDocument();
     });
     expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
-  });
-
-  it("returns to email step when back is clicked", async () => {
-    mockAuth.signInWithOtp.mockResolvedValue({
-      data: { user: null, session: null },
-      error: null,
-    });
-
-    renderWithProviders(<LoginPage />);
-
-    await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
-    await userEvent.click(screen.getByText("Continue"));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Code")).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByText("Back"));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    });
-    expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
-  });
-
-  it("calls verifyOtp with correct email and code", async () => {
-    mockAuth.signInWithOtp.mockResolvedValue({
-      data: { user: null, session: null },
-      error: null,
-    });
-    mockAuth.verifyOtp.mockResolvedValue({
-      data: { session: mockSession, user: mockUser },
-      error: null,
-    });
-
-    renderWithProviders(<LoginPage />);
-
-    await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
-    await userEvent.click(screen.getByText("Continue"));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Code")).toBeInTheDocument();
-    });
-    await userEvent.type(screen.getByLabelText("Code"), "123456");
-    await userEvent.click(screen.getByText("Verify"));
-
-    expect(mockAuth.verifyOtp).toHaveBeenCalledWith({
-      email: "test@example.com",
-      token: "123456",
-      type: "email",
-    });
   });
 });

--- a/frontend/src/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/auth/__tests__/LoginPage.test.tsx
@@ -98,6 +98,23 @@ describe("LoginPage", () => {
         type: "email",
       });
     });
+
+    it("stays on email step when send fails", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
+      });
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Email")).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
+    });
   });
 
   describe("production mode", () => {
@@ -161,22 +178,5 @@ describe("LoginPage", () => {
       });
       expect(screen.queryByText("Check your email")).not.toBeInTheDocument();
     });
-  });
-
-  it("stays on email step when send fails", async () => {
-    mockAuth.signInWithOtp.mockResolvedValue({
-      data: { user: null, session: null },
-      error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
-    });
-
-    renderWithProviders(<LoginPage />);
-
-    await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
-    await userEvent.click(screen.getByText("Continue"));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    });
-    expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/auth/__tests__/LoginPage.test.tsx
@@ -117,7 +117,7 @@ describe("LoginPage", () => {
       await userEvent.click(screen.getByText("Continue"));
 
       await waitFor(() => {
-        expect(screen.getByText(/sign-in link/)).toBeInTheDocument();
+        expect(screen.getByText("Check your email")).toBeInTheDocument();
       });
       expect(screen.getByText("test@example.com")).toBeInTheDocument();
       expect(screen.queryByLabelText("Code")).not.toBeInTheDocument();
@@ -135,7 +135,7 @@ describe("LoginPage", () => {
       await userEvent.click(screen.getByText("Continue"));
 
       await waitFor(() => {
-        expect(screen.getByText(/sign-in link/)).toBeInTheDocument();
+        expect(screen.getByText("Check your email")).toBeInTheDocument();
       });
 
       await userEvent.click(screen.getByText("Back"));

--- a/frontend/src/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/auth/__tests__/LoginPage.test.tsx
@@ -144,6 +144,23 @@ describe("LoginPage", () => {
         expect(screen.getByLabelText("Email")).toBeInTheDocument();
       });
     });
+
+    it("stays on email step when send fails", async () => {
+      mockAuth.signInWithOtp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
+      });
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+      await userEvent.click(screen.getByText("Continue"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Email")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Check your email")).not.toBeInTheDocument();
+    });
   });
 
   it("stays on email step when send fails", async () => {

--- a/frontend/src/auth/useResend.ts
+++ b/frontend/src/auth/useResend.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect, useCallback } from "react";
+import type { AuthError } from "@supabase/supabase-js";
+import { safeErrorMessage } from "./errors";
+
+interface UseResendOptions {
+  onResend: () => Promise<{ error: AuthError | null }>;
+  cooldownSeconds: number;
+  /** Context-specific error override for `over_email_send_rate_limit`. */
+  rateLimitMessage: string;
+}
+
+interface UseResendResult {
+  error: string | null;
+  success: boolean;
+  isResending: boolean;
+  handleResend: () => Promise<void>;
+}
+
+/**
+ * Encapsulates the resend state machine shared by OtpStep and CheckEmailStep:
+ * loading flag, success/error banners, and auto-clearing when the cooldown expires.
+ */
+export function useResend({
+  onResend,
+  cooldownSeconds,
+  rateLimitMessage,
+}: UseResendOptions): UseResendResult {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+
+  // Clear banners when the cooldown expires so they don't linger
+  // alongside an active resend button.
+  useEffect(() => {
+    if (cooldownSeconds === 0) {
+      setSuccess(false);
+      setError(null);
+    }
+  }, [cooldownSeconds]);
+
+  const handleResend = useCallback(async () => {
+    setError(null);
+    setSuccess(false);
+    setIsResending(true);
+    try {
+      const { error: resendError } = await onResend();
+      if (resendError) {
+        setError(
+          safeErrorMessage(resendError, {
+            over_email_send_rate_limit: rateLimitMessage,
+          })
+        );
+      } else {
+        setSuccess(true);
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setIsResending(false);
+    }
+  }, [onResend, rateLimitMessage]);
+
+  return { error, success, isResending, handleResend };
+}


### PR DESCRIPTION
## Summary
- In production, Supabase sends a magic link rather than an OTP code. The UI now branches based on environment:
  - **Development**: Shows OTP code input (unchanged behavior, with Mailpit auto-fill)
  - **Production**: Shows a new `CheckEmailStep` screen with "We sent a sign-in link" message, back button, and resend with cooldown — no code input field
- Updated verbiage in the production flow to say "sign-in link" and "Resend email" instead of "code" and "Resend code"

## Test plan

### Claude Code
- [x] All 675 frontend tests pass (`make test-frontend`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New `CheckEmailStep.test.tsx` covers rendering, back, resend, cooldown, error, and success states
- [x] Updated `LoginPage.test.tsx` with dev-mode and production-mode test groups

### OpenClaw
- [ ] Manual verification in dev: OTP code input still appears after entering email
- [ ] Manual verification in production/staging: "Check your email" screen appears with no code input
- [ ] Verify magic link from production email works end-to-end

https://claude.ai/code/session_01PtFkBbB3s5B26U7rnVv29F