### PR TITLE
feat: multiple OAuth connections per provider with email display

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -476,16 +476,34 @@ func resolveOAuthCredentials(ctx context.Context, deps *Deps, userID string, req
 		}
 	}
 
-	// Look up the user's OAuth connection for this provider.
-	conn, err := db.GetOAuthConnectionByProvider(ctx, deps.DB, userID, providerID)
+	// Look up the user's OAuth connections for this provider. Multiple
+	// connections may exist (e.g. two Google accounts). Use the most recently
+	// created active connection as the default when no agent binding is set.
+	conns, err := db.GetOAuthConnectionsByProvider(ctx, deps.DB, userID, providerID)
 	if err != nil {
-		return zero, fmt.Errorf("look up OAuth connection for provider %q: %w", providerID, err)
+		return zero, fmt.Errorf("look up OAuth connections for provider %q: %w", providerID, err)
 	}
-	if conn == nil {
+	if len(conns) == 0 {
 		return zero, &connectors.OAuthRefreshError{
 			Provider:     providerID,
 			Message:      fmt.Sprintf("no OAuth connection for provider %q — user must connect via Settings", providerID),
 			NotConnected: true,
+		}
+	}
+
+	// Pick the first active connection (ordered by created_at DESC).
+	var conn *db.OAuthConnection
+	for i := range conns {
+		if conns[i].Status == db.OAuthStatusActive {
+			conn = &conns[i]
+			break
+		}
+	}
+	if conn == nil {
+		// All connections exist but none are active.
+		return zero, &connectors.OAuthRefreshError{
+			Provider: providerID,
+			Message:  fmt.Sprintf("OAuth connection for %q has status %q — user must re-authorize", providerID, conns[0].Status),
 		}
 	}
 

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -265,6 +265,13 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 						Message: "bound OAuth connection no longer exists — reassign credentials for this connector",
 					}
 				}
+				// Verify the bound connection belongs to the executing user.
+				// Without this, a binding could reference another user's connection.
+				if conn.UserID != userID {
+					return connectors.Credentials{}, &connectors.ValidationError{
+						Message: "bound OAuth connection does not belong to this user",
+					}
+				}
 				// Use the bound connection directly (not a provider re-query)
 				// so the specific oauth_connection_id in the binding is honoured.
 				return resolveOAuthCredentialsFromConnection(ctx, deps, conn)

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -686,14 +686,27 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 	// When empty, create a new connection alongside any existing ones.
 	var existing *db.DeleteOAuthConnectionResult
 	if replaceID != "" {
-		existing, err = db.DeleteOAuthConnectionByID(ctx, tx, userID, replaceID)
-		if err != nil {
-			var connErr *db.OAuthConnectionError
-			if !errors.As(err, &connErr) || connErr.Code != db.OAuthConnectionErrNotFound {
-				return fmt.Errorf("delete existing connection: %w", err)
-			}
-			// Not found is fine — connection may have been deleted already.
+		// Validate that the connection being replaced belongs to the same
+		// provider. Without this check a crafted URL could delete a
+		// connection for a different provider (e.g. replace a Slack
+		// connection while authorizing Google).
+		oldConn, lookupErr := db.GetOAuthConnectionByID(ctx, tx, replaceID)
+		if lookupErr != nil {
+			return fmt.Errorf("lookup connection to replace: %w", lookupErr)
 		}
+		if oldConn != nil && oldConn.UserID == userID && oldConn.Provider == providerID {
+			existing, err = db.DeleteOAuthConnectionByID(ctx, tx, userID, replaceID)
+			if err != nil {
+				var connErr *db.OAuthConnectionError
+				if !errors.As(err, &connErr) || connErr.Code != db.OAuthConnectionErrNotFound {
+					return fmt.Errorf("delete existing connection: %w", err)
+				}
+			}
+		} else if oldConn != nil && oldConn.Provider != providerID {
+			log.Printf("[%s] storeOAuthTokens: replaceID %q belongs to provider %q, not %q — ignoring", TraceID(ctx), replaceID, oldConn.Provider, providerID)
+			// Ignore the replaceID — create a new connection instead.
+		}
+		// If oldConn is nil or belongs to another user, just ignore and create new.
 	}
 
 	// Track the old refresh token vault ID so we can reuse it if the new

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -85,6 +85,9 @@ type oauthConnectionResponse struct {
 	// OAuth URLs (e.g. "mycompany.zendesk.com" for Zendesk, "mystore.myshopify.com"
 	// for Shopify). Empty for providers with static OAuth endpoints.
 	Instance string `json:"instance,omitempty"`
+	// DisplayName is a human-readable identifier for this connection, typically
+	// the authenticated user's email address. Empty when email is not available.
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 type oauthConnectionListResponse struct {
@@ -110,7 +113,7 @@ func RegisterOAuthRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.Handle("GET /oauth/{provider}/authorize", AllowQueryParamToken(requireProfile(handleOAuthAuthorize(deps))))
 	mux.Handle("GET /oauth/{provider}/callback", handleOAuthCallback(deps))
 	mux.Handle("GET /oauth/connections", requireProfile(handleListOAuthConnections(deps)))
-	mux.Handle("DELETE /oauth/connections/{provider}", requireProfile(handleDeleteOAuthConnection(deps)))
+	mux.Handle("DELETE /oauth/connections/{connection_id}", requireProfile(handleDeleteOAuthConnection(deps)))
 }
 
 // --- CSRF state helpers ---
@@ -135,9 +138,14 @@ func oauthStateSecret(deps *Deps) string {
 // Zendesk subdomain (e.g. "mycompany"). Pass "" for providers with static
 // OAuth endpoints (e.g. Google, Slack).
 //
+// The replaceID parameter, if non-empty, is the ID of an existing OAuth
+// connection to replace. When set, storeOAuthTokens deletes only that
+// specific connection instead of all connections for the provider. When
+// empty, a new connection is created alongside any existing ones.
+//
 // The returnTo parameter is the frontend path the user should be sent back
 // to after the callback (e.g. "/agents/1"). Pass "" to redirect to "/".
-func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop, returnTo string) (string, error) {
+func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop, returnTo, replaceID string) (string, error) {
 	secret := oauthStateSecret(deps)
 	if secret == "" {
 		return "", fmt.Errorf("no OAuth state secret configured")
@@ -155,6 +163,9 @@ func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop
 	}
 	if returnTo != "" {
 		claims["return_to"] = returnTo
+	}
+	if replaceID != "" {
+		claims["replace_id"] = replaceID
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(secret))
@@ -175,6 +186,10 @@ type oauthState struct {
 	// the OAuth callback completes (e.g. "/agents/1"). Empty falls back
 	// to the root path "/".
 	ReturnTo string
+	// ReplaceID is the ID of an existing OAuth connection to replace. When
+	// set, storeOAuthTokens deletes only that specific connection. When empty,
+	// a new connection is created alongside any existing ones.
+	ReplaceID string
 }
 
 // verifyOAuthState validates the signed state JWT and returns the encoded
@@ -215,7 +230,8 @@ func verifyOAuthState(deps *Deps, stateStr string) (*oauthState, error) {
 	}
 	shop, _ := claims["shop"].(string)
 	returnTo, _ := claims["return_to"].(string)
-	return &oauthState{UserID: sub, Provider: prov, Scopes: scopes, Shop: shop, ReturnTo: returnTo}, nil
+	replaceID, _ := claims["replace_id"].(string)
+	return &oauthState{UserID: sub, Provider: prov, Scopes: scopes, Shop: shop, ReturnTo: returnTo, ReplaceID: replaceID}, nil
 }
 
 // --- Helpers ---
@@ -451,8 +467,10 @@ func handleOAuthAuthorize(deps *Deps) http.HandlerFunc {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "invalid return_to parameter"))
 			return
 		}
+		// Optional: replace an existing connection instead of creating alongside.
+		replaceID := r.URL.Query().Get("replace")
 		profile := Profile(r.Context())
-		state, err := createOAuthState(deps, profile.ID, providerID, cfg.Scopes, instanceID, returnTo)
+		state, err := createOAuthState(deps, profile.ID, providerID, cfg.Scopes, instanceID, returnTo, replaceID)
 		if err != nil {
 			log.Printf("[%s] OAuthAuthorize: create state: %v", TraceID(r.Context()), err)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to initiate OAuth flow"))
@@ -622,7 +640,18 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		if err := storeOAuthTokens(r.Context(), deps, profile.ID, providerID, storedScopes, token, stateExtraData); err != nil {
+		// Run best-effort email enrichers (fetches user email from provider
+		// userinfo endpoints). Failures are logged but don't block the flow.
+		if softExtra := runSoftEnrichers(ctx, providerID, token.AccessToken); softExtra != nil {
+			if stateExtraData == nil {
+				stateExtraData = make(map[string]string)
+			}
+			for k, v := range softExtra {
+				stateExtraData[k] = v
+			}
+		}
+
+		if err := storeOAuthTokens(r.Context(), deps, profile.ID, providerID, storedScopes, token, stateExtraData, state.ReplaceID); err != nil {
 			log.Printf("[%s] OAuthCallback: store tokens: %v", TraceID(r.Context()), err)
 			redirectToFrontend(w, r, deps, providerID, "error", "Failed to store connection", state.ReturnTo)
 			return
@@ -640,7 +669,11 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 // alongside any fields extracted from the token response. This is used for
 // data carried through the state token (e.g. shop_domain for Shopify).
 // It may be nil when no state-derived extra data is needed.
-func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string, scopes []string, token *oauth2.Token, stateExtra map[string]string) error {
+//
+// replaceID, if non-empty, is the ID of an existing connection to replace.
+// When set, only that specific connection is deleted. When empty, a new
+// connection is created alongside any existing ones for the same provider.
+func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string, scopes []string, token *oauth2.Token, stateExtra map[string]string, replaceID string) error {
 	tx, owned, err := db.BeginOrContinue(ctx, deps.DB)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -649,14 +682,18 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
 	}
 
-	// Delete existing connection if present (re-auth flow).
-	existing, err := db.DeleteOAuthConnection(ctx, tx, userID, providerID)
-	if err != nil {
-		var connErr *db.OAuthConnectionError
-		if !errors.As(err, &connErr) || connErr.Code != db.OAuthConnectionErrNotFound {
-			return fmt.Errorf("delete existing connection: %w", err)
+	// When replaceID is set, delete that specific connection (reconnect flow).
+	// When empty, create a new connection alongside any existing ones.
+	var existing *db.DeleteOAuthConnectionResult
+	if replaceID != "" {
+		existing, err = db.DeleteOAuthConnectionByID(ctx, tx, userID, replaceID)
+		if err != nil {
+			var connErr *db.OAuthConnectionError
+			if !errors.As(err, &connErr) || connErr.Code != db.OAuthConnectionErrNotFound {
+				return fmt.Errorf("delete existing connection: %w", err)
+			}
+			// Not found is fine — connection may have been deleted already.
 		}
-		// Not found is fine — first connection.
 	}
 
 	// Track the old refresh token vault ID so we can reuse it if the new
@@ -922,6 +959,19 @@ func instanceFromExtraData(extraData json.RawMessage) string {
 	return ""
 }
 
+// emailFromExtraData extracts the email field from an OAuth connection's
+// extra_data JSON. Returns "" if no email is present.
+func emailFromExtraData(extraData json.RawMessage) string {
+	if len(extraData) == 0 {
+		return ""
+	}
+	var extra map[string]string
+	if err := json.Unmarshal(extraData, &extra); err != nil {
+		return ""
+	}
+	return extra["email"]
+}
+
 // handleListOAuthConnections returns all OAuth connections for the authenticated user.
 func handleListOAuthConnections(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -947,6 +997,7 @@ func handleListOAuthConnections(deps *Deps) http.HandlerFunc {
 				Status:      c.Status,
 				ConnectedAt: c.CreatedAt,
 				Instance:    instanceFromExtraData(c.ExtraData),
+				DisplayName: emailFromExtraData(c.ExtraData),
 			}
 		}
 
@@ -954,7 +1005,7 @@ func handleListOAuthConnections(deps *Deps) http.HandlerFunc {
 	}
 }
 
-// handleDeleteOAuthConnection disconnects an OAuth provider for the authenticated user.
+// handleDeleteOAuthConnection disconnects a specific OAuth connection by its ID.
 func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if deps.Vault == nil || deps.DB == nil {
@@ -963,23 +1014,23 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 		}
 
 		profile := Profile(r.Context())
-		providerID := r.PathValue("provider")
-		if !validProviderID(providerID) {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "invalid provider ID"))
+		connectionID := r.PathValue("connection_id")
+		if connectionID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "missing connection ID"))
 			return
 		}
 
 		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
 		if err != nil {
 			log.Printf("[%s] DeleteOAuthConnection: begin tx: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth provider"))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth connection"))
 			return
 		}
 		if owned {
 			defer db.RollbackTx(r.Context(), tx) //nolint:errcheck // best-effort cleanup
 		}
 
-		result, err := db.DeleteOAuthConnection(r.Context(), tx, profile.ID, providerID)
+		result, err := db.DeleteOAuthConnectionByID(r.Context(), tx, profile.ID, connectionID)
 		if err != nil {
 			var connErr *db.OAuthConnectionError
 			if errors.As(err, &connErr) && connErr.Code == db.OAuthConnectionErrNotFound {
@@ -987,7 +1038,7 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 				return
 			}
 			log.Printf("[%s] DeleteOAuthConnection: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth provider"))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth connection"))
 			return
 		}
 
@@ -996,13 +1047,13 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 		// (matching the pattern in handleDeleteCredential).
 		if err := deps.Vault.DeleteSecret(r.Context(), tx, result.AccessTokenVaultID); err != nil {
 			log.Printf("[%s] DeleteOAuthConnection: vault delete access: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth provider"))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth connection"))
 			return
 		}
 		if result.RefreshTokenVaultID != nil {
 			if err := deps.Vault.DeleteSecret(r.Context(), tx, *result.RefreshTokenVaultID); err != nil {
 				log.Printf("[%s] DeleteOAuthConnection: vault delete refresh: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth provider"))
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth connection"))
 				return
 			}
 		}
@@ -1010,13 +1061,13 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 		if owned {
 			if err := db.CommitTx(r.Context(), tx); err != nil {
 				log.Printf("[%s] DeleteOAuthConnection: commit: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth provider"))
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth connection"))
 				return
 			}
 		}
 
 		RespondJSON(w, http.StatusOK, oauthDisconnectResponse{
-			Provider:       providerID,
+			Provider:       connectionID,
 			DisconnectedAt: time.Now().UTC(),
 		})
 	}

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -1033,6 +1033,18 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Look up the connection first so we can return the provider name.
+		conn, err := db.GetOAuthConnectionByID(r.Context(), deps.DB, connectionID)
+		if err != nil {
+			log.Printf("[%s] DeleteOAuthConnection: lookup: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disconnect OAuth connection"))
+			return
+		}
+		if conn == nil || conn.UserID != profile.ID {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrOAuthConnectionNotFound, "OAuth connection not found"))
+			return
+		}
+
 		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
 		if err != nil {
 			log.Printf("[%s] DeleteOAuthConnection: begin tx: %v", TraceID(r.Context()), err)
@@ -1080,7 +1092,7 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusOK, oauthDisconnectResponse{
-			Provider:       connectionID,
+			Provider:       conn.Provider,
 			DisconnectedAt: time.Now().UTC(),
 		})
 	}

--- a/api/oauth_email_enrichers.go
+++ b/api/oauth_email_enrichers.go
@@ -87,20 +87,41 @@ func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]strin
 }
 
 // fetchMicrosoftEmail fetches the user's email from Microsoft Graph.
+// Tries the "mail" field first, falling back to "userPrincipalName".
 func fetchMicrosoftEmail(ctx context.Context, accessToken string) (map[string]string, error) {
-	extra, err := fetchEmailFromJSON(ctx, accessToken, "https://graph.microsoft.com/v1.0/me", "mail")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://graph.microsoft.com/v1.0/me", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create request: %w", err)
 	}
-	if extra["email"] != "" {
-		return extra, nil
-	}
-	// Fall back to userPrincipalName if mail is empty.
-	extra2, err := fetchEmailFromJSON(ctx, accessToken, "https://graph.microsoft.com/v1.0/me", "userPrincipalName")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := emailHTTPClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	return extra2, nil
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if mail, _ := data["mail"].(string); mail != "" {
+		return map[string]string{"email": mail}, nil
+	}
+	if upn, _ := data["userPrincipalName"].(string); upn != "" {
+		return map[string]string{"email": upn}, nil
+	}
+	return nil, fmt.Errorf("no email found in Microsoft profile")
 }
 
 // fetchSlackEmail fetches the user's email from Slack's OIDC userinfo endpoint.

--- a/api/oauth_email_enrichers.go
+++ b/api/oauth_email_enrichers.go
@@ -1,0 +1,162 @@
+// OAuth email enrichers fetch the authenticated user's email from provider
+// userinfo endpoints after a successful token exchange. Unlike hard enrichers
+// (postOAuthEnrichers), these are best-effort: a failure to fetch the email
+// does not block storing the OAuth connection.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// softOAuthEnrichers maps provider IDs to best-effort enrichers that fetch
+// the authenticated user's email after OAuth token exchange. Failures are
+// logged but do not block the connection from being stored.
+//
+// Add a new entry here when a provider exposes a userinfo or profile endpoint
+// that includes the user's email address.
+var softOAuthEnrichers = map[string]postOAuthEnricher{
+	"google":    fetchGoogleEmail,
+	"github":    fetchGitHubEmail,
+	"microsoft": fetchMicrosoftEmail,
+	"slack":     fetchSlackEmail,
+}
+
+// emailHTTPClient is a shared HTTP client for email enrichers.
+var emailHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// fetchGoogleEmail fetches the user's email from Google's userinfo endpoint.
+func fetchGoogleEmail(ctx context.Context, accessToken string) (map[string]string, error) {
+	return fetchEmailFromJSON(ctx, accessToken, "https://www.googleapis.com/oauth2/v3/userinfo", "email")
+}
+
+// fetchGitHubEmail fetches the user's email from GitHub's user endpoint.
+// Falls back to the /user/emails endpoint for users with private emails.
+func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]string, error) {
+	extra, err := fetchEmailFromJSON(ctx, accessToken, "https://api.github.com/user", "email")
+	if err == nil && extra["email"] != "" {
+		return extra, nil
+	}
+
+	// GitHub users can have a private email; fall back to /user/emails.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user/emails", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create github emails request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := emailHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github emails request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github emails returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read github emails response: %w", err)
+	}
+
+	var emails []struct {
+		Email   string `json:"email"`
+		Primary bool   `json:"primary"`
+	}
+	if err := json.Unmarshal(body, &emails); err != nil {
+		return nil, fmt.Errorf("parse github emails: %w", err)
+	}
+
+	for _, e := range emails {
+		if e.Primary && e.Email != "" {
+			return map[string]string{"email": e.Email}, nil
+		}
+	}
+	if len(emails) > 0 && emails[0].Email != "" {
+		return map[string]string{"email": emails[0].Email}, nil
+	}
+
+	return nil, fmt.Errorf("no email found in GitHub response")
+}
+
+// fetchMicrosoftEmail fetches the user's email from Microsoft Graph.
+func fetchMicrosoftEmail(ctx context.Context, accessToken string) (map[string]string, error) {
+	extra, err := fetchEmailFromJSON(ctx, accessToken, "https://graph.microsoft.com/v1.0/me", "mail")
+	if err != nil {
+		return nil, err
+	}
+	if extra["email"] != "" {
+		return extra, nil
+	}
+	// Fall back to userPrincipalName if mail is empty.
+	extra2, err := fetchEmailFromJSON(ctx, accessToken, "https://graph.microsoft.com/v1.0/me", "userPrincipalName")
+	if err != nil {
+		return nil, err
+	}
+	return extra2, nil
+}
+
+// fetchSlackEmail fetches the user's email from Slack's OIDC userinfo endpoint.
+func fetchSlackEmail(ctx context.Context, accessToken string) (map[string]string, error) {
+	return fetchEmailFromJSON(ctx, accessToken, "https://slack.com/api/openid.connect.userInfo", "email")
+}
+
+// fetchEmailFromJSON is a generic helper that calls a JSON endpoint with the
+// access token and extracts a string field into {"email": value}.
+func fetchEmailFromJSON(ctx context.Context, accessToken, url, field string) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := emailHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	email, _ := data[field].(string)
+	if email == "" {
+		return nil, fmt.Errorf("field %q not found or empty", field)
+	}
+
+	return map[string]string{"email": email}, nil
+}
+
+// runSoftEnrichers runs the best-effort email enrichers for a provider.
+// Returns extra data to merge into the connection's extra_data, or nil
+// if no enricher exists or the enricher fails.
+func runSoftEnrichers(ctx context.Context, providerID, accessToken string) map[string]string {
+	enricher, ok := softOAuthEnrichers[providerID]
+	if !ok {
+		return nil
+	}
+	extra, err := enricher(ctx, accessToken)
+	if err != nil {
+		log.Printf("oauth: soft enricher for %q failed (non-fatal): %v", providerID, err)
+		return nil
+	}
+	return extra
+}

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -205,7 +205,7 @@ func TestCreateAndVerifyOAuthState(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "")
+	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestVerifyOAuthState_InvalidSignature(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "")
+	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestVerifyOAuthState_MissingClaims(t *testing.T) {
 func TestVerifyOAuthState_NoSecret(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{}
-	_, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "")
+	_, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
 	if err == nil {
 		t.Fatal("expected error when no secret configured")
 	}
@@ -514,7 +514,7 @@ func TestListOAuthConnections_IsolatedByUser(t *testing.T) {
 	}
 }
 
-// ── DELETE /v1/oauth/connections/{provider} ───────────────────────────────────
+// ── DELETE /v1/oauth/connections/{connection_id} ─────────────────────────────
 
 func TestDeleteOAuthConnection_Success(t *testing.T) {
 	t.Parallel()
@@ -523,12 +523,12 @@ func TestDeleteOAuthConnection_Success(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 
 	v := vault.NewMockVaultStore()
-	insertTestOAuthConnection(t, tx, v, uid, "google", []string{"openid"}, true)
+	connID := insertTestOAuthConnection(t, tx, v, uid, "google", []string{"openid"}, true)
 
 	deps := oauthDepsWithVault(tx, v)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/google", uid)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/"+connID, uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -540,8 +540,8 @@ func TestDeleteOAuthConnection_Success(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if resp.Provider != "google" {
-		t.Errorf("expected google, got %s", resp.Provider)
+	if resp.Provider != connID {
+		t.Errorf("expected %s, got %s", connID, resp.Provider)
 	}
 
 	// Verify the connection is actually gone
@@ -563,7 +563,7 @@ func TestDeleteOAuthConnection_NotFound(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/google", uid)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/nonexistent_conn_id", uid)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -586,13 +586,13 @@ func TestDeleteOAuthConnection_OtherUserCannot(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid2, "u2_"+uid2[:8])
 
 	v := vault.NewMockVaultStore()
-	insertTestOAuthConnection(t, tx, v, uid1, "google", []string{"openid"}, false)
+	connID := insertTestOAuthConnection(t, tx, v, uid1, "google", []string{"openid"}, false)
 
 	deps := oauthDepsWithVault(tx, v)
 	router := NewRouter(deps)
 
 	// User 2 tries to delete user 1's connection
-	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/google", uid2)
+	r := authenticatedRequest(t, http.MethodDelete, "/oauth/connections/"+connID, uid2)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -667,7 +667,7 @@ func TestOAuthCallback_ProviderMismatch(t *testing.T) {
 	router := NewRouter(deps)
 
 	// Create state for "microsoft" but hit google callback
-	state, err := createOAuthState(deps, uid, "microsoft", []string{"openid"}, "", "")
+	state, err := createOAuthState(deps, uid, "microsoft", []string{"openid"}, "", "", "")
 	if err != nil {
 		t.Fatalf("create state: %v", err)
 	}
@@ -696,7 +696,7 @@ func TestOAuthCallback_ProviderError(t *testing.T) {
 
 	// State validation now runs before the provider error check, so we need a
 	// valid state token to reach the error-handling branch.
-	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "")
+	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -751,7 +751,7 @@ func TestOAuthCallback_MissingCode(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "")
+	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "", "")
 	if err != nil {
 		t.Fatalf("create state: %v", err)
 	}
@@ -804,7 +804,7 @@ func TestStoreOAuthTokens_CreateNew(t *testing.T) {
 		TokenType:    "Bearer",
 	}
 
-	err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token, nil)
+	err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token, nil, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}
@@ -843,18 +843,24 @@ func TestStoreOAuthTokens_ReplacesExisting(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil); err != nil {
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
-	// Re-auth with new tokens
+	// Get the first connection's ID to use as replaceID
+	conn1, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, "google")
+	if err != nil {
+		t.Fatalf("get first connection: %v", err)
+	}
+
+	// Re-auth with new tokens, replacing the first connection
 	token2 := &oauth2.Token{
 		AccessToken:  "access-new",
 		RefreshToken: "refresh-new",
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil); err != nil {
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -886,7 +892,7 @@ func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil); err != nil {
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -901,13 +907,14 @@ func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
 	oldRefreshVaultID := *conn1.RefreshTokenVaultID
 
 	// Re-authorization — provider omits the refresh token this time.
+	// Pass conn1.ID as replaceID to replace the existing connection.
 	token2 := &oauth2.Token{
 		AccessToken:  "access-new",
 		RefreshToken: "",
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil); err != nil {
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -958,7 +965,7 @@ func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil); err != nil {
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -968,14 +975,14 @@ func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
 	}
 	oldRefreshVaultID := *conn1.RefreshTokenVaultID
 
-	// Re-authorization WITH a new refresh token.
+	// Re-authorization WITH a new refresh token, replacing the first connection.
 	token2 := &oauth2.Token{
 		AccessToken:  "access-new",
 		RefreshToken: "refresh-new",
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil); err != nil {
+	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -1089,7 +1096,7 @@ func TestCreateAndVerifyOAuthState_WithShop(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-456", "shopify", []string{"write_orders"}, "mystore", "")
+	state, err := createOAuthState(deps, "user-456", "shopify", []string{"write_orders"}, "mystore", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -1116,7 +1123,7 @@ func TestCreateAndVerifyOAuthState_EmptyShop(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "")
+	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -1300,7 +1307,7 @@ func TestStoreOAuthTokens_WithStateExtra(t *testing.T) {
 	}
 
 	stateExtra := map[string]string{"shop_domain": "mystore.myshopify.com"}
-	err := storeOAuthTokens(t.Context(), deps, uid, "shopify", []string{"write_orders"}, token, stateExtra)
+	err := storeOAuthTokens(t.Context(), deps, uid, "shopify", []string{"write_orders"}, token, stateExtra, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}
@@ -1811,7 +1818,7 @@ func TestStoreOAuthTokens_WithZendeskSubdomain(t *testing.T) {
 	}
 
 	stateExtra := map[string]string{"subdomain": "mycompany"}
-	err := storeOAuthTokens(t.Context(), deps, uid, "zendesk", []string{"read", "write"}, token, stateExtra)
+	err := storeOAuthTokens(t.Context(), deps, uid, "zendesk", []string{"read", "write"}, token, stateExtra, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -540,8 +540,8 @@ func TestDeleteOAuthConnection_Success(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if resp.Provider != connID {
-		t.Errorf("expected %s, got %s", connID, resp.Provider)
+	if resp.Provider != "google" {
+		t.Errorf("expected google, got %s", resp.Provider)
 	}
 
 	// Verify the connection is actually gone

--- a/db/migrations/20260313201757_allow_multiple_oauth_connections.sql
+++ b/db/migrations/20260313201757_allow_multiple_oauth_connections.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Allow multiple OAuth connections per provider per user (e.g. two Google
+-- accounts for different agents). The old unique constraint enforced one
+-- connection per provider. Replace it with a plain index for query perf.
+
+ALTER TABLE oauth_connections DROP CONSTRAINT IF EXISTS oauth_connections_user_id_provider_key;
+CREATE INDEX IF NOT EXISTS idx_oauth_connections_user_provider ON oauth_connections (user_id, provider);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_oauth_connections_user_provider;
+ALTER TABLE oauth_connections ADD CONSTRAINT oauth_connections_user_id_provider_key UNIQUE (user_id, provider);

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -118,6 +118,33 @@ func GetOAuthConnectionByProvider(ctx context.Context, db DBTX, userID, provider
 	return &c, nil
 }
 
+// GetOAuthConnectionsByProvider returns all OAuth connections for a given user
+// and provider, ordered by created_at descending (newest first). Use this when
+// multiple connections per provider are allowed.
+func GetOAuthConnectionsByProvider(ctx context.Context, db DBTX, userID, provider string) ([]OAuthConnection, error) {
+	rows, err := db.Query(ctx, `
+		SELECT `+oauthConnectionColumns+`
+		FROM oauth_connections
+		WHERE user_id = $1 AND provider = $2
+		ORDER BY created_at DESC`,
+		userID, provider,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var conns []OAuthConnection
+	for rows.Next() {
+		c, err := scanOAuthConnection(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		conns = append(conns, c)
+	}
+	return conns, rows.Err()
+}
+
 // CreateOAuthConnection inserts a new OAuth connection row.
 // Returns a *OAuthConnectionError with code OAuthConnectionErrDuplicate if
 // the (user_id, provider) unique constraint is violated.
@@ -215,6 +242,10 @@ type DeleteOAuthConnectionResult struct {
 
 // DeleteOAuthConnection deletes an OAuth connection by user and provider.
 // Returns the vault secret IDs so the caller can delete the vault secrets too.
+//
+// Deprecated: Use DeleteOAuthConnectionByID for multi-connection support.
+// This function deletes ALL connections for the given provider; it's retained
+// for backward compatibility but should not be used in new code.
 func DeleteOAuthConnection(ctx context.Context, db DBTX, userID, provider string) (*DeleteOAuthConnectionResult, error) {
 	var result DeleteOAuthConnectionResult
 	err := db.QueryRow(ctx, `
@@ -222,6 +253,26 @@ func DeleteOAuthConnection(ctx context.Context, db DBTX, userID, provider string
 		WHERE user_id = $1 AND provider = $2
 		RETURNING access_token_vault_id, refresh_token_vault_id`,
 		userID, provider,
+	).Scan(&result.AccessTokenVaultID, &result.RefreshTokenVaultID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, &OAuthConnectionError{Code: OAuthConnectionErrNotFound, Message: "OAuth connection not found"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteOAuthConnectionByID deletes a single OAuth connection by its ID.
+// The userID parameter ensures the caller owns the connection (defense-in-depth).
+// Returns the vault secret IDs so the caller can delete the vault secrets too.
+func DeleteOAuthConnectionByID(ctx context.Context, db DBTX, userID, connectionID string) (*DeleteOAuthConnectionResult, error) {
+	var result DeleteOAuthConnectionResult
+	err := db.QueryRow(ctx, `
+		DELETE FROM oauth_connections
+		WHERE id = $1 AND user_id = $2
+		RETURNING access_token_vault_id, refresh_token_vault_id`,
+		connectionID, userID,
 	).Scan(&result.AccessTokenVaultID, &result.RefreshTokenVaultID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, &OAuthConnectionError{Code: OAuthConnectionErrNotFound, Message: "OAuth connection not found"}

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // OAuth connection status values. Must match the CHECK constraint on
@@ -58,8 +57,7 @@ func (e *OAuthConnectionError) Error() string { return e.Message }
 type OAuthConnectionErrCode int
 
 const (
-	OAuthConnectionErrNotFound  OAuthConnectionErrCode = iota
-	OAuthConnectionErrDuplicate                        // unique (user_id, provider) violation
+	OAuthConnectionErrNotFound OAuthConnectionErrCode = iota
 )
 
 // oauthConnectionColumns is the shared SELECT column list for oauth_connections queries.
@@ -146,8 +144,6 @@ func GetOAuthConnectionsByProvider(ctx context.Context, db DBTX, userID, provide
 }
 
 // CreateOAuthConnection inserts a new OAuth connection row.
-// Returns a *OAuthConnectionError with code OAuthConnectionErrDuplicate if
-// the (user_id, provider) unique constraint is violated.
 func CreateOAuthConnection(ctx context.Context, db DBTX, p CreateOAuthConnectionParams) (*OAuthConnection, error) {
 	row := db.QueryRow(ctx, `
 		INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, refresh_token_vault_id, scopes, token_expiry, extra_data)
@@ -157,10 +153,6 @@ func CreateOAuthConnection(ctx context.Context, db DBTX, p CreateOAuthConnection
 	)
 	c, err := scanOAuthConnection(row.Scan)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
-			return nil, &OAuthConnectionError{Code: OAuthConnectionErrDuplicate, Message: "OAuth connection already exists for this provider"}
-		}
 		return nil, err
 	}
 	return &c, nil
@@ -238,29 +230,6 @@ func UpdateOAuthConnectionStatus(ctx context.Context, db DBTX, id, userID, statu
 type DeleteOAuthConnectionResult struct {
 	AccessTokenVaultID  string
 	RefreshTokenVaultID *string
-}
-
-// DeleteOAuthConnection deletes an OAuth connection by user and provider.
-// Returns the vault secret IDs so the caller can delete the vault secrets too.
-//
-// Deprecated: Use DeleteOAuthConnectionByID for multi-connection support.
-// This function deletes ALL connections for the given provider; it's retained
-// for backward compatibility but should not be used in new code.
-func DeleteOAuthConnection(ctx context.Context, db DBTX, userID, provider string) (*DeleteOAuthConnectionResult, error) {
-	var result DeleteOAuthConnectionResult
-	err := db.QueryRow(ctx, `
-		DELETE FROM oauth_connections
-		WHERE user_id = $1 AND provider = $2
-		RETURNING access_token_vault_id, refresh_token_vault_id`,
-		userID, provider,
-	).Scan(&result.AccessTokenVaultID, &result.RefreshTokenVaultID)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, &OAuthConnectionError{Code: OAuthConnectionErrNotFound, Message: "OAuth connection not found"}
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
 }
 
 // DeleteOAuthConnectionByID deletes a single OAuth connection by its ID.

--- a/frontend/src/hooks/useDisconnectOAuth.ts
+++ b/frontend/src/hooks/useDisconnectOAuth.ts
@@ -8,21 +8,21 @@ export function useDisconnectOAuth() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async (provider: string) => {
+    mutationFn: async (connectionId: string) => {
       if (!session?.access_token) {
         throw new Error("Not authenticated");
       }
 
       const { data, error } = await client.DELETE(
-        "/v1/oauth/connections/{provider}",
+        "/v1/oauth/connections/{connection_id}",
         {
           headers: { Authorization: `Bearer ${session.access_token}` },
-          params: { path: { provider } },
+          params: { path: { connection_id: connectionId } },
         },
       );
       if (error) {
         throw new Error(
-          getApiErrorMessage(error, "Failed to disconnect provider"),
+          getApiErrorMessage(error, "Failed to disconnect connection"),
         );
       }
       return data;
@@ -33,7 +33,7 @@ export function useDisconnectOAuth() {
   });
 
   return {
-    disconnect: (provider: string) => mutation.mutateAsync(provider),
+    disconnect: (connectionId: string) => mutation.mutateAsync(connectionId),
     isLoading: mutation.isPending,
   };
 }

--- a/frontend/src/lib/__tests__/oauth.test.ts
+++ b/frontend/src/lib/__tests__/oauth.test.ts
@@ -54,4 +54,20 @@ describe("getOAuthAuthorizeUrl", () => {
     const url = getOAuthAuthorizeUrl("google", "tok_z", undefined);
     expect(url).not.toContain("scope=");
   });
+
+  it("appends replace param when replaceId is provided", () => {
+    const url = getOAuthAuthorizeUrl("google", "tok_r", {
+      scopes: ["openid"],
+      replaceId: "oconn_abc123",
+    });
+    expect(url).toContain("scope=openid");
+    expect(url).toContain("replace=oconn_abc123");
+  });
+
+  it("omits replace param when replaceId is not set", () => {
+    const url = getOAuthAuthorizeUrl("google", "tok_n", {
+      scopes: ["openid"],
+    });
+    expect(url).not.toContain("replace=");
+  });
 });

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -14,17 +14,7 @@ export { providerLabel } from "@/lib/labels";
 export const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
 
 /**
- * Builds the URL to initiate an OAuth authorization flow for a provider.
- * The backend redirects from this URL to the provider's consent screen.
- * After the OAuth flow completes, the user is redirected back to the
- * current page (window.location.pathname + search + hash).
- */
-/**
  * Options for building an OAuth authorize URL.
- *
- * @param replaceId - When set, the backend replaces the specified existing
- *   connection instead of creating a new one alongside it. Used for the
- *   "Reconnect" flow.
  */
 interface OAuthAuthorizeOptions {
   scopes?: string[];

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -19,11 +19,28 @@ export const SHOP_REQUIRED_PROVIDERS = new Set(["shopify"]);
  * After the OAuth flow completes, the user is redirected back to the
  * current page (window.location.pathname + search + hash).
  */
+/**
+ * Options for building an OAuth authorize URL.
+ *
+ * @param replaceId - When set, the backend replaces the specified existing
+ *   connection instead of creating a new one alongside it. Used for the
+ *   "Reconnect" flow.
+ */
+interface OAuthAuthorizeOptions {
+  scopes?: string[];
+  replaceId?: string;
+}
+
 export function getOAuthAuthorizeUrl(
   providerId: string,
   accessToken: string,
-  scopes?: string[],
+  scopesOrOptions?: string[] | OAuthAuthorizeOptions,
 ): string {
+  // Backward-compatible: accept either scopes array or options object.
+  const options: OAuthAuthorizeOptions = Array.isArray(scopesOrOptions)
+    ? { scopes: scopesOrOptions }
+    : scopesOrOptions ?? {};
+
   const baseUrl =
     import.meta.env.VITE_API_BASE_URL?.replace(/\/v1\/?$/, "") ?? "/api";
   const url = new URL(window.location.href);
@@ -32,10 +49,13 @@ export function getOAuthAuthorizeUrl(
   url.searchParams.delete("oauth_error");
   const returnTo = url.pathname + (url.search || "") + url.hash;
   let result = `${baseUrl}/v1/oauth/${providerId}/authorize?access_token=${encodeURIComponent(accessToken)}&return_to=${encodeURIComponent(returnTo)}`;
-  if (scopes?.length) {
-    for (const s of scopes) {
+  if (options.scopes?.length) {
+    for (const s of options.scopes) {
       result += `&scope=${encodeURIComponent(s)}`;
     }
+  }
+  if (options.replaceId) {
+    result += `&replace=${encodeURIComponent(options.replaceId)}`;
   }
   return result;
 }

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -35,8 +35,6 @@ import { useCredentials } from "@/hooks/useCredentials";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
-import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
-import { InlineConfirmButton } from "@/components/InlineConfirmButton";
 import {
   providerLabel,
   getOAuthAuthorizeUrl,
@@ -51,6 +49,8 @@ import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
+import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
+import type { OAuthConnection } from "@/hooks/useOAuthConnections";
 
 export interface ConnectorCredentialsSectionProps {
   agentId: number;
@@ -214,23 +214,29 @@ function OAuthCredentialRow({
   providers,
 }: {
   requiredCredential: RequiredCredential;
-  connections: {
-    provider: string;
-    status: string;
-    scopes: string[];
-    connected_at: string;
-  }[];
+  connections: OAuthConnection[];
   providers: { id: string; has_credentials: boolean }[];
 }) {
   const { session } = useAuth();
-  const { disconnect, isLoading: isDisconnecting } = useDisconnectOAuth();
   const [shopDialogOpen, setShopDialogOpen] = useState(false);
+  const [disconnectTarget, setDisconnectTarget] = useState<{
+    id: string;
+    displayName?: string;
+  } | null>(null);
 
   const providerId = requiredCredential.oauth_provider ?? "";
-  const connection = connections.find((c) => c.provider === providerId);
+  const providerConnections = connections.filter(
+    (c) => c.provider === providerId,
+  );
+  const activeConnections = providerConnections.filter(
+    (c) => c.status === "active",
+  );
+  const needsReauthConnection = providerConnections.find(
+    (c) => c.status === "needs_reauth",
+  );
   const provider = providers.find((p) => p.id === providerId);
-  const isConnected = connection?.status === "active";
-  const needsReauth = connection?.status === "needs_reauth";
+  const hasAnyConnection = providerConnections.length > 0;
+  const isConnected = activeConnections.length > 0;
 
   function handleConnect() {
     if (!session?.access_token || !providerId) return;
@@ -241,19 +247,21 @@ function OAuthCredentialRow({
     window.location.href = getOAuthAuthorizeUrl(
       providerId,
       session.access_token,
-      requiredCredential.oauth_scopes,
+      { scopes: requiredCredential.oauth_scopes },
     );
   }
 
-  async function handleDisconnect() {
-    try {
-      await disconnect(providerId);
-      toast.success(`${providerLabel(providerId)} disconnected.`);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to disconnect.";
-      toast.error(message);
+  function handleReconnect(connectionId: string) {
+    if (!session?.access_token || !providerId) return;
+    if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
+      setShopDialogOpen(true);
+      return;
     }
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      { scopes: requiredCredential.oauth_scopes, replaceId: connectionId },
+    );
   }
 
   return (
@@ -263,7 +271,7 @@ function OAuthCredentialRow({
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
-            ) : needsReauth ? (
+            ) : needsReauthConnection ? (
               <AlertTriangle className="size-5 shrink-0 text-amber-500" />
             ) : (
               <Circle className="text-muted-foreground size-5 shrink-0" />
@@ -282,34 +290,15 @@ function OAuthCredentialRow({
               </div>
               <p className="text-muted-foreground text-xs">
                 {isConnected
-                  ? `Connected ${new Date(connection.connected_at).toLocaleDateString()}`
-                  : needsReauth
+                  ? `${activeConnections.length} account${activeConnections.length !== 1 ? "s" : ""} connected`
+                  : needsReauthConnection
                     ? "Re-authorization required"
                     : "Not connected"}
               </p>
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            {isConnected ? (
-              <InlineConfirmButton
-                confirmLabel="Disconnect"
-                isProcessing={isDisconnecting}
-                onConfirm={handleDisconnect}
-              >
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label={`Disconnect ${providerLabel(providerId)}`}
-                >
-                  <Unplug className="text-muted-foreground size-4" />
-                </Button>
-              </InlineConfirmButton>
-            ) : needsReauth ? (
-              <Button variant="outline" size="sm" onClick={handleConnect}>
-                <LogIn className="size-3" />
-                Re-authorize
-              </Button>
-            ) : (
+            {!hasAnyConnection && (
               <Button
                 variant="outline"
                 size="sm"
@@ -320,9 +309,81 @@ function OAuthCredentialRow({
                 Connect {providerLabel(providerId)}
               </Button>
             )}
+            {hasAnyConnection && provider?.has_credentials && (
+              <Button variant="outline" size="sm" onClick={handleConnect}>
+                <Plus className="size-3" />
+                Add account
+              </Button>
+            )}
           </div>
         </div>
-        {!isConnected && !needsReauth && !provider?.has_credentials && (
+
+        {/* List each connection */}
+        {providerConnections.length > 0 && (
+          <div className="mt-3 space-y-2 border-t pt-3">
+            {providerConnections.map((conn) => (
+              <div
+                key={conn.id}
+                className="bg-muted/50 flex items-center justify-between rounded-md px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm">
+                    {conn.display_name || providerLabel(conn.provider)}
+                    {conn.instance && !conn.display_name && (
+                      <span className="text-muted-foreground ml-1">
+                        ({conn.instance})
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {conn.status === "active"
+                      ? `Connected ${new Date(conn.connected_at).toLocaleDateString()}`
+                      : conn.status === "needs_reauth"
+                        ? "Needs re-authorization"
+                        : conn.status}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  {conn.status === "needs_reauth" ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleReconnect(conn.id)}
+                    >
+                      <LogIn className="size-3" />
+                      Re-authorize
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleReconnect(conn.id)}
+                      aria-label="Reconnect"
+                    >
+                      <LogIn className="size-3" />
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() =>
+                      setDisconnectTarget({
+                        id: conn.id,
+                        displayName: conn.display_name,
+                      })
+                    }
+                    aria-label={`Disconnect ${conn.display_name ?? providerLabel(conn.provider)}`}
+                  >
+                    <Unplug className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!hasAnyConnection && !provider?.has_credentials && (
           <p className="text-muted-foreground mt-2 pl-8 text-xs">
             OAuth is not available yet — ask your admin to configure{" "}
             {providerLabel(providerId)} OAuth credentials.
@@ -336,6 +397,18 @@ function OAuthCredentialRow({
           onOpenChange={setShopDialogOpen}
           providerId={providerId}
           oauthScopes={requiredCredential.oauth_scopes}
+        />
+      )}
+
+      {disconnectTarget && (
+        <DisconnectOAuthDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setDisconnectTarget(null);
+          }}
+          connectionId={disconnectTarget.id}
+          providerName={providerLabel(providerId)}
+          displayName={disconnectTarget.displayName}
         />
       )}
     </>
@@ -548,7 +621,7 @@ function AgentCredentialBinding({
   agentId: number;
   connectorId: string;
   credentials: CredentialSummary[];
-  connections: { id: string; provider: string; status: string; scopes: string[]; connected_at: string }[];
+  connections: OAuthConnection[];
   anyLoading: boolean;
 }) {
   const { binding, isLoading: bindingLoading } =
@@ -641,7 +714,8 @@ function AgentCredentialBinding({
           <option value="">Default (auto-resolve)</option>
           {activeConnections.map((conn) => (
             <option key={`oauth:${conn.id}`} value={`oauth:${conn.id}`}>
-              {providerLabel(conn.provider)} OAuth (connected{" "}
+              {providerLabel(conn.provider)} OAuth
+              {conn.display_name ? ` — ${conn.display_name}` : ""} (connected{" "}
               {new Date(conn.connected_at).toLocaleDateString()})
             </option>
           ))}

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -218,7 +218,9 @@ function OAuthCredentialRow({
   providers: { id: string; has_credentials: boolean }[];
 }) {
   const { session } = useAuth();
-  const [shopDialogOpen, setShopDialogOpen] = useState(false);
+  const [shopDialogState, setShopDialogState] = useState<{
+    replaceId?: string;
+  } | null>(null);
   const [disconnectTarget, setDisconnectTarget] = useState<{
     id: string;
     displayName?: string;
@@ -241,7 +243,7 @@ function OAuthCredentialRow({
   function handleConnect() {
     if (!session?.access_token || !providerId) return;
     if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
-      setShopDialogOpen(true);
+      setShopDialogState({});
       return;
     }
     window.location.href = getOAuthAuthorizeUrl(
@@ -254,7 +256,7 @@ function OAuthCredentialRow({
   function handleReconnect(connectionId: string) {
     if (!session?.access_token || !providerId) return;
     if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
-      setShopDialogOpen(true);
+      setShopDialogState({ replaceId: connectionId });
       return;
     }
     window.location.href = getOAuthAuthorizeUrl(
@@ -391,12 +393,15 @@ function OAuthCredentialRow({
         )}
       </div>
 
-      {SHOP_REQUIRED_PROVIDERS.has(providerId) && (
+      {SHOP_REQUIRED_PROVIDERS.has(providerId) && shopDialogState && (
         <ShopDomainDialog
-          open={shopDialogOpen}
-          onOpenChange={setShopDialogOpen}
+          open
+          onOpenChange={(open) => {
+            if (!open) setShopDialogState(null);
+          }}
           providerId={providerId}
           oauthScopes={requiredCredential.oauth_scopes}
+          replaceId={shopDialogState.replaceId}
         />
       )}
 
@@ -420,11 +425,13 @@ function ShopDomainDialog({
   onOpenChange,
   providerId,
   oauthScopes,
+  replaceId,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   providerId: string;
   oauthScopes?: string[];
+  replaceId?: string;
 }) {
   const { session } = useAuth();
   const [shop, setShop] = useState("");
@@ -435,7 +442,10 @@ function ShopDomainDialog({
     const trimmed = shop.trim().toLowerCase();
     if (!trimmed) return;
     const subdomain = trimmed.replace(/\.myshopify\.com$/, "");
-    const url = getOAuthAuthorizeUrl(providerId, session.access_token, oauthScopes);
+    const url = getOAuthAuthorizeUrl(providerId, session.access_token, {
+      scopes: oauthScopes,
+      replaceId,
+    });
     window.location.href = `${url}&shop=${encodeURIComponent(subdomain)}`;
     onOpenChange(false);
   }

--- a/frontend/src/pages/agents/connectors/DisconnectOAuthDialog.tsx
+++ b/frontend/src/pages/agents/connectors/DisconnectOAuthDialog.tsx
@@ -1,0 +1,82 @@
+import { Loader2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
+
+interface DisconnectOAuthDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connectionId: string;
+  providerName: string;
+  displayName?: string;
+}
+
+export function DisconnectOAuthDialog({
+  open,
+  onOpenChange,
+  connectionId,
+  providerName,
+  displayName,
+}: DisconnectOAuthDialogProps) {
+  const { disconnect, isLoading } = useDisconnectOAuth();
+
+  async function handleDisconnect() {
+    try {
+      await disconnect(connectionId);
+      toast.success(`Disconnected ${providerName}`);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to disconnect",
+      );
+    }
+  }
+
+  const label = displayName
+    ? `${providerName} (${displayName})`
+    : providerName;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="text-destructive size-5" />
+            Disconnect {label}?
+          </DialogTitle>
+          <DialogDescription>
+            Disconnecting will remove this account from{" "}
+            <strong>all agents and connectors</strong> that use it. Actions
+            requiring this credential will fail until a new connection is
+            established.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDisconnect}
+            disabled={isLoading}
+          >
+            {isLoading && <Loader2 className="animate-spin" />}
+            Disconnect
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/agents/connectors/RemoveCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RemoveCredentialDialog.tsx
@@ -54,9 +54,10 @@ export function RemoveCredentialDialog({
                 {" "}
                 (<strong>{credential.label}</strong>)
               </>
-            )}
-            . Actions requiring this credential will fail until new credentials
-            are stored. This action is irreversible.
+            )}{" "}
+            and remove it from <strong>all agents</strong> that use it. Actions
+            requiring this credential will fail until a new credential is
+            stored. This action is irreversible.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -91,12 +91,16 @@ export function SetupConnectorCredentialsDialog({
     : null;
   const hasOAuthCredentials = !!provider?.has_credentials;
 
-  // Check if already connected
-  const existingConnection = effectiveOAuthProvider
-    ? connections.find((c) => c.provider === effectiveOAuthProvider)
-    : null;
-  const isAlreadyConnected = existingConnection?.status === "active";
-  const needsReauth = existingConnection?.status === "needs_reauth";
+  // Check if already connected (any active connection for this provider)
+  const providerConnections = effectiveOAuthProvider
+    ? connections.filter((c) => c.provider === effectiveOAuthProvider)
+    : [];
+  const isAlreadyConnected = providerConnections.some(
+    (c) => c.status === "active",
+  );
+  const needsReauth =
+    !isAlreadyConnected &&
+    providerConnections.some((c) => c.status === "needs_reauth");
 
   // Find static (API key / basic) credential requirements
   const staticCredentials = requiredCredentials.filter(

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -93,9 +93,10 @@ export function ConnectedAccountsSection() {
   const { connections, isLoading, error } = useOAuthConnections();
   const { providers } = useOAuthProviders();
 
-  const [instanceDialogProvider, setInstanceDialogProvider] = useState<
-    string | null
-  >(null);
+  const [instanceDialogState, setInstanceDialogState] = useState<{
+    provider: string;
+    replaceId?: string;
+  } | null>(null);
 
   const [disconnectTarget, setDisconnectTarget] = useState<{
     id: string;
@@ -106,7 +107,7 @@ export function ConnectedAccountsSection() {
   function handleConnect(providerId: string) {
     if (!session?.access_token) return;
     if (providerId in INSTANCE_SUBDOMAIN_PROVIDERS) {
-      setInstanceDialogProvider(providerId);
+      setInstanceDialogState({ provider: providerId });
       return;
     }
     window.location.href = getOAuthAuthorizeUrl(
@@ -118,9 +119,7 @@ export function ConnectedAccountsSection() {
   function handleReconnect(connectionId: string, providerId: string) {
     if (!session?.access_token) return;
     if (providerId in INSTANCE_SUBDOMAIN_PROVIDERS) {
-      // For instance-based providers, re-open the subdomain dialog.
-      // The replace param will be added after the subdomain is entered.
-      setInstanceDialogProvider(providerId);
+      setInstanceDialogState({ provider: providerId, replaceId: connectionId });
       return;
     }
     window.location.href = getOAuthAuthorizeUrl(
@@ -289,25 +288,28 @@ export function ConnectedAccountsSection() {
         )}
       </CardContent>
 
-      {instanceDialogProvider &&
+      {instanceDialogState &&
         session?.access_token &&
-        instanceDialogProvider in INSTANCE_SUBDOMAIN_PROVIDERS && (
+        instanceDialogState.provider in INSTANCE_SUBDOMAIN_PROVIDERS && (
           <InstanceSubdomainDialog
             open
-            config={INSTANCE_SUBDOMAIN_PROVIDERS[instanceDialogProvider]!}
+            config={INSTANCE_SUBDOMAIN_PROVIDERS[instanceDialogState.provider]!}
             onOpenChange={(open) => {
-              if (!open) setInstanceDialogProvider(null);
+              if (!open) setInstanceDialogState(null);
             }}
             onSubmit={(value) => {
-              if (!session?.access_token || !instanceDialogProvider) return;
+              if (!session?.access_token || !instanceDialogState) return;
               const cfg =
-                INSTANCE_SUBDOMAIN_PROVIDERS[instanceDialogProvider]!;
+                INSTANCE_SUBDOMAIN_PROVIDERS[instanceDialogState.provider]!;
               const url = getOAuthAuthorizeUrl(
-                instanceDialogProvider,
+                instanceDialogState.provider,
                 session.access_token,
+                instanceDialogState.replaceId
+                  ? { replaceId: instanceDialogState.replaceId }
+                  : undefined,
               );
               window.location.href = `${url}&${cfg.queryParam}=${encodeURIComponent(value)}`;
-              setInstanceDialogProvider(null);
+              setInstanceDialogState(null);
             }}
           />
         )}

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -4,14 +4,12 @@ import {
   Link2,
   Loader2,
   LogIn,
+  Plus,
   Unplug,
 } from "lucide-react";
-import { toast } from "sonner";
 import { useAuth } from "@/auth/AuthContext";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
-import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
-import { InlineConfirmButton } from "@/components/InlineConfirmButton";
 import { providerLabel, getOAuthAuthorizeUrl } from "@/lib/oauth";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -32,6 +30,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { DisconnectOAuthDialog } from "@/pages/agents/connectors/DisconnectOAuthDialog";
 
 /**
  * Config for providers that need a per-instance subdomain before the OAuth
@@ -93,22 +92,16 @@ export function ConnectedAccountsSection() {
   const { session } = useAuth();
   const { connections, isLoading, error } = useOAuthConnections();
   const { providers } = useOAuthProviders();
-  const { disconnect, isLoading: isDisconnecting } = useDisconnectOAuth();
-
-  async function handleDisconnect(provider: string) {
-    try {
-      await disconnect(provider);
-      toast.success(`${providerLabel(provider)} disconnected.`);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to disconnect.";
-      toast.error(message);
-    }
-  }
 
   const [instanceDialogProvider, setInstanceDialogProvider] = useState<
     string | null
   >(null);
+
+  const [disconnectTarget, setDisconnectTarget] = useState<{
+    id: string;
+    provider: string;
+    displayName?: string;
+  } | null>(null);
 
   function handleConnect(providerId: string) {
     if (!session?.access_token) return;
@@ -116,18 +109,42 @@ export function ConnectedAccountsSection() {
       setInstanceDialogProvider(providerId);
       return;
     }
-    // Open in same window — the callback redirects back to settings
     window.location.href = getOAuthAuthorizeUrl(
       providerId,
       session.access_token,
     );
   }
 
-  // Providers that are ready to connect but don't have an active connection
+  function handleReconnect(connectionId: string, providerId: string) {
+    if (!session?.access_token) return;
+    if (providerId in INSTANCE_SUBDOMAIN_PROVIDERS) {
+      // For instance-based providers, re-open the subdomain dialog.
+      // The replace param will be added after the subdomain is entered.
+      setInstanceDialogProvider(providerId);
+      return;
+    }
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      { replaceId: connectionId },
+    );
+  }
+
+  // Providers that are ready to connect (have credentials configured)
+  const configuredProviders = providers.filter((p) => p.has_credentials);
+
+  // Group connections by provider for display
   const connectedProviderIds = new Set(connections.map((c) => c.provider));
-  const availableProviders = providers.filter(
-    (p) => p.has_credentials && !connectedProviderIds.has(p.id),
+
+  // Providers with no connections yet — show as initial "Connect" buttons
+  const unconnectedProviders = configuredProviders.filter(
+    (p) => !connectedProviderIds.has(p.id),
   );
+
+  // Providers that already have connections — show "Add another account" buttons
+  const connectedProviderIdsWithCredentials = configuredProviders
+    .filter((p) => connectedProviderIds.has(p.id))
+    .map((p) => p.id);
 
   return (
     <Card>
@@ -161,13 +178,18 @@ export function ConnectedAccountsSection() {
           <div className="space-y-3">
             {connections.map((conn) => (
               <div
-                key={conn.provider}
+                key={conn.id}
                 className="flex items-center justify-between rounded-lg border p-4"
               >
                 <div className="space-y-0.5">
                   <p className="text-sm font-medium">
                     {providerLabel(conn.provider)}
-                    {conn.instance && (
+                    {conn.display_name && (
+                      <span className="text-muted-foreground ml-1.5 font-normal">
+                        ({conn.display_name})
+                      </span>
+                    )}
+                    {!conn.display_name && conn.instance && (
                       <span className="text-muted-foreground ml-1.5 font-normal">
                         ({conn.instance})
                       </span>
@@ -186,33 +208,64 @@ export function ConnectedAccountsSection() {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => handleConnect(conn.provider)}
+                      onClick={() => handleReconnect(conn.id, conn.provider)}
                     >
                       <LogIn className="size-4" />
                       Re-authorize
                     </Button>
                   ) : (
-                    <InlineConfirmButton
-                      confirmLabel="Disconnect"
-                      isProcessing={isDisconnecting}
-                      onConfirm={() => handleDisconnect(conn.provider)}
-                    >
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          handleReconnect(conn.id, conn.provider)
+                        }
+                      >
+                        <LogIn className="size-4" />
+                        Reconnect
+                      </Button>
                       <Button
                         variant="ghost"
                         size="icon"
                         aria-label={`Disconnect ${providerLabel(conn.provider)}`}
+                        onClick={() =>
+                          setDisconnectTarget({
+                            id: conn.id,
+                            provider: conn.provider,
+                            displayName: conn.display_name,
+                          })
+                        }
                       >
                         <Unplug className="text-muted-foreground size-4" />
                       </Button>
-                    </InlineConfirmButton>
+                    </>
                   )}
                 </div>
               </div>
             ))}
 
-            {availableProviders.length > 0 && (
+            {/* "Add another account" for providers that already have connections */}
+            {connectedProviderIdsWithCredentials.length > 0 && (
               <div className="flex flex-wrap gap-2 pt-2">
-                {availableProviders.map((provider) => (
+                {connectedProviderIdsWithCredentials.map((providerId) => (
+                  <Button
+                    key={`add-${providerId}`}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleConnect(providerId)}
+                  >
+                    <Plus className="size-4" />
+                    Add another {providerLabel(providerId)} account
+                  </Button>
+                ))}
+              </div>
+            )}
+
+            {/* "Connect" for providers with no connections yet */}
+            {unconnectedProviders.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-2">
+                {unconnectedProviders.map((provider) => (
                   <Button
                     key={provider.id}
                     variant="outline"
@@ -226,7 +279,7 @@ export function ConnectedAccountsSection() {
               </div>
             )}
 
-            {connections.length === 0 && availableProviders.length === 0 && (
+            {connections.length === 0 && configuredProviders.length === 0 && (
               <p className="text-muted-foreground py-4 text-center text-sm">
                 No OAuth providers are configured yet. Set up client credentials
                 to enable OAuth connections.
@@ -258,6 +311,18 @@ export function ConnectedAccountsSection() {
             }}
           />
         )}
+
+      {disconnectTarget && (
+        <DisconnectOAuthDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setDisconnectTarget(null);
+          }}
+          connectionId={disconnectTarget.id}
+          providerName={providerLabel(disconnectTarget.provider)}
+          displayName={disconnectTarget.displayName}
+        />
+      )}
     </Card>
   );
 }

--- a/frontend/src/pages/settings/__tests__/ConnectedAccountsSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/ConnectedAccountsSection.test.tsx
@@ -210,6 +210,7 @@ describe("ConnectedAccountsSection", () => {
     mockApiFetch(
       [
         {
+          id: "conn-123",
           provider: "google",
           scopes: ["openid"],
           status: "active",
@@ -240,9 +241,9 @@ describe("ConnectedAccountsSection", () => {
 
     await waitFor(() => {
       expect(mockDelete).toHaveBeenCalledWith(
-        "/v1/oauth/connections/{provider}",
+        "/v1/oauth/connections/{connection_id}",
         expect.objectContaining({
-          params: { path: { provider: "google" } },
+          params: { path: { connection_id: "conn-123" } },
         }),
       );
     });

--- a/spec/openapi/components/paths/oauth.yaml
+++ b/spec/openapi/components/paths/oauth.yaml
@@ -84,6 +84,18 @@ oauthAuthorize:
           type: array
           items:
             type: string
+      - name: replace
+        in: query
+        required: false
+        description: >
+          ID of an existing OAuth connection to replace (reconnect flow).
+          When set, the specified connection is deleted and replaced by the
+          new one after successful authorization. When omitted, a new
+          connection is created alongside any existing ones for the same
+          provider. The connection must belong to the authenticated user
+          and the same provider being authorized.
+        schema:
+          type: string
 
     responses:
       '307':
@@ -199,11 +211,20 @@ oauthConnections:
               $ref: '../schemas/oauth.yaml#/OAuthConnectionListResponse'
             example:
               connections:
-                - provider: "google"
+                - id: "oconn_abc123"
+                  provider: "google"
                   scopes: ["openid", "https://www.googleapis.com/auth/userinfo.email"]
                   status: "active"
                   connected_at: "2026-03-05T10:00:00Z"
-                - provider: "microsoft"
+                  display_name: "user@gmail.com"
+                - id: "oconn_def456"
+                  provider: "google"
+                  scopes: ["openid", "https://www.googleapis.com/auth/gmail.send"]
+                  status: "active"
+                  connected_at: "2026-03-06T09:00:00Z"
+                  display_name: "work@company.com"
+                - id: "oconn_ghi789"
+                  provider: "microsoft"
                   scopes: ["openid", "offline_access", "User.Read"]
                   status: "active"
                   connected_at: "2026-03-05T11:30:00Z"

--- a/spec/openapi/components/paths/oauth.yaml
+++ b/spec/openapi/components/paths/oauth.yaml
@@ -470,13 +470,15 @@ oauthProviderConfigByProvider:
 oauthDisconnect:
   delete:
     operationId: deleteOAuthConnection
-    summary: Disconnect OAuth Provider
+    summary: Disconnect OAuth Connection
     description: |
-      Disconnects an OAuth provider for the authenticated user. Deletes the
-      OAuth connection row and removes the encrypted tokens from the vault.
+      Disconnects a specific OAuth connection by its ID. Deletes the
+      OAuth connection row, removes the encrypted tokens from the vault,
+      and cascades to remove any agent-connector credential bindings that
+      reference this connection.
 
       After disconnection, any connector actions that depend on this OAuth
-      provider will fail until the user re-authorizes.
+      connection will fail until the user connects a new account.
 
       ## Security
 
@@ -490,10 +492,10 @@ oauthDisconnect:
       - SupabaseSession: []
 
     parameters:
-      - name: provider
+      - name: connection_id
         in: path
         required: true
-        description: The OAuth provider ID to disconnect
+        description: The OAuth connection ID to disconnect (e.g. "oconn_abc123")
         schema:
           type: string
 

--- a/spec/openapi/components/schemas/oauth.yaml
+++ b/spec/openapi/components/schemas/oauth.yaml
@@ -82,6 +82,13 @@ OAuthConnection:
         or shop domain for Shopify (e.g. "mystore.myshopify.com"). Omitted for
         providers with static OAuth endpoints (e.g. Google, Slack).
       example: "mycompany.zendesk.com"
+    display_name:
+      type: string
+      description: >
+        A human-readable identifier for this connection, typically the
+        authenticated user's email address. Omitted when no identifying
+        information is available.
+      example: "user@example.com"
 
 OAuthConnectionListResponse:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -5647,6 +5647,13 @@ paths:
             type: array
             items:
               type: string
+        - name: replace
+          in: query
+          required: false
+          description: |
+            ID of an existing OAuth connection to replace (reconnect flow). When set, the specified connection is deleted and replaced by the new one after successful authorization. When omitted, a new connection is created alongside any existing ones for the same provider. The connection must belong to the authenticated user and the same provider being authorized.
+          schema:
+            type: string
       responses:
         '307':
           description: Redirects to the OAuth provider's authorization endpoint
@@ -5745,13 +5752,24 @@ paths:
                 $ref: '#/components/schemas/OAuthConnectionListResponse'
               example:
                 connections:
-                  - provider: google
+                  - id: oconn_abc123
+                    provider: google
                     scopes:
                       - openid
                       - https://www.googleapis.com/auth/userinfo.email
                     status: active
                     connected_at: '2026-03-05T10:00:00Z'
-                  - provider: microsoft
+                    display_name: user@gmail.com
+                  - id: oconn_def456
+                    provider: google
+                    scopes:
+                      - openid
+                      - https://www.googleapis.com/auth/gmail.send
+                    status: active
+                    connected_at: '2026-03-06T09:00:00Z'
+                    display_name: work@company.com
+                  - id: oconn_ghi789
+                    provider: microsoft
                     scopes:
                       - openid
                       - offline_access

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -5766,16 +5766,18 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /v1/oauth/connections/{provider}:
+  /v1/oauth/connections/{connection_id}:
     delete:
       operationId: deleteOAuthConnection
-      summary: Disconnect OAuth Provider
+      summary: Disconnect OAuth Connection
       description: |
-        Disconnects an OAuth provider for the authenticated user. Deletes the
-        OAuth connection row and removes the encrypted tokens from the vault.
+        Disconnects a specific OAuth connection by its ID. Deletes the
+        OAuth connection row, removes the encrypted tokens from the vault,
+        and cascades to remove any agent-connector credential bindings that
+        reference this connection.
 
         After disconnection, any connector actions that depend on this OAuth
-        provider will fail until the user re-authorizes.
+        connection will fail until the user connects a new account.
 
         ## Security
 
@@ -5786,10 +5788,10 @@ paths:
       security:
         - SupabaseSession: []
       parameters:
-        - name: provider
+        - name: connection_id
           in: path
           required: true
-          description: The OAuth provider ID to disconnect
+          description: The OAuth connection ID to disconnect (e.g. "oconn_abc123")
           schema:
             type: string
       responses:
@@ -10512,6 +10514,11 @@ components:
           description: |
             For providers with per-instance OAuth URLs (e.g. Zendesk, Shopify), the instance identifier — subdomain for Zendesk (e.g. "mycompany.zendesk.com") or shop domain for Shopify (e.g. "mystore.myshopify.com"). Omitted for providers with static OAuth endpoints (e.g. Google, Slack).
           example: mycompany.zendesk.com
+        display_name:
+          type: string
+          description: |
+            A human-readable identifier for this connection, typically the authenticated user's email address. Omitted when no identifying information is available.
+          example: user@example.com
     OAuthConnectionListResponse:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -298,7 +298,7 @@ paths:
   /v1/oauth/connections:
     $ref: './components/paths/oauth.yaml#/oauthConnections'
 
-  /v1/oauth/connections/{provider}:
+  /v1/oauth/connections/{connection_id}:
     $ref: './components/paths/oauth.yaml#/oauthDisconnect'
 
   /v1/oauth/provider-configs:


### PR DESCRIPTION
## Summary

- **Multiple connections per provider**: Drop the `UNIQUE (user_id, provider)` constraint on `oauth_connections`, allowing users to connect multiple accounts for the same provider (e.g., two Google accounts). Added `replace_id` flow so "Reconnect" replaces a specific connection while "Add account" creates alongside existing ones.
- **Email enrichment**: Best-effort email enrichers for Google, GitHub, Microsoft, and Slack fetch the user's email after OAuth token exchange. Stored in `extra_data` and exposed as `display_name` in the API and UI.
- **Cascade disconnect warnings**: New `DisconnectOAuthDialog` warns users that disconnecting removes the credential from **all agents and connectors**. Enhanced `RemoveCredentialDialog` with similar cascade warning for API credentials.
- **Delete by connection ID**: Changed `DELETE /oauth/connections/{provider}` to `DELETE /oauth/connections/{connection_id}` for precise control when multiple connections exist per provider.

## Test plan

### Claude Code
- [x] Backend tests pass (`go test ./api/... ./db/...`)
- [x] Frontend tests pass (all 719 tests, including updated `ConnectedAccountsSection` test)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Go builds clean (`go build ./...`)

### OpenClaw
- [ ] Connect Google account A → verify shown in settings. Click "Add another account" → connect Google account B → verify both shown.
- [ ] Assign different accounts to different agents via the agent credential binding dropdown. Verify dropdown shows email (display_name).
- [ ] Click disconnect on a connection → verify warning dialog appears mentioning impact on all agents. Confirm → connection removed.
- [ ] Connect Google OAuth → verify email appears next to "Google" in settings and connector pages.
- [ ] Run migration on staging: `20260313201757_allow_multiple_oauth_connections.sql`
- [ ] Test reconnect flow: click Reconnect on an existing connection → verify it replaces that specific connection (not all connections for that provider).

https://claude.ai/code/session_01MC34FMPk5vf78bQkb53rzh