### PR TITLE
Update openapi.bundle.yaml

### DIFF
--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -2556,6 +2556,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApprovalSummary'
+              examples:
+                approved_with_result:
+                  summary: Approved approval with execution result
+                  value:
+                    approval_id: appr_abc456
+                    agent_id: 42
+                    action:
+                      type: email.send
+                      version: '1'
+                      parameters:
+                        to: recipient@example.com
+                        subject: Hello World
+                    context:
+                      description: Send welcome email to new user
+                      risk_level: low
+                    status: approved
+                    execution_status: success
+                    execution_result:
+                      message_id: msg_abc123
+                    executed_at: '2026-02-11T13:21:01Z'
+                    expires_at: '2026-02-11T13:25:00Z'
+                    approved_at: '2026-02-11T13:21:00Z'
+                    created_at: '2026-02-11T13:20:00Z'
+                denied:
+                  summary: Denied approval
+                  value:
+                    approval_id: appr_xyz789
+                    agent_id: 42
+                    action:
+                      type: file.delete
+                      version: '1'
+                      parameters:
+                        path: /important/data.csv
+                    context:
+                      description: Delete temporary file
+                      risk_level: high
+                    status: denied
+                    expires_at: '2026-02-11T13:25:00Z'
+                    denied_at: '2026-02-11T13:22:00Z'
+                    created_at: '2026-02-11T13:20:00Z'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':


### PR DESCRIPTION
## Summary

- Regenerated `spec/openapi/openapi.bundle.yaml` via `make bundle` to sync with the source spec
- Adds response examples for the GET approval summary endpoint (approved with execution result, denied)

## Test plan

### Claude Code
- [x] Verified bundle regenerates cleanly with `make bundle`
- [x] Confirmed diff contains only the expected example additions

### OpenClaw
- [ ] Verify the examples render correctly in API docs/Redoc

https://claude.ai/code/session_01N7r48P52yPkQNULhUsjo6U