### PR TITLE
Disable SMS notifications during beta

### DIFF
--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -53,7 +53,7 @@ const (
 	ErrDowngradeLimitExceeded   ErrorCode = "downgrade_limit_exceeded"
 	ErrBillingNotEnabled        ErrorCode = "billing_not_enabled"
 	ErrSMSRequiresPaidPlan      ErrorCode = "sms_requires_paid_plan"
-	ErrSMSUnavailableBeta       ErrorCode = "sms_unavailable_beta"
+	ErrChannelUnavailableBeta   ErrorCode = "channel_unavailable_beta"
 	// OAuth
 	ErrOAuthProviderNotFound     ErrorCode = "oauth_provider_not_found"
 	ErrOAuthProviderUnconfigured ErrorCode = "oauth_provider_unconfigured"

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -53,6 +53,7 @@ const (
 	ErrDowngradeLimitExceeded   ErrorCode = "downgrade_limit_exceeded"
 	ErrBillingNotEnabled        ErrorCode = "billing_not_enabled"
 	ErrSMSRequiresPaidPlan      ErrorCode = "sms_requires_paid_plan"
+	ErrSMSUnavailableBeta       ErrorCode = "sms_unavailable_beta"
 	// OAuth
 	ErrOAuthProviderNotFound     ErrorCode = "oauth_provider_not_found"
 	ErrOAuthProviderUnconfigured ErrorCode = "oauth_provider_unconfigured"

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -2,9 +2,14 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
 )
@@ -113,7 +118,9 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 		// Gate beta-disabled channels: reject enabling any channel disabled during beta.
 		for _, p := range req.Preferences {
 			if p.Enabled && betaDisabledChannels[p.Channel] {
-				RespondError(w, r, http.StatusForbidden, Forbidden(ErrSMSUnavailableBeta, "SMS notifications are not yet available. They will be enabled after the beta period."))
+				label := cases.Title(language.English).String(strings.NewReplacer("-", " ").Replace(p.Channel))
+				msg := fmt.Sprintf("%s notifications are not yet available. They will be enabled after the beta period.", label)
+				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelUnavailableBeta, msg))
 				return
 			}
 		}

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -57,6 +57,12 @@ var paidOnlyChannels = map[string]bool{
 	"sms": true,
 }
 
+// betaDisabledChannels lists channels that are disabled during the beta period.
+// These channels are always unavailable regardless of plan.
+var betaDisabledChannels = map[string]bool{
+	"sms": true,
+}
+
 func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		profile := Profile(r.Context())
@@ -104,25 +110,16 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			seen[p.Channel] = true
 		}
 
-		// Gate SMS behind paid tier: reject enabling SMS on the free plan.
-		// Look up the plan once — reused for both the gate check and the response.
-		planID := userPlanID(r.Context(), deps.DB, profile.ID)
-		if seen["sms"] {
-			for _, p := range req.Preferences {
-				if p.Channel == "sms" && p.Enabled {
-					if !isPaidPlan(planID) {
-						resp := Forbidden(ErrSMSRequiresPaidPlan, "SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS.")
-						resp.Error.Details = map[string]any{
-							"current_plan":  planID,
-							"required_plan": db.PlanPayAsYouGo,
-						}
-						RespondError(w, r, http.StatusForbidden, resp)
-						return
-					}
-					break
-				}
+		// Gate beta-disabled channels: reject enabling any channel disabled during beta.
+		for _, p := range req.Preferences {
+			if p.Enabled && betaDisabledChannels[p.Channel] {
+				RespondError(w, r, http.StatusForbidden, Forbidden(ErrSMSUnavailableBeta, "SMS notifications are not yet available. They will be enabled after the beta period."))
+				return
 			}
 		}
+
+		// Look up plan for the response (SMS availability in response payload).
+		planID := userPlanID(r.Context(), deps.DB, profile.ID)
 
 		for _, p := range req.Preferences {
 			if err := db.UpsertNotificationPreference(r.Context(), deps.DB, profile.ID, p.Channel, p.Enabled); err != nil {
@@ -180,10 +177,16 @@ func buildPreferencesResponse(prefs []db.NotificationPreference, planID string) 
 	for _, ch := range allChannels {
 		enabled, exists := channelMap[ch]
 		if !exists {
-			enabled = true // missing rows default to enabled
+			if betaDisabledChannels[ch] {
+				enabled = false // beta-disabled channels default to off
+			} else {
+				enabled = true // missing rows default to enabled
+			}
 		}
 		available := true
-		if paidOnlyChannels[ch] {
+		if betaDisabledChannels[ch] {
+			available = false // always unavailable during beta
+		} else if paidOnlyChannels[ch] {
 			available = paid
 		}
 		result = append(result, notificationPreferenceResponse{

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -33,22 +33,12 @@ func TestUpdateNotificationPreferences_EnableSMS_FreeTier_Rejected(t *testing.T)
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal error response: %v", err)
 	}
-	if resp.Error.Code != ErrSMSRequiresPaidPlan {
-		t.Errorf("expected error code %q, got %q", ErrSMSRequiresPaidPlan, resp.Error.Code)
-	}
-	// Verify error includes plan details for the frontend.
-	if resp.Error.Details == nil {
-		t.Fatal("expected error details with plan info")
-	}
-	if resp.Error.Details["current_plan"] != db.PlanFree {
-		t.Errorf("expected current_plan=%q, got %v", db.PlanFree, resp.Error.Details["current_plan"])
-	}
-	if resp.Error.Details["required_plan"] != db.PlanPayAsYouGo {
-		t.Errorf("expected required_plan=%q, got %v", db.PlanPayAsYouGo, resp.Error.Details["required_plan"])
+	if resp.Error.Code != ErrSMSUnavailableBeta {
+		t.Errorf("expected error code %q, got %q", ErrSMSUnavailableBeta, resp.Error.Code)
 	}
 }
 
-func TestUpdateNotificationPreferences_EnableSMS_PaidTier_Allowed(t *testing.T) {
+func TestUpdateNotificationPreferences_EnableSMS_PaidTier_RejectedDuringBeta(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -63,8 +53,9 @@ func TestUpdateNotificationPreferences_EnableSMS_PaidTier_Allowed(t *testing.T) 
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	// SMS is disabled during beta regardless of plan.
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -151,7 +142,7 @@ func TestUpdateNotificationPreferences_MixedChannels_FreeTier_SMSBlocked(t *test
 	}
 }
 
-func TestGetNotificationPreferences_SMSAvailable_PaidTier(t *testing.T) {
+func TestGetNotificationPreferences_SMSUnavailable_PaidTier_DuringBeta(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -174,9 +165,19 @@ func TestGetNotificationPreferences_SMSAvailable_PaidTier(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
+	// SMS should be unavailable during beta regardless of plan.
 	for _, p := range resp.Preferences {
-		if !p.Available {
-			t.Errorf("expected all channels available on paid plan, got %q unavailable", p.Channel)
+		if p.Channel == "sms" {
+			if p.Available {
+				t.Error("expected SMS unavailable during beta even on paid plan")
+			}
+			if p.Enabled {
+				t.Error("expected SMS to default to disabled during beta")
+			}
+		} else {
+			if !p.Available {
+				t.Errorf("expected %q available on paid plan", p.Channel)
+			}
 		}
 	}
 }

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -33,8 +33,8 @@ func TestUpdateNotificationPreferences_EnableSMS_FreeTier_Rejected(t *testing.T)
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal error response: %v", err)
 	}
-	if resp.Error.Code != ErrSMSUnavailableBeta {
-		t.Errorf("expected error code %q, got %q", ErrSMSUnavailableBeta, resp.Error.Code)
+	if resp.Error.Code != ErrChannelUnavailableBeta {
+		t.Errorf("expected error code %q, got %q", ErrChannelUnavailableBeta, resp.Error.Code)
 	}
 }
 

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -343,14 +343,17 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 			t.Errorf("expected preference for channel %q", ch)
 			continue
 		}
-		if !p.Enabled {
+		if ch == "sms" {
+			if p.Enabled {
+				t.Error("expected SMS to default to disabled during beta")
+			}
+			if p.Available {
+				t.Error("expected SMS to be unavailable during beta")
+			}
+		} else if !p.Enabled {
 			t.Errorf("expected channel %q to default to enabled", ch)
 		}
-		if ch == "sms" {
-			if p.Available {
-				t.Error("expected SMS to be unavailable on free plan")
-			}
-		} else {
+		if ch != "sms" {
 			if !p.Available {
 				t.Errorf("expected channel %q to be available", ch)
 			}
@@ -389,9 +392,13 @@ func TestUpdateNotificationPreferences_Toggle(t *testing.T) {
 			if p.Enabled {
 				t.Error("expected email to be disabled")
 			}
-		case "web-push", "sms":
+		case "web-push":
 			if !p.Enabled {
 				t.Errorf("expected %q to remain enabled", p.Channel)
+			}
+		case "sms":
+			if p.Enabled {
+				t.Error("expected SMS to default to disabled during beta")
 			}
 		}
 	}

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -1,5 +1,4 @@
-import { Link } from "react-router-dom";
-import { Bell, Loader2, AlertTriangle, ArrowUpRight, Lock } from "lucide-react";
+import { Bell, Loader2, AlertTriangle, Lock } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useProfile } from "@/hooks/useProfile";
@@ -29,7 +28,7 @@ const CHANNEL_LABELS: Record<string, { name: string; description: string }> = {
   },
   sms: {
     name: "SMS",
-    description: "Text message notifications for urgent approval requests.",
+    description: "Text message notifications for urgent approval requests. Available after the beta.",
   },
   "mobile-push": {
     name: "Mobile Push",
@@ -131,13 +130,9 @@ export function NotificationSection() {
                       </p>
                     </div>
                     {planGated ? (
-                      <Link
-                        to="/billing"
-                        className="inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-xs font-medium text-amber-700 no-underline transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400 dark:hover:bg-amber-950/50"
-                      >
-                        Available on paid plan
-                        <ArrowUpRight className="size-3" />
-                      </Link>
+                      <span className="inline-flex items-center whitespace-nowrap rounded-md border border-muted bg-muted/50 px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
+                        Coming soon
+                      </span>
                     ) : (
                       <Switch
                         checked={pref.enabled}

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -17,7 +17,7 @@ vi.mock("../../../api/client");
 const allEnabled = [
   { channel: "email", enabled: true, available: true },
   { channel: "web-push", enabled: true, available: true },
-  { channel: "sms", enabled: true, available: true },
+  { channel: "sms", enabled: false, available: false },
   { channel: "mobile-push", enabled: true, available: true },
 ];
 
@@ -118,7 +118,7 @@ describe("NotificationSection", () => {
     const prefs = [
       { channel: "email", enabled: true, available: true },
       { channel: "web-push", enabled: false, available: true },
-      { channel: "sms", enabled: true, available: true },
+      { channel: "sms", enabled: false, available: false },
       { channel: "mobile-push", enabled: true, available: true },
     ];
     mockApiFetch(profileWithContact, prefs);
@@ -133,8 +133,9 @@ describe("NotificationSection", () => {
       const unchecked = switches.filter(
         (s) => s.getAttribute("data-state") === "unchecked",
       );
-      // 3 channels enabled (email, sms, mobile-push) + 2 unchecked (web-push, product updates)
-      expect(checked).toHaveLength(3);
+      // 2 channels enabled (email, mobile-push) + 2 unchecked (web-push, product updates)
+      // SMS has no switch (beta-disabled)
+      expect(checked).toHaveLength(2);
       expect(unchecked).toHaveLength(2);
     });
   });
@@ -153,18 +154,18 @@ describe("NotificationSection", () => {
     });
   });
 
-  it("shows warning when phone is missing and SMS notifications enabled", async () => {
+  it("does not show phone warning when SMS is beta-disabled", async () => {
     mockApiFetch(profileNoContact, allEnabled);
 
     render(<NotificationSection />, { wrapper });
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Add a phone number above to receive SMS notifications.",
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText("SMS")).toBeInTheDocument();
     });
+    // SMS is gated during beta, so no phone warning should appear.
+    expect(
+      screen.queryByText(/Add a phone number/),
+    ).not.toBeInTheDocument();
   });
 
   it("does not show warnings when contact info is present", async () => {
@@ -187,7 +188,7 @@ describe("NotificationSection", () => {
     const prefs = [
       { channel: "email", enabled: false, available: true },
       { channel: "web-push", enabled: true, available: true },
-      { channel: "sms", enabled: false, available: true },
+      { channel: "sms", enabled: false, available: false },
       { channel: "mobile-push", enabled: true, available: true },
     ];
     mockApiFetch(profileNoContact, prefs);
@@ -326,20 +327,16 @@ describe("NotificationSection", () => {
     });
   });
 
-  it("shows SMS as gated with upgrade link on free plan", async () => {
+  it("shows SMS as coming soon during beta", async () => {
     mockApiFetch(profileWithContact, smsGated);
 
     render(<NotificationSection />, { wrapper });
 
     await waitFor(() => {
       expect(
-        screen.getByText("Available on paid plan"),
+        screen.getByText("Coming soon"),
       ).toBeInTheDocument();
     });
-    const upgradeLink = screen.getByRole("link", {
-      name: /Available on paid plan/,
-    });
-    expect(upgradeLink).toHaveAttribute("href", "/billing");
   });
 
   it("does not show toggle button for plan-gated SMS", async () => {
@@ -352,7 +349,7 @@ describe("NotificationSection", () => {
     });
 
     // Should have 3 channel switches (email, web-push, mobile-push) + 1 product updates = 4
-    // SMS should not have a switch (plan-gated)
+    // SMS should not have a switch (beta-disabled)
     const switches = screen.getAllByRole("switch");
     expect(switches).toHaveLength(4);
   });


### PR DESCRIPTION
## Summary
- SMS notifications are greyed out for all users (regardless of plan) with a "Coming soon" badge
- SMS defaults to disabled instead of enabled when no preference row exists
- Description updated to note SMS will be available after the beta
- Backend rejects enabling SMS with `sms_unavailable_beta` error code for all users

## Test plan

### Claude Code
- [x] Backend tests updated and passing (notification preferences + profiles)
- [x] Frontend tests updated and passing (NotificationSection)
- [x] TypeScript compilation clean (`tsc --noEmit`)

### OpenClaw
- [ ] Verify the SMS row appears greyed out in the settings page
- [ ] Confirm "Coming soon" badge renders correctly in light and dark mode
- [ ] Verify the "Available after the beta" description text reads well

https://claude.ai/code/session_01FYSqzbNXynaTVvDEVy8SrN