### PR TITLE
Replace Rocktown Capital with Supersuit Technologies LLC

### DIFF
--- a/frontend/src/pages/policy/CookiePolicyPage.tsx
+++ b/frontend/src/pages/policy/CookiePolicyPage.tsx
@@ -5,9 +5,8 @@ export function CookiePolicyPage() {
   return (
     <PolicyLayout title="Cookie Policy" lastUpdated="February 28, 2026">
       <p>
-        This Cookie Policy explains how Rocktown Capital LLC, doing business as
-        Supersuit Technologies (&quot;we,&quot; &quot;us,&quot; or
-        &quot;our&quot;), uses cookies and similar local storage technologies
+        This Cookie Policy explains how Supersuit Technologies LLC
+        (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) uses cookies and similar local storage technologies
         when you use Permission Slip at{" "}
         <a
           href="https://app.permissionslip.dev"

--- a/frontend/src/pages/policy/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/policy/PrivacyPolicyPage.tsx
@@ -5,7 +5,7 @@ export function PrivacyPolicyPage() {
   return (
     <PolicyLayout title="Privacy Policy" lastUpdated="February 28, 2026">
       <p>
-        Rocktown Capital LLC, doing business as Supersuit Technologies
+        Supersuit Technologies LLC
         (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;), operates Permission
         Slip (&quot;the Service&quot;) at{" "}
         <a
@@ -334,8 +334,7 @@ export function PrivacyPolicyPage() {
           <a href="mailto:support@supersuit.tech">support@supersuit.tech</a>
         </li>
         <li>
-          <strong>Entity:</strong> Rocktown Capital LLC (d/b/a Supersuit
-          Technologies)
+          <strong>Entity:</strong> Supersuit Technologies LLC
         </li>
         <li>
           <strong>Governing law:</strong> Commonwealth of Virginia, USA

--- a/frontend/src/pages/policy/TermsOfServicePage.tsx
+++ b/frontend/src/pages/policy/TermsOfServicePage.tsx
@@ -7,9 +7,9 @@ export function TermsOfServicePage() {
     <PolicyLayout title="Terms of Service" lastUpdated="February 28, 2026">
       <p>
         These Terms of Service (&quot;Terms&quot;) govern your access to and use
-        of Permission Slip (&quot;the Service&quot;), operated by Rocktown
-        Capital LLC, doing business as Supersuit Technologies (&quot;we,&quot;
-        &quot;us,&quot; or &quot;our&quot;), located in the Commonwealth of
+        of Permission Slip (&quot;the Service&quot;), operated by Supersuit
+        Technologies LLC (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;),
+        located in the Commonwealth of
         Virginia, USA.
       </p>
       <p>
@@ -304,8 +304,8 @@ export function TermsOfServicePage() {
       <p>
         The Permission Slip source code is licensed under the Apache 2.0
         license. The &quot;Permission Slip&quot; and &quot;Supersuit
-        Technologies&quot; names and logos are trademarks of Rocktown Capital
-        LLC. Your data remains yours &mdash; we claim no ownership of the
+        Technologies&quot; names and logos are trademarks of Supersuit
+        Technologies LLC. Your data remains yours &mdash; we claim no ownership of the
         content you process through the Service.
       </p>
 
@@ -379,8 +379,8 @@ export function TermsOfServicePage() {
       {/* ------------------------------------------------------------------ */}
       <h2>13. Indemnification</h2>
       <p>
-        You agree to indemnify and hold harmless Rocktown Capital LLC (d/b/a
-        Supersuit Technologies), its officers, directors, employees, and agents
+        You agree to indemnify and hold harmless Supersuit Technologies LLC,
+        its officers, directors, employees, and agents
         from any claims, damages, losses, or expenses (including reasonable
         attorney fees) arising from:
       </p>
@@ -518,7 +518,7 @@ export function TermsOfServicePage() {
         These Terms, together with our{" "}
         <Link to="/policy/privacy">Privacy Policy</Link> and{" "}
         <Link to="/policy/cookies">Cookie Policy</Link>, constitute the entire
-        agreement between you and Rocktown Capital LLC regarding your use of the
+        agreement between you and Supersuit Technologies LLC regarding your use of the
         Service.
       </p>
 
@@ -553,8 +553,7 @@ export function TermsOfServicePage() {
           <a href="mailto:support@supersuit.tech">support@supersuit.tech</a>
         </li>
         <li>
-          <strong>Entity:</strong> Rocktown Capital LLC (d/b/a Supersuit
-          Technologies)
+          <strong>Entity:</strong> Supersuit Technologies LLC
         </li>
         <li>
           <strong>Governing law:</strong> Commonwealth of Virginia, USA


### PR DESCRIPTION
## Summary
- Replaced all 7 references to "Rocktown Capital LLC (d/b/a Supersuit Technologies)" with "Supersuit Technologies LLC" across the privacy policy, terms of service, and cookie policy pages
- Reflects the official company rename

## Test plan

### Claude Code
- [x] Frontend tests pass (710/710)
- [x] TypeScript compilation clean
- [x] Verified zero remaining "Rocktown Capital" references in codebase

### OpenClaw
- [ ] Visual review of policy pages to confirm legal language reads correctly
- [ ] Legal team sign-off on updated entity name

https://claude.ai/code/session_01G62LbeQsJkRKqM7EsgNAxK