### PR TITLE
Fix connector credential row overflow on mobile

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -245,8 +245,8 @@ function OAuthCredentialRow({
   return (
     <>
       <div className="rounded-lg border p-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
             ) : needsReauth ? (
@@ -254,8 +254,8 @@ function OAuthCredentialRow({
             ) : (
               <Circle className="text-muted-foreground size-5 shrink-0" />
             )}
-            <div>
-              <div className="flex items-center gap-2">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
                 <p className="text-sm font-medium">
                   {providerLabel(providerId)}
                 </p>
@@ -275,7 +275,7 @@ function OAuthCredentialRow({
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             {isConnected ? (
               <>
                 <span className="text-xs font-medium text-green-600 dark:text-green-400">
@@ -439,15 +439,15 @@ function StaticCredentialRow({
   return (
     <>
       <div className="rounded-lg border p-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
             ) : (
               <Circle className="text-muted-foreground size-5 shrink-0" />
             )}
-            <div>
-              <div className="flex items-center gap-2">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
                 <p className="text-sm font-medium">
                   {serviceLabel(requiredCredential.service)}
                 </p>
@@ -473,7 +473,7 @@ function StaticCredentialRow({
               )}
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <span
               className={`text-xs font-medium ${
                 isConnected


### PR DESCRIPTION
## Summary
- The credential rows on connector pages used `flex items-center justify-between` with no wrapping, causing the right-side "Connected" text and action buttons to overflow outside the card boundary on narrow mobile screens
- Fixed both `OAuthCredentialRow` and `StaticCredentialRow` by adding `flex-wrap` to the outer container and `min-w-0 flex-1` to the left content div so it can shrink, and `shrink-0` to the right-side action div so it wraps cleanly instead of overflowing
- Badge row also gets `flex-wrap` so "OAuth" + "Recommended" badges don't overflow on very small screens

## Test plan
- [ ] Open a connector detail page on a narrow mobile viewport (e.g. iPhone SE ~375px)
- [ ] Verify the credential row no longer overflows the card boundary
- [ ] Verify connected state shows green "Connected" + disconnect icon within the card
- [ ] Verify disconnected state shows "Connect [Provider]" button within the card
- [ ] Verify "Needs Re-auth" badge and Re-authorize button wrap correctly

### Claude Code
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] All 713 frontend tests pass

### OpenClaw
- [ ] Visual review on real mobile device

https://claude.ai/code/session_01CakthGCwUKUu2ZDAjQT7rU