### PR TITLE
Replace Twilio SMS with simple webhook POST

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -20,6 +20,7 @@ jobs:
           PR_URL: ${{ inputs.pr_url }}
           PR_TITLE: ${{ inputs.pr_title }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         run: |
           if [ -z "$WEBHOOK_URL" ]; then
             echo "::error::WEBHOOK_URL secret is not set"
@@ -34,9 +35,15 @@ jobs:
             MESSAGE="permission-slip: Claude Code needs your attention"
           fi
 
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+          CURL_ARGS=(-s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{\"message\": \"${MESSAGE}\"}")
+
+          if [ -n "$WEBHOOK_SECRET" ]; then
+            CURL_ARGS+=(-H "Authorization: Bearer ${WEBHOOK_SECRET}")
+          fi
+
+          RESPONSE=$(curl "${CURL_ARGS[@]}")
 
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: ""
       pr_title:
-        description: "PR title (optional — included in SMS when provided)"
+        description: "PR title (optional — included in payload when provided)"
         required: false
         default: ""
 
@@ -15,29 +15,14 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Twilio SMS
+      - name: Send Webhook
         env:
           PR_URL: ${{ inputs.pr_url }}
           PR_TITLE: ${{ inputs.pr_title }}
-          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
-          TWILIO_PHONE_FROM: ${{ secrets.TWILIO_PHONE_FROM }}
-          TWILIO_PHONE_TO: ${{ secrets.TWILIO_PHONE_TO }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
         run: |
-          if [ -z "$TWILIO_ACCOUNT_SID" ]; then
-            echo "::error::TWILIO_ACCOUNT_SID secret is not set"
-            exit 1
-          fi
-          if [ -z "$TWILIO_AUTH_TOKEN" ]; then
-            echo "::error::TWILIO_AUTH_TOKEN secret is not set"
-            exit 1
-          fi
-          if [ -z "$TWILIO_PHONE_FROM" ]; then
-            echo "::error::TWILIO_PHONE_FROM secret is not set"
-            exit 1
-          fi
-          if [ -z "$TWILIO_PHONE_TO" ]; then
-            echo "::error::TWILIO_PHONE_TO secret is not set"
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "::error::WEBHOOK_URL secret is not set"
             exit 1
           fi
 
@@ -49,18 +34,15 @@ jobs:
             MESSAGE="permission-slip: Claude Code needs your attention"
           fi
 
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
-            "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json" \
-            -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
-            --data-urlencode "To=${TWILIO_PHONE_TO}" \
-            --data-urlencode "From=${TWILIO_PHONE_FROM}" \
-            --data-urlencode "Body=${MESSAGE}")
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"message\": \"${MESSAGE}\"}")
 
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "::notice::status=$HTTP_STATUS body=$BODY"
 
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "::error::Twilio SMS failed with status $HTTP_STATUS"
+            echo "::error::Webhook failed with status $HTTP_STATUS"
             exit 1
           fi

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -35,6 +35,9 @@ jobs:
             MESSAGE="permission-slip: Claude Code needs your attention"
           fi
 
+          PAYLOAD=$(jq -n --arg msg "$MESSAGE" --arg secret "$NOTIFY_WEBHOOK_SECRET" \
+            '{message: $msg, secret: $secret}')
+
           curl -s -X POST "$NOTIFY_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{\"message\": \"${MESSAGE}\", \"secret\": \"${NOTIFY_WEBHOOK_SECRET}\"}"
+            -d "$PAYLOAD"

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -19,11 +19,11 @@ jobs:
         env:
           PR_URL: ${{ inputs.pr_url }}
           PR_TITLE: ${{ inputs.pr_title }}
-          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+          NOTIFY_WEBHOOK_SECRET: ${{ secrets.NOTIFY_WEBHOOK_SECRET }}
         run: |
-          if [ -z "$WEBHOOK_URL" ]; then
-            echo "::error::WEBHOOK_URL secret is not set"
+          if [ -z "$NOTIFY_WEBHOOK_URL" ]; then
+            echo "::error::NOTIFY_WEBHOOK_URL secret is not set"
             exit 1
           fi
 
@@ -35,21 +35,6 @@ jobs:
             MESSAGE="permission-slip: Claude Code needs your attention"
           fi
 
-          CURL_ARGS=(-s -w "\nHTTP_STATUS:%{http_code}" -X POST "$WEBHOOK_URL" \
+          curl -s -X POST "$NOTIFY_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{\"message\": \"${MESSAGE}\"}")
-
-          if [ -n "$WEBHOOK_SECRET" ]; then
-            CURL_ARGS+=(-H "Authorization: Bearer ${WEBHOOK_SECRET}")
-          fi
-
-          RESPONSE=$(curl "${CURL_ARGS[@]}")
-
-          HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "::notice::status=$HTTP_STATUS body=$BODY"
-
-          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "::error::Webhook failed with status $HTTP_STATUS"
-            exit 1
-          fi
+            -d "{\"message\": \"${MESSAGE}\", \"secret\": \"${NOTIFY_WEBHOOK_SECRET}\"}"


### PR DESCRIPTION
## Summary

- Replaced the Twilio SMS API call in `trigger-webhook.yml` with a simple HTTP POST to a `WEBHOOK_URL` secret
- Removes dependency on four Twilio-specific secrets (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_FROM`, `TWILIO_PHONE_TO`) in favor of a single `WEBHOOK_URL` secret
- Keeps the same message construction logic (context-aware messages with optional PR title/URL)

## Test plan

### Claude Code
- [x] Verify workflow YAML is valid
- [x] Confirm no other files reference the removed Twilio secrets for this workflow

### OpenClaw
- [ ] Add `WEBHOOK_URL` repository secret pointing to desired webhook endpoint
- [ ] Remove old Twilio secrets if no longer needed elsewhere
- [ ] Trigger workflow manually to verify notifications work end-to-end

https://claude.ai/code/session_01WxgEjQQb9cBfFnSxzaNvkP