### PR TITLE
feat: add enable-all wildcard option for connector action configs

### DIFF
--- a/api/action_config_validate.go
+++ b/api/action_config_validate.go
@@ -57,6 +57,9 @@ func ValidateConfigurationReference(
 
 	// 3. Validate action type matches.
 	// Wildcard configs (action_type = "*") match any action type.
+	// SECURITY: This is safe because execution still requires a standing approval
+	// (or interactive approval) that matches the specific action type being
+	// executed. The wildcard config alone does not grant execution rights.
 	if ac.ActionType != db.WildcardActionType && ac.ActionType != actionType {
 		resp := BadRequest(ErrConfigActionTypeMismatch, "Action type does not match configuration")
 		resp.Error.Details = map[string]any{
@@ -69,6 +72,7 @@ func ValidateConfigurationReference(
 
 	// 4. Validate parameters against configuration constraints.
 	// Wildcard configs allow any parameters — skip validation entirely.
+	// SECURITY: Safe for the same reason as step 3 — standing approvals gate execution.
 	if ac.ActionType != db.WildcardActionType {
 		if err := db.ValidateParametersAgainstConfig(ac.Parameters, parameters); err != nil {
 			var configErr *db.ConfigValidationError

--- a/api/action_config_validate.go
+++ b/api/action_config_validate.go
@@ -56,7 +56,8 @@ func ValidateConfigurationReference(
 	}
 
 	// 3. Validate action type matches.
-	if ac.ActionType != actionType {
+	// Wildcard configs (action_type = "*") match any action type.
+	if ac.ActionType != db.WildcardActionType && ac.ActionType != actionType {
 		resp := BadRequest(ErrConfigActionTypeMismatch, "Action type does not match configuration")
 		resp.Error.Details = map[string]any{
 			"configuration_action_type": ac.ActionType,
@@ -67,20 +68,23 @@ func ValidateConfigurationReference(
 	}
 
 	// 4. Validate parameters against configuration constraints.
-	if err := db.ValidateParametersAgainstConfig(ac.Parameters, parameters); err != nil {
-		var configErr *db.ConfigValidationError
-		if errors.As(err, &configErr) {
-			resp := BadRequest(ErrInvalidParameters, "Parameters do not comply with configuration constraints")
-			resp.Error.Details = map[string]any{
-				"parameter":        configErr.Parameter,
-				"constraint_error": configErr.Reason,
+	// Wildcard configs allow any parameters — skip validation entirely.
+	if ac.ActionType != db.WildcardActionType {
+		if err := db.ValidateParametersAgainstConfig(ac.Parameters, parameters); err != nil {
+			var configErr *db.ConfigValidationError
+			if errors.As(err, &configErr) {
+				resp := BadRequest(ErrInvalidParameters, "Parameters do not comply with configuration constraints")
+				resp.Error.Details = map[string]any{
+					"parameter":        configErr.Parameter,
+					"constraint_error": configErr.Reason,
+				}
+				RespondError(w, r, http.StatusBadRequest, resp)
+				return nil
 			}
-			RespondError(w, r, http.StatusBadRequest, resp)
+			log.Printf("[%s] ValidateConfigurationReference: param validation: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to validate parameters"))
 			return nil
 		}
-		log.Printf("[%s] ValidateConfigurationReference: param validation: %v", TraceID(r.Context()), err)
-		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to validate parameters"))
-		return nil
 	}
 
 	return &ConfigValidationResult{Config: ac}

--- a/api/action_config_validate_test.go
+++ b/api/action_config_validate_test.go
@@ -407,6 +407,35 @@ func TestValidateConfigurationReference_WildcardMatchesAnyActionType(t *testing.
 	}
 }
 
+func TestValidateConfigurationReference_WildcardDisabledConfig(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".some_action", "Some Action")
+
+	configID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfigFull(t, tx, configID, agentID, uid, connID, "*", testhelper.ActionConfigOpts{
+		Name:   "All Actions",
+		Status: "disabled",
+	})
+
+	// A disabled wildcard config should be rejected. The query filters by
+	// status='active', so it returns not-found (400) rather than found-but-disabled (403).
+	deps, w, r := newTestRequest(tx)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, connID+".some_action", json.RawMessage(`{}`))
+	if result != nil {
+		t.Fatal("expected nil result for disabled wildcard config")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for disabled config (filtered by query), got %d", w.Code)
+	}
+	assertErrorCode(t, w.Body.Bytes(), string(ErrInvalidConfiguration))
+}
+
 func TestValidateConfigurationReference_WildcardAcceptsAnyParameters(t *testing.T) {
 	t.Parallel()
 	tx, _, agentID, connID, configID := setupWildcardConfigTest(t)

--- a/api/action_config_validate_test.go
+++ b/api/action_config_validate_test.go
@@ -361,3 +361,75 @@ func assertErrorCode(t *testing.T, body []byte, expectedCode string) {
 		t.Errorf("expected error code %q, got %q", expectedCode, resp.Error.Code)
 	}
 }
+
+// ── Wildcard Action Type Tests ──────────────────────────────────────────────
+
+// setupWildcardConfigTest creates a wildcard (action_type="*") config.
+// Returns (tx, userID, agentID, connectorID, configID).
+func setupWildcardConfigTest(t *testing.T) (db.DBTX, string, int64, string, string) {
+	t.Helper()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".some_action", "Some Action")
+
+	configID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfigFull(t, tx, configID, agentID, uid, connID, "*", testhelper.ActionConfigOpts{
+		Name: "All Actions",
+	})
+
+	return tx, uid, agentID, connID, configID
+}
+
+func TestValidateConfigurationReference_WildcardMatchesAnyActionType(t *testing.T) {
+	t.Parallel()
+	tx, _, agentID, connID, configID := setupWildcardConfigTest(t)
+
+	// Wildcard config should accept any action type.
+	actionTypes := []string{
+		connID + ".some_action",
+		connID + ".another_action",
+		"completely.different.action",
+	}
+
+	for _, at := range actionTypes {
+		t.Run(at, func(t *testing.T) {
+			deps, w, r := newTestRequest(tx)
+			execParams := json.RawMessage(`{"any_param":"any_value"}`)
+			result := ValidateConfigurationReference(w, r, deps, configID, agentID, at, execParams)
+			if result == nil {
+				t.Errorf("expected wildcard config to match action type %q, got error: %s", at, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestValidateConfigurationReference_WildcardAcceptsAnyParameters(t *testing.T) {
+	t.Parallel()
+	tx, _, agentID, connID, configID := setupWildcardConfigTest(t)
+
+	// Wildcard config should accept any parameters (including extra ones).
+	tests := []struct {
+		name       string
+		execParams string
+	}{
+		{"empty params", `{}`},
+		{"single param", `{"key":"value"}`},
+		{"many params", `{"a":"1","b":"2","c":"3","d":"4"}`},
+		{"nested objects", `{"config":{"nested":{"deep":"value"}}}`},
+		{"arrays", `{"items":[1,2,3]}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deps, w, r := newTestRequest(tx)
+			result := ValidateConfigurationReference(w, r, deps, configID, agentID, connID+".some_action", json.RawMessage(tc.execParams))
+			if result == nil {
+				t.Errorf("expected wildcard config to accept %s, got error: %s", tc.name, w.Body.String())
+			}
+		})
+	}
+}

--- a/api/action_configurations.go
+++ b/api/action_configurations.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
@@ -94,19 +95,45 @@ func handleCreateActionConfig(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Validate parameters is a JSON object (if provided).
-		params := req.Parameters
-		if len(params) == 0 {
-			params = []byte("{}")
-		} else if err := ValidateJSONObject(params); err != nil {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "parameters must be a JSON object"))
+		// Reject action types that contain "*" but are not exactly "*".
+		if req.ActionType != db.WildcardActionType && strings.Contains(req.ActionType, "*") {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_type must be '*' for wildcard or a specific action type without '*'"))
 			return
 		}
 
-		// Reject malformed $pattern wrappers (e.g. without any "*").
-		if err := db.ValidateConfigParameters(params); err != nil {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
-			return
+		// Wildcard configs cover all actions with all parameters agent-controlled.
+		// Force empty parameters and skip parameter validation.
+		var params json.RawMessage
+		if req.ActionType == db.WildcardActionType {
+			params = []byte("{}")
+		} else {
+			// Validate parameters is a JSON object (if provided).
+			params = req.Parameters
+			if len(params) == 0 {
+				params = []byte("{}")
+			} else if err := ValidateJSONObject(params); err != nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "parameters must be a JSON object"))
+				return
+			}
+
+			// Reject malformed $pattern wrappers (e.g. without any "*").
+			if err := db.ValidateConfigParameters(params); err != nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
+				return
+			}
+
+			// Validate that the action type exists for this connector (replaces
+			// the dropped composite FK).
+			exists, err := db.ConnectorActionExists(r.Context(), deps.DB, req.ConnectorID, req.ActionType)
+			if err != nil {
+				log.Printf("[%s] CreateActionConfig: check connector action: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create action configuration"))
+				return
+			}
+			if !exists {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Invalid connector or action type reference"))
+				return
+			}
 		}
 
 		if !verifyCredentialOwnership(w, r, deps, req.CredentialID, profile.ID) {
@@ -245,9 +272,21 @@ func handleUpdateActionConfig(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Validate parameters is a JSON object (if provided).
+		// Wildcard configs (action_type = "*") do not allow parameter changes —
+		// their parameters must remain {}. Look up the existing config to check.
 		var params []byte
 		if req.Parameters != nil {
+			existing, err := db.GetActionConfigByID(r.Context(), deps.DB, configID, profile.ID)
+			if err != nil {
+				log.Printf("[%s] UpdateActionConfig: lookup for wildcard check: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update action configuration"))
+				return
+			}
+			if existing != nil && existing.ActionType == db.WildcardActionType {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "cannot modify parameters on a wildcard (enable-all) configuration"))
+				return
+			}
+
 			if err := ValidateJSONObject(req.Parameters); err != nil {
 				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "parameters must be a JSON object"))
 				return

--- a/api/action_configurations.go
+++ b/api/action_configurations.go
@@ -282,7 +282,11 @@ func handleUpdateActionConfig(deps *Deps) http.HandlerFunc {
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update action configuration"))
 				return
 			}
-			if existing != nil && existing.ActionType == db.WildcardActionType {
+			if existing == nil {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrActionConfigNotFound, "Action configuration not found"))
+				return
+			}
+			if existing.ActionType == db.WildcardActionType {
 				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "cannot modify parameters on a wildcard (enable-all) configuration"))
 				return
 			}

--- a/api/action_configurations.go
+++ b/api/action_configurations.go
@@ -95,6 +95,9 @@ func handleCreateActionConfig(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Normalize action type — trim whitespace so " read_file " matches "read_file" at execution time.
+		req.ActionType = strings.TrimSpace(req.ActionType)
+
 		// Reject action types that contain "*" but are not exactly "*".
 		if req.ActionType != db.WildcardActionType && strings.Contains(req.ActionType, "*") {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_type must be '*' for wildcard or a specific action type without '*'"))

--- a/db/action_configurations.go
+++ b/db/action_configurations.go
@@ -243,3 +243,22 @@ func DeleteActionConfig(ctx context.Context, db DBTX, configID, userID string) (
 	}
 	return ac, nil
 }
+
+// WildcardActionType is the reserved action_type value that means
+// "all actions on this connector".
+const WildcardActionType = "*"
+
+// ConnectorActionExists checks whether a (connector_id, action_type) pair
+// exists in the connector_actions table. Used to validate non-wildcard
+// action types now that the composite FK has been dropped.
+func ConnectorActionExists(ctx context.Context, db DBTX, connectorID, actionType string) (bool, error) {
+	var exists bool
+	err := db.QueryRow(ctx,
+		`SELECT EXISTS(
+			SELECT 1 FROM connector_actions
+			WHERE connector_id = $1 AND action_type = $2
+		)`,
+		connectorID, actionType,
+	).Scan(&exists)
+	return exists, err
+}

--- a/db/action_configurations.go
+++ b/db/action_configurations.go
@@ -245,7 +245,14 @@ func DeleteActionConfig(ctx context.Context, db DBTX, configID, userID string) (
 }
 
 // WildcardActionType is the reserved action_type value that means
-// "all actions on this connector".
+// "all actions on this connector". A wildcard config covers every current
+// and future action — the agent can choose any action and any parameter
+// values at execution time. Only one wildcard config is allowed per
+// agent + connector pair (enforced by idx_action_config_wildcard_unique).
+//
+// SECURITY: Wildcard configs skip action-type and parameter validation at
+// execution time, but standing approvals still gate actual execution
+// per-action-type.
 const WildcardActionType = "*"
 
 // ConnectorActionExists checks whether a (connector_id, action_type) pair

--- a/db/action_configurations_test.go
+++ b/db/action_configurations_test.go
@@ -883,3 +883,157 @@ func TestDeleteActionConfig_WrongUser(t *testing.T) {
 		t.Error("config should still exist after failed delete by wrong user")
 	}
 }
+
+// ── Wildcard Action Type ────────────────────────────────────────────────────
+
+func TestWildcardActionType_InsertSuccess(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+
+	// Wildcard config — no matching connector_action row needed
+	configID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfigFull(t, tx, configID, agentID, uid, connID, "*", testhelper.ActionConfigOpts{
+		Name: "All Actions",
+	})
+
+	ac, err := db.GetActionConfigByID(t.Context(), tx, configID, uid)
+	if err != nil {
+		t.Fatalf("GetActionConfigByID: %v", err)
+	}
+	if ac == nil {
+		t.Fatal("expected non-nil result for wildcard config")
+	}
+	if ac.ActionType != "*" {
+		t.Errorf("expected action_type '*', got %q", ac.ActionType)
+	}
+}
+
+func TestWildcardActionType_UniquenessConstraint(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+
+	// First wildcard config succeeds
+	testhelper.InsertActionConfigFull(t, tx, testhelper.GenerateID(t, "ac_"), agentID, uid, connID, "*", testhelper.ActionConfigOpts{
+		Name: "All Actions 1",
+	})
+
+	// Second wildcard config for same agent+connector should fail
+	err := testhelper.WithSavepoint(t, tx, func() error {
+		_, err := tx.Exec(context.Background(),
+			`INSERT INTO action_configurations (id, agent_id, user_id, connector_id, action_type, parameters, name)
+			 VALUES ($1, $2, $3, $4, '*', '{}', 'All Actions 2')`,
+			testhelper.GenerateID(t, "ac_"), agentID, uid, connID)
+		return err
+	})
+	if err == nil {
+		t.Error("expected unique constraint violation for duplicate wildcard config, but insert succeeded")
+	}
+}
+
+func TestWildcardActionType_AllowedAlongsideSpecific(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, "test.action", "Test Action")
+
+	// Wildcard config
+	testhelper.InsertActionConfigFull(t, tx, testhelper.GenerateID(t, "ac_"), agentID, uid, connID, "*", testhelper.ActionConfigOpts{
+		Name: "All Actions",
+	})
+
+	// Specific config for the same agent+connector should also work
+	testhelper.InsertActionConfig(t, tx, testhelper.GenerateID(t, "ac_"), agentID, uid, connID, "test.action")
+
+	configs, err := db.ListActionConfigsByAgent(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("ListActionConfigsByAgent: %v", err)
+	}
+	if len(configs) != 2 {
+		t.Errorf("expected 2 configs (wildcard + specific), got %d", len(configs))
+	}
+}
+
+func TestWildcardActionType_UniquePerConnector(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	conn1 := testhelper.GenerateID(t, "conn_")
+	conn2 := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, conn1)
+	testhelper.InsertConnector(t, tx, conn2)
+
+	// Wildcard config for connector 1
+	testhelper.InsertActionConfigFull(t, tx, testhelper.GenerateID(t, "ac_"), agentID, uid, conn1, "*", testhelper.ActionConfigOpts{
+		Name: "All Conn1 Actions",
+	})
+
+	// Wildcard config for connector 2 — should succeed (different connector)
+	testhelper.InsertActionConfigFull(t, tx, testhelper.GenerateID(t, "ac_"), agentID, uid, conn2, "*", testhelper.ActionConfigOpts{
+		Name: "All Conn2 Actions",
+	})
+
+	configs, err := db.ListActionConfigsByAgent(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("ListActionConfigsByAgent: %v", err)
+	}
+	if len(configs) != 2 {
+		t.Errorf("expected 2 wildcard configs (one per connector), got %d", len(configs))
+	}
+}
+
+// ── ConnectorActionExists ────────────────────────────────────────────────────
+
+func TestConnectorActionExists_Found(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, "test.action", "Test Action")
+
+	exists, err := db.ConnectorActionExists(t.Context(), tx, connID, "test.action")
+	if err != nil {
+		t.Fatalf("ConnectorActionExists: %v", err)
+	}
+	if !exists {
+		t.Error("expected connector action to exist")
+	}
+}
+
+func TestConnectorActionExists_NotFound(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+
+	exists, err := db.ConnectorActionExists(t.Context(), tx, connID, "nonexistent")
+	if err != nil {
+		t.Fatalf("ConnectorActionExists: %v", err)
+	}
+	if exists {
+		t.Error("expected connector action to not exist")
+	}
+}
+
+func TestWildcardActionType_IndexExists(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	testhelper.RequireIndex(t, tx, "action_configurations", "idx_action_config_wildcard_unique")
+}

--- a/db/migrations/20260311213936_allow_wildcard_action_type.sql
+++ b/db/migrations/20260311213936_allow_wildcard_action_type.sql
@@ -15,6 +15,9 @@ CREATE UNIQUE INDEX idx_action_config_wildcard_unique
 
 DROP INDEX IF EXISTS idx_action_config_wildcard_unique;
 
+-- Remove wildcard configs that would violate the FK being restored.
+DELETE FROM action_configurations WHERE action_type = '*';
+
 ALTER TABLE action_configurations
   ADD CONSTRAINT action_configurations_connector_id_action_type_fkey
   FOREIGN KEY (connector_id, action_type)

--- a/db/migrations/20260311213936_allow_wildcard_action_type.sql
+++ b/db/migrations/20260311213936_allow_wildcard_action_type.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+-- Drop composite FK so action_type = '*' (wildcard) can be stored without
+-- a matching row in connector_actions.  Non-wildcard types are validated at
+-- the application layer instead.
+ALTER TABLE action_configurations
+  DROP CONSTRAINT action_configurations_connector_id_action_type_fkey;
+
+-- Enforce at most one wildcard config per agent+connector.
+CREATE UNIQUE INDEX idx_action_config_wildcard_unique
+  ON action_configurations (agent_id, connector_id)
+  WHERE action_type = '*';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_action_config_wildcard_unique;
+
+ALTER TABLE action_configurations
+  ADD CONSTRAINT action_configurations_connector_id_action_type_fkey
+  FOREIGN KEY (connector_id, action_type)
+  REFERENCES connector_actions(connector_id, action_type) ON DELETE CASCADE;

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -3,6 +3,9 @@ import { Label } from "@/components/ui/label";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import validation from "@/lib/validation";
 
+/** Reserved action_type value meaning "all actions on this connector". */
+export const WILDCARD_ACTION_TYPE = "*";
+
 const selectClassName =
   "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
 

--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -22,7 +22,10 @@ export function ActionConfigRow({
   onEdit,
   onDelete,
 }: ActionConfigRowProps) {
-  const action = actions.find((a) => a.action_type === config.action_type);
+  const isWildcardConfig = config.action_type === "*";
+  const action = isWildcardConfig
+    ? null
+    : actions.find((a) => a.action_type === config.action_type);
   const credential = config.credential_id
     ? credentials.find((c) => c.id === config.credential_id)
     : null;
@@ -42,15 +45,28 @@ export function ActionConfigRow({
         </div>
       </TableCell>
       <TableCell>
-        <div>
-          <p className="text-sm">{action?.name ?? config.action_type}</p>
-          <p className="text-muted-foreground font-mono text-xs">
-            {config.action_type}
-          </p>
-        </div>
+        {isWildcardConfig ? (
+          <div>
+            <Badge className="bg-primary/10 text-primary border-primary/20 border">
+              All Actions
+            </Badge>
+            <p className="text-muted-foreground mt-0.5 font-mono text-xs">*</p>
+          </div>
+        ) : (
+          <div>
+            <p className="text-sm">{action?.name ?? config.action_type}</p>
+            <p className="text-muted-foreground font-mono text-xs">
+              {config.action_type}
+            </p>
+          </div>
+        )}
       </TableCell>
       <TableCell>
-        {paramEntries.length > 0 ? (
+        {isWildcardConfig ? (
+          <span className="text-muted-foreground text-xs italic">
+            All parameters — agent chooses freely
+          </span>
+        ) : paramEntries.length > 0 ? (
           <div className="space-y-0.5">
             {paramEntries.map(([key, value]) => (
               <ParameterPill key={key} name={key} value={value} />

--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -5,7 +5,7 @@ import { TableRow, TableCell } from "@/components/ui/table";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import type { CredentialSummary } from "@/hooks/useCredentials";
-import { isPatternWrapper } from "./ActionConfigFormFields";
+import { isPatternWrapper, WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 
 interface ActionConfigRowProps {
   config: ActionConfiguration;
@@ -22,7 +22,7 @@ export function ActionConfigRow({
   onEdit,
   onDelete,
 }: ActionConfigRowProps) {
-  const isWildcardConfig = config.action_type === "*";
+  const isWildcardConfig = config.action_type === WILDCARD_ACTION_TYPE;
   const action = isWildcardConfig
     ? null
     : actions.find((a) => a.action_type === config.action_type);

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight, Loader2, Plus, Settings, Zap } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -57,13 +58,22 @@ export function ActionConfigurationsSection({
     useCreateActionConfig();
 
   const handleEnableAll = async () => {
-    await createActionConfig({
-      agent_id: agentId,
-      connector_id: connectorId,
-      action_type: "*",
-      name: `All ${connectorName} Actions`,
-      parameters: {},
-    });
+    try {
+      await createActionConfig({
+        agent_id: agentId,
+        connector_id: connectorId,
+        action_type: "*",
+        name: `All ${connectorName} Actions`,
+        parameters: {},
+      });
+      toast.success(`All ${connectorName} actions enabled`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to enable all actions",
+      );
+    }
   };
 
   return (

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -19,6 +19,7 @@ import type { ActionConfiguration } from "@/hooks/useActionConfigs";
 import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import type { CredentialSummary } from "@/hooks/useCredentials";
+import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 import { ActionConfigRow } from "./ActionConfigRow";
 import { AddActionConfigDialog } from "./AddActionConfigDialog";
 import { EditActionConfigDialog } from "./EditActionConfigDialog";
@@ -62,7 +63,7 @@ export function ActionConfigurationsSection({
       await createActionConfig({
         agent_id: agentId,
         connector_id: connectorId,
-        action_type: "*",
+        action_type: WILDCARD_ACTION_TYPE,
         name: `All ${connectorName} Actions`,
         parameters: {},
       });

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Loader2, Plus, Settings } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2, Plus, Settings, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -15,6 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
+import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import { ActionConfigRow } from "./ActionConfigRow";
@@ -25,6 +26,7 @@ import { DeleteActionConfigDialog } from "./DeleteActionConfigDialog";
 interface ActionConfigurationsSectionProps {
   agentId: number;
   connectorId: string;
+  connectorName: string;
   actions: ConnectorAction[];
   credentials: CredentialSummary[];
   configs: ActionConfiguration[];
@@ -35,6 +37,7 @@ interface ActionConfigurationsSectionProps {
 export function ActionConfigurationsSection({
   agentId,
   connectorId,
+  connectorName,
   actions,
   credentials,
   configs,
@@ -48,6 +51,20 @@ export function ActionConfigurationsSection({
   const [deleteTarget, setDeleteTarget] = useState<ActionConfiguration | null>(
     null,
   );
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const { createActionConfig, isPending: isEnablingAll } =
+    useCreateActionConfig();
+
+  const handleEnableAll = async () => {
+    await createActionConfig({
+      agent_id: agentId,
+      connector_id: connectorId,
+      action_type: "*",
+      name: `All ${connectorName} Actions`,
+      parameters: {},
+    });
+  };
 
   return (
     <Card>
@@ -76,14 +93,14 @@ export function ActionConfigurationsSection({
         ) : error ? (
           <p className="text-destructive text-sm">{error}</p>
         ) : configs.length === 0 ? (
-          <div className="text-muted-foreground space-y-1 py-4 text-center text-sm">
-            <p>No action configurations yet.</p>
-            <p>
-              Create a configuration to define exactly how this agent can use an
-              action — which parameters are locked in and which the agent can
-              choose freely.
-            </p>
-          </div>
+          <EnableAllEmptyState
+            onEnableAll={handleEnableAll}
+            isEnablingAll={isEnablingAll}
+            showAdvanced={showAdvanced}
+            onToggleAdvanced={() => setShowAdvanced((v) => !v)}
+            onAddCustom={() => setAddDialogOpen(true)}
+            actionsDisabled={actions.length === 0}
+          />
         ) : (
           <div className="overflow-hidden rounded-lg">
             <Table>
@@ -157,5 +174,76 @@ export function ActionConfigurationsSection({
         />
       )}
     </Card>
+  );
+}
+
+function EnableAllEmptyState({
+  onEnableAll,
+  isEnablingAll,
+  showAdvanced,
+  onToggleAdvanced,
+  onAddCustom,
+  actionsDisabled,
+}: {
+  onEnableAll: () => void;
+  isEnablingAll: boolean;
+  showAdvanced: boolean;
+  onToggleAdvanced: () => void;
+  onAddCustom: () => void;
+  actionsDisabled: boolean;
+}) {
+  return (
+    <div className="space-y-4 py-4 text-center">
+      <div className="space-y-3">
+        <Button
+          size="lg"
+          onClick={onEnableAll}
+          disabled={isEnablingAll || actionsDisabled}
+        >
+          {isEnablingAll ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Zap className="size-4" />
+          )}
+          Enable All Actions
+        </Button>
+        <p className="text-muted-foreground mx-auto max-w-md text-sm">
+          Your agent can use any action from this connector. Every action still
+          requires your approval before it runs.
+        </p>
+      </div>
+
+      <div className="pt-2">
+        <button
+          type="button"
+          onClick={onToggleAdvanced}
+          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
+        >
+          {showAdvanced ? (
+            <ChevronDown className="size-3" />
+          ) : (
+            <ChevronRight className="size-3" />
+          )}
+          Advanced: configure individual actions
+        </button>
+        {showAdvanced && (
+          <div className="mt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onAddCustom}
+              disabled={actionsDisabled}
+            >
+              <Plus className="size-4" />
+              Add Custom Configuration
+            </Button>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Lock specific parameters or restrict which actions your agent can
+              use.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
@@ -156,6 +156,7 @@ export function ConnectorConfigPage() {
       <ActionConfigurationsSection
         agentId={agentId}
         connectorId={connectorId}
+        connectorName={connector.name}
         actions={connector.actions}
         credentials={credentials}
         configs={connectorConfigs}

--- a/frontend/src/pages/agents/connectors/DeleteActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/DeleteActionConfigDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { useDeleteActionConfig } from "@/hooks/useDeleteActionConfig";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
+import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 
 interface DeleteActionConfigDialogProps {
   open: boolean;
@@ -47,7 +48,7 @@ export function DeleteActionConfigDialog({
         <DialogHeader>
           <DialogTitle>Delete Action Configuration</DialogTitle>
           <DialogDescription>
-            {config.action_type === "*" ? (
+            {config.action_type === WILDCARD_ACTION_TYPE ? (
               <>
                 This will permanently delete the enable-all configuration{" "}
                 <strong>{config.name}</strong>. The agent will lose access to{" "}

--- a/frontend/src/pages/agents/connectors/DeleteActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/DeleteActionConfigDialog.tsx
@@ -47,10 +47,21 @@ export function DeleteActionConfigDialog({
         <DialogHeader>
           <DialogTitle>Delete Action Configuration</DialogTitle>
           <DialogDescription>
-            This will permanently delete the configuration{" "}
-            <strong>{config.name}</strong> ({config.action_type}). The agent
-            will no longer be able to reference this configuration. This action
-            is irreversible.
+            {config.action_type === "*" ? (
+              <>
+                This will permanently delete the enable-all configuration{" "}
+                <strong>{config.name}</strong>. The agent will lose access to{" "}
+                <strong>all actions</strong> on this connector. This action is
+                irreversible.
+              </>
+            ) : (
+              <>
+                This will permanently delete the configuration{" "}
+                <strong>{config.name}</strong> ({config.action_type}). The agent
+                will no longer be able to reference this configuration. This
+                action is irreversible.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -65,9 +65,13 @@ export function EditActionConfigDialog({
     inferModesFromConfig(config.parameters),
   );
 
+  const isWildcard = config.action_type === "*";
   const action = useMemo(
-    () => actions.find((a) => a.action_type === config.action_type) ?? null,
-    [actions, config.action_type],
+    () =>
+      isWildcard
+        ? null
+        : actions.find((a) => a.action_type === config.action_type) ?? null,
+    [actions, config.action_type, isWildcard],
   );
 
   const schema = useMemo(
@@ -128,9 +132,11 @@ export function EditActionConfigDialog({
           <DialogHeader>
             <DialogTitle>Edit Action Configuration</DialogTitle>
             <DialogDescription>
-              Update the configuration for{" "}
-              <strong>{action?.name ?? config.action_type}</strong>. The action
-              type and connector cannot be changed.
+              {isWildcard
+                ? "Update the name, description, credential, or status for this enable-all configuration. Parameters cannot be changed on wildcard configurations."
+                : <>Update the configuration for{" "}
+                  <strong>{action?.name ?? config.action_type}</strong>. The action
+                  type and connector cannot be changed.</>}
             </DialogDescription>
           </DialogHeader>
 
@@ -138,12 +144,16 @@ export function EditActionConfigDialog({
             {/* Action (read-only) */}
             <div className="space-y-2">
               <Label>Action</Label>
-              <p className="text-sm">
-                {action?.name ?? config.action_type}{" "}
-                <span className="text-muted-foreground font-mono text-xs">
-                  ({config.action_type})
-                </span>
-              </p>
+              {isWildcard ? (
+                <p className="text-sm font-medium">All Actions <span className="text-muted-foreground font-mono text-xs">(*)</span></p>
+              ) : (
+                <p className="text-sm">
+                  {action?.name ?? config.action_type}{" "}
+                  <span className="text-muted-foreground font-mono text-xs">
+                    ({config.action_type})
+                  </span>
+                </p>
+              )}
             </div>
 
             <NameField
@@ -175,7 +185,14 @@ export function EditActionConfigDialog({
               disabled={isPending}
             />
 
-            {action && (
+            {isWildcard ? (
+              <div className="space-y-2">
+                <Label>Parameters</Label>
+                <p className="text-muted-foreground text-sm italic">
+                  All parameters — agent chooses freely. Parameters cannot be modified on wildcard configurations.
+                </p>
+              </div>
+            ) : action ? (
               <div className="space-y-2">
                 <Label>Parameters</Label>
                 <ActionConfigParameterFields
@@ -187,7 +204,7 @@ export function EditActionConfigDialog({
                   disabled={isPending}
                 />
               </div>
-            )}
+            ) : null}
           </div>
 
           <DialogFooter>

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -20,6 +20,7 @@ import {
   parseParametersSchema,
 } from "./ActionConfigParameterFields";
 import {
+  WILDCARD_ACTION_TYPE,
   NameField,
   DescriptionField,
   CredentialSelect,
@@ -65,7 +66,7 @@ export function EditActionConfigDialog({
     inferModesFromConfig(config.parameters),
   );
 
-  const isWildcard = config.action_type === "*";
+  const isWildcard = config.action_type === WILDCARD_ACTION_TYPE;
   const action = useMemo(
     () =>
       isWildcard

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -80,11 +80,13 @@ function renderSection({
   configs = [] as ActionConfiguration[],
   isLoading = false,
   error = null as string | null,
+  connectorName = "GitHub",
 } = {}) {
   return renderWithProviders(
     <ActionConfigurationsSection
       agentId={42}
       connectorId="github"
+      connectorName={connectorName}
       actions={mockActions}
       credentials={mockCredentials}
       configs={configs}
@@ -101,12 +103,17 @@ describe("ActionConfigurationsSection", () => {
     setupAuthMocks({ authenticated: true });
   });
 
-  it("shows empty state when no configurations exist", () => {
+  it("shows empty state with Enable All Actions button", () => {
     renderSection();
     expect(
-      screen.getByText("No action configurations yet."),
+      screen.getByText("Enable All Actions"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Add Configuration")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your agent can use any action from this connector/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Advanced: configure individual actions"),
+    ).toBeInTheDocument();
   });
 
   it("shows loading state", () => {
@@ -312,5 +319,76 @@ describe("ActionConfigurationsSection", () => {
     ];
     renderSection({ configs: disabledConfig });
     expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it("calls create with wildcard action_type when clicking Enable All Actions", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({
+      data: {
+        id: "ac_wildcard",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "*",
+        parameters: {},
+        status: "active",
+        name: "All GitHub Actions",
+        created_at: "2026-03-11T10:00:00Z",
+        updated_at: "2026-03-11T10:00:00Z",
+      },
+    });
+
+    renderSection();
+    await user.click(screen.getByText("Enable All Actions"));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/v1/action-configurations", {
+        headers: { Authorization: "Bearer token" },
+        body: {
+          agent_id: 42,
+          connector_id: "github",
+          action_type: "*",
+          name: "All GitHub Actions",
+          parameters: {},
+        },
+      });
+    });
+  });
+
+  it("renders wildcard config with All Actions badge", () => {
+    const wildcardConfig: ActionConfiguration[] = [
+      {
+        id: "ac_wildcard",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "*",
+        credential_id: null,
+        parameters: {},
+        status: "active",
+        name: "All GitHub Actions",
+        description: null,
+        created_at: "2026-03-11T10:00:00Z",
+        updated_at: "2026-03-11T10:00:00Z",
+      },
+    ];
+    renderSection({ configs: wildcardConfig });
+
+    expect(screen.getByText("All GitHub Actions")).toBeInTheDocument();
+    expect(screen.getByText("All Actions")).toBeInTheDocument();
+    expect(
+      screen.getByText(/All parameters — agent chooses freely/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows advanced option to add custom config in empty state", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    // Click the advanced toggle
+    await user.click(
+      screen.getByText("Advanced: configure individual actions"),
+    );
+    expect(
+      screen.getByText("Add Custom Configuration"),
+    ).toBeInTheDocument();
   });
 });

--- a/spec/openapi/components/schemas/action_configurations.yaml
+++ b/spec/openapi/components/schemas/action_configurations.yaml
@@ -37,7 +37,11 @@ ActionConfiguration:
       type: string
       maxLength: 128
       description: |
-        Action type from the connector's action catalog.
+        Action type from the connector's action catalog, or `"*"` to enable
+        **all** actions on this connector. A wildcard configuration covers
+        every current and future action — the agent can choose any action and
+        any parameter values. Only one wildcard configuration is allowed per
+        agent + connector pair.
       example: "github.create_issue"
 
     credential_id:
@@ -156,7 +160,11 @@ CreateActionConfigRequest:
     action_type:
       type: string
       maxLength: 128
-      description: Action type from the connector's action catalog.
+      description: |
+        Action type from the connector's action catalog, or `"*"` to enable
+        **all** actions on this connector. When `"*"` is used, parameters are
+        forced to `{}` (the agent can choose any parameter values at execution
+        time). Only one wildcard configuration is allowed per agent + connector.
       example: "github.create_issue"
 
     credential_id:
@@ -226,7 +234,9 @@ UpdateActionConfigRequest:
     parameters:
       type: object
       additionalProperties: true
-      description: Updated parameter values.
+      description: |
+        Updated parameter values. Cannot be modified on wildcard (`action_type = "*"`)
+        configurations — their parameters are always `{}`.
       example:
         repo: "supersuit-tech/api"
         title: "*"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -6922,7 +6922,11 @@ components:
           type: string
           maxLength: 128
           description: |
-            Action type from the connector's action catalog.
+            Action type from the connector's action catalog, or `"*"` to enable
+            **all** actions on this connector. A wildcard configuration covers
+            every current and future action — the agent can choose any action and
+            any parameter values. Only one wildcard configuration is allowed per
+            agent + connector pair.
           example: github.create_issue
         credential_id:
           type: string
@@ -7030,7 +7034,11 @@ components:
         action_type:
           type: string
           maxLength: 128
-          description: Action type from the connector's action catalog.
+          description: |
+            Action type from the connector's action catalog, or `"*"` to enable
+            **all** actions on this connector. When `"*"` is used, parameters are
+            forced to `{}` (the agent can choose any parameter values at execution
+            time). Only one wildcard configuration is allowed per agent + connector.
           example: github.create_issue
         credential_id:
           type: string
@@ -7093,7 +7101,9 @@ components:
         parameters:
           type: object
           additionalProperties: true
-          description: Updated parameter values.
+          description: |
+            Updated parameter values. Cannot be modified on wildcard (`action_type = "*"`)
+            configurations — their parameters are always `{}`.
           example:
             repo: supersuit-tech/api
             title: '*'


### PR DESCRIPTION
## Summary

- Adds an "Enable All Actions" option as the primary CTA in the empty state of the connector action configurations section
- Uses `action_type = "*"` as a wildcard that covers all current and future actions on a connector, with all parameters agent-controlled
- Custom action configurations are still available as an "Advanced" option, deprioritized in the UI
- Includes explanatory text: "Your agent can use any action from this connector. Every action still requires your approval before it runs."

### Backend changes
- **Migration**: Drops composite FK `(connector_id, action_type) → connector_actions` to allow `*` as action_type. Adds partial unique index enforcing one wildcard config per agent+connector pair.
- **DB layer**: Adds `ConnectorActionExists()` to validate non-wildcard action types at the application layer (replacing the dropped FK)
- **API handler**: Wildcard configs force `parameters = {}`, skip parameter validation. Non-wildcard types validated via `ConnectorActionExists`. Rejects partial wildcards like `"google.*"`. Update handler blocks parameter changes on wildcard configs.
- **Execution validation**: `ValidateConfigurationReference` skips action type matching and parameter validation for wildcard configs — any action type and any parameters are accepted.
- **OpenAPI spec**: Updated `action_type` descriptions to document `"*"` as valid wildcard value.

### Frontend changes
- **Empty state**: Shows "Enable All Actions" button (primary) with approval note, and "Advanced: configure individual actions" collapsible section
- **Table row**: Wildcard configs show "All Actions" badge and "All parameters — agent chooses freely" instead of per-parameter pills
- **Props**: `connectorName` passed through from `ConnectorConfigPage` for auto-generated config name

## Test plan

### Claude Code
- [x] Backend DB tests: wildcard insert, uniqueness constraint, alongside specific configs, per-connector uniqueness, `ConnectorActionExists`
- [x] Backend API tests: `ValidateConfigurationReference` with wildcard matches any action type and any parameters
- [x] Frontend tests: empty state renders "Enable All Actions", clicking creates wildcard config, wildcard config row renders correctly, advanced toggle works
- [x] All 713 frontend tests pass, all db+api backend tests pass
- [x] TypeScript type check passes

### OpenClaw
- [ ] Manual test: navigate to connector config page with no configs → see "Enable All Actions" as primary CTA
- [ ] Manual test: click "Enable All Actions" → config created with `action_type: "*"` → row shows "All Actions" badge
- [ ] Manual test: verify agent execution with wildcard config accepts any action type and parameters
- [ ] Manual test: verify second wildcard config for same agent+connector is rejected (409/unique violation)
- [ ] Visual review: empty state layout, badge styling, collapsible advanced section

https://claude.ai/code/session_0196bqMKJH3XfpvPPEVLL7py