### PR TITLE
Replace constraint mode cycling button with dropdown

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -4,7 +4,8 @@ import { Label } from "@/components/ui/label";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
@@ -187,26 +188,25 @@ function ConstraintModeDropdown({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {allModes.map((m) => {
-          const cfg = modeConfig[m];
-          return (
-            <DropdownMenuItem
-              key={m}
-              onClick={() => onChange(m)}
-              className={m === mode ? "bg-accent" : ""}
-            >
-              <span className="flex items-center gap-2">
+        <DropdownMenuRadioGroup
+          value={mode}
+          onValueChange={(v) => {
+            if (v !== mode) onChange(v as ParamMode);
+          }}
+        >
+          {allModes.map((m) => {
+            const cfg = modeConfig[m];
+            return (
+              <DropdownMenuRadioItem key={m} value={m}>
                 {cfg.icon}
-                <span>
-                  <span className="font-medium">{cfg.label}</span>
-                  <span className="text-muted-foreground ml-2 text-xs">
-                    {cfg.description}
-                  </span>
+                <span className="font-medium">{cfg.label}</span>
+                <span className="text-muted-foreground text-xs">
+                  {cfg.description}
                 </span>
-              </span>
-            </DropdownMenuItem>
-          );
-        })}
+              </DropdownMenuRadioItem>
+            );
+          })}
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -1,8 +1,14 @@
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { Asterisk, Lock, Regex } from "lucide-react";
+import { Asterisk, ChevronDown, Lock, Regex } from "lucide-react";
 import type { ParamMode } from "./ActionConfigFormFields";
 import type { ParametersSchema } from "@/lib/parameterSchema";
 
@@ -93,7 +99,7 @@ export function ActionConfigParameterFields({
                 disabled={disabled || mode === "wildcard"}
                 className={mode === "wildcard" ? "bg-muted" : ""}
               />
-              <ConstraintModeButton
+              <ConstraintModeDropdown
                 mode={mode}
                 disabled={disabled}
                 onChange={(nextMode) => {
@@ -131,8 +137,30 @@ function inferModeFromValue(value: string): ParamMode {
   return "fixed";
 }
 
-/** Cycles through Fixed → Pattern → Wildcard. */
-function ConstraintModeButton({
+const modeConfig: Record<
+  ParamMode,
+  { icon: React.ReactNode; label: string; description: string }
+> = {
+  fixed: {
+    icon: <Lock className="size-3" />,
+    label: "Fixed",
+    description: "Exact value",
+  },
+  pattern: {
+    icon: <Regex className="size-3" />,
+    label: "Pattern",
+    description: "Glob matching with *",
+  },
+  wildcard: {
+    icon: <Asterisk className="size-3" />,
+    label: "Wildcard",
+    description: "Agent chooses freely",
+  },
+};
+
+const allModes: ParamMode[] = ["fixed", "pattern", "wildcard"];
+
+function ConstraintModeDropdown({
   mode,
   disabled,
   onChange,
@@ -141,51 +169,46 @@ function ConstraintModeButton({
   disabled?: boolean;
   onChange: (next: ParamMode) => void;
 }) {
-  function handleClick() {
-    if (mode === "fixed") onChange("pattern");
-    else if (mode === "pattern") onChange("wildcard");
-    else onChange("fixed");
-  }
-
-  const config: Record<
-    ParamMode,
-    { icon: React.ReactNode; label: string; title: string; variant: "default" | "outline" | "secondary" }
-  > = {
-    fixed: {
-      icon: <Regex className="size-3" />,
-      label: "Pattern",
-      title: "Switch to pattern mode (glob matching with *)",
-      variant: "outline",
-    },
-    pattern: {
-      icon: <Asterisk className="size-3" />,
-      label: "Wildcard",
-      title: "Switch to wildcard mode (agent chooses any value)",
-      variant: "secondary",
-    },
-    wildcard: {
-      icon: <Lock className="size-3" />,
-      label: "Fixed",
-      title: "Switch to fixed mode (exact value)",
-      variant: "default",
-    },
-  };
-
-  const { icon, label, title, variant } = config[mode];
+  const current = modeConfig[mode];
 
   return (
-    <Button
-      type="button"
-      variant={variant}
-      size="sm"
-      onClick={handleClick}
-      disabled={disabled}
-      title={title}
-      className="shrink-0"
-    >
-      {icon}
-      {label}
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className="shrink-0 gap-1.5"
+        >
+          {current.icon}
+          {current.label}
+          <ChevronDown className="size-3 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {allModes.map((m) => {
+          const cfg = modeConfig[m];
+          return (
+            <DropdownMenuItem
+              key={m}
+              onClick={() => onChange(m)}
+              className={m === mode ? "bg-accent" : ""}
+            >
+              <span className="flex items-center gap-2">
+                {cfg.icon}
+                <span>
+                  <span className="font-medium">{cfg.label}</span>
+                  <span className="text-muted-foreground ml-2 text-xs">
+                    {cfg.description}
+                  </span>
+                </span>
+              </span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -22,6 +22,11 @@ interface ActionConfigParameterFieldsProps {
   disabled?: boolean;
 }
 
+/**
+ * Renders parameter fields for action configuration, with a constraint mode
+ * dropdown (Fixed/Pattern/Wildcard) per parameter. Used in both the Add and
+ * Edit action configuration dialogs.
+ */
 export function ActionConfigParameterFields({
   parametersSchema,
   values,
@@ -167,6 +172,7 @@ function isParamMode(value: string): value is ParamMode {
   return allModes.includes(value as ParamMode);
 }
 
+/** Dropdown selector for constraint mode (Fixed/Pattern/Wildcard) with radio semantics. */
 function ConstraintModeDropdown({
   mode,
   disabled,

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -163,6 +163,10 @@ const modeConfig: Record<
 
 const allModes: ParamMode[] = ["fixed", "pattern", "wildcard"];
 
+function isParamMode(value: string): value is ParamMode {
+  return allModes.includes(value as ParamMode);
+}
+
 function ConstraintModeDropdown({
   mode,
   disabled,
@@ -194,7 +198,7 @@ function ConstraintModeDropdown({
         <DropdownMenuRadioGroup
           value={mode}
           onValueChange={(v) => {
-            if (v !== mode) onChange(v as ParamMode);
+            if (v !== mode && isParamMode(v)) onChange(v);
           }}
         >
           {allModes.map((m) => {

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -104,13 +104,15 @@ export function ActionConfigParameterFields({
                 mode={mode}
                 disabled={disabled}
                 onChange={(nextMode) => {
+                  const prevMode = mode;
                   onModeChange(key, nextMode);
                   if (nextMode === "wildcard") {
                     onValueChange(key, "*");
-                  } else {
-                    // Fixed or Pattern — clear the value so the user can type
+                  } else if (prevMode === "wildcard") {
+                    // Coming from wildcard — clear the "*" sentinel
                     onValueChange(key, "");
                   }
+                  // Switching between fixed ↔ pattern preserves the typed value
                 }}
               />
             </div>
@@ -180,6 +182,7 @@ function ConstraintModeDropdown({
           variant="outline"
           size="sm"
           disabled={disabled}
+          title={current.description}
           className="shrink-0 gap-1.5"
         >
           {current.icon}

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderWithProviders } from "../../../../test-helpers";
@@ -203,10 +203,10 @@ describe("ActionConfigurationsSection", () => {
     );
 
     // Set title to wildcard via dropdown.
-    // All params start in Fixed mode. Each has a dropdown trigger button.
-    const fixedButtons = screen.getAllByRole("button", { name: /Fixed/ });
-    // title is the second param field (repo=0, title=1, body=2).
-    await user.click(fixedButtons[1]!);
+    // Target the dropdown trigger within the "title" parameter group.
+    const titleInput = screen.getByLabelText("title");
+    const titleGroup = titleInput.closest(".space-y-1\\.5")!;
+    await user.click(within(titleGroup as HTMLElement).getByRole("button", { name: /Fixed/ }));
     // Select "Wildcard" from the dropdown menu.
     await user.click(screen.getByRole("menuitemradio", { name: /Wildcard/ }));
 

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -208,7 +208,7 @@ describe("ActionConfigurationsSection", () => {
     // title is the second param field (repo=0, title=1, body=2).
     await user.click(fixedButtons[1]!);
     // Select "Wildcard" from the dropdown menu.
-    await user.click(screen.getByRole("menuitem", { name: /Wildcard/ }));
+    await user.click(screen.getByRole("menuitemradio", { name: /Wildcard/ }));
 
     await user.click(screen.getByText("Create Configuration"));
 

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -202,15 +202,13 @@ describe("ActionConfigurationsSection", () => {
       "my-repo",
     );
 
-    // Set title to wildcard: Fixed → Pattern → Wildcard (two clicks).
-    // All params start in Fixed mode, so buttons say "Pattern".
-    // Use role-based selectors to avoid matching <strong> tags in help text.
-    const patternButtons = screen.getAllByRole("button", { name: /Pattern/ });
+    // Set title to wildcard via dropdown.
+    // All params start in Fixed mode. Each has a dropdown trigger button.
+    const fixedButtons = screen.getAllByRole("button", { name: /Fixed/ });
     // title is the second param field (repo=0, title=1, body=2).
-    await user.click(patternButtons[1]!);
-    // Now the title button says "Wildcard" — click it.
-    const wildcardButtons = screen.getAllByRole("button", { name: /Wildcard/ });
-    await user.click(wildcardButtons[0]!);
+    await user.click(fixedButtons[1]!);
+    // Select "Wildcard" from the dropdown menu.
+    await user.click(screen.getByRole("menuitem", { name: /Wildcard/ }));
 
     await user.click(screen.getByText("Create Configuration"));
 


### PR DESCRIPTION
## Summary
- Replaced the unintuitive cycling button (Fixed → Pattern → Wildcard) on the action configuration page with a proper dropdown menu
- The dropdown shows the **current** mode with its icon, and opens to reveal all three options with descriptions
- Each dropdown item shows the mode name and a short description (e.g. "Fixed — Exact value")

## Test plan
### Claude Code
- [x] Frontend tests pass (677/677)
- [x] TypeScript compiles cleanly

### OpenClaw
- [ ] Visually verify the dropdown renders correctly in Add and Edit action config dialogs
- [ ] Confirm switching between Fixed/Pattern/Wildcard works as expected
- [ ] Check dropdown alignment and styling in dark mode

https://claude.ai/code/session_01G7aPEhVWozxiTZNqUaCizh