### PR TITLE
Clean up connector credential card styling

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -418,7 +418,7 @@ function StaticCredentialRow({
   return (
     <>
       <div className="rounded-lg border p-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -241,12 +241,10 @@ function OAuthCredentialRow({
     }
   }
 
-  const scopes = requiredCredential.oauth_scopes ?? [];
-
   return (
     <>
       <div className="rounded-lg border p-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
@@ -271,69 +269,46 @@ function OAuthCredentialRow({
                 {isConnected
                   ? `Connected ${new Date(connection.connected_at).toLocaleDateString()}`
                   : needsReauth
-                    ? "Connection expired or was revoked \u2014 re-authorize to restore access"
-                    : `Connect your ${providerLabel(providerId)} account via OAuth for automatic token management`}
+                    ? "Re-authorization required"
+                    : "Not connected"}
               </p>
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {isConnected ? (
-              <>
-                <span className="text-xs font-medium text-green-600 dark:text-green-400">
-                  Connected
-                </span>
-                <InlineConfirmButton
-                  confirmLabel="Disconnect"
-                  isProcessing={isDisconnecting}
-                  onConfirm={handleDisconnect}
-                >
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Disconnect ${providerLabel(providerId)}`}
-                  >
-                    <Unplug className="text-muted-foreground size-4" />
-                  </Button>
-                </InlineConfirmButton>
-              </>
-            ) : needsReauth ? (
-              <>
-                <Badge variant="destructive" className="gap-1 text-xs">
-                  <AlertTriangle className="size-3" />
-                  Needs Re-auth
-                </Badge>
-                <Button variant="outline" size="sm" onClick={handleConnect}>
-                  <LogIn className="size-3" />
-                  Re-authorize
-                </Button>
-              </>
-            ) : (
-              <>
-                <span className="text-muted-foreground text-xs font-medium">
-                  Not connected
-                </span>
+              <InlineConfirmButton
+                confirmLabel="Disconnect"
+                isProcessing={isDisconnecting}
+                onConfirm={handleDisconnect}
+              >
                 <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleConnect}
-                  disabled={!provider?.has_credentials}
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Disconnect ${providerLabel(providerId)}`}
                 >
-                  <LogIn className="size-3" />
-                  Connect {providerLabel(providerId)}
+                  <Unplug className="text-muted-foreground size-4" />
                 </Button>
-              </>
+              </InlineConfirmButton>
+            ) : needsReauth ? (
+              <Button variant="outline" size="sm" onClick={handleConnect}>
+                <LogIn className="size-3" />
+                Re-authorize
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleConnect}
+                disabled={!provider?.has_credentials}
+              >
+                <LogIn className="size-3" />
+                Connect {providerLabel(providerId)}
+              </Button>
             )}
           </div>
         </div>
-        {scopes.length > 0 && !isConnected && (
-          <div className="mt-2 pl-8">
-            <p className="text-muted-foreground text-[11px]">
-              Permissions requested: {scopes.join(", ")}
-            </p>
-          </div>
-        )}
         {!isConnected && !needsReauth && !provider?.has_credentials && (
-          <p className="text-muted-foreground mt-2 text-xs">
+          <p className="text-muted-foreground mt-2 pl-8 text-xs">
             OAuth is not available yet — ask your admin to configure{" "}
             {providerLabel(providerId)} OAuth credentials.
           </p>

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
@@ -370,6 +370,42 @@ describe("ConnectorCredentialsSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows re-authorization state for expired connection", async () => {
+    setupMockGet({
+      "/v1/oauth/connections": {
+        data: {
+          connections: [
+            {
+              provider: "slack",
+              status: "needs_reauth",
+              scopes: ["chat:write"],
+              connected_at: "2026-01-01T10:00:00Z",
+            },
+          ],
+        },
+      },
+      "/v1/oauth/providers": {
+        data: { providers: [{ id: "slack", has_credentials: true }] },
+      },
+    });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        connectorId="slack"
+        requiredCredentials={[{
+          service: "slack",
+          auth_type: "oauth2" as const,
+          oauth_provider: "slack",
+        }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Re-authorization required")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Re-authorize/ })).toBeInTheDocument();
+  });
+
   it("shows both OAuth and API key options for mixed credentials", async () => {
     setupMockGet();
 

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
@@ -324,11 +324,7 @@ describe("ConnectorCredentialsSection", () => {
       expect(screen.getByText("OAuth")).toBeInTheDocument();
     });
     expect(screen.getByText("Recommended")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Connect your Slack account via OAuth for automatic token management",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Not connected")).toBeInTheDocument();
   });
 
   it("shows OAuth connected status when user has connection", async () => {
@@ -367,7 +363,7 @@ describe("ConnectorCredentialsSection", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Connected")).toBeInTheDocument();
+      expect(screen.getByText(/^Connected/)).toBeInTheDocument();
     });
     expect(
       screen.getByLabelText("Disconnect Slack"),


### PR DESCRIPTION
## Summary

- Removes the "Permissions requested" scope list from OAuth credential rows — users already see scopes on the OAuth consent screen, so listing them here is redundant noise
- Simplifies the description text to a short status string ("Not connected", "Connected {date}", "Re-authorization required") instead of a long sentence that wraps badly on narrow viewports
- Removes the duplicate status label from the right side of each row — the icon and description already communicate this clearly
- Drops flex-wrap from the credential row container so the name area and action button stay on the same line at all widths

## Test plan

### Claude Code
- [x] All 723 frontend tests pass
- [x] TypeScript compiles clean

### OpenClaw
- [ ] Visual QA on connector detail page — verify credential card looks clean with no scope list
- [ ] Check "Not connected", "Connected", and "Needs Re-auth" states all render correctly

https://claude.ai/code/session_012S5xgJ8Sz1GZJjdtUhvtuY