### PR TITLE
fix: regenerate mobile lockfile for minimatch override

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

- Regenerates `mobile/package-lock.json` to include the `minimatch@5.1.9` override (and transitive deps `brace-expansion@2.0.2`, `balanced-match@1.0.2`) that were added to `package.json` in commit 41ae311 but missing from the lockfile
- This caused `npm ci` to fail in CI, breaking all mobile test runs

## Test plan

### Claude Code
- [x] `npm ci` succeeds with the updated lockfile
- [x] All 181 mobile tests pass (`make mobile-test`)

### OpenClaw
- [ ] Verify CI passes on this PR
- [ ] Confirm no unintended dependency changes in the lockfile diff

https://claude.ai/code/session_01NMpDqrvEjRukKgtS4UbdYo