### PR TITLE
Check normal PR comments when addressing review feedback

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -117,10 +117,10 @@ For each item in `work-items.json`, apply the appropriate action:
 
 #### Comments and Reviews
 
-For each comment or review in the `comments` array:
+For each comment or review in the `comments` array (including `review`, `review_comment`, and `issue_comment` types — normal PR comments often contain actionable feedback just like inline review comments):
 
 1. **Read** the instruction in the comment body.
-2. **Identify** the file and line it's attached to (for inline review comments — use `path` and `line` fields). For PR reviews, the body applies to the PR as a whole — check `state` for context (`CHANGES_REQUESTED` signals required fixes).
+2. **Identify** the file and line it's attached to (for inline review comments — use `path` and `line` fields). For PR reviews, the body applies to the PR as a whole — check `state` for context (`CHANGES_REQUESTED` signals required fixes). For issue comments (normal PR conversation), treat them as general feedback that may reference specific files or areas of the code.
 3. **Decide** whether to act on it or disagree:
    - **If you agree**: Implement the change. Commit with a clear message referencing the comment.
    - **If you disagree**: Leave a reply on that comment thread explaining your reasoning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 - Always include the pull request URL at the end of every message where a PR already exists, formatted exactly as: `Pull request: <url>` — no bold, no markdown link syntax, just the plain text and URL so the link doesn't break.
 - Whenever you bring up a problem, always suggest a recommendation for how to address it.
 - When asked to review for improvements or issues: fix anything you're confident should be fixed (commit & push), then mention any additional findings that are more subjective or optional so the user can decide.
+- **Check all comment types:** When asked to address PR review comments, also check normal PR comments (issue comments) for feedback worth implementing. Reviewers sometimes leave actionable suggestions in the general conversation thread instead of inline review comments — treat them the same way.
 - **Train the reviewer:** When you address a PR review comment, you MUST react to it AND leave a threaded reply. Do both of these for EVERY review comment you respond to:
   1. **React** with 👍 (agree/fixed) or 👎 (disagree/won't fix) using the GitHub API:
      ```bash


### PR DESCRIPTION
## Summary

- Adds a new instruction in CLAUDE.md to also check normal PR comments (issue comments) when asked to address PR review comments, since reviewers sometimes leave actionable feedback in the general conversation thread
- Updates the watch skill's SKILL.md to explicitly call out that `issue_comment` types should be treated as actionable feedback alongside `review` and `review_comment` types

## Test plan

- [ ] Verify CLAUDE.md renders correctly with the new bullet point
- [ ] Verify watch skill SKILL.md instructions are clear about treating all comment types equally

https://claude.ai/code/session_01J14Hbuv8FxAsjumaAe4DTq