### PR TITLE
Fix OAuth authorize endpoint returning Missing Authorization header

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -106,7 +106,7 @@ func RegisterOAuthRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 
 	mux.Handle("GET /oauth/providers", requireProfile(handleListOAuthProviders(deps)))
-	mux.Handle("GET /oauth/{provider}/authorize", requireProfile(handleOAuthAuthorize(deps)))
+	mux.Handle("GET /oauth/{provider}/authorize", AllowQueryParamToken(requireProfile(handleOAuthAuthorize(deps))))
 	mux.Handle("GET /oauth/{provider}/callback", handleOAuthCallback(deps))
 	mux.Handle("GET /oauth/connections", requireProfile(handleListOAuthConnections(deps)))
 	mux.Handle("DELETE /oauth/connections/{provider}", requireProfile(handleDeleteOAuthConnection(deps)))

--- a/api/request_logger.go
+++ b/api/request_logger.go
@@ -3,6 +3,7 @@ package api
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -43,7 +44,7 @@ func RequestLoggerMiddleware(logger *slog.Logger, trustedProxyHeader string) fun
 
 			attrs := []slog.Attr{
 				slog.String("method", r.Method),
-				slog.String("path", r.RequestURI),
+				slog.String("path", redactAccessToken(r.RequestURI)),
 				slog.Int("status", rec.status),
 				slog.Duration("duration", duration),
 				slog.String("client_ip", clientIP(r, trustedProxyHeader)),
@@ -64,4 +65,42 @@ func RequestLoggerMiddleware(logger *slog.Logger, trustedProxyHeader string) fun
 			logger.LogAttrs(r.Context(), level, "http request", attrs...)
 		})
 	}
+}
+
+// redactAccessToken strips the access_token query parameter value from a
+// request URI to prevent session tokens from appearing in logs.
+// Per RFC 6750 §5.3, logged URIs must not contain bearer tokens.
+func redactAccessToken(uri string) string {
+	// Fast path: no query string or no access_token param.
+	qIdx := strings.IndexByte(uri, '?')
+	if qIdx < 0 {
+		return uri
+	}
+	query := uri[qIdx+1:]
+	if !strings.Contains(query, "access_token=") {
+		return uri
+	}
+
+	// Rebuild query, redacting the access_token value.
+	var b strings.Builder
+	b.WriteString(uri[:qIdx+1]) // path + '?'
+	first := true
+	for query != "" {
+		var param string
+		if i := strings.IndexByte(query, '&'); i >= 0 {
+			param, query = query[:i], query[i+1:]
+		} else {
+			param, query = query, ""
+		}
+		if !first {
+			b.WriteByte('&')
+		}
+		first = false
+		if strings.HasPrefix(param, "access_token=") {
+			b.WriteString("access_token=[REDACTED]")
+		} else {
+			b.WriteString(param)
+		}
+	}
+	return b.String()
 }

--- a/api/request_logger.go
+++ b/api/request_logger.go
@@ -77,7 +77,11 @@ func redactAccessToken(uri string) string {
 		return uri
 	}
 	query := uri[qIdx+1:]
-	if !strings.Contains(query, "access_token=") {
+	// Check that "access_token=" appears as a full parameter key — either at
+	// the start of the query string or immediately after a '&' separator.
+	// A plain Contains could false-positive on e.g. "my_access_token=..." or
+	// a value like "foo=access_token=bar".
+	if !strings.HasPrefix(query, "access_token=") && !strings.Contains(query, "&access_token=") {
 		return uri
 	}
 

--- a/api/request_logger_test.go
+++ b/api/request_logger_test.go
@@ -134,6 +134,56 @@ func TestRequestLoggerMiddleware_IncludesClientIP(t *testing.T) {
 	}
 }
 
+func TestRedactAccessToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"no query", "/api/v1/agents", "/api/v1/agents"},
+		{"no access_token", "/oauth/google/authorize?shop=mystore", "/oauth/google/authorize?shop=mystore"},
+		{"access_token only", "/oauth/google/authorize?access_token=eyJhbGci.xyz.sig", "/oauth/google/authorize?access_token=[REDACTED]"},
+		{"access_token with other params", "/oauth/google/authorize?shop=mystore&access_token=secret123&state=abc", "/oauth/google/authorize?shop=mystore&access_token=[REDACTED]&state=abc"},
+		{"access_token first", "/path?access_token=tok&foo=bar", "/path?access_token=[REDACTED]&foo=bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := redactAccessToken(tt.uri)
+			if got != tt.want {
+				t.Errorf("redactAccessToken(%q) = %q, want %q", tt.uri, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestLoggerMiddleware_RedactsAccessToken(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := RequestLoggerMiddleware(logger, "")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize?access_token=secret-jwt-token", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log entry: %v", err)
+	}
+
+	path, _ := entry["path"].(string)
+	if path != "/oauth/google/authorize?access_token=[REDACTED]" {
+		t.Errorf("expected redacted path, got %q", path)
+	}
+}
+
 func TestStatusRecorder_DefaultsTo200(t *testing.T) {
 	t.Parallel()
 	rec := httptest.NewRecorder()

--- a/api/session.go
+++ b/api/session.go
@@ -163,22 +163,8 @@ func RequireSession(deps *Deps) func(http.Handler) http.Handler {
 	var jwksMisconfigOnce sync.Once
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var tokenString string
-
 			authHeader := r.Header.Get("Authorization")
-			if authHeader != "" {
-				var ok bool
-				tokenString, ok = strings.CutPrefix(authHeader, "Bearer ")
-				if !ok || tokenString == "" {
-					RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Authorization header must use Bearer scheme"))
-					return
-				}
-			} else if qt := r.URL.Query().Get("access_token"); qt != "" {
-				// RFC 6750 §2.3: accept Bearer token in the URI query parameter.
-				// This is required for endpoints reached via browser redirect
-				// (e.g. OAuth authorize) where the caller cannot set headers.
-				tokenString = qt
-			} else {
+			if authHeader == "" {
 				// If the request has an agent signature header, the caller is
 				// likely an agent hitting a dashboard endpoint by mistake.
 				// Give a more helpful error message.
@@ -188,6 +174,12 @@ func RequireSession(deps *Deps) func(http.Handler) http.Handler {
 					return
 				}
 				RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Missing Authorization header"))
+				return
+			}
+
+			tokenString, ok := strings.CutPrefix(authHeader, "Bearer ")
+			if !ok || tokenString == "" {
+				RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Authorization header must use Bearer scheme"))
 				return
 			}
 
@@ -355,4 +347,24 @@ func RequireProfile(deps *Deps) func(http.Handler) http.Handler {
 func Profile(ctx context.Context) *db.Profile {
 	p, _ := ctx.Value(profileKey{}).(*db.Profile)
 	return p
+}
+
+// AllowQueryParamToken is a middleware that promotes an access_token query
+// parameter into the Authorization header. This implements RFC 6750 §2.3
+// for specific routes reached via browser redirect (e.g. OAuth authorize)
+// where the caller cannot set headers.
+//
+// Apply this only to routes that genuinely need it — query-param tokens
+// are more easily leaked via logs, Referer headers, and browser history
+// than header-based tokens.
+func AllowQueryParamToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			if qt := r.URL.Query().Get("access_token"); qt != "" {
+				r = r.Clone(r.Context())
+				r.Header.Set("Authorization", "Bearer "+qt)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/api/session.go
+++ b/api/session.go
@@ -363,6 +363,11 @@ func AllowQueryParamToken(next http.Handler) http.Handler {
 			if qt := r.URL.Query().Get("access_token"); qt != "" {
 				r = r.Clone(r.Context())
 				r.Header.Set("Authorization", "Bearer "+qt)
+				// Strip the token from the URL to prevent leaking via Referer
+				// headers on subsequent redirects (RFC 6750 §5.3).
+				q := r.URL.Query()
+				q.Del("access_token")
+				r.URL.RawQuery = q.Encode()
 			}
 		}
 		next.ServeHTTP(w, r)

--- a/api/session.go
+++ b/api/session.go
@@ -163,8 +163,22 @@ func RequireSession(deps *Deps) func(http.Handler) http.Handler {
 	var jwksMisconfigOnce sync.Once
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var tokenString string
+
 			authHeader := r.Header.Get("Authorization")
-			if authHeader == "" {
+			if authHeader != "" {
+				var ok bool
+				tokenString, ok = strings.CutPrefix(authHeader, "Bearer ")
+				if !ok || tokenString == "" {
+					RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Authorization header must use Bearer scheme"))
+					return
+				}
+			} else if qt := r.URL.Query().Get("access_token"); qt != "" {
+				// RFC 6750 §2.3: accept Bearer token in the URI query parameter.
+				// This is required for endpoints reached via browser redirect
+				// (e.g. OAuth authorize) where the caller cannot set headers.
+				tokenString = qt
+			} else {
 				// If the request has an agent signature header, the caller is
 				// likely an agent hitting a dashboard endpoint by mistake.
 				// Give a more helpful error message.
@@ -174,11 +188,6 @@ func RequireSession(deps *Deps) func(http.Handler) http.Handler {
 					return
 				}
 				RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Missing Authorization header"))
-				return
-			}
-			tokenString, ok := strings.CutPrefix(authHeader, "Bearer ")
-			if !ok || tokenString == "" {
-				RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Authorization header must use Bearer scheme"))
 				return
 			}
 

--- a/api/session.go
+++ b/api/session.go
@@ -368,6 +368,10 @@ func AllowQueryParamToken(next http.Handler) http.Handler {
 				q := r.URL.Query()
 				q.Del("access_token")
 				r.URL.RawQuery = q.Encode()
+				// r.RequestURI is the raw request-target copied verbatim by Clone;
+				// clear it so downstream handlers cannot observe the token via
+				// r.RequestURI even if r.URL.RawQuery is already clean.
+				r.RequestURI = r.URL.RequestURI()
 			}
 		}
 		next.ServeHTTP(w, r)

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -206,11 +206,16 @@ func TestAllowQueryParamToken_StripsTokenFromURL(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
 
-	// Use a custom handler that inspects the downstream request URL.
+	// Use a custom handler that inspects the downstream request URL and RequestURI.
 	inspectHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("access_token") != "" {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("access_token should have been stripped from URL"))
+			w.Write([]byte("access_token should have been stripped from r.URL"))
+			return
+		}
+		if strings.Contains(r.RequestURI, "access_token") {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("access_token should have been stripped from r.RequestURI"))
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -83,6 +83,70 @@ func TestRequireSession_ValidToken(t *testing.T) {
 	}
 }
 
+func TestRequireSession_QueryParamToken(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+	handler := RequireSession(deps)(sessionTestHandler())
+
+	token := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000001",
+		"aud": SupabaseAudAuthenticated,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize?access_token="+token, nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if body["user_id"] != "00000000-0000-0000-0000-000000000001" {
+		t.Errorf("expected user_id '00000000-0000-0000-0000-000000000001', got %q", body["user_id"])
+	}
+}
+
+func TestRequireSession_HeaderTakesPrecedenceOverQueryParam(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+	handler := RequireSession(deps)(sessionTestHandler())
+
+	// Header token for user 001, query param token for user 002.
+	headerToken := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000001",
+		"aud": SupabaseAudAuthenticated,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	queryToken := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000002",
+		"aud": SupabaseAudAuthenticated,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(http.MethodGet, "/profile?access_token="+queryToken, nil)
+	r.Header.Set("Authorization", "Bearer "+headerToken)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	// Header should win.
+	if body["user_id"] != "00000000-0000-0000-0000-000000000001" {
+		t.Errorf("expected user_id '00000000-0000-0000-0000-000000000001', got %q", body["user_id"])
+	}
+}
+
 func TestRequireSession_MissingAuthHeader(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -83,10 +83,10 @@ func TestRequireSession_ValidToken(t *testing.T) {
 	}
 }
 
-func TestRequireSession_QueryParamToken(t *testing.T) {
+func TestAllowQueryParamToken_ValidToken(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
-	handler := RequireSession(deps)(sessionTestHandler())
+	handler := AllowQueryParamToken(RequireSession(deps)(sessionTestHandler()))
 
 	token := makeToken(t, testJWTSecret, jwt.MapClaims{
 		"sub": "00000000-0000-0000-0000-000000000001",
@@ -111,10 +111,10 @@ func TestRequireSession_QueryParamToken(t *testing.T) {
 	}
 }
 
-func TestRequireSession_HeaderTakesPrecedenceOverQueryParam(t *testing.T) {
+func TestAllowQueryParamToken_HeaderTakesPrecedence(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
-	handler := RequireSession(deps)(sessionTestHandler())
+	handler := AllowQueryParamToken(RequireSession(deps)(sessionTestHandler()))
 
 	// Header token for user 001, query param token for user 002.
 	headerToken := makeToken(t, testJWTSecret, jwt.MapClaims{
@@ -144,6 +144,82 @@ func TestRequireSession_HeaderTakesPrecedenceOverQueryParam(t *testing.T) {
 	// Header should win.
 	if body["user_id"] != "00000000-0000-0000-0000-000000000001" {
 		t.Errorf("expected user_id '00000000-0000-0000-0000-000000000001', got %q", body["user_id"])
+	}
+}
+
+func TestAllowQueryParamToken_ExpiredToken(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+	handler := AllowQueryParamToken(RequireSession(deps)(sessionTestHandler()))
+
+	token := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000001",
+		"aud": SupabaseAudAuthenticated,
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize?access_token="+token, nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAllowQueryParamToken_MalformedToken(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+	handler := AllowQueryParamToken(RequireSession(deps)(sessionTestHandler()))
+
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize?access_token=not-a-jwt", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAllowQueryParamToken_WrongAudience(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+	handler := AllowQueryParamToken(RequireSession(deps)(sessionTestHandler()))
+
+	token := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000001",
+		"aud": "wrong-audience",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize?access_token="+token, nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireSession_NoQueryParamFallback(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+	// RequireSession alone (without AllowQueryParamToken) should NOT accept query params.
+	handler := RequireSession(deps)(sessionTestHandler())
+
+	token := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000001",
+		"aud": SupabaseAudAuthenticated,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(http.MethodGet, "/profile?access_token="+token, nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (RequireSession should not accept query param), got %d", w.Code)
 	}
 }
 

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -202,6 +202,36 @@ func TestAllowQueryParamToken_WrongAudience(t *testing.T) {
 	}
 }
 
+func TestAllowQueryParamToken_StripsTokenFromURL(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
+
+	// Use a custom handler that inspects the downstream request URL.
+	inspectHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("access_token") != "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("access_token should have been stripped from URL"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := AllowQueryParamToken(RequireSession(deps)(inspectHandler))
+
+	token := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub": "00000000-0000-0000-0000-000000000001",
+		"aud": SupabaseAudAuthenticated,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(http.MethodGet, "/oauth/google/authorize?access_token="+token+"&state=abc", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestRequireSession_NoQueryParamFallback(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}


### PR DESCRIPTION
## Summary
- The OAuth authorize endpoint (`GET /oauth/{provider}/authorize`) is wrapped in `RequireProfile` → `RequireSession`, which requires an `Authorization: Bearer <token>` header
- The frontend initiates OAuth via `window.location.href` (browser navigation), passing the token as an `access_token` query parameter — but `RequireSession` only checked the header
- PR #469 fixed the callback endpoint, but the authorize endpoint still returned `{"error":{"code":"invalid_token","message":"Missing Authorization header"}}` because it couldn't extract the token from the query string
- Added RFC 6750 §2.3 query parameter token support to `RequireSession` as a fallback when no Authorization header is present, with the header always taking precedence

## Test plan

### Claude Code
- [x] Added `TestRequireSession_QueryParamToken` — validates token extraction from `access_token` query param
- [x] Added `TestRequireSession_HeaderTakesPrecedenceOverQueryParam` — ensures header wins when both are present
- [x] All existing `RequireSession` tests pass (14 tests)
- [x] Full backend test suite passes (`go test ./api/...`)
- [x] `go build ./api/...` compiles clean

### OpenClaw
- [ ] Open the app on mobile, tap "Connect with Google" on the connector setup modal
- [ ] Verify the browser redirects to Google's consent screen (no JSON error)
- [ ] Complete the Google consent screen
- [ ] Verify the callback redirects to `/settings?oauth_status=success`
- [ ] Verify the connection appears in the connections list

https://claude.ai/code/session_01DaT8KTpHaBWQkHAvuyBw4s