### PR TITLE
fix: scope agent credential dropdown to matching connector

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -644,9 +644,14 @@ function AgentCredentialBinding({
   const isLoading = anyLoading || bindingLoading;
   const isPending = assigning || removing;
 
-  // Build options for the dropdown
+  // Build options scoped to this connector — only show credentials whose
+  // service matches the connector ID and OAuth connections whose provider
+  // matches, so e.g. Slack creds don't appear in a Google connector dropdown.
+  const scopedCredentials = credentials.filter(
+    (c) => c.service === connectorId,
+  );
   const activeConnections = connections.filter(
-    (c) => c.status === "active" && c.id,
+    (c) => c.status === "active" && c.id && c.provider === connectorId,
   );
 
   const currentValue = binding?.credential_id
@@ -687,7 +692,7 @@ function AgentCredentialBinding({
   if (isLoading) return null;
 
   // Don't show if there are no credentials or connections to choose from
-  if (credentials.length === 0 && activeConnections.length === 0) return null;
+  if (scopedCredentials.length === 0 && activeConnections.length === 0) return null;
 
   return (
     <div className="mb-4 rounded-lg border p-3">
@@ -729,7 +734,7 @@ function AgentCredentialBinding({
               {new Date(conn.connected_at).toLocaleDateString()})
             </option>
           ))}
-          {credentials.map((cred) => (
+          {scopedCredentials.map((cred) => (
             <option key={`cred:${cred.id}`} value={`cred:${cred.id}`}>
               {cred.label ?? cred.service} (added{" "}
               {new Date(cred.created_at).toLocaleDateString()})

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- The agent credential binding dropdown was showing **all** user credentials and OAuth connections, regardless of which connector was being configured
- Now filters credentials by `service === connectorId` and OAuth connections by `provider === connectorId`
- This prevents cross-connector credential leakage in the UI (e.g. Slack API keys appearing in the Google connector dropdown)
- The backend already validated this match on assignment — this brings the frontend in line

## Test plan

### Claude Code
- [x] Frontend tests pass (721/721)
- [x] TypeScript compiles cleanly

### OpenClaw
- [ ] Manually verify: add credentials for two different services (e.g. Slack and GitHub), enable both connectors on an agent, and confirm each dropdown only shows credentials matching that connector
- [ ] Verify OAuth connections also only appear for matching providers

https://claude.ai/code/session_01NDZtZYGaSzQ4i4UcDwqJYN