### PR TITLE
Fix activity feed test expecting source_id to be absent

### DIFF
--- a/api/audit_events_test.go
+++ b/api/audit_events_test.go
@@ -794,7 +794,7 @@ func TestExportAuditLogs_InvalidEventType(t *testing.T) {
 	}
 }
 
-func TestExportAuditLogs_ActivityFeedOmitsIDAndSourceID(t *testing.T) {
+func TestExportAuditLogs_ActivityFeedOmitsID(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -805,7 +805,8 @@ func TestExportAuditLogs_ActivityFeedOmitsIDAndSourceID(t *testing.T) {
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	// The activity feed (GET /audit-events) should NOT include id or source_id
+	// The activity feed (GET /audit-events) should NOT include id but SHOULD
+	// include source_id (added for click-through detail views).
 	r := authenticatedRequest(t, http.MethodGet, "/audit-events", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
@@ -826,8 +827,8 @@ func TestExportAuditLogs_ActivityFeedOmitsIDAndSourceID(t *testing.T) {
 	if _, ok := raw.Data[0]["id"]; ok {
 		t.Error("activity feed response should NOT include 'id' field")
 	}
-	if _, ok := raw.Data[0]["source_id"]; ok {
-		t.Error("activity feed response should NOT include 'source_id' field")
+	if _, ok := raw.Data[0]["source_id"]; !ok {
+		t.Error("activity feed response should include 'source_id' field")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The `TestExportAuditLogs_ActivityFeedOmitsIDAndSourceID` test was asserting that `source_id` should NOT appear in the activity feed response
- However, commit 0981051 ("Redesign activity feed") intentionally added `source_id` to the `auditEventResponse` struct so the frontend can link events back to their source approval for detail views
- The test was introduced in the same commit but contradicted the code change, causing CI failures
- Updated the test to expect `source_id` to be present and renamed it to `TestExportAuditLogs_ActivityFeedOmitsID` to reflect that only `id` should be omitted

## Test plan
- [x] `go test ./api/...` passes — the renamed test verifies `id` is absent and `source_id` is present
- [x] Full `go test ./...` passes with no failures
- [x] `go build ./...` compiles cleanly

https://claude.ai/code/session_01RB4d98dVe8jekhgsSDigyx