### PR TITLE
Fix mobile responsive layout for card rows across all pages

### DIFF
--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -58,7 +58,7 @@ export function AgentCredentialsSection({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <CardTitle>Credentials</CardTitle>
         {!isLoading && !error && totalCount > 0 && (
           <span className="text-muted-foreground text-sm">
@@ -99,7 +99,7 @@ export function AgentCredentialsSection({
               return (
                 <div
                   key={service}
-                  className="flex items-center justify-between rounded-lg border p-3"
+                  className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="flex items-center gap-3">
                     {isConnected ? (
@@ -109,7 +109,7 @@ export function AgentCredentialsSection({
                     )}
                     <p className="text-sm font-medium">{service}</p>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
                     <span
                       className={`text-xs font-medium ${
                         isConnected

--- a/frontend/src/pages/agents/DeactivateSection.tsx
+++ b/frontend/src/pages/agents/DeactivateSection.tsx
@@ -42,8 +42,8 @@ export function DeactivateSection({ agentId }: { agentId: number }) {
           <CardTitle className="text-destructive">Danger Zone</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
               <p className="text-sm font-medium">Deactivate this agent</p>
               <p className="text-muted-foreground text-xs">
                 This will revoke all standing approvals and prevent the agent
@@ -53,6 +53,7 @@ export function DeactivateSection({ agentId }: { agentId: number }) {
             <Button
               variant="destructive"
               size="sm"
+              className="shrink-0 self-start sm:self-center"
               onClick={() => setConfirmOpen(true)}
             >
               Deactivate

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -77,7 +77,7 @@ export function ActionConfigurationsSection({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
+      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <Settings className="text-muted-foreground size-5" />
           <CardTitle>Action Configurations</CardTitle>
@@ -85,6 +85,7 @@ export function ActionConfigurationsSection({
         {configs.length > 0 && (
           <Button
             size="sm"
+            className="shrink-0 self-start sm:self-center"
             onClick={() => setAddDialogOpen(true)}
             disabled={actions.length === 0}
           >

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -269,7 +269,7 @@ function OAuthCredentialRow({
   return (
     <>
       <div className="rounded-lg border p-3">
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
@@ -299,7 +299,7 @@ function OAuthCredentialRow({
               </p>
             </div>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
             {!hasAnyConnection && (
               <Button
                 variant="outline"
@@ -516,7 +516,7 @@ function StaticCredentialRow({
   return (
     <>
       <div className="rounded-lg border p-3">
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
@@ -550,7 +550,7 @@ function StaticCredentialRow({
               )}
             </div>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
             <span
               className={`text-xs font-medium ${
                 isConnected

--- a/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
+++ b/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
@@ -109,8 +109,8 @@ export function DisableConnectorSection({
           <CardTitle className="text-destructive">Danger Zone</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
               <p className="text-sm font-medium">Disable this connector</p>
               <p className="text-muted-foreground text-xs">
                 Temporarily prevent the agent from using {connectorName}. Your
@@ -121,6 +121,7 @@ export function DisableConnectorSection({
             <Button
               variant="destructive"
               size="sm"
+              className="shrink-0 self-start sm:self-center"
               onClick={() => setDisableConfirmOpen(true)}
               disabled={isRemoving}
             >
@@ -131,8 +132,8 @@ export function DisableConnectorSection({
           {oauthProvider && (
             <>
               <div className="border-t" />
-              <div className="flex items-center justify-between">
-                <div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
                   <p className="text-sm font-medium">
                     Remove this connector
                   </p>
@@ -145,6 +146,7 @@ export function DisableConnectorSection({
                 <Button
                   variant="destructive"
                   size="sm"
+                  className="shrink-0 self-start sm:self-center"
                   disabled={isRemoving}
                   onClick={() => setRemoveConfirmOpen(true)}
                 >

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -178,9 +178,9 @@ export function ConnectedAccountsSection() {
             {connections.map((conn) => (
               <div
                 key={conn.id}
-                className="flex items-center justify-between rounded-lg border p-4"
+                className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
               >
-                <div className="space-y-0.5">
+                <div className="min-w-0 space-y-0.5">
                   <p className="text-sm font-medium">
                     {providerLabel(conn.provider)}
                     {conn.display_name && (
@@ -201,7 +201,7 @@ export function ConnectedAccountsSection() {
                     {new Date(conn.connected_at).toLocaleDateString()}
                   </p>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex shrink-0 items-center gap-2">
                   {statusBadge(conn.status)}
                   {conn.status === "needs_reauth" ? (
                     <Button

--- a/frontend/src/pages/settings/CredentialSection.tsx
+++ b/frontend/src/pages/settings/CredentialSection.tsx
@@ -44,7 +44,7 @@ export function CredentialSection() {
     <>
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-2">
               <KeyRound className="text-muted-foreground size-5" />
               <CardTitle>Credential Vault</CardTitle>
@@ -64,6 +64,7 @@ export function CredentialSection() {
               <Button
                 variant="outline"
                 size="sm"
+                className="shrink-0 self-start sm:self-center"
                 onClick={() => setAddDialogOpen(true)}
               >
                 <Plus className="size-4" />
@@ -97,16 +98,16 @@ export function CredentialSection() {
               {credentials.map((cred) => (
                 <div
                   key={cred.id}
-                  className="flex items-center justify-between rounded-lg border p-4"
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
-                  <div className="space-y-0.5">
+                  <div className="min-w-0 space-y-0.5">
                     <p className="text-sm font-medium">{cred.service}</p>
                     <p className="text-xs text-muted-foreground">
                       {cred.label ?? "Credential"} &middot; Added{" "}
                       {new Date(cred.created_at).toLocaleDateString()}
                     </p>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2">
                     <Badge variant="secondary">Active</Badge>
                     <InlineConfirmButton
                       confirmLabel="Delete"

--- a/frontend/src/pages/settings/DangerZoneSection.tsx
+++ b/frontend/src/pages/settings/DangerZoneSection.tsx
@@ -38,8 +38,8 @@ export function DangerZoneSection() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-between rounded-lg border border-destructive/30 p-4">
-            <div className="space-y-0.5">
+          <div className="flex flex-col gap-3 rounded-lg border border-destructive/30 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 space-y-0.5">
               <p className="text-sm font-medium">Delete Account</p>
               <p className="text-xs text-muted-foreground">
                 Permanently delete your account and all associated data.
@@ -48,6 +48,7 @@ export function DangerZoneSection() {
             <Button
               variant="destructive"
               size="sm"
+              className="shrink-0 self-start sm:self-center"
               onClick={() => setDialogOpen(true)}
             >
               Delete Account

--- a/frontend/src/pages/settings/OAuthProviderSection.tsx
+++ b/frontend/src/pages/settings/OAuthProviderSection.tsx
@@ -83,9 +83,9 @@ export function OAuthProviderSection() {
               {configuredByoaProviders.map((config) => (
                 <div
                   key={config.provider}
-                  className="flex items-center justify-between rounded-lg border p-4"
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
-                  <div className="space-y-0.5">
+                  <div className="min-w-0 space-y-0.5">
                     <div className="flex items-center gap-2">
                       <KeyRound className="text-muted-foreground size-4" />
                       <p className="text-sm font-medium">
@@ -97,7 +97,7 @@ export function OAuthProviderSection() {
                       {new Date(config.created_at).toLocaleDateString()}
                     </p>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2">
                     <Badge variant="secondary">BYOA</Badge>
                     <InlineConfirmButton
                       confirmLabel="Remove"
@@ -119,9 +119,9 @@ export function OAuthProviderSection() {
               {unconfiguredProviders.map((provider) => (
                 <div
                   key={provider.id}
-                  className="flex items-center justify-between rounded-lg border border-dashed p-4"
+                  className="flex flex-col gap-3 rounded-lg border border-dashed p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
-                  <div className="space-y-0.5">
+                  <div className="min-w-0 space-y-0.5">
                     <p className="text-sm font-medium">
                       {providerLabel(provider.id)}
                     </p>
@@ -132,6 +132,7 @@ export function OAuthProviderSection() {
                   <Button
                     variant="outline"
                     size="sm"
+                    className="shrink-0 self-start sm:self-center"
                     onClick={() =>
                       setBYOADialog({
                         provider: provider.id,

--- a/frontend/src/pages/settings/PaymentMethodSection.tsx
+++ b/frontend/src/pages/settings/PaymentMethodSection.tsx
@@ -168,7 +168,7 @@ export function PaymentMethodSection() {
     <>
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-2">
               <CreditCard className="text-muted-foreground size-5" />
               <CardTitle>Payment Methods</CardTitle>
@@ -182,6 +182,7 @@ export function PaymentMethodSection() {
             <Button
               variant="outline"
               size="sm"
+              className="shrink-0 self-start sm:self-center"
               onClick={() => setAddDialogOpen(true)}
               disabled={atCardLimit}
               title={
@@ -220,7 +221,7 @@ export function PaymentMethodSection() {
               {paymentMethods.map((pm) => (
                 <div
                   key={pm.id}
-                  className="flex items-center justify-between rounded-lg border p-4"
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="min-w-0 flex-1 space-y-0.5">
                     <div className="flex items-center gap-2">

--- a/frontend/src/pages/settings/SecuritySection.tsx
+++ b/frontend/src/pages/settings/SecuritySection.tsx
@@ -122,9 +122,9 @@ export function SecuritySection() {
               {factors.map((factor) => (
                 <div
                   key={factor.id}
-                  className="flex items-center justify-between rounded-lg border p-4"
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
-                  <div className="space-y-0.5">
+                  <div className="min-w-0 space-y-0.5">
                     <p className="text-sm font-medium">
                       {factor.friendly_name ?? "Authenticator App"}
                     </p>

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- Card rows with text + action buttons were using `flex items-center justify-between`, which crammed all content onto a single line on mobile viewports — making text unreadable and buttons hard to tap.
- Changed to `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` so rows stack vertically on mobile and stay horizontal on larger screens.
- Applied consistently across 11 files: connector config page, settings pages (credentials, connected accounts, security, payment methods, OAuth providers, danger zone), agent detail pages (credentials, deactivate section), and action configurations.

## Test plan
### Claude Code
- [x] Frontend tests pass (721/721)
- [x] TypeScript compilation passes with no errors
- [ ] Visually verify connector config page on mobile viewport (< 640px)
- [ ] Visually verify settings page sections on mobile viewport

### OpenClaw
- [ ] Manual check on actual mobile device via ngrok
- [ ] Verify no layout regressions on desktop viewports
- [ ] Confirm buttons remain easy to tap on mobile

https://claude.ai/code/session_014bV7QDW7TfAKtqvGqHZjAN