### PR TITLE
Fix CI: update profiles_test.go for web-push beta disable

### DIFF
--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -335,7 +335,7 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	}
 
 	// All channels default to enabled when no preferences are set.
-	// SMS should not be available on the free plan.
+	// SMS and web-push are unavailable during beta regardless of plan.
 	requiredChannels := []string{"email", "web-push", "sms", "mobile-push"}
 	for _, ch := range requiredChannels {
 		p, ok := prefsByChannel[ch]
@@ -343,20 +343,17 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 			t.Errorf("expected preference for channel %q", ch)
 			continue
 		}
-		if ch == "sms" {
+		if ch == "sms" || ch == "web-push" {
 			if p.Enabled {
-				t.Error("expected SMS to default to disabled during beta")
+				t.Errorf("expected %q to default to disabled during beta", ch)
 			}
 			if p.Available {
-				t.Error("expected SMS to be unavailable during beta")
+				t.Errorf("expected %q to be unavailable during beta", ch)
 			}
 		} else if !p.Enabled {
 			t.Errorf("expected channel %q to default to enabled", ch)
-		}
-		if ch != "sms" {
-			if !p.Available {
-				t.Errorf("expected channel %q to be available", ch)
-			}
+		} else if !p.Available {
+			t.Errorf("expected channel %q to be available", ch)
 		}
 	}
 }

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -393,8 +393,8 @@ func TestUpdateNotificationPreferences_Toggle(t *testing.T) {
 				t.Error("expected email to be disabled")
 			}
 		case "web-push":
-			if !p.Enabled {
-				t.Errorf("expected %q to remain enabled", p.Channel)
+			if p.Enabled {
+				t.Errorf("expected %q to default to disabled during beta", p.Channel)
 			}
 		case "sms":
 			if p.Enabled {

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -352,8 +352,11 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 			}
 		} else if !p.Enabled {
 			t.Errorf("expected channel %q to default to enabled", ch)
-		} else if !p.Available {
-			t.Errorf("expected channel %q to be available", ch)
+		}
+		if ch != "sms" && ch != "web-push" {
+			if !p.Available {
+				t.Errorf("expected channel %q to be available", ch)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- PR #517 added `web-push` to `betaDisabledChannels` but PR #518's fix only updated `notification_preferences_test.go`
- `TestGetNotificationPreferences_Defaults` in `profiles_test.go` still asserted `web-push` was available and enabled, causing 5 consecutive CI failures on main
- Updates the assertion to treat `web-push` the same as `sms` (both beta-disabled)

## Test plan

### Claude Code
- [x] CI backend tests pass (the specific fix is for `TestGetNotificationPreferences_Defaults`)
- [x] No other test regressions

### OpenClaw
- [ ] Verify CI is green on main after merge

https://claude.ai/code/session_016i35W1qrcEbaW9CNeNB2hU