### PR TITLE
Add GitHub Actions workflow to auto-publish @permission-slip/cli to npm

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -9,6 +9,8 @@ jobs:
   publish:
     name: Publish @permission-slip/cli
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -17,6 +19,8 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
 
       - name: Install dependencies
         run: cd cli && npm ci
@@ -26,6 +30,16 @@ jobs:
 
       - name: Build
         run: cd cli && npm run build
+
+      - name: Verify package version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#cli/v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+        working-directory: cli
 
       - name: Publish to npm
         run: cd cli && npm publish --access public

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,33 @@
+name: Publish CLI to npm
+
+on:
+  push:
+    tags:
+      - 'cli/v*'
+
+jobs:
+  publish:
+    name: Publish @permission-slip/cli
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: cd cli && npm ci
+
+      - name: Run tests
+        run: cd cli && npm test
+
+      - name: Build
+        run: cd cli && npm run build
+
+      - name: Publish to npm
+        run: cd cli && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-cli.yml` that triggers on `cli/v*` tags (e.g. `cli/v0.1.0`)
- Runs `npm ci`, `npm test`, and `npm run build` before publishing
- Publishes with `--access public` to npm using the `NPM_TOKEN` secret
- Closes #485 (the publish workflow portion — CLI implementation is tracked separately)

## Test plan

### Claude Code
- [ ] Verify workflow YAML is valid (no syntax errors)

### OpenClaw
- [ ] Create `@permission-slip` npm org on npmjs.com
- [ ] Generate npm automation token and add as `NPM_TOKEN` repo secret
- [ ] Once `cli/` directory exists and is ready, push a `cli/v0.1.0` tag and confirm the workflow runs successfully and the package appears on npmjs.com

https://claude.ai/code/session_0175mVg3r65xcagdJPPQ4WRA