### PR TITLE
Fix Google OAuth token refresh loop

### DIFF
--- a/oauth/providers/google.go
+++ b/oauth/providers/google.go
@@ -9,12 +9,21 @@ import (
 func init() {
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
+			// prompt=consent forces Google to show the consent screen on every
+			// authorization, which ensures a refresh token is always returned.
+			// Without this, Google only returns a refresh token on the first
+			// authorization — subsequent re-authorizations silently omit it,
+			// leaving the connection without a way to refresh and forcing the
+			// user into a repeated re-auth loop.
 			ID:           "google",
 			AuthorizeURL: "https://accounts.google.com/o/oauth2/v2/auth",
 			TokenURL:     "https://oauth2.googleapis.com/token",
 			Scopes: []string{
 				"openid",
 				"https://www.googleapis.com/auth/userinfo.email",
+			},
+			AuthorizeParams: map[string]string{
+				"prompt": "consent",
 			},
 			ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 			ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),


### PR DESCRIPTION
## Summary

- Add `prompt=consent` to Google OAuth provider's `AuthorizeParams`, ensuring Google always returns a refresh token on re-authorization
- Without this, Google only issues a refresh token on the *first* authorization — subsequent re-auths silently omit it, trapping users in a `needs_reauth` loop
- Especially impactful for apps in Google's "testing" mode where refresh tokens expire after 7 days

## Test plan

### Claude Code
- [x] Verify `go vet` passes on the changed package
- [x] Confirm the change mirrors the existing pattern used by Atlassian provider

### OpenClaw
- [ ] Deploy to staging and test Google OAuth flow end-to-end
- [ ] Verify re-authorization after token expiry yields a new refresh token
- [ ] Confirm background refresh job works correctly with the new token
- [ ] Consider publishing the Google app to move past the 7-day refresh token limit

https://claude.ai/code/session_01H8JJ6yfkThfoKUvbkx7zYM