### PR TITLE
Fix OAuth/BYOA/config routes returning 404

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -18,7 +18,7 @@ func init() {
 // RegisterConfigRoutes adds server configuration endpoints to the mux.
 func RegisterConfigRoutes(mux *http.ServeMux, deps *Deps) {
 	requireSession := RequireSession(deps)
-	mux.Handle("GET /v1/config", requireSession(handleGetConfig(deps)))
+	mux.Handle("GET /config", requireSession(handleGetConfig(deps)))
 }
 
 // handleGetConfig returns server-level feature flags that the frontend needs

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -18,7 +18,7 @@ func TestGetConfig_BillingDisabled(t *testing.T) {
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: false}
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/config", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/config", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -44,7 +44,7 @@ func TestGetConfig_BillingEnabled(t *testing.T) {
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/config", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/config", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -67,7 +67,7 @@ func TestGetConfig_Unauthenticated(t *testing.T) {
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	r := httptest.NewRequest(http.MethodGet, "/v1/config", nil)
+	r := httptest.NewRequest(http.MethodGet, "/config", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -106,11 +106,11 @@ func RegisterOAuthRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	requireSession := RequireSession(deps)
 
-	mux.Handle("GET /v1/oauth/providers", requireProfile(handleListOAuthProviders(deps)))
-	mux.Handle("GET /v1/oauth/{provider}/authorize", requireProfile(handleOAuthAuthorize(deps)))
-	mux.Handle("GET /v1/oauth/{provider}/callback", requireSession(handleOAuthCallback(deps)))
-	mux.Handle("GET /v1/oauth/connections", requireProfile(handleListOAuthConnections(deps)))
-	mux.Handle("DELETE /v1/oauth/connections/{provider}", requireProfile(handleDeleteOAuthConnection(deps)))
+	mux.Handle("GET /oauth/providers", requireProfile(handleListOAuthProviders(deps)))
+	mux.Handle("GET /oauth/{provider}/authorize", requireProfile(handleOAuthAuthorize(deps)))
+	mux.Handle("GET /oauth/{provider}/callback", requireSession(handleOAuthCallback(deps)))
+	mux.Handle("GET /oauth/connections", requireProfile(handleListOAuthConnections(deps)))
+	mux.Handle("DELETE /oauth/connections/{provider}", requireProfile(handleDeleteOAuthConnection(deps)))
 }
 
 // --- CSRF state helpers ---

--- a/api/oauth_byoa.go
+++ b/api/oauth_byoa.go
@@ -74,10 +74,10 @@ func init() {
 func RegisterOAuthBYOARoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 
-	mux.Handle("POST /v1/oauth/provider-configs", requireProfile(handleCreateOAuthProviderConfig(deps)))
-	mux.Handle("GET /v1/oauth/provider-configs", requireProfile(handleListOAuthProviderConfigs(deps)))
-	mux.Handle("PUT /v1/oauth/provider-configs/{provider}", requireProfile(handleUpdateOAuthProviderConfig(deps)))
-	mux.Handle("DELETE /v1/oauth/provider-configs/{provider}", requireProfile(handleDeleteOAuthProviderConfig(deps)))
+	mux.Handle("POST /oauth/provider-configs", requireProfile(handleCreateOAuthProviderConfig(deps)))
+	mux.Handle("GET /oauth/provider-configs", requireProfile(handleListOAuthProviderConfigs(deps)))
+	mux.Handle("PUT /oauth/provider-configs/{provider}", requireProfile(handleUpdateOAuthProviderConfig(deps)))
+	mux.Handle("DELETE /oauth/provider-configs/{provider}", requireProfile(handleDeleteOAuthProviderConfig(deps)))
 }
 
 // --- Helpers ---

--- a/api/oauth_byoa_test.go
+++ b/api/oauth_byoa_test.go
@@ -58,7 +58,7 @@ func TestCreateOAuthProviderConfig_Success(t *testing.T) {
 	router := NewRouter(deps)
 
 	body := `{"provider":"salesforce","client_id":"my-id","client_secret":"my-secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -119,7 +119,7 @@ func TestCreateOAuthProviderConfig_DuplicateReturnsConflict(t *testing.T) {
 	body := `{"provider":"salesforce","client_id":"id1","client_secret":"secret1"}`
 
 	// First create should succeed.
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -128,7 +128,7 @@ func TestCreateOAuthProviderConfig_DuplicateReturnsConflict(t *testing.T) {
 
 	// Second create should return 409.
 	body2 := `{"provider":"salesforce","client_id":"id2","client_secret":"secret2"}`
-	r2 := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body2)
+	r2 := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body2)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusConflict {
@@ -146,7 +146,7 @@ func TestCreateOAuthProviderConfig_UnknownProviderReturns404(t *testing.T) {
 	router := NewRouter(deps)
 
 	body := `{"provider":"unknown-provider","client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -165,7 +165,7 @@ func TestCreateOAuthProviderConfig_InvalidProviderIDReturns400(t *testing.T) {
 	router := NewRouter(deps)
 
 	body := `{"provider":"INVALID ID!","client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -193,7 +193,7 @@ func TestCreateOAuthProviderConfig_MissingFieldsReturns400(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, tc.body)
+			r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, tc.body)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, r)
 			if w.Code != http.StatusBadRequest {
@@ -223,7 +223,7 @@ func TestCreateOAuthProviderConfig_CredentialTooLongReturns400(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, tc.body)
+			r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, tc.body)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, r)
 			if w.Code != http.StatusBadRequest {
@@ -244,7 +244,7 @@ func TestUpdateOAuthProviderConfig_CredentialTooLongReturns400(t *testing.T) {
 
 	// Create a config first so the PUT has something to update.
 	createBody := `{"provider":"salesforce","client_id":"cid","client_secret":"csecret"}`
-	cr := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, createBody)
+	cr := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, createBody)
 	cw := httptest.NewRecorder()
 	router.ServeHTTP(cw, cr)
 	if cw.Code != http.StatusCreated {
@@ -262,7 +262,7 @@ func TestUpdateOAuthProviderConfig_CredentialTooLongReturns400(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := authenticatedJSONRequest(t, http.MethodPut, "/v1/oauth/provider-configs/salesforce", uid, tc.body)
+			r := authenticatedJSONRequest(t, http.MethodPut, "/oauth/provider-configs/salesforce", uid, tc.body)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, r)
 			if w.Code != http.StatusBadRequest {
@@ -283,7 +283,7 @@ func TestListOAuthProviderConfigs_Empty(t *testing.T) {
 	deps, _ := byoaDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/provider-configs", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/provider-configs", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -311,7 +311,7 @@ func TestListOAuthProviderConfigs_ReturnsCreated(t *testing.T) {
 
 	// Create a config first.
 	body := `{"provider":"salesforce","client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -319,7 +319,7 @@ func TestListOAuthProviderConfigs_ReturnsCreated(t *testing.T) {
 	}
 
 	// List should return the created config.
-	r2 := authenticatedRequest(t, http.MethodGet, "/v1/oauth/provider-configs", uid)
+	r2 := authenticatedRequest(t, http.MethodGet, "/oauth/provider-configs", uid)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {
@@ -351,7 +351,7 @@ func TestListOAuthProviderConfigs_IsolatedByUser(t *testing.T) {
 
 	// User 1 creates a config.
 	body := `{"provider":"salesforce","client_id":"id1","client_secret":"secret1"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid1, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid1, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -359,7 +359,7 @@ func TestListOAuthProviderConfigs_IsolatedByUser(t *testing.T) {
 	}
 
 	// User 2 should see an empty list.
-	r2 := authenticatedRequest(t, http.MethodGet, "/v1/oauth/provider-configs", uid2)
+	r2 := authenticatedRequest(t, http.MethodGet, "/oauth/provider-configs", uid2)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {
@@ -388,7 +388,7 @@ func TestDeleteOAuthProviderConfig_Success(t *testing.T) {
 
 	// Create a config.
 	body := `{"provider":"salesforce","client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -401,7 +401,7 @@ func TestDeleteOAuthProviderConfig_Success(t *testing.T) {
 	}
 
 	// Delete the config.
-	r2 := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/provider-configs/salesforce", uid)
+	r2 := authenticatedRequest(t, http.MethodDelete, "/oauth/provider-configs/salesforce", uid)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {
@@ -455,7 +455,7 @@ func TestDeleteOAuthProviderConfig_NotFoundReturns404(t *testing.T) {
 	deps, _ := byoaDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/provider-configs/salesforce", uid)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/provider-configs/salesforce", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -473,7 +473,7 @@ func TestDeleteOAuthProviderConfig_InvalidIDReturns400(t *testing.T) {
 	deps, _ := byoaDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/provider-configs/INVALID!", uid)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/provider-configs/INVALID!", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -495,7 +495,7 @@ func TestUpdateOAuthProviderConfig_Success(t *testing.T) {
 
 	// Create a config first.
 	createBody := `{"provider":"salesforce","client_id":"old-id","client_secret":"old-secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, createBody)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, createBody)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -509,7 +509,7 @@ func TestUpdateOAuthProviderConfig_Success(t *testing.T) {
 
 	// Update the config with new credentials.
 	updateBody := `{"client_id":"new-id","client_secret":"new-secret"}`
-	r2 := authenticatedJSONRequest(t, http.MethodPut, "/v1/oauth/provider-configs/salesforce", uid, updateBody)
+	r2 := authenticatedJSONRequest(t, http.MethodPut, "/oauth/provider-configs/salesforce", uid, updateBody)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {
@@ -558,7 +558,7 @@ func TestUpdateOAuthProviderConfig_NotFoundReturns404(t *testing.T) {
 	router := NewRouter(deps)
 
 	body := `{"client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPut, "/v1/oauth/provider-configs/salesforce", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPut, "/oauth/provider-configs/salesforce", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -577,7 +577,7 @@ func TestUpdateOAuthProviderConfig_InvalidIDReturns400(t *testing.T) {
 	router := NewRouter(deps)
 
 	body := `{"client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPut, "/v1/oauth/provider-configs/INVALID!", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPut, "/oauth/provider-configs/INVALID!", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -599,7 +599,7 @@ func TestListOAuthProviderConfigs_IncludesUpdatedAt(t *testing.T) {
 
 	// Create a config.
 	body := `{"provider":"salesforce","client_id":"id","client_secret":"secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -607,7 +607,7 @@ func TestListOAuthProviderConfigs_IncludesUpdatedAt(t *testing.T) {
 	}
 
 	// List should include updated_at.
-	r2 := authenticatedRequest(t, http.MethodGet, "/v1/oauth/provider-configs", uid)
+	r2 := authenticatedRequest(t, http.MethodGet, "/oauth/provider-configs", uid)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {
@@ -647,7 +647,7 @@ func TestBYOA_OverridesBuiltInForAuthorize(t *testing.T) {
 
 	// Register BYOA credentials for google.
 	body := `{"provider":"google","client_id":"byoa-client-id","client_secret":"byoa-client-secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -682,7 +682,7 @@ func TestBYOA_DeleteRevertsToBuiltIn(t *testing.T) {
 
 	// Register BYOA for google.
 	body := `{"provider":"google","client_id":"byoa-id","client_secret":"byoa-secret"}`
-	r := authenticatedJSONRequest(t, http.MethodPost, "/v1/oauth/provider-configs", uid, body)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/oauth/provider-configs", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 	if w.Code != http.StatusCreated {
@@ -690,7 +690,7 @@ func TestBYOA_DeleteRevertsToBuiltIn(t *testing.T) {
 	}
 
 	// Delete BYOA config.
-	r2 := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/provider-configs/google", uid)
+	r2 := authenticatedRequest(t, http.MethodDelete, "/oauth/provider-configs/google", uid)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -103,7 +103,7 @@ func TestListOAuthProviders_ReturnsRegistered(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/providers", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/providers", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -152,7 +152,7 @@ func TestListOAuthProviders_EmptyWhenNilRegistry(t *testing.T) {
 	deps.OAuthProviders = nil
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/providers", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/providers", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -310,7 +310,7 @@ func TestOAuthAuthorize_Redirect(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -349,7 +349,7 @@ func TestOAuthAuthorize_ProviderNotFound(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/nonexistent/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/nonexistent/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -367,7 +367,7 @@ func TestOAuthAuthorize_ProviderUnconfigured(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/unconfigured/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/unconfigured/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -391,7 +391,7 @@ func TestOAuthAuthorize_InvalidProviderID(t *testing.T) {
 	router := NewRouter(deps)
 
 	// Provider ID with uppercase and special chars should be rejected
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/INVALID%21/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/INVALID%21/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -406,7 +406,7 @@ func TestOAuthAuthorize_Unauthenticated(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := httptest.NewRequest(http.MethodGet, "/v1/oauth/google/authorize", nil)
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -426,7 +426,7 @@ func TestListOAuthConnections_Empty(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/connections", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/connections", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -455,7 +455,7 @@ func TestListOAuthConnections_ReturnsUserConnections(t *testing.T) {
 	deps := oauthDepsWithVault(tx, v)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/connections", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/connections", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -497,7 +497,7 @@ func TestListOAuthConnections_IsolatedByUser(t *testing.T) {
 	router := NewRouter(deps)
 
 	// User 2 should see no connections
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/connections", uid2)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/connections", uid2)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -528,7 +528,7 @@ func TestDeleteOAuthConnection_Success(t *testing.T) {
 	deps := oauthDepsWithVault(tx, v)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/connections/google", uid)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/google", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -563,7 +563,7 @@ func TestDeleteOAuthConnection_NotFound(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/connections/google", uid)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/google", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -592,7 +592,7 @@ func TestDeleteOAuthConnection_OtherUserCannot(t *testing.T) {
 	router := NewRouter(deps)
 
 	// User 2 tries to delete user 1's connection
-	r := authenticatedRequest(t, http.MethodDelete, "/v1/oauth/connections/google", uid2)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/google", uid2)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -621,7 +621,7 @@ func TestOAuthCallback_MissingState(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/callback?code=test-code", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -644,7 +644,7 @@ func TestOAuthCallback_InvalidState(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/callback?code=test-code&state=invalid-jwt", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code&state=invalid-jwt", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -672,7 +672,7 @@ func TestOAuthCallback_ProviderMismatch(t *testing.T) {
 		t.Fatalf("create state: %v", err)
 	}
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -702,7 +702,7 @@ func TestOAuthCallback_UserMismatch(t *testing.T) {
 		t.Fatalf("create state: %v", err)
 	}
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), uid2)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), uid2)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -724,7 +724,7 @@ func TestOAuthCallback_ProviderError(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/callback?error=access_denied&error_description=User+denied+consent", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?error=access_denied&error_description=User+denied+consent", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -754,7 +754,7 @@ func TestOAuthCallback_MissingCode(t *testing.T) {
 		t.Fatalf("create state: %v", err)
 	}
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/callback?state="+url.QueryEscape(state), uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?state="+url.QueryEscape(state), uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1034,7 +1034,7 @@ func TestOAuthAuthorize_Shopify_RequiresShopParam(t *testing.T) {
 	router := NewRouter(deps)
 
 	// No shop param → 400
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/shopify/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/shopify/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1052,7 +1052,7 @@ func TestOAuthAuthorize_Shopify_InvalidShop(t *testing.T) {
 	deps := oauthDepsWithShopify(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/shopify/authorize?shop=-invalid", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/shopify/authorize?shop=-invalid", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1070,7 +1070,7 @@ func TestOAuthAuthorize_Shopify_ValidShop(t *testing.T) {
 	deps := oauthDepsWithShopify(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/shopify/authorize?shop=mystore", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/shopify/authorize?shop=mystore", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1108,7 +1108,7 @@ func TestOAuthAuthorize_Shopify_FullDomainShop(t *testing.T) {
 	router := NewRouter(deps)
 
 	// Full domain form should also work
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/shopify/authorize?shop=mystore.myshopify.com", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/shopify/authorize?shop=mystore.myshopify.com", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1136,7 +1136,7 @@ func TestOAuthAuthorize_NonShopProvider_IgnoresShopParam(t *testing.T) {
 	router := NewRouter(deps)
 
 	// Google provider should work without shop param and ignore it
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/google/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1556,7 +1556,7 @@ func TestOAuthAuthorize_Zendesk_RequiresSubdomainParam(t *testing.T) {
 	router := NewRouter(deps)
 
 	// No subdomain param → 400
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/zendesk/authorize", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/zendesk/authorize", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1574,7 +1574,7 @@ func TestOAuthAuthorize_Zendesk_InvalidSubdomain(t *testing.T) {
 	deps := oauthDepsWithZendesk(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/zendesk/authorize?subdomain=-invalid", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/zendesk/authorize?subdomain=-invalid", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1592,7 +1592,7 @@ func TestOAuthAuthorize_Zendesk_ValidSubdomain(t *testing.T) {
 	deps := oauthDepsWithZendesk(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/zendesk/authorize?subdomain=mycompany", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/zendesk/authorize?subdomain=mycompany", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -1640,7 +1640,7 @@ func TestOAuthAuthorize_Zendesk_FullDomainSubdomain(t *testing.T) {
 	router := NewRouter(deps)
 
 	// Full domain form should also work
-	r := authenticatedRequest(t, http.MethodGet, "/v1/oauth/zendesk/authorize?subdomain=mycompany.zendesk.com", uid)
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/zendesk/authorize?subdomain=mycompany.zendesk.com", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 


### PR DESCRIPTION
## Summary
- OAuth, BYOA, and config route handlers were registered with a `/v1/` prefix (e.g. `GET /v1/oauth/providers`), but `main.go` already strips `/api/v1` via `http.StripPrefix` before routing to the inner mux
- Frontend requests to `/api/v1/oauth/providers` arrived at the inner mux as `/oauth/providers`, which didn't match the registered `/v1/` routes — causing **404s for all OAuth, BYOA, and config endpoints**
- This is why the "Set up Google" dialog showed "OAuth is not available yet" despite credentials being configured — the `/api/v1/oauth/providers` endpoint was returning 404, so the frontend couldn't fetch provider data
- Removed the redundant `/v1/` prefix from routes in `oauth.go`, `oauth_byoa.go`, and `config.go` to match all other route groups

## Test plan

### Claude Code
- [x] Backend API tests pass (`go test ./api/...`)
- [x] Frontend tests pass (`npm test` — 710 tests)
- [x] `go vet` clean on affected packages

### OpenClaw
- [ ] Verify Google connector "Connect with Google" button appears when GOOGLE_CLIENT_ID/SECRET are set
- [ ] Verify OAuth flow completes end-to-end (authorize → callback → connection saved)
- [ ] Verify BYOA provider config CRUD works from Settings page
- [ ] Verify `/api/v1/config` endpoint returns expected data

https://claude.ai/code/session_01Snpadg76bLH5h4cWvodtc7