### PR TITLE
Grant vault v0.3.0 decrypt fn to app_backend, add permissions docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Follow this checklist whenever a migration introduces a new table, uses a new ex
 
 7. **Extension upgrades?** Supabase extensions evolve across versions (e.g., vault v0.2.8 → v0.3.0 moved `_crypto_aead_det_decrypt` from pgsodium to vault schema). When granting on extension functions, consider version differences and use `IF EXISTS` guards on pg_proc to handle both old and new versions gracefully.
 
-8. **Wrap grants in IF EXISTS guards.** Extension schemas (vault, pgsodium) don't exist in plain Postgres (CI/test). Always wrap extension grants in `DO $$ IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '...') THEN ... END IF; $$`.
+8. **Wrap grants in IF EXISTS guards.** Extension schemas (vault, pgsodium) don't exist in plain Postgres (CI/test). For schema-level or table-level grants, check schema existence: `DO $$ IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '...') THEN ... END IF; $$`. For function-level grants, use a `BEGIN / EXCEPTION WHEN undefined_function THEN NULL; END;` block to silently skip when the function doesn't exist — this is tighter than a name-only pg_proc check and handles signature changes across extension versions.
 
 ## Database Seed Data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,52 @@ A test (`TestMigrationTimestampsUnique` in `db/migrations_integrity_test.go`) va
 
 **Extension-managed objects need explicit grants.** `ALTER DEFAULT PRIVILEGES` only applies to tables created *after* the grant runs — it never covers tables created by extensions (e.g., `vault.secrets`, pgcrypto functions). Whenever a migration grants access to an extension-managed schema, always add explicit `GRANT ... ON <table> TO app_backend` for every object the app touches, not just the functions and views.
 
+## app_backend Role Permissions
+
+The Go backend runs as the `app_backend` PostgreSQL role (non-superuser). Every database object the backend touches needs an explicit grant. This section documents what's granted and the principles to follow when adding new objects.
+
+### What's Currently Granted
+
+| Schema | Object | Grant | Migration |
+|--------|--------|-------|-----------|
+| `public` | All existing tables | SELECT, INSERT, UPDATE, DELETE | `20260309003720` |
+| `public` | All sequences | USAGE, SELECT | `20260309003720` |
+| `public` | Future tables/sequences | ALTER DEFAULT PRIVILEGES | `20260309003720` |
+| `public` | All RLS-enabled tables | `app_backend_all` policy (FOR ALL) | `20260310111634` |
+| `auth` | Schema | USAGE | `20260310102034` |
+| `auth` | `auth.users` | SELECT only | `20260309212920` |
+| `vault` | Schema | USAGE | `20260311123718` |
+| `vault` | `vault.decrypted_secrets` | SELECT | `20260311123718` |
+| `vault` | `vault.secrets` | SELECT, INSERT, UPDATE, DELETE | `20260312023009` |
+| `vault` | `vault.create_secret()` | EXECUTE | `20260311123718` |
+| `vault` | `vault.update_secret()` | EXECUTE | `20260311123718` |
+| `vault` | `vault._crypto_aead_det_decrypt()` | EXECUTE (vault v0.3.0+) | `20260312123238` |
+| `pgsodium` | Schema | USAGE | `20260312113621` |
+| `pgsodium` | `pgsodium._crypto_aead_det_decrypt()` | EXECUTE (vault v0.2.x) | `20260312113621` |
+
+### When Adding New Grants — Checklist
+
+Follow this checklist whenever a migration introduces a new table, uses a new extension, or accesses a new schema:
+
+1. **New public table?** `ALTER DEFAULT PRIVILEGES` covers it automatically for DML. But you MUST also:
+   - Enable RLS: `ALTER TABLE <name> ENABLE ROW LEVEL SECURITY;`
+   - Add policy: `CREATE POLICY app_backend_all ON <name> FOR ALL TO app_backend USING (true) WITH CHECK (true);`
+   - The RLS test (`TestAppBackendHasPoliciesOnAllRLSTables`) will catch this if you forget.
+
+2. **New extension table/view?** Extensions create objects *before* `ALTER DEFAULT PRIVILEGES` runs, so they are NEVER covered. Add an explicit `GRANT SELECT/INSERT/UPDATE/DELETE ON <schema>.<table> TO app_backend;` for each object the backend touches.
+
+3. **New extension function?** Grant EXECUTE on the exact function signature. Don't grant on ALL FUNCTIONS — follow least-privilege.
+
+4. **New schema?** Grant `USAGE ON SCHEMA <name> TO app_backend;` — without USAGE, no objects in the schema are accessible regardless of object-level grants.
+
+5. **SECURITY INVOKER views?** Views are SECURITY INVOKER by default. If a view calls functions or reads from tables in other schemas, `app_backend` needs grants on **every object the view touches**, not just SELECT on the view itself. This is the root cause of the `vault.decrypted_secrets` + `pgsodium._crypto_aead_det_decrypt` issue — the view runs as the caller (app_backend), so it needs EXECUTE on internal decrypt functions.
+
+6. **SECURITY DEFINER functions?** These run as the function owner (typically superuser). No additional grants needed for objects they access internally. `vault.create_secret()` and `vault.update_secret()` are SECURITY DEFINER — that's why they work without extra grants on pgsodium internals.
+
+7. **Extension upgrades?** Supabase extensions evolve across versions (e.g., vault v0.2.8 → v0.3.0 moved `_crypto_aead_det_decrypt` from pgsodium to vault schema). When granting on extension functions, consider version differences and use `IF EXISTS` guards on pg_proc to handle both old and new versions gracefully.
+
+8. **Wrap grants in IF EXISTS guards.** Extension schemas (vault, pgsodium) don't exist in plain Postgres (CI/test). Always wrap extension grants in `DO $$ IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '...') THEN ... END IF; $$`.
+
 ## Database Seed Data
 
 Whenever you make changes to database schema, tables, or migrations, review the seed file and update it to reflect the new schema. Add seed data for any new tables or columns so the seed remains comprehensive and stable. The seed should always be runnable against the current schema without errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Follow this checklist whenever a migration introduces a new table, uses a new ex
 
 6. **SECURITY DEFINER functions?** These run as the function owner (typically superuser). No additional grants needed for objects they access internally. `vault.create_secret()` and `vault.update_secret()` are SECURITY DEFINER — that's why they work without extra grants on pgsodium internals.
 
-7. **Extension upgrades?** Supabase extensions evolve across versions (e.g., vault v0.2.8 → v0.3.0 moved `_crypto_aead_det_decrypt` from pgsodium to vault schema). When granting on extension functions, consider version differences and use `IF EXISTS` guards on pg_proc to handle both old and new versions gracefully.
+7. **Extension upgrades?** Supabase extensions evolve across versions (e.g., vault v0.2.8 → v0.3.0 moved `_crypto_aead_det_decrypt` from pgsodium to vault schema). When granting on extension functions, consider version differences. Use a `BEGIN / EXCEPTION WHEN undefined_function OR invalid_schema_name THEN NULL; END;` block (see item 8) to handle both old and new signatures gracefully — this is tighter than a `pg_proc` name-only check because it validates the exact signature at grant time.
 
 8. **Wrap grants in IF EXISTS guards.** Extension schemas (vault, pgsodium) don't exist in plain Postgres (CI/test). For schema-level or table-level grants, check schema existence: `DO $$ IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '...') THEN ... END IF; $$`. For function-level grants, use a `BEGIN / EXCEPTION WHEN undefined_function THEN NULL; END;` block to silently skip when the function doesn't exist — this is tighter than a name-only pg_proc check and handles signature changes across extension versions.
 

--- a/db/migrations/20260312123238_grant_vault_decrypt_fn_to_app_backend.sql
+++ b/db/migrations/20260312123238_grant_vault_decrypt_fn_to_app_backend.sql
@@ -10,21 +10,16 @@
 -- which only covers vault v0.2.x where the view calls pgsodium directly.
 -- This migration covers v0.3.0+ where the view calls a vault-schema wrapper.
 --
--- Wrapped in a DO block so the migration is safe when the function doesn't
--- exist (older vault version or plain Postgres without supabase_vault).
+-- Uses BEGIN/EXCEPTION to gracefully skip when the function doesn't exist
+-- (older vault version or plain Postgres without supabase_vault).
 
 -- +goose StatementBegin
 DO $$
 BEGIN
     -- Vault v0.3.0+ wrapper function used by vault.decrypted_secrets view.
-    IF EXISTS (
-        SELECT 1 FROM pg_proc p
-        JOIN pg_namespace n ON p.pronamespace = n.oid
-        WHERE n.nspname = 'vault'
-          AND p.proname = '_crypto_aead_det_decrypt'
-    ) THEN
-        GRANT EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea) TO app_backend;
-    END IF;
+    GRANT EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea) TO app_backend;
+EXCEPTION WHEN undefined_function OR invalid_schema_name THEN
+    NULL; -- vault v0.3.0 not installed; skip
 END
 $$;
 -- +goose StatementEnd
@@ -34,14 +29,9 @@ $$;
 -- +goose StatementBegin
 DO $$
 BEGIN
-    IF EXISTS (
-        SELECT 1 FROM pg_proc p
-        JOIN pg_namespace n ON p.pronamespace = n.oid
-        WHERE n.nspname = 'vault'
-          AND p.proname = '_crypto_aead_det_decrypt'
-    ) THEN
-        REVOKE EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea) FROM app_backend;
-    END IF;
+    REVOKE EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea) FROM app_backend;
+EXCEPTION WHEN undefined_function OR invalid_schema_name THEN
+    NULL; -- vault v0.3.0 not installed; skip
 END
 $$;
 -- +goose StatementEnd

--- a/db/migrations/20260312123238_grant_vault_decrypt_fn_to_app_backend.sql
+++ b/db/migrations/20260312123238_grant_vault_decrypt_fn_to_app_backend.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+
+-- Vault v0.3.0 moved the decrypt function from pgsodium into the vault schema:
+--   vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea)
+-- The decrypted_secrets view (SECURITY INVOKER) calls this function, so
+-- app_backend needs EXECUTE on it. Without this grant, reading decrypted
+-- secrets fails with "permission denied for function _crypto_aead_det_decrypt".
+--
+-- The prior migration (20260312113621) granted pgsodium._crypto_aead_det_decrypt
+-- which only covers vault v0.2.x where the view calls pgsodium directly.
+-- This migration covers v0.3.0+ where the view calls a vault-schema wrapper.
+--
+-- Wrapped in a DO block so the migration is safe when the function doesn't
+-- exist (older vault version or plain Postgres without supabase_vault).
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- Vault v0.3.0+ wrapper function used by vault.decrypted_secrets view.
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON p.pronamespace = n.oid
+        WHERE n.nspname = 'vault'
+          AND p.proname = '_crypto_aead_det_decrypt'
+    ) THEN
+        GRANT EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea) TO app_backend;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON p.pronamespace = n.oid
+        WHERE n.nspname = 'vault'
+          AND p.proname = '_crypto_aead_det_decrypt'
+    ) THEN
+        REVOKE EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea) FROM app_backend;
+    END IF;
+END
+$$;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

- Adds migration granting `EXECUTE ON FUNCTION vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea)` to `app_backend` for vault v0.3.0 compatibility
- Adds comprehensive "app_backend Role Permissions" documentation to CLAUDE.md with a reference table of all current grants and an 8-point checklist for adding new grants

## Root Cause

Follow-up to #502. The prior fix granted `pgsodium._crypto_aead_det_decrypt(bytea, bytea, bytea, bytea)` which only works for vault v0.2.x. In vault v0.3.0, the `decrypted_secrets` view was rewritten to call `vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea)` — a new C wrapper in the **vault** schema — and the upgrade migration revoked all public access to it.

Without this grant, reading decrypted secrets on vault v0.3.0+ would fail with the same "permission denied for function _crypto_aead_det_decrypt" error.

## What Changed

**Migration** (`20260312123238_grant_vault_decrypt_fn_to_app_backend.sql`):
- Grants EXECUTE on `vault._crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea)` to app_backend
- Wrapped in IF EXISTS guard on pg_proc so it's a no-op when vault v0.3.0 isn't installed

**Documentation** (`CLAUDE.md`):
- Reference table of all 14 grants across public/auth/vault/pgsodium schemas
- 8-point checklist covering: new tables (RLS + policy), extension objects, function signatures, schema USAGE, SECURITY INVOKER vs DEFINER, extension version awareness, IF EXISTS guards

## Test plan

### Claude Code
- [x] `TestMigrationTimestampsUnique` — passes
- [x] `TestMigrationTimestampsSorted` — passes
- [x] `TestRLSEnabledOnAllTables` — passes
- [x] `TestAppBackendHasPoliciesOnAllRLSTables` — passes
- [x] Migration applies cleanly on fresh database

### OpenClaw
- [ ] Deploy and confirm vault decrypt still works (tests both v0.2.x pgsodium grant and v0.3.0 vault grant)
- [ ] Review permissions documentation in CLAUDE.md for accuracy

https://claude.ai/code/session_01BFJJa4AcZtKh3sipA7G39F