### PR TITLE
Fix CLI request payload to match server format

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers",
   "license": "MIT",
   "type": "module",

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -236,7 +236,11 @@ export class ApiClient {
     }>({
       method: "POST",
       routerPath: "/approvals/request",
-      body: { request_id: requestId, action_id: actionId, parameters: params, context },
+      body: {
+        request_id: requestId,
+        action: { type: actionId, parameters: params },
+        context: context ?? {},
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- Fixed the `requestApproval` method in the CLI client to send the `action` field as a nested object (`{ type, parameters }`) instead of flat `action_id` + `parameters` fields, matching what the server's `POST /approvals/request` handler expects.
- Ensured `context` is always sent as a JSON object (defaults to `{}`) since the server validates it as required.
- Bumped CLI version to 0.1.1.

Closes #504

## Test plan
- [ ] Existing CLI tests pass (`npm test` in `cli/`)
- [ ] CLI builds cleanly (`npm run build` in `cli/`)
- [ ] Manual test: `permission-slip request --action email.send --params '{"to":"test@example.com"}' --description "Test"` no longer returns `"action is required"` error

### Claude Code
- [x] Verify all existing tests pass
- [x] Verify TypeScript compilation succeeds

### OpenClaw
- [ ] Manual end-to-end test with a registered agent against staging
- [ ] Verify approval shows up correctly in the dashboard after request

https://claude.ai/code/session_01Wf4DkMPBDKwyAowff6whjq