### PR TITLE
Fix OAuth refresh token lost during re-authorization

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -657,17 +657,26 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 		}
 		// Not found is fine — first connection.
 	}
+
+	// Track the old refresh token vault ID so we can reuse it if the new
+	// token exchange doesn't include a refresh token (Google edge case where
+	// prompt=consent + access_type=offline still omits the refresh token).
+	var oldRefreshVaultID *string
 	if existing != nil {
-		// Clean up old vault secrets. A failure here aborts the PostgreSQL
-		// transaction, so we must return immediately (same pattern as
-		// handleDeleteOAuthConnection).
+		oldRefreshVaultID = existing.RefreshTokenVaultID
+
+		// Always clean up the old access token secret.
 		if err := deps.Vault.DeleteSecret(ctx, tx, existing.AccessTokenVaultID); err != nil {
 			return fmt.Errorf("delete orphaned access token secret: %w", err)
 		}
-		if existing.RefreshTokenVaultID != nil {
+
+		// Only delete the old refresh token secret if the new token includes
+		// a replacement. Otherwise we reuse the existing vault entry.
+		if existing.RefreshTokenVaultID != nil && token.RefreshToken != "" {
 			if err := deps.Vault.DeleteSecret(ctx, tx, *existing.RefreshTokenVaultID); err != nil {
 				return fmt.Errorf("delete orphaned refresh token secret: %w", err)
 			}
+			oldRefreshVaultID = nil // cleared — will create fresh below
 		}
 	}
 
@@ -688,6 +697,12 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 			return fmt.Errorf("vault create refresh token: %w", err)
 		}
 		refreshVaultID = &id
+	} else if oldRefreshVaultID != nil {
+		// New token omitted the refresh token — reuse the old vault secret.
+		log.Printf("WARNING: OAuth token exchange for provider %q did not return a refresh token; preserving existing refresh token from previous authorization", providerID)
+		refreshVaultID = oldRefreshVaultID
+	} else if existing != nil {
+		log.Printf("WARNING: OAuth token exchange for provider %q did not return a refresh token and no previous refresh token exists", providerID)
 	}
 
 	var tokenExpiry *time.Time

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -699,10 +699,10 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 		refreshVaultID = &id
 	} else if oldRefreshVaultID != nil {
 		// New token omitted the refresh token — reuse the old vault secret.
-		log.Printf("WARNING: OAuth token exchange for provider %q did not return a refresh token; preserving existing refresh token from previous authorization", providerID)
+		log.Printf("[%s] WARNING: OAuth token exchange for provider %q did not return a refresh token; preserving existing refresh token from previous authorization", TraceID(ctx), providerID)
 		refreshVaultID = oldRefreshVaultID
 	} else if existing != nil {
-		log.Printf("WARNING: OAuth token exchange for provider %q did not return a refresh token and no previous refresh token exists", providerID)
+		log.Printf("[%s] WARNING: OAuth token exchange for provider %q did not return a refresh token and no previous refresh token exists", TraceID(ctx), providerID)
 	}
 
 	var tokenExpiry *time.Time

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -871,6 +871,142 @@ func TestStoreOAuthTokens_ReplacesExisting(t *testing.T) {
 	}
 }
 
+func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := oauthDeps(tx)
+
+	// First authorization — includes refresh token.
+	token1 := &oauth2.Token{
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-old",
+		Expiry:       time.Now().Add(time.Hour),
+		TokenType:    "Bearer",
+	}
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil); err != nil {
+		t.Fatalf("first storeOAuthTokens: %v", err)
+	}
+
+	// Verify refresh token was stored.
+	conn1, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, "google")
+	if err != nil {
+		t.Fatalf("get connection after first auth: %v", err)
+	}
+	if conn1.RefreshTokenVaultID == nil {
+		t.Fatal("expected refresh token vault ID after first auth")
+	}
+	oldRefreshVaultID := *conn1.RefreshTokenVaultID
+
+	// Re-authorization — provider omits the refresh token this time.
+	token2 := &oauth2.Token{
+		AccessToken:  "access-new",
+		RefreshToken: "",
+		Expiry:       time.Now().Add(2 * time.Hour),
+		TokenType:    "Bearer",
+	}
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil); err != nil {
+		t.Fatalf("second storeOAuthTokens: %v", err)
+	}
+
+	// Connection should still have a refresh token vault ID (preserved).
+	conn2, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, "google")
+	if err != nil {
+		t.Fatalf("get connection after re-auth: %v", err)
+	}
+	if conn2.RefreshTokenVaultID == nil {
+		t.Fatal("expected refresh token vault ID to be preserved after re-auth without refresh token")
+	}
+	if *conn2.RefreshTokenVaultID != oldRefreshVaultID {
+		t.Errorf("expected reused vault ID %s, got %s", oldRefreshVaultID, *conn2.RefreshTokenVaultID)
+	}
+
+	// The old refresh token value should still be readable.
+	mockVault := deps.Vault.(*vault.MockVaultStore)
+	refreshBytes, err := mockVault.ReadSecret(t.Context(), tx, *conn2.RefreshTokenVaultID)
+	if err != nil {
+		t.Fatalf("read preserved refresh token: %v", err)
+	}
+	if string(refreshBytes) != "refresh-old" {
+		t.Errorf("expected preserved refresh token %q, got %q", "refresh-old", string(refreshBytes))
+	}
+
+	// Access token should be the new one.
+	accessBytes, err := mockVault.ReadSecret(t.Context(), tx, conn2.AccessTokenVaultID)
+	if err != nil {
+		t.Fatalf("read new access token: %v", err)
+	}
+	if string(accessBytes) != "access-new" {
+		t.Errorf("expected new access token %q, got %q", "access-new", string(accessBytes))
+	}
+}
+
+func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := oauthDeps(tx)
+
+	// First authorization.
+	token1 := &oauth2.Token{
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-old",
+		Expiry:       time.Now().Add(time.Hour),
+		TokenType:    "Bearer",
+	}
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil); err != nil {
+		t.Fatalf("first storeOAuthTokens: %v", err)
+	}
+
+	conn1, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, "google")
+	if err != nil {
+		t.Fatalf("get connection: %v", err)
+	}
+	oldRefreshVaultID := *conn1.RefreshTokenVaultID
+
+	// Re-authorization WITH a new refresh token.
+	token2 := &oauth2.Token{
+		AccessToken:  "access-new",
+		RefreshToken: "refresh-new",
+		Expiry:       time.Now().Add(2 * time.Hour),
+		TokenType:    "Bearer",
+	}
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil); err != nil {
+		t.Fatalf("second storeOAuthTokens: %v", err)
+	}
+
+	conn2, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, "google")
+	if err != nil {
+		t.Fatalf("get connection after re-auth: %v", err)
+	}
+	if conn2.RefreshTokenVaultID == nil {
+		t.Fatal("expected refresh token vault ID")
+	}
+	// Should be a DIFFERENT vault ID (new secret created).
+	if *conn2.RefreshTokenVaultID == oldRefreshVaultID {
+		t.Error("expected new vault ID, got the old one")
+	}
+
+	// Old vault secret should be deleted.
+	mockVault := deps.Vault.(*vault.MockVaultStore)
+	if mockVault.HasSecret(oldRefreshVaultID) {
+		t.Error("old refresh token vault secret should have been deleted")
+	}
+
+	// New refresh token should be readable.
+	refreshBytes, err := mockVault.ReadSecret(t.Context(), tx, *conn2.RefreshTokenVaultID)
+	if err != nil {
+		t.Fatalf("read new refresh token: %v", err)
+	}
+	if string(refreshBytes) != "refresh-new" {
+		t.Errorf("expected %q, got %q", "refresh-new", string(refreshBytes))
+	}
+}
+
 // ── Shopify per-shop URL helpers ──────────────────────────────────────────────
 
 func TestValidateShopSubdomain(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes the "token expired and no refresh token available — user must re-authorize" error that forces users to re-authorize Google OAuth every hour
- Root cause: during re-authorization, `storeOAuthTokens()` deleted the old refresh token from vault before checking whether the new token exchange included a replacement — if Google omitted it (edge case despite `prompt=consent`), the token was permanently lost
- Now preserves the old refresh token vault secret when the new exchange doesn't include one, and logs a warning for visibility

## Test plan

### Claude Code
- [x] Added `TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld` — verifies old refresh token is preserved when re-auth response omits it
- [x] Added `TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld` — verifies old token is properly replaced when a new one is returned (regression guard)
- [x] All `api` package tests pass
- [x] Build compiles cleanly

### OpenClaw
- [ ] Verify the fix in staging: authorize Google, wait for token expiry, confirm automatic refresh works without re-auth prompt
- [ ] Check server logs for the new WARNING line to confirm the edge case is being surfaced

https://claude.ai/code/session_01PaMrL4gTEZdEf3qN83MpvZ