### PR TITLE
Grant pgsodium EXECUTE to app_backend for vault decryption

### DIFF
--- a/db/migrations/20260311123718_grant_vault_access_to_app_backend.sql
+++ b/db/migrations/20260311123718_grant_vault_access_to_app_backend.sql
@@ -15,9 +15,8 @@ BEGIN
         GRANT SELECT ON vault.decrypted_secrets TO app_backend;
 
         -- Grant execute on public vault API functions by exact signature.
-        -- NOTE: pgsodium schema grants (needed for vault.decrypted_secrets to
-        -- call _crypto_aead_det_decrypt) are in a separate migration:
-        -- 20260312113621_grant_pgsodium_execute_to_app_backend.sql
+        -- The internal _crypto_aead_* functions are owned by a Supabase superuser
+        -- and cannot be granted by the postgres role.
         GRANT EXECUTE ON FUNCTION vault.create_secret(text, text, text, uuid) TO app_backend;
         GRANT EXECUTE ON FUNCTION vault.update_secret(uuid, text, text, text, uuid) TO app_backend;
 

--- a/db/migrations/20260311123718_grant_vault_access_to_app_backend.sql
+++ b/db/migrations/20260311123718_grant_vault_access_to_app_backend.sql
@@ -15,8 +15,9 @@ BEGIN
         GRANT SELECT ON vault.decrypted_secrets TO app_backend;
 
         -- Grant execute on public vault API functions by exact signature.
-        -- The internal _crypto_aead_* functions are owned by a Supabase superuser
-        -- and cannot be granted by the postgres role.
+        -- NOTE: pgsodium schema grants (needed for vault.decrypted_secrets to
+        -- call _crypto_aead_det_decrypt) are in a separate migration:
+        -- 20260312113621_grant_pgsodium_execute_to_app_backend.sql
         GRANT EXECUTE ON FUNCTION vault.create_secret(text, text, text, uuid) TO app_backend;
         GRANT EXECUTE ON FUNCTION vault.update_secret(uuid, text, text, text, uuid) TO app_backend;
 

--- a/db/migrations/20260312113621_grant_pgsodium_execute_to_app_backend.sql
+++ b/db/migrations/20260312113621_grant_pgsodium_execute_to_app_backend.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+
+-- The vault.decrypted_secrets view is SECURITY INVOKER (default) and calls
+-- pgsodium._crypto_aead_det_decrypt() internally. Without EXECUTE on pgsodium
+-- functions, app_backend gets "permission denied for function
+-- _crypto_aead_det_decrypt (SQLSTATE 42501)" when reading decrypted secrets.
+--
+-- The prior migration (20260311123718) skipped this grant with a comment that
+-- these functions "cannot be granted by the postgres role". That is only true
+-- on Supabase's managed cloud platform; on self-hosted Postgres, the migration
+-- role is superuser and can grant freely.
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgsodium') THEN
+        GRANT USAGE ON SCHEMA pgsodium TO app_backend;
+        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgsodium TO app_backend;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgsodium') THEN
+        REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA pgsodium FROM app_backend;
+        REVOKE USAGE ON SCHEMA pgsodium FROM app_backend;
+    END IF;
+END
+$$;
+-- +goose StatementEnd

--- a/db/migrations/20260312113621_grant_pgsodium_execute_to_app_backend.sql
+++ b/db/migrations/20260312113621_grant_pgsodium_execute_to_app_backend.sql
@@ -15,7 +15,10 @@ DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgsodium') THEN
         GRANT USAGE ON SCHEMA pgsodium TO app_backend;
-        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgsodium TO app_backend;
+        -- Only grant the specific decrypt function used by vault.decrypted_secrets.
+        -- Granting ALL FUNCTIONS would expose key-management and raw crypto
+        -- operations that app_backend has no business calling.
+        GRANT EXECUTE ON FUNCTION pgsodium._crypto_aead_det_decrypt(bytea, bytea, bytea, bytea) TO app_backend;
     END IF;
 END
 $$;
@@ -27,7 +30,7 @@ $$;
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgsodium') THEN
-        REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA pgsodium FROM app_backend;
+        REVOKE EXECUTE ON FUNCTION pgsodium._crypto_aead_det_decrypt(bytea, bytea, bytea, bytea) FROM app_backend;
         REVOKE USAGE ON SCHEMA pgsodium FROM app_backend;
     END IF;
 END


### PR DESCRIPTION
## Summary

- Adds migration granting `USAGE ON SCHEMA pgsodium` and `EXECUTE ON ALL FUNCTIONS IN SCHEMA pgsodium` to `app_backend`
- Fixes "permission denied for function _crypto_aead_det_decrypt (SQLSTATE 42501)" when approving requests that read OAuth tokens from vault
- Updates comment in existing vault migration to cross-reference the new grant

## Root Cause

The `vault.decrypted_secrets` view is `SECURITY INVOKER` and internally calls `pgsodium._crypto_aead_det_decrypt()`. The prior migration (20260311123718) skipped granting pgsodium functions with a comment that they "cannot be granted by the postgres role" — which is only true on Supabase's managed cloud platform. On self-hosted Postgres, migrations run as superuser and can grant freely.

## Test plan

### Claude Code
- [ ] Verify migration timestamp is unique and in sorted order (`make test-backend` / `TestMigrationTimestampsUnique`)
- [ ] Verify migration applies cleanly on fresh database

### OpenClaw
- [ ] Deploy and confirm approval flow works (no more `_crypto_aead_det_decrypt` permission error)
- [ ] Verify vault secret reads work for OAuth token retrieval

https://claude.ai/code/session_01GKJtY5kGudsXUPko452NDm