### PR TITLE
Fix misleading CLI next_step for one-off approvals

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@permission-slip/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0"

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -244,6 +244,21 @@ export class ApiClient {
     });
   }
 
+  /** GET /approvals/{id}/status — check approval and execution status */
+  async approvalStatus(approvalId: string) {
+    return this.request<{
+      approval_id: string;
+      status: string;
+      expires_at: string;
+      created_at: string;
+      execution_status?: string;
+      execution_result?: unknown;
+    }>({
+      method: "GET",
+      routerPath: `/approvals/${approvalId}/status`,
+    });
+  }
+
   /** POST /actions/execute */
   async execute(
     tokenOrConfigId: { token: string } | { configuration_id: string; request_id?: string },

--- a/cli/src/commands/execute.ts
+++ b/cli/src/commands/execute.ts
@@ -1,16 +1,16 @@
 /**
- * permission-slip execute --token <token> [--action <id>] [--params '{}'] [--server <url>]
- *   or
  * permission-slip execute --configuration <id> [--params '{}'] [--server <url>]
  *
- * Executes an approved action using either:
- *  - A one-off execution token (obtained after the user approves a request)
- *  - A standing approval configuration (--configuration)
+ * Executes an action using a standing approval configuration.
  *
- * NOTE: The /approvals/{id}/verify endpoint (which trades an approval ID for
- * a token) is currently "Planned" server-side. Until it is implemented, agents
- * must obtain the token out-of-band (the user shares it after approving on the
- * dashboard) and pass it directly with --token.
+ * Standing approvals are pre-approved recurring action configurations. Use
+ * `permission-slip capabilities` to see available standing approvals and
+ * their configuration IDs.
+ *
+ * NOTE: For one-off approvals (created via `permission-slip request`), the
+ * server auto-executes the action when the approver approves it — you do NOT
+ * need to call `execute`. Use `permission-slip request-status` to check the
+ * outcome instead.
  */
 
 import type { Command } from "commander";
@@ -21,8 +21,8 @@ import { output, type OutputOptions } from "../output.js";
 export function executeCommand(program: Command): void {
   program
     .command("execute")
-    .description("Execute an approved action")
-    .option("--token <token>", "Execution token (shared by the user after approving on the dashboard)")
+    .description("Execute an action using a standing approval (one-off approvals auto-execute on approval)")
+    .option("--token <token>", "Execution token (advanced — most agents should use --configuration instead)")
     .option("--configuration <id>", "Standing approval configuration ID")
     .option("--action <action_id>", "Action type (required with --token)")
     .option("--params <json>", "Action parameters as JSON string", "{}")

--- a/cli/src/commands/request-status.ts
+++ b/cli/src/commands/request-status.ts
@@ -1,0 +1,43 @@
+/**
+ * permission-slip request-status --approval-id <id> [--server <url>]
+ *
+ * Checks the status of a previously submitted approval request.
+ * Returns the approval status plus execution outcome once the action
+ * has been auto-executed on approval.
+ */
+
+import type { Command } from "commander";
+import { ApiClient } from "../api/client.js";
+import { resolveAgentId } from "./status.js";
+import { output, type OutputOptions } from "../output.js";
+
+export function requestStatusCommand(program: Command): void {
+  program
+    .command("request-status")
+    .description("Check the status of an approval request")
+    .requiredOption("--approval-id <id>", "Approval ID returned by the request command")
+    .option(
+      "--server <url>",
+      "Permission Slip server URL",
+      "https://app.permissionslip.dev",
+    )
+    .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
+    .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
+    .action(async (opts: {
+      approvalId: string;
+      server: string;
+      agentId?: string;
+      pretty?: boolean;
+    }) => {
+      const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
+      try {
+        const agentId = resolveAgentId(opts.server, opts.agentId);
+        const client = new ApiClient({ serverUrl: opts.server, agentId });
+        const result = await client.approvalStatus(opts.approvalId);
+        output(result, outputOpts);
+      } catch (err) {
+        output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -64,7 +64,7 @@ export function requestCommand(program: Command): void {
             next_step:
               "Your request is pending approval. Once approved, the action will execute automatically — no further action is needed from you. " +
               "To check the outcome, run: " +
-              `permission-slip request-status --approval-id ${result.approval_id}` +
+              `permission-slip request-status --approval-id ${shellQuote(result.approval_id)}` +
               (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : ""),
           },
           outputOpts,

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -2,7 +2,8 @@
  * permission-slip request --action <action_id> [--params '{}'] [--server <url>]
  *
  * Requests one-off approval for an action. Returns the approval ID and URL.
- * The user must approve on the dashboard and share a confirmation code.
+ * Once the approver approves on the dashboard, the action executes automatically
+ * — there is no separate execute step for one-off approvals.
  */
 
 import type { Command } from "commander";
@@ -61,8 +62,9 @@ export function requestCommand(program: Command): void {
           {
             ...result,
             next_step:
-              "Wait for the user to approve on the dashboard. Once they share the execution token with you, run: " +
-              `permission-slip execute --token <token> --action ${shellQuote(opts.action)} --params ${shellQuote(opts.params)}` +
+              "Your request is pending approval. Once approved, the action will execute automatically — no further action is needed from you. " +
+              "To check the outcome, run: " +
+              `permission-slip request-status --approval-id ${result.approval_id}` +
               (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : ""),
           },
           outputOpts,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,8 +11,9 @@
  *   status        Show current registration state
  *   capabilities  List available action configurations and standing approvals
  *   connectors    List available connectors
- *   request       Request approval for an action
- *   execute       Execute an approved action
+ *   request        Request approval for an action (auto-executes on approval)
+ *   request-status Check the status/outcome of an approval request
+ *   execute        Execute an action using a standing approval
  *   config        Show saved configuration and registrations
  *   whoami        Show agent identity and registration info
  *
@@ -26,6 +27,7 @@ import { statusCommand } from "./commands/status.js";
 import { capabilitiesCommand } from "./commands/capabilities.js";
 import { connectorsCommand } from "./commands/connectors.js";
 import { requestCommand } from "./commands/request.js";
+import { requestStatusCommand } from "./commands/request-status.js";
 import { executeCommand } from "./commands/execute.js";
 import { configCommand } from "./commands/config.js";
 import { whoamiCommand } from "./commands/whoami.js";
@@ -50,6 +52,7 @@ statusCommand(program);
 capabilitiesCommand(program);
 connectorsCommand(program);
 requestCommand(program);
+requestStatusCommand(program);
 executeCommand(program);
 configCommand(program);
 whoamiCommand(program);


### PR DESCRIPTION
## Summary

Closes #509

- **Fixed `request` next_step message**: No longer tells agents to wait for an execution token. Now explains that the action auto-executes on approval and suggests `request-status` to check the outcome.
- **Added `request-status` command**: New command backed by the existing `GET /approvals/{id}/status` endpoint, letting agents poll for approval status and execution results.
- **Clarified `execute` command**: Updated description and help text to make clear it's for standing approvals only — one-off approvals don't need `execute`.

## Test plan

### Claude Code
- [ ] Verify `npm run build` passes in `cli/`
- [ ] Verify `npm test` passes in `cli/`
- [ ] Verify `permission-slip request --help` shows updated description
- [ ] Verify `permission-slip request-status --help` shows new command
- [ ] Verify `permission-slip execute --help` mentions standing approvals

### OpenClaw
- [ ] End-to-end: run `request`, approve on dashboard, confirm auto-execution works without `execute`
- [ ] End-to-end: run `request-status --approval-id <id>` after approval and confirm execution result is returned
- [ ] Verify standing approval flow with `execute --configuration` still works

https://claude.ai/code/session_01WAjQ7jPHTcFiE3e34YSNiF