### PR TITLE
Replace notification buttons with toggle switches

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@sentry/react": "^10.40.0",
         "@stripe/react-stripe-js": "^5.6.1",
         "@stripe/stripe-js": "^8.9.0",
@@ -2088,6 +2089,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@sentry/react": "^10.40.0",
     "@stripe/react-stripe-js": "^5.6.1",
     "@stripe/stripe-js": "^8.9.0",

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-colors outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="bg-background pointer-events-none block size-4 rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -8,7 +8,7 @@ import { trackEvent, PostHogEvents } from "@/lib/posthog";
 import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "@/hooks/useUpdateNotificationPreferences";
 import type { components } from "@/api/schema";
-import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   Card,
   CardContent,
@@ -139,14 +139,11 @@ export function NotificationSection() {
                         <ArrowUpRight className="size-3" />
                       </Link>
                     ) : (
-                      <Button
-                        variant={pref.enabled ? "default" : "outline"}
-                        size="sm"
+                      <Switch
+                        checked={pref.enabled}
                         disabled={isUpdating}
-                        onClick={() => handleToggle(pref.channel, pref.enabled)}
-                      >
-                        {pref.enabled ? "Enabled" : "Disabled"}
-                      </Button>
+                        onCheckedChange={() => handleToggle(pref.channel, pref.enabled)}
+                      />
                     )}
                   </div>
                   {!planGated && warning && pref.enabled && (
@@ -170,14 +167,11 @@ export function NotificationSection() {
                     and tips.
                   </p>
                 </div>
-                <Button
-                  variant={profile?.marketing_opt_in ? "default" : "outline"}
-                  size="sm"
+                <Switch
+                  checked={profile?.marketing_opt_in ?? false}
                   disabled={isUpdatingProfile || !profile}
-                  onClick={handleToggleProductUpdates}
-                >
-                  {profile?.marketing_opt_in ? "Enabled" : "Disabled"}
-                </Button>
+                  onCheckedChange={handleToggleProductUpdates}
+                />
               </div>
               {!profile?.email && profile?.marketing_opt_in && (
                 <div className="mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -142,6 +142,7 @@ export function NotificationSection() {
                       <Switch
                         checked={pref.enabled}
                         disabled={isUpdating}
+                        aria-label={`${label?.name ?? pref.channel} notifications`}
                         onCheckedChange={() => handleToggle(pref.channel, pref.enabled)}
                       />
                     )}
@@ -170,6 +171,7 @@ export function NotificationSection() {
                 <Switch
                   checked={profile?.marketing_opt_in ?? false}
                   disabled={isUpdatingProfile || !profile}
+                  aria-label="Product updates notifications"
                   onCheckedChange={handleToggleProductUpdates}
                 />
               </div>

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -143,7 +143,7 @@ export function NotificationSection() {
                         checked={pref.enabled}
                         disabled={isUpdating}
                         aria-label={`${label?.name ?? pref.channel} notifications`}
-                        onCheckedChange={() => handleToggle(pref.channel, pref.enabled)}
+                        onCheckedChange={(checked) => handleToggle(pref.channel, !checked)}
                       />
                     )}
                   </div>

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -225,9 +225,8 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Email")).toBeInTheDocument();
     });
 
-    // Click the first switch (email)
-    const switches = screen.getAllByRole("switch");
-    await user.click(switches[0]!);
+    // Click the Email switch by accessible name
+    await user.click(screen.getByRole("switch", { name: /email notifications/i }));
 
     await waitFor(() => {
       expect(mockPut).toHaveBeenCalledWith(
@@ -258,9 +257,8 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Mobile Push")).toBeInTheDocument();
     });
 
-    // Find the Mobile Push switch (last channel switch, index 3) and click it
-    const switches = screen.getAllByRole("switch");
-    await user.click(switches[3]!);
+    // Find the Mobile Push switch by accessible name
+    await user.click(screen.getByRole("switch", { name: /mobile push notifications/i }));
 
     await waitFor(() => {
       expect(mockPut).toHaveBeenCalledWith(
@@ -300,10 +298,8 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Product updates")).toBeInTheDocument();
     });
 
-    // The product updates switch is the last one (after all channel switches)
-    const switches = screen.getAllByRole("switch");
-    const productUpdatesSwitch = switches[switches.length - 1]!;
-    await user.click(productUpdatesSwitch);
+    // Find the Product updates switch by accessible name
+    await user.click(screen.getByRole("switch", { name: /product updates notifications/i }));
 
     await waitFor(() => {
       expect(mockPatch).toHaveBeenCalledWith(

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -126,16 +126,16 @@ describe("NotificationSection", () => {
     render(<NotificationSection />, { wrapper });
 
     await waitFor(() => {
-      const buttons = screen.getAllByRole("button");
-      const enabledButtons = buttons.filter(
-        (b) => b.textContent === "Enabled",
+      const switches = screen.getAllByRole("switch");
+      const checked = switches.filter(
+        (s) => s.getAttribute("data-state") === "checked",
       );
-      const disabledButtons = buttons.filter(
-        (b) => b.textContent === "Disabled",
+      const unchecked = switches.filter(
+        (s) => s.getAttribute("data-state") === "unchecked",
       );
-      // 3 channels enabled (email, sms, mobile-push) + 2 disabled (web-push, product updates)
-      expect(enabledButtons).toHaveLength(3);
-      expect(disabledButtons).toHaveLength(2);
+      // 3 channels enabled (email, sms, mobile-push) + 2 unchecked (web-push, product updates)
+      expect(checked).toHaveLength(3);
+      expect(unchecked).toHaveLength(2);
     });
   });
 
@@ -225,11 +225,9 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Email")).toBeInTheDocument();
     });
 
-    // Click the first "Enabled" button (email)
-    const enabledButtons = screen.getAllByRole("button").filter(
-      (b) => b.textContent === "Enabled",
-    );
-    await user.click(enabledButtons[0]!);
+    // Click the first switch (email)
+    const switches = screen.getAllByRole("switch");
+    await user.click(switches[0]!);
 
     await waitFor(() => {
       expect(mockPut).toHaveBeenCalledWith(
@@ -260,13 +258,9 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Mobile Push")).toBeInTheDocument();
     });
 
-    // Find the Mobile Push row's Enabled button and click it
-    const enabledButtons = screen.getAllByRole("button").filter(
-      (b) => b.textContent === "Enabled",
-    );
-    // Mobile Push is the last enabled channel button (after email, web-push, sms)
-    const mobilePushBtn = enabledButtons[enabledButtons.length - 1]!;
-    await user.click(mobilePushBtn);
+    // Find the Mobile Push switch (last channel switch, index 3) and click it
+    const switches = screen.getAllByRole("switch");
+    await user.click(switches[3]!);
 
     await waitFor(() => {
       expect(mockPut).toHaveBeenCalledWith(
@@ -306,12 +300,10 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Product updates")).toBeInTheDocument();
     });
 
-    // The product updates button is the last "Disabled" button
-    const disabledButtons = screen.getAllByRole("button").filter(
-      (b) => b.textContent === "Disabled",
-    );
-    const productUpdatesBtn = disabledButtons[disabledButtons.length - 1]!;
-    await user.click(productUpdatesBtn);
+    // The product updates switch is the last one (after all channel switches)
+    const switches = screen.getAllByRole("switch");
+    const productUpdatesSwitch = switches[switches.length - 1]!;
+    await user.click(productUpdatesSwitch);
 
     await waitFor(() => {
       expect(mockPatch).toHaveBeenCalledWith(
@@ -363,12 +355,10 @@ describe("NotificationSection", () => {
       expect(screen.getByText("SMS")).toBeInTheDocument();
     });
 
-    // Should have 3 enabled buttons (email, web-push, mobile-push)
-    // SMS should not have a toggle button
-    const enabledButtons = screen.getAllByRole("button").filter(
-      (b) => b.textContent === "Enabled",
-    );
-    expect(enabledButtons).toHaveLength(3);
+    // Should have 3 channel switches (email, web-push, mobile-push) + 1 product updates = 4
+    // SMS should not have a switch (plan-gated)
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(4);
   });
 
   it("does not show missing phone warning for plan-gated SMS", async () => {


### PR DESCRIPTION
## Summary
- Replaced confusing "Enabled"/"Disabled" button toggles with standard toggle switch components in the notification settings
- Added `@radix-ui/react-switch` dependency and created a reusable `Switch` UI component (shadcn pattern)
- Updated all tests to use `role="switch"` queries instead of button text filtering

## Context
The previous UI used filled/outline buttons with "Enabled"/"Disabled" text that looked like status badges rather than interactive controls. Toggle switches provide immediate visual affordance for on/off state.

**Wiring verification**: Confirmed that the notification preference state management is correctly wired — `handleToggle` properly inverts the current state, the API validates/upserts/re-fetches, and React Query invalidation refreshes the UI. The `mobile-push` DB CHECK constraint was already fixed in migration `20260304040949`.

## Test plan

### Claude Code
- [x] All 16 NotificationSection tests pass with updated switch queries
- [x] All 677 frontend tests pass (`make test-frontend`)
- [x] TypeScript compilation clean (`npx tsc --noEmit`)

### OpenClaw
- [ ] Visual review: verify toggle switches render correctly in dark/light mode
- [ ] Manual test: toggle each notification channel on/off and confirm state persists
- [ ] Manual test: verify plan-gated SMS still shows upgrade link (not a switch)

https://claude.ai/code/session_014oE1v8jvMenDYC3GxmPXLn