### PR TITLE
Fix cross-user data leakage on agent pages

### DIFF
--- a/frontend/src/hooks/__tests__/useSignOut.test.tsx
+++ b/frontend/src/hooks/__tests__/useSignOut.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { AuthError } from "@supabase/supabase-js";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockAuth, setupAuthMocks } from "../../auth/__tests__/fixtures";
@@ -76,5 +77,25 @@ describe("useSignOut", () => {
     });
 
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("clears React Query cache on sign-out", async () => {
+    mockAuth.signOut.mockResolvedValue({ error: null });
+
+    const { result } = renderHook(
+      () => ({ signOut: useSignOut(), queryClient: useQueryClient() }),
+      { wrapper },
+    );
+
+    // Seed the cache with data from the current user.
+    result.current.queryClient.setQueryData(["agent", 42], { agent_id: 42 });
+    expect(result.current.queryClient.getQueryData(["agent", 42])).toBeDefined();
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    // Cache should be empty after sign-out.
+    expect(result.current.queryClient.getQueryData(["agent", 42])).toBeUndefined();
   });
 });

--- a/frontend/src/hooks/useSignOut.ts
+++ b/frontend/src/hooks/useSignOut.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useAuth } from "@/auth/AuthContext";
 import { MFA_PENDING_ENROLLMENT_KEY } from "@/auth/mfaPendingEnrollment";
@@ -11,6 +12,7 @@ import { MFA_PENDING_ENROLLMENT_KEY } from "@/auth/mfaPendingEnrollment";
  */
 export function useSignOut() {
   const { signOut } = useAuth();
+  const queryClient = useQueryClient();
 
   const handleSignOut = useCallback(async () => {
     // Clear MFA enrollment state before sign-out so it doesn't leak
@@ -21,12 +23,16 @@ export function useSignOut() {
       // sessionStorage unavailable
     }
 
+    // Clear all cached query data so the next user doesn't see
+    // the previous user's agents, connectors, approvals, etc.
+    queryClient.clear();
+
     const { error } = await signOut();
     if (error) {
       console.error("Sign out failed:", error);
       toast.error("Sign out failed. Please try again.");
     }
-  }, [signOut]);
+  }, [signOut, queryClient]);
 
   return handleSignOut;
 }

--- a/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { ArrowLeft, ExternalLink, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useAgent } from "@/hooks/useAgent";
 import { useActionConfigs } from "@/hooks/useActionConfigs";
 import { useConnectorDetail } from "@/hooks/useConnectorDetail";
 import { useAgentConnectors } from "@/hooks/useAgentConnectors";
@@ -24,6 +25,11 @@ export function ConnectorConfigPage() {
   // prevents the fetch without creating a query keyed on NaN.
   const agentId = paramsValid ? parsedAgentId : 0;
 
+  // Verify the current user owns this agent. The backend scopes by user,
+  // so a non-owned agent returns 404. Without this check the page would
+  // still render public connector catalog data for arbitrary agent IDs.
+  const { agent, isLoading: agentLoading, error: agentError } = useAgent(agentId);
+
   const {
     connector,
     isLoading: connectorLoading,
@@ -43,7 +49,7 @@ export function ConnectorConfigPage() {
   const connectorConfigs = configs.filter((c) => c.connector_id === connectorId);
 
   const hasRequiredCredentials =
-    !connectorLoading && !!connector && connector.required_credentials.length > 0;
+    !connectorLoading && !!connector && (connector.required_credentials?.length ?? 0) > 0;
   const hasConfigCredentials = connectorConfigs.some((c) => !!c.credential_id);
   const shouldFetchCredentials = hasRequiredCredentials || hasConfigCredentials;
   const { credentials } = useCredentials({ enabled: shouldFetchCredentials });
@@ -59,6 +65,34 @@ export function ConnectorConfigPage() {
         <p className="text-destructive text-sm">
           Invalid agent ID or connector ID.
         </p>
+      </div>
+    );
+  }
+
+  // Block access until we confirm the current user owns this agent.
+  if (agentLoading) {
+    return (
+      <div className="space-y-4">
+        <BackLink to={backTo} />
+        <div
+          className="flex items-center justify-center py-12"
+          role="status"
+          aria-label="Loading agent"
+        >
+          <Loader2
+            className="text-muted-foreground size-6 animate-spin"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (agentError || !agent) {
+    return (
+      <div className="space-y-4">
+        <BackLink to={backTo} />
+        <p className="text-destructive text-sm">Agent not found.</p>
       </div>
     );
   }

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
@@ -73,6 +73,13 @@ const mockCredentialsResponse = {
   ],
 };
 
+const mockAgentResponse = {
+  agent_id: 42,
+  status: "registered",
+  metadata: { name: "Test Agent" },
+  created_at: "2026-02-10T10:00:00Z",
+};
+
 const mockActionConfigsResponse = {
   data: [],
 };
@@ -115,6 +122,9 @@ describe("ConnectorConfigPage", () => {
 
   it("renders connector details after loading", async () => {
     mockGet.mockImplementation((path: string) => {
+      if (path === "/v1/agents/{agent_id}") {
+        return Promise.resolve({ data: mockAgentResponse });
+      }
       if (path === "/v1/connectors/{connector_id}") {
         return Promise.resolve({ data: mockDetailResponse });
       }
@@ -156,8 +166,37 @@ describe("ConnectorConfigPage", () => {
     expect(screen.getByText("Disable")).toBeInTheDocument();
   });
 
+  it("shows 'Agent not found' when user does not own the agent", async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/v1/agents/{agent_id}") {
+        return Promise.resolve({ error: { message: "Not found" } });
+      }
+      // Connector detail is a public endpoint and still resolves,
+      // but the ownership gate should prevent rendering it.
+      if (path === "/v1/connectors/{connector_id}") {
+        return Promise.resolve({ data: mockDetailResponse });
+      }
+      if (path === "/v1/agents/{agent_id}/connectors") {
+        return Promise.resolve({ error: { message: "Not found" } });
+      }
+      if (path === "/v1/action-configurations") {
+        return Promise.resolve({ data: mockActionConfigsResponse });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent not found.")).toBeInTheDocument();
+    });
+  });
+
   it("shows error when connector not found", async () => {
     mockGet.mockImplementation((path: string) => {
+      if (path === "/v1/agents/{agent_id}") {
+        return Promise.resolve({ data: mockAgentResponse });
+      }
       if (path === "/v1/connectors/{connector_id}") {
         return Promise.reject(new Error("Not found"));
       }
@@ -182,6 +221,9 @@ describe("ConnectorConfigPage", () => {
 
   it("shows credentials as not configured when none stored", async () => {
     mockGet.mockImplementation((path: string) => {
+      if (path === "/v1/agents/{agent_id}") {
+        return Promise.resolve({ data: mockAgentResponse });
+      }
       if (path === "/v1/connectors/{connector_id}") {
         return Promise.resolve({ data: mockDetailResponse });
       }


### PR DESCRIPTION
## Summary

- **Clear React Query cache on sign-out** (`useSignOut.ts`): Without this, cached agent/connector/approval data from User A persisted in the browser's memory and was visible to User B after login on the same tab. Added `queryClient.clear()` before the Supabase sign-out call.
- **Add agent ownership gate to ConnectorConfigPage**: The page at `/agents/:id/connectors/:connectorId` rendered public connector catalog data for arbitrary agent IDs because it didn't call `useAgent()` to verify ownership. Now it blocks rendering until the backend confirms the current user owns the agent (returning 404 for non-owned agents).
- **Defensive null check**: Added optional chaining on `connector.required_credentials` access to prevent crashes when connector data is in a partial/loading state.

**Backend was already secure** — all agent DB queries are scoped by the authenticated user's ID. These fixes close the frontend gaps.

## Test plan

### Claude Code
- [x] All 712 frontend tests pass (including new test for cache clearing and agent ownership denial)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Production build succeeds (`vite build`)

### OpenClaw
- [ ] Manual test: Log in as User A, navigate to an agent config page, log out, log in as User B — verify User A's agent data is not visible
- [ ] Manual test: As User B, navigate directly to `/agents/<User A's agent ID>/connectors/google` — verify "Agent not found" is shown
- [ ] Verify no regressions on normal agent config flow (view agent, enable/disable connectors)

https://claude.ai/code/session_01MgDDDcrLXvyTN9sXdetqZG