### PR TITLE
Fix OAuth account email visibility and badge contrast

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -128,7 +128,10 @@ function StatusBadge({ status }: { status: "active" | "disabled" }) {
     );
   }
   return (
-    <Badge variant="secondary" className="text-muted-foreground">
+    <Badge
+      variant="secondary"
+      className="bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+    >
       Disabled
     </Badge>
   );

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -338,7 +338,7 @@ function OAuthCredentialRow({
                     )}
                   </p>
                   <p className="text-muted-foreground text-xs">
-                    {conn.display_name && `${providerLabel(conn.provider)} · `}
+                    {conn.display_name && `${providerLabel(conn.provider)}${conn.instance ? ` (${conn.instance})` : ""} · `}
                     {conn.status === "active"
                       ? `Connected ${new Date(conn.connected_at).toLocaleDateString()}`
                       : conn.status === "needs_reauth"
@@ -734,7 +734,7 @@ function AgentCredentialBinding({
           {activeConnections.map((conn) => (
             <option key={`oauth:${conn.id}`} value={`oauth:${conn.id}`}>
               {conn.display_name
-                ? `${conn.display_name} — ${providerLabel(conn.provider)} OAuth`
+                ? `${conn.display_name} — ${providerLabel(conn.provider)} OAuth${conn.instance ? ` (${conn.instance})` : ""}`
                 : `${providerLabel(conn.provider)} OAuth`}{" "}
               (connected{" "}
               {new Date(conn.connected_at).toLocaleDateString()})

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -329,15 +329,16 @@ function OAuthCredentialRow({
                 className="bg-muted/50 flex items-center justify-between rounded-md px-3 py-2"
               >
                 <div className="min-w-0">
-                  <p className="truncate text-sm">
+                  <p className="truncate text-sm font-medium">
                     {conn.display_name || providerLabel(conn.provider)}
                     {conn.instance && !conn.display_name && (
-                      <span className="text-muted-foreground ml-1">
+                      <span className="text-muted-foreground ml-1 font-normal">
                         ({conn.instance})
                       </span>
                     )}
                   </p>
                   <p className="text-muted-foreground text-xs">
+                    {conn.display_name && `${providerLabel(conn.provider)} · `}
                     {conn.status === "active"
                       ? `Connected ${new Date(conn.connected_at).toLocaleDateString()}`
                       : conn.status === "needs_reauth"
@@ -704,7 +705,10 @@ function AgentCredentialBinding({
               Assigned
             </Badge>
           ) : (
-            <Badge variant="secondary" className="text-muted-foreground">
+            <Badge
+              variant="secondary"
+              className="bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+            >
               Using default
             </Badge>
           )}
@@ -724,8 +728,10 @@ function AgentCredentialBinding({
           <option value="">Default (auto-resolve)</option>
           {activeConnections.map((conn) => (
             <option key={`oauth:${conn.id}`} value={`oauth:${conn.id}`}>
-              {providerLabel(conn.provider)} OAuth
-              {conn.display_name ? ` — ${conn.display_name}` : ""} (connected{" "}
+              {conn.display_name
+                ? `${conn.display_name} — ${providerLabel(conn.provider)} OAuth`
+                : `${providerLabel(conn.provider)} OAuth`}{" "}
+              (connected{" "}
               {new Date(conn.connected_at).toLocaleDateString()})
             </option>
           ))}

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -182,12 +182,7 @@ export function ConnectedAccountsSection() {
               >
                 <div className="space-y-0.5">
                   <p className="text-sm font-medium">
-                    {providerLabel(conn.provider)}
-                    {conn.display_name && (
-                      <span className="text-muted-foreground ml-1.5 font-normal">
-                        ({conn.display_name})
-                      </span>
-                    )}
+                    {conn.display_name || providerLabel(conn.provider)}
                     {!conn.display_name && conn.instance && (
                       <span className="text-muted-foreground ml-1.5 font-normal">
                         ({conn.instance})
@@ -195,6 +190,7 @@ export function ConnectedAccountsSection() {
                     )}
                   </p>
                   <p className="text-muted-foreground text-xs">
+                    {conn.display_name && `${providerLabel(conn.provider)} · `}
                     {conn.scopes.length} scope
                     {conn.scopes.length !== 1 ? "s" : ""} granted &middot;
                     Connected{" "}

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -190,7 +190,7 @@ export function ConnectedAccountsSection() {
                     )}
                   </p>
                   <p className="text-muted-foreground text-xs">
-                    {conn.display_name && `${providerLabel(conn.provider)} · `}
+                    {conn.display_name && `${providerLabel(conn.provider)}${conn.instance ? ` (${conn.instance})` : ""} · `}
                     {conn.scopes.length} scope
                     {conn.scopes.length !== 1 ? "s" : ""} granted &middot;
                     Connected{" "}


### PR DESCRIPTION
## Summary
- **Email as primary text**: OAuth connections now show the email address (display_name) as the bold primary text instead of burying it in parentheses as muted/secondary text. Provider name moves to the subtitle line for context.
- **Dropdown shows email first**: The credential dropdown now leads with `email — Provider OAuth` so users can immediately identify which account they're selecting.
- **Badge contrast fix**: "Using default" and "Disabled" badges used `text-muted-foreground` on `variant="secondary"`, creating near-invisible text. Replaced with explicit `gray-100/700` (light) and `gray-800/300` (dark) for reliable contrast.

## Test plan
### Claude Code
- [x] All 721 frontend tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Audited codebase — fixed all instances of the muted-on-secondary pattern (2 total)

### OpenClaw
- [ ] Visually verify the "Using default" badge is readable in both light and dark mode
- [ ] Verify OAuth email is visible in the credential dropdown on a connector page
- [ ] Verify OAuth email shows as primary text in the settings Connected Accounts section
- [ ] Verify OAuth email shows as primary text in the connector credentials connection list

https://claude.ai/code/session_01PK8roXyoMoy15684G7pSKa