### PR TITLE
Deduplicate resolved approvals in recent activity feed

### DIFF
--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -197,16 +197,29 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 	// Suppress approval.requested events that have a corresponding resolution
 	// event (approved/denied/cancelled) for the same source_id. This keeps the
 	// activity feed clean by showing only the final state of each approval.
-	where = append(where, `NOT (
-		ae.event_type = 'approval.requested'
-		AND ae.source_id IS NOT NULL
-		AND EXISTS (
-			SELECT 1 FROM audit_events ae2
-			WHERE ae2.source_id = ae.source_id
-			  AND ae2.user_id = ae.user_id
-			  AND ae2.event_type IN ('approval.approved', 'approval.denied', 'approval.cancelled')
-		)
-	)`)
+	// Skip the dedup when the caller explicitly filters by approval.requested —
+	// an explicit filter signals intent to see all matching events (e.g. audits).
+	requestedTypeExplicit := false
+	if filter != nil {
+		for _, et := range filter.EventTypes {
+			if et == AuditEventApprovalRequested {
+				requestedTypeExplicit = true
+				break
+			}
+		}
+	}
+	if !requestedTypeExplicit {
+		where = append(where, `NOT (
+			ae.event_type = 'approval.requested'
+			AND ae.source_id IS NOT NULL
+			AND EXISTS (
+				SELECT 1 FROM audit_events ae2
+				WHERE ae2.source_id = ae.source_id
+				  AND ae2.user_id = ae.user_id
+				  AND ae2.event_type IN ('approval.approved', 'approval.denied', 'approval.cancelled')
+			)
+		)`)
+	}
 
 	limitPlaceholder := b.addArg(fetchLimit)
 

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -194,6 +194,20 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 		}
 	}
 
+	// Suppress approval.requested events that have a corresponding resolution
+	// event (approved/denied/cancelled) for the same source_id. This keeps the
+	// activity feed clean by showing only the final state of each approval.
+	where = append(where, `NOT (
+		ae.event_type = 'approval.requested'
+		AND ae.source_id IS NOT NULL
+		AND EXISTS (
+			SELECT 1 FROM audit_events ae2
+			WHERE ae2.source_id = ae.source_id
+			  AND ae2.user_id = ae.user_id
+			  AND ae2.event_type IN ('approval.approved', 'approval.denied', 'approval.cancelled')
+		)
+	)`)
+
 	limitPlaceholder := b.addArg(fetchLimit)
 
 	query := fmt.Sprintf(

--- a/db/audit_events_test.go
+++ b/db/audit_events_test.go
@@ -437,6 +437,34 @@ func TestListAuditEvents(t *testing.T) {
 		}
 	})
 
+	t.Run("DeduplicationSkippedWhenFilteringByRequested", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		// Same source_id: requested + approved.
+		sourceID := testhelper.GenerateID(t, "appr_")
+		base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.requested", "pending", sourceID, base)
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.approved", "approved", sourceID, base.Add(time.Minute))
+
+		// Explicit filter for approval.requested should bypass dedup and return all.
+		filter := &db.AuditEventFilter{
+			EventTypes: []db.AuditEventType{db.AuditEventApprovalRequested},
+		}
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, filter, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 approval.requested event (dedup bypassed), got %d", len(page.Events))
+		}
+		if page.Events[0].EventType != db.AuditEventApprovalRequested {
+			t.Errorf("expected approval.requested, got %s", page.Events[0].EventType)
+		}
+	})
+
 	t.Run("DeduplicatesAcrossResolutionTypes", func(t *testing.T) {
 		t.Parallel()
 		tx := testhelper.SetupTestDB(t)

--- a/db/audit_events_test.go
+++ b/db/audit_events_test.go
@@ -392,6 +392,96 @@ func TestListAuditEvents(t *testing.T) {
 		}
 	})
 
+	t.Run("DeduplicatesResolvedApproval", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		// Same source_id for both events — simulates a requested→approved lifecycle.
+		sourceID := testhelper.GenerateID(t, "appr_")
+		base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.requested", "pending", sourceID, base)
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.approved", "approved", sourceID, base.Add(time.Minute))
+
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 event (deduped), got %d", len(page.Events))
+		}
+		if page.Events[0].EventType != db.AuditEventApprovalApproved {
+			t.Errorf("expected approval.approved, got %s", page.Events[0].EventType)
+		}
+	})
+
+	t.Run("ShowsUnresolvedPendingApproval", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		// Only a requested event, no resolution — should still appear.
+		testhelper.InsertAuditEvent(t, tx, uid, agentID, "approval.requested", "pending", testhelper.GenerateID(t, "appr_"))
+
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 pending event, got %d", len(page.Events))
+		}
+		if page.Events[0].EventType != db.AuditEventApprovalRequested {
+			t.Errorf("expected approval.requested, got %s", page.Events[0].EventType)
+		}
+	})
+
+	t.Run("DeduplicatesAcrossResolutionTypes", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+		base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+		// Approval that was denied.
+		denied := testhelper.GenerateID(t, "appr_")
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.requested", "pending", denied, base)
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.denied", "denied", denied, base.Add(time.Minute))
+
+		// Approval that was cancelled.
+		cancelled := testhelper.GenerateID(t, "appr_")
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.requested", "pending", cancelled, base.Add(2*time.Minute))
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.cancelled", "cancelled", cancelled, base.Add(3*time.Minute))
+
+		// Approval still pending (no resolution).
+		testhelper.InsertAuditEventAt(t, tx, uid, agentID, "approval.requested", "pending", testhelper.GenerateID(t, "appr_"), base.Add(4*time.Minute))
+
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Should see: pending request + cancelled + denied = 3 (not 5).
+		if len(page.Events) != 3 {
+			t.Fatalf("expected 3 events (2 resolved + 1 pending), got %d", len(page.Events))
+		}
+
+		types := map[db.AuditEventType]int{}
+		for _, e := range page.Events {
+			types[e.EventType]++
+		}
+		if types[db.AuditEventApprovalRequested] != 1 {
+			t.Errorf("expected 1 approval.requested (unresolved), got %d", types[db.AuditEventApprovalRequested])
+		}
+		if types[db.AuditEventApprovalDenied] != 1 {
+			t.Errorf("expected 1 approval.denied, got %d", types[db.AuditEventApprovalDenied])
+		}
+		if types[db.AuditEventApprovalCancelled] != 1 {
+			t.Errorf("expected 1 approval.cancelled, got %d", types[db.AuditEventApprovalCancelled])
+		}
+	})
+
 	t.Run("MixedEventTypes", func(t *testing.T) {
 		t.Parallel()
 		tx := testhelper.SetupTestDB(t)

--- a/db/migrations/20260313201750_audit_events_source_resolution_index.sql
+++ b/db/migrations/20260313201750_audit_events_source_resolution_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Supports the NOT EXISTS subquery in ListAuditEvents that deduplicates
+-- approval.requested events when a resolution (approved/denied/cancelled) exists.
+CREATE INDEX idx_audit_events_source_resolution
+    ON audit_events (source_id, user_id, event_type)
+    WHERE source_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_audit_events_source_resolution;


### PR DESCRIPTION
## Summary
- Suppresses `approval.requested` events from the activity feed when a corresponding resolution event (`approval.approved`, `approval.denied`, `approval.cancelled`) exists for the same `source_id`
- Unresolved pending requests still appear — only resolved duplicates are hidden
- Adds a partial index `idx_audit_events_source_resolution` on `(source_id, user_id, event_type)` for efficient subquery lookups
- Compliance export endpoint (`ExportAuditLogs`) is unchanged — retains the full audit trail

## Test plan

### Claude Code
- [x] Added `DeduplicatesResolvedApproval` test — verifies only the approved event appears when both requested + approved exist
- [x] Added `ShowsUnresolvedPendingApproval` test — verifies pending requests without resolution still show
- [x] Added `DeduplicatesAcrossResolutionTypes` test — verifies dedup works for denied and cancelled resolutions
- [x] All existing audit event tests pass (44 tests)

### OpenClaw
- [ ] Verify on staging: create an approval, approve it, and confirm the activity feed shows only the approved entry
- [ ] Verify pending approvals still appear in the activity feed before resolution
- [ ] Check activity page pagination still works correctly with mixed deduplicated/non-deduplicated events

https://claude.ai/code/session_01E4CAhboii3HaCSXfP1v3sD