### PR TITLE
Move connector actions into a dialog

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorActionsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorActionsDialog.tsx
@@ -1,0 +1,70 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+} from "@/components/ui/table";
+import type { ConnectorAction } from "@/hooks/useConnectorDetail";
+import { ActionRow } from "./ConnectorActionsSection";
+
+interface ConnectorActionsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  actions: ConnectorAction[];
+}
+
+export function ConnectorActionsDialog({
+  open,
+  onOpenChange,
+  actions,
+}: ConnectorActionsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Available Actions</DialogTitle>
+          <DialogDescription>
+            All actions this connector supports. Configure how your agent uses
+            them by adding action configurations.
+          </DialogDescription>
+        </DialogHeader>
+        {actions.length === 0 ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            No actions defined for this connector.
+          </p>
+        ) : (
+          <div className="overflow-hidden rounded-lg">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-none bg-primary hover:bg-primary">
+                  <TableHead className="font-semibold text-primary-foreground">
+                    Action
+                  </TableHead>
+                  <TableHead className="font-semibold text-primary-foreground">
+                    Risk
+                  </TableHead>
+                  <TableHead className="font-semibold text-primary-foreground">
+                    Parameters
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody className="[&>tr:nth-child(even)]:bg-muted">
+                {actions.map((action) => (
+                  <ActionRow key={action.action_type} action={action} />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/agents/connectors/ConnectorActionsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorActionsSection.tsx
@@ -62,7 +62,7 @@ export function ConnectorActionsSection({
   );
 }
 
-function ActionRow({ action }: { action: ConnectorAction }) {
+export function ActionRow({ action }: { action: ConnectorAction }) {
   const params = action.parameters_schema;
   const requiredFields =
     params && "required" in params && Array.isArray(params.required)
@@ -109,7 +109,7 @@ function ActionRow({ action }: { action: ConnectorAction }) {
   );
 }
 
-function RiskBadge({ level }: { level?: "low" | "medium" | "high" }) {
+export function RiskBadge({ level }: { level?: "low" | "medium" | "high" }) {
   switch (level) {
     case "low":
       return (

--- a/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
@@ -1,12 +1,13 @@
+import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, ExternalLink, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useActionConfigs } from "@/hooks/useActionConfigs";
 import { useConnectorDetail } from "@/hooks/useConnectorDetail";
 import { useAgentConnectors } from "@/hooks/useAgentConnectors";
 import { useCredentials } from "@/hooks/useCredentials";
 import { ConnectorOverviewSection } from "./ConnectorOverviewSection";
-import { ConnectorActionsSection } from "./ConnectorActionsSection";
+import { ConnectorActionsDialog } from "./ConnectorActionsDialog";
 import { ActionConfigurationsSection } from "./ActionConfigurationsSection";
 import { ConnectorCredentialsSection } from "./ConnectorCredentialsSection";
 import { DisableConnectorSection } from "./DisableConnectorSection";
@@ -46,6 +47,8 @@ export function ConnectorConfigPage() {
   const hasConfigCredentials = connectorConfigs.some((c) => !!c.credential_id);
   const shouldFetchCredentials = hasRequiredCredentials || hasConfigCredentials;
   const { credentials } = useCredentials({ enabled: shouldFetchCredentials });
+
+  const [actionsDialogOpen, setActionsDialogOpen] = useState(false);
 
   const backTo = `/agents/${rawAgentId}`;
 
@@ -103,7 +106,19 @@ export function ConnectorConfigPage() {
         connector={connector}
         enabledAt={agentConnector?.enabled_at}
       />
-      <ConnectorActionsSection actions={connector.actions} />
+      <button
+        type="button"
+        onClick={() => setActionsDialogOpen(true)}
+        className="text-muted-foreground hover:text-foreground -mt-4 inline-flex items-center gap-1 text-sm transition-colors"
+      >
+        <ExternalLink className="size-3.5" />
+        View all {connector.actions.length} available actions
+      </button>
+      <ConnectorActionsDialog
+        open={actionsDialogOpen}
+        onOpenChange={setActionsDialogOpen}
+        actions={connector.actions}
+      />
       <ActionConfigurationsSection
         agentId={agentId}
         connectorId={connectorId}

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
@@ -141,11 +141,10 @@ describe("ConnectorConfigPage", () => {
       screen.getByText("GitHub integration for repository management"),
     ).toBeInTheDocument();
 
-    // Actions section
-    expect(screen.getByText("Create Issue")).toBeInTheDocument();
-    expect(screen.getByText("Merge Pull Request")).toBeInTheDocument();
-    expect(screen.getByText("Low")).toBeInTheDocument();
-    expect(screen.getByText("High")).toBeInTheDocument();
+    // Actions are behind a dialog — verify the trigger link is visible
+    expect(
+      screen.getByText("View all 2 available actions"),
+    ).toBeInTheDocument();
 
     // Credentials section (loads asynchronously via useCredentials)
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Moved the connector actions table from an inline section on the connector detail page into a dialog/modal
- Added a subtle "View all N available actions" link with an external-link icon below the connector overview
- Action configurations section is now elevated to be immediately below the overview, making it the primary focus area where users take action

## Test plan
### Claude Code
- [x] Frontend tests pass (`make test-frontend` — 677 passing)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### OpenClaw
- [ ] Visually verify the connector detail page layout looks good
- [ ] Verify the "View all N available actions" link opens the dialog correctly
- [ ] Confirm action configurations are now prominently positioned below overview

https://claude.ai/code/session_01J2geGvFWsrWdDmBEhEt8Jz