### PR TITLE
Optimize /watch skill with shell-based polling loop

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -58,7 +58,12 @@ The agent orchestrates the session by running the shell scripts and only doing A
 ### Step 1: Run the polling script
 
 ```bash
-bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" ${AUTO_MERGE:+--automerge} 2>&1
+# First run (no --work-dir):
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") 2>&1
+# Capture WORK_DIR from the session context JSON in the output.
+
+# Subsequent runs (reuse WORK_DIR to preserve state):
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") --work-dir "$WORK_DIR" 2>&1
 ```
 
 The script handles:
@@ -284,7 +289,7 @@ After the agent finishes processing work items, go back to **Step 1** and run th
 When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has already been posted by the script. Run the post-session script:
 
 ```bash
-bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" ${AUTO_MERGE:+--automerge} 2>&1
+bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") 2>&1
 ```
 
 This handles:

--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -9,6 +9,33 @@ argument-hint: "<PR_URL> [--automerge]"
 
 Poll a GitHub Pull Request for all comments (general and inline review comments) and PR reviews (top-level review submissions) and autonomously act on each one.
 
+This skill uses shell scripts for all mechanical bookkeeping (polling, fetching, deduplication, idle tracking, checklist parsing, wrap-up generation) and only invokes the agent for tasks requiring AI reasoning (implementing changes, resolving conflicts, diagnosing CI failures).
+
+## Architecture
+
+```
+watch-poll.sh          — Deterministic polling loop (no AI needed)
+  ├── Fetches comments from 3 GitHub API endpoints
+  ├── Deduplicates by tracking last-seen IDs
+  ├── Filters out bot-authored comments
+  ├── Merges from main, detects conflicts
+  ├── Parses PR body for unchecked Claude Code checklist items
+  ├── Writes work-items.json when there's actionable work
+  └── Generates wrap-up comment from action-log.json on idle timeout
+
+watch-post.sh          — Post-session tasks (no AI needed)
+  ├── Triggers CI and audit workflows
+  ├── Waits for completion
+  ├── Auto-merges if enabled and checks pass
+  └── Triggers webhook notification
+
+Agent (this skill)     — Only invoked when reasoning is needed
+  ├── Implements review comment requests
+  ├── Resolves merge conflicts
+  ├── Diagnoses and fixes CI failures
+  └── Appends actions to action-log.json
+```
+
 ## Setup
 
 Parse the arguments from: `$ARGUMENTS`
@@ -22,105 +49,79 @@ Set these variables for the session:
 - `PR_NUMBER` — the extracted PR number
 - `AUTO_MERGE` — `true` if `--automerge` was passed, `false` otherwise
 - `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
+- `SKILL_DIR` — the directory containing this skill file (`.claude/skills/watch`)
 
-## Pre-Poll: Merge from Main
+## Orchestration Loop
 
-Before entering the polling loop, merge the latest main into the branch. This ensures the branch starts from a clean, up-to-date state before processing review comments.
+The agent orchestrates the session by running the shell scripts and only doing AI work when the scripts signal that it's needed.
 
-```bash
-git fetch origin main
-git merge origin/main --no-edit
-```
-
-If the merge produces conflicts, follow the same conflict resolution procedure described in Polling Loop step 2. Run tests and build after resolving.
-
-CI is manual-only (`workflow_dispatch`), so there are no check runs to inspect at this point. CI will be triggered once at the end of the watch session (see Post-Poll step 11).
-
-## Polling Loop
-
-Poll every **60 seconds**. On each poll cycle:
-
-### 1. Fetch All Comments and Reviews
-
-Fetch **all** comments and reviews using all three endpoints (PR reviews, review comments, and issue-level comments are separate):
+### Step 1: Run the polling script
 
 ```bash
-# PR reviews (top-level review submissions — approve, request changes, comment)
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}/reviews?per_page=100"
-
-# Review comments (inline on diffs)
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}/comments?per_page=100"
-
-# Issue-level comments (general PR conversation)
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/issues/${PR_NUMBER}/comments?per_page=100"
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" ${AUTO_MERGE:+--automerge} 2>&1
 ```
 
-Handle pagination if there are more than 100 results per endpoint.
+The script handles:
+- Fetching comments from all 3 GitHub API endpoints (reviews, review comments, issue comments)
+- Deduplication via last-seen ID tracking per endpoint
+- Filtering out bot-authored comments
+- Merging from main and detecting conflicts
+- Parsing the PR body for unchecked `### Claude Code` checklist items
+- Idle counter tracking (6 consecutive empty cycles = timeout)
+- Generating and posting the wrap-up comment on idle timeout
 
-**PR reviews note:** Each review object has a `body` (which may be empty) and a `state` (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED`, `PENDING`). Only process reviews that have a non-empty `body` — empty-body reviews (e.g., a bare approval with no text) have no actionable instructions. Ignore reviews with state `PENDING` (these are drafts not yet submitted).
+### Step 2: Check script output
 
-### 2. Merge from Main
+The script communicates via stdout signals and exit codes:
 
-Keep the branch up to date by merging from main on every poll cycle. This prevents the branch from drifting too far from the base branch and avoids large conflict resolutions later.
+**Exit code 0 + `AGENT_NEEDED`**: The script found actionable work. Read `WORK_ITEMS_FILE` for the structured work items:
 
-```bash
-# Fetch the latest base branch
-git fetch origin main
-
-# Merge main into the current branch
-git merge origin/main --no-edit
+```json
+{
+  "pr_number": "123",
+  "pr_url": "https://github.com/.../pull/123",
+  "branch": "feature-branch",
+  "cycle": 1,
+  "comments": [
+    {
+      "type": "review_comment",
+      "id": 456,
+      "author": "reviewer",
+      "body": "Please rename this variable",
+      "path": "src/main.go",
+      "line": 42,
+      "diff_hunk": "...",
+      "node_id": "..."
+    }
+  ],
+  "merge_status": "clean|updated|conflict",
+  "conflict_files": ["file1.go", "file2.ts"],
+  "checklist_items": [
+    {"type": "checklist", "text": "Add unit tests for the new handler"}
+  ]
+}
 ```
 
-**If the merge succeeds cleanly** (no conflicts and no new commits), continue to the next step — the branch is already up to date.
+**Exit code 0 + `IDLE_TIMEOUT`**: The session ended due to inactivity. The script already posted the wrap-up comment. Proceed to Step 4 (post-session).
 
-**If the merge succeeds with new commits**, the branch has been updated. Continue to the next step — tests will be run before pushing.
+**Exit code 100**: Pre-poll merge conflict. The script detected conflicts before the polling loop started. Read `WORK_ITEMS_FILE` for conflict details and resolve them (see Step 3), then re-run the polling script.
 
-**If the merge produces conflicts**, resolve them thoughtfully:
+### Step 3: Process work items (AI reasoning)
 
-1. **Run `git diff --name-only --diff-filter=U`** to list all conflicted files.
-2. **For each conflicted file:**
-   a. **Read the entire file** to understand the full context — not just the conflict markers.
-   b. **Read the PR diff** (`git diff origin/main..HEAD -- <file>`) to understand what this branch intended to change.
-   c. **Read the base branch version** (`git show origin/main:<file>`) to understand what changed upstream.
-   d. **Understand intent from both sides** — what was the PR trying to accomplish? What did the base branch change introduce? Check recent commit messages on both sides (`git log --oneline HEAD..origin/main -- <file>` and `git log --oneline origin/main..HEAD -- <file>`) for context.
-   e. **Resolve the conflict** by editing the file to preserve the intent of both sides. Do NOT blindly accept "ours" or "theirs" — merge the logic correctly so both changes coexist. If the changes are truly incompatible (e.g., both sides renamed the same function differently), prefer the PR branch's version but note this in the decision log.
-   f. **Stage the resolved file** with `git add <file>`.
-3. **After resolving all files**, complete the merge commit:
-   ```bash
-   git commit -m "Merge origin/main: resolve conflicts in <list of files>"
-   ```
-4. **Run tests** (`make test`) and **build** (`make build`) to verify the resolution didn't break anything. If tests fail, investigate and fix before proceeding.
-5. **Reset the idle counter to 0** — a merge conflict resolution counts as meaningful activity.
+For each item in `work-items.json`, apply the appropriate action:
 
-**If the conflict cannot be resolved confidently** (e.g., large-scale structural changes on both sides that require product decisions), do NOT force a resolution. Instead:
-- Abort the merge (`git merge --abort`)
-- Post a comment on the PR explaining which files conflict and why automatic resolution isn't safe
-- Log this in the decision log as an open question
+#### Comments and Reviews
 
-### 3. Track and Process New Comments
+For each comment or review in the `comments` array:
 
-- Track the **last-seen ID** for each endpoint separately (review IDs, review comment IDs, and issue comment IDs).
-- On the **first poll**, process ALL existing comments and reviews.
-- On subsequent polls, only process items with IDs greater than the last-seen ID for that endpoint.
-- Process new items in **chronological order** — never skip any, even if multiple arrive between polls.
-- Ignore comments and reviews authored by yourself (the bot).
-- For PR reviews, use the review `id` field for tracking. Only process reviews with a non-empty `body` and a non-`PENDING` state.
-
-### 4. Act on Each Comment or Review
-
-For each new comment or review:
-
-1. **Read** the instruction in the comment/review body.
-2. **Identify** the file and line it's attached to (for inline review comments). For PR reviews, the body applies to the PR as a whole — check the review's `state` for additional context (e.g., `CHANGES_REQUESTED` signals required fixes).
+1. **Read** the instruction in the comment body.
+2. **Identify** the file and line it's attached to (for inline review comments — use `path` and `line` fields). For PR reviews, the body applies to the PR as a whole — check `state` for context (`CHANGES_REQUESTED` signals required fixes).
 3. **Decide** whether to act on it or disagree:
    - **If you agree**: Implement the change. Commit with a clear message referencing the comment.
    - **If you disagree**: Leave a reply on that comment thread explaining your reasoning.
 4. **Do not ask questions** — make your best judgment and implement.
 5. **After implementing**: Run relevant tests (`make test-backend` for Go, `make test-frontend` for frontend, `make test` if unsure).
-
-### 5. Resolve Conversations
-
-After addressing a review comment, **resolve the conversation** using the GitHub GraphQL API:
+6. **Resolve the conversation** using the GitHub GraphQL API:
 
 ```bash
 GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api graphql -f query='
@@ -133,7 +134,7 @@ mutation {
 }'
 ```
 
-To get the thread node ID, use the `node_id` field from the review comment, or query for PR review threads:
+To get the thread node ID, query for PR review threads and match by `databaseId`:
 
 ```bash
 GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api graphql -f query='
@@ -157,9 +158,47 @@ query {
 }'
 ```
 
-Match threads by comment `databaseId` to find the correct `id` for resolving.
+7. **Log the action** by appending to the action log file (see Action Log Format below).
 
-### 6. Decision Log
+#### Merge Conflicts
+
+If `merge_status` is `"conflict"` and `conflict_files` is non-empty:
+
+1. **Run `git diff --name-only --diff-filter=U`** to list all conflicted files.
+2. **For each conflicted file:**
+   a. **Read the entire file** to understand the full context — not just the conflict markers.
+   b. **Read the PR diff** (`git diff origin/main..HEAD -- <file>`) to understand what this branch intended to change.
+   c. **Read the base branch version** (`git show origin/main:<file>`) to understand what changed upstream.
+   d. **Understand intent from both sides** — check recent commit messages on both sides for context.
+   e. **Resolve the conflict** by editing the file to preserve the intent of both sides. Do NOT blindly accept "ours" or "theirs". If changes are truly incompatible, prefer the PR branch's version but note this in the action log.
+   f. **Stage the resolved file** with `git add <file>`.
+3. **Complete the merge commit:**
+   ```bash
+   git commit -m "Merge origin/main: resolve conflicts in <list of files>"
+   ```
+4. **Run tests** (`make test`) and **build** (`make build`) to verify the resolution.
+5. **Log conflict resolutions** in the action log.
+
+**If the conflict cannot be resolved confidently**, abort the merge (`git merge --abort`), post a comment on the PR explaining why, and log it as an open question.
+
+#### Checklist Items
+
+For each item in the `checklist_items` array:
+
+1. **Read and understand** the checklist item text.
+2. **Implement** the requested change (adding tests, fixing lint, updating docs, etc.).
+3. **Run relevant tests** to verify.
+4. **Commit** with a clear message referencing the checklist item.
+5. **Check off the item** in the PR body:
+   ```bash
+   CURRENT_BODY=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}" --jq '.body')
+   UPDATED_BODY=$(echo "$CURRENT_BODY" | sed 's/- \[ \] <exact item text>/- [x] <exact item text>/')
+   GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}" -X PATCH -f body="$UPDATED_BODY"
+   ```
+   Update the PR body after each item to avoid race conditions.
+6. **Log the action** in the action log.
+
+#### Decision Log
 
 For anything you **considered but chose not to do**, or **had questions about**, or **made a judgment call on**:
 
@@ -168,215 +207,105 @@ For anything you **considered but chose not to do**, or **had questions about**,
   - `- [ ] Considered X but chose Y because Z (commit abc123)`
   - `- [ ] Question: Should we also handle edge case X?`
 
-### 7. Process PR Body Checklist
+#### Push Changes
 
-On each poll cycle, fetch the PR body and check for unchecked checklist items that Claude Code can address.
-
-#### Fetch the PR body
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}" --jq '.body'
-```
-
-#### Identify unchecked items
-
-Parse the PR body for unchecked checklist items (`- [ ]`). These may appear under any heading, but pay special attention to items under headings like `### Claude Code`, `### Automated`, or similar sections that indicate tasks meant for Claude Code.
-
-**Skip** items that are clearly meant for humans or for OpenClaw (e.g., items under `### OpenClaw`, `### Manual`, or items that require human judgment like "get stakeholder sign-off", "manually verify in production", "design review").
-
-#### Act on each item
-
-For each unchecked item that Claude Code can address:
-
-1. **Read and understand** the checklist item.
-2. **Implement** the requested change — this might be adding tests, fixing lint issues, updating documentation, running checks, adding error handling, etc.
-3. **Run relevant tests** to verify the change doesn't break anything.
-4. **Commit** with a clear message referencing the checklist item.
-5. **Check off the item** in the PR body by updating it via the API:
-
-```bash
-# Fetch current body, update the checkbox, and PATCH it back
-CURRENT_BODY=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}" --jq '.body')
-# Replace the specific "- [ ] <item text>" with "- [x] <item text>"
-UPDATED_BODY=$(echo "$CURRENT_BODY" | sed 's/- \[ \] <exact item text>/- [x] <exact item text>/')
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/pulls/${PR_NUMBER}" -X PATCH -f body="$UPDATED_BODY"
-```
-
-**Important:** Update the PR body after each item (not in batch) to avoid race conditions if the PR body is edited concurrently.
-
-If new checklist items were processed, reset the idle counter to 0.
-
-### 8. Push Changes
-
-After processing all new comments and checklist items in a poll cycle, push your commits:
+After processing all work items, push your commits:
 
 ```bash
 git push -u origin <current-branch>
 ```
 
-### 9. Continue Polling
+### Step 3b: Update the action log
 
-After each cycle, wait 60 seconds and poll again.
+After processing all work items, append entries to the action log file (`ACTION_LOG_FILE` from the script output). The agent must read the current log, append new entries, and write it back.
 
-**Idle timeout:** Track the number of consecutive poll cycles with **no new comments, reviews, merge conflicts, or checklist items processed**. If **6 consecutive cycles** pass with no new activity (i.e., 6 minutes of inactivity), **stop polling** and post a wrap-up comment on the PR before exiting (see step 10).
+#### Action Log Format
 
-If any cycle finds new comments, reviews, merge conflicts that needed resolution, new commits merged in from main, or unchecked checklist items that were processed, reset the idle counter to 0.
+The action log is a JSON array. Each entry has a `type` field and type-specific fields:
 
-### 10. Post Wrap-Up Comment on Idle Exit
+```json
+[
+  {
+    "type": "change",
+    "description": "Rename variable for clarity",
+    "detail": "Renamed `usr` to `currentUser` per reviewer request",
+    "commit": "abc1234"
+  },
+  {
+    "type": "implemented",
+    "author": "reviewer-username",
+    "request": "rename the variable",
+    "commit": "abc1234"
+  },
+  {
+    "type": "declined",
+    "author": "reviewer-username",
+    "request": "add caching here",
+    "reason": "premature optimization, no performance issue observed"
+  },
+  {
+    "type": "conflict_resolution",
+    "file": "src/main.go",
+    "detail": "branch added handler, main renamed package — kept both changes",
+    "commit": "def5678"
+  },
+  {
+    "type": "checklist_done",
+    "text": "Add unit tests for the new handler",
+    "detail": "Added 3 test cases covering success, auth failure, and validation",
+    "commit": "ghi9012"
+  },
+  {
+    "type": "checklist_skipped",
+    "text": "Get stakeholder sign-off",
+    "reason": "requires human action / OpenClaw task"
+  },
+  {
+    "type": "judgment",
+    "description": "Whether to split the handler file",
+    "choice": "split into handler.go and handler_test.go",
+    "reason": "file was over 500 lines, splitting improves maintainability"
+  },
+  {
+    "type": "open_question",
+    "description": "Should we also add rate limiting to this endpoint?"
+  }
+]
+```
 
-When stopping due to the idle timeout, post a comment on the PR summarizing the entire watch session. Use the following command:
+### Step 4: Loop back to polling
+
+After the agent finishes processing work items, go back to **Step 1** and run the polling script again. The script maintains state across invocations via temp files in its work directory.
+
+**Important**: Pass the same work directory to the script on subsequent runs so it preserves last-seen IDs and the action log. The script's `WORK_DIR` is printed in its session context output — capture it on the first run and reuse it.
+
+### Step 5: Post-session tasks
+
+When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has already been posted by the script. Run the post-session script:
 
 ```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/issues/${PR_NUMBER}/comments" -f body="<comment body>"
+bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" ${AUTO_MERGE:+--automerge} 2>&1
 ```
 
-The comment must include these sections:
+This handles:
+- Triggering CI and audit workflows
+- Waiting for them to complete
+- Auto-merging if enabled and checks pass
+- Triggering the webhook notification
 
-**a) Summary of Changes** — A concise overview of all changes made during this watch session. List each commit with its message and what it addressed.
+**If the post-session script exits with code 101 (CI failure) or 102 (audit failure):**
 
-**b) Merge Conflict Resolutions** — If any merge conflicts were resolved during the session, list each one:
-- Which files had conflicts
-- What the competing changes were (branch vs. base)
-- How the conflict was resolved and why
+1. Read the failure logs from the file path in the script output.
+2. Reproduce locally by running the relevant commands.
+3. Fix the issue, commit, and push.
+4. Post an addendum comment:
+   ```markdown
+   ## 🔧 Post-Session Check Fixes
 
-**c) PR Checklist Items** — A summary of checklist items processed from the PR body:
-- Which items were completed (checked off) and what was done for each.
-- Which items were skipped because they require human action or are meant for OpenClaw.
-
-**d) Decision Log** — A record of key choices made during the session:
-- **Implemented:** What review comments were acted on and how.
-- **Declined / Disagreed:** Any review comments you chose not to implement, with reasoning.
-- **Judgment Calls:** Ambiguous requests where you picked an approach — explain what you chose and why.
-- **Open Questions:** Anything that may need human follow-up or further discussion.
-
-Format the comment in markdown. Example structure:
-
-```markdown
-## 🤖 Watch Session Summary
-
-### Changes Made
-- **`<short description>`** (`<commit hash>`) — <what was changed and why>
-- ...
-
-### Merge Conflict Resolutions
-- **`<file>`** — <branch changed X, main changed Y> → resolved by <approach> (`<commit hash>`)
-- ...
-
-*(Omit this section if no merge conflicts occurred.)*
-
-### PR Checklist Items
-- ✅ **`<item text>`** — <what was done> (`<commit hash>`)
-- ⏭️ **`<item text>`** — skipped (requires human action / OpenClaw task)
-- ...
-
-*(Omit this section if no checklist items were in the PR body.)*
-
-### Decision Log
-
-#### ✅ Implemented
-- <comment author> asked for X → implemented in `<commit hash>`
-- ...
-
-#### ❌ Declined
-- <comment author> suggested X → declined because Y
-- ...
-
-#### ⚖️ Judgment Calls
-- <description of ambiguous situation> → chose X because Y
-- ...
-
-#### ❓ Open Questions
-- <anything that needs human follow-up>
-- ...
-
----
-*Watch session ended after 6 minutes of inactivity. Processed N comments across M poll cycles.*
-```
-
-If no changes were made during the session (e.g., all comments were already addressed before watching started, or no comments existed), still post the comment noting that no action was needed.
-
-### 11. Post-Poll: Trigger CI and Fix Failing Checks
-
-CI is manual-only, so after posting the wrap-up comment, **trigger CI once** against the final state of the branch, wait for it to complete, and fix any failures.
-
-#### a) Trigger the CI and audit workflows
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run ci.yml --ref "$(git branch --show-current)"
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run audit.yml --ref "$(git branch --show-current)"
-```
-
-#### b) Wait for the run to appear and complete
-
-Poll until the run triggered above finishes. First, wait ~5 seconds for the run to register, then poll:
-
-```bash
-# Find the most recent run on this branch
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh run list --workflow=ci.yml --branch "$(git branch --show-current)" --limit 1 --json databaseId,status,conclusion
-```
-
-Poll every 30 seconds until `status` is `completed`. Do the same for the audit workflow:
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh run list --workflow=audit.yml --branch "$(git branch --show-current)" --limit 1 --json databaseId,status,conclusion
-```
-
-Wait for both workflows to complete before proceeding.
-
-#### c) Check results
-
-If `conclusion` is `success`, no action needed — exit cleanly.
-
-If `conclusion` is `failure`:
-
-1. Fetch the failed run's logs:
-   ```bash
-   GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh run view <run-id> --log-failed
+   Fixed failing checks after watch session ended:
+   - **`<description>`** (`<commit hash>`) — <what was failing and how it was fixed>
    ```
-2. **Read the failure logs** to understand what went wrong.
-3. **Reproduce locally** by running the relevant commands (`make test-backend`, `make test-frontend`, `make build`).
-4. **Fix the issue** — read surrounding code context, understand the root cause, implement the fix.
-5. **Run tests and build locally** to verify the fix.
-6. **Commit** with a clear message (e.g., `fix: resolve failing CI — <brief description>`).
-7. **Push** to the branch.
-8. **Trigger CI again** (repeat from step a) to verify the fix. If it fails again, repeat the fix cycle up to 3 times before posting a comment that CI cannot be fixed automatically.
-
-If fixes were pushed, append an addendum to the wrap-up comment (post a new comment) noting the additional fixes made:
-
-```markdown
-## 🔧 Post-Session Check Fixes
-
-Fixed failing checks after watch session ended:
-- **`<description>`** (`<commit hash>`) — <what was failing and how it was fixed>
-```
-
-### 12. Auto-Merge (if enabled)
-
-If `AUTO_MERGE` is `true` and **both** CI and audit workflows passed (`conclusion` is `success`), merge the PR:
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr merge ${PR_NUMBER} --squash --delete-branch
-```
-
-If the merge fails (e.g., branch protection rules, required reviews not met), post a comment on the PR explaining why auto-merge could not complete:
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh api "/repos/supersuit-tech/permission-slip/issues/${PR_NUMBER}/comments" -f body="⚠️ **Auto-merge failed.** The \`--automerge\` flag was set, but the merge could not be completed. Reason: <error details>. Please merge manually."
-```
-
-If `AUTO_MERGE` is `false`, or if CI/audit failed, skip this step.
-
-### 13. Trigger Webhook Notification
-
-After all polling, wrap-up, check fixes, and optional auto-merge are complete, trigger the webhook workflow to notify that the watch session has finished:
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run trigger-webhook.yml -f pr_url="${PR_URL}"
-```
-
-`PR_URL` is the PR URL extracted from the arguments during Setup. This fires the `trigger-webhook.yml` workflow in the `supersuit-tech/permission-slip` repo, which sends a webhook notification with the PR URL.
-
-This step runs unconditionally — whether or not changes were made during the session.
+5. Re-run the post-session script. Repeat up to 3 times before posting a comment that CI cannot be fixed automatically.
 
 ## Important Rules
 
@@ -386,3 +315,4 @@ This step runs unconditionally — whether or not changes were made during the s
 - **Run tests** before pushing to make sure nothing is broken.
 - **Run `make build`** before pushing to catch TypeScript compilation errors.
 - **Be thorough** — read surrounding code context before making changes.
+- **Always update the action log** after completing work — the wrap-up comment is generated from it.

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -3,7 +3,12 @@
 # Handles all mechanical bookkeeping (fetching, deduplication, idle timeout)
 # and only invokes the Claude agent when there's actionable work.
 #
-# Usage: bash watch-poll.sh <PR_URL> [--automerge]
+# Usage: bash watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>]
+#
+# Options:
+#   --automerge       Enable auto-merge after checks pass
+#   --work-dir <path> Reuse an existing work directory (preserves state
+#                     across invocations: last-seen IDs, action log, cache)
 #
 # Environment:
 #   GH_HOST, GH_REPO — set by caller (defaults provided below)
@@ -18,11 +23,18 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Arguments
 # ---------------------------------------------------------------------------
-PR_URL="${1:?Usage: watch-poll.sh <PR_URL> [--automerge]}"
+PR_URL="${1:?Usage: watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>]}"
 AUTO_MERGE=false
-if [[ "${2:-}" == "--automerge" ]]; then
-  AUTO_MERGE=true
-fi
+EXISTING_WORK_DIR=""
+
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --automerge) AUTO_MERGE=true; shift ;;
+    --work-dir) EXISTING_WORK_DIR="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
 
 PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
 if [[ -z "$PR_NUMBER" ]]; then
@@ -39,7 +51,11 @@ BRANCH=$(git branch --show-current)
 # ---------------------------------------------------------------------------
 # Working directory for session state
 # ---------------------------------------------------------------------------
-WORK_DIR=$(mktemp -d "/tmp/watch-session-XXXXXX")
+if [[ -n "$EXISTING_WORK_DIR" && -d "$EXISTING_WORK_DIR" ]]; then
+  WORK_DIR="$EXISTING_WORK_DIR"
+else
+  WORK_DIR=$(mktemp -d "/tmp/watch-session-XXXXXX")
+fi
 # No EXIT trap — the caller (SKILL.md) is responsible for cleanup
 # since work-items.json and action-log.json must survive across script exits.
 
@@ -51,10 +67,11 @@ WORK_ITEMS_FILE="$WORK_DIR/work-items.json"
 ACTION_LOG_FILE="$WORK_DIR/action-log.json"
 CHECKLIST_CACHE_FILE="$WORK_DIR/checklist-cache.txt"
 
-echo "0" > "$LAST_REVIEW_ID_FILE"
-echo "0" > "$LAST_REVIEW_COMMENT_ID_FILE"
-echo "0" > "$LAST_ISSUE_COMMENT_ID_FILE"
-echo "[]" > "$ACTION_LOG_FILE"
+# Only initialize state files if they don't already exist (fresh session)
+[[ -f "$LAST_REVIEW_ID_FILE" ]] || echo "0" > "$LAST_REVIEW_ID_FILE"
+[[ -f "$LAST_REVIEW_COMMENT_ID_FILE" ]] || echo "0" > "$LAST_REVIEW_COMMENT_ID_FILE"
+[[ -f "$LAST_ISSUE_COMMENT_ID_FILE" ]] || echo "0" > "$LAST_ISSUE_COMMENT_ID_FILE"
+[[ -f "$ACTION_LOG_FILE" ]] || echo "[]" > "$ACTION_LOG_FILE"
 
 # Bot username(s) to filter out
 BOT_USERS=("claude-code[bot]" "github-actions[bot]" "claude[bot]")
@@ -259,15 +276,15 @@ fetch_checklist_items() {
     cached=$(cat "$CHECKLIST_CACHE_FILE")
   fi
 
-  local new_items="[]"
-  while IFS= read -r item_text; do
-    [[ -z "$item_text" ]] && continue
-    if [[ -z "$cached" ]] || ! echo "$cached" | grep -qF "$item_text"; then
-      new_items=$(echo "$new_items" | jq --arg text "$item_text" '. + [{type: "checklist", text: $text}]')
-    fi
-  done < <(echo "$items" | jq -r '.[].text')
-
-  echo "$new_items"
+  # Filter out already-processed items using jq (avoids pipe subshell issues)
+  if [[ -z "$cached" ]]; then
+    echo "$items"
+  else
+    # Build a jq filter that excludes exact matches against cached lines
+    echo "$items" | jq --arg cache "$cached" '
+      ($cache | split("\n") | map(select(length > 0))) as $done |
+      [.[] | select(.text as $t | $done | index($t) | not)]'
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -278,12 +295,15 @@ check_off_item() {
   local current_body
   current_body=$(gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.body' 2>/dev/null || echo "")
 
-  # Escape special characters for sed
-  local escaped_text
-  escaped_text=$(printf '%s' "$item_text" | sed 's/[&/\]/\\&/g')
-
+  # Use python3 for literal string replacement (avoids sed regex escaping issues)
   local updated_body
-  updated_body=$(echo "$current_body" | sed "s/- \[ \] ${escaped_text}/- [x] ${escaped_text}/")
+  updated_body=$(python3 -c "
+import sys
+body = sys.stdin.read()
+old = '- [ ] ' + sys.argv[1]
+new = '- [x] ' + sys.argv[1]
+print(body.replace(old, new, 1), end='')
+" "$item_text" <<< "$current_body")
 
   gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" -X PATCH -f body="$updated_body" > /dev/null 2>&1
 
@@ -441,7 +461,7 @@ ${open_questions}
 
   wrapup="${wrapup}
 ---
-*Watch session ended after ${MAX_IDLE_CYCLES} minutes of inactivity. Processed ${comment_count} comments across ${total_cycles} poll cycles.*"
+*Watch session ended after $((MAX_IDLE_CYCLES * POLL_INTERVAL / 60)) minutes of inactivity. Processed ${comment_count} comments across ${total_cycles} poll cycles.*"
 
   echo "$wrapup" > "$WORK_DIR/wrap-up.md"
   echo "$wrapup"

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -1,0 +1,593 @@
+#!/usr/bin/env bash
+# watch-poll.sh — Deterministic polling loop for the /watch skill.
+# Handles all mechanical bookkeeping (fetching, deduplication, idle timeout)
+# and only invokes the Claude agent when there's actionable work.
+#
+# Usage: bash watch-poll.sh <PR_URL> [--automerge]
+#
+# Environment:
+#   GH_HOST, GH_REPO — set by caller (defaults provided below)
+#
+# Outputs (in WORK_DIR):
+#   work-items.json  — new items for the agent to process
+#   action-log.json  — agent appends its actions here; used for wrap-up
+#   wrap-up.md       — generated session summary posted to the PR
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+PR_URL="${1:?Usage: watch-poll.sh <PR_URL> [--automerge]}"
+AUTO_MERGE=false
+if [[ "${2:-}" == "--automerge" ]]; then
+  AUTO_MERGE=true
+fi
+
+PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "ERROR: Could not parse PR number from URL: $PR_URL" >&2
+  exit 1
+fi
+
+OWNER="supersuit-tech"
+REPO="permission-slip"
+export GH_HOST="${GH_HOST:-github.com}"
+export GH_REPO="${GH_REPO:-${OWNER}/${REPO}}"
+BRANCH=$(git branch --show-current)
+
+# ---------------------------------------------------------------------------
+# Working directory for session state
+# ---------------------------------------------------------------------------
+WORK_DIR=$(mktemp -d "/tmp/watch-session-XXXXXX")
+# No EXIT trap — the caller (SKILL.md) is responsible for cleanup
+# since work-items.json and action-log.json must survive across script exits.
+
+# State files
+LAST_REVIEW_ID_FILE="$WORK_DIR/last-review-id"
+LAST_REVIEW_COMMENT_ID_FILE="$WORK_DIR/last-review-comment-id"
+LAST_ISSUE_COMMENT_ID_FILE="$WORK_DIR/last-issue-comment-id"
+WORK_ITEMS_FILE="$WORK_DIR/work-items.json"
+ACTION_LOG_FILE="$WORK_DIR/action-log.json"
+CHECKLIST_CACHE_FILE="$WORK_DIR/checklist-cache.txt"
+
+echo "0" > "$LAST_REVIEW_ID_FILE"
+echo "0" > "$LAST_REVIEW_COMMENT_ID_FILE"
+echo "0" > "$LAST_ISSUE_COMMENT_ID_FILE"
+echo "[]" > "$ACTION_LOG_FILE"
+
+# Bot username(s) to filter out
+BOT_USERS=("claude-code[bot]" "github-actions[bot]" "claude[bot]")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+POLL_INTERVAL=60
+MAX_IDLE_CYCLES=6
+IDLE_COUNTER=0
+CYCLE=0
+
+# ---------------------------------------------------------------------------
+# Helper: run gh with correct env
+# ---------------------------------------------------------------------------
+gh_api() {
+  GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh api "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Fetch comments from all three endpoints, filter to new + non-bot
+# Returns JSON array of work items
+# ---------------------------------------------------------------------------
+fetch_new_comments() {
+  local last_review_id last_rc_id last_ic_id
+  last_review_id=$(cat "$LAST_REVIEW_ID_FILE")
+  last_rc_id=$(cat "$LAST_REVIEW_COMMENT_ID_FILE")
+  last_ic_id=$(cat "$LAST_ISSUE_COMMENT_ID_FILE")
+
+  local items="[]"
+
+  # --- PR Reviews ---
+  local reviews
+  reviews=$(gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" 2>/dev/null || echo "[]")
+
+  local new_reviews
+  new_reviews=$(echo "$reviews" | jq -r --argjson last "$last_review_id" '
+    [.[] | select(
+      .id > $last
+      and .body != null and .body != ""
+      and .state != "PENDING"
+    )] | sort_by(.id)')
+
+  # Filter out bots
+  new_reviews=$(echo "$new_reviews" | jq -r --argjson bots "$(printf '%s\n' "${BOT_USERS[@]}" | jq -R . | jq -s .)" '
+    [.[] | select(.user.login as $u | $bots | index($u) | not)]')
+
+  local max_review_id
+  max_review_id=$(echo "$new_reviews" | jq -r '[.[].id] | max // 0')
+  if [[ "$max_review_id" != "0" && "$max_review_id" != "null" ]]; then
+    echo "$max_review_id" > "$LAST_REVIEW_ID_FILE"
+  fi
+
+  # Map reviews to work items
+  items=$(echo "$items" | jq --argjson revs "$new_reviews" '
+    . + [$revs[] | {
+      type: "review",
+      id: .id,
+      author: .user.login,
+      state: .state,
+      body: .body,
+      submitted_at: .submitted_at,
+      node_id: .node_id
+    }]')
+
+  # --- Review Comments (inline on diffs) ---
+  local review_comments
+  review_comments=$(gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" 2>/dev/null || echo "[]")
+
+  local new_rcs
+  new_rcs=$(echo "$review_comments" | jq -r --argjson last "$last_rc_id" '
+    [.[] | select(.id > $last)] | sort_by(.id)')
+
+  new_rcs=$(echo "$new_rcs" | jq -r --argjson bots "$(printf '%s\n' "${BOT_USERS[@]}" | jq -R . | jq -s .)" '
+    [.[] | select(.user.login as $u | $bots | index($u) | not)]')
+
+  local max_rc_id
+  max_rc_id=$(echo "$new_rcs" | jq -r '[.[].id] | max // 0')
+  if [[ "$max_rc_id" != "0" && "$max_rc_id" != "null" ]]; then
+    echo "$max_rc_id" > "$LAST_REVIEW_COMMENT_ID_FILE"
+  fi
+
+  items=$(echo "$items" | jq --argjson rcs "$new_rcs" '
+    . + [$rcs[] | {
+      type: "review_comment",
+      id: .id,
+      author: .user.login,
+      body: .body,
+      path: .path,
+      line: (.line // .original_line),
+      diff_hunk: .diff_hunk,
+      created_at: .created_at,
+      node_id: .node_id,
+      in_reply_to_id: .in_reply_to_id
+    }]')
+
+  # --- Issue Comments (general PR conversation) ---
+  local issue_comments
+  issue_comments=$(gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null || echo "[]")
+
+  local new_ics
+  new_ics=$(echo "$issue_comments" | jq -r --argjson last "$last_ic_id" '
+    [.[] | select(.id > $last)] | sort_by(.id)')
+
+  new_ics=$(echo "$new_ics" | jq -r --argjson bots "$(printf '%s\n' "${BOT_USERS[@]}" | jq -R . | jq -s .)" '
+    [.[] | select(.user.login as $u | $bots | index($u) | not)]')
+
+  local max_ic_id
+  max_ic_id=$(echo "$new_ics" | jq -r '[.[].id] | max // 0')
+  if [[ "$max_ic_id" != "0" && "$max_ic_id" != "null" ]]; then
+    echo "$max_ic_id" > "$LAST_ISSUE_COMMENT_ID_FILE"
+  fi
+
+  items=$(echo "$items" | jq --argjson ics "$new_ics" '
+    . + [$ics[] | {
+      type: "issue_comment",
+      id: .id,
+      author: .user.login,
+      body: .body,
+      created_at: .created_at,
+      node_id: .node_id
+    }]')
+
+  echo "$items"
+}
+
+# ---------------------------------------------------------------------------
+# Merge from main, detect conflicts
+# Returns: "clean", "updated", or "conflict"
+# ---------------------------------------------------------------------------
+merge_from_main() {
+  git fetch origin main 2>/dev/null
+
+  local merge_output
+  if merge_output=$(git merge origin/main --no-edit 2>&1); then
+    if echo "$merge_output" | grep -q "Already up to date"; then
+      echo "clean"
+    else
+      echo "updated"
+    fi
+  else
+    # Merge failed — conflicts
+    echo "conflict"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Get conflicted files (when merge status is "conflict")
+# ---------------------------------------------------------------------------
+get_conflict_files() {
+  git diff --name-only --diff-filter=U 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Parse PR body for unchecked Claude Code checklist items
+# ---------------------------------------------------------------------------
+fetch_checklist_items() {
+  local pr_body
+  pr_body=$(gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.body' 2>/dev/null || echo "")
+
+  if [[ -z "$pr_body" ]]; then
+    echo "[]"
+    return
+  fi
+
+  # Save full body for later use
+  echo "$pr_body" > "$WORK_DIR/pr-body.txt"
+
+  # Extract unchecked items under Claude Code section
+  # We look for lines matching "- [ ] <text>" that appear after a "### Claude Code" heading
+  # and before the next heading of equal or higher level
+  local in_claude_section=false
+  local items="[]"
+
+  while IFS= read -r line; do
+    # Detect section headers
+    if [[ "$line" =~ ^###[[:space:]] ]]; then
+      if [[ "$line" =~ [Cc]laude[[:space:]]*[Cc]ode ]] || [[ "$line" =~ [Aa]utomated ]]; then
+        in_claude_section=true
+        continue
+      else
+        in_claude_section=false
+        continue
+      fi
+    fi
+    # Higher-level heading exits any section
+    if [[ "$line" =~ ^##[[:space:]] ]] && [[ ! "$line" =~ ^###[[:space:]] ]]; then
+      in_claude_section=false
+      continue
+    fi
+
+    # Collect unchecked items in Claude Code section
+    if $in_claude_section && [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[[[:space:]]\][[:space:]](.+) ]]; then
+      local item_text="${BASH_REMATCH[1]}"
+      items=$(echo "$items" | jq --arg text "$item_text" '. + [{type: "checklist", text: $text}]')
+    fi
+  done <<< "$pr_body"
+
+  # Compare with cache to only return new/unprocessed items
+  local cached=""
+  if [[ -f "$CHECKLIST_CACHE_FILE" ]]; then
+    cached=$(cat "$CHECKLIST_CACHE_FILE")
+  fi
+
+  local new_items="[]"
+  while IFS= read -r item_text; do
+    [[ -z "$item_text" ]] && continue
+    if [[ -z "$cached" ]] || ! echo "$cached" | grep -qF "$item_text"; then
+      new_items=$(echo "$new_items" | jq --arg text "$item_text" '. + [{type: "checklist", text: $text}]')
+    fi
+  done < <(echo "$items" | jq -r '.[].text')
+
+  echo "$new_items"
+}
+
+# ---------------------------------------------------------------------------
+# Mark a checklist item as done in the PR body
+# ---------------------------------------------------------------------------
+check_off_item() {
+  local item_text="$1"
+  local current_body
+  current_body=$(gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.body' 2>/dev/null || echo "")
+
+  # Escape special characters for sed
+  local escaped_text
+  escaped_text=$(printf '%s' "$item_text" | sed 's/[&/\]/\\&/g')
+
+  local updated_body
+  updated_body=$(echo "$current_body" | sed "s/- \[ \] ${escaped_text}/- [x] ${escaped_text}/")
+
+  gh_api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" -X PATCH -f body="$updated_body" > /dev/null 2>&1
+
+  # Update cache
+  echo "$item_text" >> "$CHECKLIST_CACHE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Build work-items.json for the agent
+# ---------------------------------------------------------------------------
+build_work_items() {
+  local comments="$1"
+  local merge_status="$2"
+  local conflict_files="$3"
+  local checklist_items="$4"
+
+  local work_items
+  work_items=$(jq -n \
+    --argjson comments "$comments" \
+    --arg merge_status "$merge_status" \
+    --arg conflict_files "$conflict_files" \
+    --argjson checklist "$checklist_items" \
+    --arg pr_number "$PR_NUMBER" \
+    --arg pr_url "$PR_URL" \
+    --arg branch "$BRANCH" \
+    --argjson cycle "$CYCLE" \
+    '{
+      pr_number: $pr_number,
+      pr_url: $pr_url,
+      branch: $branch,
+      cycle: $cycle,
+      comments: $comments,
+      merge_status: $merge_status,
+      conflict_files: ($conflict_files | split("\n") | map(select(. != ""))),
+      checklist_items: $checklist
+    }')
+
+  echo "$work_items" > "$WORK_ITEMS_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Generate wrap-up comment from action log
+# ---------------------------------------------------------------------------
+generate_wrapup() {
+  local total_cycles="$1"
+  local action_log
+  action_log=$(cat "$ACTION_LOG_FILE")
+
+  local changes conflicts checklist_done checklist_skipped
+  local implemented declined judgments open_questions
+
+  changes=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "change")] |
+    if length == 0 then "No changes made during this session."
+    else map("- **`" + .description + "`** (`" + .commit + "`) — " + .detail) | join("\n")
+    end')
+
+  conflicts=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "conflict_resolution")] |
+    if length == 0 then ""
+    else "### Merge Conflict Resolutions\n" + (map("- **`" + .file + "`** — " + .detail + " (`" + .commit + "`)") | join("\n"))
+    end')
+
+  checklist_done=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "checklist_done")] |
+    if length == 0 then ""
+    else map("- ✅ **`" + .text + "`** — " + .detail + " (`" + .commit + "`)") | join("\n")
+    end')
+
+  checklist_skipped=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "checklist_skipped")] |
+    if length == 0 then ""
+    else map("- ⏭️ **`" + .text + "`** — skipped (" + .reason + ")") | join("\n")
+    end')
+
+  implemented=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "implemented")] |
+    if length == 0 then "No review comments acted on."
+    else map("- " + .author + " asked for " + .request + " → implemented in `" + .commit + "`") | join("\n")
+    end')
+
+  declined=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "declined")] |
+    if length == 0 then ""
+    else map("- " + .author + " suggested " + .request + " → declined because " + .reason) | join("\n")
+    end')
+
+  judgments=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "judgment")] |
+    if length == 0 then ""
+    else map("- " + .description + " → chose " + .choice + " because " + .reason) | join("\n")
+    end')
+
+  open_questions=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "open_question")] |
+    if length == 0 then ""
+    else map("- " + .description) | join("\n")
+    end')
+
+  local comment_count
+  comment_count=$(echo "$action_log" | jq '[.[] | select(.type == "implemented" or .type == "declined")] | length')
+
+  # Build the markdown
+  local wrapup="## 🤖 Watch Session Summary
+
+### Changes Made
+${changes}
+"
+
+  if [[ -n "$conflicts" ]]; then
+    wrapup="${wrapup}
+${conflicts}
+"
+  fi
+
+  local has_checklist=false
+  if [[ -n "$checklist_done" || -n "$checklist_skipped" ]]; then
+    has_checklist=true
+    wrapup="${wrapup}
+### PR Checklist Items
+"
+    [[ -n "$checklist_done" ]] && wrapup="${wrapup}${checklist_done}
+"
+    [[ -n "$checklist_skipped" ]] && wrapup="${wrapup}${checklist_skipped}
+"
+  fi
+
+  wrapup="${wrapup}
+### Decision Log
+
+#### ✅ Implemented
+${implemented}
+"
+
+  if [[ -n "$declined" ]]; then
+    wrapup="${wrapup}
+#### ❌ Declined
+${declined}
+"
+  fi
+
+  if [[ -n "$judgments" ]]; then
+    wrapup="${wrapup}
+#### ⚖️ Judgment Calls
+${judgments}
+"
+  fi
+
+  if [[ -n "$open_questions" ]]; then
+    wrapup="${wrapup}
+#### ❓ Open Questions
+${open_questions}
+"
+  fi
+
+  wrapup="${wrapup}
+---
+*Watch session ended after ${MAX_IDLE_CYCLES} minutes of inactivity. Processed ${comment_count} comments across ${total_cycles} poll cycles.*"
+
+  echo "$wrapup" > "$WORK_DIR/wrap-up.md"
+  echo "$wrapup"
+}
+
+# ---------------------------------------------------------------------------
+# Post wrap-up comment to PR
+# ---------------------------------------------------------------------------
+post_wrapup_comment() {
+  local body="$1"
+  gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body" > /dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Main output: print session context for the agent to use
+# ---------------------------------------------------------------------------
+print_session_context() {
+  cat <<EOF
+{
+  "pr_url": "${PR_URL}",
+  "pr_number": "${PR_NUMBER}",
+  "branch": "${BRANCH}",
+  "auto_merge": ${AUTO_MERGE},
+  "work_dir": "${WORK_DIR}",
+  "work_items_file": "${WORK_ITEMS_FILE}",
+  "action_log_file": "${ACTION_LOG_FILE}"
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# MAIN LOOP
+# ---------------------------------------------------------------------------
+echo "=== Watch session started ==="
+echo "PR: ${PR_URL} (#${PR_NUMBER})"
+echo "Branch: ${BRANCH}"
+echo "Auto-merge: ${AUTO_MERGE}"
+echo "Work dir: ${WORK_DIR}"
+echo ""
+
+# Print session context for the calling agent
+print_session_context
+
+# --- Pre-poll merge from main ---
+echo "[pre-poll] Merging from main..."
+pre_merge=$(merge_from_main)
+if [[ "$pre_merge" == "conflict" ]]; then
+  conflict_files=$(get_conflict_files)
+  echo "[pre-poll] CONFLICTS detected in: ${conflict_files}"
+  # Build work items with just the conflict
+  build_work_items "[]" "conflict" "$conflict_files" "[]"
+  echo "AGENT_NEEDED"
+  echo "REASON=pre-poll merge conflict"
+  echo "WORK_ITEMS_FILE=${WORK_ITEMS_FILE}"
+  # Agent will be invoked by the caller; we wait for it to finish
+  # then continue the loop. For now, just signal and let the skill handle it.
+  exit 100  # Special exit code: agent needed before loop starts
+else
+  echo "[pre-poll] Merge: ${pre_merge}"
+fi
+
+# --- Polling loop ---
+while true; do
+  CYCLE=$((CYCLE + 1))
+  echo ""
+  echo "=== Poll cycle ${CYCLE} ==="
+
+  had_activity=false
+
+  # 1. Fetch new comments
+  echo "[${CYCLE}] Fetching comments..."
+  new_comments=$(fetch_new_comments)
+  comment_count=$(echo "$new_comments" | jq 'length')
+
+  if [[ "$comment_count" -gt 0 ]]; then
+    echo "[${CYCLE}] Found ${comment_count} new comments/reviews"
+    had_activity=true
+  fi
+
+  # 2. Merge from main
+  echo "[${CYCLE}] Merging from main..."
+  merge_status=$(merge_from_main)
+  conflict_files=""
+  if [[ "$merge_status" == "conflict" ]]; then
+    conflict_files=$(get_conflict_files)
+    echo "[${CYCLE}] CONFLICTS: ${conflict_files}"
+    had_activity=true
+  elif [[ "$merge_status" == "updated" ]]; then
+    echo "[${CYCLE}] Branch updated from main"
+    had_activity=true
+  else
+    echo "[${CYCLE}] Already up to date"
+  fi
+
+  # 3. Check PR body checklist
+  echo "[${CYCLE}] Checking PR body checklist..."
+  checklist_items=$(fetch_checklist_items)
+  checklist_count=$(echo "$checklist_items" | jq 'length')
+
+  if [[ "$checklist_count" -gt 0 ]]; then
+    echo "[${CYCLE}] Found ${checklist_count} unchecked checklist items"
+    had_activity=true
+  fi
+
+  # 4. Decide whether to invoke the agent
+  if $had_activity; then
+    IDLE_COUNTER=0
+
+    build_work_items "$new_comments" "$merge_status" "$conflict_files" "$checklist_items"
+
+    echo "AGENT_NEEDED"
+    echo "REASON=cycle ${CYCLE}: ${comment_count} comments, merge=${merge_status}, ${checklist_count} checklist items"
+    echo "WORK_ITEMS_FILE=${WORK_ITEMS_FILE}"
+    echo "ACTION_LOG_FILE=${ACTION_LOG_FILE}"
+
+    # The caller (SKILL.md) reads these signals and invokes the agent.
+    # After the agent finishes, it calls this script again with --resume
+    # to continue the loop. For simplicity, we exit here and let the
+    # skill orchestrate the agent invocation.
+    exit 0
+  else
+    IDLE_COUNTER=$((IDLE_COUNTER + 1))
+    echo "[${CYCLE}] No activity. Idle counter: ${IDLE_COUNTER}/${MAX_IDLE_CYCLES}"
+  fi
+
+  # 5. Check idle timeout
+  if [[ $IDLE_COUNTER -ge $MAX_IDLE_CYCLES ]]; then
+    echo ""
+    echo "=== Idle timeout reached (${MAX_IDLE_CYCLES} cycles) ==="
+
+    # Generate and post wrap-up
+    echo "[wrap-up] Generating session summary..."
+    wrapup=$(generate_wrapup "$CYCLE")
+    echo "[wrap-up] Posting to PR..."
+    post_wrapup_comment "$wrapup"
+
+    # CI triggering is handled by watch-post.sh (Step 5 in SKILL.md)
+    echo "IDLE_TIMEOUT"
+    echo "WRAPUP_POSTED=true"
+    echo "AUTO_MERGE=${AUTO_MERGE}"
+    echo "TOTAL_CYCLES=${CYCLE}"
+
+    exit 0
+  fi
+
+  # 6. Sleep before next poll
+  echo "[${CYCLE}] Sleeping ${POLL_INTERVAL}s..."
+  sleep "$POLL_INTERVAL"
+done

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -39,6 +39,18 @@ gh_cmd() {
 }
 
 # ---------------------------------------------------------------------------
+# Snapshot latest run IDs before triggering (to detect new runs)
+# ---------------------------------------------------------------------------
+get_latest_run_id() {
+  local workflow="$1"
+  gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 1 --json databaseId 2>/dev/null \
+    | jq -r '.[0].databaseId // "0"'
+}
+
+ci_prev_run_id=$(get_latest_run_id "ci.yml")
+audit_prev_run_id=$(get_latest_run_id "audit.yml")
+
+# ---------------------------------------------------------------------------
 # Trigger CI and audit workflows
 # ---------------------------------------------------------------------------
 echo "[post] Triggering CI workflow on ${BRANCH}..."
@@ -52,6 +64,7 @@ gh_cmd workflow run audit.yml --ref "$BRANCH" 2>/dev/null || echo "[post] WARNIN
 # ---------------------------------------------------------------------------
 wait_for_workflow() {
   local workflow="$1"
+  local prev_run_id="$2"
   local max_wait=600  # 10 minutes
   local elapsed=0
 
@@ -66,7 +79,8 @@ wait_for_workflow() {
     conclusion=$(echo "$result" | jq -r '.[0].conclusion // "unknown"')
     run_id=$(echo "$result" | jq -r '.[0].databaseId // "unknown"')
 
-    if [[ "$status" == "completed" ]]; then
+    # Skip stale runs from before we triggered
+    if [[ "$run_id" != "unknown" && "$run_id" != "$prev_run_id" && "$status" == "completed" ]]; then
       echo "${conclusion}:${run_id}"
       return
     fi
@@ -79,13 +93,13 @@ wait_for_workflow() {
 }
 
 echo "[post] Waiting for CI workflow..."
-ci_result=$(wait_for_workflow "ci.yml")
+ci_result=$(wait_for_workflow "ci.yml" "$ci_prev_run_id")
 ci_conclusion="${ci_result%%:*}"
 ci_run_id="${ci_result##*:}"
 echo "[post] CI result: ${ci_conclusion} (run ${ci_run_id})"
 
 echo "[post] Waiting for audit workflow..."
-audit_result=$(wait_for_workflow "audit.yml")
+audit_result=$(wait_for_workflow "audit.yml" "$audit_prev_run_id")
 audit_conclusion="${audit_result%%:*}"
 audit_run_id="${audit_result##*:}"
 echo "[post] Audit result: ${audit_conclusion} (run ${audit_run_id})"

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# watch-post.sh — Post-session tasks for the /watch skill.
+# Handles CI triggering, waiting, auto-merge, and webhook notification.
+# Invoked after the polling loop ends (idle timeout) and the agent has
+# finished all its work.
+#
+# Usage: bash watch-post.sh <PR_URL> [--automerge]
+#
+# This script handles steps 11-13 from the original SKILL.md:
+#   11. Trigger CI and audit, wait, fix failures (signals agent for fixes)
+#   12. Auto-merge if enabled and checks pass
+#   13. Trigger webhook notification
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+PR_URL="${1:?Usage: watch-post.sh <PR_URL> [--automerge]}"
+AUTO_MERGE=false
+if [[ "${2:-}" == "--automerge" ]]; then
+  AUTO_MERGE=true
+fi
+
+PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
+OWNER="supersuit-tech"
+REPO="permission-slip"
+export GH_HOST="${GH_HOST:-github.com}"
+export GH_REPO="${GH_REPO:-${OWNER}/${REPO}}"
+
+BRANCH=$(git branch --show-current)
+
+gh_api() {
+  GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh api "$@"
+}
+
+gh_cmd() {
+  GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Trigger CI and audit workflows
+# ---------------------------------------------------------------------------
+echo "[post] Triggering CI workflow on ${BRANCH}..."
+gh_cmd workflow run ci.yml --ref "$BRANCH" 2>/dev/null || echo "[post] WARNING: Failed to trigger ci.yml"
+
+echo "[post] Triggering audit workflow on ${BRANCH}..."
+gh_cmd workflow run audit.yml --ref "$BRANCH" 2>/dev/null || echo "[post] WARNING: Failed to trigger audit.yml"
+
+# ---------------------------------------------------------------------------
+# Wait for workflows to complete
+# ---------------------------------------------------------------------------
+wait_for_workflow() {
+  local workflow="$1"
+  local max_wait=600  # 10 minutes
+  local elapsed=0
+
+  sleep 5  # Wait for run to register
+
+  while [[ $elapsed -lt $max_wait ]]; do
+    local result
+    result=$(gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 1 --json databaseId,status,conclusion 2>/dev/null || echo "[]")
+
+    local status conclusion run_id
+    status=$(echo "$result" | jq -r '.[0].status // "unknown"')
+    conclusion=$(echo "$result" | jq -r '.[0].conclusion // "unknown"')
+    run_id=$(echo "$result" | jq -r '.[0].databaseId // "unknown"')
+
+    if [[ "$status" == "completed" ]]; then
+      echo "${conclusion}:${run_id}"
+      return
+    fi
+
+    sleep 30
+    elapsed=$((elapsed + 30))
+  done
+
+  echo "timeout:unknown"
+}
+
+echo "[post] Waiting for CI workflow..."
+ci_result=$(wait_for_workflow "ci.yml")
+ci_conclusion="${ci_result%%:*}"
+ci_run_id="${ci_result##*:}"
+echo "[post] CI result: ${ci_conclusion} (run ${ci_run_id})"
+
+echo "[post] Waiting for audit workflow..."
+audit_result=$(wait_for_workflow "audit.yml")
+audit_conclusion="${audit_result%%:*}"
+audit_run_id="${audit_result##*:}"
+echo "[post] Audit result: ${audit_conclusion} (run ${audit_run_id})"
+
+# ---------------------------------------------------------------------------
+# Report CI results
+# ---------------------------------------------------------------------------
+if [[ "$ci_conclusion" == "failure" ]]; then
+  echo ""
+  echo "CI_FAILED"
+  echo "CI_RUN_ID=${ci_run_id}"
+  # Fetch failed logs for the agent
+  echo "[post] Fetching failed CI logs..."
+  gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "/tmp/ci-failed-logs.txt" || true
+  echo "CI_LOGS_FILE=/tmp/ci-failed-logs.txt"
+  echo "AGENT_NEEDED"
+  echo "REASON=CI failure needs diagnosis and fix"
+  # Exit with special code — caller invokes agent to fix
+  exit 101
+fi
+
+if [[ "$audit_conclusion" == "failure" ]]; then
+  echo ""
+  echo "AUDIT_FAILED"
+  echo "AUDIT_RUN_ID=${audit_run_id}"
+  echo "[post] Fetching failed audit logs..."
+  gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "/tmp/audit-failed-logs.txt" || true
+  echo "AUDIT_LOGS_FILE=/tmp/audit-failed-logs.txt"
+  echo "AGENT_NEEDED"
+  echo "REASON=Audit failure needs diagnosis and fix"
+  exit 102
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-merge if enabled and both workflows passed
+# ---------------------------------------------------------------------------
+if [[ "$AUTO_MERGE" == "true" && "$ci_conclusion" == "success" && "$audit_conclusion" == "success" ]]; then
+  echo "[post] Auto-merge enabled and checks passed. Merging PR..."
+  if ! gh_cmd pr merge "$PR_NUMBER" --squash --delete-branch 2>/dev/null; then
+    echo "[post] Auto-merge failed. Posting comment..."
+    gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
+      -f body="⚠️ **Auto-merge failed.** The \`--automerge\` flag was set, but the merge could not be completed. Please merge manually." \
+      > /dev/null 2>&1
+  else
+    echo "[post] PR merged successfully."
+  fi
+elif [[ "$AUTO_MERGE" == "true" ]]; then
+  echo "[post] Auto-merge enabled but checks did not pass. Skipping merge."
+fi
+
+# ---------------------------------------------------------------------------
+# Trigger webhook notification
+# ---------------------------------------------------------------------------
+echo "[post] Triggering webhook notification..."
+gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
+
+echo ""
+echo "POST_COMPLETE"
+echo "CI=${ci_conclusion}"
+echo "AUDIT=${audit_conclusion}"
+echo "AUTO_MERGE=${AUTO_MERGE}"


### PR DESCRIPTION
## Summary

- Extracts all mechanical bookkeeping from the `/watch` skill into two shell scripts (`watch-poll.sh` and `watch-post.sh`), so the agent is only invoked when there's actual work requiring AI reasoning
- `watch-poll.sh` handles: polling loop, GitHub API fetching across 3 endpoints, ID-based deduplication, bot comment filtering, merge-from-main detection, PR body checklist parsing, idle timeout tracking, and wrap-up comment generation from a structured action log
- `watch-post.sh` handles: CI/audit workflow triggering, waiting for completion, auto-merge when enabled, and webhook notification
- SKILL.md rewritten to orchestrate the scripts and only engage the agent for: implementing review comments, resolving merge conflicts, diagnosing CI failures, and maintaining the action log

**Expected impact:** ~90% token reduction for idle sessions (agent never invoked), ~30-50% reduction for active sessions (agent only sees structured work items, not raw API responses and bookkeeping logic).

## Test plan

### Claude Code
- [x] Verify `watch-poll.sh` passes `bash -n` syntax check
- [x] Verify `watch-post.sh` passes `bash -n` syntax check
- [x] Test jq filters work correctly for review dedup, bot filtering, and wrap-up generation
- [x] Test checklist parsing correctly identifies items under `### Claude Code` and ignores `### OpenClaw`
- [ ] Run against a real PR to compare token usage before/after

### OpenClaw
- [ ] Review shell script error handling and edge cases
- [ ] Validate the handoff protocol (exit codes, signal strings) is robust
- [ ] Test with a PR that has merge conflicts to verify conflict detection works
- [ ] Monitor token usage across several watch sessions to confirm savings

https://claude.ai/code/session_01Ft7qgszwAs3V8nVkVim9iE