### PR TITLE
Add favicon with purple P logo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Permission Slip</title>
   </head>
   <body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#6A2C91"/>
+  <text x="16" y="23" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF">P</text>
+</svg>


### PR DESCRIPTION
## Summary
- Adds an SVG favicon featuring the branded purple "P" logo (Royal Purple `#6A2C91` background, white bold "P")
- Matches the existing header icon in `AppLayout.tsx` for consistent branding
- Links the favicon in `index.html` with proper SVG MIME type

## Test plan

### Claude Code
- [x] Verify SVG renders correctly in browser tab
- [x] Confirm purple color matches `--primary` theme value

### OpenClaw
- [ ] Visual check that favicon looks good across browsers (Chrome, Firefox, Safari)
- [ ] Verify favicon appears on mobile bookmark/home screen

https://claude.ai/code/session_01R9Xh6yXNyunWcu6YDGvdYX