### PR TITLE
Fix calendar action execution failure for aliased time params

### DIFF
--- a/connectors/google/calendar_helpers.go
+++ b/connectors/google/calendar_helpers.go
@@ -27,6 +27,10 @@ func normalizeCalendarTimeParams(raw json.RawMessage) json.RawMessage {
 	changed := false
 	for alias, canonical := range aliases {
 		if _, hasCanonical := m[canonical]; hasCanonical {
+			if _, hasAlias := m[alias]; hasAlias {
+				delete(m, alias)
+				changed = true
+			}
 			continue
 		}
 		if val, hasAlias := m[alias]; hasAlias {

--- a/connectors/google/calendar_helpers.go
+++ b/connectors/google/calendar_helpers.go
@@ -1,11 +1,51 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
+
+// normalizeCalendarTimeParams rewrites common time-parameter aliases in the raw
+// JSON so the typed unmarshal succeeds even when an LLM agent sends "start"/"end"
+// instead of the schema-defined "start_time"/"end_time". Only absent canonical
+// keys are backfilled — if the agent sends both "start" and "start_time", the
+// canonical key wins and the alias is ignored.
+func normalizeCalendarTimeParams(raw json.RawMessage) json.RawMessage {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return raw // let the caller's Unmarshal report the error
+	}
+
+	aliases := map[string]string{
+		"start": "start_time",
+		"end":   "end_time",
+	}
+
+	changed := false
+	for alias, canonical := range aliases {
+		if _, hasCanonical := m[canonical]; hasCanonical {
+			continue
+		}
+		if val, hasAlias := m[alias]; hasAlias {
+			m[canonical] = val
+			delete(m, alias)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return raw
+	}
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		return raw
+	}
+	return out
+}
 
 // validateTimeRange checks that start and end are valid RFC 3339 timestamps
 // and that end is strictly after start. Used by create_calendar_event and

--- a/connectors/google/calendar_helpers_test.go
+++ b/connectors/google/calendar_helpers_test.go
@@ -100,6 +100,24 @@ func TestNormalizeCalendarTimeParams_AliasRemoved(t *testing.T) {
 	}
 }
 
+func TestNormalizeCalendarTimeParams_AliasRemovedWhenCanonicalPresent(t *testing.T) {
+	t.Parallel()
+	input := `{"start_time":"canonical","start":"alias","end_time":"canonical2","end":"alias2"}`
+	result := normalizeCalendarTimeParams(json.RawMessage(input))
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if _, ok := m["start"]; ok {
+		t.Error("alias key 'start' should have been removed even when canonical is present")
+	}
+	if _, ok := m["end"]; ok {
+		t.Error("alias key 'end' should have been removed even when canonical is present")
+	}
+}
+
 func TestNormalizeCalendarTimeParams_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	input := json.RawMessage(`not valid json`)

--- a/connectors/google/calendar_helpers_test.go
+++ b/connectors/google/calendar_helpers_test.go
@@ -1,0 +1,111 @@
+package google
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeCalendarTimeParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantKey  string
+		wantVal  string
+		wantKey2 string
+		wantVal2 string
+	}{
+		{
+			name:     "aliases start/end to start_time/end_time",
+			input:    `{"summary":"Hello","start":"2026-03-13T10:00:00-05:00","end":"2026-03-13T11:00:00-05:00"}`,
+			wantKey:  "start_time",
+			wantVal:  "2026-03-13T10:00:00-05:00",
+			wantKey2: "end_time",
+			wantVal2: "2026-03-13T11:00:00-05:00",
+		},
+		{
+			name:     "canonical names preserved when present",
+			input:    `{"summary":"Hello","start_time":"2026-03-13T10:00:00-05:00","end_time":"2026-03-13T11:00:00-05:00"}`,
+			wantKey:  "start_time",
+			wantVal:  "2026-03-13T10:00:00-05:00",
+			wantKey2: "end_time",
+			wantVal2: "2026-03-13T11:00:00-05:00",
+		},
+		{
+			name:     "canonical wins over alias when both present",
+			input:    `{"start_time":"canonical","start":"alias","end_time":"canonical2","end":"alias2"}`,
+			wantKey:  "start_time",
+			wantVal:  "canonical",
+			wantKey2: "end_time",
+			wantVal2: "canonical2",
+		},
+		{
+			name:     "partial alias only start",
+			input:    `{"start":"2026-03-13T10:00:00-05:00","end_time":"2026-03-13T11:00:00-05:00"}`,
+			wantKey:  "start_time",
+			wantVal:  "2026-03-13T10:00:00-05:00",
+			wantKey2: "end_time",
+			wantVal2: "2026-03-13T11:00:00-05:00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := normalizeCalendarTimeParams(json.RawMessage(tt.input))
+
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(result, &m); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+
+			checkKey := func(key, want string) {
+				raw, ok := m[key]
+				if !ok {
+					t.Errorf("expected key %q in result", key)
+					return
+				}
+				var got string
+				if err := json.Unmarshal(raw, &got); err != nil {
+					t.Errorf("failed to unmarshal %q: %v", key, err)
+					return
+				}
+				if got != want {
+					t.Errorf("%s = %q, want %q", key, got, want)
+				}
+			}
+
+			checkKey(tt.wantKey, tt.wantVal)
+			checkKey(tt.wantKey2, tt.wantVal2)
+		})
+	}
+}
+
+func TestNormalizeCalendarTimeParams_AliasRemoved(t *testing.T) {
+	t.Parallel()
+	input := `{"summary":"Hello","start":"2026-03-13T10:00:00-05:00","end":"2026-03-13T11:00:00-05:00"}`
+	result := normalizeCalendarTimeParams(json.RawMessage(input))
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if _, ok := m["start"]; ok {
+		t.Error("alias key 'start' should have been removed")
+	}
+	if _, ok := m["end"]; ok {
+		t.Error("alias key 'end' should have been removed")
+	}
+}
+
+func TestNormalizeCalendarTimeParams_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	input := json.RawMessage(`not valid json`)
+	result := normalizeCalendarTimeParams(input)
+	// Should return input unchanged
+	if string(result) != string(input) {
+		t.Errorf("expected unchanged input for invalid JSON, got %s", string(result))
+	}
+}

--- a/connectors/google/create_calendar_event.go
+++ b/connectors/google/create_calendar_event.go
@@ -76,7 +76,7 @@ type calendarEventResponse struct {
 // Execute creates a Google Calendar event and returns its metadata.
 func (a *createCalendarEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params createCalendarEventParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+	if err := json.Unmarshal(normalizeCalendarTimeParams(req.Parameters), &params); err != nil {
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
 	}
 	if err := params.validate(); err != nil {

--- a/connectors/google/create_meeting.go
+++ b/connectors/google/create_meeting.go
@@ -97,7 +97,7 @@ type meetingEntryPoint struct {
 // Execute creates a Google Calendar event with an attached Google Meet link.
 func (a *createMeetingAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params createMeetingParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+	if err := json.Unmarshal(normalizeCalendarTimeParams(req.Parameters), &params); err != nil {
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
 	}
 	if err := params.validate(); err != nil {

--- a/connectors/google/update_calendar_event.go
+++ b/connectors/google/update_calendar_event.go
@@ -61,7 +61,7 @@ func (p *updateCalendarEventParams) normalize() {
 // Execute patches an existing Google Calendar event and returns its updated metadata.
 func (a *updateCalendarEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params updateCalendarEventParams
-	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+	if err := json.Unmarshal(normalizeCalendarTimeParams(req.Parameters), &params); err != nil {
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
 	}
 	if err := params.validate(); err != nil {


### PR DESCRIPTION
## Summary
- LLM agents sometimes send `start`/`end` instead of the schema-defined `start_time`/`end_time` when creating calendar events, causing execution to fail with "missing required parameter: start_time" after user approval
- Added `normalizeCalendarTimeParams()` helper that maps common aliases (`start` → `start_time`, `end` → `end_time`) in the raw JSON before unmarshal
- Applied to all three calendar actions: `create_calendar_event`, `create_meeting`, and `update_calendar_event`

## Test plan

### Claude Code
- [x] Added unit tests for `normalizeCalendarTimeParams` covering alias mapping, canonical preservation, both-present precedence, partial aliases, alias removal, and invalid JSON
- [x] All existing google connector tests pass
- [x] `go vet` passes clean

### OpenClaw
- [ ] Test with an agent that sends `start`/`end` params to verify the action now executes successfully
- [ ] Test that agents sending the correct `start_time`/`end_time` continue to work unchanged
- [ ] [Follow-up] Apply normalization at approval ingestion so the approval detail view no longer shows red "missing" badges when aliases are used (separate from execution fix)

https://claude.ai/code/session_01C6yznr1rX1iJpmPyELg3Zx