### PR TITLE
Replace integrations page with agent-centric connector grid

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -695,21 +695,19 @@ The X connector requires these scopes:
 
 ### 3. Configure in Permission Slip
 
-1. In Permission Slip, go to an agent's configuration page and click the relevant connector
-2. Click **Configure** next to the X provider
-3. Enter your **Client ID** and **Client Secret** from the X Developer Portal
-4. Connect your X account via the connector's credential configuration page
+1. In Permission Slip, go to an agent's configuration page and click the X connector card
+2. On the connector's configuration page, enter your **Client ID** and **Client Secret** from the X Developer Portal
+3. Connect your X account via the credential configuration section
 
 ## Self-Hosted BYOA Setup
 
 For self-hosted deployments without platform-level OAuth credentials, users configure their own OAuth apps through the connector configuration UI:
 
 1. Follow the Google or Microsoft setup steps above to create an OAuth app
-2. In Permission Slip, navigate to an agent's configuration page and click the relevant connector
-3. Click **Configure** next to the provider
-4. Enter your Client ID and Client Secret
-5. The credentials are encrypted and stored in the vault
-6. You can now connect your account via the connector's credential configuration page
+2. In Permission Slip, navigate to an agent's configuration page and click the relevant connector card
+3. On the connector's configuration page, enter your Client ID and Client Secret
+4. The credentials are encrypted and stored in the vault
+5. You can now connect your account via the credential configuration section
 
 ## External Connector OAuth
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -695,21 +695,21 @@ The X connector requires these scopes:
 
 ### 3. Configure in Permission Slip
 
-1. In Permission Slip, go to **Settings > OAuth App Credentials**
+1. In Permission Slip, go to an agent's configuration page and click the relevant connector
 2. Click **Configure** next to the X provider
 3. Enter your **Client ID** and **Client Secret** from the X Developer Portal
-4. Connect your X account via **Settings > Connected Accounts**
+4. Connect your X account via the connector's credential configuration page
 
 ## Self-Hosted BYOA Setup
 
-For self-hosted deployments without platform-level OAuth credentials, users configure their own OAuth apps through the Settings UI:
+For self-hosted deployments without platform-level OAuth credentials, users configure their own OAuth apps through the connector configuration UI:
 
 1. Follow the Google or Microsoft setup steps above to create an OAuth app
-2. In Permission Slip, go to **Settings > OAuth App Credentials**
+2. In Permission Slip, navigate to an agent's configuration page and click the relevant connector
 3. Click **Configure** next to the provider
 4. Enter your Client ID and Client Secret
 5. The credentials are encrypted and stored in the vault
-6. You can now connect your account via **Settings > Connected Accounts**
+6. You can now connect your account via the connector's credential configuration page
 
 ## External Connector OAuth
 
@@ -747,11 +747,11 @@ For more details on creating external connectors, see [Creating Connectors](crea
 
 The OAuth provider doesn't have client credentials. Either:
 - Set the platform-level environment variables (`GOOGLE_CLIENT_ID`, etc.)
-- Configure BYOA credentials in Settings > OAuth App Credentials
+- Configure BYOA credentials via the connector configuration page on an agent
 
 ### "Needs Re-auth" status
 
-The refresh token has expired or been revoked. Click **Re-authorize** in Settings > Connected Accounts to re-establish the connection.
+The refresh token has expired or been revoked. Click **Re-authorize** on the connector's credential configuration page to re-establish the connection.
 
 ### Redirect URI mismatch
 

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -3,7 +3,6 @@ import {
   LogOut,
   User,
   Shield,
-  Plug,
   CreditCard,
   Moon,
   LifeBuoy,
@@ -65,10 +64,6 @@ export function UserMenu() {
             <DropdownMenuItem onSelect={() => navigate("/settings/security")}>
               <Shield />
               <span>Security</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => navigate("/settings/integrations")}>
-              <Plug />
-              <span>Integrations</span>
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => navigate("/settings/billing")}>
               <CreditCard />

--- a/frontend/src/components/__tests__/UserMenu.test.tsx
+++ b/frontend/src/components/__tests__/UserMenu.test.tsx
@@ -75,7 +75,6 @@ describe("UserMenu", () => {
     await userEvent.click(screen.getByLabelText("User menu"));
     expect(screen.getByText("Profile")).toBeInTheDocument();
     expect(screen.getByText("Security")).toBeInTheDocument();
-    expect(screen.getByText("Integrations")).toBeInTheDocument();
     expect(screen.getByText("Billing")).toBeInTheDocument();
     expect(screen.getByText("Dark Mode")).toBeInTheDocument();
     expect(screen.getByText("Sign Out")).toBeInTheDocument();

--- a/frontend/src/pages/agents/AgentConfigPage.tsx
+++ b/frontend/src/pages/agents/AgentConfigPage.tsx
@@ -5,7 +5,7 @@ import { useAgent } from "@/hooks/useAgent";
 import { useAgentConnectors } from "@/hooks/useAgentConnectors";
 import { AgentInfoSection } from "./AgentInfoSection";
 import { AgentConnectorsSection } from "./AgentConnectorsSection";
-import { AgentCredentialsSection } from "./AgentCredentialsSection";
+
 import { DeactivateSection } from "./DeactivateSection";
 
 export function AgentConfigPage() {
@@ -60,12 +60,6 @@ export function AgentConfigPage() {
       <BackLink />
       <AgentInfoSection agent={agent} />
       <AgentConnectorsSection
-        agentId={agentId}
-        connectors={connectors}
-        isLoading={connectorsLoading}
-        error={connectorsError}
-      />
-      <AgentCredentialsSection
         agentId={agentId}
         connectors={connectors}
         isLoading={connectorsLoading}

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -1,34 +1,21 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Loader2, Plus, Plug } from "lucide-react";
+import { Loader2, Plug, Search } from "lucide-react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardHeader,
   CardTitle,
+  CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Table,
-  TableHeader,
-  TableBody,
-  TableHead,
-  TableRow,
-  TableCell,
-} from "@/components/ui/table";
-import { useDisableAgentConnector } from "@/hooks/useDisableAgentConnector";
-import type { AgentConnector } from "@/hooks/useAgentConnectors";
-import { AddConnectorDialog } from "./AddConnectorDialog";
 import { ConnectorLogo } from "@/components/ConnectorLogo";
+import { useConnectors } from "@/hooks/useConnectors";
+import type { ConnectorSummary } from "@/hooks/useConnectors";
+import { useEnableAgentConnector } from "@/hooks/useEnableAgentConnector";
+import type { AgentConnector } from "@/hooks/useAgentConnectors";
 
 interface AgentConnectorsSectionProps {
   agentId: number;
@@ -39,228 +26,167 @@ interface AgentConnectorsSectionProps {
 
 export function AgentConnectorsSection({
   agentId,
-  connectors,
-  isLoading,
-  error,
+  connectors: enabledConnectors,
+  isLoading: enabledLoading,
+  error: enabledError,
 }: AgentConnectorsSectionProps) {
-  const [addDialogOpen, setAddDialogOpen] = useState(false);
-
-  return (
-    <>
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Enabled Connectors</CardTitle>
-          <Button
-            size="sm"
-            onClick={() => setAddDialogOpen(true)}
-            disabled={isLoading || !!error}
-          >
-            <Plus className="size-4" />
-            Add Connector
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div
-              className="flex items-center justify-center py-8"
-              role="status"
-              aria-label="Loading connectors"
-            >
-              <Loader2
-                className="text-muted-foreground size-6 animate-spin"
-                aria-hidden="true"
-              />
-            </div>
-          ) : error ? (
-            <p className="text-destructive text-sm">{error}</p>
-          ) : connectors.length === 0 ? (
-            <EmptyConnectors onAdd={() => setAddDialogOpen(true)} />
-          ) : (
-            <ConnectorsTable connectors={connectors} agentId={agentId} />
-          )}
-        </CardContent>
-      </Card>
-
-      <AddConnectorDialog
-        open={addDialogOpen}
-        onOpenChange={setAddDialogOpen}
-        agentId={agentId}
-        enabledConnectors={connectors}
-      />
-    </>
-  );
-}
-
-function EmptyConnectors({ onAdd }: { onAdd: () => void }) {
-  return (
-    <div className="flex flex-col items-center justify-center py-8 text-center">
-      <Plug className="text-muted-foreground mb-3 size-10" />
-      <p className="text-muted-foreground mb-1 text-sm font-medium">
-        No connectors enabled
-      </p>
-      <p className="text-muted-foreground mb-4 max-w-xs text-xs">
-        Enable connectors for this agent to allow it to submit actions from
-        external services.
-      </p>
-      <Button variant="outline" size="sm" onClick={onAdd}>
-        <Plus className="size-4" />
-        Add Connector
-      </Button>
-    </div>
-  );
-}
-
-function ConnectorsTable({
-  connectors,
-  agentId,
-}: {
-  connectors: AgentConnector[];
-  agentId: number;
-}) {
-  return (
-    <div className="overflow-hidden rounded-lg">
-      <Table>
-        <TableHeader>
-          <TableRow className="border-none bg-primary hover:bg-primary">
-            <TableHead className="font-semibold text-primary-foreground">
-              Connector
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
-              Actions
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
-              Enabled
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
-              <span className="sr-only">Actions</span>
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="[&>tr:nth-child(even)]:bg-muted">
-          {connectors.map((connector) => (
-            <ConnectorRow
-              key={connector.id}
-              connector={connector}
-              agentId={agentId}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </div>
-  );
-}
-
-function ConnectorRow({
-  connector,
-  agentId,
-}: {
-  connector: AgentConnector;
-  agentId: number;
-}) {
+  const {
+    connectors: allConnectors,
+    isLoading: allLoading,
+    error: allError,
+  } = useConnectors();
+  const { enableConnector } = useEnableAgentConnector();
   const navigate = useNavigate();
-  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
-  const { disableConnector, isLoading: disabling } = useDisableAgentConnector();
+  const [search, setSearch] = useState("");
+  const [enablingId, setEnablingId] = useState<string | null>(null);
 
-  async function handleRemove() {
+  const isLoading = enabledLoading || allLoading;
+  const error = enabledError ?? allError;
+
+  const enabledIds = new Set(enabledConnectors.map((c) => c.id));
+
+  const filtered = search.trim()
+    ? allConnectors.filter(
+        (c) =>
+          c.name.toLowerCase().includes(search.toLowerCase()) ||
+          c.description?.toLowerCase().includes(search.toLowerCase()),
+      )
+    : allConnectors;
+
+  async function handleClick(connector: ConnectorSummary) {
+    if (enabledIds.has(connector.id)) {
+      navigate(`/agents/${agentId}/connectors/${connector.id}`);
+      return;
+    }
+
+    setEnablingId(connector.id);
     try {
-      const result = await disableConnector({
-        agentId,
-        connectorId: connector.id,
-      });
-      const revoked = result.revoked_standing_approvals;
-      if (revoked > 0) {
-        toast.success(
-          `${connector.name} disabled. ${revoked} standing approval${revoked === 1 ? "" : "s"} revoked.`,
-        );
-      } else {
-        toast.success(`${connector.name} disabled`);
-      }
-      setRemoveDialogOpen(false);
+      await enableConnector({ agentId, connectorId: connector.id });
+      toast.success(`${connector.name} enabled`);
+      navigate(`/agents/${agentId}/connectors/${connector.id}`);
     } catch {
-      toast.error(`Failed to disable ${connector.name}`);
+      toast.error(`Failed to enable ${connector.name}`);
+    } finally {
+      setEnablingId(null);
     }
   }
 
   return (
-    <>
-      <TableRow>
-        <TableCell>
-          <div className="flex items-center gap-2.5">
-            <ConnectorLogo
-              name={connector.name}
-              logoSvg={connector.logo_svg}
-              size="sm"
+    <Card>
+      <CardHeader>
+        <CardTitle>Connectors</CardTitle>
+        <CardDescription>
+          Services this agent can interact with. Click a connector to configure
+          credentials and actions.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div
+            className="flex items-center justify-center py-8"
+            role="status"
+            aria-label="Loading connectors"
+          >
+            <Loader2
+              className="text-muted-foreground size-6 animate-spin"
+              aria-hidden="true"
             />
-            <div>
-              <p className="font-medium">{connector.name}</p>
-              {connector.description && (
-                <p className="text-muted-foreground text-xs">
-                  {connector.description}
-                </p>
-              )}
-            </div>
           </div>
-        </TableCell>
-        <TableCell className="text-muted-foreground text-sm">
-          {connector.actions.join(", ")}
-        </TableCell>
-        <TableCell className="text-muted-foreground text-sm">
-          {connector.enabled_at
-            ? new Date(connector.enabled_at).toLocaleDateString()
-            : "—"}
-        </TableCell>
-        <TableCell className="text-right">
-          <div className="flex items-center justify-end gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() =>
-                navigate(`/agents/${agentId}/connectors/${connector.id}`)
-              }
-            >
-              Configure
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-destructive hover:text-destructive"
-              onClick={() => setRemoveDialogOpen(true)}
-            >
-              Remove
-            </Button>
+        ) : error ? (
+          <p className="text-destructive text-sm">{error}</p>
+        ) : allConnectors.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Plug className="text-muted-foreground mb-3 size-10" />
+            <p className="text-muted-foreground text-sm">
+              No connectors are available yet.
+            </p>
           </div>
-        </TableCell>
-      </TableRow>
+        ) : (
+          <div className="space-y-3">
+            {allConnectors.length >= 4 && (
+              <div className="relative">
+                <Search className="text-muted-foreground absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+                <Input
+                  placeholder="Search connectors..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-9"
+                />
+              </div>
+            )}
 
-      <Dialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Remove {connector.name}</DialogTitle>
-            <DialogDescription>
-              This will disable the <strong>{connector.name}</strong> connector
-              for this agent. Any active standing approvals for actions from
-              this connector will be automatically revoked.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
+            {filtered.length === 0 ? (
+              <p className="text-muted-foreground py-6 text-center text-sm">
+                No connectors match &ldquo;{search}&rdquo;
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {filtered.map((connector) => (
+                  <ConnectorCard
+                    key={connector.id}
+                    connector={connector}
+                    isEnabled={enabledIds.has(connector.id)}
+                    isEnabling={enablingId === connector.id}
+                    disabled={enablingId !== null}
+                    onClick={handleClick}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ConnectorCard({
+  connector,
+  isEnabled,
+  isEnabling,
+  disabled,
+  onClick,
+}: {
+  connector: ConnectorSummary;
+  isEnabled: boolean;
+  isEnabling: boolean;
+  disabled: boolean;
+  onClick: (connector: ConnectorSummary) => void;
+}) {
+  const actionCount = connector.actions.length;
+
+  return (
+    <button
+      type="button"
+      className="border-border bg-card hover:bg-accent flex flex-col items-center gap-2 rounded-lg border p-3 text-center transition-colors disabled:opacity-50"
+      onClick={() => onClick(connector)}
+      disabled={disabled && !isEnabling}
+    >
+      {isEnabling ? (
+        <Loader2 className="text-muted-foreground size-10 animate-spin" />
+      ) : (
+        <ConnectorLogo
+          name={connector.name}
+          logoSvg={connector.logo_svg}
+          size="lg"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-center gap-1.5">
+          <p className="text-sm font-medium leading-tight">{connector.name}</p>
+          {isEnabled && (
+            <Badge
               variant="secondary"
-              onClick={() => setRemoveDialogOpen(false)}
-              disabled={disabling}
+              className="px-1.5 py-0 text-[10px] leading-4"
             >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleRemove}
-              disabled={disabling}
-            >
-              {disabling && <Loader2 className="animate-spin" />}
-              Remove
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+              Enabled
+            </Badge>
+          )}
+        </div>
+        <p className="text-muted-foreground mt-0.5 text-xs leading-tight">
+          {actionCount} action{actionCount !== 1 ? "s" : ""}
+        </p>
+      </div>
+    </button>
   );
 }

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -24,6 +24,11 @@ interface AgentConnectorsSectionProps {
   error: string | null;
 }
 
+/**
+ * Searchable grid of all available connectors for an agent.
+ * Enabled connectors show an "Enabled" badge and navigate directly to config.
+ * Non-enabled connectors are auto-enabled on click before navigating.
+ */
 export function AgentConnectorsSection({
   agentId,
   connectors: enabledConnectors,

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -41,7 +41,7 @@ export function AgentConnectorsSection({
   const [enablingId, setEnablingId] = useState<string | null>(null);
 
   const isLoading = enabledLoading || allLoading;
-  const error = enabledError ?? allError;
+  const error = allError ?? enabledError;
 
   const enabledIds = new Set(enabledConnectors.map((c) => c.id));
 
@@ -160,7 +160,7 @@ function ConnectorCard({
       type="button"
       className="border-border bg-card hover:bg-accent flex flex-col items-center gap-2 rounded-lg border p-3 text-center transition-colors disabled:opacity-50"
       onClick={() => onClick(connector)}
-      disabled={disabled && !isEnabling}
+      disabled={disabled}
     >
       {isEnabling ? (
         <Loader2 className="text-muted-foreground size-10 animate-spin" />
@@ -183,6 +183,11 @@ function ConnectorCard({
             </Badge>
           )}
         </div>
+        {connector.description && (
+          <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-tight">
+            {connector.description}
+          </p>
+        )}
         <p className="text-muted-foreground mt-0.5 text-xs leading-tight">
           {actionCount} action{actionCount !== 1 ? "s" : ""}
         </p>

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -70,7 +70,8 @@ export function AgentConnectorsSection({
       await enableConnector({ agentId, connectorId: connector.id });
       toast.success(`${connector.name} enabled`);
       navigate(`/agents/${agentId}/connectors/${connector.id}`);
-    } catch {
+    } catch (err) {
+      console.error(`Failed to enable connector ${connector.id}:`, err);
       toast.error(`Failed to enable ${connector.name}`);
     } finally {
       setEnablingId(null);

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -50,11 +50,12 @@ export function AgentConnectorsSection({
 
   const enabledIds = new Set(enabledConnectors.map((c) => c.id));
 
-  const filtered = search.trim()
+  const query = search.trim().toLowerCase();
+  const filtered = query
     ? allConnectors.filter(
         (c) =>
-          c.name.toLowerCase().includes(search.toLowerCase()) ||
-          c.description?.toLowerCase().includes(search.toLowerCase()),
+          c.name.toLowerCase().includes(query) ||
+          c.description?.toLowerCase().includes(query),
       )
     : allConnectors;
 

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -124,7 +124,7 @@ export function AgentConnectorsSection({
 
             {filtered.length === 0 ? (
               <p className="text-muted-foreground py-6 text-center text-sm">
-                No connectors match &ldquo;{search}&rdquo;
+                No connectors match &ldquo;{search.trim()}&rdquo;
               </p>
             ) : (
               <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">

--- a/frontend/src/pages/agents/__tests__/AgentConnectorsSection.test.tsx
+++ b/frontend/src/pages/agents/__tests__/AgentConnectorsSection.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProviders } from "../../../test-helpers";
 import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
 import {
   mockGet,
+  mockPut,
   resetClientMocks,
 } from "../../../api/__mocks__/client";
 import { AgentConnectorsSection } from "../AgentConnectorsSection";
@@ -171,5 +172,63 @@ describe("AgentConnectorsSection", () => {
     expect(screen.getByText("GitHub")).toBeInTheDocument();
     expect(screen.queryByText("Gmail")).not.toBeInTheDocument();
     expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+  });
+
+  it("shows no-match message when search has no results", async () => {
+    const user = userEvent.setup();
+    mockAllConnectors([
+      { id: "gmail", name: "Gmail", description: "Email", actions: ["a"], required_credentials: [] },
+      { id: "github", name: "GitHub", description: "Code", actions: ["b"], required_credentials: [] },
+      { id: "slack", name: "Slack", description: "Chat", actions: ["c"], required_credentials: [] },
+      { id: "stripe", name: "Stripe", description: "Payments", actions: ["d"], required_credentials: [] },
+    ]);
+    renderWithProviders(
+      <AgentConnectorsSection
+        agentId={42}
+        connectors={[]}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText("Search connectors...");
+    await user.type(searchInput, "zzz-no-match");
+
+    expect(screen.getByText(/No connectors match/)).toBeInTheDocument();
+  });
+
+  it("enables and navigates when clicking a non-enabled connector", async () => {
+    const user = userEvent.setup();
+    mockAllConnectors();
+    mockPut.mockResolvedValue({ data: {}, error: undefined });
+
+    renderWithProviders(
+      <AgentConnectorsSection
+        agentId={42}
+        connectors={mockEnabledConnectors}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    // GitHub is not enabled — clicking it should call PUT to enable
+    await user.click(screen.getByText("GitHub").closest("button")!);
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalledWith(
+        "/v1/agents/{agent_id}/connectors/{connector_id}",
+        expect.objectContaining({
+          params: { path: { agent_id: 42, connector_id: "github" } },
+        }),
+      );
+    });
   });
 });

--- a/frontend/src/pages/agents/__tests__/AgentConnectorsSection.test.tsx
+++ b/frontend/src/pages/agents/__tests__/AgentConnectorsSection.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderWithProviders } from "../../../test-helpers";
@@ -12,7 +12,7 @@ import { AgentConnectorsSection } from "../AgentConnectorsSection";
 vi.mock("../../../lib/supabaseClient");
 vi.mock("../../../api/client");
 
-const mockConnectors = [
+const mockEnabledConnectors = [
   {
     id: "gmail",
     name: "Gmail",
@@ -21,15 +21,38 @@ const mockConnectors = [
     required_credentials: ["gmail"],
     enabled_at: "2026-02-18T10:00:00Z",
   },
+];
+
+function mockAllConnectors(connectors = [
+  {
+    id: "gmail",
+    name: "Gmail",
+    description: "Send and manage emails via Gmail API",
+    actions: ["email.send", "email.read"],
+    required_credentials: ["gmail"],
+  },
   {
     id: "github",
     name: "GitHub",
     description: "GitHub integration",
     actions: ["github.create_issue"],
     required_credentials: ["github"],
-    enabled_at: "2026-02-19T10:00:00Z",
   },
-];
+  {
+    id: "slack",
+    name: "Slack",
+    description: "Slack messaging",
+    actions: ["slack.send_message"],
+    required_credentials: ["slack"],
+  },
+]) {
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/connectors") {
+      return Promise.resolve({ data: { data: connectors } });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
 
 describe("AgentConnectorsSection", () => {
   beforeEach(() => {
@@ -39,6 +62,7 @@ describe("AgentConnectorsSection", () => {
   });
 
   it("shows loading state", () => {
+    mockAllConnectors();
     renderWithProviders(
       <AgentConnectorsSection
         agentId={42}
@@ -50,7 +74,8 @@ describe("AgentConnectorsSection", () => {
     expect(screen.getByRole("status")).toBeInTheDocument();
   });
 
-  it("shows error state", () => {
+  it("shows error state", async () => {
+    mockAllConnectors();
     renderWithProviders(
       <AgentConnectorsSection
         agentId={42}
@@ -59,10 +84,49 @@ describe("AgentConnectorsSection", () => {
         error="Something went wrong"
       />,
     );
-    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
   });
 
-  it("shows empty state with Add Connector CTA", () => {
+  it("shows all available connectors as cards", async () => {
+    mockAllConnectors();
+    renderWithProviders(
+      <AgentConnectorsSection
+        agentId={42}
+        connectors={mockEnabledConnectors}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail")).toBeInTheDocument();
+    });
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+  });
+
+  it("shows Enabled badge on enabled connectors", async () => {
+    mockAllConnectors();
+    renderWithProviders(
+      <AgentConnectorsSection
+        agentId={42}
+        connectors={mockEnabledConnectors}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail")).toBeInTheDocument();
+    });
+    // Only Gmail is enabled
+    expect(screen.getAllByText("Enabled")).toHaveLength(1);
+  });
+
+  it("shows empty state when no connectors available", async () => {
+    mockAllConnectors([]);
     renderWithProviders(
       <AgentConnectorsSection
         agentId={42}
@@ -71,79 +135,41 @@ describe("AgentConnectorsSection", () => {
         error={null}
       />,
     );
-    expect(screen.getByText("No connectors enabled")).toBeInTheDocument();
-    // One in the header, one in the empty state
-    const addButtons = screen.getAllByText("Add Connector");
-    expect(addButtons.length).toBeGreaterThanOrEqual(2);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No connectors are available yet."),
+      ).toBeInTheDocument();
+    });
   });
 
-  it("renders connector rows with Configure and Remove buttons", () => {
+  it("filters connectors by search", async () => {
+    const user = userEvent.setup();
+    // Need 4+ connectors to show search
+    mockAllConnectors([
+      { id: "gmail", name: "Gmail", description: "Email", actions: ["a"], required_credentials: [] },
+      { id: "github", name: "GitHub", description: "Code", actions: ["b"], required_credentials: [] },
+      { id: "slack", name: "Slack", description: "Chat", actions: ["c"], required_credentials: [] },
+      { id: "stripe", name: "Stripe", description: "Payments", actions: ["d"], required_credentials: [] },
+    ]);
     renderWithProviders(
       <AgentConnectorsSection
         agentId={42}
-        connectors={mockConnectors}
+        connectors={[]}
         isLoading={false}
         error={null}
       />,
     );
-    expect(screen.getByText("Gmail")).toBeInTheDocument();
-    expect(screen.getByText("GitHub")).toBeInTheDocument();
-    expect(screen.getAllByText("Configure")).toHaveLength(2);
-    expect(screen.getAllByText("Remove")).toHaveLength(2);
-  });
 
-  it("opens Add Connector dialog", async () => {
-    const user = userEvent.setup();
-    mockGet.mockResolvedValue({
-      data: {
-        data: [
-          {
-            id: "slack",
-            name: "Slack",
-            description: "Slack messaging",
-            actions: ["slack.send_message"],
-            required_credentials: ["slack"],
-          },
-        ],
-      },
+    await waitFor(() => {
+      expect(screen.getByText("Gmail")).toBeInTheDocument();
     });
 
-    renderWithProviders(
-      <AgentConnectorsSection
-        agentId={42}
-        connectors={mockConnectors}
-        isLoading={false}
-        error={null}
-      />,
-    );
+    const searchInput = screen.getByPlaceholderText("Search connectors...");
+    await user.type(searchInput, "git");
 
-    const addButton = screen.getAllByText("Add Connector")[0];
-    if (addButton) {
-      await user.click(addButton);
-    }
-    expect(
-      screen.getByText(
-        "Enable a connector for this agent to allow it to submit actions from external services.",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("opens Remove confirmation dialog", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <AgentConnectorsSection
-        agentId={42}
-        connectors={mockConnectors}
-        isLoading={false}
-        error={null}
-      />,
-    );
-
-    const removeButtons = screen.getAllByText("Remove");
-    const firstRemove = removeButtons[0];
-    if (firstRemove) {
-      await user.click(firstRemove);
-    }
-    expect(screen.getByText("Remove Gmail")).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.queryByText("Gmail")).not.toBeInTheDocument();
+    expect(screen.queryByText("Slack")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/settings/SettingsLayout.tsx
+++ b/frontend/src/pages/settings/SettingsLayout.tsx
@@ -1,22 +1,47 @@
-import { Routes, Route, Navigate, useSearchParams } from "react-router-dom";
+import { useEffect } from "react";
+import { Routes, Route, Navigate, useSearchParams, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { providerLabel } from "@/lib/oauth";
 import { SettingsNav } from "./SettingsNav";
 import { ProfilePage } from "./ProfilePage";
 import { SecurityPage } from "./SecurityPage";
-import { IntegrationsPage } from "./IntegrationsPage";
 import { BillingSettingsPage } from "./BillingSettingsPage";
 import { AccountPage } from "./AccountPage";
 
 /**
- * If the user lands on /settings with an oauth_status query param (from an
- * OAuth callback), redirect them to the integrations sub-page so the
- * ConnectedAccountsSection can pick it up.
+ * Handles the OAuth callback redirect from the backend. The backend sends
+ * users to /settings?oauth_status=success&oauth_provider=github after OAuth
+ * completes. This component shows a toast and redirects to /settings/profile.
  */
 function SettingsIndex() {
   const [searchParams] = useSearchParams();
-  if (searchParams.get("oauth_status")) {
-    return <Navigate to={`/settings/integrations?${searchParams.toString()}`} replace />;
-  }
-  return <Navigate to="/settings/profile" replace />;
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const oauthStatus = searchParams.get("oauth_status");
+    const oauthProvider = searchParams.get("oauth_provider");
+    if (oauthStatus) {
+      if (oauthStatus === "success") {
+        toast.success(
+          `Successfully connected ${oauthProvider ? providerLabel(oauthProvider) : "account"}.`,
+        );
+      } else {
+        const oauthError = searchParams.get("oauth_error");
+        const label = oauthProvider
+          ? providerLabel(oauthProvider)
+          : "account";
+        const detail = oauthError
+          ? `Failed to connect ${label}: ${oauthError}`
+          : `Failed to connect ${label}. Please try again.`;
+        toast.error(detail);
+      }
+      navigate("/settings/profile", { replace: true });
+      return;
+    }
+    navigate("/settings/profile", { replace: true });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- run once on mount
+
+  return null;
 }
 
 export function SettingsLayout() {
@@ -31,7 +56,6 @@ export function SettingsLayout() {
             <Route index element={<SettingsIndex />} />
             <Route path="profile" element={<ProfilePage />} />
             <Route path="security" element={<SecurityPage />} />
-            <Route path="integrations" element={<IntegrationsPage />} />
             <Route path="billing" element={<BillingSettingsPage />} />
             <Route path="account" element={<AccountPage />} />
             <Route path="*" element={<Navigate to="/settings/profile" replace />} />

--- a/frontend/src/pages/settings/SettingsLayout.tsx
+++ b/frontend/src/pages/settings/SettingsLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Routes, Route, Navigate, useSearchParams, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { providerLabel } from "@/lib/oauth";
@@ -16,8 +16,12 @@ import { AccountPage } from "./AccountPage";
 function SettingsIndex() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const firedRef = useRef(false);
 
   useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+
     const oauthStatus = searchParams.get("oauth_status");
     const oauthProvider = searchParams.get("oauth_provider");
     if (oauthStatus) {
@@ -35,8 +39,6 @@ function SettingsIndex() {
           : `Failed to connect ${label}. Please try again.`;
         toast.error(detail);
       }
-      navigate("/settings/profile", { replace: true });
-      return;
     }
     navigate("/settings/profile", { replace: true });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- run once on mount

--- a/frontend/src/pages/settings/SettingsNav.tsx
+++ b/frontend/src/pages/settings/SettingsNav.tsx
@@ -2,7 +2,6 @@ import { Link, useLocation } from "react-router-dom";
 import {
   User,
   Shield,
-  Plug,
   CreditCard,
   Settings,
 } from "lucide-react";
@@ -18,7 +17,6 @@ interface SettingsNavItem {
 const settingsNavItems: SettingsNavItem[] = [
   { label: "Profile", path: "/settings/profile", icon: User },
   { label: "Security", path: "/settings/security", icon: Shield },
-  { label: "Integrations", path: "/settings/integrations", icon: Plug },
   { label: "Billing", path: "/settings/billing", icon: CreditCard },
   { label: "Account", path: "/settings/account", icon: Settings },
 ];

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { Route, Routes, MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setupAuthMocks, mockMfa } from "../../../auth/__tests__/fixtures";
 import { mockGet, resetClientMocks } from "../../../api/__mocks__/client";
@@ -10,6 +11,7 @@ import { SettingsLayout } from "../SettingsLayout";
 
 vi.mock("../../../lib/supabaseClient");
 vi.mock("../../../api/client");
+vi.mock("sonner");
 
 const mockProfile = {
   id: "user-123",
@@ -135,6 +137,30 @@ describe("SettingsLayout", () => {
     await waitFor(() => {
       // Should redirect to profile page since integrations was removed
       expect(screen.getAllByText("Account").length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("shows success toast on OAuth callback redirect", async () => {
+    mockApiFetch();
+    renderSettingsAt("/settings?oauth_status=success&oauth_provider=github");
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Successfully connected GitHub.",
+      );
+    });
+  });
+
+  it("shows error toast on failed OAuth callback", async () => {
+    mockApiFetch();
+    renderSettingsAt(
+      "/settings?oauth_status=error&oauth_provider=google&oauth_error=access_denied",
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to connect Google: access_denied",
+      );
     });
   });
 

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -102,7 +102,6 @@ describe("SettingsLayout", () => {
     // Each nav item renders twice (desktop sidebar + mobile tabs)
     expect(screen.getAllByRole("link", { name: /Profile/ }).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByRole("link", { name: /Security/ }).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByRole("link", { name: /Integrations/ }).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByRole("link", { name: /Billing/ }).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByRole("link", { name: /Account/ }).length).toBeGreaterThanOrEqual(1);
   });
@@ -129,14 +128,14 @@ describe("SettingsLayout", () => {
     });
   });
 
-  it("renders integrations sections on /settings/integrations", async () => {
+  it("redirects /settings/integrations to /settings/profile", async () => {
     mockApiFetch();
     renderSettingsAt("/settings/integrations");
 
     await waitFor(() => {
-      expect(screen.getByText("Connected Accounts")).toBeInTheDocument();
+      // Should redirect to profile page since integrations was removed
+      expect(screen.getAllByText("Account").length).toBeGreaterThanOrEqual(2);
     });
-    expect(screen.getByText("Credential Vault")).toBeInTheDocument();
   });
 
   it("renders danger zone on /settings/account", async () => {


### PR DESCRIPTION
## Summary

- **Rewrote `AgentConnectorsSection`** as a searchable grid of all available connectors, replacing the table of only-enabled connectors. Each card shows the connector logo, name, action count, and an "Enabled" badge. Clicking navigates to the connector config page (auto-enabling if needed).
- **Removed `AgentCredentialsSection`** from the agent page — credentials are managed per-connector on the detail page, not as a standalone section.
- **Removed the Settings > Integrations page** — it showed confusing credential abstractions ("Connected Accounts", "OAuth App Credentials", "Credential Vault") that errored when no integrations were configured. The nav item and route are gone.
- **Moved OAuth callback toast** to `SettingsIndex` so it still fires when the backend redirects after OAuth completion.

## Test plan

### Claude Code
- [x] All 679 frontend tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Vite build succeeds

### OpenClaw
- [ ] Verify agent config page shows searchable grid of connectors
- [ ] Verify clicking an enabled connector navigates to its config page
- [ ] Verify clicking a non-enabled connector enables it and navigates to config
- [ ] Verify search filters connectors by name/description
- [ ] Verify "Integrations" is no longer in settings nav or user menu
- [ ] Verify OAuth callback still shows success/error toast after redirect
- [ ] Verify `/settings/integrations` gracefully redirects to `/settings/profile`

https://claude.ai/code/session_01NVbpyshnxXnjraVvGmbs2c