### PR TITLE
Fix global mobile overflow styling

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,7 +126,10 @@
   * {
     @apply border-border;
   }
+  html {
+    @apply overflow-x-hidden;
+  }
   body {
-    @apply bg-background text-foreground font-sans antialiased;
+    @apply bg-background text-foreground font-sans antialiased overflow-x-hidden;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `overflow-x: hidden` to `html` and `body` elements globally to prevent horizontal scrolling on mobile devices
- Adds `overflow-hidden` to `DialogContent` component so child content (pre blocks, long text, code snippets) can never push past the dialog boundary
- These two changes together prevent the recurring issue of content overflowing on narrow viewports

## Test plan

### Claude Code
- [x] Frontend tests pass (89 files, 713 tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### OpenClaw
- [ ] Verify on a mobile device that the "Add an Agent" dialog no longer overflows
- [ ] Check other dialogs (AddConnector, ReviewPendingAgent) still display correctly on mobile
- [ ] Confirm no content is unintentionally clipped by the new overflow-hidden on dialogs

https://claude.ai/code/session_014E6R3F7UGqe7T5pF1qiEg2