### PR TITLE
Add OAuth credential setup modal after enabling connector

### DIFF
--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -5,7 +5,12 @@
 
 export { providerLabel } from "@/lib/labels";
 
-/** Providers that require a shop subdomain for per-shop OAuth URLs. */
+/**
+ * Providers that require a shop subdomain to construct per-shop OAuth URLs.
+ * When a provider is in this set, the UI prompts the user for their store
+ * subdomain (e.g. "mystore") which is appended as `&shop=mystore` to the
+ * authorize URL.
+ */
 export const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
 
 /**

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -5,6 +5,9 @@
 
 export { providerLabel } from "@/lib/labels";
 
+/** Providers that require a shop subdomain for per-shop OAuth URLs. */
+export const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
+
 /**
  * Builds the URL to initiate an OAuth authorization flow for a provider.
  * The backend redirects from this URL to the provider's consent screen.

--- a/frontend/src/pages/agents/AddConnectorDialog.tsx
+++ b/frontend/src/pages/agents/AddConnectorDialog.tsx
@@ -46,6 +46,7 @@ export function AddConnectorDialog({
   useEffect(() => {
     if (!open) {
       setSetupConnector(null);
+      setSearch("");
     }
   }, [open]);
 

--- a/frontend/src/pages/agents/AddConnectorDialog.tsx
+++ b/frontend/src/pages/agents/AddConnectorDialog.tsx
@@ -40,7 +40,9 @@ export function AddConnectorDialog({
   const [search, setSearch] = useState("");
   const [setupConnector, setSetupConnector] = useState<ConnectorSummary | null>(null);
 
-  // Reset setup state when parent closes the dialog externally
+  // Reset setup state when the parent closes the dialog externally (e.g. by
+  // navigating away). Without this, reopening the add-connector dialog would
+  // skip straight to the stale setup modal for the previously-enabled connector.
   useEffect(() => {
     if (!open) {
       setSetupConnector(null);

--- a/frontend/src/pages/agents/AddConnectorDialog.tsx
+++ b/frontend/src/pages/agents/AddConnectorDialog.tsx
@@ -130,7 +130,7 @@ export function AddConnectorDialog({
 
     {setupConnector && (
       <SetupConnectorCredentialsDialog
-        open={!!setupConnector}
+        open
         onOpenChange={(nextOpen) => {
           if (!nextOpen) {
             setSetupConnector(null);

--- a/frontend/src/pages/agents/AddConnectorDialog.tsx
+++ b/frontend/src/pages/agents/AddConnectorDialog.tsx
@@ -15,6 +15,7 @@ import { useConnectors } from "@/hooks/useConnectors";
 import { useEnableAgentConnector } from "@/hooks/useEnableAgentConnector";
 import type { AgentConnector } from "@/hooks/useAgentConnectors";
 import type { ConnectorSummary } from "@/hooks/useConnectors";
+import { SetupConnectorCredentialsDialog } from "./connectors/SetupConnectorCredentialsDialog";
 
 interface AddConnectorDialogProps {
   open: boolean;
@@ -37,6 +38,7 @@ export function AddConnectorDialog({
   const { enableConnector } = useEnableAgentConnector();
   const [enablingId, setEnablingId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [setupConnector, setSetupConnector] = useState<ConnectorSummary | null>(null);
 
   const enabledIds = new Set(enabledConnectors.map((c) => c.id));
   const available = allConnectors.filter((c) => !enabledIds.has(c.id));
@@ -54,7 +56,7 @@ export function AddConnectorDialog({
     try {
       await enableConnector({ agentId, connectorId: connector.id });
       toast.success(`${connector.name} enabled`);
-      onOpenChange(false);
+      setSetupConnector(connector);
     } catch {
       toast.error(`Failed to enable ${connector.name}`);
     } finally {
@@ -63,7 +65,8 @@ export function AddConnectorDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <>
+    <Dialog open={open && !setupConnector} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Add Connector</DialogTitle>
@@ -124,6 +127,22 @@ export function AddConnectorDialog({
         )}
       </DialogContent>
     </Dialog>
+
+    {setupConnector && (
+      <SetupConnectorCredentialsDialog
+        open={!!setupConnector}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            setSetupConnector(null);
+            onOpenChange(false);
+          }
+        }}
+        connectorId={setupConnector.id}
+        connectorName={setupConnector.name}
+        connectorLogoSvg={setupConnector.logo_svg}
+      />
+    )}
+    </>
   );
 }
 

--- a/frontend/src/pages/agents/AddConnectorDialog.tsx
+++ b/frontend/src/pages/agents/AddConnectorDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Loader2, Plus, Plug, Search } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -39,6 +39,13 @@ export function AddConnectorDialog({
   const [enablingId, setEnablingId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [setupConnector, setSetupConnector] = useState<ConnectorSummary | null>(null);
+
+  // Reset setup state when parent closes the dialog externally
+  useEffect(() => {
+    if (!open) {
+      setSetupConnector(null);
+    }
+  }, [open]);
 
   const enabledIds = new Set(enabledConnectors.map((c) => c.id));
   const available = allConnectors.filter((c) => !enabledIds.has(c.id));

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -28,6 +28,8 @@ interface AddCredentialDialogProps {
   fieldPlaceholder?: string;
   /** Override the dialog title (default: "Add Credential"). */
   title?: string;
+  /** Called after credentials are successfully stored. */
+  onSuccess?: () => void;
 }
 
 export function AddCredentialDialog({
@@ -38,6 +40,7 @@ export function AddCredentialDialog({
   fieldLabel,
   fieldPlaceholder,
   title,
+  onSuccess,
 }: AddCredentialDialogProps) {
   const { storeCredential, isLoading } = useStoreCredential();
   const [label, setLabel] = useState("");
@@ -72,6 +75,7 @@ export function AddCredentialDialog({
       toast.success(`Credentials stored for ${credential.service}`);
       resetForm();
       onOpenChange(false);
+      onSuccess?.();
     } catch (err) {
       toast.error(
         err instanceof Error

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -37,14 +37,15 @@ import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
 import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
 import { InlineConfirmButton } from "@/components/InlineConfirmButton";
-import { providerLabel, getOAuthAuthorizeUrl } from "@/lib/oauth";
+import {
+  providerLabel,
+  getOAuthAuthorizeUrl,
+  SHOP_REQUIRED_PROVIDERS,
+} from "@/lib/oauth";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
-
-/** Providers that require a shop subdomain for per-shop OAuth URLs. */
-const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
 
 export interface ConnectorCredentialsSectionProps {
   connectorId: string;

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -37,6 +37,21 @@ interface SetupConnectorCredentialsDialogProps {
   connectorLogoSvg?: string;
 }
 
+/**
+ * Modal shown immediately after enabling a connector, guiding the user through
+ * credential setup (OAuth or API key) in a single flow.
+ *
+ * Handles six states:
+ * - Loading: fetching connector detail, OAuth providers, and connections
+ * - No credentials required: connector is ready to use
+ * - Already connected: OAuth connection is active
+ * - Needs reauth: OAuth connection expired or revoked
+ * - OAuth available: prominent "Connect with {Provider}" button
+ * - OAuth unavailable / static only: API key or basic auth input
+ *
+ * For connectors that support both OAuth and static credentials, OAuth is
+ * shown prominently with a "Use API key instead" link in the footer.
+ */
 export function SetupConnectorCredentialsDialog({
   open,
   onOpenChange,

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import {
+  AlertTriangle,
   CheckCircle2,
   KeyRound,
   Loader2,
   LogIn,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -45,7 +47,7 @@ export function SetupConnectorCredentialsDialog({
   const { connector, isLoading: detailLoading } =
     useConnectorDetail(connectorId);
   const { providers, isLoading: providersLoading } = useOAuthProviders();
-  const { connections } = useOAuthConnections();
+  const { connections, isLoading: connectionsLoading } = useOAuthConnections();
 
   const [shopSubdomain, setShopSubdomain] = useState("");
   const [addCredentialOpen, setAddCredentialOpen] =
@@ -53,7 +55,7 @@ export function SetupConnectorCredentialsDialog({
   const [addCredentialTarget, setAddCredentialTarget] =
     useState<RequiredCredential | null>(null);
 
-  const isLoading = detailLoading || providersLoading;
+  const isLoading = detailLoading || providersLoading || connectionsLoading;
   const requiredCredentials = connector?.required_credentials ?? [];
 
   // Find OAuth credential requirement
@@ -78,6 +80,7 @@ export function SetupConnectorCredentialsDialog({
     ? connections.find((c) => c.provider === effectiveOAuthProvider)
     : null;
   const isAlreadyConnected = existingConnection?.status === "active";
+  const needsReauth = existingConnection?.status === "needs_reauth";
 
   // Find static (API key / basic) credential requirements
   const staticCredentials = requiredCredentials.filter(
@@ -153,6 +156,11 @@ export function SetupConnectorCredentialsDialog({
               providerName={providerLabel(effectiveOAuthProvider ?? connectorId)}
               onClose={() => onOpenChange(false)}
             />
+          ) : needsReauth && hasOAuth ? (
+            <NeedsReauthContent
+              providerName={providerLabel(effectiveOAuthProvider ?? connectorId)}
+              onReauthorize={handleOAuthConnect}
+            />
           ) : hasOAuth && hasOAuthCredentials ? (
             <OAuthSetupContent
               providerName={providerLabel(
@@ -177,7 +185,7 @@ export function SetupConnectorCredentialsDialog({
             !hasNoCredentials &&
             !isAlreadyConnected &&
             staticCredentials.length > 0 &&
-            !hasOAuth && (
+            (!hasOAuth || !hasOAuthCredentials) && (
               <StaticOnlyContent
                 credentials={staticCredentials}
                 onConnect={handleUseApiKey}
@@ -188,6 +196,7 @@ export function SetupConnectorCredentialsDialog({
             <div>
               {!isLoading &&
                 hasOAuth &&
+                hasOAuthCredentials &&
                 !isAlreadyConnected &&
                 staticCredentials.length > 0 && (
                   <Button
@@ -204,7 +213,9 @@ export function SetupConnectorCredentialsDialog({
             <Button variant="ghost" onClick={() => onOpenChange(false)}>
               {hasNoCredentials || isAlreadyConnected
                 ? "Done"
-                : "Set up later"}
+                : needsReauth
+                  ? "Skip for now"
+                  : "Set up later"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -268,6 +279,31 @@ function AlreadyConnectedContent({
   );
 }
 
+function NeedsReauthContent({
+  providerName,
+  onReauthorize,
+}: {
+  providerName: string;
+  onReauthorize: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 text-center">
+      <AlertTriangle className="size-10 text-amber-500" />
+      <p className="text-sm font-medium">
+        {providerName} connection expired
+      </p>
+      <p className="text-muted-foreground max-w-xs text-sm">
+        Your {providerName} connection has expired or was revoked.
+        Re-authorize to restore access.
+      </p>
+      <Button className="mt-2" onClick={onReauthorize}>
+        <LogIn className="size-4" />
+        Re-authorize {providerName}
+      </Button>
+    </div>
+  );
+}
+
 function OAuthSetupContent({
   providerName,
   scopes,
@@ -292,8 +328,7 @@ function OAuthSetupContent({
 
       {needsShopDomain && (
         <div className="flex w-full max-w-xs items-center gap-2">
-          <input
-            className="border-input bg-background placeholder:text-muted-foreground flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-sm"
+          <Input
             placeholder="mystore"
             value={shopSubdomain}
             onChange={(e) => onShopSubdomainChange(e.target.value)}

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -89,7 +89,7 @@ export function SetupConnectorCredentialsDialog({
 
   const hasOAuth = !!effectiveOAuthProvider;
   const hasNoCredentials =
-    requiredCredentials.length === 0 && !matchingProvider;
+    !isLoading && requiredCredentials.length === 0 && !matchingProvider;
   const needsShopDomain =
     effectiveOAuthProvider != null &&
     SHOP_REQUIRED_PROVIDERS.has(effectiveOAuthProvider);
@@ -228,7 +228,6 @@ export function SetupConnectorCredentialsDialog({
             setAddCredentialOpen(nextOpen);
             if (!nextOpen) {
               setAddCredentialTarget(null);
-              onOpenChange(false);
             }
           }}
           credential={addCredentialTarget}

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -1,0 +1,368 @@
+import { useState } from "react";
+import {
+  CheckCircle2,
+  KeyRound,
+  Loader2,
+  LogIn,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ConnectorLogo } from "@/components/ConnectorLogo";
+import { useAuth } from "@/auth/AuthContext";
+import { useConnectorDetail } from "@/hooks/useConnectorDetail";
+import { useOAuthProviders } from "@/hooks/useOAuthProviders";
+import { useOAuthConnections } from "@/hooks/useOAuthConnections";
+import { providerLabel, getOAuthAuthorizeUrl } from "@/lib/oauth";
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import { AddCredentialDialog } from "./AddCredentialDialog";
+
+/** Providers that require a shop subdomain for per-shop OAuth URLs. */
+const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
+
+interface SetupConnectorCredentialsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connectorId: string;
+  connectorName: string;
+  connectorLogoSvg?: string;
+}
+
+export function SetupConnectorCredentialsDialog({
+  open,
+  onOpenChange,
+  connectorId,
+  connectorName,
+  connectorLogoSvg,
+}: SetupConnectorCredentialsDialogProps) {
+  const { session } = useAuth();
+  const { connector, isLoading: detailLoading } =
+    useConnectorDetail(connectorId);
+  const { providers, isLoading: providersLoading } = useOAuthProviders();
+  const { connections } = useOAuthConnections();
+
+  const [shopSubdomain, setShopSubdomain] = useState("");
+  const [addCredentialOpen, setAddCredentialOpen] =
+    useState(false);
+  const [addCredentialTarget, setAddCredentialTarget] =
+    useState<RequiredCredential | null>(null);
+
+  const isLoading = detailLoading || providersLoading;
+  const requiredCredentials = connector?.required_credentials ?? [];
+
+  // Find OAuth credential requirement
+  const oauthCredential = requiredCredentials.find(
+    (c) => c.auth_type === "oauth2",
+  );
+
+  // Check for implicit OAuth (connector has a matching built-in provider but
+  // no explicit oauth2 credential in manifest — e.g. Shopify).
+  const matchingProvider = providers.find((p) => p.id === connectorId);
+  const hasImplicitOAuth = !oauthCredential && !!matchingProvider;
+
+  const effectiveOAuthProvider =
+    oauthCredential?.oauth_provider ?? (hasImplicitOAuth ? connectorId : null);
+  const provider = effectiveOAuthProvider
+    ? providers.find((p) => p.id === effectiveOAuthProvider)
+    : null;
+  const hasOAuthCredentials = !!provider?.has_credentials;
+
+  // Check if already connected
+  const existingConnection = effectiveOAuthProvider
+    ? connections.find((c) => c.provider === effectiveOAuthProvider)
+    : null;
+  const isAlreadyConnected = existingConnection?.status === "active";
+
+  // Find static (API key / basic) credential requirements
+  const staticCredentials = requiredCredentials.filter(
+    (c) => c.auth_type !== "oauth2",
+  );
+
+  const hasOAuth = !!effectiveOAuthProvider;
+  const hasNoCredentials =
+    requiredCredentials.length === 0 && !matchingProvider;
+  const needsShopDomain =
+    effectiveOAuthProvider != null &&
+    SHOP_REQUIRED_PROVIDERS.has(effectiveOAuthProvider);
+
+  function handleOAuthConnect() {
+    if (!session?.access_token || !effectiveOAuthProvider) return;
+
+    if (needsShopDomain) {
+      const trimmed = shopSubdomain.trim().toLowerCase();
+      if (!trimmed) return;
+      const subdomain = trimmed.replace(/\.myshopify\.com$/, "");
+      const url = getOAuthAuthorizeUrl(
+        effectiveOAuthProvider,
+        session.access_token,
+      );
+      window.location.href = `${url}&shop=${encodeURIComponent(subdomain)}`;
+      return;
+    }
+
+    window.location.href = getOAuthAuthorizeUrl(
+      effectiveOAuthProvider,
+      session.access_token,
+    );
+  }
+
+  function handleUseApiKey(credential: RequiredCredential) {
+    setAddCredentialTarget(credential);
+    setAddCredentialOpen(true);
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <ConnectorLogo
+                name={connectorName}
+                logoSvg={connectorLogoSvg}
+                size="lg"
+              />
+              <div>
+                <DialogTitle>Set up {connectorName}</DialogTitle>
+                <DialogDescription>
+                  {hasNoCredentials && !isLoading
+                    ? `${connectorName} has been enabled and is ready to use.`
+                    : `Connect your ${connectorName} account to start using this connector.`}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2
+                className="text-muted-foreground size-6 animate-spin"
+                aria-hidden="true"
+              />
+            </div>
+          ) : hasNoCredentials ? (
+            <NoCredentialsContent onClose={() => onOpenChange(false)} />
+          ) : isAlreadyConnected ? (
+            <AlreadyConnectedContent
+              providerName={providerLabel(effectiveOAuthProvider ?? connectorId)}
+              onClose={() => onOpenChange(false)}
+            />
+          ) : hasOAuth && hasOAuthCredentials ? (
+            <OAuthSetupContent
+              providerName={providerLabel(
+                effectiveOAuthProvider ?? connectorId,
+              )}
+              scopes={oauthCredential?.oauth_scopes ?? []}
+              needsShopDomain={needsShopDomain}
+              shopSubdomain={shopSubdomain}
+              onShopSubdomainChange={setShopSubdomain}
+              onConnect={handleOAuthConnect}
+            />
+          ) : hasOAuth && !hasOAuthCredentials ? (
+            <OAuthUnavailableContent
+              providerName={providerLabel(
+                effectiveOAuthProvider ?? connectorId,
+              )}
+            />
+          ) : null}
+
+          {/* Static credentials shown when there's no OAuth, or OAuth is unavailable */}
+          {!isLoading &&
+            !hasNoCredentials &&
+            !isAlreadyConnected &&
+            staticCredentials.length > 0 &&
+            !hasOAuth && (
+              <StaticOnlyContent
+                credentials={staticCredentials}
+                onConnect={handleUseApiKey}
+              />
+            )}
+
+          <DialogFooter className="flex flex-row items-center sm:justify-between">
+            <div>
+              {!isLoading &&
+                hasOAuth &&
+                !isAlreadyConnected &&
+                staticCredentials.length > 0 && (
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="text-muted-foreground px-0"
+                    onClick={() => handleUseApiKey(staticCredentials[0]!)}
+                  >
+                    <KeyRound className="size-3" />
+                    Use API key instead
+                  </Button>
+                )}
+            </div>
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              {hasNoCredentials || isAlreadyConnected
+                ? "Done"
+                : "Set up later"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {addCredentialTarget && (
+        <AddCredentialDialog
+          open={addCredentialOpen}
+          onOpenChange={(nextOpen) => {
+            setAddCredentialOpen(nextOpen);
+            if (!nextOpen) {
+              setAddCredentialTarget(null);
+              onOpenChange(false);
+            }
+          }}
+          credential={addCredentialTarget}
+        />
+      )}
+    </>
+  );
+}
+
+function NoCredentialsContent({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 text-center">
+      <CheckCircle2 className="size-10 text-green-600 dark:text-green-400" />
+      <p className="text-sm font-medium">
+        No additional setup needed
+      </p>
+      <p className="text-muted-foreground max-w-xs text-sm">
+        This connector is ready to use — no credentials required.
+      </p>
+      <Button className="mt-2" onClick={onClose}>
+        Done
+      </Button>
+    </div>
+  );
+}
+
+function AlreadyConnectedContent({
+  providerName,
+  onClose,
+}: {
+  providerName: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 text-center">
+      <CheckCircle2 className="size-10 text-green-600 dark:text-green-400" />
+      <p className="text-sm font-medium">
+        Already connected to {providerName}
+      </p>
+      <p className="text-muted-foreground max-w-xs text-sm">
+        Your {providerName} account is already connected. This connector is
+        ready to use.
+      </p>
+      <Button className="mt-2" onClick={onClose}>
+        Done
+      </Button>
+    </div>
+  );
+}
+
+function OAuthSetupContent({
+  providerName,
+  scopes,
+  needsShopDomain,
+  shopSubdomain,
+  onShopSubdomainChange,
+  onConnect,
+}: {
+  providerName: string;
+  scopes: string[];
+  needsShopDomain: boolean;
+  shopSubdomain: string;
+  onShopSubdomainChange: (value: string) => void;
+  onConnect: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-6 text-center">
+      <p className="text-muted-foreground max-w-sm text-sm">
+        Sign in with {providerName} to securely connect your account. Your
+        tokens are encrypted and automatically refreshed.
+      </p>
+
+      {needsShopDomain && (
+        <div className="flex w-full max-w-xs items-center gap-2">
+          <input
+            className="border-input bg-background placeholder:text-muted-foreground flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-sm"
+            placeholder="mystore"
+            value={shopSubdomain}
+            onChange={(e) => onShopSubdomainChange(e.target.value)}
+          />
+          <span className="text-muted-foreground whitespace-nowrap text-sm">
+            .myshopify.com
+          </span>
+        </div>
+      )}
+
+      <Button
+        size="lg"
+        className="w-full max-w-xs"
+        onClick={onConnect}
+        disabled={needsShopDomain && !shopSubdomain.trim()}
+      >
+        <LogIn className="size-4" />
+        Connect with {providerName}
+      </Button>
+
+      {scopes.length > 0 && (
+        <p className="text-muted-foreground text-xs">
+          Permissions requested: {scopes.join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function OAuthUnavailableContent({
+  providerName,
+}: {
+  providerName: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 text-center">
+      <p className="text-muted-foreground max-w-sm text-sm">
+        OAuth is not available yet for {providerName}. Ask your admin to
+        configure {providerName} OAuth credentials, or use an API key if
+        available.
+      </p>
+    </div>
+  );
+}
+
+function StaticOnlyContent({
+  credentials,
+  onConnect,
+}: {
+  credentials: RequiredCredential[];
+  onConnect: (credential: RequiredCredential) => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-6 text-center">
+      <p className="text-muted-foreground max-w-sm text-sm">
+        Provide your credentials to connect this service. Credentials are
+        encrypted at rest and never exposed to agents.
+      </p>
+      {credentials.map((cred) => (
+        <Button
+          key={cred.service}
+          size="lg"
+          className="w-full max-w-xs"
+          onClick={() => onConnect(cred)}
+        >
+          <KeyRound className="size-4" />
+          Add {cred.auth_type === "basic" ? "credentials" : "API key"}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -159,7 +159,11 @@ export function SetupConnectorCredentialsDialog({
           </DialogHeader>
 
           {isLoading ? (
-            <div className="flex items-center justify-center py-12">
+            <div
+              className="flex items-center justify-center py-12"
+              role="status"
+              aria-label="Loading connector details"
+            >
               <Loader2
                 className="text-muted-foreground size-6 animate-spin"
                 aria-hidden="true"

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -232,6 +232,7 @@ export function SetupConnectorCredentialsDialog({
             }
           }}
           credential={addCredentialTarget}
+          onSuccess={() => onOpenChange(false)}
         />
       )}
     </>

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -21,12 +21,13 @@ import { useAuth } from "@/auth/AuthContext";
 import { useConnectorDetail } from "@/hooks/useConnectorDetail";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
-import { providerLabel, getOAuthAuthorizeUrl } from "@/lib/oauth";
+import {
+  providerLabel,
+  getOAuthAuthorizeUrl,
+  SHOP_REQUIRED_PROVIDERS,
+} from "@/lib/oauth";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { AddCredentialDialog } from "./AddCredentialDialog";
-
-/** Providers that require a shop subdomain for per-shop OAuth URLs. */
-const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
 
 interface SetupConnectorCredentialsDialogProps {
   open: boolean;


### PR DESCRIPTION
## Summary
- When a user clicks "Enable" on a connector in the Add Connector dialog, a new **Set Up Credentials** modal now appears instead of just closing
- The modal prominently shows a **"Connect with {Provider}"** OAuth button when OAuth is available
- API key setup is offered as an alternative via a **"Use API key instead"** link in the footer
- Connectors with no credential requirements show a success state
- Users can always click **"Set up later"** to skip and configure later

## Test plan

### Claude Code
- [x] Frontend TypeScript compilation passes (`npx tsc --noEmit`)
- [x] All 85 frontend test files pass (677 tests)

### OpenClaw
- [ ] Enable a connector with OAuth (e.g., Google) → verify setup modal appears with "Connect with Google" button
- [ ] Click "Connect with Google" → verify OAuth redirect works
- [ ] Enable a connector with only API key → verify API key setup shown prominently
- [ ] Enable a connector with no credentials → verify success/done state
- [ ] Test "Set up later" closes modal cleanly
- [ ] Test "Use API key instead" opens the API key dialog
- [ ] Verify already-connected OAuth providers show "Already connected" state

https://claude.ai/code/session_014wLGc7ypeCYcUgNT6kRTw8