### PR TITLE
Add focused PLG dashboard for unconfigured agents

### DIFF
--- a/frontend/src/hooks/__tests__/useUnconfiguredAgent.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnconfiguredAgent.test.tsx
@@ -1,0 +1,133 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../test-helpers";
+import { mockGet, resetClientMocks } from "../../api/__mocks__/client";
+import { useUnconfiguredAgent } from "../useUnconfiguredAgent";
+import type { Agent } from "../useAgents";
+
+vi.mock("../../lib/supabaseClient");
+vi.mock("../../api/client");
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    agent_id: 1,
+    status: "registered",
+    created_at: "2026-01-01T00:00:00Z",
+    metadata: { name: "Test Agent" },
+    ...overrides,
+  };
+}
+
+describe("useUnconfiguredAgent", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("returns isUnconfigured false when agents are still loading", () => {
+    const { result } = renderHook(
+      () => useUnconfiguredAgent([], true),
+      { wrapper },
+    );
+
+    expect(result.current.isUnconfigured).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns isUnconfigured false when no agents exist", () => {
+    const { result } = renderHook(
+      () => useUnconfiguredAgent([], false),
+      { wrapper },
+    );
+
+    expect(result.current.isUnconfigured).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns isUnconfigured true for single registered agent with no connectors", async () => {
+    mockGet.mockResolvedValue({ data: { data: [] } });
+
+    const agents = [makeAgent()];
+    const { result } = renderHook(
+      () => useUnconfiguredAgent(agents, false),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isUnconfigured).toBe(true);
+    });
+    expect(result.current.agentId).toBe(1);
+  });
+
+  it("returns isUnconfigured false for single registered agent with connectors", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: "github",
+            name: "GitHub",
+            actions: ["github.create_issue"],
+            required_credentials: [],
+            enabled_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    const agents = [makeAgent()];
+    const { result } = renderHook(
+      () => useUnconfiguredAgent(agents, false),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isUnconfigured).toBe(false);
+  });
+
+  it("returns isUnconfigured false when multiple registered agents exist", () => {
+    const agents = [
+      makeAgent({ agent_id: 1 }),
+      makeAgent({ agent_id: 2 }),
+    ];
+    const { result } = renderHook(
+      () => useUnconfiguredAgent(agents, false),
+      { wrapper },
+    );
+
+    expect(result.current.isUnconfigured).toBe(false);
+  });
+
+  it("returns isUnconfigured false when single agent is pending", () => {
+    const agents = [makeAgent({ status: "pending" })];
+    const { result } = renderHook(
+      () => useUnconfiguredAgent(agents, false),
+      { wrapper },
+    );
+
+    expect(result.current.isUnconfigured).toBe(false);
+    // Should not attempt to fetch connectors (agentId is 0)
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("returns isUnconfigured false on connector fetch error", async () => {
+    mockGet.mockRejectedValue(new Error("Network error"));
+
+    const agents = [makeAgent()];
+    const { result } = renderHook(
+      () => useUnconfiguredAgent(agents, false),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isUnconfigured).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useUnconfiguredAgent.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnconfiguredAgent.test.tsx
@@ -62,6 +62,7 @@ describe("useUnconfiguredAgent", () => {
       expect(result.current.isUnconfigured).toBe(true);
     });
     expect(result.current.agentId).toBe(1);
+    expect(result.current.agentName).toBe("Test Agent");
   });
 
   it("returns isUnconfigured false for single registered agent with connectors", async () => {

--- a/frontend/src/hooks/__tests__/useUnconfiguredAgent.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnconfiguredAgent.test.tsx
@@ -36,7 +36,9 @@ describe("useUnconfiguredAgent", () => {
     );
 
     expect(result.current.isUnconfigured).toBe(false);
-    expect(result.current.isLoading).toBe(true);
+    // isLoading is false because the hook only tracks connector loading,
+    // not the agents loading state (Dashboard handles that separately).
+    expect(result.current.isLoading).toBe(false);
   });
 
   it("returns isUnconfigured false when no agents exist", () => {

--- a/frontend/src/hooks/useUnconfiguredAgent.ts
+++ b/frontend/src/hooks/useUnconfiguredAgent.ts
@@ -1,0 +1,35 @@
+import type { Agent } from "./useAgents";
+import { useAgentConnectors } from "./useAgentConnectors";
+
+/**
+ * Detects the "unconfigured agent" state: exactly one registered agent
+ * with zero connectors enabled. Used by the dashboard to show a focused
+ * PLG experience guiding the user to configure their agent.
+ */
+export function useUnconfiguredAgent(agents: Agent[], agentsLoading: boolean) {
+  const registeredAgents = agents.filter((a) => a.status === "registered");
+  const singleRegistered =
+    !agentsLoading && registeredAgents.length === 1
+      ? registeredAgents[0]
+      : null;
+
+  const agentId = singleRegistered?.agent_id ?? 0;
+
+  // useAgentConnectors guards with `enabled: agentId > 0`, so passing 0
+  // prevents any network request when the criteria aren't met.
+  const {
+    connectors,
+    isLoading: connectorsLoading,
+    error: connectorsError,
+  } = useAgentConnectors(agentId);
+
+  const isLoading = agentsLoading || (agentId > 0 && connectorsLoading);
+  const isUnconfigured =
+    !isLoading && agentId > 0 && connectors.length === 0 && !connectorsError;
+
+  return {
+    isUnconfigured,
+    isLoading,
+    agentId,
+  };
+}

--- a/frontend/src/hooks/useUnconfiguredAgent.ts
+++ b/frontend/src/hooks/useUnconfiguredAgent.ts
@@ -1,5 +1,6 @@
 import type { Agent } from "./useAgents";
 import { useAgentConnectors } from "./useAgentConnectors";
+import { getAgentDisplayName } from "@/lib/agents";
 
 /**
  * Detects the "unconfigured agent" state: exactly one registered agent
@@ -31,5 +32,8 @@ export function useUnconfiguredAgent(agents: Agent[], agentsLoading: boolean) {
     isUnconfigured,
     isLoading,
     agentId,
+    agentName: singleRegistered
+      ? getAgentDisplayName(singleRegistered)
+      : undefined,
   };
 }

--- a/frontend/src/hooks/useUnconfiguredAgent.ts
+++ b/frontend/src/hooks/useUnconfiguredAgent.ts
@@ -24,7 +24,11 @@ export function useUnconfiguredAgent(agents: Agent[], agentsLoading: boolean) {
     error: connectorsError,
   } = useAgentConnectors(agentId);
 
-  const isLoading = agentsLoading || (agentId > 0 && connectorsLoading);
+  // Only report loading during the connector fetch phase (not during agents
+  // loading). The Dashboard already handles the agents loading state via its
+  // own isLoading. Including agentsLoading here would suppress dashboard cards
+  // for ALL users during the initial load, not just the single-agent case.
+  const isLoading = agentId > 0 && connectorsLoading;
   const isUnconfigured =
     !isLoading && agentId > 0 && connectors.length === 0 && !connectorsError;
 

--- a/frontend/src/pages/dashboard/AgentConfigHero.tsx
+++ b/frontend/src/pages/dashboard/AgentConfigHero.tsx
@@ -1,0 +1,72 @@
+import { Link } from "react-router-dom";
+import { Plug, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface ConfigStepProps {
+  step: number;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+function ConfigStep({ step, icon, title, description }: ConfigStepProps) {
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+        Step {step}
+      </div>
+      <div className="bg-primary/10 text-primary mb-3 flex size-12 items-center justify-center rounded-full">
+        {icon}
+      </div>
+      <h3 className="mb-1 text-sm font-semibold">{title}</h3>
+      <p className="text-muted-foreground max-w-[200px] text-xs">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+interface AgentConfigHeroProps {
+  agentId: number;
+}
+
+export function AgentConfigHero({ agentId }: AgentConfigHeroProps) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center px-6 py-16 text-center md:py-24">
+        <div className="bg-primary/10 text-primary mb-6 flex size-16 items-center justify-center rounded-full">
+          <Plug className="size-8" />
+        </div>
+
+        <h1 className="mb-3 text-2xl font-bold tracking-tight">
+          Your agent is ready &mdash; now give it superpowers
+        </h1>
+        <p className="text-muted-foreground mb-12 max-w-md text-sm">
+          Connect services like GitHub, Gmail, or Slack so your agent can take
+          actions on your behalf. You&rsquo;ll approve every action before it
+          happens.
+        </p>
+
+        <div className="mb-12 grid w-full max-w-lg grid-cols-1 gap-8 md:grid-cols-2">
+          <ConfigStep
+            step={1}
+            icon={<Plug className="size-6" />}
+            title="Add a connector"
+            description="Choose which services your agent can interact with"
+          />
+          <ConfigStep
+            step={2}
+            icon={<ShieldCheck className="size-6" />}
+            title="Set permissions"
+            description="Approve, deny, or create standing rules for every action"
+          />
+        </div>
+
+        <Button size="lg" asChild>
+          <Link to={`/agents/${agentId}`}>Configure Your Agent</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/dashboard/AgentConfigHero.tsx
+++ b/frontend/src/pages/dashboard/AgentConfigHero.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Plug, ShieldCheck } from "lucide-react";
+import { Check, Plug, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
@@ -8,18 +8,35 @@ interface ConfigStepProps {
   icon: React.ReactNode;
   title: string;
   description: string;
+  completed?: boolean;
 }
 
-function ConfigStep({ step, icon, title, description }: ConfigStepProps) {
+function ConfigStep({
+  step,
+  icon,
+  title,
+  description,
+  completed,
+}: ConfigStepProps) {
   return (
     <div className="flex flex-col items-center text-center">
       <div className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
         Step {step}
       </div>
-      <div className="bg-primary/10 text-primary mb-3 flex size-12 items-center justify-center rounded-full">
-        {icon}
+      <div
+        className={
+          completed
+            ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 mb-3 flex size-12 items-center justify-center rounded-full"
+            : "bg-primary/10 text-primary mb-3 flex size-12 items-center justify-center rounded-full"
+        }
+      >
+        {completed ? <Check className="size-6" /> : icon}
       </div>
-      <h3 className="mb-1 text-sm font-semibold">{title}</h3>
+      <h3
+        className={`mb-1 text-sm font-semibold ${completed ? "text-muted-foreground line-through" : ""}`}
+      >
+        {title}
+      </h3>
       <p className="text-muted-foreground max-w-[200px] text-xs">
         {description}
       </p>
@@ -27,11 +44,22 @@ function ConfigStep({ step, icon, title, description }: ConfigStepProps) {
   );
 }
 
-interface AgentConfigHeroProps {
-  agentId: number;
+function StepConnector() {
+  return (
+    <div className="hidden items-center justify-center md:flex">
+      <div className="bg-border h-px w-8" />
+    </div>
+  );
 }
 
-export function AgentConfigHero({ agentId }: AgentConfigHeroProps) {
+interface AgentConfigHeroProps {
+  agentId: number;
+  agentName?: string;
+}
+
+export function AgentConfigHero({ agentId, agentName }: AgentConfigHeroProps) {
+  const displayName = agentName ?? "Your agent";
+
   return (
     <Card>
       <CardContent className="flex flex-col items-center px-6 py-16 text-center md:py-24">
@@ -40,7 +68,7 @@ export function AgentConfigHero({ agentId }: AgentConfigHeroProps) {
         </div>
 
         <h1 className="mb-3 text-2xl font-bold tracking-tight">
-          Your agent is ready &mdash; now give it superpowers
+          {displayName} is ready &mdash; now give it superpowers
         </h1>
         <p className="text-muted-foreground mb-12 max-w-md text-sm">
           Connect services like GitHub, Gmail, or Slack so your agent can take
@@ -48,15 +76,24 @@ export function AgentConfigHero({ agentId }: AgentConfigHeroProps) {
           happens.
         </p>
 
-        <div className="mb-12 grid w-full max-w-lg grid-cols-1 gap-8 md:grid-cols-2">
+        <div className="mb-12 grid w-full max-w-2xl grid-cols-1 items-start gap-6 md:grid-cols-5">
           <ConfigStep
             step={1}
+            icon={<Check className="size-6" />}
+            title="Register agent"
+            description="Connected and verified"
+            completed
+          />
+          <StepConnector />
+          <ConfigStep
+            step={2}
             icon={<Plug className="size-6" />}
             title="Add a connector"
             description="Choose which services your agent can interact with"
           />
+          <StepConnector />
           <ConfigStep
-            step={2}
+            step={3}
             icon={<ShieldCheck className="size-6" />}
             title="Set permissions"
             description="Approve, deny, or create standing rules for every action"
@@ -64,7 +101,7 @@ export function AgentConfigHero({ agentId }: AgentConfigHeroProps) {
         </div>
 
         <Button size="lg" asChild>
-          <Link to={`/agents/${agentId}`}>Configure Your Agent</Link>
+          <Link to={`/agents/${agentId}`}>Configure {displayName}</Link>
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -10,7 +10,9 @@ import { RecentActivityCard } from "./RecentActivityCard";
 import { RegisteredAgentsCard } from "./RegisteredAgentsCard";
 import { StandingApprovalsCard } from "./StandingApprovalsCard";
 import { AgentOnboardingHero } from "./AgentOnboardingHero";
+import { AgentConfigHero } from "./AgentConfigHero";
 import { InviteCodeDialog } from "./InviteCodeDialog";
+import { useUnconfiguredAgent } from "@/hooks/useUnconfiguredAgent";
 
 export function Dashboard() {
   useApprovalEvents();
@@ -20,6 +22,8 @@ export function Dashboard() {
     useStandingApprovals();
   const { events, isLoading: eventsLoading } = useAuditEvents();
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
+  const { isUnconfigured, agentId: unconfiguredAgentId } =
+    useUnconfiguredAgent(agents, isLoading);
 
   const showOnboarding = !isLoading && !error && agents.length === 0;
   const hasActiveAgents = agents.some((a) => a.status === "registered");
@@ -35,8 +39,8 @@ export function Dashboard() {
   const showStandingApprovals =
     standingLoading || standingApprovals.length > 0 || hasActivity;
 
-  // Only prompt for notifications after the user has an active agent
-  const showNotificationBanner = hasActiveAgents;
+  // Only prompt for notifications after the user has an active, configured agent
+  const showNotificationBanner = hasActiveAgents && !isUnconfigured;
 
   return (
     <div className="space-y-6">
@@ -50,6 +54,11 @@ export function Dashboard() {
             open={inviteDialogOpen}
             onOpenChange={setInviteDialogOpen}
           />
+        </>
+      ) : isUnconfigured ? (
+        <>
+          <AgentConfigHero agentId={unconfiguredAgentId} />
+          <RegisteredAgentsCard />
         </>
       ) : (
         <>

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -22,8 +22,12 @@ export function Dashboard() {
     useStandingApprovals();
   const { events, isLoading: eventsLoading } = useAuditEvents();
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
-  const { isUnconfigured, agentId: unconfiguredAgentId } =
-    useUnconfiguredAgent(agents, isLoading);
+  const {
+    isUnconfigured,
+    isLoading: unconfiguredLoading,
+    agentId: unconfiguredAgentId,
+    agentName: unconfiguredAgentName,
+  } = useUnconfiguredAgent(agents, isLoading);
 
   const showOnboarding = !isLoading && !error && agents.length === 0;
   const hasActiveAgents = agents.some((a) => a.status === "registered");
@@ -33,11 +37,15 @@ export function Dashboard() {
   // Progressive disclosure: show cards only when relevant to the user's journey.
   // While a hook is still fetching we don't yet know whether data exists,
   // so default to showing the card to avoid jarring pop-in for returning users.
+  // Suppress other cards while we're checking whether the agent is unconfigured,
+  // to avoid flashing the full dashboard before switching to the hero.
   const showPendingApprovals =
-    approvalsLoading || hasActiveAgents || hasPendingApprovals;
-  const showActivity = eventsLoading || hasActivity;
+    !unconfiguredLoading &&
+    (approvalsLoading || hasActiveAgents || hasPendingApprovals);
+  const showActivity = !unconfiguredLoading && (eventsLoading || hasActivity);
   const showStandingApprovals =
-    standingLoading || standingApprovals.length > 0 || hasActivity;
+    !unconfiguredLoading &&
+    (standingLoading || standingApprovals.length > 0 || hasActivity);
 
   // Only prompt for notifications after the user has an active, configured agent
   const showNotificationBanner = hasActiveAgents && !isUnconfigured;
@@ -57,7 +65,10 @@ export function Dashboard() {
         </>
       ) : isUnconfigured ? (
         <>
-          <AgentConfigHero agentId={unconfiguredAgentId} />
+          <AgentConfigHero
+            agentId={unconfiguredAgentId}
+            agentName={unconfiguredAgentName}
+          />
           <RegisteredAgentsCard />
         </>
       ) : (

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -22,12 +22,8 @@ export function Dashboard() {
     useStandingApprovals();
   const { events, isLoading: eventsLoading } = useAuditEvents();
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
-  const {
-    isUnconfigured,
-    isLoading: unconfiguredLoading,
-    agentId: unconfiguredAgentId,
-    agentName: unconfiguredAgentName,
-  } = useUnconfiguredAgent(agents, isLoading);
+  const { isUnconfigured, agentId: unconfiguredAgentId, agentName: unconfiguredAgentName } =
+    useUnconfiguredAgent(agents, isLoading);
 
   const showOnboarding = !isLoading && !error && agents.length === 0;
   const hasActiveAgents = agents.some((a) => a.status === "registered");
@@ -37,19 +33,19 @@ export function Dashboard() {
   // Progressive disclosure: show cards only when relevant to the user's journey.
   // While a hook is still fetching we don't yet know whether data exists,
   // so default to showing the card to avoid jarring pop-in for returning users.
-  // Suppress other cards while we're checking whether the agent is unconfigured,
-  // to avoid flashing the full dashboard before switching to the hero.
   const showPendingApprovals =
-    !unconfiguredLoading &&
-    (approvalsLoading || hasActiveAgents || hasPendingApprovals);
-  const showActivity = !unconfiguredLoading && (eventsLoading || hasActivity);
+    approvalsLoading || hasActiveAgents || hasPendingApprovals;
+  const showActivity = eventsLoading || hasActivity;
   const showStandingApprovals =
-    !unconfiguredLoading &&
-    (standingLoading || standingApprovals.length > 0 || hasActivity);
+    standingLoading || standingApprovals.length > 0 || hasActivity;
 
   // Only prompt for notifications after the user has an active, configured agent
   const showNotificationBanner = hasActiveAgents && !isUnconfigured;
 
+  // Dashboard has three states based on the user's onboarding progress:
+  // 1. No agents registered → AgentOnboardingHero (register first agent)
+  // 2. Single registered agent, no connectors → AgentConfigHero (configure agent)
+  // 3. Configured agent(s) → Full dashboard (cards for agents, approvals, activity)
   return (
     <div className="space-y-6">
       {showNotificationBanner && <NotificationBanner />}

--- a/frontend/src/pages/dashboard/__tests__/AgentConfigHero.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/AgentConfigHero.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { AgentConfigHero } from "../AgentConfigHero";
+
+function renderWithRouter(agentId: number) {
+  return render(
+    <MemoryRouter>
+      <AgentConfigHero agentId={agentId} />
+    </MemoryRouter>,
+  );
+}
+
+describe("AgentConfigHero", () => {
+  it("renders headline and description", () => {
+    renderWithRouter(42);
+
+    expect(
+      screen.getByText(/Your agent is ready.*now give it superpowers/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Connect services like GitHub, Gmail, or Slack/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders two configuration steps", () => {
+    renderWithRouter(42);
+
+    expect(screen.getByText("Add a connector")).toBeInTheDocument();
+    expect(screen.getByText("Set permissions")).toBeInTheDocument();
+  });
+
+  it("links CTA to the agent config page", () => {
+    renderWithRouter(42);
+
+    const link = screen.getByRole("link", { name: "Configure Your Agent" });
+    expect(link).toHaveAttribute("href", "/agents/42");
+  });
+});

--- a/frontend/src/pages/dashboard/__tests__/AgentConfigHero.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/AgentConfigHero.test.tsx
@@ -3,37 +3,52 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect } from "vitest";
 import { AgentConfigHero } from "../AgentConfigHero";
 
-function renderWithRouter(agentId: number) {
+function renderHero(agentId: number, agentName?: string) {
   return render(
     <MemoryRouter>
-      <AgentConfigHero agentId={agentId} />
+      <AgentConfigHero agentId={agentId} agentName={agentName} />
     </MemoryRouter>,
   );
 }
 
 describe("AgentConfigHero", () => {
-  it("renders headline and description", () => {
-    renderWithRouter(42);
+  it("renders headline with agent name when provided", () => {
+    renderHero(42, "Claude Bot");
+
+    expect(
+      screen.getByText(/Claude Bot is ready.*now give it superpowers/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders fallback headline when no agent name is provided", () => {
+    renderHero(42);
 
     expect(
       screen.getByText(/Your agent is ready.*now give it superpowers/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Connect services like GitHub, Gmail, or Slack/),
-    ).toBeInTheDocument();
   });
 
-  it("renders two configuration steps", () => {
-    renderWithRouter(42);
+  it("shows completed register step and pending config steps", () => {
+    renderHero(42, "My Agent");
 
+    expect(screen.getByText("Register agent")).toBeInTheDocument();
     expect(screen.getByText("Add a connector")).toBeInTheDocument();
     expect(screen.getByText("Set permissions")).toBeInTheDocument();
   });
 
-  it("links CTA to the agent config page", () => {
-    renderWithRouter(42);
+  it("links CTA to the agent config page with agent name", () => {
+    renderHero(42, "Claude Bot");
 
-    const link = screen.getByRole("link", { name: "Configure Your Agent" });
+    const link = screen.getByRole("link", { name: "Configure Claude Bot" });
+    expect(link).toHaveAttribute("href", "/agents/42");
+  });
+
+  it("links CTA with fallback name when no agent name", () => {
+    renderHero(42);
+
+    const link = screen.getByRole("link", {
+      name: "Configure Your agent",
+    });
     expect(link).toHaveAttribute("href", "/agents/42");
   });
 });

--- a/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -14,7 +14,7 @@ function mockEmptyResponses() {
   mockGet.mockResolvedValue({ data: { data: [], has_more: false } });
 }
 
-/** Mock GET so /v1/agents returns agents and /v1/audit-events returns events. */
+/** Mock GET so /v1/agents returns a configured agent (with connectors) and activity. */
 function mockWithAgents() {
   mockGet.mockImplementation((url: string) => {
     if (url === "/v1/agents") {
@@ -30,6 +30,21 @@ function mockWithAgents() {
             },
           ],
           has_more: false,
+        },
+      });
+    }
+    if (url === "/v1/agents/{agent_id}/connectors") {
+      return Promise.resolve({
+        data: {
+          data: [
+            {
+              id: "github",
+              name: "GitHub",
+              actions: ["github.create_issue"],
+              required_credentials: [],
+              enabled_at: "2026-01-01T00:00:00Z",
+            },
+          ],
         },
       });
     }
@@ -49,6 +64,32 @@ function mockWithAgents() {
           has_more: false,
         },
       });
+    }
+    return Promise.resolve({ data: { data: [], has_more: false } });
+  });
+}
+
+/** Mock GET so /v1/agents returns a single registered agent with no connectors. */
+function mockUnconfiguredAgent() {
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/agents") {
+      return Promise.resolve({
+        data: {
+          data: [
+            {
+              agent_id: 1,
+              status: "registered",
+              last_active_at: null,
+              request_count_30d: 0,
+              metadata: { name: "My Agent" },
+            },
+          ],
+          has_more: false,
+        },
+      });
+    }
+    if (url === "/v1/agents/{agent_id}/connectors") {
+      return Promise.resolve({ data: { data: [] } });
     }
     return Promise.resolve({ data: { data: [], has_more: false } });
   });
@@ -122,5 +163,27 @@ describe("Dashboard", () => {
     await waitFor(() => {
       expect(screen.getByText("Add an Agent")).toBeInTheDocument();
     });
+  });
+
+  it("renders config hero when single agent has no connectors", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockUnconfiguredAgent();
+
+    render(<Dashboard />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Your agent is ready.*now give it superpowers/),
+      ).toBeInTheDocument();
+    });
+
+    // Should show the agent card but not the other dashboard cards
+    expect(screen.getByText("Registered Agents")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Configure Your Agent" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Pending Approvals")).not.toBeInTheDocument();
+    expect(screen.queryByText("Recent Activity")).not.toBeInTheDocument();
+    expect(screen.queryByText("Standing Approvals")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -130,14 +130,12 @@ describe("Dashboard", () => {
 
     render(<Dashboard />, { wrapper });
 
-    // Wait for agent, connector, and event fetches to complete so all
-    // dashboard cards are rendered (unconfiguredLoading must also resolve).
     await waitFor(() => {
       expect(screen.getByText("Registered Agents")).toBeInTheDocument();
-      expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
-      expect(screen.getByText("Recent Activity")).toBeInTheDocument();
-      expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
     });
+    expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
+    expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+    expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
 
     // Onboarding hero should NOT appear
     expect(

--- a/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -130,14 +130,14 @@ describe("Dashboard", () => {
 
     render(<Dashboard />, { wrapper });
 
-    // Wait for both agent and connector fetches to complete so unconfiguredLoading
-    // is false and all dashboard cards are rendered.
+    // Wait for agent, connector, and event fetches to complete so all
+    // dashboard cards are rendered (unconfiguredLoading must also resolve).
     await waitFor(() => {
       expect(screen.getByText("Registered Agents")).toBeInTheDocument();
       expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
+      expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+      expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
     });
-    expect(screen.getByText("Recent Activity")).toBeInTheDocument();
-    expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
 
     // Onboarding hero should NOT appear
     expect(

--- a/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -130,10 +130,12 @@ describe("Dashboard", () => {
 
     render(<Dashboard />, { wrapper });
 
+    // Wait for both agent and connector fetches to complete so unconfiguredLoading
+    // is false and all dashboard cards are rendered.
     await waitFor(() => {
       expect(screen.getByText("Registered Agents")).toBeInTheDocument();
+      expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
     });
-    expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
     expect(screen.getByText("Recent Activity")).toBeInTheDocument();
     expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
 
@@ -173,14 +175,14 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/Your agent is ready.*now give it superpowers/),
+        screen.getByText(/My Agent is ready.*now give it superpowers/),
       ).toBeInTheDocument();
     });
 
     // Should show the agent card but not the other dashboard cards
     expect(screen.getByText("Registered Agents")).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Configure Your Agent" }),
+      screen.getByRole("link", { name: "Configure My Agent" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("Pending Approvals")).not.toBeInTheDocument();
     expect(screen.queryByText("Recent Activity")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- When a user has a single registered agent with no connectors enabled, the dashboard now shows a focused PLG hero experience instead of empty standard cards (pending approvals, recent activity, standing approvals)
- The hero guides the user to configure their agent with a clear CTA linking to the agent config page
- The notification banner is also hidden in this state since it's not yet relevant
- Once a connector is added, the dashboard automatically transitions to the normal full view

## Implementation

- **`useUnconfiguredAgent` hook** — detects the unconfigured state by checking for exactly 1 registered agent with 0 connectors. Conditionally fetches connectors only when relevant.
- **`AgentConfigHero` component** — centered hero card following the same visual pattern as the existing onboarding hero, with two-step guide (add connector, set permissions) and CTA button
- **`Dashboard.tsx`** — adds a third conditional branch between "no agents" and "has agents" states

## Test plan

### Claude Code
- [x] Unit tests for `useUnconfiguredAgent` hook (7 tests covering all state combinations)
- [x] Unit tests for `AgentConfigHero` component (3 tests)
- [x] Updated Dashboard integration test for unconfigured state
- [x] All 688 frontend tests pass
- [x] TypeScript compilation passes

### OpenClaw
- [ ] Visual review of the unconfigured agent hero in browser
- [ ] Verify hero disappears after adding a connector
- [ ] Verify normal dashboard appears for users with multiple agents
- [ ] Review UX copy for tone and clarity

https://claude.ai/code/session_01JK6sCoh6ss7ZCQzTvt1oDQ