### PR TITLE
Improve action config empty state UX

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -161,7 +161,7 @@ export function ActionConfigurationsSection({
             <button
               type="button"
               onClick={handleEnableAll}
-              disabled={isEnablingAll}
+              disabled={isEnablingAll || actions.length === 0}
               className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
             >
               {isEnablingAll ? (

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
   CardContent,
+  CardFooter,
 } from "@/components/ui/card";
 import {
   Table,
@@ -84,14 +85,16 @@ export function ActionConfigurationsSection({
           <Settings className="text-muted-foreground size-5" />
           <CardTitle>Action Configurations</CardTitle>
         </div>
-        <Button
-          size="sm"
-          onClick={() => setAddDialogOpen(true)}
-          disabled={actions.length === 0}
-        >
-          <Plus className="size-4" />
-          Add Configuration
-        </Button>
+        {configs.length > 0 && (
+          <Button
+            size="sm"
+            onClick={() => setAddDialogOpen(true)}
+            disabled={actions.length === 0}
+          >
+            <Plus className="size-4" />
+            Add Configuration
+          </Button>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -151,6 +154,25 @@ export function ActionConfigurationsSection({
           </div>
         )}
       </CardContent>
+
+      {configs.length > 0 &&
+        !configs.some((c) => c.action_type === WILDCARD_ACTION_TYPE) && (
+          <CardFooter className="justify-center border-t pt-4">
+            <button
+              type="button"
+              onClick={handleEnableAll}
+              disabled={isEnablingAll}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
+            >
+              {isEnablingAll ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Zap className="size-3" />
+              )}
+              Enable All Actions
+            </button>
+          </CardFooter>
+        )}
 
       <AddActionConfigDialog
         open={addDialogOpen}

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -162,7 +162,7 @@ export function ActionConfigurationsSection({
               type="button"
               onClick={handleEnableAll}
               disabled={isEnablingAll || actions.length === 0}
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
+              className="text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1 text-xs transition-colors"
             >
               {isEnablingAll ? (
                 <Loader2 className="size-3 animate-spin" />

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -413,10 +413,45 @@ describe("ActionConfigurationsSection", () => {
       },
     ];
     renderSection({ configs: wildcardConfig });
-    // The "Enable All Actions" text in the table row should exist but not a footer button
-    const allButtons = screen.getAllByText("All Actions");
-    // Only the badge in the table, not a footer link
-    expect(allButtons).toHaveLength(1);
+    // Footer button must not be rendered
+    expect(
+      screen.queryByRole("button", { name: /Enable All Actions/ }),
+    ).not.toBeInTheDocument();
+    // The "All Actions" badge in the table row should still be present
+    expect(screen.getByText("All Actions")).toBeInTheDocument();
+  });
+
+  it("calls create with wildcard action_type when clicking footer Enable All Actions", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({
+      data: {
+        id: "ac_wildcard",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "*",
+        parameters: {},
+        status: "active",
+        name: "All GitHub Actions",
+        created_at: "2026-03-11T10:00:00Z",
+        updated_at: "2026-03-11T10:00:00Z",
+      },
+    });
+
+    renderSection({ configs: mockConfigs });
+    await user.click(screen.getByRole("button", { name: /Enable All Actions/ }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/v1/action-configurations", {
+        headers: { Authorization: "Bearer token" },
+        body: {
+          agent_id: 42,
+          connector_id: "github",
+          action_type: "*",
+          name: "All GitHub Actions",
+          parameters: {},
+        },
+      });
+    });
   });
 
   it("shows advanced option to add custom config in empty state", async () => {

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -164,9 +164,19 @@ describe("ActionConfigurationsSection", () => {
     expect(screen.getByText("Not assigned")).toBeInTheDocument();
   });
 
-  it("opens Add dialog when clicking Add Configuration", async () => {
-    const user = userEvent.setup();
+  it("hides Add Configuration button in empty state", () => {
     renderSection();
+    expect(screen.queryByText("Add Configuration")).not.toBeInTheDocument();
+  });
+
+  it("shows Add Configuration button when configs exist", () => {
+    renderSection({ configs: mockConfigs });
+    expect(screen.getByText("Add Configuration")).toBeInTheDocument();
+  });
+
+  it("opens Add dialog when clicking Add Configuration with configs", async () => {
+    const user = userEvent.setup();
+    renderSection({ configs: mockConfigs });
 
     await user.click(screen.getByText("Add Configuration"));
     expect(
@@ -191,7 +201,7 @@ describe("ActionConfigurationsSection", () => {
       },
     });
 
-    renderSection();
+    renderSection({ configs: mockConfigs });
     await user.click(screen.getByText("Add Configuration"));
 
     // Select action
@@ -377,6 +387,36 @@ describe("ActionConfigurationsSection", () => {
     expect(
       screen.getByText(/All parameters — agent chooses freely/),
     ).toBeInTheDocument();
+  });
+
+  it("shows Enable All Actions footer link when configs exist and none are wildcard", () => {
+    renderSection({ configs: mockConfigs });
+    // The table has configs, so a footer link should appear
+    const footerLink = screen.getByRole("button", { name: /Enable All Actions/ });
+    expect(footerLink).toBeInTheDocument();
+  });
+
+  it("hides Enable All Actions footer link when a wildcard config exists", () => {
+    const wildcardConfig: ActionConfiguration[] = [
+      {
+        id: "ac_wildcard",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "*",
+        credential_id: null,
+        parameters: {},
+        status: "active",
+        name: "All GitHub Actions",
+        description: null,
+        created_at: "2026-03-11T10:00:00Z",
+        updated_at: "2026-03-11T10:00:00Z",
+      },
+    ];
+    renderSection({ configs: wildcardConfig });
+    // The "Enable All Actions" text in the table row should exist but not a footer button
+    const allButtons = screen.getAllByText("All Actions");
+    // Only the badge in the table, not a footer link
+    expect(allButtons).toHaveLength(1);
   });
 
   it("shows advanced option to add custom config in empty state", async () => {


### PR DESCRIPTION
## Summary

- Removed the "Add Configuration" button from the card header when no configurations exist — the empty state already provides "Enable All Actions" as the primary CTA, with "Add Custom Configuration" available under the advanced toggle
- Added a subtle "Enable All Actions" footer link when manual configurations exist (hidden when a wildcard config is already present), giving users an escape hatch to switch from granular to wildcard mode

## Test plan

### Claude Code
- [x] Verify all 718 frontend tests pass
- [x] Verify TypeScript compiles cleanly
- [x] Verify empty state no longer shows "Add Configuration" button in header
- [x] Verify "Enable All Actions" footer link appears when non-wildcard configs exist
- [x] Verify footer link is hidden when a wildcard config already exists

### OpenClaw
- [ ] Visual review on mobile — confirm footer link is legible and tappable
- [ ] Confirm the empty → populated transition feels right (button disappearing from header, appearing in footer)

https://claude.ai/code/session_01NJNEomhpE9rXjbUN8ch5DS