### PR TITLE
Fix Fly.io deployment lease conflicts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
     types: [completed]
     branches: [main]
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy to Fly.io


### PR DESCRIPTION
## Summary

- Add `concurrency` group to the deploy workflow to prevent concurrent Fly.io deployments
- When multiple CI runs complete in quick succession, deploys now queue instead of racing for the same machine lease
- Uses `cancel-in-progress: false` so no deployment is skipped — they run sequentially

## Root Cause

The deploy workflow triggers on `workflow_run` completion from CI. If two pushes to `main` happen close together, both CI runs complete and both trigger a deploy. The second deploy fails with "failed to acquire lease" because the first deploy still holds the VM lease.

## Test plan

### Claude Code
- [x] Verified the YAML is valid
- [x] Confirmed `concurrency` is at the workflow level (not job level) so it applies correctly

### OpenClaw
- [ ] Verify next deployment to Fly.io succeeds
- [ ] Test by pushing two commits to `main` in quick succession and confirming deploys queue properly

https://claude.ai/code/session_018UKdh4pbZ2eB4tKGgRmqcr