### PR TITLE
Remove credential auto-resolve — require explicit binding

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -219,204 +219,58 @@ func validatePaymentMethod(ctx context.Context, deps *Deps, userID string, pp *p
 	}, nil
 }
 
-// resolveCredentialsWithFallback tries to resolve credentials in priority order.
-// For connectors supporting multiple auth methods (e.g. OAuth + API key), it
-// tries OAuth first, then falls back to static credentials if the user hasn't
-// connected their OAuth account.
+// resolveCredentialsWithFallback resolves credentials for a connector action.
+// It requires an explicit credential binding on the agent — no auto-resolve.
+// If no binding exists, it returns a validation error prompting the user to
+// assign a credential in the agent's connector settings.
 func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
-	// If there's a built-in OAuth provider for this connector but the manifest
-	// only declares static credentials (e.g. Shopify), synthesize an oauth2
-	// entry so OAuth is tried first with static as fallback.
-	hasExplicitOAuth := false
-	for _, rc := range reqCreds {
-		if rc.AuthType == "oauth2" {
-			hasExplicitOAuth = true
-			break
-		}
-	}
-	if !hasExplicitOAuth && deps.OAuthProviders != nil {
-		if _, providerExists := deps.OAuthProviders.Get(connectorID); providerExists {
-			reqCreds = append([]db.RequiredCredential{{
-				AuthType:      "oauth2",
-				OAuthProvider: &connectorID,
-			}}, reqCreds...)
-		}
-	}
-
 	if len(reqCreds) == 0 {
 		return connectors.NewCredentials(nil), nil
 	}
 
-	// Check for an agent-specific credential binding. If one exists, use it
-	// directly instead of falling through to user-global resolution.
-	if agentID > 0 {
-		binding, err := db.GetAgentConnectorCredential(ctx, deps.DB, agentID, connectorID)
-		if err != nil {
-			log.Printf("resolve agent connector credential: %v", err)
-			// Fall through to global resolution on lookup error.
-		} else if binding != nil {
-			if binding.OAuthConnectionID != nil {
-				conn, oauthErr := db.GetOAuthConnectionByID(ctx, deps.DB, *binding.OAuthConnectionID)
-				if oauthErr != nil {
-					return connectors.Credentials{}, fmt.Errorf("look up bound OAuth connection: %w", oauthErr)
-				}
-				if conn == nil {
-					return connectors.Credentials{}, &connectors.ValidationError{
-						Message: "bound OAuth connection no longer exists — reassign credentials for this connector",
-					}
-				}
-				// Verify the bound connection belongs to the executing user.
-				// Without this, a binding could reference another user's connection.
-				if conn.UserID != userID {
-					return connectors.Credentials{}, &connectors.ValidationError{
-						Message: "bound OAuth connection does not belong to this user",
-					}
-				}
-				// Use the bound connection directly (not a provider re-query)
-				// so the specific oauth_connection_id in the binding is honoured.
-				return resolveOAuthCredentialsFromConnection(ctx, deps, conn)
-			}
-			if binding.CredentialID != nil {
-				creds, credErr := resolveStaticCredentialByID(ctx, deps, *binding.CredentialID)
-				if credErr != nil {
-					return connectors.Credentials{}, credErr
-				}
-				return creds, nil
-			}
+	// Require an explicit credential binding. No auto-resolve — the user must
+	// assign a credential to the agent+connector before it can execute.
+	if agentID == 0 {
+		return connectors.Credentials{}, &connectors.ValidationError{
+			Message: "no credential assigned — assign a credential to this connector before running actions",
 		}
 	}
 
-	// Single credential type: use the existing path directly.
-	if len(reqCreds) == 1 {
-		rc := reqCreds[0]
-		if rc.AuthType == "oauth2" {
-			return resolveOAuthCredentials(ctx, deps, userID, &rc)
-		}
-		return resolveStaticCredentials(ctx, deps, userID, actionType)
+	binding, err := db.GetAgentConnectorCredential(ctx, deps.DB, agentID, connectorID)
+	if err != nil {
+		return connectors.Credentials{}, fmt.Errorf("look up agent connector credential: %w", err)
 	}
-
-	// Multiple credential types: try OAuth first, fall back to static.
-	for _, rc := range reqCreds {
-		if rc.AuthType == "oauth2" {
-			creds, err := resolveOAuthCredentials(ctx, deps, userID, &rc)
-			if err == nil {
-				return creds, nil
-			}
-			var oauthErr *connectors.OAuthRefreshError
-			if errors.As(err, &oauthErr) {
-				// For implicit OAuth (system-injected, not declared in the
-				// connector manifest), any OAuth failure should fall back to
-				// static credentials — the user's primary auth was always static.
-				if !hasExplicitOAuth {
-					continue
-				}
-				// For explicit OAuth, only fall back when the user has no
-				// connection at all. If the connection exists but needs
-				// re-auth or refresh failed, fail immediately so the user
-				// knows to reconnect.
-				if oauthErr.NotConnected {
-					continue
-				}
-			}
-			return connectors.Credentials{}, err
+	if binding == nil {
+		return connectors.Credentials{}, &connectors.ValidationError{
+			Message: "no credential assigned — go to the agent's connector settings and assign a credential",
 		}
 	}
 
-	// No OAuth connection available — fall back to static credentials.
-	for _, rc := range reqCreds {
-		if rc.AuthType != "oauth2" {
-			creds, err := resolveStaticCredentialsByService(ctx, deps, userID, rc.Service)
-			if err == nil {
-				return creds, nil
-			}
-			// If the specific static credential isn't found either, continue
-			// to try others or fall through to the final error.
-			var valErr *connectors.ValidationError
-			if errors.As(err, &valErr) {
-				continue
-			}
-			return connectors.Credentials{}, err
+	if binding.OAuthConnectionID != nil {
+		conn, oauthErr := db.GetOAuthConnectionByID(ctx, deps.DB, *binding.OAuthConnectionID)
+		if oauthErr != nil {
+			return connectors.Credentials{}, fmt.Errorf("look up bound OAuth connection: %w", oauthErr)
 		}
+		if conn == nil {
+			return connectors.Credentials{}, &connectors.ValidationError{
+				Message: "bound OAuth connection no longer exists — reassign credentials for this connector",
+			}
+		}
+		// Verify the bound connection belongs to the executing user.
+		if conn.UserID != userID {
+			return connectors.Credentials{}, &connectors.ValidationError{
+				Message: "bound OAuth connection does not belong to this user",
+			}
+		}
+		return resolveOAuthCredentialsFromConnection(ctx, deps, conn)
+	}
+	if binding.CredentialID != nil {
+		return resolveStaticCredentialByID(ctx, deps, *binding.CredentialID)
 	}
 
-	// Build a helpful message listing which credential options are available.
-	var methods []string
-	for _, rc := range reqCreds {
-		if rc.AuthType == "oauth2" {
-			provider := "OAuth"
-			if rc.OAuthProvider != nil {
-				provider = *rc.OAuthProvider + " OAuth"
-			}
-			methods = append(methods, provider+" (Settings → Connected Accounts)")
-		} else {
-			methods = append(methods, rc.Service+" "+rc.AuthType)
-		}
-	}
 	return connectors.Credentials{}, &connectors.ValidationError{
-		Message: fmt.Sprintf("no credentials available — configure one of: %s", strings.Join(methods, ", ")),
+		Message: "credential binding is incomplete — reassign a credential for this connector",
 	}
-}
-
-// resolveStaticCredentialsByService fetches and decrypts static credentials for
-// a specific service. Used when falling back from OAuth to API key.
-func resolveStaticCredentialsByService(ctx context.Context, deps *Deps, userID, service string) (connectors.Credentials, error) {
-	return decryptServiceCredentials(ctx, deps, userID, service)
-}
-
-// resolveStaticCredentials fetches and decrypts static credentials (api_key, basic, custom)
-// for the given action type.
-func resolveStaticCredentials(ctx context.Context, deps *Deps, userID, actionType string) (connectors.Credentials, error) {
-	var zero connectors.Credentials
-	services, err := db.GetRequiredServicesByActionType(ctx, deps.DB, actionType)
-	if err != nil {
-		return zero, fmt.Errorf("look up required services: %w", err)
-	}
-	credMap := make(map[string]string, len(services))
-	for _, service := range services {
-		creds, err := decryptServiceCredentials(ctx, deps, userID, service)
-		if err != nil {
-			return connectors.Credentials{}, err
-		}
-		// Merge into the combined map (multi-service connectors need all credentials).
-		for k, v := range creds.ToMap() {
-			credMap[k] = v
-		}
-	}
-	return connectors.NewCredentials(credMap), nil
-}
-
-// decryptServiceCredentials fetches and decrypts credentials for a single
-// service from the vault. Shared by resolveStaticCredentials (multi-service)
-// and resolveStaticCredentialsByService (single-service fallback).
-func decryptServiceCredentials(ctx context.Context, deps *Deps, userID, service string) (connectors.Credentials, error) {
-	var zero connectors.Credentials
-	if deps.Vault == nil {
-		return zero, fmt.Errorf("credential vault is not configured but connector requires service %q", service)
-	}
-	decrypted, err := db.GetDecryptedCredentials(ctx, deps.DB, deps.Vault.ReadSecret, userID, service, nil)
-	if err != nil {
-		var credErr *db.CredentialError
-		if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
-			return zero, &connectors.ValidationError{
-				Message: fmt.Sprintf("no credentials stored for service %q", service),
-			}
-		}
-		return zero, fmt.Errorf("decrypt credentials for service %q: %w", service, err)
-	}
-	credMap := make(map[string]string, len(decrypted))
-	for k, v := range decrypted {
-		switch vv := v.(type) {
-		case string:
-			credMap[k] = vv
-		default:
-			b, jsonErr := json.Marshal(v)
-			if jsonErr != nil {
-				return zero, fmt.Errorf("marshal credential %q for service %q: %w", k, service, jsonErr)
-			}
-			credMap[k] = string(b)
-		}
-	}
-	return connectors.NewCredentials(credMap), nil
 }
 
 // resolveStaticCredentialByID fetches and decrypts a specific credential by its
@@ -461,62 +315,6 @@ func resolveStaticCredentialByID(ctx context.Context, deps *Deps, credentialID s
 	return connectors.NewCredentials(credMap), nil
 }
 
-// resolveOAuthCredentials looks up the user's OAuth connection for the required
-// provider, refreshes the token if it's expired or near-expiry, and returns
-// credentials containing the valid access token.
-func resolveOAuthCredentials(ctx context.Context, deps *Deps, userID string, reqCred *db.RequiredCredential) (connectors.Credentials, error) {
-	var zero connectors.Credentials
-	if deps.Vault == nil {
-		return zero, fmt.Errorf("credential vault is not configured but connector requires OAuth credentials")
-	}
-	if deps.OAuthProviders == nil {
-		return zero, fmt.Errorf("OAuth provider registry is not configured")
-	}
-
-	providerID := ""
-	if reqCred.OAuthProvider != nil {
-		providerID = *reqCred.OAuthProvider
-	}
-	if providerID == "" {
-		return zero, &connectors.ValidationError{
-			Message: "connector requires OAuth but no oauth_provider is configured",
-		}
-	}
-
-	// Look up the user's OAuth connections for this provider. Multiple
-	// connections may exist (e.g. two Google accounts). Use the most recently
-	// created active connection as the default when no agent binding is set.
-	conns, err := db.GetOAuthConnectionsByProvider(ctx, deps.DB, userID, providerID)
-	if err != nil {
-		return zero, fmt.Errorf("look up OAuth connections for provider %q: %w", providerID, err)
-	}
-	if len(conns) == 0 {
-		return zero, &connectors.OAuthRefreshError{
-			Provider:     providerID,
-			Message:      fmt.Sprintf("no OAuth connection for provider %q — user must connect via Settings", providerID),
-			NotConnected: true,
-		}
-	}
-
-	// Pick the first active connection (ordered by created_at DESC).
-	var conn *db.OAuthConnection
-	for i := range conns {
-		if conns[i].Status == db.OAuthStatusActive {
-			conn = &conns[i]
-			break
-		}
-	}
-	if conn == nil {
-		// All connections exist but none are active.
-		return zero, &connectors.OAuthRefreshError{
-			Provider: providerID,
-			Message:  fmt.Sprintf("OAuth connection for %q has status %q — user must re-authorize", providerID, conns[0].Status),
-		}
-	}
-
-	return credentialsFromOAuthConnection(ctx, deps, conn)
-}
-
 // resolveOAuthCredentialsFromConnection resolves credentials from a specific
 // OAuth connection (already fetched by ID). This is used by agent-specific
 // credential bindings to honour the exact bound connection rather than
@@ -533,10 +331,8 @@ func resolveOAuthCredentialsFromConnection(ctx context.Context, deps *Deps, conn
 	return credentialsFromOAuthConnection(ctx, deps, conn)
 }
 
-// credentialsFromOAuthConnection is the shared implementation for building
-// credentials from an OAuthConnection. Both resolveOAuthCredentials (provider
-// lookup path) and resolveOAuthCredentialsFromConnection (agent binding path)
-// delegate here after their own connection lookup and dependency checks.
+// credentialsFromOAuthConnection builds credentials from an OAuthConnection.
+// resolveOAuthCredentialsFromConnection delegates here after dependency checks.
 //
 // It validates the connection status, refreshes the token if near-expiry,
 // reads the access token from the vault, and merges provider extra data.

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -42,8 +42,8 @@ func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, user
 	}
 
 	// Look up all required credentials for this action's connector.
-	// A connector may support multiple auth methods (e.g. both oauth2 and api_key).
-	// We try OAuth first; if the user has no OAuth connection, fall back to static credentials.
+	// Credentials must be explicitly bound to the agent+connector pair;
+	// see resolveCredentialsWithFallback for details.
 	reqCreds, err := db.GetRequiredCredentialsByActionType(ctx, deps.DB, actionType)
 	if err != nil {
 		return nil, fmt.Errorf("look up required credentials: %w", err)
@@ -265,7 +265,7 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 		return resolveOAuthCredentialsFromConnection(ctx, deps, conn)
 	}
 	if binding.CredentialID != nil {
-		return resolveStaticCredentialByID(ctx, deps, *binding.CredentialID)
+		return resolveStaticCredentialByID(ctx, deps, userID, *binding.CredentialID)
 	}
 
 	return connectors.Credentials{}, &connectors.ValidationError{
@@ -274,13 +274,25 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 }
 
 // resolveStaticCredentialByID fetches and decrypts a specific credential by its
-// ID (from the agent_connector_credentials binding). This bypasses the
-// service-based lookup and goes straight to the vault.
-func resolveStaticCredentialByID(ctx context.Context, deps *Deps, credentialID string) (connectors.Credentials, error) {
+// ID (from the agent_connector_credentials binding). Verifies the credential
+// belongs to the executing user before decrypting.
+func resolveStaticCredentialByID(ctx context.Context, deps *Deps, userID, credentialID string) (connectors.Credentials, error) {
 	var zero connectors.Credentials
 	if deps.Vault == nil {
 		return zero, fmt.Errorf("credential vault is not configured")
 	}
+
+	// Verify the credential belongs to the executing user (defense-in-depth).
+	owned, err := db.CredentialBelongsToUser(ctx, deps.DB, credentialID, userID)
+	if err != nil {
+		return zero, fmt.Errorf("check credential ownership: %w", err)
+	}
+	if !owned {
+		return zero, &connectors.ValidationError{
+			Message: "bound credential does not belong to this user",
+		}
+	}
+
 	vaultSecretID, err := db.GetVaultSecretIDByCredentialID(ctx, deps.DB, credentialID)
 	if err != nil {
 		var credErr *db.CredentialError

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -23,6 +23,7 @@ type oauthExecFixture struct {
 	TX       db.DBTX
 	Deps     *Deps
 	UserID   string
+	AgentID  int64
 	Vault    *vault.MockVaultStore
 	ConnReg  *connectors.Registry
 	OAuthReg *oauth.Registry
@@ -75,10 +76,14 @@ func setupOAuthExecutionTest(t *testing.T, opts oauthExecOpts) oauthExecFixture 
 	testhelper.InsertConnectorAction(t, tx, connID, actionType, "Test Action")
 	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, provider, provider, nil)
 
+	// Agent + agent_connector (required for credential resolution).
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
 	// Vault.
 	v := vault.NewMockVaultStore()
 
-	// OAuth connection (optional).
+	// OAuth connection (optional) + credential binding.
 	if opts.Connection != nil {
 		connOAuthID := testhelper.GenerateID(t, "oconn_")
 		// Default scopes to empty array to satisfy NOT NULL constraint.
@@ -86,6 +91,20 @@ func setupOAuthExecutionTest(t *testing.T, opts oauthExecOpts) oauthExecFixture 
 			opts.Connection.Scopes = []string{}
 		}
 		testhelper.InsertOAuthConnectionFull(t, tx, connOAuthID, uid, provider, *opts.Connection)
+
+		// Create an explicit credential binding to this OAuth connection.
+		conn, connErr := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, provider)
+		if connErr != nil {
+			t.Fatalf("get oauth connection: %v", connErr)
+		}
+		bindingID := testhelper.GenerateID(t, "accr_")
+		_, bindErr := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+			ID: bindingID, AgentID: agentID, ConnectorID: connID,
+			ApproverID: uid, OAuthConnectionID: &conn.ID,
+		})
+		if bindErr != nil {
+			t.Fatalf("upsert binding: %v", bindErr)
+		}
 	}
 
 	// Connector registry.
@@ -128,6 +147,7 @@ func setupOAuthExecutionTest(t *testing.T, opts oauthExecOpts) oauthExecFixture 
 		TX:       tx,
 		Deps:     deps,
 		UserID:   uid,
+		AgentID:  agentID,
 		Vault:    v,
 		ConnReg:  reg,
 		OAuthReg: oauthReg,
@@ -225,7 +245,7 @@ func TestExecuteConnectorAction_OAuthPath_Success(t *testing.T) {
 		t.Fatalf("update tokens: %v", err)
 	}
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -242,41 +262,34 @@ func TestExecuteConnectorAction_OAuthPath_Success(t *testing.T) {
 	}
 }
 
-func TestExecuteConnectorAction_OAuthPath_NoConnection(t *testing.T) {
+func TestExecuteConnectorAction_OAuthPath_NoConnection_NoBinding(t *testing.T) {
 	t.Parallel()
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{
-		// No Connection — tests the "user hasn't connected" case.
+		// No Connection — no binding will be created either.
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
-		t.Fatal("expected error when no OAuth connection exists")
+		t.Fatal("expected error when no credential binding exists")
 	}
-	if !connectors.IsOAuthRefreshError(err) {
-		t.Errorf("expected OAuthRefreshError, got %T: %v", err, err)
-	}
-	// Verify the error message mentions the provider so agents can display helpful info.
-	if !strings.Contains(err.Error(), "google") {
-		t.Errorf("expected error to mention provider name, got: %s", err.Error())
+	// Without a binding, the error should tell the user to assign a credential.
+	if !strings.Contains(err.Error(), "no credential assigned") {
+		t.Errorf("expected 'no credential assigned' error, got: %v", err)
 	}
 }
 
-// TestExecuteConnectorAction_DualAuth_FallbackToAPIKey verifies that when a
-// connector supports both OAuth and API key, and the user has no OAuth connection
-// but has an API key credential, execution succeeds using the API key.
-func TestExecuteConnectorAction_DualAuth_FallbackToAPIKey(t *testing.T) {
+// TestExecuteConnectorAction_DualAuth_NoBinding_ReturnsError verifies that when a
+// connector supports both OAuth and API key, but no credential binding exists,
+// execution fails with a clear error instead of auto-resolving.
+func TestExecuteConnectorAction_DualAuth_NoBinding_ReturnsError(t *testing.T) {
 	t.Parallel()
 
-	var capturedCreds connectors.Credentials
 	f := setupOAuthExecutionTest(t, oauthExecOpts{
 		ConnectorID: "testnotion",
 		ActionType:  "testnotion.search",
 		Provider:    "notion",
-		// No OAuth connection — will trigger fallback.
-		OnExec: func(creds connectors.Credentials) {
-			capturedCreds = creds
-		},
+		// No OAuth connection — no binding will be created.
 	})
 
 	// Add a static api_key credential alongside the OAuth one.
@@ -288,13 +301,13 @@ func TestExecuteConnectorAction_DualAuth_FallbackToAPIKey(t *testing.T) {
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, f.TX, credID, f.UserID, "testnotion", vaultID)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
-	if err != nil {
-		t.Fatalf("expected fallback to API key, got error: %v", err)
+	// Without a binding, execution should fail even though credentials exist.
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
+	if err == nil {
+		t.Fatal("expected error when no credential binding exists")
 	}
-
-	if token, ok := capturedCreds.Get("api_key"); !ok || token != "ntn_test_key_123" {
-		t.Errorf("expected api_key=ntn_test_key_123, got %q (ok=%v)", token, ok)
+	if !strings.Contains(err.Error(), "no credential assigned") {
+		t.Errorf("expected 'no credential assigned' error, got: %v", err)
 	}
 }
 
@@ -321,7 +334,7 @@ func TestExecuteConnectorAction_DualAuth_NeedsReauth_NoFallback(t *testing.T) {
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, f.TX, credID, f.UserID, "testnotion", vaultID)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for needs_reauth — should NOT fall back to API key")
 	}
@@ -337,7 +350,7 @@ func TestExecuteConnectorAction_OAuthPath_NeedsReauth(t *testing.T) {
 		Connection: &testhelper.OAuthConnectionOpts{Status: "needs_reauth"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for needs_reauth connection")
 	}
@@ -354,7 +367,7 @@ func TestExecuteConnectorAction_OAuthPath_RevokedConnection(t *testing.T) {
 		Connection: &testhelper.OAuthConnectionOpts{Status: "revoked"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.list_emails", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.list_emails", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for revoked connection")
 	}
@@ -368,7 +381,7 @@ func TestExecuteConnectorAction_OAuthPath_NoVault(t *testing.T) {
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{NoVault: true})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when vault is nil")
 	}
@@ -379,7 +392,7 @@ func TestExecuteConnectorAction_OAuthPath_NoOAuthRegistry(t *testing.T) {
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{NoOAuthRegistry: true})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when OAuth registry is nil")
 	}
@@ -398,7 +411,7 @@ func TestExecuteConnectorAction_OAuthPath_ExpiredTokenNoRefreshToken(t *testing.
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, &pastExpiry)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error for expired token without refresh token")
 	}
@@ -431,7 +444,7 @@ func TestExecuteConnectorAction_OAuthPath_NonExpiredTokenSkipsRefresh(t *testing
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, &farFuture)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -462,7 +475,7 @@ func TestExecuteConnectorAction_OAuthPath_NilTokenExpirySkipsRefresh(t *testing.
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, nil)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -520,7 +533,7 @@ func TestExecuteConnectorAction_OAuthPath_RefreshesExpiredToken(t *testing.T) {
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, &refreshVaultID, &pastExpiry)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -590,7 +603,7 @@ func TestExecuteConnectorAction_OAuthPath_RefreshFailsTokenRevoked(t *testing.T)
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, &refreshVaultID, &pastExpiry)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when refresh token is revoked")
 	}
@@ -605,22 +618,85 @@ func TestExecuteConnectorAction_OAuthPath_RefreshFailsTokenRevoked(t *testing.T)
 	}
 }
 
-// ── resolveCredentialsWithFallback: multi-credential fallback ────────────────
+// ── resolveCredentialsWithFallback: no auto-resolve ─────────────────────────
 
-func TestResolveCredentialsWithFallback_OAuthFallsBackToAPIKey(t *testing.T) {
+func TestResolveCredentialsWithFallback_NoAgentID_ReturnsError(t *testing.T) {
 	t.Parallel()
 
-	// Set up a connector with BOTH OAuth and API key credentials, but
-	// no OAuth connection — should fall back to the API key.
+	// agentID=0 should always return an error — credentials require
+	// an explicit agent binding.
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 
-	connID := "trkfb"
+	connID := "trkno"
 	testhelper.InsertConnector(t, tx, connID)
 	testhelper.InsertConnectorAction(t, tx, connID, connID+".do_thing", "Do Thing")
-	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID+"_oauth", connID, nil)
 	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore()}
+
+	reqCreds, err := db.GetRequiredCredentialsByActionType(t.Context(), tx, connID+".do_thing")
+	if err != nil {
+		t.Fatalf("get creds: %v", err)
+	}
+
+	_, err = resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".do_thing", connID, reqCreds)
+	if err == nil {
+		t.Fatal("expected error when agentID is 0")
+	}
+	if !strings.Contains(err.Error(), "no credential assigned") {
+		t.Errorf("expected 'no credential assigned' error, got: %v", err)
+	}
+}
+
+func TestResolveCredentialsWithFallback_NoBinding_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Agent exists but has no credential binding — should return an error
+	// instead of auto-resolving.
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "trknb"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".do_thing", "Do Thing")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore()}
+
+	reqCreds, err := db.GetRequiredCredentialsByActionType(t.Context(), tx, connID+".do_thing")
+	if err != nil {
+		t.Fatalf("get creds: %v", err)
+	}
+
+	_, err = resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, reqCreds)
+	if err == nil {
+		t.Fatal("expected error when no credential binding exists")
+	}
+	if !strings.Contains(err.Error(), "no credential assigned") {
+		t.Errorf("expected 'no credential assigned' error, got: %v", err)
+	}
+}
+
+func TestResolveCredentialsWithFallback_WithStaticBinding_Works(t *testing.T) {
+	t.Parallel()
+
+	// Agent has an explicit static credential binding — should resolve.
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "trksb"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".do_thing", "Do Thing")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
 
 	v := vault.NewMockVaultStore()
 	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-api-key"})
@@ -628,20 +704,24 @@ func TestResolveCredentialsWithFallback_OAuthFallsBackToAPIKey(t *testing.T) {
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
 
-	oauthReg := oauth.NewRegistry()
-	_ = oauthReg.Register(oauth.Provider{
-		ID: connID, AuthorizeURL: "https://example.com/auth", TokenURL: "https://example.com/token",
-		ClientID: "cid", ClientSecret: "cs", Source: oauth.SourceBuiltIn,
+	// Create an explicit binding.
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, err := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: connID,
+		ApproverID: uid, CredentialID: &credID,
 	})
+	if err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
 
-	deps := &Deps{DB: tx, Vault: v, OAuthProviders: oauthReg}
+	deps := &Deps{DB: tx, Vault: v}
 
 	reqCreds, err := db.GetRequiredCredentialsByActionType(t.Context(), tx, connID+".do_thing")
 	if err != nil {
 		t.Fatalf("get creds: %v", err)
 	}
 
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".do_thing", connID, reqCreds)
+	creds, err := resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, reqCreds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -651,21 +731,22 @@ func TestResolveCredentialsWithFallback_OAuthFallsBackToAPIKey(t *testing.T) {
 	}
 }
 
-func TestResolveCredentialsWithFallback_OAuthSucceedsWhenAvailable(t *testing.T) {
+func TestResolveCredentialsWithFallback_WithOAuthBinding_Works(t *testing.T) {
 	t.Parallel()
 
-	// Set up a connector with BOTH OAuth and API key, WITH an active
-	// OAuth connection — should use OAuth, not fall back.
+	// Agent has an explicit OAuth connection binding — should resolve.
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 
-	connID := "trkoau"
+	connID := "trkob"
 	provider := connID
 	testhelper.InsertConnector(t, tx, connID)
 	testhelper.InsertConnectorAction(t, tx, connID, connID+".do_thing", "Do Thing")
 	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID+"_oauth", provider, nil)
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
 
 	v := vault.NewMockVaultStore()
 	accessVaultID, _ := v.CreateSecret(t.Context(), tx, "access", []byte("oauth-access-token"))
@@ -674,8 +755,8 @@ func TestResolveCredentialsWithFallback_OAuthSucceedsWhenAvailable(t *testing.T)
 	futureExpiry := time.Now().Add(1 * time.Hour)
 	connOAuthID := testhelper.GenerateID(t, "oconn_")
 	testhelper.InsertOAuthConnectionFull(t, tx, connOAuthID, uid, provider, testhelper.OAuthConnectionOpts{
-		Status:  "active",
-		Scopes:  []string{},
+		Status: "active",
+		Scopes: []string{},
 	})
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, provider)
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), tx, conn.ID, uid, accessVaultID, nil, &futureExpiry)
@@ -686,6 +767,16 @@ func TestResolveCredentialsWithFallback_OAuthSucceedsWhenAvailable(t *testing.T)
 		ClientID: "cid", ClientSecret: "cs", Source: oauth.SourceBuiltIn,
 	})
 
+	// Create an explicit binding to the OAuth connection.
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, err := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: connID,
+		ApproverID: uid, OAuthConnectionID: &conn.ID,
+	})
+	if err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
 	deps := &Deps{DB: tx, Vault: v, OAuthProviders: oauthReg}
 
 	reqCreds, err := db.GetRequiredCredentialsByActionType(t.Context(), tx, connID+".do_thing")
@@ -693,7 +784,7 @@ func TestResolveCredentialsWithFallback_OAuthSucceedsWhenAvailable(t *testing.T)
 		t.Fatalf("get creds: %v", err)
 	}
 
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".do_thing", connID, reqCreds)
+	creds, err := resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, reqCreds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -703,43 +794,9 @@ func TestResolveCredentialsWithFallback_OAuthSucceedsWhenAvailable(t *testing.T)
 	}
 }
 
-func TestResolveCredentialsWithFallback_BothFail_ReturnsError(t *testing.T) {
-	t.Parallel()
+// ── executeConnectorAction: static credential path with binding ─────────────
 
-	// No OAuth connection AND no API key stored — both fail.
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "trkbf"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, connID+".do_thing", "Do Thing")
-	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID+"_oauth", connID, nil)
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
-
-	v := vault.NewMockVaultStore()
-	oauthReg := oauth.NewRegistry()
-	_ = oauthReg.Register(oauth.Provider{
-		ID: connID, AuthorizeURL: "https://example.com/auth", TokenURL: "https://example.com/token",
-		ClientID: "cid", ClientSecret: "cs", Source: oauth.SourceBuiltIn,
-	})
-
-	deps := &Deps{DB: tx, Vault: v, OAuthProviders: oauthReg}
-
-	reqCreds, err := db.GetRequiredCredentialsByActionType(t.Context(), tx, connID+".do_thing")
-	if err != nil {
-		t.Fatalf("get creds: %v", err)
-	}
-
-	_, err = resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".do_thing", connID, reqCreds)
-	if err == nil {
-		t.Fatal("expected error when both auth methods fail")
-	}
-}
-
-// ── executeConnectorAction: static credential path ──────────────────────────
-
-func TestExecuteConnectorAction_StaticPath_StillWorks(t *testing.T) {
+func TestExecuteConnectorAction_StaticPath_WithBinding(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -750,6 +807,9 @@ func TestExecuteConnectorAction_StaticPath_StillWorks(t *testing.T) {
 	testhelper.InsertConnectorAction(t, tx, connID, "testslack.send_message", "Send Message")
 	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "slack", "api_key")
 
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
 	v := vault.NewMockVaultStore()
 	credJSON, _ := json.Marshal(map[string]string{"api_key": "xoxb-test-token"})
 	vaultID, err := v.CreateSecret(t.Context(), tx, "cred", credJSON)
@@ -758,6 +818,16 @@ func TestExecuteConnectorAction_StaticPath_StillWorks(t *testing.T) {
 	}
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, "slack", vaultID)
+
+	// Create an explicit binding.
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, err = db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: connID,
+		ApproverID: uid, CredentialID: &credID,
+	})
+	if err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
 
 	var capturedCreds connectors.Credentials
 	reg := connectors.NewRegistry()
@@ -769,7 +839,7 @@ func TestExecuteConnectorAction_StaticPath_StillWorks(t *testing.T) {
 
 	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
 
-	result, err := executeConnectorAction(t.Context(), deps, 0, uid, "testslack.send_message", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), deps, agentID, uid, "testslack.send_message", json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -783,171 +853,6 @@ func TestExecuteConnectorAction_StaticPath_StillWorks(t *testing.T) {
 	}
 	if tok != "xoxb-test-token" {
 		t.Errorf("expected api_key %q, got %q", "xoxb-test-token", tok)
-	}
-}
-
-// ── Implicit OAuth provider fallback tests ──────────────────────────────────
-// These test the code path where a connector declares only static credentials
-// (api_key) but has a matching built-in OAuth provider in the registry.
-// resolveCredentialsWithFallback should synthesize an oauth2 entry and try
-// OAuth first, falling back to static credentials if OAuth isn't available.
-
-func TestResolveCredentialsWithFallback_ImplicitOAuth_UsesOAuthWhenConnected(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testshopify"
-	provider := "testshopify"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_products", "List Products")
-	// Only declare api_key — no explicit oauth2 credential.
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "shopify_api_key", "api_key")
-
-	v := vault.NewMockVaultStore()
-	accessToken, err := v.CreateSecret(t.Context(), tx, "access", []byte("shpat_oauth_token"))
-	if err != nil {
-		t.Fatalf("vault create: %v", err)
-	}
-
-	// Create an active OAuth connection for the provider.
-	connOAuthID := testhelper.GenerateID(t, "oconn_")
-	testhelper.InsertOAuthConnectionFull(t, tx, connOAuthID, uid, provider, testhelper.OAuthConnectionOpts{
-		Status:              "active",
-		Scopes:              []string{"write_products"},
-		AccessTokenVaultID:  accessToken,
-		TokenExpiry:         func() *time.Time { t := time.Now().Add(time.Hour); return &t }(),
-	})
-
-	// Register a matching OAuth provider.
-	oauthReg := oauth.NewRegistry()
-	_ = oauthReg.Register(oauth.Provider{
-		ID:           provider,
-		AuthorizeURL: "https://test.myshopify.com/admin/oauth/authorize",
-		TokenURL:     "https://test.myshopify.com/admin/oauth/access_token",
-		ClientID:     "test-id",
-		ClientSecret: "test-secret",
-		Source:       oauth.SourceBuiltIn,
-	})
-
-	reqCreds := []db.RequiredCredential{{Service: "shopify_api_key", AuthType: "api_key"}}
-	deps := &Deps{DB: tx, Vault: v, OAuthProviders: oauthReg}
-
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".list_products", connID, reqCreds)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tok, ok := creds.Get("access_token")
-	if !ok {
-		t.Fatal("expected access_token in credentials (from OAuth)")
-	}
-	if tok != "shpat_oauth_token" {
-		t.Errorf("expected OAuth token %q, got %q", "shpat_oauth_token", tok)
-	}
-}
-
-func TestResolveCredentialsWithFallback_ImplicitOAuth_FallsBackToStatic(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testshopify"
-	provider := "testshopify"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_products", "List Products")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "shopify_api_key", "api_key")
-
-	v := vault.NewMockVaultStore()
-	// Store a static API key credential (no OAuth connection).
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "shpat_static_key"})
-	vaultID, err := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	if err != nil {
-		t.Fatalf("vault create: %v", err)
-	}
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, "shopify_api_key", vaultID)
-
-	oauthReg := oauth.NewRegistry()
-	_ = oauthReg.Register(oauth.Provider{
-		ID:           provider,
-		AuthorizeURL: "https://test.myshopify.com/admin/oauth/authorize",
-		TokenURL:     "https://test.myshopify.com/admin/oauth/access_token",
-		ClientID:     "test-id",
-		ClientSecret: "test-secret",
-		Source:       oauth.SourceBuiltIn,
-	})
-
-	reqCreds := []db.RequiredCredential{{Service: "shopify_api_key", AuthType: "api_key"}}
-	deps := &Deps{DB: tx, Vault: v, OAuthProviders: oauthReg}
-
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".list_products", connID, reqCreds)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tok, ok := creds.Get("api_key")
-	if !ok {
-		t.Fatal("expected api_key in credentials (static fallback)")
-	}
-	if tok != "shpat_static_key" {
-		t.Errorf("expected static key %q, got %q", "shpat_static_key", tok)
-	}
-}
-
-func TestResolveCredentialsWithFallback_ImplicitOAuth_NeedsReauthFallsBack(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-
-	connID := "testshopify"
-	provider := "testshopify"
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_products", "List Products")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "shopify_api_key", "api_key")
-
-	v := vault.NewMockVaultStore()
-
-	// Create a needs_reauth OAuth connection.
-	connOAuthID := testhelper.GenerateID(t, "oconn_")
-	testhelper.InsertOAuthConnectionFull(t, tx, connOAuthID, uid, provider, testhelper.OAuthConnectionOpts{
-		Status: "needs_reauth",
-		Scopes: []string{"write_products"},
-	})
-
-	// Store a static API key credential as fallback.
-	credJSON, _ := json.Marshal(map[string]string{"api_key": "shpat_static_key"})
-	vaultID, err := v.CreateSecret(t.Context(), tx, "cred", credJSON)
-	if err != nil {
-		t.Fatalf("vault create: %v", err)
-	}
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, "shopify_api_key", vaultID)
-
-	oauthReg := oauth.NewRegistry()
-	_ = oauthReg.Register(oauth.Provider{
-		ID:           provider,
-		AuthorizeURL: "https://test.myshopify.com/admin/oauth/authorize",
-		TokenURL:     "https://test.myshopify.com/admin/oauth/access_token",
-		ClientID:     "test-id",
-		ClientSecret: "test-secret",
-		Source:       oauth.SourceBuiltIn,
-	})
-
-	reqCreds := []db.RequiredCredential{{Service: "shopify_api_key", AuthType: "api_key"}}
-	deps := &Deps{DB: tx, Vault: v, OAuthProviders: oauthReg}
-
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".list_products", connID, reqCreds)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	tok, ok := creds.Get("api_key")
-	if !ok {
-		t.Fatal("expected api_key in credentials (static fallback after needs_reauth)")
-	}
-	if tok != "shpat_static_key" {
-		t.Errorf("expected static key %q, got %q", "shpat_static_key", tok)
 	}
 }
 
@@ -1071,6 +976,7 @@ func TestHandleConnectorError_NonOAuthError_NotHandled(t *testing.T) {
 type paymentExecFixture struct {
 	TX         db.DBTX
 	UserID     string
+	AgentID    int64
 	ConnID     string
 	ActionType string
 	Vault      *vault.MockVaultStore
@@ -1111,11 +1017,25 @@ func setupPaymentExecTest(t *testing.T, opts paymentExecOpts) *paymentExecFixtur
 	}
 	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
 
+	// Agent + agent_connector + credential binding.
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
 	v := vault.NewMockVaultStore()
 	credJSON, _ := json.Marshal(map[string]string{"api_key": "test-key"})
 	vaultID, _ := v.CreateSecret(t.Context(), tx, "cred", credJSON)
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultID)
+
+	// Create explicit credential binding.
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, bindErr := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: connID,
+		ApproverID: uid, CredentialID: &credID,
+	})
+	if bindErr != nil {
+		t.Fatalf("upsert binding: %v", bindErr)
+	}
 
 	reg := connectors.NewRegistry()
 	if opts.Connector != nil {
@@ -1127,6 +1047,7 @@ func setupPaymentExecTest(t *testing.T, opts paymentExecOpts) *paymentExecFixtur
 	return &paymentExecFixture{
 		TX:         tx,
 		UserID:     uid,
+		AgentID:    agentID,
 		ConnID:     connID,
 		ActionType: actionType,
 		Vault:      v,
@@ -1162,7 +1083,7 @@ func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
 	})
 
 	amount := 5000
-	result, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
 	})
@@ -1203,7 +1124,7 @@ func TestExecuteConnectorAction_PaymentMethod_MissingRequired(t *testing.T) {
 	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	// No payment params provided.
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when payment_method_id is missing")
 	}
@@ -1226,7 +1147,7 @@ func TestExecuteConnectorAction_PaymentMethod_PerTxLimitExceeded(t *testing.T) {
 	})
 
 	amount := 5000 // Exceeds 1000 limit
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
 	})
@@ -1274,7 +1195,7 @@ func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T)
 	}
 
 	amount := 2000 // 9000 + 2000 = 11000 > 10000 monthly limit
-	_, err = executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
+	_, err = executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
 	})
@@ -1310,7 +1231,7 @@ func TestExecuteConnectorAction_PaymentMethod_NotFound(t *testing.T) {
 	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	amount := 100
-	_, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: "00000000-0000-0000-0000-000000000099",
 		AmountCents:     &amount,
 	})
@@ -1332,7 +1253,7 @@ func TestExecuteConnectorAction_NoPaymentMethod_WhenNotRequired(t *testing.T) {
 	f := setupPaymentExecTest(t, paymentExecOpts{RequiresPayment: &noPayment})
 
 	// No payment params — should succeed because action doesn't require payment.
-	result, err := executeConnectorAction(t.Context(), f.Deps, 0, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/standing_approvals_connector_test.go
+++ b/api/standing_approvals_connector_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
 	"github.com/supersuit-tech/permission-slip-web/vault"
 )
@@ -57,14 +58,26 @@ func TestExecuteStandingApproval_ConnectorExecution(t *testing.T) {
 	testhelper.InsertConnector(t, tx, "testconn")
 	testhelper.InsertConnectorAction(t, tx, "testconn", "testconn.do_thing", "Do Thing")
 	testhelper.InsertConnectorRequiredCredential(t, tx, "testconn", "testconn_service", "api_key")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, "testconn")
 
 	// Store a credential the mock vault can decrypt.
 	mockVault := vault.NewMockVaultStore()
+	credID := "cred_test1"
 	secretID, err := mockVault.CreateSecret(context.Background(), tx, "test-cred", []byte(`{"api_key":"secret_value_123"}`))
 	if err != nil {
 		t.Fatalf("failed to create mock vault secret: %v", err)
 	}
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, "cred_test1", uid, "testconn_service", secretID)
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, "testconn_service", secretID)
+
+	// Create explicit credential binding.
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, bindErr := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: "testconn",
+		ApproverID: uid, CredentialID: &credID,
+	})
+	if bindErr != nil {
+		t.Fatalf("upsert binding: %v", bindErr)
+	}
 
 	// Set up mock connector action.
 	resultData := json.RawMessage(`{"issue_id":42}`)

--- a/api/standing_approvals_connector_test.go
+++ b/api/standing_approvals_connector_test.go
@@ -408,7 +408,7 @@ func TestExecuteStandingApproval_MissingCredentials(t *testing.T) {
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertStandingApprovalWithActionType(t, tx, saID, agentID, uid, "testconn.need_creds")
 
-	// Connector requires credentials, but user has none stored.
+	// Connector requires credentials, but no credential binding was created for the agent.
 	testhelper.InsertConnector(t, tx, "testconn")
 	testhelper.InsertConnectorAction(t, tx, "testconn", "testconn.need_creds", "Need Creds")
 	testhelper.InsertConnectorRequiredCredential(t, tx, "testconn", "testconn_service", "api_key")

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -410,7 +410,7 @@ RequiredCredentials: []connectors.ManifestCredential{
 },
 ```
 
-At execution time, `resolveCredentialsWithFallback` tries OAuth first. If the user has no OAuth connection, it falls back to static credentials (API key). The `ValidateCredentials` method must accept either credential type:
+At execution time, `resolveCredentialsWithFallback` uses the credential explicitly assigned to the agent+connector pair. There is no auto-resolve — the user must assign a credential in the agent's connector settings before actions can execute. The `ValidateCredentials` method must accept either credential type since the binding could be either OAuth or static:
 
 ```go
 func (c *MyConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -680,8 +680,10 @@ function AgentCredentialBinding({
 
   if (isLoading) return null;
 
-  // Don't show if there are no credentials or connections to choose from
-  if (credentials.length === 0 && activeConnections.length === 0) return null;
+  // Don't show if there are no credentials, connections, or existing binding.
+  // A stale binding (pointing to a deleted credential) must still be visible
+  // so the user can reassign it.
+  if (credentials.length === 0 && activeConnections.length === 0 && !binding) return null;
 
   return (
     <div className="mb-4 rounded-lg border p-3">

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -43,7 +43,6 @@ import {
 import {
   useAgentConnectorCredential,
   useAssignAgentConnectorCredential,
-  useRemoveAgentConnectorCredential,
 } from "@/hooks/useAgentConnectorCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
@@ -638,11 +637,9 @@ function AgentCredentialBinding({
     useAgentConnectorCredential(agentId, connectorId);
   const { assign, isPending: assigning } =
     useAssignAgentConnectorCredential();
-  const { remove, isPending: removing } =
-    useRemoveAgentConnectorCredential();
 
   const isLoading = anyLoading || bindingLoading;
-  const isPending = assigning || removing;
+  const isPending = assigning;
 
   // Build options for the dropdown
   const activeConnections = connections.filter(
@@ -656,13 +653,10 @@ function AgentCredentialBinding({
       : "";
 
   async function handleChange(value: string) {
-    if (isPending) return;
+    if (isPending || !value) return;
 
     try {
-      if (!value) {
-        await remove({ agentId, connectorId });
-        toast.success("Credential unassigned from this agent.");
-      } else if (value.startsWith("oauth:")) {
+      if (value.startsWith("oauth:")) {
         await assign({
           agentId,
           connectorId,
@@ -704,15 +698,15 @@ function AgentCredentialBinding({
               Assigned
             </Badge>
           ) : (
-            <Badge variant="secondary" className="text-muted-foreground">
-              Using default
+            <Badge variant="destructive">
+              Not set
             </Badge>
           )}
         </div>
         <p className="text-muted-foreground text-xs">
           {currentValue
             ? "This agent uses a specific credential for this connector."
-            : "This agent uses your default credential. Assign a specific one to override."}
+            : "Select a credential for this agent. The connector won\u2019t work until one is assigned."}
         </p>
         <select
           id="agent-credential-select"
@@ -721,7 +715,7 @@ function AgentCredentialBinding({
           onChange={(e) => handleChange(e.target.value)}
           disabled={isPending}
         >
-          <option value="">Default (auto-resolve)</option>
+          {!currentValue && <option value="">Select a credential…</option>}
           {activeConnections.map((conn) => (
             <option key={`oauth:${conn.id}`} value={`oauth:${conn.id}`}>
               {providerLabel(conn.provider)} OAuth


### PR DESCRIPTION
## Summary

- Removed the auto-resolve credential logic that silently picked the newest OAuth connection or fell back to static credentials without explicit user intent
- Credentials now require an explicit binding on each agent+connector pair before actions can execute
- Frontend dropdown no longer offers a "Default (auto-resolve)" option; shows a clear "Not set" warning badge and "Select a credential…" placeholder when no credential is assigned

## Test plan

### Claude Code
- [x] Backend compiles cleanly (`go build ./api/ ./db/ ./connectors/ ./oauth/ ./vault/`)
- [x] All backend API tests pass (`go test ./api/...`)
- [x] Frontend TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Updated tests verify: agentID=0 returns error, no binding returns error, static binding works, OAuth binding works

### OpenClaw
- [ ] Manually verify the credential dropdown in the agent connector settings UI
- [ ] Confirm that existing agents with no credential binding see the "Not set" badge and can't execute until a credential is assigned
- [ ] Verify that assigning a credential via the dropdown works correctly
- [ ] Check that agents with existing bindings continue to work without changes

https://claude.ai/code/session_01NofrQaavX4GeVidXPQFLgA