### PR TITLE
Bump OpenAPI spec version to 0.1.0 (pre-launch)

### DIFF
--- a/spec/openapi.bundle.yaml
+++ b/spec/openapi.bundle.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Permission Slip API
-  version: 1.0.0
+  version: 0.1.0
   description: |
     Permission Slip is a centralized middle-man service that sits between AI agents and external 
     APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 

--- a/spec/openapi/README.md
+++ b/spec/openapi/README.md
@@ -156,6 +156,12 @@ docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
   -o /local/generated/go-client
 ```
 
+## Versioning
+
+The `info.version` in the OpenAPI spec tracks the **product/API version** using [semver](https://semver.org/). While pre-launch, the version is `0.x.y` to signal that breaking changes may occur without a major version bump.
+
+The `/v1/` prefix in URL paths (e.g., `/api/v1/approvals/request`) is a **routing convention**, not a semantic version. It simply means "first version of the API surface." There are no plans to introduce `/v2/` or change this prefix — if the API evolves in breaking ways, we'll use the spec version, feature flags, or request headers to manage compatibility rather than minting a new URL prefix.
+
 ## Key Features
 
 ### Strict Validation

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Permission Slip API
-  version: 1.0.0
+  version: 0.1.0
   description: |
     Permission Slip is a centralized middle-man service that sits between AI agents and external 
     APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Permission Slip API
-  version: 1.0.0
+  version: 0.1.0
   description: |
     Permission Slip is a centralized middle-man service that sits between AI agents and external 
     APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 


### PR DESCRIPTION
## Summary
- Bumps OpenAPI `info.version` from `1.0.0` to `0.1.0` across all three spec files to reflect pre-launch status
- Adds a **Versioning** section to `spec/openapi/README.md` explaining that the `/v1/` URL prefix is a routing convention with no plans to change

## Test plan

### Claude Code
- [ ] Verify no tests reference the spec version string (they don't — version is metadata only)
- [ ] Confirm `make build` still passes

### OpenClaw
- [ ] Review the Versioning docs section for accuracy and tone

https://claude.ai/code/session_017vfXiVcGfMERRQm8NokATF