### PR TITLE
Sort enabled connectors first in agent connector grid

### DIFF
--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -53,13 +53,21 @@ export function AgentConnectorsSection({
   const enabledIds = new Set(enabledConnectors.map((c) => c.id));
 
   const query = search.trim().toLowerCase();
-  const filtered = query
-    ? allConnectors.filter(
-        (c) =>
-          c.name.toLowerCase().includes(query) ||
-          c.description?.toLowerCase().includes(query),
-      )
-    : allConnectors;
+  const filtered = (
+    query
+      ? allConnectors.filter(
+          (c) =>
+            c.name.toLowerCase().includes(query) ||
+            c.description?.toLowerCase().includes(query),
+        )
+      : allConnectors
+  )
+    .slice()
+    .sort((a, b) => {
+      const aEnabled = enabledIds.has(a.id) ? 0 : 1;
+      const bEnabled = enabledIds.has(b.id) ? 0 : 1;
+      return aEnabled - bEnabled;
+    });
 
   async function handleClick(connector: ConnectorSummary) {
     if (enabledIds.has(connector.id)) {


### PR DESCRIPTION
## Summary
- Enabled connectors are now sorted to the top of the connector grid on the agent detail page
- Previously, enabled connectors (like Google) could be buried among many disabled ones in alphabetical order
- The sort is stable — enabled connectors maintain their relative order among themselves, as do disabled ones

## Test plan
### Claude Code
- [x] All 710 frontend tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### OpenClaw
- [ ] Visually verify on the agent detail page that enabled connectors appear first in the grid
- [ ] Verify search filtering still works correctly with the new sort order

https://claude.ai/code/session_01Xm5aqHTBgDewGBBtSGEKxZ