### PR TITLE
Show API key labels in credential dropdown

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -732,7 +732,8 @@ function AgentCredentialBinding({
           ))}
           {scopedCredentials.map((cred) => (
             <option key={`cred:${cred.id}`} value={`cred:${cred.id}`}>
-              {cred.label ?? cred.service} (added{" "}
+              {serviceLabel(cred.service)}
+              {cred.label ? ` — ${cred.label}` : ""} (added{" "}
               {new Date(cred.created_at).toLocaleDateString()})
             </option>
           ))}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- The agent credential binding dropdown now shows the human-readable service type (via `serviceLabel()`) alongside the user-defined label
- Before: `Personal Access Token (added 3/13/2026)` — no way to distinguish multiple keys
- After: `GitHub Personal Access Token — Test (added 3/13/2026)` — label included when present

## Test plan

### Claude Code
- [x] Frontend tests pass (90 files, 721 tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### OpenClaw
- [ ] Manually verify dropdown text with multiple API keys for the same connector
- [ ] Verify dropdown with credentials that have no label (should show just the service type)

https://claude.ai/code/session_01GZbnVactWWq67i9fPhYy2D