### PR TITLE
Disable web-push notifications during beta

### DIFF
--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -65,7 +65,8 @@ var paidOnlyChannels = map[string]bool{
 // betaDisabledChannels lists channels that are disabled during the beta period.
 // These channels are always unavailable regardless of plan.
 var betaDisabledChannels = map[string]bool{
-	"sms": true,
+	"sms":      true,
+	"web-push": true,
 }
 
 func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useAgents } from "@/hooks/useAgents";
 import { useApprovals } from "@/hooks/useApprovals";
 import { useStandingApprovals } from "@/hooks/useStandingApprovals";
 import { useAuditEvents } from "@/hooks/useAuditEvents";
-import { NotificationBanner } from "./NotificationBanner";
 import { PendingApprovalsCard } from "./PendingApprovalsCard";
 import { RecentActivityCard } from "./RecentActivityCard";
 import { RegisteredAgentsCard } from "./RegisteredAgentsCard";
@@ -39,16 +38,12 @@ export function Dashboard() {
   const showStandingApprovals =
     standingLoading || standingApprovals.length > 0 || hasActivity;
 
-  // Only prompt for notifications after the user has an active, configured agent
-  const showNotificationBanner = hasActiveAgents && !isUnconfigured;
-
   // Dashboard has three states based on the user's onboarding progress:
   // 1. No agents registered → AgentOnboardingHero (register first agent)
   // 2. Single registered agent, no connectors → AgentConfigHero (configure agent)
   // 3. Configured agent(s) → Full dashboard (cards for agents, approvals, activity)
   return (
     <div className="space-y-6">
-      {showNotificationBanner && <NotificationBanner />}
       {showOnboarding ? (
         <>
           <AgentOnboardingHero


### PR DESCRIPTION
## Summary
- Added `web-push` to `betaDisabledChannels` in the backend, so it defaults to disabled, shows "Coming soon" in settings, and blocks users from enabling it via the API
- Removed the `NotificationBanner` from the dashboard that prompted users to enable browser push notifications

## Context
Web push notifications don't work on iOS/iPhone unless the site is installed as a PWA (Progressive Web App) via "Add to Home Screen" — and Permission Slip doesn't have PWA support. Rather than expose a broken experience on mobile, we're hiding web push entirely during beta. Users on iPhone should use the native mobile app for push notifications instead.

## Test plan
### Claude Code
- [x] Frontend TypeScript compiles cleanly
- [x] All 724 frontend tests pass
- [x] Verified no test references to `web-push` or `betaDisabledChannels` that would break

### OpenClaw
- [ ] Verify web-push no longer appears as a toggle in Settings > Notifications
- [ ] Verify the "Enable push notifications" banner no longer appears on the dashboard
- [ ] Verify existing web-push subscriptions don't send notifications (existing users with web-push enabled in DB)

https://claude.ai/code/session_01VkEoPQtfzxUbnVw1cb6ULr