### PR TITLE
Fix OAuth authorize flow to include connector-specific scopes

### DIFF
--- a/frontend/src/lib/__tests__/oauth.test.ts
+++ b/frontend/src/lib/__tests__/oauth.test.ts
@@ -1,7 +1,25 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { getOAuthAuthorizeUrl } from "../oauth";
 
 describe("getOAuthAuthorizeUrl", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Pin window.location so tests don't depend on jsdom's default URL.
+    Object.defineProperty(window, "location", {
+      value: new URL("http://localhost/settings/connectors"),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
   it("builds authorize URL without scopes", () => {
     const url = getOAuthAuthorizeUrl("google", "tok_123");
     expect(url).toContain("/v1/oauth/google/authorize?");

--- a/frontend/src/lib/__tests__/oauth.test.ts
+++ b/frontend/src/lib/__tests__/oauth.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { getOAuthAuthorizeUrl } from "../oauth";
+
+describe("getOAuthAuthorizeUrl", () => {
+  it("builds authorize URL without scopes", () => {
+    const url = getOAuthAuthorizeUrl("google", "tok_123");
+    expect(url).toContain("/v1/oauth/google/authorize?");
+    expect(url).toContain("access_token=tok_123");
+    expect(url).not.toContain("scope=");
+  });
+
+  it("appends scopes as repeated query params", () => {
+    const url = getOAuthAuthorizeUrl("slack", "tok_abc", [
+      "chat:write",
+      "channels:read",
+    ]);
+    expect(url).toContain("scope=chat%3Awrite");
+    expect(url).toContain("scope=channels%3Aread");
+  });
+
+  it("URL-encodes scopes with special characters", () => {
+    const url = getOAuthAuthorizeUrl("google", "tok_x", [
+      "https://www.googleapis.com/auth/gmail.send",
+    ]);
+    expect(url).toContain(
+      "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.send",
+    );
+  });
+
+  it("skips scopes when array is empty", () => {
+    const url = getOAuthAuthorizeUrl("google", "tok_y", []);
+    expect(url).not.toContain("scope=");
+  });
+
+  it("skips scopes when undefined", () => {
+    const url = getOAuthAuthorizeUrl("google", "tok_z", undefined);
+    expect(url).not.toContain("scope=");
+  });
+});

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -22,6 +22,7 @@ export const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
 export function getOAuthAuthorizeUrl(
   providerId: string,
   accessToken: string,
+  scopes?: string[],
 ): string {
   const baseUrl =
     import.meta.env.VITE_API_BASE_URL?.replace(/\/v1\/?$/, "") ?? "/api";
@@ -30,5 +31,11 @@ export function getOAuthAuthorizeUrl(
   url.searchParams.delete("oauth_provider");
   url.searchParams.delete("oauth_error");
   const returnTo = url.pathname + (url.search || "") + url.hash;
-  return `${baseUrl}/v1/oauth/${providerId}/authorize?access_token=${encodeURIComponent(accessToken)}&return_to=${encodeURIComponent(returnTo)}`;
+  let result = `${baseUrl}/v1/oauth/${providerId}/authorize?access_token=${encodeURIComponent(accessToken)}&return_to=${encodeURIComponent(returnTo)}`;
+  if (scopes?.length) {
+    for (const s of scopes) {
+      result += `&scope=${encodeURIComponent(s)}`;
+    }
+  }
+  return result;
 }

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -226,6 +226,7 @@ function OAuthCredentialRow({
     window.location.href = getOAuthAuthorizeUrl(
       providerId,
       session.access_token,
+      requiredCredential.oauth_scopes,
     );
   }
 
@@ -344,6 +345,7 @@ function OAuthCredentialRow({
           open={shopDialogOpen}
           onOpenChange={setShopDialogOpen}
           providerId={providerId}
+          oauthScopes={requiredCredential.oauth_scopes}
         />
       )}
     </>
@@ -354,10 +356,12 @@ function ShopDomainDialog({
   open,
   onOpenChange,
   providerId,
+  oauthScopes,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   providerId: string;
+  oauthScopes?: string[];
 }) {
   const { session } = useAuth();
   const [shop, setShop] = useState("");
@@ -368,7 +372,7 @@ function ShopDomainDialog({
     const trimmed = shop.trim().toLowerCase();
     if (!trimmed) return;
     const subdomain = trimmed.replace(/\.myshopify\.com$/, "");
-    const url = getOAuthAuthorizeUrl(providerId, session.access_token);
+    const url = getOAuthAuthorizeUrl(providerId, session.access_token, oauthScopes);
     window.location.href = `${url}&shop=${encodeURIComponent(subdomain)}`;
     onOpenChange(false);
   }

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -120,6 +120,7 @@ export function SetupConnectorCredentialsDialog({
       const url = getOAuthAuthorizeUrl(
         effectiveOAuthProvider,
         session.access_token,
+        oauthCredential?.oauth_scopes,
       );
       window.location.href = `${url}&shop=${encodeURIComponent(subdomain)}`;
       return;
@@ -128,6 +129,7 @@ export function SetupConnectorCredentialsDialog({
     window.location.href = getOAuthAuthorizeUrl(
       effectiveOAuthProvider,
       session.access_token,
+      oauthCredential?.oauth_scopes,
     );
   }
 


### PR DESCRIPTION
## Summary

- The frontend's `getOAuthAuthorizeUrl()` was not passing connector-declared OAuth scopes to the backend authorize endpoint
- This caused Google (and all other OAuth connectors) to issue tokens with only identity scopes (`openid`, `userinfo.email`), resulting in "Request had insufficient authentication scopes" errors when executing actions like sending emails or creating calendar events
- The backend already supports extra scopes via repeated `scope` query params — this change threads the connector manifest's `oauth_scopes` through from all frontend call sites

## Changes

- **`frontend/src/lib/oauth.ts`** — Added optional `scopes` parameter to `getOAuthAuthorizeUrl`
- **`ConnectorCredentialsSection.tsx`** — Pass `requiredCredential.oauth_scopes` when initiating OAuth (including ShopDomainDialog)
- **`SetupConnectorCredentialsDialog.tsx`** — Pass `oauthCredential?.oauth_scopes` in both shop-domain and normal paths
- **`frontend/src/lib/__tests__/oauth.test.ts`** — Unit tests for scope inclusion in authorize URLs

## Test plan

### Claude Code
- [x] Frontend tests pass (`make test-frontend` — 723 tests)
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Verify the Settings page connect flow still works without scopes (no regression)

### OpenClaw
- [ ] Disconnect and reconnect Google account from a connector page — verify consent screen shows API permissions (gmail.send, calendar.events, etc.)
- [ ] Execute a Google connector action (e.g., send email) — verify it succeeds without "insufficient scopes" error
- [ ] Verify existing non-Google OAuth connectors still work (Slack, GitHub, etc.)

https://claude.ai/code/session_01M5z6qiM1wAA5ptcA1GzAop