### PR TITLE
Add --max-turns flag to /watch command

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -2,7 +2,7 @@
 name: watch
 description: Poll a GitHub PR for new comments and PR reviews and act on them autonomously. Use when the user wants to monitor a PR for feedback and have Claude implement requested changes automatically.
 disable-model-invocation: true
-argument-hint: "<PR_URL> [--automerge]"
+argument-hint: "<PR_URL> [--automerge] [--max-turns <N>]"
 ---
 
 # Watch PR for Comments and Reviews
@@ -40,7 +40,7 @@ Agent (this skill)     — Only invoked when reasoning is needed
 
 Parse the arguments from: `$ARGUMENTS`
 
-Extract the PR URL and any flags. The format is: `<PR_URL> [--automerge]`
+Extract the PR URL and any flags. The format is: `<PR_URL> [--automerge] [--max-turns <N>]`
 
 Parse the PR number from the URL (e.g., `https://github.com/supersuit-tech/permission-slip/pull/123` → `123`).
 
@@ -48,6 +48,7 @@ Set these variables for the session:
 - `PR_URL` — the PR URL extracted from the arguments
 - `PR_NUMBER` — the extracted PR number
 - `AUTO_MERGE` — `true` if `--automerge` was passed, `false` otherwise
+- `MAX_TURNS` — the value of `--max-turns` if passed, `0` otherwise (0 = unlimited)
 - `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
 - `SKILL_DIR` — the directory containing this skill file (`.claude/skills/watch`)
 
@@ -59,11 +60,11 @@ The agent orchestrates the session by running the shell scripts and only doing A
 
 ```bash
 # First run (no --work-dir):
-bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") 2>&1
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") $([[ "$MAX_TURNS" -gt 0 ]] && echo "--max-turns $MAX_TURNS") 2>&1
 # Capture WORK_DIR from the session context JSON in the output.
 
 # Subsequent runs (reuse WORK_DIR to preserve state):
-bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") --work-dir "$WORK_DIR" 2>&1
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") $([[ "$MAX_TURNS" -gt 0 ]] && echo "--max-turns $MAX_TURNS") --work-dir "$WORK_DIR" 2>&1
 ```
 
 The script handles:
@@ -73,6 +74,7 @@ The script handles:
 - Merging from main and detecting conflicts
 - Parsing the PR body for unchecked `### Claude Code` checklist items
 - Idle counter tracking (6 consecutive empty cycles = timeout)
+- Turn limit tracking (exits when `--max-turns` agent invocations reached)
 - Generating and posting the wrap-up comment on idle timeout
 
 ### Step 2: Check script output
@@ -107,7 +109,7 @@ The script communicates via stdout signals and exit codes:
 }
 ```
 
-**Exit code 0 + `IDLE_TIMEOUT`**: The session ended due to inactivity. The script already posted the wrap-up comment. Proceed to Step 4 (post-session).
+**Exit code 0 + `IDLE_TIMEOUT`**: The session ended due to inactivity or the `--max-turns` limit being reached. The script already posted the wrap-up comment. Proceed to Step 4 (post-session).
 
 **Exit code 100**: Pre-poll merge conflict. The script detected conflicts before the polling loop started. Read `WORK_ITEMS_FILE` for conflict details and resolve them (see Step 3), then re-run the polling script.
 

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -3,12 +3,15 @@
 # Handles all mechanical bookkeeping (fetching, deduplication, idle timeout)
 # and only invokes the Claude agent when there's actionable work.
 #
-# Usage: bash watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>]
+# Usage: bash watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>] [--max-turns <N>]
 #
 # Options:
 #   --automerge       Enable auto-merge after checks pass
 #   --work-dir <path> Reuse an existing work directory (preserves state
 #                     across invocations: last-seen IDs, action log, cache)
+#   --max-turns <N>   Maximum number of agent turns before ending the session.
+#                     Each turn = one AGENT_NEEDED signal (one round of AI work).
+#                     When reached, the session wraps up as if idle-timeout.
 #
 # Environment:
 #   GH_HOST, GH_REPO — set by caller (defaults provided below)
@@ -23,15 +26,17 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Arguments
 # ---------------------------------------------------------------------------
-PR_URL="${1:?Usage: watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>]}"
+PR_URL="${1:?Usage: watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>] [--max-turns <N>]}"
 AUTO_MERGE=false
 EXISTING_WORK_DIR=""
+MAX_TURNS=0  # 0 = unlimited
 
 shift
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --automerge) AUTO_MERGE=true; shift ;;
     --work-dir) EXISTING_WORK_DIR="$2"; shift 2 ;;
+    --max-turns) MAX_TURNS="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
@@ -66,12 +71,14 @@ LAST_ISSUE_COMMENT_ID_FILE="$WORK_DIR/last-issue-comment-id"
 WORK_ITEMS_FILE="$WORK_DIR/work-items.json"
 ACTION_LOG_FILE="$WORK_DIR/action-log.json"
 CHECKLIST_CACHE_FILE="$WORK_DIR/checklist-cache.txt"
+TURNS_FILE="$WORK_DIR/turns-count"
 
 # Only initialize state files if they don't already exist (fresh session)
 [[ -f "$LAST_REVIEW_ID_FILE" ]] || echo "0" > "$LAST_REVIEW_ID_FILE"
 [[ -f "$LAST_REVIEW_COMMENT_ID_FILE" ]] || echo "0" > "$LAST_REVIEW_COMMENT_ID_FILE"
 [[ -f "$LAST_ISSUE_COMMENT_ID_FILE" ]] || echo "0" > "$LAST_ISSUE_COMMENT_ID_FILE"
 [[ -f "$ACTION_LOG_FILE" ]] || echo "[]" > "$ACTION_LOG_FILE"
+[[ -f "$TURNS_FILE" ]] || echo "0" > "$TURNS_FILE"
 
 # Bot username(s) to filter out
 BOT_USERS=("claude-code[bot]" "github-actions[bot]" "claude[bot]")
@@ -495,12 +502,38 @@ EOF
 # ---------------------------------------------------------------------------
 # MAIN LOOP
 # ---------------------------------------------------------------------------
+CURRENT_TURNS=$(cat "$TURNS_FILE")
+
 echo "=== Watch session started ==="
 echo "PR: ${PR_URL} (#${PR_NUMBER})"
 echo "Branch: ${BRANCH}"
 echo "Auto-merge: ${AUTO_MERGE}"
+echo "Max turns: ${MAX_TURNS} (0=unlimited)"
+echo "Turns used: ${CURRENT_TURNS}"
 echo "Work dir: ${WORK_DIR}"
 echo ""
+
+# --- Check turn limit before doing anything ---
+if [[ "$MAX_TURNS" -gt 0 && "$CURRENT_TURNS" -ge "$MAX_TURNS" ]]; then
+  echo "=== Turn limit reached (${CURRENT_TURNS}/${MAX_TURNS}) ==="
+
+  # Print session context for the calling agent
+  print_session_context
+
+  # Generate and post wrap-up
+  echo "[wrap-up] Generating session summary..."
+  wrapup=$(generate_wrapup "$CURRENT_TURNS")
+  echo "[wrap-up] Posting to PR..."
+  post_wrapup_comment "$wrapup"
+
+  echo "IDLE_TIMEOUT"
+  echo "REASON=turn limit reached (${CURRENT_TURNS}/${MAX_TURNS})"
+  echo "WRAPUP_POSTED=true"
+  echo "AUTO_MERGE=${AUTO_MERGE}"
+  echo "TOTAL_CYCLES=${CURRENT_TURNS}"
+
+  exit 0
+fi
 
 # Print session context for the calling agent
 print_session_context
@@ -513,6 +546,8 @@ if [[ "$pre_merge" == "conflict" ]]; then
   echo "[pre-poll] CONFLICTS detected in: ${conflict_files}"
   # Build work items with just the conflict
   build_work_items "[]" "conflict" "$conflict_files" "[]"
+  # Increment turns counter
+  echo $((CURRENT_TURNS + 1)) > "$TURNS_FILE"
   echo "AGENT_NEEDED"
   echo "REASON=pre-poll merge conflict"
   echo "WORK_ITEMS_FILE=${WORK_ITEMS_FILE}"
@@ -571,6 +606,10 @@ while true; do
     IDLE_COUNTER=0
 
     build_work_items "$new_comments" "$merge_status" "$conflict_files" "$checklist_items"
+
+    # Increment turns counter
+    CURRENT_TURNS=$(cat "$TURNS_FILE")
+    echo $((CURRENT_TURNS + 1)) > "$TURNS_FILE"
 
     echo "AGENT_NEEDED"
     echo "REASON=cycle ${CYCLE}: ${comment_count} comments, merge=${merge_status}, ${checklist_count} checklist items"


### PR DESCRIPTION
## Summary
- Adds a `--max-turns <N>` argument to the `/watch` command that limits how many agent invocation turns a session will perform before wrapping up
- Turn count persists across script re-invocations via a state file in the work directory
- When the limit is reached, the session generates a wrap-up summary and exits gracefully (same path as idle timeout)

## Test plan
### Claude Code
- [ ] Verify `bash watch-poll.sh <url> --max-turns 2` correctly parses and stores the argument
- [ ] Verify turn counter file is created and incremented on AGENT_NEEDED signals
- [ ] Verify session wraps up when turn limit is reached

### OpenClaw
- [ ] Run `/watch <PR_URL> --max-turns 3` on a real PR and confirm it stops after 3 rounds of work
- [ ] Verify wrap-up comment is posted correctly when turn limit triggers exit

https://claude.ai/code/session_01XQeK6NbnfRzexF1VvTvQmQ