### PR TITLE
Fix push notification error with user-friendly messages

### DIFF
--- a/frontend/src/hooks/useSubscribePush.ts
+++ b/frontend/src/hooks/useSubscribePush.ts
@@ -21,6 +21,30 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   return outputArray;
 }
 
+/**
+ * Translates browser PushManager.subscribe() errors into user-friendly messages.
+ * The browser throws DOMExceptions with technical names that mean nothing to users.
+ */
+function getPushSubscribeErrorMessage(err: unknown): string {
+  if (!(err instanceof DOMException)) {
+    return "Something went wrong enabling notifications. Please try again.";
+  }
+
+  if (err.name === "NotAllowedError") {
+    return "Notification permission was denied. Please allow notifications in your browser settings and try again.";
+  }
+
+  if (err.name === "InvalidStateError") {
+    return "There is a conflicting notification subscription. Try clearing your browser's site data and re-enabling notifications.";
+  }
+
+  if (err.name === "AbortError" || err.message.includes("push service")) {
+    return "Could not reach the push notification service. Check your internet connection and try again.";
+  }
+
+  return "Something went wrong enabling notifications. Please try again.";
+}
+
 export function useSubscribePush() {
   const { session } = useAuth();
   const queryClient = useQueryClient();
@@ -43,11 +67,16 @@ export function useSubscribePush() {
 
       // Subscribe to push
       const serverKey = urlBase64ToUint8Array(vapidKey);
-      const pushSubscription = await registration.pushManager.subscribe({
-        userVisibleOnly: true,
-        // Cast is safe: Uint8Array.buffer is always an ArrayBuffer (never SharedArrayBuffer)
-        applicationServerKey: serverKey.buffer as ArrayBuffer,
-      });
+      let pushSubscription: PushSubscription;
+      try {
+        pushSubscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          // Safe: urlBase64ToUint8Array creates a fresh Uint8Array (always backed by ArrayBuffer, not SharedArrayBuffer)
+          applicationServerKey: serverKey.buffer as ArrayBuffer,
+        });
+      } catch (err) {
+        throw new Error(getPushSubscribeErrorMessage(err));
+      }
 
       const subJSON = pushSubscription.toJSON();
       const endpoint = subJSON.endpoint;


### PR DESCRIPTION
## Summary
- Wrap `pushManager.subscribe()` in a try-catch that maps browser `DOMException` types to user-friendly error messages
- Previously, clicking "Enable notifications" showed the raw browser error "Registration failed – push service error" which gives users no actionable guidance
- Now shows specific messages for: permission denied, conflicting subscription, push service unreachable, and a generic fallback

## Test plan
- [ ] Click "Enable notifications" on the dashboard and verify the error message is user-friendly
- [ ] Block notification permissions in browser settings, click enable, verify "permission denied" message appears
- [ ] Verify successful push subscription still works end-to-end

### Claude Code
- [x] Frontend tests pass (`make test-frontend`)
- [x] TypeScript compiles cleanly (`tsc -b`)

### OpenClaw
- [ ] Verify the fix resolves the "push service error" in the deployed environment
- [ ] Test across Chrome, Firefox, Safari

https://claude.ai/code/session_01P7oK5gsJquqRaEiVts6VpA