### PR TITLE
Redesign activity feed: focus on actions, add click-through details

### DIFF
--- a/api/approvals.go
+++ b/api/approvals.go
@@ -50,6 +50,24 @@ type denyResponse struct {
 	DeniedAt   time.Time `json:"denied_at"`
 }
 
+// approvalDetailResponse includes execution details for the activity feed
+// detail panel. Extends the base approvalResponse with execution fields.
+type approvalDetailResponse struct {
+	ApprovalID      string     `json:"approval_id"`
+	AgentID         int64      `json:"agent_id"`
+	Action          any        `json:"action"`
+	Context         any        `json:"context"`
+	Status          string     `json:"status"`
+	ExecutionStatus *string    `json:"execution_status,omitempty"`
+	ExecutionResult any        `json:"execution_result,omitempty"`
+	ExecutedAt      *time.Time `json:"executed_at,omitempty"`
+	ExpiresAt       time.Time  `json:"expires_at"`
+	ApprovedAt      *time.Time `json:"approved_at,omitempty"`
+	DeniedAt        *time.Time `json:"denied_at,omitempty"`
+	CancelledAt     *time.Time `json:"cancelled_at,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+}
+
 func init() {
 	RegisterRouteGroup(RegisterApprovalRoutes)
 }
@@ -58,6 +76,7 @@ func init() {
 func RegisterApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /approvals", requireProfile(handleListApprovals(deps)))
+	mux.Handle("GET /approvals/{approval_id}", requireProfile(handleGetApproval(deps)))
 	mux.Handle("POST /approvals/{approval_id}/approve", requireProfile(handleApproveApproval(deps)))
 	mux.Handle("POST /approvals/{approval_id}/deny", requireProfile(handleDenyApproval(deps)))
 }
@@ -120,6 +139,35 @@ func handleListApprovals(deps *Deps) http.HandlerFunc {
 			resp.NextCursor = &c
 		}
 
+		RespondJSON(w, http.StatusOK, resp)
+	}
+}
+
+// handleGetApproval returns a single approval by ID for the authenticated user.
+// Used by the activity feed detail panel to show full action parameters,
+// context, and execution results for historical approvals.
+func handleGetApproval(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		approvalID := r.PathValue("approval_id")
+
+		if strings.TrimSpace(approvalID) == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "approval_id is required"))
+			return
+		}
+
+		appr, err := db.GetApprovalByIDAndApprover(r.Context(), deps.DB, approvalID, profile.ID)
+		if err != nil {
+			log.Printf("[%s] GetApprovalByIDAndApprover: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get approval"))
+			return
+		}
+		if appr == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Approval not found"))
+			return
+		}
+
+		resp := toApprovalDetailResponse(*appr)
 		RespondJSON(w, http.StatusOK, resp)
 	}
 }
@@ -331,6 +379,44 @@ func toApprovalResponse(a db.Approval) approvalResponse {
 			resp.Context = ctx
 		} else {
 			log.Printf("WARNING: corrupt context JSONB for approval %s: %v", a.ApprovalID, err)
+		}
+	}
+
+	return resp
+}
+
+// toApprovalDetailResponse converts a db.Approval to the detail response
+// that includes execution fields for the activity feed detail panel.
+func toApprovalDetailResponse(a db.Approval) approvalDetailResponse {
+	resp := approvalDetailResponse{
+		ApprovalID:      a.ApprovalID,
+		AgentID:         a.AgentID,
+		Status:          a.Status,
+		ExecutionStatus: a.ExecutionStatus,
+		ExecutedAt:      a.ExecutedAt,
+		ExpiresAt:       a.ExpiresAt,
+		ApprovedAt:      a.ApprovedAt,
+		DeniedAt:        a.DeniedAt,
+		CancelledAt:     a.CancelledAt,
+		CreatedAt:       a.CreatedAt,
+	}
+
+	if len(a.Action) > 0 {
+		var action any
+		if err := json.Unmarshal(a.Action, &action); err == nil {
+			resp.Action = action
+		}
+	}
+	if len(a.Context) > 0 {
+		var ctx any
+		if err := json.Unmarshal(a.Context, &ctx); err == nil {
+			resp.Context = ctx
+		}
+	}
+	if len(a.ExecutionResult) > 0 {
+		var result any
+		if err := json.Unmarshal(a.ExecutionResult, &result); err == nil {
+			resp.ExecutionResult = result
 		}
 	}
 

--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -14,8 +14,8 @@ import (
 )
 
 // auditEventResponse is the JSON representation of a single audit event
-// for the activity feed (GET /audit-events). Does NOT include id or source_id
-// since the activity feed is for display purposes only.
+// for the activity feed (GET /audit-events). Includes source_id and source_type
+// so the frontend can link events back to their source approval for detail views.
 type auditEventResponse struct {
 	EventType       string    `json:"event_type"`
 	Timestamp       time.Time `json:"timestamp"`
@@ -23,6 +23,8 @@ type auditEventResponse struct {
 	AgentMeta       any       `json:"agent_metadata,omitempty"`
 	Action          any       `json:"action,omitempty"`
 	Outcome         string    `json:"outcome"`
+	SourceID        string    `json:"source_id,omitempty"`
+	SourceType      string    `json:"source_type,omitempty"`
 	ConnectorID     *string   `json:"connector_id,omitempty"`
 	ExecutionStatus *string   `json:"execution_status,omitempty"`
 	ExecutionError  *string   `json:"execution_error,omitempty"`
@@ -400,6 +402,8 @@ func toAuditEventResponse(e db.AuditEvent) auditEventResponse {
 		AgentMeta:       unmarshalJSONB(e.AgentMeta),
 		Action:          unmarshalJSONB(e.Action),
 		Outcome:         e.Outcome,
+		SourceID:        e.SourceID,
+		SourceType:      e.SourceType,
 		ConnectorID:     e.ConnectorID,
 		ExecutionStatus: e.ExecutionStatus,
 		ExecutionError:  e.ExecutionError,

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -52,6 +52,7 @@ type AuditEvent struct {
 	Action          []byte  // raw JSONB (approval action details, nullable)
 	Outcome         string  // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
 	SourceID        string  // unique ID per event source (e.g. approval_id)
+	SourceType      string  // "approval", "standing_approval", "agent", "payment_method_transaction"
 	ConnectorID     *string // which connector handled the action (nullable for lifecycle events)
 	ExecutionStatus *string // "success", "failure", "timeout", "skipped" (nullable)
 	ExecutionError  *string // failure details (nullable)
@@ -197,7 +198,7 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 
 	query := fmt.Sprintf(
 		`SELECT ae.id, ae.event_type, ae.created_at, ae.agent_id, ae.agent_meta, ae.action,
-		        %s AS outcome, ae.source_id, ae.connector_id, ae.execution_status, ae.execution_error
+		        %s AS outcome, ae.source_id, ae.source_type, ae.connector_id, ae.execution_status, ae.execution_error
 		 FROM audit_events ae
 		 LEFT JOIN agents a ON ae.agent_id = a.agent_id
 		 WHERE %s
@@ -318,7 +319,7 @@ func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Tim
 
 	query := fmt.Sprintf(
 		`SELECT ae.id, ae.event_type, ae.created_at, ae.agent_id, ae.agent_meta, ae.action,
-		        %s AS outcome, ae.source_id, ae.connector_id, ae.execution_status, ae.execution_error
+		        %s AS outcome, ae.source_id, ae.source_type, ae.connector_id, ae.execution_status, ae.execution_error
 		 FROM audit_events ae
 		 LEFT JOIN agents a ON ae.agent_id = a.agent_id
 		 WHERE %s
@@ -354,7 +355,7 @@ func scanAuditEvents(rows pgx.Rows) ([]AuditEvent, error) {
 		var eventType string
 		if err := rows.Scan(
 			&e.ID, &eventType, &e.Timestamp, &e.AgentID, &e.AgentMeta, &e.Action,
-			&e.Outcome, &e.SourceID, &e.ConnectorID, &e.ExecutionStatus, &e.ExecutionError,
+			&e.Outcome, &e.SourceID, &e.SourceType, &e.ConnectorID, &e.ExecutionStatus, &e.ExecutionError,
 		); err != nil {
 			return nil, fmt.Errorf("scan audit event: %w", err)
 		}

--- a/frontend/src/hooks/__tests__/useApprovalDetail.test.tsx
+++ b/frontend/src/hooks/__tests__/useApprovalDetail.test.tsx
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setupAuthMocks } from "../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../test-helpers";
+import { mockGet, resetClientMocks } from "../../api/__mocks__/client";
+import { useApprovalDetail } from "../useApprovalDetail";
+
+vi.mock("../../lib/supabaseClient");
+vi.mock("../../api/client");
+
+const mockApprovalResponse = {
+  approval_id: "apr_123",
+  agent_id: 1,
+  action: { type: "email.send", parameters: { to: "a@b.com" } },
+  context: { risk_level: "low" },
+  status: "approved",
+  execution_status: "success",
+  execution_result: { message_id: "msg_456" },
+  expires_at: "2026-02-21T12:00:00Z",
+  created_at: "2026-02-20T11:00:00Z",
+};
+
+describe("useApprovalDetail", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not fetch when approvalId is null", () => {
+    setupAuthMocks({ authenticated: true });
+
+    const { result } = renderHook(() => useApprovalDetail(null), { wrapper });
+
+    expect(result.current.approval).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when not authenticated", () => {
+    setupAuthMocks({ authenticated: false });
+
+    const { result } = renderHook(() => useApprovalDetail("apr_123"), {
+      wrapper,
+    });
+
+    expect(result.current.approval).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("fetches approval details when authenticated with an ID", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockResolvedValue({ data: mockApprovalResponse });
+
+    const { result } = renderHook(() => useApprovalDetail("apr_123"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.approval).toEqual(mockApprovalResponse);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith("/v1/approvals/{approval_id}", {
+      headers: { Authorization: "Bearer token" },
+      params: { path: { approval_id: "apr_123" } },
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns error state on API failure", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockResolvedValue({ error: { message: "Not found" } });
+
+    const { result } = renderHook(() => useApprovalDetail("apr_bad"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        "Unable to load approval details.",
+      );
+    });
+    expect(result.current.approval).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useApprovalDetail.ts
+++ b/frontend/src/hooks/useApprovalDetail.ts
@@ -36,7 +36,7 @@ export function useApprovalDetail(approvalId: string | null) {
       return data;
     },
     enabled: !!accessToken && !!approvalId,
-    staleTime: 60_000,
+    staleTime: Infinity,
   });
 
   return {

--- a/frontend/src/hooks/useApprovalDetail.ts
+++ b/frontend/src/hooks/useApprovalDetail.ts
@@ -1,0 +1,49 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type ApprovalDetail = components["schemas"]["ApprovalSummary"];
+
+/**
+ * Fetches a single approval by ID for the activity feed detail panel.
+ * Only fetches when approvalId is non-null (lazy loading).
+ */
+export function useApprovalDetail(approvalId: string | null) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["approval-detail", approvalId],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      if (!approvalId) throw new Error("Missing approval ID");
+      const { data, error } = await client.GET(
+        "/v1/approvals/{approval_id}",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          params: { path: { approval_id: approvalId } },
+        },
+      );
+      if (error) throw new Error("Failed to load approval details");
+      return data;
+    },
+    enabled: !!accessToken && !!approvalId,
+    staleTime: 60_000,
+  });
+
+  return {
+    approval: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load approval details."
+      : null,
+  };
+}

--- a/frontend/src/lib/auditEvents.tsx
+++ b/frontend/src/lib/auditEvents.tsx
@@ -27,8 +27,17 @@ export const OUTCOME_FILTERS: { label: string; value: OutcomeFilter }[] = [
   { label: "All", value: "all" },
   { label: "Approved", value: "approved" },
   { label: "Denied", value: "denied" },
+  { label: "Pending", value: "pending" },
   { label: "Auto-executed", value: "auto_executed" },
 ];
+
+/**
+ * Default event_type filter that excludes lifecycle noise (agent.registered,
+ * agent.deactivated). Used by both the dashboard card and the activity page
+ * when no explicit event_type filter is set.
+ */
+export const ACTION_EVENT_TYPES =
+  "approval.requested,approval.approved,approval.denied,approval.cancelled,action.executed,standing_approval.executed,payment_method.charged";
 
 interface OutcomeStyle {
   label: string;
@@ -150,20 +159,26 @@ export function OutcomeBadge({ outcome }: { outcome: string }) {
 /**
  * Shared table row for rendering a single audit event.
  * Accepts a `formatTimestamp` prop so callers can choose relative vs absolute display.
+ * When `onClick` is provided, the row becomes clickable with a hover highlight.
  */
 export function AuditEventRow({
   event,
   formatTimestamp,
   timestampTitle,
   actionMaxWidth = "max-w-[200px]",
+  onClick,
 }: {
   event: AuditEvent;
   formatTimestamp: (ts: string) => string;
   timestampTitle?: string;
   actionMaxWidth?: string;
+  onClick?: (event: AuditEvent) => void;
 }) {
   return (
-    <TableRow>
+    <TableRow
+      className={onClick ? "cursor-pointer transition-colors hover:bg-accent" : undefined}
+      onClick={onClick ? () => onClick(event) : undefined}
+    >
       <TableCell className="whitespace-nowrap text-xs">
         {timestampTitle ? (
           <span title={timestampTitle}>

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -27,6 +27,9 @@ import { ActionPreviewSummary } from "@/components/ActionPreviewSummary";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { RiskBadge } from "@/pages/dashboard/approval-components";
 
+/** Matches Radix Sheet exit animation duration so content stays rendered during close. */
+export const SHEET_CLOSE_DELAY_MS = 300;
+
 interface ActivityDetailSheetProps {
   event: AuditEvent | null;
   open: boolean;
@@ -242,7 +245,8 @@ export function ActivityDetailSheet({
           </SheetDescription>
         </SheetHeader>
 
-        {event && <div className="space-y-5 px-4 pb-6">
+        {event && (
+          <div className="space-y-5 px-4 pb-6">
           {/* Event header */}
           <div className="flex items-center justify-between gap-3">
             <OutcomeBadge outcome={event.outcome} />
@@ -305,7 +309,8 @@ export function ActivityDetailSheet({
               <p className="text-sm">{getActionSummary(event)}</p>
             </div>
           )}
-        </div>}
+        </div>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -1,0 +1,346 @@
+import {
+  Loader2,
+  Bot,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Clock,
+} from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import {
+  type AuditEvent,
+  OutcomeBadge,
+  getAuditAgentName,
+  getActionSummary,
+} from "@/lib/auditEvents";
+import { formatAbsoluteTime, formatRelativeTime } from "@/lib/utils";
+import { useApprovalDetail } from "@/hooks/useApprovalDetail";
+import { useActionSchema } from "@/hooks/useActionSchema";
+import { ActionPreviewSummary } from "@/components/ActionPreviewSummary";
+import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
+import { RiskBadge } from "@/pages/dashboard/approval-components";
+
+interface ActivityDetailSheetProps {
+  event: AuditEvent | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Extract the action type from an audit event. */
+function getActionType(event: AuditEvent): string {
+  const action = event.action as Record<string, unknown> | null | undefined;
+  if (!action) return "";
+  return typeof action.type === "string" ? action.type : "";
+}
+
+/** Returns true if this event type can link back to an approval record. */
+function isApprovalEvent(event: AuditEvent): boolean {
+  return (
+    event.source_type === "approval" &&
+    !!event.source_id &&
+    event.event_type !== "agent.registered" &&
+    event.event_type !== "agent.deactivated"
+  );
+}
+
+function ExecutionStatusSection({
+  status,
+  error,
+}: {
+  status: string;
+  error?: string | null;
+}) {
+  const isSuccess = status === "success";
+  const isFailure = status === "failure";
+  const isTimeout = status === "timeout";
+
+  const Icon = isSuccess
+    ? CheckCircle2
+    : isFailure || isTimeout
+      ? XCircle
+      : Clock;
+  const color = isSuccess
+    ? "text-green-600 dark:text-green-400"
+    : isFailure || isTimeout
+      ? "text-red-600 dark:text-red-400"
+      : "text-muted-foreground";
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+        Execution
+      </h4>
+      <div className="flex items-center gap-2">
+        <Icon className={`size-4 ${color}`} />
+        <span className="text-sm font-medium capitalize">{status}</span>
+      </div>
+      {error && (
+        <div className="bg-destructive/10 border-destructive/20 rounded-md border p-3">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="text-destructive mt-0.5 size-4 shrink-0" />
+            <p className="text-destructive text-sm">{error}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ApprovalDetails({ approvalId }: { approvalId: string }) {
+  const { approval, isLoading, error } = useApprovalDetail(approvalId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-4">
+        <Loader2 className="text-muted-foreground size-4 animate-spin" />
+        <span className="text-muted-foreground text-sm">Loading details...</span>
+      </div>
+    );
+  }
+
+  if (error || !approval) {
+    return (
+      <p className="text-muted-foreground text-sm py-2">
+        {error ?? "Approval details not available."}
+      </p>
+    );
+  }
+
+  const action = approval.action as Record<string, unknown> | undefined;
+  const actionType = typeof action?.type === "string" ? action.type : "";
+  const parameters = (action?.parameters ?? {}) as Record<string, unknown>;
+  const context = approval.context as Record<string, unknown> | undefined;
+  const riskLevel = context?.risk_level as "low" | "medium" | "high" | undefined;
+  const description = typeof context?.description === "string" ? context.description : null;
+  const executionResult = approval.execution_result as Record<string, unknown> | undefined;
+
+  return (
+    <ApprovalContent
+      actionType={actionType}
+      parameters={parameters}
+      riskLevel={riskLevel}
+      description={description}
+      executionStatus={approval.execution_status ?? undefined}
+      executionResult={executionResult}
+    />
+  );
+}
+
+function ApprovalContent({
+  actionType,
+  parameters,
+  riskLevel,
+  description,
+  executionStatus,
+  executionResult,
+}: {
+  actionType: string;
+  parameters: Record<string, unknown>;
+  riskLevel?: "low" | "medium" | "high" | null;
+  description?: string | null;
+  executionStatus?: string;
+  executionResult?: Record<string, unknown>;
+}) {
+  const { schema, actionName } = useActionSchema(actionType);
+
+  return (
+    <div className="space-y-5">
+      {/* Action Summary */}
+      {actionType && (
+        <div className="space-y-2">
+          <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+            Action
+          </h4>
+          <div className="bg-muted/50 rounded-lg border p-3">
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-sm font-semibold">
+                {actionName ?? actionType}
+              </span>
+              {riskLevel && <RiskBadge level={riskLevel} />}
+            </div>
+            {actionName && (
+              <span className="text-muted-foreground font-mono text-xs">
+                {actionType}
+              </span>
+            )}
+            {description && (
+              <p className="text-muted-foreground mt-2 text-sm">{description}</p>
+            )}
+            {Object.keys(parameters).length > 0 && (
+              <div className="border-t mt-3 pt-3">
+                <ActionPreviewSummary
+                  actionType={actionType}
+                  parameters={parameters}
+                  schema={schema}
+                  actionName={actionName}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Parameters */}
+      {Object.keys(parameters).length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+            Parameters
+          </h4>
+          <div className="bg-muted/50 overflow-x-auto rounded-lg border p-3">
+            <SchemaParameterDetails
+              parameters={parameters}
+              schema={schema}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Execution Result */}
+      {executionStatus && (
+        <ExecutionStatusSection status={executionStatus} />
+      )}
+      {executionResult && Object.keys(executionResult).length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+            Execution Result
+          </h4>
+          <pre className="bg-muted/50 overflow-x-auto rounded-lg border p-3 text-xs">
+            {JSON.stringify(executionResult, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ActivityDetailSheet({
+  event,
+  open,
+  onOpenChange,
+}: ActivityDetailSheetProps) {
+  if (!event) return null;
+
+  const actionType = getActionType(event);
+  const shouldFetchApproval = isApprovalEvent(event);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>Activity Detail</SheetTitle>
+          <SheetDescription className="sr-only">
+            Details for this activity event
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="space-y-5 px-4 pb-6">
+          {/* Event header */}
+          <div className="flex items-center justify-between gap-3">
+            <OutcomeBadge outcome={event.outcome} />
+            <span className="text-muted-foreground text-xs" title={formatRelativeTime(event.timestamp)}>
+              {formatAbsoluteTime(event.timestamp)}
+            </span>
+          </div>
+
+          {/* Agent */}
+          <div className="space-y-2">
+            <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+              Agent
+            </h4>
+            <div className="flex items-center gap-3">
+              <div className="bg-muted rounded-full p-2">
+                <Bot className="text-muted-foreground size-4" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">{getAuditAgentName(event)}</p>
+                <p className="text-muted-foreground font-mono text-xs">
+                  ID: {event.agent_id}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Connector */}
+          {event.connector_id && (
+            <div className="space-y-2">
+              <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+                Connector
+              </h4>
+              <Badge variant="outline" className="capitalize">
+                {event.connector_id}
+              </Badge>
+            </div>
+          )}
+
+          {/* Action summary from audit event */}
+          {actionType && !shouldFetchApproval && (
+            <InlineActionDetails event={event} actionType={actionType} />
+          )}
+
+          {/* Full details from approval record */}
+          {shouldFetchApproval && event.source_id && (
+            <ApprovalDetails approvalId={event.source_id} />
+          )}
+
+          {/* Execution status from audit event (for standing approvals) */}
+          {event.execution_status && !shouldFetchApproval && (
+            <ExecutionStatusSection
+              status={event.execution_status}
+              error={event.execution_error}
+            />
+          )}
+
+          {/* Lifecycle event message */}
+          {!actionType && (
+            <div className="bg-muted/50 rounded-lg border p-4 text-center">
+              <p className="text-sm">{getActionSummary(event)}</p>
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/**
+ * Inline action details for events that have params directly on the audit event
+ * (e.g., standing_approval.executed, payment_method.charged).
+ */
+function InlineActionDetails({
+  event,
+  actionType,
+}: {
+  event: AuditEvent;
+  actionType: string;
+}) {
+  const action = event.action as Record<string, unknown>;
+  const parameters = (action?.parameters ?? {}) as Record<string, unknown>;
+
+  // Payment events have their own fields instead of parameters
+  if (event.event_type === "payment_method.charged") {
+    return (
+      <div className="space-y-2">
+        <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+          Payment Details
+        </h4>
+        <div className="bg-muted/50 rounded-lg border p-3 text-sm">
+          <p>{getActionSummary(event)}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ApprovalContent
+      actionType={actionType}
+      parameters={parameters}
+    />
+  );
+}

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -120,6 +120,7 @@ function ApprovalDetails({ approvalId }: { approvalId: string }) {
   const riskLevel = context?.risk_level as "low" | "medium" | "high" | undefined;
   const description = typeof context?.description === "string" ? context.description : null;
   const executionResult = approval.execution_result as Record<string, unknown> | undefined;
+  const executionError = typeof executionResult?.error === "string" ? executionResult.error : undefined;
 
   return (
     <ApprovalContent
@@ -128,6 +129,7 @@ function ApprovalDetails({ approvalId }: { approvalId: string }) {
       riskLevel={riskLevel}
       description={description}
       executionStatus={approval.execution_status ?? undefined}
+      executionError={executionError}
       executionResult={executionResult}
     />
   );
@@ -139,6 +141,7 @@ function ApprovalContent({
   riskLevel,
   description,
   executionStatus,
+  executionError,
   executionResult,
 }: {
   actionType: string;
@@ -146,6 +149,7 @@ function ApprovalContent({
   riskLevel?: "low" | "medium" | "high" | null;
   description?: string | null;
   executionStatus?: string;
+  executionError?: string;
   executionResult?: Record<string, unknown>;
 }) {
   const { schema, actionName } = useActionSchema(actionType);
@@ -204,7 +208,7 @@ function ApprovalContent({
 
       {/* Execution Result */}
       {executionStatus && (
-        <ExecutionStatusSection status={executionStatus} />
+        <ExecutionStatusSection status={executionStatus} error={executionError} />
       )}
       {executionResult && Object.keys(executionResult).length > 0 && (
         <div className="space-y-2">
@@ -225,10 +229,8 @@ export function ActivityDetailSheet({
   open,
   onOpenChange,
 }: ActivityDetailSheetProps) {
-  if (!event) return null;
-
-  const actionType = getActionType(event);
-  const shouldFetchApproval = isApprovalEvent(event);
+  const actionType = event ? getActionType(event) : "";
+  const shouldFetchApproval = event ? isApprovalEvent(event) : false;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -240,7 +242,7 @@ export function ActivityDetailSheet({
           </SheetDescription>
         </SheetHeader>
 
-        <div className="space-y-5 px-4 pb-6">
+        {event && <div className="space-y-5 px-4 pb-6">
           {/* Event header */}
           <div className="flex items-center justify-between gap-3">
             <OutcomeBadge outcome={event.outcome} />
@@ -303,7 +305,7 @@ export function ActivityDetailSheet({
               <p className="text-sm">{getActionSummary(event)}</p>
             </div>
           )}
-        </div>
+        </div>}
       </SheetContent>
     </Sheet>
   );

--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -47,6 +47,7 @@ function EmptyState() {
 export function ActivityPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const rawOutcome = searchParams.get("outcome") ?? "all";
   const outcomeFilter: OutcomeFilter = VALID_OUTCOMES.has(rawOutcome as OutcomeFilter)
@@ -94,6 +95,7 @@ export function ActivityPage() {
 
   const handleRowClick = useCallback((event: AuditEvent) => {
     setSelectedEvent(event);
+    setIsSheetOpen(true);
   }, []);
 
   return (
@@ -207,8 +209,11 @@ export function ActivityPage() {
 
       <ActivityDetailSheet
         event={selectedEvent}
-        open={selectedEvent !== null}
-        onOpenChange={(open) => { if (!open) setSelectedEvent(null); }}
+        open={isSheetOpen}
+        onOpenChange={(open) => {
+          setIsSheetOpen(open);
+          if (!open) setTimeout(() => setSelectedEvent(null), 300);
+        }}
       />
     </div>
   );

--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useState, useCallback } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { Activity, ArrowLeft, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -11,8 +11,10 @@ import {
 } from "@/components/ui/table";
 import { formatAbsoluteTime, formatRelativeTime } from "@/lib/utils";
 import {
+  type AuditEvent,
   type OutcomeFilter,
   ALL_OUTCOME_FILTERS,
+  ACTION_EVENT_TYPES,
   AuditEventRow,
 } from "@/lib/auditEvents";
 import { useInfiniteAuditEvents } from "@/hooks/useInfiniteAuditEvents";
@@ -20,6 +22,7 @@ import type { AuditEventFilters } from "@/hooks/useAuditEvents";
 import { useAgents } from "@/hooks/useAgents";
 import { ActivityFilters } from "./ActivityFilters";
 import { RetentionBanner } from "./RetentionBanner";
+import { ActivityDetailSheet } from "./ActivityDetailSheet";
 
 /** Set of valid outcome values for URL param validation. */
 const VALID_OUTCOMES = new Set(
@@ -35,8 +38,7 @@ function EmptyState() {
       </p>
       <p className="text-muted-foreground max-w-xs text-xs">
         Try adjusting your filters or check back later. Approval decisions,
-        standing approval executions, agent events, and payment charges will
-        appear here.
+        standing approval executions, and payment charges will appear here.
       </p>
     </div>
   );
@@ -44,6 +46,7 @@ function EmptyState() {
 
 export function ActivityPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
 
   const rawOutcome = searchParams.get("outcome") ?? "all";
   const outcomeFilter: OutcomeFilter = VALID_OUTCOMES.has(rawOutcome as OutcomeFilter)
@@ -69,9 +72,10 @@ export function ActivityPage() {
     [setSearchParams],
   );
 
+  // Default to action event types when no explicit event_type filter is set
   const filters: AuditEventFilters = {
     ...(outcomeFilter !== "all" && { outcome: outcomeFilter }),
-    ...(eventTypeFilter && { event_type: eventTypeFilter }),
+    event_type: eventTypeFilter || ACTION_EVENT_TYPES,
     ...(agentFilter != null && { agent_id: agentFilter }),
   };
 
@@ -87,6 +91,10 @@ export function ActivityPage() {
   } = useInfiniteAuditEvents(filters);
 
   const { agents } = useAgents();
+
+  const handleRowClick = useCallback((event: AuditEvent) => {
+    setSelectedEvent(event);
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -167,6 +175,7 @@ export function ActivityPage() {
                     formatTimestamp={formatAbsoluteTime}
                     timestampTitle={formatRelativeTime(event.timestamp)}
                     actionMaxWidth="max-w-[300px]"
+                    onClick={handleRowClick}
                   />
                 ))}
               </TableBody>
@@ -195,6 +204,12 @@ export function ActivityPage() {
           )}
         </>
       )}
+
+      <ActivityDetailSheet
+        event={selectedEvent}
+        open={selectedEvent !== null}
+        onOpenChange={(open) => { if (!open) setSelectedEvent(null); }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -22,7 +22,7 @@ import type { AuditEventFilters } from "@/hooks/useAuditEvents";
 import { useAgents } from "@/hooks/useAgents";
 import { ActivityFilters } from "./ActivityFilters";
 import { RetentionBanner } from "./RetentionBanner";
-import { ActivityDetailSheet } from "./ActivityDetailSheet";
+import { ActivityDetailSheet, SHEET_CLOSE_DELAY_MS } from "./ActivityDetailSheet";
 
 /** Set of valid outcome values for URL param validation. */
 const VALID_OUTCOMES = new Set(
@@ -212,7 +212,7 @@ export function ActivityPage() {
         open={isSheetOpen}
         onOpenChange={(open) => {
           setIsSheetOpen(open);
-          if (!open) setTimeout(() => setSelectedEvent(null), 300);
+          if (!open) setTimeout(() => setSelectedEvent(null), SHEET_CLOSE_DELAY_MS);
         }}
       />
     </div>

--- a/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
+++ b/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import { mockGet, resetClientMocks } from "../../../api/__mocks__/client";
+import {
+  FIXED_NOW,
+  mockAuditEvents,
+  mockPaymentChargedEvent,
+} from "../../../lib/__tests__/auditEventFixtures";
+import { ActivityDetailSheet } from "../ActivityDetailSheet";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+/** Build a minimal AuditEvent-like object for the sheet. */
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    ...mockAuditEvents[0],
+    ...overrides,
+  };
+}
+
+describe("ActivityDetailSheet", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(FIXED_NOW);
+    vi.restoreAllMocks();
+    resetClientMocks();
+    setupAuthMocks({ authenticated: true });
+    wrapper = createAuthWrapper();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing visible when open is false", () => {
+    const event = makeEvent();
+    const { container } = render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={false}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+    // Sheet is in DOM but not visible — the title should not be shown
+    expect(container.querySelector("[data-state='open']")).toBeNull();
+  });
+
+  it("renders sheet title when open", async () => {
+    const event = makeEvent();
+    render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Activity Detail")).toBeInTheDocument();
+    });
+  });
+
+  it("shows agent name and ID", async () => {
+    const event = makeEvent();
+    render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("My Bot")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/ID: 1/)).toBeInTheDocument();
+  });
+
+  it("shows outcome badge", async () => {
+    const event = makeEvent({ outcome: "denied" });
+    render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Denied")).toBeInTheDocument();
+    });
+  });
+
+  it("shows lifecycle event message when no action", async () => {
+    const event = makeEvent({
+      event_type: "agent.registered",
+      action: null,
+      outcome: "registered",
+    });
+    render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent registered")).toBeInTheDocument();
+    });
+  });
+
+  it("fetches approval details for approval events with source_id", async () => {
+    const event = makeEvent({
+      source_type: "approval",
+      source_id: "apr_123",
+      event_type: "approval.approved",
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/v1/approvals/")) {
+        return Promise.resolve({
+          data: {
+            approval_id: "apr_123",
+            agent_id: 1,
+            action: { type: "email.send", parameters: { to: "a@b.com" } },
+            context: { risk_level: "low" },
+            status: "approved",
+            execution_status: "success",
+            expires_at: "2026-02-21T12:00:00Z",
+            created_at: "2026-02-20T11:00:00Z",
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    // Should show loading then approval details
+    await waitFor(() => {
+      expect(screen.getByText("Action")).toBeInTheDocument();
+    });
+  });
+
+  it("shows payment details for payment events", async () => {
+    render(
+      <ActivityDetailSheet
+        event={mockPaymentChargedEvent as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Payment Details")).toBeInTheDocument();
+    });
+  });
+
+  it("shows inline action details for standing approval events", async () => {
+    const event = makeEvent({
+      event_type: "standing_approval.executed",
+      source_type: "standing_approval",
+      source_id: "sa_123",
+      action: {
+        type: "email.read",
+        version: "1",
+        parameters: { folder: "inbox" },
+      },
+      outcome: "auto_executed",
+    });
+
+    render(
+      <ActivityDetailSheet
+        event={event as never}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Action")).toBeInTheDocument();
+    });
+  });
+
+  it("does not crash when event is present but open is false", () => {
+    const { container } = render(
+      <ActivityDetailSheet
+        event={makeEvent() as never}
+        open={false}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it("does not crash when event is null and open is false", () => {
+    const { container } = render(
+      <ActivityDetailSheet
+        event={null}
+        open={false}
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+    expect(container).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/pages/dashboard/RecentActivityCard.tsx
@@ -27,7 +27,7 @@ import {
   useAuditEvents,
   type AuditEventFilters,
 } from "@/hooks/useAuditEvents";
-import { ActivityDetailSheet } from "@/pages/activity/ActivityDetailSheet";
+import { ActivityDetailSheet, SHEET_CLOSE_DELAY_MS } from "@/pages/activity/ActivityDetailSheet";
 
 function OutcomeFilterTabs({
   value,
@@ -170,7 +170,7 @@ export function RecentActivityCard() {
         open={isSheetOpen}
         onOpenChange={(open) => {
           setIsSheetOpen(open);
-          if (!open) setTimeout(() => setSelectedEvent(null), 300);
+          if (!open) setTimeout(() => setSelectedEvent(null), SHEET_CLOSE_DELAY_MS);
         }}
       />
     </>

--- a/frontend/src/pages/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/pages/dashboard/RecentActivityCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { Loader2, Activity } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -17,14 +17,17 @@ import {
 } from "@/components/ui/table";
 import { formatRelativeTime } from "@/lib/utils";
 import {
+  type AuditEvent,
   type OutcomeFilter,
   OUTCOME_FILTERS,
+  ACTION_EVENT_TYPES,
   AuditEventRow,
 } from "@/lib/auditEvents";
 import {
   useAuditEvents,
   type AuditEventFilters,
 } from "@/hooks/useAuditEvents";
+import { ActivityDetailSheet } from "@/pages/activity/ActivityDetailSheet";
 
 function OutcomeFilterTabs({
   value,
@@ -72,83 +75,99 @@ function EmptyState() {
 
 export function RecentActivityCard() {
   const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
 
-  const filters: AuditEventFilters =
-    outcomeFilter !== "all" ? { outcome: outcomeFilter } : {};
+  const filters: AuditEventFilters = {
+    event_type: ACTION_EVENT_TYPES,
+    ...(outcomeFilter !== "all" && { outcome: outcomeFilter }),
+  };
 
   const { events, hasMore, isLoading, error, refetch } = useAuditEvents(filters);
 
+  const handleRowClick = useCallback((event: AuditEvent) => {
+    setSelectedEvent(event);
+  }, []);
+
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <CardTitle>Recent Activity</CardTitle>
-          <OutcomeFilterTabs
-            value={outcomeFilter}
-            onChange={setOutcomeFilter}
-          />
-        </div>
-      </CardHeader>
-      <CardContent className="px-3 md:px-6">
-        {isLoading ? (
-          <div
-            className="flex items-center justify-center py-8"
-            role="status"
-            aria-label="Loading activity"
-          >
-            <Loader2 className="text-muted-foreground size-6 animate-spin" />
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <CardTitle>Recent Activity</CardTitle>
+            <OutcomeFilterTabs
+              value={outcomeFilter}
+              onChange={setOutcomeFilter}
+            />
           </div>
-        ) : error ? (
-          <div className="flex flex-col items-center justify-center py-8 text-center">
-            <p className="text-destructive mb-2 text-sm">{error}</p>
-            <Button variant="ghost" size="sm" onClick={() => refetch()}>
-              Retry
-            </Button>
-          </div>
-        ) : events.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <div className="overflow-hidden rounded-lg">
-            <Table>
-              <TableHeader>
-                <TableRow className="border-none bg-primary hover:bg-primary">
-                  <TableHead className="font-semibold text-primary-foreground">
-                    When
-                  </TableHead>
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Agent
-                  </TableHead>
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Action
-                  </TableHead>
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Outcome
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody className="[&>tr:nth-child(even)]:bg-muted">
-                {events.map((event) => (
-                  <AuditEventRow
-                    key={`${event.timestamp}-${event.agent_id}-${event.event_type}`}
-                    event={event}
-                    formatTimestamp={formatRelativeTime}
-                  />
-                ))}
-              </TableBody>
-            </Table>
+        </CardHeader>
+        <CardContent className="px-3 md:px-6">
+          {isLoading ? (
+            <div
+              className="flex items-center justify-center py-8"
+              role="status"
+              aria-label="Loading activity"
+            >
+              <Loader2 className="text-muted-foreground size-6 animate-spin" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <p className="text-destructive mb-2 text-sm">{error}</p>
+              <Button variant="ghost" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </div>
+          ) : events.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className="overflow-hidden rounded-lg">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-none bg-primary hover:bg-primary">
+                    <TableHead className="font-semibold text-primary-foreground">
+                      When
+                    </TableHead>
+                    <TableHead className="font-semibold text-primary-foreground">
+                      Agent
+                    </TableHead>
+                    <TableHead className="font-semibold text-primary-foreground">
+                      Action
+                    </TableHead>
+                    <TableHead className="font-semibold text-primary-foreground">
+                      Outcome
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="[&>tr:nth-child(even)]:bg-muted">
+                  {events.map((event) => (
+                    <AuditEventRow
+                      key={`${event.timestamp}-${event.agent_id}-${event.event_type}`}
+                      event={event}
+                      formatTimestamp={formatRelativeTime}
+                      onClick={handleRowClick}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+        {hasMore && (
+          <div className="px-6 pb-4 text-center">
+            <Link
+              to="/activity"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              View All Activity
+            </Link>
           </div>
         )}
-      </CardContent>
-      {hasMore && (
-        <div className="px-6 pb-4 text-center">
-          <Link
-            to="/activity"
-            className="text-sm font-medium text-primary hover:underline"
-          >
-            View All Activity
-          </Link>
-        </div>
-      )}
-    </Card>
+      </Card>
+
+      <ActivityDetailSheet
+        event={selectedEvent}
+        open={selectedEvent !== null}
+        onOpenChange={(open) => { if (!open) setSelectedEvent(null); }}
+      />
+    </>
   );
 }

--- a/frontend/src/pages/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/pages/dashboard/RecentActivityCard.tsx
@@ -76,6 +76,7 @@ function EmptyState() {
 export function RecentActivityCard() {
   const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
   const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const filters: AuditEventFilters = {
     event_type: ACTION_EVENT_TYPES,
@@ -86,6 +87,7 @@ export function RecentActivityCard() {
 
   const handleRowClick = useCallback((event: AuditEvent) => {
     setSelectedEvent(event);
+    setIsSheetOpen(true);
   }, []);
 
   return (
@@ -165,8 +167,11 @@ export function RecentActivityCard() {
 
       <ActivityDetailSheet
         event={selectedEvent}
-        open={selectedEvent !== null}
-        onOpenChange={(open) => { if (!open) setSelectedEvent(null); }}
+        open={isSheetOpen}
+        onOpenChange={(open) => {
+          setIsSheetOpen(open);
+          if (!open) setTimeout(() => setSelectedEvent(null), 300);
+        }}
       />
     </>
   );

--- a/frontend/src/pages/dashboard/__tests__/RecentActivityCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/RecentActivityCard.test.tsx
@@ -188,7 +188,28 @@ describe("RecentActivityCard", () => {
     });
   });
 
-  // TODO: Restore "View All Activity" link tests once /activity route exists (issue #203)
+  it("shows View All Activity link when has_more is true", async () => {
+    mockAuditFetch();
+
+    render(<RecentActivityCard />, { wrapper });
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: "View All Activity" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/activity");
+    });
+  });
+
+  it("hides View All Activity link when has_more is false", async () => {
+    mockAuditFetch({ ...mockAuditEventsResponse, has_more: false });
+
+    render(<RecentActivityCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("My Bot")).toHaveLength(2);
+    });
+    expect(screen.queryByRole("link", { name: "View All Activity" })).not.toBeInTheDocument();
+  });
 
   it("falls back to Agent <id> when metadata has no name", async () => {
     mockAuditFetch({

--- a/spec/openapi/components/paths/approvals.yaml
+++ b/spec/openapi/components/paths/approvals.yaml
@@ -679,6 +679,57 @@ listApprovals:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+getApproval:
+  get:
+    operationId: getApproval
+    summary: Get Approval Details
+    description: |
+      Returns the full details of a single approval by ID. Includes action
+      parameters, context, execution status, and execution result. Used by the
+      activity feed detail panel to show what an agent tried to do and what
+      happened.
+
+      Only returns approvals owned by the authenticated user (as approver).
+
+    tags:
+      - Approvals
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/ApprovalId'
+
+    responses:
+      '200':
+        description: Approval details retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/approvals.yaml#/ApprovalSummary'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Approval not found or not owned by user
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            example:
+              error:
+                code: "approval_not_found"
+                message: "Approval not found"
+                retryable: false
+                trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
 approveApproval:
   post:
     operationId: approveApproval

--- a/spec/openapi/components/paths/approvals.yaml
+++ b/spec/openapi/components/paths/approvals.yaml
@@ -707,6 +707,46 @@ getApproval:
           application/json:
             schema:
               $ref: '../schemas/approvals.yaml#/ApprovalSummary'
+            examples:
+              approved_with_result:
+                summary: Approved approval with execution result
+                value:
+                  approval_id: "appr_abc456"
+                  agent_id: 42
+                  action:
+                    type: "email.send"
+                    version: "1"
+                    parameters:
+                      to: "recipient@example.com"
+                      subject: "Hello World"
+                  context:
+                    description: "Send welcome email to new user"
+                    risk_level: "low"
+                  status: "approved"
+                  execution_status: "success"
+                  execution_result:
+                    message_id: "msg_abc123"
+                  executed_at: "2026-02-11T13:21:01Z"
+                  expires_at: "2026-02-11T13:25:00Z"
+                  approved_at: "2026-02-11T13:21:00Z"
+                  created_at: "2026-02-11T13:20:00Z"
+              denied:
+                summary: Denied approval
+                value:
+                  approval_id: "appr_xyz789"
+                  agent_id: 42
+                  action:
+                    type: "file.delete"
+                    version: "1"
+                    parameters:
+                      path: "/important/data.csv"
+                  context:
+                    description: "Delete temporary file"
+                    risk_level: "high"
+                  status: "denied"
+                  expires_at: "2026-02-11T13:25:00Z"
+                  denied_at: "2026-02-11T13:22:00Z"
+                  created_at: "2026-02-11T13:20:00Z"
 
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'

--- a/spec/openapi/components/schemas/audit_events.yaml
+++ b/spec/openapi/components/schemas/audit_events.yaml
@@ -64,6 +64,19 @@ AuditEvent:
         - charged
       description: The outcome of the event.
       example: "approved"
+    source_id:
+      type: string
+      description: |
+        Identifier linking this event to its source record (e.g. approval_id,
+        standing approval execution id, agent id). Used by the frontend to
+        fetch full details for click-through views.
+      example: "appr_abc123"
+    source_type:
+      type: string
+      description: |
+        The type of source record this event originated from. Possible values:
+        "approval", "standing_approval", "agent", "payment_method_transaction".
+      example: "approval"
     connector_id:
       type: string
       nullable: true

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -2532,6 +2532,48 @@ paths:
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /v1/approvals/{approval_id}:
+    get:
+      operationId: getApproval
+      summary: Get Approval Details
+      description: |
+        Returns the full details of a single approval by ID. Includes action
+        parameters, context, execution status, and execution result. Used by the
+        activity feed detail panel to show what an agent tried to do and what
+        happened.
+
+        Only returns approvals owned by the authenticated user (as approver).
+      tags:
+        - Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/ApprovalId'
+      responses:
+        '200':
+          description: Approval details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Approval not found or not owned by user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: approval_not_found
+                  message: Approval not found
+                  retryable: false
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/approvals/{approval_id}/approve:
     post:
       operationId: approveApproval
@@ -8107,6 +8149,19 @@ components:
             - charged
           description: The outcome of the event.
           example: approved
+        source_id:
+          type: string
+          description: |
+            Identifier linking this event to its source record (e.g. approval_id,
+            standing approval execution id, agent id). Used by the frontend to
+            fetch full details for click-through views.
+          example: appr_abc123
+        source_type:
+          type: string
+          description: |
+            The type of source record this event originated from. Possible values:
+            "approval", "standing_approval", "agent", "payment_method_transaction".
+          example: approval
         connector_id:
           type: string
           nullable: true

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -173,6 +173,9 @@ paths:
   /v1/approvals/events:
     $ref: './components/paths/approvals.yaml#/approvalEvents'
 
+  /v1/approvals/{approval_id}:
+    $ref: './components/paths/approvals.yaml#/getApproval'
+
   /v1/approvals/{approval_id}/approve:
     $ref: './components/paths/approvals.yaml#/approveApproval'
 


### PR DESCRIPTION
## Summary

- **Filter lifecycle noise by default**: Activity feed now excludes `agent.registered` and `agent.deactivated` events, showing only what agents tried to do (approvals, executions, payments)
- **Click-through detail panel**: Clicking any activity row opens a side panel showing full action parameters, agent context, risk level, execution status/results, and connector info
- **Backend support**: Added `source_id`/`source_type` to activity feed API response and a new `GET /v1/approvals/{approval_id}` endpoint for fetching full approval details

## Test plan

### Claude Code
- [ ] Verify backend compiles and tests pass (`make test-backend`)
- [x] Verify frontend tests pass (`make test-frontend`) — all 691 tests passing
- [x] Verify TypeScript compilation (`tsc --noEmit`) — clean
- [x] Add tests for `ActivityDetailSheet` component (10 tests)
- [x] Add tests for `useApprovalDetail` hook (4 tests)

### OpenClaw
- [ ] Manual: Verify dashboard no longer shows "Agent registered" / "Agent deactivated" rows
- [ ] Manual: Click an activity row and verify the detail panel opens with correct data
- [ ] Manual: Verify approval events show full parameters fetched from the approval record
- [ ] Manual: Verify standing approval events show inline parameters from the audit event
- [ ] Manual: Verify the activity page event type dropdown still allows filtering for lifecycle events
- [ ] Manual: Verify the new "Pending" filter tab works on the dashboard card

https://claude.ai/code/session_01PGMuT8ptwB6C9fDv7xU1eg