### PR TITLE
Fix Sentry PERMISSION-SLIP-GO-6: missing email on notification dispatch

### DIFF
--- a/db/onboarding.go
+++ b/db/onboarding.go
@@ -58,10 +58,11 @@ func CreateProfile(ctx context.Context, db DBTX, userID, username string, market
 
 	var p Profile
 	err = db.QueryRow(ctx,
-		`INSERT INTO profiles (id, username, marketing_opt_in) VALUES ($1, $2, $3)
-		 RETURNING id, username, marketing_opt_in, created_at`,
+		`INSERT INTO profiles (id, username, email, marketing_opt_in)
+		 VALUES ($1, $2, (SELECT email FROM auth.users WHERE id = $1), $3)
+		 RETURNING id, username, email, phone, marketing_opt_in, created_at`,
 		userID, username, marketingOptIn,
-	).Scan(&p.ID, &p.Username, &p.MarketingOptIn, &p.CreatedAt)
+	).Scan(&p.ID, &p.Username, &p.Email, &p.Phone, &p.MarketingOptIn, &p.CreatedAt)
 
 	if err != nil {
 		var pgErr *pgconn.PgError

--- a/notify/dispatcher.go
+++ b/notify/dispatcher.go
@@ -74,6 +74,11 @@ func (d *Dispatcher) DispatchSync(ctx context.Context, approval Approval, recipi
 func (d *Dispatcher) enabledSenders(ctx context.Context, recipient Recipient) []Sender {
 	var toSend []Sender
 	for _, s := range d.senders {
+		// Skip channels where the recipient lacks the required contact info.
+		if !recipientHasContact(s.Name(), recipient) {
+			log.Printf("notify: channel %q skipped for user %s — missing contact info", s.Name(), recipient.UserID)
+			continue
+		}
 		if d.prefs != nil {
 			enabled, err := d.prefs.IsChannelEnabled(ctx, recipient.UserID, s.Name())
 			if err != nil {
@@ -87,6 +92,20 @@ func (d *Dispatcher) enabledSenders(ctx context.Context, recipient Recipient) []
 		toSend = append(toSend, s)
 	}
 	return toSend
+}
+
+// recipientHasContact returns true if the recipient has the contact info
+// required by the given channel. Channels not listed here are assumed to
+// not need any specific contact field (e.g. web-push uses the UserID).
+func recipientHasContact(channel string, r Recipient) bool {
+	switch channel {
+	case "email":
+		return r.Email != nil && *r.Email != ""
+	case "sms":
+		return r.Phone != nil && *r.Phone != ""
+	default:
+		return true
+	}
 }
 
 // sendAll delivers to every sender concurrently and waits for all to finish.


### PR DESCRIPTION
## Summary

Fixes [PERMISSION-SLIP-GO-6](https://supersuit-technologies.sentry.io/issues/7328933976/) — `recipient has no email address` errors flooding Sentry.

**Root cause:** `CreateProfile` never populated `profiles.email` from `auth.users.email`, so every new account had `NULL` email in the profiles table. When the notification dispatcher tried to send email notifications, the email sender failed and reported to Sentry.

**Changes:**
- `db/onboarding.go`: `CreateProfile` now sets `profiles.email` from `auth.users.email` via subquery, so new accounts inherit their login email by default
- `notify/dispatcher.go`: `enabledSenders` now skips channels when the recipient lacks required contact info (email for "email" channel, phone for "sms" channel) instead of attempting delivery and reporting a spurious error to Sentry

## Test plan

### Claude Code
- [ ] Verify `CreateProfile` sets email from auth.users in database tests
- [ ] Verify dispatcher skips email channel when `Recipient.Email` is nil
- [ ] Verify dispatcher still sends when email is present
- [ ] Run `make test-backend`

### OpenClaw
- [ ] Verify in staging that new signups get their email populated in profiles
- [ ] Confirm Sentry error rate drops after deploy
- [ ] Check existing users — consider a backfill migration if needed for users who signed up before this fix

https://claude.ai/code/session_01N2TseQN21Z7WnEumbXf9mk