### PR TITLE
Fix auth modal not showing on connector card click

### DIFF
--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -16,6 +16,7 @@ import { useConnectors } from "@/hooks/useConnectors";
 import type { ConnectorSummary } from "@/hooks/useConnectors";
 import { useEnableAgentConnector } from "@/hooks/useEnableAgentConnector";
 import type { AgentConnector } from "@/hooks/useAgentConnectors";
+import { SetupConnectorCredentialsDialog } from "./connectors/SetupConnectorCredentialsDialog";
 
 interface AgentConnectorsSectionProps {
   agentId: number;
@@ -44,6 +45,7 @@ export function AgentConnectorsSection({
   const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const [enablingId, setEnablingId] = useState<string | null>(null);
+  const [setupConnector, setSetupConnector] = useState<ConnectorSummary | null>(null);
 
   const isLoading = enabledLoading || allLoading;
   const error = allError ?? enabledError;
@@ -69,7 +71,7 @@ export function AgentConnectorsSection({
     try {
       await enableConnector({ agentId, connectorId: connector.id });
       toast.success(`${connector.name} enabled`);
-      navigate(`/agents/${agentId}/connectors/${connector.id}`);
+      setSetupConnector(connector);
     } catch (err) {
       console.error(`Failed to enable connector ${connector.id}:`, err);
       toast.error(`Failed to enable ${connector.name}`);
@@ -79,6 +81,7 @@ export function AgentConnectorsSection({
   }
 
   return (
+    <>
     <Card>
       <CardHeader>
         <CardTitle>Connectors</CardTitle>
@@ -144,6 +147,23 @@ export function AgentConnectorsSection({
         )}
       </CardContent>
     </Card>
+
+    {setupConnector && (
+      <SetupConnectorCredentialsDialog
+        open
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            const connectorId = setupConnector.id;
+            setSetupConnector(null);
+            navigate(`/agents/${agentId}/connectors/${connectorId}`);
+          }
+        }}
+        connectorId={setupConnector.id}
+        connectorName={setupConnector.name}
+        connectorLogoSvg={setupConnector.logo_svg}
+      />
+    )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- The `SetupConnectorCredentialsDialog` (OAuth + API key setup modal) was wired into `AddConnectorDialog` but **not** into `AgentConnectorsSection` — the main connector grid on the dashboard
- When clicking a non-enabled connector card, it enabled the connector and navigated straight to the config page, skipping the credential setup flow entirely
- Now the auth modal appears immediately after enabling, showing OAuth setup (with optional "Use API key instead" link) or API key input when OAuth isn't available — matching the existing `AddConnectorDialog` behavior
- On modal close, navigates to the connector config page as before

## Test plan

### Claude Code
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 710 frontend tests pass (`make test-frontend`)

### OpenClaw
- [ ] Click a non-enabled connector card → verify the auth setup modal appears
- [ ] Verify OAuth "Connect with {Provider}" button works for OAuth connectors
- [ ] Verify "Use API key instead" link appears in footer for connectors with both OAuth and API key support
- [ ] Verify API-key-only connectors show the API key input directly
- [ ] Close the modal → verify navigation to connector config page
- [ ] Click an already-enabled connector → verify it navigates directly to config (no modal)

https://claude.ai/code/session_019aPZb9PtQuXfBaXuxtgbUz