### PR TITLE
Normalize action parameter aliases at approval ingestion

### DIFF
--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/shared"
 )
@@ -100,6 +101,18 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 	if err := ValidateJSONObject(params); err != nil {
 		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "parameters must be a JSON object"))
 		return
+	}
+
+	// ── Normalize parameter aliases ──────────────────────────────
+
+	if deps.Connectors != nil {
+		if action, ok := deps.Connectors.GetAction(req.Action.Type); ok {
+			if aliaser, ok := action.(connectors.ParameterAliaser); ok {
+				if aliases := aliaser.ParameterAliases(); len(aliases) > 0 {
+					params = connectors.NormalizeParameters(aliases, params)
+				}
+			}
+		}
 	}
 
 	// ── Check monthly request quota ─────────────────────────────

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -129,20 +129,11 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Optional: validate configuration reference.
-		if req.Configuration != nil {
-			// ValidateConfigurationReference expects action.parameters, not
-			// the full action object. Extract it from the already-parsed map.
-			actionParams := json.RawMessage(actionObj["parameters"])
-			result := ValidateConfigurationReference(w, r, deps, req.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
-			if result == nil {
-				return // error already written
-			}
-		}
-
 		// Normalize parameter aliases before storage so canonical keys are stored.
 		// Actions declare their own aliases via ParameterAliaser; the API layer
 		// rewrites them here so the stored action JSON is always canonical.
+		// Must run before ValidateConfigurationReference so constraints are
+		// evaluated against canonical keys, not raw aliases.
 		if deps.Connectors != nil {
 			if action, ok := deps.Connectors.GetAction(actionType); ok {
 				if aliaser, ok := action.(connectors.ParameterAliaser); ok {
@@ -156,6 +147,17 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 						}
 					}
 				}
+			}
+		}
+
+		// Optional: validate configuration reference — sees canonical keys after normalization.
+		if req.Configuration != nil {
+			// ValidateConfigurationReference expects action.parameters, not
+			// the full action object. Extract it from the already-parsed map.
+			actionParams := json.RawMessage(actionObj["parameters"])
+			result := ValidateConfigurationReference(w, r, deps, req.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
+			if result == nil {
+				return // error already written
 			}
 		}
 

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/shared"
 )
@@ -136,6 +137,25 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			result := ValidateConfigurationReference(w, r, deps, req.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
 			if result == nil {
 				return // error already written
+			}
+		}
+
+		// Normalize parameter aliases before storage so canonical keys are stored.
+		// Actions declare their own aliases via ParameterAliaser; the API layer
+		// rewrites them here so the stored action JSON is always canonical.
+		if deps.Connectors != nil {
+			if action, ok := deps.Connectors.GetAction(actionType); ok {
+				if aliaser, ok := action.(connectors.ParameterAliaser); ok {
+					if aliases := aliaser.ParameterAliases(); len(aliases) > 0 {
+						if rawParams, hasParams := actionObj["parameters"]; hasParams {
+							normalized := connectors.NormalizeParameters(aliases, rawParams)
+							actionObj["parameters"] = normalized
+							if updated, err := json.Marshal(actionObj); err == nil {
+								req.Action = updated
+							}
+						}
+					}
+				}
 			}
 		}
 

--- a/connectors/calendly/list_available_times.go
+++ b/connectors/calendly/list_available_times.go
@@ -16,6 +16,15 @@ type listAvailableTimesAction struct {
 	conn *CalendlyConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents sometimes send "start"/"end" instead of "start_time"/"end_time".
+func (a *listAvailableTimesAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"start": "start_time",
+		"end":   "end_time",
+	}
+}
+
 type listAvailableTimesParams struct {
 	EventTypeURI string `json:"event_type_uri"`
 	StartTime    string `json:"start_time"`

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -16,6 +16,18 @@ type Action interface {
 	Execute(ctx context.Context, req ActionRequest) (*ActionResult, error)
 }
 
+// ParameterAliaser is an optional interface implemented by actions that
+// accept common aliases for their parameter names. The API layer checks for
+// this interface at approval ingestion time and rewrites aliases to canonical
+// keys before storing, so stored parameters are always canonical.
+//
+// Example: an action that expects "start_time" may return
+// map[string]string{"start": "start_time"} so that agents sending "start"
+// have their parameter automatically rewritten before storage and execution.
+type ParameterAliaser interface {
+	ParameterAliases() map[string]string // alias key → canonical key
+}
+
 // Connector represents an integration with an external service.
 // It owns shared configuration (HTTP clients, base URLs, auth helpers)
 // and registers the actions it supports.

--- a/connectors/expedia/get_hotel.go
+++ b/connectors/expedia/get_hotel.go
@@ -16,6 +16,15 @@ type getHotelAction struct {
 	conn *ExpediaConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents sometimes send "check_in"/"check_out" instead of "checkin"/"checkout".
+func (a *getHotelAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"check_in":  "checkin",
+		"check_out": "checkout",
+	}
+}
+
 // getHotelParams are the parameters parsed from ActionRequest.Parameters.
 type getHotelParams struct {
 	PropertyID string `json:"property_id"`

--- a/connectors/expedia/search_hotels.go
+++ b/connectors/expedia/search_hotels.go
@@ -18,6 +18,15 @@ type searchHotelsAction struct {
 	conn *ExpediaConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents sometimes send "check_in"/"check_out" instead of "checkin"/"checkout".
+func (a *searchHotelsAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"check_in":  "checkin",
+		"check_out": "checkout",
+	}
+}
+
 // searchHotelsParams are the parameters parsed from ActionRequest.Parameters.
 type searchHotelsParams struct {
 	Checkin    string    `json:"checkin"`

--- a/connectors/google/create_calendar_event.go
+++ b/connectors/google/create_calendar_event.go
@@ -16,6 +16,15 @@ type createCalendarEventAction struct {
 	conn *GoogleConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents sometimes send "start"/"end" instead of "start_time"/"end_time".
+func (a *createCalendarEventAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"start": "start_time",
+		"end":   "end_time",
+	}
+}
+
 // createCalendarEventParams is the user-facing parameter schema.
 type createCalendarEventParams struct {
 	Summary     string   `json:"summary"`

--- a/connectors/google/create_meeting.go
+++ b/connectors/google/create_meeting.go
@@ -22,6 +22,15 @@ type createMeetingAction struct {
 	conn *GoogleConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents sometimes send "start"/"end" instead of "start_time"/"end_time".
+func (a *createMeetingAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"start": "start_time",
+		"end":   "end_time",
+	}
+}
+
 // createMeetingParams is the user-facing parameter schema.
 type createMeetingParams struct {
 	Summary     string   `json:"summary"`

--- a/connectors/google/update_calendar_event.go
+++ b/connectors/google/update_calendar_event.go
@@ -16,6 +16,15 @@ type updateCalendarEventAction struct {
 	conn *GoogleConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents sometimes send "start"/"end" instead of "start_time"/"end_time".
+func (a *updateCalendarEventAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"start": "start_time",
+		"end":   "end_time",
+	}
+}
+
 // updateCalendarEventParams is the user-facing parameter schema.
 type updateCalendarEventParams struct {
 	EventID        string   `json:"event_id"`

--- a/connectors/microsoft/create_calendar_event.go
+++ b/connectors/microsoft/create_calendar_event.go
@@ -15,6 +15,16 @@ type createCalendarEventAction struct {
 	conn *MicrosoftConnector
 }
 
+// ParameterAliases maps common agent shorthand to the canonical parameter names.
+// Agents familiar with Google Calendar may send "start_time"/"end_time" instead
+// of the Microsoft convention "start"/"end".
+func (a *createCalendarEventAction) ParameterAliases() map[string]string {
+	return map[string]string{
+		"start_time": "start",
+		"end_time":   "end",
+	}
+}
+
 // createCalendarEventParams is the user-facing parameter schema.
 type createCalendarEventParams struct {
 	Subject   string   `json:"subject"`

--- a/connectors/normalize.go
+++ b/connectors/normalize.go
@@ -8,6 +8,10 @@ import "encoding/json"
 //
 // If both an alias key and the canonical key are present, the canonical value
 // is kept and the alias key is dropped.
+//
+// Alias chains are not supported: each alias must map directly to a final
+// canonical key. If "a"→"b" and "b"→"c" are both in the map, the result is
+// undefined — the iteration order of Go maps is non-deterministic.
 func NormalizeParameters(aliases map[string]string, params json.RawMessage) json.RawMessage {
 	if len(aliases) == 0 || len(params) == 0 {
 		return params

--- a/connectors/normalize.go
+++ b/connectors/normalize.go
@@ -1,0 +1,47 @@
+package connectors
+
+import "encoding/json"
+
+// NormalizeParameters rewrites alias keys in params to their canonical names
+// according to the provided alias map. Returns the original bytes unchanged if
+// no aliases match, the map is empty, or params cannot be parsed (fail-open).
+//
+// If both an alias key and the canonical key are present, the canonical value
+// is kept and the alias key is dropped.
+func NormalizeParameters(aliases map[string]string, params json.RawMessage) json.RawMessage {
+	if len(aliases) == 0 || len(params) == 0 {
+		return params
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(params, &m); err != nil {
+		return params
+	}
+
+	changed := false
+	for alias, canonical := range aliases {
+		if _, hasCanonical := m[canonical]; hasCanonical {
+			// Canonical key already present — drop the alias if also present.
+			if _, hasAlias := m[alias]; hasAlias {
+				delete(m, alias)
+				changed = true
+			}
+			continue
+		}
+		if val, hasAlias := m[alias]; hasAlias {
+			m[canonical] = val
+			delete(m, alias)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return params
+	}
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		return params
+	}
+	return out
+}

--- a/connectors/normalize_test.go
+++ b/connectors/normalize_test.go
@@ -1,0 +1,113 @@
+package connectors
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeParameters(t *testing.T) {
+	aliases := map[string]string{
+		"start": "start_time",
+		"end":   "end_time",
+	}
+
+	tests := []struct {
+		name    string
+		aliases map[string]string
+		params  string
+		want    string
+	}{
+		{
+			name:    "alias rewritten to canonical",
+			aliases: aliases,
+			params:  `{"start":"2024-01-15T09:00:00Z","end":"2024-01-15T10:00:00Z","summary":"Meeting"}`,
+			want:    `{"start_time":"2024-01-15T09:00:00Z","end_time":"2024-01-15T10:00:00Z","summary":"Meeting"}`,
+		},
+		{
+			name:    "canonical names pass through unchanged",
+			aliases: aliases,
+			params:  `{"start_time":"2024-01-15T09:00:00Z","end_time":"2024-01-15T10:00:00Z","summary":"Meeting"}`,
+			want:    `{"start_time":"2024-01-15T09:00:00Z","end_time":"2024-01-15T10:00:00Z","summary":"Meeting"}`,
+		},
+		{
+			name:    "canonical wins when both present",
+			aliases: aliases,
+			params:  `{"start":"alias-val","start_time":"canonical-val","summary":"Meeting"}`,
+			want:    `{"start_time":"canonical-val","summary":"Meeting"}`,
+		},
+		{
+			name:    "partial alias only start",
+			aliases: aliases,
+			params:  `{"start":"2024-01-15T09:00:00Z","summary":"Meeting"}`,
+			want:    `{"start_time":"2024-01-15T09:00:00Z","summary":"Meeting"}`,
+		},
+		{
+			name:    "no matching keys passes through",
+			aliases: aliases,
+			params:  `{"summary":"Meeting","location":"Office"}`,
+			want:    `{"summary":"Meeting","location":"Office"}`,
+		},
+		{
+			name:    "nil aliases map returns unchanged",
+			aliases: nil,
+			params:  `{"start":"2024-01-15T09:00:00Z"}`,
+			want:    `{"start":"2024-01-15T09:00:00Z"}`,
+		},
+		{
+			name:    "empty aliases map returns unchanged",
+			aliases: map[string]string{},
+			params:  `{"start":"2024-01-15T09:00:00Z"}`,
+			want:    `{"start":"2024-01-15T09:00:00Z"}`,
+		},
+		{
+			name:    "invalid JSON returns original unchanged",
+			aliases: aliases,
+			params:  `not-json`,
+			want:    `not-json`,
+		},
+		{
+			name:    "empty params returns unchanged",
+			aliases: aliases,
+			params:  ``,
+			want:    ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeParameters(tt.aliases, json.RawMessage(tt.params))
+			if !jsonEqual(t, string(got), tt.want) {
+				t.Errorf("NormalizeParameters() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// jsonEqual compares two JSON strings by unmarshaling both and comparing
+// the resulting maps, so key ordering doesn't matter.
+func jsonEqual(t *testing.T, a, b string) bool {
+	t.Helper()
+	if a == b {
+		return true
+	}
+	var ma, mb map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(a), &ma); err != nil {
+		return a == b
+	}
+	if err := json.Unmarshal([]byte(b), &mb); err != nil {
+		return a == b
+	}
+	if len(ma) != len(mb) {
+		return false
+	}
+	for k, va := range ma {
+		vb, ok := mb[k]
+		if !ok {
+			return false
+		}
+		if string(va) != string(vb) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- Adds optional `ParameterAliaser` interface to the `connectors` package so individual actions can declare alias→canonical key mappings without modifying the `Action` interface (which has ~496 implementations)
- Adds generic `NormalizeParameters()` helper that rewrites alias keys at parse time; fails-open on invalid JSON or no matches
- Wires normalization at **approval ingestion** (`POST /approvals/request`) before `db.InsertApproval` — stored parameters are canonical from the start, fixing UI "missing field" badges
- Wires normalization at **standing approval execution** (`POST /actions/execute`) for the same fail-safe
- Adds `ParameterAliases()` to four connector groups with confirmed mismatches:
  - Google Calendar `create_calendar_event`, `update_calendar_event`, `create_meeting`: `start`→`start_time`, `end`→`end_time`
  - Calendly `list_available_times`: `start`→`start_time`, `end`→`end_time`
  - Microsoft `create_calendar_event`: reverse convention — `start_time`→`start`, `end_time`→`end`
  - Expedia `search_hotels`, `get_hotel`: `check_in`→`checkin`, `check_out`→`checkout`

Fixes #488. Amadeus nested field aliases tracked in #491.

## Test plan

### Claude Code
- [ ] `go test ./connectors/...` — `TestNormalizeParameters` covers all alias/canonical/conflict/invalid-JSON cases
- [ ] `go test ./api/...` — existing API tests pass with new normalization wired in
- [ ] `make build` — no compile errors

### OpenClaw
- [ ] Manual: call `POST /approvals/request` with `start`/`end` for a Google Calendar action — stored `action` JSON should have `start_time`/`end_time`
- [ ] Manual: call `POST /approvals/request` with `start_time`/`end_time` for Microsoft Calendar — stored JSON should have `start`/`end`
- [ ] Manual: verify UI no longer shows "missing" badges for approvals submitted with alias keys
- [ ] Manual: verify `POST /actions/execute` with alias params works end-to-end

https://claude.ai/code/session_01QKeAP4AL11kPjLAC6pzURL