### PR TITLE
chore: bump cli version to 0.1.4 and sync package.json in version-tag skill

### DIFF
--- a/.claude/skills/version-tag/SKILL.md
+++ b/.claude/skills/version-tag/SKILL.md
@@ -64,7 +64,48 @@ SHA=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip \
 
 If the command fails or `SHA` is empty, print an error and stop.
 
-### 4. Create and Push the Tag
+### 4. Sync package.json Version
+
+Check whether `<package>/package.json` exists in the repo and whether its `version` field matches the target version. If it doesn't match, bump it via the GitHub API (creating a commit directly on `main`) and update `SHA` to the new commit.
+
+```bash
+# Fetch the file metadata and content
+FILE_RESP=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip \
+  gh api repos/supersuit-tech/permission-slip/contents/<package>/package.json \
+  --jq '{sha: .sha, content: .content}')
+
+FILE_SHA=$(echo "$FILE_RESP" | jq -r '.sha')
+# Decode content (GitHub returns base64 with newlines)
+CURRENT_CONTENT=$(echo "$FILE_RESP" | jq -r '.content' | base64 -d)
+PKG_VERSION=$(echo "$CURRENT_CONTENT" | jq -r '.version')
+
+if [ "$PKG_VERSION" != "<version>" ]; then
+  echo "package.json version is $PKG_VERSION, bumping to <version>..."
+
+  # Produce updated JSON preserving formatting
+  UPDATED_CONTENT=$(echo "$CURRENT_CONTENT" | jq --arg v "<version>" '.version = $v')
+  ENCODED=$(echo "$UPDATED_CONTENT" | base64 -w 0)
+
+  COMMIT_RESP=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip \
+    gh api repos/supersuit-tech/permission-slip/contents/<package>/package.json \
+    -X PUT \
+    -f message="chore: bump <package> version to <version>" \
+    -f content="$ENCODED" \
+    -f sha="$FILE_SHA")
+
+  # Update SHA to point to the new commit so the tag lands on it
+  SHA=$(echo "$COMMIT_RESP" | jq -r '.commit.sha')
+  if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+    echo "::error::Failed to bump package.json — could not get new commit SHA"
+    exit 1
+  fi
+  echo "Committed package.json bump: $SHA"
+fi
+```
+
+If the file doesn't exist (404), skip this step silently and proceed with the original `SHA`.
+
+### 5. Create and Push the Tag
 
 Create the tag reference on GitHub directly via the API — no local branch switching or `git push` needed:
 
@@ -77,7 +118,7 @@ GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip \
 
 If the command fails, print the error output and stop.
 
-### 5. Confirm
+### 6. Confirm
 
 Print a summary:
 ```

--- a/.claude/skills/version-tag/SKILL.md
+++ b/.claude/skills/version-tag/SKILL.md
@@ -75,23 +75,25 @@ FILE_RESP=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip \
   --jq '{sha: .sha, content: .content}')
 
 FILE_SHA=$(echo "$FILE_RESP" | jq -r '.sha')
-# Decode content (GitHub returns base64 with newlines)
-CURRENT_CONTENT=$(echo "$FILE_RESP" | jq -r '.content' | base64 -d)
+# Decode content (GitHub returns base64 with newlines; use portable flags for Linux + macOS)
+CURRENT_CONTENT=$(echo "$FILE_RESP" | jq -r '.content' | base64 --decode 2>/dev/null || echo "$FILE_RESP" | jq -r '.content' | base64 -D 2>/dev/null)
 PKG_VERSION=$(echo "$CURRENT_CONTENT" | jq -r '.version')
 
 if [ "$PKG_VERSION" != "<version>" ]; then
   echo "package.json version is $PKG_VERSION, bumping to <version>..."
 
-  # Produce updated JSON preserving formatting
+  # NOTE: jq reformats the JSON to 2-space indentation. Intentional: keeps files canonical.
   UPDATED_CONTENT=$(echo "$CURRENT_CONTENT" | jq --arg v "<version>" '.version = $v')
-  ENCODED=$(echo "$UPDATED_CONTENT" | base64 -w 0)
+  # tr -d '\n' is portable across Linux and macOS (avoids GNU-only base64 -w 0)
+  ENCODED=$(echo "$UPDATED_CONTENT" | base64 | tr -d '\n')
 
   COMMIT_RESP=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip \
     gh api repos/supersuit-tech/permission-slip/contents/<package>/package.json \
     -X PUT \
     -f message="chore: bump <package> version to <version>" \
     -f content="$ENCODED" \
-    -f sha="$FILE_SHA")
+    -f sha="$FILE_SHA" \
+    -f branch="main")
 
   # Update SHA to point to the new commit so the tag lands on it
   SHA=$(echo "$COMMIT_RESP" | jq -r '.commit.sha')

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bumps `cli/package.json` from `0.1.1` to `0.1.4` to match the existing `cli/v0.1.4` tag. The `publish-cli` workflow has a version gate that requires `package.json` version to equal the tag version — without this bump, the workflow was failing silently after the tag was pushed.
- Updates the `/version-tag` skill to automatically sync `<package>/package.json` to the target version before creating the tag (committing directly to `main` via the GitHub Contents API). This prevents future drift between tags and `package.json` versions.

## Test plan

- [ ] Merge this PR so `main` has `cli/package.json` at `0.1.4`
- [ ] Delete and recreate the `cli/v0.1.4` tag pointing to the new `main` tip (so the workflow runs against the updated `package.json`)
- [ ] Verify the `publish-cli` workflow completes and `@permission-slip/cli@0.1.4` appears on npm
- [ ] Run `/version-tag cli` again in future — confirm it auto-bumps `package.json` before tagging

### Claude Code
- [x] Verify no test regressions (`make test-frontend` / `make test-backend` as applicable)

### OpenClaw
- [ ] Confirm npm publish succeeded and package is visible at expected version

https://claude.ai/code/session_01B1L7GL7ikJ7aCwiKPgkskZ