### PR TITLE
Validate action parameters against connector schema at request time

### DIFF
--- a/api/action_param_validate.go
+++ b/api/action_param_validate.go
@@ -80,7 +80,7 @@ func validateActionParameters(
 		hint = fmt.Sprintf("see GET /connectors/%s for the full parameter schema", parts[0])
 	}
 
-	resp := BadRequest(ErrInvalidParameters, "action parameters are missing required fields")
+	resp := BadRequest(ErrMissingRequiredParameters, "action parameters are missing required fields")
 	resp.Error.Details = map[string]any{
 		"missing_fields": missing,
 		"hint":           hint,

--- a/api/action_param_validate.go
+++ b/api/action_param_validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
 )
@@ -27,13 +26,13 @@ func validateActionParameters(
 	parameters json.RawMessage,
 ) bool {
 	// Look up the schema from the database.
-	schema, err := db.GetActionParametersSchema(r.Context(), d, actionType)
+	actionSchema, err := db.GetActionParametersSchema(r.Context(), d, actionType)
 	if err != nil {
 		log.Printf("[%s] validateActionParameters: schema lookup: %v", TraceID(r.Context()), err)
 		// Fail-open on DB errors — don't block the request.
 		return true
 	}
-	if len(schema) == 0 {
+	if actionSchema == nil || len(actionSchema.Schema) == 0 {
 		// No schema defined for this action — fail-open.
 		return true
 	}
@@ -42,7 +41,7 @@ func validateActionParameters(
 	var schemaDef struct {
 		Required []string `json:"required"`
 	}
-	if err := json.Unmarshal(schema, &schemaDef); err != nil {
+	if err := json.Unmarshal(actionSchema.Schema, &schemaDef); err != nil {
 		log.Printf("[%s] validateActionParameters: parse schema: %v", TraceID(r.Context()), err)
 		// Malformed schema — fail-open.
 		return true
@@ -74,11 +73,8 @@ func validateActionParameters(
 		return true
 	}
 
-	// Build connector hint from the action type (e.g., "github.create_issue" → "github").
-	hint := "see GET /connectors for the full parameter schema"
-	if parts := strings.SplitN(actionType, ".", 2); len(parts) == 2 && parts[0] != "" {
-		hint = fmt.Sprintf("see GET /connectors/%s for the full parameter schema", parts[0])
-	}
+	// Use the connector ID from the DB row for the hint URL.
+	hint := fmt.Sprintf("see GET /connectors/%s for the full parameter schema", actionSchema.ConnectorID)
 
 	resp := BadRequest(ErrMissingRequiredParameters, "action parameters are missing required fields")
 	resp.Error.Details = map[string]any{

--- a/api/action_param_validate.go
+++ b/api/action_param_validate.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// validateActionParameters checks the supplied parameters against the
+// connector's parameters_schema for the given action type. It validates
+// that all required fields are present.
+//
+// Behaviour:
+//   - Fail-open: if no schema exists for the action type, validation is skipped.
+//   - Only required-field validation is performed (not full JSON Schema).
+//   - Returns true if validation passed (or was skipped). Returns false if
+//     validation failed and an error response was already written.
+func validateActionParameters(
+	w http.ResponseWriter,
+	r *http.Request,
+	d db.DBTX,
+	actionType string,
+	parameters json.RawMessage,
+) bool {
+	// Look up the schema from the database.
+	schema, err := db.GetActionParametersSchema(r.Context(), d, actionType)
+	if err != nil {
+		log.Printf("[%s] validateActionParameters: schema lookup: %v", TraceID(r.Context()), err)
+		// Fail-open on DB errors — don't block the request.
+		return true
+	}
+	if len(schema) == 0 {
+		// No schema defined for this action — fail-open.
+		return true
+	}
+
+	// Parse the schema to extract required fields.
+	var schemaDef struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(schema, &schemaDef); err != nil {
+		log.Printf("[%s] validateActionParameters: parse schema: %v", TraceID(r.Context()), err)
+		// Malformed schema — fail-open.
+		return true
+	}
+	if len(schemaDef.Required) == 0 {
+		// No required fields — nothing to validate.
+		return true
+	}
+
+	// Parse the supplied parameters.
+	var params map[string]json.RawMessage
+	if len(parameters) > 0 {
+		if err := json.Unmarshal(parameters, &params); err != nil {
+			// Parameters aren't a valid JSON object — report as missing all required fields.
+			params = nil
+		}
+	}
+
+	// Check for missing required fields.
+	var missing []string
+	for _, field := range schemaDef.Required {
+		val, exists := params[field]
+		if !exists || isRawJSONNull(val) {
+			missing = append(missing, field)
+		}
+	}
+
+	if len(missing) == 0 {
+		return true
+	}
+
+	// Build connector hint from the action type (e.g., "github.create_issue" → "github").
+	hint := "see GET /connectors for the full parameter schema"
+	if parts := strings.SplitN(actionType, ".", 2); len(parts) == 2 && parts[0] != "" {
+		hint = fmt.Sprintf("see GET /connectors/%s for the full parameter schema", parts[0])
+	}
+
+	resp := BadRequest(ErrInvalidParameters, "action parameters are missing required fields")
+	resp.Error.Details = map[string]any{
+		"missing_fields": missing,
+		"hint":           hint,
+	}
+	RespondError(w, r, http.StatusBadRequest, resp)
+	return false
+}

--- a/api/action_param_validate_test.go
+++ b/api/action_param_validate_test.go
@@ -52,8 +52,8 @@ func TestAgentRequestApproval_MissingRequiredParameter(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if errResp.Error.Code != ErrInvalidParameters {
-		t.Errorf("expected error code %q, got %q", ErrInvalidParameters, errResp.Error.Code)
+	if errResp.Error.Code != ErrMissingRequiredParameters {
+		t.Errorf("expected error code %q, got %q", ErrMissingRequiredParameters, errResp.Error.Code)
 	}
 
 	// Check that missing_fields contains "target".
@@ -195,8 +195,8 @@ func TestAgentRequestApproval_NoParametersWithRequiredFields(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if errResp.Error.Code != ErrInvalidParameters {
-		t.Errorf("expected error code %q, got %q", ErrInvalidParameters, errResp.Error.Code)
+	if errResp.Error.Code != ErrMissingRequiredParameters {
+		t.Errorf("expected error code %q, got %q", ErrMissingRequiredParameters, errResp.Error.Code)
 	}
 }
 

--- a/api/action_param_validate_test.go
+++ b/api/action_param_validate_test.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestAgentRequestApproval_MissingRequiredParameter(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Create a connector with an action that has required fields.
+	testhelper.InsertConnector(t, tx, "testconn")
+	testhelper.InsertConnectorActionFull(t, tx, "testconn", "testconn.do_thing", "Do Thing", testhelper.ConnectorActionOpts{
+		ParametersSchema: []byte(`{
+			"type": "object",
+			"required": ["name", "target"],
+			"properties": {
+				"name":   {"type": "string"},
+				"target": {"type": "string"},
+				"note":   {"type": "string"}
+			}
+		}`),
+	})
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// Submit with missing "target" (only "name" present).
+	reqBody := `{"request_id":"req_missing_param","action":{"type":"testconn.do_thing","parameters":{"name":"hello"}},"context":{"description":"test"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error.Code != ErrInvalidParameters {
+		t.Errorf("expected error code %q, got %q", ErrInvalidParameters, errResp.Error.Code)
+	}
+
+	// Check that missing_fields contains "target".
+	details := errResp.Error.Details
+	if details == nil {
+		t.Fatal("expected error details to be present")
+	}
+	missingRaw, ok := details["missing_fields"]
+	if !ok {
+		t.Fatal("expected missing_fields in details")
+	}
+	missingSlice, ok := missingRaw.([]any)
+	if !ok {
+		t.Fatalf("expected missing_fields to be a slice, got %T", missingRaw)
+	}
+	found := false
+	for _, f := range missingSlice {
+		if f == "target" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'target' in missing_fields, got %v", missingSlice)
+	}
+
+	// Check hint.
+	hint, ok := details["hint"]
+	if !ok {
+		t.Fatal("expected hint in details")
+	}
+	hintStr, ok := hint.(string)
+	if !ok || hintStr == "" {
+		t.Errorf("expected non-empty hint string, got %v", hint)
+	}
+}
+
+func TestAgentRequestApproval_ValidParameters(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Create a connector with an action that has required fields.
+	testhelper.InsertConnector(t, tx, "testconn")
+	testhelper.InsertConnectorActionFull(t, tx, "testconn", "testconn.do_thing", "Do Thing", testhelper.ConnectorActionOpts{
+		ParametersSchema: []byte(`{
+			"type": "object",
+			"required": ["name"],
+			"properties": {
+				"name": {"type": "string"}
+			}
+		}`),
+	})
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// Submit with all required fields present.
+	reqBody := `{"request_id":"req_valid_params","action":{"type":"testconn.do_thing","parameters":{"name":"hello"}},"context":{"description":"test"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgentRequestApproval_UnknownActionNoSchema(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// Submit with an action type that has no schema in the DB — should pass through.
+	reqBody := `{"request_id":"req_unknown_action","action":{"type":"unknown.action","parameters":{"anything":"goes"}},"context":{"description":"test"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (fail-open), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAgentRequestApproval_NoParametersWithRequiredFields(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Create a connector with an action that has required fields.
+	testhelper.InsertConnector(t, tx, "testconn")
+	testhelper.InsertConnectorActionFull(t, tx, "testconn", "testconn.do_thing", "Do Thing", testhelper.ConnectorActionOpts{
+		ParametersSchema: []byte(`{
+			"type": "object",
+			"required": ["name"],
+			"properties": {
+				"name": {"type": "string"}
+			}
+		}`),
+	})
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// Submit with no parameters at all — should fail with missing required fields.
+	reqBody := `{"request_id":"req_no_params","action":{"type":"testconn.do_thing"},"context":{"description":"test"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error.Code != ErrInvalidParameters {
+		t.Errorf("expected error code %q, got %q", ErrInvalidParameters, errResp.Error.Code)
+	}
+}
+
+func TestAgentRequestApproval_NullParameterValue(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	testhelper.InsertConnector(t, tx, "testconn")
+	testhelper.InsertConnectorActionFull(t, tx, "testconn", "testconn.do_thing", "Do Thing", testhelper.ConnectorActionOpts{
+		ParametersSchema: []byte(`{
+			"type": "object",
+			"required": ["name"],
+			"properties": {
+				"name": {"type": "string"}
+			}
+		}`),
+	})
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// Submit with required field set to null — should fail.
+	reqBody := `{"request_id":"req_null_param","action":{"type":"testconn.do_thing","parameters":{"name":null}},"context":{"description":"test"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -150,11 +150,16 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		// Validate action parameters against the connector's parameters_schema.
+		// Runs after alias normalization so canonical keys are checked.
+		// Fail-open: skipped if the action has no schema.
+		actionParams := json.RawMessage(actionObj["parameters"])
+		if !validateActionParameters(w, r, deps.DB, actionType, actionParams) {
+			return
+		}
+
 		// Optional: validate configuration reference — sees canonical keys after normalization.
 		if req.Configuration != nil {
-			// ValidateConfigurationReference expects action.parameters, not
-			// the full action object. Extract it from the already-parsed map.
-			actionParams := json.RawMessage(actionObj["parameters"])
 			result := ValidateConfigurationReference(w, r, deps, req.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
 			if result == nil {
 				return // error already written

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -68,6 +68,9 @@ const (
 	ErrPaymentMethodRequired    ErrorCode = "payment_method_required"
 	ErrPaymentLimitExceeded     ErrorCode = "payment_limit_exceeded"
 
+	// Parameter validation (request-time, distinct from execution-time invalid_parameters)
+	ErrMissingRequiredParameters ErrorCode = "missing_required_parameters"
+
 	// 429 Too Many Requests (quota)
 	ErrMonthlyQuotaExceeded ErrorCode = "monthly_quota_exceeded"
 )

--- a/db/action_schema.go
+++ b/db/action_schema.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// GetActionParametersSchema returns the parameters_schema JSON for the given
+// action type. Returns nil if the action type doesn't exist or has no schema.
+func GetActionParametersSchema(ctx context.Context, db DBTX, actionType string) ([]byte, error) {
+	var schema []byte
+	err := db.QueryRow(ctx,
+		`SELECT parameters_schema FROM connector_actions WHERE action_type = $1`,
+		actionType,
+	).Scan(&schema)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}

--- a/db/action_schema.go
+++ b/db/action_schema.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -14,7 +15,7 @@ func GetActionParametersSchema(ctx context.Context, db DBTX, actionType string) 
 		`SELECT parameters_schema FROM connector_actions WHERE action_type = $1`,
 		actionType,
 	).Scan(&schema)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/db/action_schema.go
+++ b/db/action_schema.go
@@ -7,19 +7,26 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// GetActionParametersSchema returns the parameters_schema JSON for the given
-// action type. Returns nil if the action type doesn't exist or has no schema.
-func GetActionParametersSchema(ctx context.Context, db DBTX, actionType string) ([]byte, error) {
-	var schema []byte
+// ActionSchema holds the connector ID and parameters schema for an action type.
+type ActionSchema struct {
+	ConnectorID string
+	Schema      []byte
+}
+
+// GetActionParametersSchema returns the connector ID and parameters_schema for
+// the given action type. Returns nil if the action type doesn't exist or has
+// no schema.
+func GetActionParametersSchema(ctx context.Context, db DBTX, actionType string) (*ActionSchema, error) {
+	var result ActionSchema
 	err := db.QueryRow(ctx,
-		`SELECT parameters_schema FROM connector_actions WHERE action_type = $1`,
+		`SELECT connector_id, parameters_schema FROM connector_actions WHERE action_type = $1`,
 		actionType,
-	).Scan(&schema)
+	).Scan(&result.ConnectorID, &result.Schema)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	return schema, nil
+	return &result, nil
 }


### PR DESCRIPTION
## Summary
- Validates action parameters against the connector's `parameters_schema` (JSON Schema `required` fields) at `POST /approvals/request` time, before the approval is created
- Returns `400 Bad Request` with `missing_fields` and a `hint` pointing to `GET /connectors/{connector_id}` when required parameters are missing
- Fail-open: requests proceed normally if the action has no schema or the schema can't be parsed

## Implementation
- **`db/action_schema.go`** — New `GetActionParametersSchema` function to look up the schema by action type
- **`api/action_param_validate.go`** — New `validateActionParameters` function that extracts `required` fields from the schema and checks them against supplied parameters
- **`api/agent_approvals.go`** — Integrated validation after alias normalization and before configuration validation

## Test plan

### Claude Code
- [x] Missing required parameter returns 400 with `missing_fields` and `hint`
- [x] Valid parameters pass through and create approval normally (200)
- [x] Unknown action type with no schema passes through (fail-open, 200)
- [x] No parameters with required fields returns 400
- [x] Null parameter value for required field returns 400
- [x] All existing tests pass
- [x] Build succeeds

### OpenClaw
- [ ] Verify error response format matches agent SDK expectations
- [ ] Test with real connectors (GitHub, Slack) to confirm schema validation works end-to-end
- [ ] Confirm alias normalization runs before schema validation in production

Closes #493

https://claude.ai/code/session_01GrVryZ84aFAKMwwYDrw5hZ