### PR TITLE
Replace pending approvals card with banner

### DIFF
--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { useApprovalEvents } from "@/hooks/useApprovalEvents";
 import { useAgents } from "@/hooks/useAgents";
-import { useApprovals } from "@/hooks/useApprovals";
+
 import { useStandingApprovals } from "@/hooks/useStandingApprovals";
 import { useAuditEvents } from "@/hooks/useAuditEvents";
 import { NotificationBanner } from "./NotificationBanner";
-import { PendingApprovalsCard } from "./PendingApprovalsCard";
+import { PendingApprovalsBanner } from "./PendingApprovalsBanner";
 import { RecentActivityCard } from "./RecentActivityCard";
 import { RegisteredAgentsCard } from "./RegisteredAgentsCard";
 import { StandingApprovalsCard } from "./StandingApprovalsCard";
@@ -17,7 +17,7 @@ import { useUnconfiguredAgent } from "@/hooks/useUnconfiguredAgent";
 export function Dashboard() {
   useApprovalEvents();
   const { agents, isLoading, error } = useAgents();
-  const { approvals, isLoading: approvalsLoading } = useApprovals();
+
   const { standingApprovals, isLoading: standingLoading } =
     useStandingApprovals();
   const { events, isLoading: eventsLoading } = useAuditEvents();
@@ -28,13 +28,10 @@ export function Dashboard() {
   const showOnboarding = !isLoading && !error && agents.length === 0;
   const hasActiveAgents = agents.some((a) => a.status === "registered");
   const hasActivity = events.length > 0;
-  const hasPendingApprovals = approvals.length > 0;
 
   // Progressive disclosure: show cards only when relevant to the user's journey.
   // While a hook is still fetching we don't yet know whether data exists,
   // so default to showing the card to avoid jarring pop-in for returning users.
-  const showPendingApprovals =
-    approvalsLoading || hasActiveAgents || hasPendingApprovals;
   const showActivity = eventsLoading || hasActivity;
   const showStandingApprovals =
     standingLoading || standingApprovals.length > 0 || hasActivity;
@@ -69,8 +66,8 @@ export function Dashboard() {
         </>
       ) : (
         <>
+          <PendingApprovalsBanner />
           <RegisteredAgentsCard />
-          {showPendingApprovals && <PendingApprovalsCard />}
           {showActivity && <RecentActivityCard />}
           {showStandingApprovals && <StandingApprovalsCard />}
         </>

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -1,0 +1,117 @@
+import { useState, useMemo } from "react";
+import { ShieldAlert } from "lucide-react";
+import { useApprovals, type ApprovalSummary } from "@/hooks/useApprovals";
+import { useAgents, type Agent } from "@/hooks/useAgents";
+import { getAgentDisplayName } from "@/lib/agents";
+import { buildSummary } from "@/components/ActionPreviewSummary";
+import { CountdownBadge, RiskBadge } from "./approval-components";
+import { ReviewApprovalDialog } from "./ReviewApprovalDialog";
+
+function resolveAgentName(
+  agentId: number,
+  agentMap: Map<number, Agent>,
+): string {
+  const agent = agentMap.get(agentId);
+  if (agent) return getAgentDisplayName(agent);
+  return String(agentId);
+}
+
+function ApprovalBannerItem({
+  approval,
+  agentDisplayName,
+  onReview,
+}: {
+  approval: ApprovalSummary;
+  agentDisplayName: string;
+  onReview: () => void;
+}) {
+  const summary = buildSummary(
+    approval.action.type,
+    approval.action.parameters as Record<string, unknown>,
+    null,
+    null,
+  );
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onReview}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onReview();
+      }}
+      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-blue-300 bg-blue-50 px-4 py-3 text-left text-sm text-blue-900 shadow-sm transition-colors hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-950/70"
+      aria-label={`Review ${approval.action.type} from ${agentDisplayName}`}
+    >
+      <ShieldAlert className="size-5 shrink-0" />
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="font-medium">
+          <span className="font-semibold">{approval.action.type}</span>
+          <span className="text-blue-700 dark:text-blue-300">
+            {" "}from {agentDisplayName}
+          </span>
+        </span>
+        <span className="hidden text-xs opacity-75 sm:inline" title={summary}>
+          {summary}
+        </span>
+        <RiskBadge level={approval.context.risk_level} />
+        <CountdownBadge expiresAt={approval.expires_at} />
+      </div>
+      <span className="shrink-0 text-xs font-medium underline underline-offset-2 opacity-75">
+        Review
+      </span>
+    </div>
+  );
+}
+
+export function PendingApprovalsBanner() {
+  const { approvals, isLoading } = useApprovals();
+  const { agents } = useAgents();
+  const [reviewingApproval, setReviewingApproval] =
+    useState<ApprovalSummary | null>(null);
+
+  const agentMap = useMemo(() => {
+    const map = new Map<number, Agent>();
+    for (const agent of agents) {
+      map.set(agent.agent_id, agent);
+    }
+    return map;
+  }, [agents]);
+
+  if (isLoading || approvals.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div
+        className="space-y-2"
+        role="status"
+        aria-label="Pending approval requests"
+      >
+        {approvals.map((approval) => (
+          <ApprovalBannerItem
+            key={approval.approval_id}
+            approval={approval}
+            agentDisplayName={resolveAgentName(approval.agent_id, agentMap)}
+            onReview={() => setReviewingApproval(approval)}
+          />
+        ))}
+      </div>
+
+      {reviewingApproval && (
+        <ReviewApprovalDialog
+          approval={reviewingApproval}
+          agentDisplayName={resolveAgentName(
+            reviewingApproval.agent_id,
+            agentMap,
+          )}
+          open
+          onOpenChange={(open) => {
+            if (!open) setReviewingApproval(null);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -133,7 +133,6 @@ describe("Dashboard", () => {
     await waitFor(() => {
       expect(screen.getByText("Registered Agents")).toBeInTheDocument();
     });
-    expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
     expect(screen.getByText("Recent Activity")).toBeInTheDocument();
     expect(screen.getByText("Standing Approvals")).toBeInTheDocument();
 

--- a/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import {
+  mockGet,
+  mockPost,
+  resetClientMocks,
+} from "../../../api/__mocks__/client";
+import { PendingApprovalsBanner } from "../PendingApprovalsBanner";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+const NOW = new Date("2026-02-21T10:00:00Z");
+
+const mockApproval = {
+  approval_id: "appr_abc123",
+  agent_id: 1,
+  action: {
+    type: "email.send",
+    version: "1",
+    parameters: {
+      from: "alice@example.com",
+      to: ["bob@example.com"],
+      subject: "Hello World",
+      body: "Test email body",
+    },
+  },
+  context: {
+    description: "Send welcome email to new user",
+    risk_level: "low" as const,
+  },
+  status: "pending" as const,
+  expires_at: new Date(NOW.getTime() + 3 * 60 * 1000).toISOString(),
+  created_at: new Date(NOW.getTime() - 2 * 60 * 1000).toISOString(),
+};
+
+const mockHighRiskApproval = {
+  approval_id: "appr_def456",
+  agent_id: 2,
+  action: {
+    type: "data.delete",
+    version: "1",
+    parameters: {
+      table: "users",
+      filter: "inactive",
+    },
+  },
+  context: {
+    description: "Delete inactive user accounts",
+    risk_level: "high" as const,
+  },
+  status: "pending" as const,
+  expires_at: new Date(NOW.getTime() + 30 * 1000).toISOString(),
+  created_at: new Date(NOW.getTime() - 4.5 * 60 * 1000).toISOString(),
+};
+
+const mockApprovalsResponse = {
+  data: [mockApproval, mockHighRiskApproval],
+};
+
+const emptyResponse = { data: [] };
+
+function mockApprovalsFetch(response = mockApprovalsResponse) {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockResolvedValue({ data: response });
+}
+
+describe("PendingApprovalsBanner", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(NOW);
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when there are no pending approvals", async () => {
+    mockApprovalsFetch(emptyResponse);
+
+    const { container } = render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  it("renders nothing while loading", () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<PendingApprovalsBanner />, { wrapper });
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders banner items when approvals exist", async () => {
+    mockApprovalsFetch();
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email.send")).toBeInTheDocument();
+    });
+    expect(screen.getByText("data.delete")).toBeInTheDocument();
+  });
+
+  it("shows agent names in banners", async () => {
+    mockApprovalsFetch();
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/from Agent 1/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/from Agent 2/)).toBeInTheDocument();
+  });
+
+  it("renders risk badges", async () => {
+    mockApprovalsFetch();
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("low")).toBeInTheDocument();
+    });
+    expect(screen.getByText("high")).toBeInTheDocument();
+  });
+
+  it("renders countdown timers", async () => {
+    mockApprovalsFetch();
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      const timerEls = screen
+        .getAllByText(/^\d+:\d{2}$/)
+        .map((el) => el.textContent ?? "");
+      expect(
+        timerEls.some((t) => t === "3:00" || t.startsWith("2:5")),
+      ).toBe(true);
+      expect(
+        timerEls.some(
+          (t) => t === "0:30" || (t.startsWith("0:2") && t !== "0:2"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("opens review dialog when banner is clicked", async () => {
+    mockApprovalsFetch();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email.send")).toBeInTheDocument();
+    });
+
+    const bannerButtons = screen.getAllByRole("button", { name: /Review/ });
+    await user.click(bannerButtons[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Review Approval Request"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("approves via review dialog", async () => {
+    mockApprovalsFetch();
+    mockPost.mockResolvedValue({
+      data: {
+        approval_id: "appr_abc123",
+        status: "approved",
+        approved_at: "2026-02-21T10:00:05Z",
+        execution_status: "success",
+        execution_result: { data: "ok" },
+      },
+    });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: /Review/ })).toHaveLength(2);
+    });
+
+    const bannerButtons = screen.getAllByRole("button", { name: /Review/ });
+    await user.click(bannerButtons[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Approve" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+    });
+  });
+
+  it("has accessible labels on banner items", async () => {
+    mockApprovalsFetch();
+
+    render(<PendingApprovalsBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Review email.send from Agent 1"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByLabelText("Review data.delete from Agent 2"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Pending approvals no longer show when there are none — no more wasted empty-state card
- When approvals exist, they render as prominent blue banners above Registered Agents for immediate visibility
- Each banner shows action type, agent name, risk badge, and countdown timer; clicking opens the review dialog

## Test plan

### Claude Code
- [x] Added `PendingApprovalsBanner.test.tsx` covering: hidden when empty, hidden while loading, renders banners with agent names/risk/countdown, opens review dialog, approve flow, accessible labels
- [x] Updated `Dashboard.test.tsx` to remove expectation for "Pending Approvals" card title
- [x] All 733 frontend tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### OpenClaw
- [ ] Visual review: confirm banner styling looks right in light and dark mode
- [ ] Verify banner appears above registered agents with real pending approvals
- [ ] Confirm dashboard looks clean with zero pending approvals (no empty section)

https://claude.ai/code/session_01X4w81eYGcrqqrzHYw9JtQ3