### PR TITLE
Add Normalizer interface for nested parameter normalization

### DIFF
--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -103,7 +103,7 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		return
 	}
 
-	// ── Normalize parameter aliases ──────────────────────────────
+	// ── Normalize parameters ─────────────────────────────────────
 
 	if deps.Connectors != nil {
 		if action, ok := deps.Connectors.GetAction(req.Action.Type); ok {
@@ -112,13 +112,6 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 					params = connectors.NormalizeParameters(aliases, params)
 				}
 			}
-		}
-	}
-
-	// ── Normalize nested parameter structures ────────────────────
-
-	if deps.Connectors != nil {
-		if action, ok := deps.Connectors.GetAction(req.Action.Type); ok {
 			if normalizer, ok := action.(connectors.Normalizer); ok {
 				params = normalizer.Normalize(params)
 			}

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -115,6 +115,16 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		}
 	}
 
+	// ── Normalize nested parameter structures ────────────────────
+
+	if deps.Connectors != nil {
+		if action, ok := deps.Connectors.GetAction(req.Action.Type); ok {
+			if normalizer, ok := action.(connectors.Normalizer); ok {
+				params = normalizer.Normalize(params)
+			}
+		}
+	}
+
 	// ── Check monthly request quota ─────────────────────────────
 
 	var blocked bool

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -129,11 +129,10 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Normalize parameter aliases before storage so canonical keys are stored.
-		// Actions declare their own aliases via ParameterAliaser; the API layer
-		// rewrites them here so the stored action JSON is always canonical.
-		// Must run before ValidateConfigurationReference so constraints are
-		// evaluated against canonical keys, not raw aliases.
+		// Normalize parameters before storage so canonical keys are stored.
+		// First rewrites flat aliases (ParameterAliaser), then applies nested
+		// normalization (Normalizer). Must run before ValidateConfigurationReference
+		// so constraints are evaluated against canonical keys.
 		if deps.Connectors != nil {
 			if action, ok := deps.Connectors.GetAction(actionType); ok {
 				if aliaser, ok := action.(connectors.ParameterAliaser); ok {
@@ -147,13 +146,6 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 						}
 					}
 				}
-			}
-		}
-
-		// Normalize nested parameter structures (e.g., snake_case → camelCase
-		// inside arrays). Runs after flat alias normalization above.
-		if deps.Connectors != nil {
-			if action, ok := deps.Connectors.GetAction(actionType); ok {
 				if normalizer, ok := action.(connectors.Normalizer); ok {
 					if rawParams, hasParams := actionObj["parameters"]; hasParams {
 						actionObj["parameters"] = normalizer.Normalize(rawParams)

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -150,6 +150,21 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		// Normalize nested parameter structures (e.g., snake_case → camelCase
+		// inside arrays). Runs after flat alias normalization above.
+		if deps.Connectors != nil {
+			if action, ok := deps.Connectors.GetAction(actionType); ok {
+				if normalizer, ok := action.(connectors.Normalizer); ok {
+					if rawParams, hasParams := actionObj["parameters"]; hasParams {
+						actionObj["parameters"] = normalizer.Normalize(rawParams)
+						if updated, err := json.Marshal(actionObj); err == nil {
+							req.Action = updated
+						}
+					}
+				}
+			}
+		}
+
 		// Optional: validate configuration reference — sees canonical keys after normalization.
 		if req.Configuration != nil {
 			// ValidateConfigurationReference expects action.parameters, not

--- a/connectors/amadeus/book_flight_normalize.go
+++ b/connectors/amadeus/book_flight_normalize.go
@@ -76,7 +76,12 @@ func normalizeTraveler(raw json.RawMessage) (json.RawMessage, bool) {
 	// Rewrite top-level snake_case fields.
 	for snake, camel := range snakeToCamelTravelerFields {
 		if _, hasCamel := t[camel]; hasCamel {
-			continue // canonical already present
+			// Canonical key already present; remove the snake_case duplicate if any.
+			if _, hasSnake := t[snake]; hasSnake {
+				delete(t, snake)
+				changed = true
+			}
+			continue
 		}
 		if val, hasSnake := t[snake]; hasSnake {
 			t[camel] = val
@@ -92,6 +97,10 @@ func normalizeTraveler(raw json.RawMessage) (json.RawMessage, bool) {
 			nameChanged := false
 			for snake, camel := range snakeToCamelTravelerFields {
 				if _, hasCamel := name[camel]; hasCamel {
+					if _, hasSnake := name[snake]; hasSnake {
+						delete(name, snake)
+						nameChanged = true
+					}
 					continue
 				}
 				if val, hasSnake := name[snake]; hasSnake {

--- a/connectors/amadeus/book_flight_normalize.go
+++ b/connectors/amadeus/book_flight_normalize.go
@@ -2,13 +2,17 @@ package amadeus
 
 import "encoding/json"
 
-// snakeToCamelTravelerFields maps snake_case traveler field names that agents
-// might send (following the system's convention) to the camelCase names that
-// Amadeus and our schema expect.
+// snakeToCamelTravelerFields maps snake_case top-level traveler field names
+// to their camelCase equivalents expected by the Amadeus API.
 var snakeToCamelTravelerFields = map[string]string{
-	"first_name":    "firstName",
-	"last_name":     "lastName",
 	"date_of_birth": "dateOfBirth",
+}
+
+// snakeToCamelNameFields maps snake_case name sub-object field names
+// to their camelCase equivalents expected by the Amadeus API.
+var snakeToCamelNameFields = map[string]string{
+	"first_name": "firstName",
+	"last_name":  "lastName",
 }
 
 // Normalize rewrites snake_case traveler fields to camelCase inside the
@@ -73,29 +77,31 @@ func normalizeTraveler(raw json.RawMessage) (json.RawMessage, bool) {
 
 	changed := false
 
-	// Rewrite top-level snake_case fields.
-	for snake, camel := range snakeToCamelTravelerFields {
-		if _, hasCamel := t[camel]; hasCamel {
-			// Canonical key already present; remove the snake_case duplicate if any.
-			if _, hasSnake := t[snake]; hasSnake {
+	// Rewrite top-level snake_case fields (e.g., date_of_birth → dateOfBirth).
+	// Also normalize name fields at top level in case agents flatten the structure.
+	for _, aliases := range []map[string]string{snakeToCamelTravelerFields, snakeToCamelNameFields} {
+		for snake, camel := range aliases {
+			if _, hasCamel := t[camel]; hasCamel {
+				if _, hasSnake := t[snake]; hasSnake {
+					delete(t, snake)
+					changed = true
+				}
+				continue
+			}
+			if val, hasSnake := t[snake]; hasSnake {
+				t[camel] = val
 				delete(t, snake)
 				changed = true
 			}
-			continue
-		}
-		if val, hasSnake := t[snake]; hasSnake {
-			t[camel] = val
-			delete(t, snake)
-			changed = true
 		}
 	}
 
-	// Rewrite name sub-object fields.
+	// Rewrite name sub-object fields (first_name → firstName, last_name → lastName).
 	if nameRaw, ok := t["name"]; ok {
 		var name map[string]json.RawMessage
 		if err := json.Unmarshal(nameRaw, &name); err == nil {
 			nameChanged := false
-			for snake, camel := range snakeToCamelTravelerFields {
+			for snake, camel := range snakeToCamelNameFields {
 				if _, hasCamel := name[camel]; hasCamel {
 					if _, hasSnake := name[snake]; hasSnake {
 						delete(name, snake)

--- a/connectors/amadeus/book_flight_normalize.go
+++ b/connectors/amadeus/book_flight_normalize.go
@@ -1,0 +1,121 @@
+package amadeus
+
+import "encoding/json"
+
+// snakeToCamelTravelerFields maps snake_case traveler field names that agents
+// might send (following the system's convention) to the camelCase names that
+// Amadeus and our schema expect.
+var snakeToCamelTravelerFields = map[string]string{
+	"first_name":    "firstName",
+	"last_name":     "lastName",
+	"date_of_birth": "dateOfBirth",
+}
+
+// Normalize rewrites snake_case traveler fields to camelCase inside the
+// travelers array. This allows agents to follow the system-wide snake_case
+// convention while the stored/executed parameters match the Amadeus API.
+//
+// Fields that are already camelCase pass through unchanged.
+func (a *bookFlightAction) Normalize(params json.RawMessage) json.RawMessage {
+	if len(params) == 0 {
+		return params
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(params, &m); err != nil {
+		return params
+	}
+
+	travelersRaw, ok := m["travelers"]
+	if !ok {
+		return params
+	}
+
+	var travelers []json.RawMessage
+	if err := json.Unmarshal(travelersRaw, &travelers); err != nil {
+		return params
+	}
+
+	changed := false
+	for i, raw := range travelers {
+		normalized, didChange := normalizeTraveler(raw)
+		if didChange {
+			travelers[i] = normalized
+			changed = true
+		}
+	}
+
+	if !changed {
+		return params
+	}
+
+	updated, err := json.Marshal(travelers)
+	if err != nil {
+		return params
+	}
+	m["travelers"] = updated
+
+	result, err := json.Marshal(m)
+	if err != nil {
+		return params
+	}
+	return result
+}
+
+// normalizeTraveler rewrites snake_case keys in a single traveler object:
+//   - top-level: date_of_birth → dateOfBirth
+//   - nested name: first_name → firstName, last_name → lastName
+func normalizeTraveler(raw json.RawMessage) (json.RawMessage, bool) {
+	var t map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return raw, false
+	}
+
+	changed := false
+
+	// Rewrite top-level snake_case fields.
+	for snake, camel := range snakeToCamelTravelerFields {
+		if _, hasCamel := t[camel]; hasCamel {
+			continue // canonical already present
+		}
+		if val, hasSnake := t[snake]; hasSnake {
+			t[camel] = val
+			delete(t, snake)
+			changed = true
+		}
+	}
+
+	// Rewrite name sub-object fields.
+	if nameRaw, ok := t["name"]; ok {
+		var name map[string]json.RawMessage
+		if err := json.Unmarshal(nameRaw, &name); err == nil {
+			nameChanged := false
+			for snake, camel := range snakeToCamelTravelerFields {
+				if _, hasCamel := name[camel]; hasCamel {
+					continue
+				}
+				if val, hasSnake := name[snake]; hasSnake {
+					name[camel] = val
+					delete(name, snake)
+					nameChanged = true
+				}
+			}
+			if nameChanged {
+				if updated, err := json.Marshal(name); err == nil {
+					t["name"] = updated
+					changed = true
+				}
+			}
+		}
+	}
+
+	if !changed {
+		return raw, false
+	}
+
+	result, err := json.Marshal(t)
+	if err != nil {
+		return raw, false
+	}
+	return result, true
+}

--- a/connectors/amadeus/book_flight_normalize.go
+++ b/connectors/amadeus/book_flight_normalize.go
@@ -78,21 +78,20 @@ func normalizeTraveler(raw json.RawMessage) (json.RawMessage, bool) {
 	changed := false
 
 	// Rewrite top-level snake_case fields (e.g., date_of_birth → dateOfBirth).
-	// Also normalize name fields at top level in case agents flatten the structure.
-	for _, aliases := range []map[string]string{snakeToCamelTravelerFields, snakeToCamelNameFields} {
-		for snake, camel := range aliases {
-			if _, hasCamel := t[camel]; hasCamel {
-				if _, hasSnake := t[snake]; hasSnake {
-					delete(t, snake)
-					changed = true
-				}
-				continue
-			}
-			if val, hasSnake := t[snake]; hasSnake {
-				t[camel] = val
+	// Name fields (first_name, last_name) are NOT normalized at the top level —
+	// they belong inside the name sub-object per the Amadeus API schema.
+	for snake, camel := range snakeToCamelTravelerFields {
+		if _, hasCamel := t[camel]; hasCamel {
+			if _, hasSnake := t[snake]; hasSnake {
 				delete(t, snake)
 				changed = true
 			}
+			continue
+		}
+		if val, hasSnake := t[snake]; hasSnake {
+			t[camel] = val
+			delete(t, snake)
+			changed = true
 		}
 	}
 

--- a/connectors/amadeus/book_flight_normalize_test.go
+++ b/connectors/amadeus/book_flight_normalize_test.go
@@ -10,7 +10,7 @@ import (
 // Verify bookFlightAction implements Normalizer at compile time.
 var _ connectors.Normalizer = (*bookFlightAction)(nil)
 
-func TestBookFlightNormalize_SnakeCaseToCalmelCase(t *testing.T) {
+func TestBookFlightNormalize_SnakeCaseToCamelCase(t *testing.T) {
 	t.Parallel()
 
 	action := &bookFlightAction{}
@@ -178,6 +178,17 @@ func TestBookFlightNormalize_CamelCaseTakesPrecedence(t *testing.T) {
 	}
 	if firstName != "John" {
 		t.Errorf("firstName = %q, want John (camelCase should take precedence)", firstName)
+	}
+
+	// Assert the snake_case duplicates were removed.
+	if _, ok := traveler["date_of_birth"]; ok {
+		t.Error("date_of_birth should have been removed when dateOfBirth was present")
+	}
+	if _, ok := name["first_name"]; ok {
+		t.Error("first_name should have been removed when firstName was present")
+	}
+	if _, ok := name["last_name"]; ok {
+		t.Error("last_name should have been removed when lastName was present")
 	}
 }
 

--- a/connectors/amadeus/book_flight_normalize_test.go
+++ b/connectors/amadeus/book_flight_normalize_test.go
@@ -1,0 +1,285 @@
+package amadeus
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// Verify bookFlightAction implements Normalizer at compile time.
+var _ connectors.Normalizer = (*bookFlightAction)(nil)
+
+func TestBookFlightNormalize_SnakeCaseToCalmelCase(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	input := json.RawMessage(`{
+		"flight_offer": {"id":"1"},
+		"travelers": [
+			{
+				"name": {"first_name": "John", "last_name": "Doe"},
+				"date_of_birth": "1990-01-15",
+				"gender": "MALE",
+				"contact": {"email": "john@example.com", "phone": "+1234567890"}
+			}
+		],
+		"payment_method_id": "pm_abc",
+		"idempotency_key": "key-1"
+	}`)
+
+	result := action.Normalize(input)
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var travelers []map[string]json.RawMessage
+	if err := json.Unmarshal(m["travelers"], &travelers); err != nil {
+		t.Fatalf("unmarshal travelers: %v", err)
+	}
+
+	if len(travelers) != 1 {
+		t.Fatalf("expected 1 traveler, got %d", len(travelers))
+	}
+
+	traveler := travelers[0]
+
+	// Check dateOfBirth (top-level rewrite).
+	if _, ok := traveler["dateOfBirth"]; !ok {
+		t.Error("expected dateOfBirth, not found")
+	}
+	if _, ok := traveler["date_of_birth"]; ok {
+		t.Error("date_of_birth should have been removed")
+	}
+
+	// Check name sub-object.
+	var name map[string]json.RawMessage
+	if err := json.Unmarshal(traveler["name"], &name); err != nil {
+		t.Fatalf("unmarshal name: %v", err)
+	}
+	if _, ok := name["firstName"]; !ok {
+		t.Error("expected firstName in name, not found")
+	}
+	if _, ok := name["lastName"]; !ok {
+		t.Error("expected lastName in name, not found")
+	}
+	if _, ok := name["first_name"]; ok {
+		t.Error("first_name should have been removed from name")
+	}
+	if _, ok := name["last_name"]; ok {
+		t.Error("last_name should have been removed from name")
+	}
+}
+
+func TestBookFlightNormalize_CamelCasePassthrough(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	// Already camelCase — should pass through unchanged.
+	input := json.RawMessage(`{
+		"flight_offer": {"id":"1"},
+		"travelers": [
+			{
+				"name": {"firstName": "John", "lastName": "Doe"},
+				"dateOfBirth": "1990-01-15",
+				"gender": "MALE",
+				"contact": {"email": "john@example.com", "phone": "+1234567890"}
+			}
+		],
+		"payment_method_id": "pm_abc",
+		"idempotency_key": "key-1"
+	}`)
+
+	result := action.Normalize(input)
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var travelers []map[string]json.RawMessage
+	if err := json.Unmarshal(m["travelers"], &travelers); err != nil {
+		t.Fatalf("unmarshal travelers: %v", err)
+	}
+
+	traveler := travelers[0]
+
+	if _, ok := traveler["dateOfBirth"]; !ok {
+		t.Error("expected dateOfBirth to remain")
+	}
+
+	var name map[string]json.RawMessage
+	if err := json.Unmarshal(traveler["name"], &name); err != nil {
+		t.Fatalf("unmarshal name: %v", err)
+	}
+	if _, ok := name["firstName"]; !ok {
+		t.Error("expected firstName to remain")
+	}
+	if _, ok := name["lastName"]; !ok {
+		t.Error("expected lastName to remain")
+	}
+}
+
+func TestBookFlightNormalize_CamelCaseTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	// Both snake_case and camelCase present — camelCase takes precedence.
+	input := json.RawMessage(`{
+		"travelers": [
+			{
+				"name": {"firstName": "John", "first_name": "Jonathan", "lastName": "Doe", "last_name": "Smith"},
+				"dateOfBirth": "1990-01-15",
+				"date_of_birth": "2000-01-01",
+				"gender": "MALE",
+				"contact": {"email": "j@e.com", "phone": "+1"}
+			}
+		],
+		"flight_offer": {"id":"1"},
+		"payment_method_id": "pm_1",
+		"idempotency_key": "key-1"
+	}`)
+
+	result := action.Normalize(input)
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var travelers []map[string]json.RawMessage
+	if err := json.Unmarshal(m["travelers"], &travelers); err != nil {
+		t.Fatalf("unmarshal travelers: %v", err)
+	}
+
+	traveler := travelers[0]
+
+	// camelCase should win.
+	var dob string
+	if err := json.Unmarshal(traveler["dateOfBirth"], &dob); err != nil {
+		t.Fatalf("unmarshal dateOfBirth: %v", err)
+	}
+	if dob != "1990-01-15" {
+		t.Errorf("dateOfBirth = %q, want 1990-01-15 (camelCase should take precedence)", dob)
+	}
+
+	var name map[string]json.RawMessage
+	if err := json.Unmarshal(traveler["name"], &name); err != nil {
+		t.Fatalf("unmarshal name: %v", err)
+	}
+	var firstName string
+	if err := json.Unmarshal(name["firstName"], &firstName); err != nil {
+		t.Fatalf("unmarshal firstName: %v", err)
+	}
+	if firstName != "John" {
+		t.Errorf("firstName = %q, want John (camelCase should take precedence)", firstName)
+	}
+}
+
+func TestBookFlightNormalize_MultipleTravelers(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	input := json.RawMessage(`{
+		"travelers": [
+			{
+				"name": {"first_name": "Alice", "last_name": "A"},
+				"date_of_birth": "1985-03-10",
+				"gender": "FEMALE",
+				"contact": {"email": "a@e.com", "phone": "+1"}
+			},
+			{
+				"name": {"firstName": "Bob", "lastName": "B"},
+				"dateOfBirth": "1990-07-20",
+				"gender": "MALE",
+				"contact": {"email": "b@e.com", "phone": "+2"}
+			}
+		],
+		"flight_offer": {"id":"1"},
+		"payment_method_id": "pm_1",
+		"idempotency_key": "key-1"
+	}`)
+
+	result := action.Normalize(input)
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	var travelers []map[string]json.RawMessage
+	if err := json.Unmarshal(m["travelers"], &travelers); err != nil {
+		t.Fatalf("unmarshal travelers: %v", err)
+	}
+
+	if len(travelers) != 2 {
+		t.Fatalf("expected 2 travelers, got %d", len(travelers))
+	}
+
+	// First traveler: was snake_case, should be rewritten.
+	if _, ok := travelers[0]["dateOfBirth"]; !ok {
+		t.Error("traveler[0]: expected dateOfBirth")
+	}
+	var name0 map[string]json.RawMessage
+	if err := json.Unmarshal(travelers[0]["name"], &name0); err != nil {
+		t.Fatalf("unmarshal name[0]: %v", err)
+	}
+	if _, ok := name0["firstName"]; !ok {
+		t.Error("traveler[0]: expected firstName")
+	}
+
+	// Second traveler: was already camelCase, should be unchanged.
+	if _, ok := travelers[1]["dateOfBirth"]; !ok {
+		t.Error("traveler[1]: expected dateOfBirth")
+	}
+}
+
+func TestBookFlightNormalize_NoTravelers(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	input := json.RawMessage(`{"flight_offer": {"id":"1"}, "payment_method_id": "pm_1"}`)
+	result := action.Normalize(input)
+
+	// Should return unchanged since no travelers key.
+	if string(result) != string(input) {
+		t.Errorf("expected unchanged output when no travelers key")
+	}
+}
+
+func TestBookFlightNormalize_EmptyParams(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	result := action.Normalize(nil)
+	if result != nil {
+		t.Errorf("expected nil for nil input, got %s", string(result))
+	}
+
+	result = action.Normalize(json.RawMessage{})
+	if len(result) != 0 {
+		t.Errorf("expected empty for empty input, got %s", string(result))
+	}
+}
+
+func TestBookFlightNormalize_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	action := &bookFlightAction{}
+
+	input := json.RawMessage(`{invalid}`)
+	result := action.Normalize(input)
+
+	// Should return input unchanged on invalid JSON.
+	if string(result) != string(input) {
+		t.Errorf("expected unchanged output for invalid JSON")
+	}
+}

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -28,6 +28,18 @@ type ParameterAliaser interface {
 	ParameterAliases() map[string]string // alias key → canonical key
 }
 
+// Normalizer is an optional interface for actions that need arbitrary
+// parameter transformation beyond flat key aliasing. The API layer calls
+// Normalize() after ParameterAliaser (if both are implemented), before
+// storing the approval or executing the action.
+//
+// Use this for nested structures (e.g., rewriting snake_case field names
+// inside arrays of objects) where ParameterAliaser's flat key→key map
+// is insufficient.
+type Normalizer interface {
+	Normalize(params json.RawMessage) json.RawMessage
+}
+
 // Connector represents an integration with an external service.
 // It owns shared configuration (HTTP clients, base URLs, auth helpers)
 // and registers the actions it supports.


### PR DESCRIPTION
## Summary

- Adds a `Normalizer` interface to `connectors/connector.go` for actions that need arbitrary nested parameter transformation beyond `ParameterAliaser`'s flat key→key map
- Wires `Normalizer` type assertion in both `api/agent_approvals.go` and `api/action_execute.go`, running after `ParameterAliaser` normalization
- Implements `Normalize()` on `amadeus.book_flight` to rewrite snake_case traveler fields (`first_name`→`firstName`, `last_name`→`lastName`, `date_of_birth`→`dateOfBirth`) inside the `travelers` array

Closes #491

## Test plan

### Claude Code
- [x] Unit tests for snake_case → camelCase normalization
- [x] Test that already-camelCase fields pass through unchanged
- [x] Test that camelCase takes precedence when both forms are present
- [x] Test multiple travelers (mix of snake_case and camelCase)
- [x] Test edge cases (no travelers, empty params, invalid JSON)
- [x] Compile-time interface assertion (`var _ connectors.Normalizer = (*bookFlightAction)(nil)`)
- [x] Verify existing amadeus tests still pass

### OpenClaw
- [ ] Verify end-to-end with a real agent sending snake_case traveler fields
- [ ] Confirm camelCase-only agents are unaffected in production
- [ ] Review whether other connectors need similar normalization

https://claude.ai/code/session_01BK6XBcXw9LUBLNbeXsf2t8