### PR TITLE
Fix Google OAuth callback failing with Missing Authorization header

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -104,11 +104,10 @@ func init() {
 // RegisterOAuthRoutes adds OAuth-related endpoints to the mux.
 func RegisterOAuthRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
-	requireSession := RequireSession(deps)
 
 	mux.Handle("GET /oauth/providers", requireProfile(handleListOAuthProviders(deps)))
 	mux.Handle("GET /oauth/{provider}/authorize", requireProfile(handleOAuthAuthorize(deps)))
-	mux.Handle("GET /oauth/{provider}/callback", requireSession(handleOAuthCallback(deps)))
+	mux.Handle("GET /oauth/{provider}/callback", handleOAuthCallback(deps))
 	mux.Handle("GET /oauth/connections", requireProfile(handleListOAuthConnections(deps)))
 	mux.Handle("DELETE /oauth/connections/{provider}", requireProfile(handleDeleteOAuthConnection(deps)))
 }
@@ -495,16 +494,14 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Verify the session user matches the state user
-		sessionUserID := UserID(r.Context())
-		if sessionUserID != state.UserID {
-			log.Printf("[%s] OAuthCallback: user mismatch: state=%s session=%s", TraceID(r.Context()), state.UserID, sessionUserID)
-			redirectToFrontend(w, r, deps, providerID, "error", "Session mismatch")
-			return
-		}
+		// The callback is a browser redirect from the OAuth provider, so there
+		// is no Authorization header (no session middleware). The user identity
+		// comes from the signed state token which was created during the
+		// authorize step while the user was authenticated.
+		userID := state.UserID
 
 		// Look up profile for the user
-		profile, err := db.GetProfileByUserID(r.Context(), deps.DB, sessionUserID)
+		profile, err := db.GetProfileByUserID(r.Context(), deps.DB, userID)
 		if err != nil || profile == nil {
 			log.Printf("[%s] OAuthCallback: profile lookup failed: %v", TraceID(r.Context()), err)
 			redirectToFrontend(w, r, deps, providerID, "error", "Profile not found")

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -12,7 +12,7 @@
 // Security:
 //   - CSRF protection via signed JWT state tokens (HS256, 10-min TTL)
 //   - State encodes user ID + provider to prevent session fixation
-//   - Callback verifies session user matches the state token's user
+//   - Callback derives user identity from the signed state token (no session required)
 //   - Tokens stored server-side in Supabase Vault (AES-256-GCM)
 //   - Provider path params validated against ProviderIDPattern
 //   - No tokens or secrets are ever returned in API responses
@@ -466,17 +466,11 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Check for error from provider (e.g. user denied consent)
-		if errCode := r.URL.Query().Get("error"); errCode != "" {
-			errDesc := r.URL.Query().Get("error_description")
-			if errDesc == "" {
-				errDesc = errCode
-			}
-			redirectToFrontend(w, r, deps, providerID, "error", errDesc)
-			return
-		}
-
-		// Validate CSRF state
+		// Validate CSRF state first — even for error responses from the provider.
+		// Since this endpoint has no session middleware, the signed state token is
+		// the sole proof that the request originated from our authorize flow.
+		// Validating it before anything else prevents unauthenticated callers from
+		// triggering frontend redirects with arbitrary error text.
 		stateStr := r.URL.Query().Get("state")
 		if stateStr == "" {
 			redirectToFrontend(w, r, deps, providerID, "error", "Missing state parameter")
@@ -491,6 +485,18 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		if state.Provider != providerID {
 			log.Printf("[%s] OAuthCallback: provider mismatch: state=%s path=%s", TraceID(r.Context()), state.Provider, providerID)
 			redirectToFrontend(w, r, deps, providerID, "error", "Provider mismatch")
+			return
+		}
+
+		// Check for error from provider (e.g. user denied consent).
+		// This runs after state validation so only legitimate OAuth flows can
+		// surface error messages to the frontend.
+		if errCode := r.URL.Query().Get("error"); errCode != "" {
+			errDesc := r.URL.Query().Get("error_description")
+			if errDesc == "" {
+				errDesc = errCode
+			}
+			redirectToFrontend(w, r, deps, providerID, "error", errDesc)
 			return
 		}
 

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -694,7 +694,14 @@ func TestOAuthCallback_ProviderError(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?error=access_denied&error_description=User+denied+consent", nil)
+	// State validation now runs before the provider error check, so we need a
+	// valid state token to reach the error-handling branch.
+	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "")
+	if err != nil {
+		t.Fatalf("createOAuthState: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?error=access_denied&error_description=User+denied+consent&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -707,6 +714,31 @@ func TestOAuthCallback_ProviderError(t *testing.T) {
 	}
 	if !strings.Contains(location, "User+denied+consent") && !strings.Contains(location, "User%20denied%20consent") {
 		t.Errorf("expected error description in redirect, got: %s", location)
+	}
+}
+
+func TestOAuthCallback_ProviderErrorWithoutState(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	deps := oauthDeps(tx)
+	router := NewRouter(deps)
+
+	// Without a valid state token, the provider error should NOT be reflected
+	// to the frontend — the request is rejected at state validation instead.
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?error=access_denied&error_description=Injected+text", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
+	}
+	location := w.Header().Get("Location")
+	if strings.Contains(location, "Injected") {
+		t.Errorf("unauthenticated error_description should not be reflected, got: %s", location)
+	}
+	if !strings.Contains(location, "Missing+state+parameter") && !strings.Contains(location, "Missing%20state%20parameter") {
+		t.Errorf("expected missing state error, got: %s", location)
 	}
 }
 

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -621,7 +621,7 @@ func TestOAuthCallback_MissingState(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code", uid)
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?code=test-code", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -644,7 +644,7 @@ func TestOAuthCallback_InvalidState(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code&state=invalid-jwt", uid)
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?code=test-code&state=invalid-jwt", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -672,37 +672,7 @@ func TestOAuthCallback_ProviderMismatch(t *testing.T) {
 		t.Fatalf("create state: %v", err)
 	}
 
-	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), uid)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, r)
-
-	if w.Code != http.StatusTemporaryRedirect {
-		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
-	}
-	location := w.Header().Get("Location")
-	if !strings.Contains(location, "oauth_status=error") {
-		t.Errorf("expected error status in redirect, got: %s", location)
-	}
-}
-
-func TestOAuthCallback_UserMismatch(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid1 := testhelper.GenerateUID(t)
-	uid2 := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid1, "u1_"+uid1[:8])
-	testhelper.InsertUser(t, tx, uid2, "u2_"+uid2[:8])
-
-	deps := oauthDeps(tx)
-	router := NewRouter(deps)
-
-	// State is for user1 but session is user2
-	state, err := createOAuthState(deps, uid1, "google", []string{"openid"}, "")
-	if err != nil {
-		t.Fatalf("create state: %v", err)
-	}
-
-	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), uid2)
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?code=test-code&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -724,7 +694,7 @@ func TestOAuthCallback_ProviderError(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?error=access_denied&error_description=User+denied+consent", uid)
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?error=access_denied&error_description=User+denied+consent", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -754,7 +724,7 @@ func TestOAuthCallback_MissingCode(t *testing.T) {
 		t.Fatalf("create state: %v", err)
 	}
 
-	r := authenticatedRequest(t, http.MethodGet, "/oauth/google/callback?state="+url.QueryEscape(state), uid)
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/callback?state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 


### PR DESCRIPTION
## Summary
- The OAuth callback endpoint (`GET /oauth/{provider}/callback`) was wrapped in `requireSession` middleware, which requires an `Authorization: Bearer <token>` header
- When Google redirects back after user consent, it's a plain browser redirect — there is no Authorization header, so the middleware returned `{"error":{"code":"invalid_token","message":"Missing Authorization header"}}`
- Removed `requireSession` from the callback route and instead use the user identity from the signed CSRF state token (HS256, 10-min TTL), which was created during the authorize step while the user was authenticated
- The state token already encodes user ID + provider + scopes, providing equivalent authentication without needing a session header

## Test plan

### Claude Code
- [x] All OAuth tests pass (`go test ./api/... -run TestOAuth`)
- [x] Full backend test suite passes (`go test ./api/...`)
- [x] `go build ./api/...` compiles clean
- [x] Removed `TestOAuthCallback_UserMismatch` (no longer applicable — no session to compare)

### OpenClaw
- [ ] Open the app on mobile, tap "Connect with Google" on the connector setup modal
- [ ] Complete the Google consent screen
- [ ] Verify the callback redirects to `/settings?oauth_status=success` instead of returning a JSON error
- [ ] Verify the connection appears in the connections list

https://claude.ai/code/session_01AKyL4biF5wqtSC1yxmjQkk