### PR TITLE
Refactor: move credentials management into a modal

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -16,6 +16,7 @@ import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
 import { providerLabel } from "@/lib/oauth";
+import { serviceLabel } from "@/lib/labels";
 import {
   useAgentConnectorCredential,
   useAssignAgentConnectorCredential,

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -115,6 +115,7 @@ export function ConnectorCredentialsSection({
         open={manageDialogOpen}
         onOpenChange={setManageDialogOpen}
         connectorId={connectorId}
+        connectorLabel={serviceLabel(connectorId)}
         hasRequiredCredentials={hasRequiredCredentials}
         hasImplicitOAuth={hasImplicitOAuth}
         hasOAuth={hasOAuth}

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -1,15 +1,5 @@
 import { useState } from "react";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Circle,
-  ExternalLink,
-  Loader2,
-  LogIn,
-  Plus,
-  Trash2,
-  Unplug,
-} from "lucide-react";
+import { Settings } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -20,36 +10,19 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useAuth } from "@/auth/AuthContext";
 import { useCredentials } from "@/hooks/useCredentials";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
-import {
-  providerLabel,
-  getOAuthAuthorizeUrl,
-  SHOP_REQUIRED_PROVIDERS,
-} from "@/lib/oauth";
+import { providerLabel } from "@/lib/oauth";
 import {
   useAgentConnectorCredential,
   useAssignAgentConnectorCredential,
 } from "@/hooks/useAgentConnectorCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
-import { serviceLabel, authTypeLabel } from "@/lib/labels";
-import { AddCredentialDialog } from "./AddCredentialDialog";
-import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
-import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
 import type { OAuthConnection } from "@/hooks/useOAuthConnections";
+import { ManageCredentialsDialog } from "./ManageCredentialsDialog";
 
 export interface ConnectorCredentialsSectionProps {
   agentId: number;
@@ -62,6 +35,8 @@ export function ConnectorCredentialsSection({
   connectorId,
   requiredCredentials,
 }: ConnectorCredentialsSectionProps) {
+  const [manageDialogOpen, setManageDialogOpen] = useState(false);
+
   const hasRequiredCredentials = requiredCredentials.length > 0;
   const hasExplicitOAuth = requiredCredentials.some(
     (c) => c.auth_type === "oauth2",
@@ -70,8 +45,6 @@ export function ConnectorCredentialsSection({
   const { credentials, isLoading, error } = useCredentials({
     enabled: hasStatic,
   });
-  // Also fetch OAuth data when there's a matching built-in provider (e.g.
-  // Shopify declares api_key in manifest but has a built-in OAuth provider).
   const {
     connections,
     isLoading: connectionsLoading,
@@ -88,13 +61,10 @@ export function ConnectorCredentialsSection({
     storedByService.set(cred.service, list);
   }
 
-  // Check if there's a matching built-in OAuth provider for this connector
-  // (covers cases like Shopify where the manifest says api_key but OAuth is available).
   const matchingProvider = providers.find((p) => p.id === connectorId);
   const hasImplicitOAuth = !hasExplicitOAuth && !!matchingProvider;
   const hasOAuth = hasExplicitOAuth || hasImplicitOAuth;
 
-  // Sort credentials: OAuth first, then static
   const sorted = [...requiredCredentials].sort((a, b) => {
     if (a.auth_type === "oauth2" && b.auth_type !== "oauth2") return -1;
     if (a.auth_type !== "oauth2" && b.auth_type === "oauth2") return 1;
@@ -103,6 +73,8 @@ export function ConnectorCredentialsSection({
 
   const anyLoading =
     isLoading || connectionsLoading || providersLoading;
+
+  const showManageButton = hasRequiredCredentials || !!matchingProvider;
 
   return (
     <Card>
@@ -124,496 +96,37 @@ export function ConnectorCredentialsSection({
           anyLoading={anyLoading}
         />
 
-        {!hasRequiredCredentials && !matchingProvider ? (
-          <p className="text-muted-foreground py-4 text-center text-sm">
-            This connector does not require any credentials.
-          </p>
-        ) : anyLoading ? (
-          <div className="flex items-center justify-center py-4">
-            <Loader2
-              className="text-muted-foreground size-5 animate-spin"
-              aria-hidden="true"
-            />
-          </div>
-        ) : error || oauthError ? (
-          <p className="text-destructive text-sm">{error ?? oauthError}</p>
-        ) : (
-          <div className="space-y-3">
-            {/* Implicit OAuth row for connectors with a matching built-in
-                provider but no explicit oauth2 credential in their manifest */}
-            {hasImplicitOAuth && (
-              <>
-                <OAuthCredentialRow
-                  requiredCredential={{
-                    service: connectorId,
-                    auth_type: "oauth2",
-                    oauth_provider: connectorId,
-                  }}
-                  connections={connections}
-                  providers={providers}
-                />
-                {sorted.length > 0 && (
-                  <div className="flex items-center gap-3 py-1">
-                    <div className="bg-border h-px flex-1" />
-                    <span className="text-muted-foreground text-xs font-medium uppercase">
-                      or
-                    </span>
-                    <div className="bg-border h-px flex-1" />
-                  </div>
-                )}
-              </>
-            )}
-
-            {sorted.map((cred, idx) => {
-              const prevCred = idx > 0 ? sorted[idx - 1] : undefined;
-              const showOrSeparator =
-                prevCred != null &&
-                prevCred.auth_type === "oauth2" &&
-                cred.auth_type !== "oauth2";
-
-              return (
-                <div key={cred.service}>
-                  {showOrSeparator && (
-                    <div className="flex items-center gap-3 py-1">
-                      <div className="bg-border h-px flex-1" />
-                      <span className="text-muted-foreground text-xs font-medium uppercase">
-                        or
-                      </span>
-                      <div className="bg-border h-px flex-1" />
-                    </div>
-                  )}
-                  {cred.auth_type === "oauth2" && cred.oauth_provider ? (
-                    <OAuthCredentialRow
-                      requiredCredential={cred}
-                      connections={connections}
-                      providers={providers}
-                    />
-                  ) : (
-                    <StaticCredentialRow
-                      requiredCredential={cred}
-                      storedCredentials={
-                        storedByService.get(cred.service) ?? []
-                      }
-                      isAlternative={hasOAuth}
-                    />
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function OAuthCredentialRow({
-  requiredCredential,
-  connections,
-  providers,
-}: {
-  requiredCredential: RequiredCredential;
-  connections: OAuthConnection[];
-  providers: { id: string; has_credentials: boolean }[];
-}) {
-  const { session } = useAuth();
-  const [shopDialogState, setShopDialogState] = useState<{
-    replaceId?: string;
-  } | null>(null);
-  const [disconnectTarget, setDisconnectTarget] = useState<{
-    id: string;
-    displayName?: string;
-  } | null>(null);
-
-  const providerId = requiredCredential.oauth_provider ?? "";
-  const providerConnections = connections.filter(
-    (c) => c.provider === providerId,
-  );
-  const activeConnections = providerConnections.filter(
-    (c) => c.status === "active",
-  );
-  const needsReauthConnection = providerConnections.find(
-    (c) => c.status === "needs_reauth",
-  );
-  const provider = providers.find((p) => p.id === providerId);
-  const hasAnyConnection = providerConnections.length > 0;
-  const isConnected = activeConnections.length > 0;
-
-  function handleConnect() {
-    if (!session?.access_token || !providerId) return;
-    if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
-      setShopDialogState({});
-      return;
-    }
-    window.location.href = getOAuthAuthorizeUrl(
-      providerId,
-      session.access_token,
-      { scopes: requiredCredential.oauth_scopes },
-    );
-  }
-
-  function handleReconnect(connectionId: string) {
-    if (!session?.access_token || !providerId) return;
-    if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
-      setShopDialogState({ replaceId: connectionId });
-      return;
-    }
-    window.location.href = getOAuthAuthorizeUrl(
-      providerId,
-      session.access_token,
-      { scopes: requiredCredential.oauth_scopes, replaceId: connectionId },
-    );
-  }
-
-  return (
-    <>
-      <div className="rounded-lg border p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
-            {isConnected ? (
-              <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
-            ) : needsReauthConnection ? (
-              <AlertTriangle className="size-5 shrink-0 text-amber-500" />
-            ) : (
-              <Circle className="text-muted-foreground size-5 shrink-0" />
-            )}
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-medium">
-                  {providerLabel(providerId)}
-                </p>
-                <Badge variant="secondary" className="text-xs">
-                  OAuth
-                </Badge>
-                <Badge variant="outline" className="text-xs">
-                  Recommended
-                </Badge>
-              </div>
-              <p className="text-muted-foreground text-xs">
-                {isConnected
-                  ? `${activeConnections.length} account${activeConnections.length !== 1 ? "s" : ""} connected`
-                  : needsReauthConnection
-                    ? "Re-authorization required"
-                    : "Not connected"}
-              </p>
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
-            {!hasAnyConnection && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleConnect}
-                disabled={!provider?.has_credentials}
-              >
-                <LogIn className="size-3" />
-                Connect {providerLabel(providerId)}
-              </Button>
-            )}
-            {hasAnyConnection && provider?.has_credentials && (
-              <Button variant="outline" size="sm" onClick={handleConnect}>
-                <Plus className="size-3" />
-                Add account
-              </Button>
-            )}
-          </div>
-        </div>
-
-        {/* List each connection */}
-        {providerConnections.length > 0 && (
-          <div className="mt-3 space-y-2 border-t pt-3">
-            {providerConnections.map((conn) => (
-              <div
-                key={conn.id}
-                className="bg-muted/50 flex items-center justify-between rounded-md px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-sm">
-                    {conn.display_name || providerLabel(conn.provider)}
-                    {conn.instance && !conn.display_name && (
-                      <span className="text-muted-foreground ml-1">
-                        ({conn.instance})
-                      </span>
-                    )}
-                  </p>
-                  <p className="text-muted-foreground text-xs">
-                    {conn.status === "active"
-                      ? `Connected ${new Date(conn.connected_at).toLocaleDateString()}`
-                      : conn.status === "needs_reauth"
-                        ? "Needs re-authorization"
-                        : conn.status}
-                  </p>
-                </div>
-                <div className="flex items-center gap-1">
-                  {conn.status === "needs_reauth" ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleReconnect(conn.id)}
-                    >
-                      <LogIn className="size-3" />
-                      Re-authorize
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleReconnect(conn.id)}
-                      aria-label="Reconnect"
-                    >
-                      <LogIn className="size-3" />
-                    </Button>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() =>
-                      setDisconnectTarget({
-                        id: conn.id,
-                        displayName: conn.display_name,
-                      })
-                    }
-                    aria-label={`Disconnect ${conn.display_name ?? providerLabel(conn.provider)}`}
-                  >
-                    <Unplug className="size-4" />
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {!hasAnyConnection && !provider?.has_credentials && (
-          <p className="text-muted-foreground mt-2 pl-8 text-xs">
-            OAuth is not available yet — ask your admin to configure{" "}
-            {providerLabel(providerId)} OAuth credentials.
-          </p>
-        )}
-      </div>
-
-      {SHOP_REQUIRED_PROVIDERS.has(providerId) && shopDialogState && (
-        <ShopDomainDialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setShopDialogState(null);
-          }}
-          providerId={providerId}
-          oauthScopes={requiredCredential.oauth_scopes}
-          replaceId={shopDialogState.replaceId}
-        />
-      )}
-
-      {disconnectTarget && (
-        <DisconnectOAuthDialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setDisconnectTarget(null);
-          }}
-          connectionId={disconnectTarget.id}
-          providerName={providerLabel(providerId)}
-          displayName={disconnectTarget.displayName}
-        />
-      )}
-    </>
-  );
-}
-
-function ShopDomainDialog({
-  open,
-  onOpenChange,
-  providerId,
-  oauthScopes,
-  replaceId,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  providerId: string;
-  oauthScopes?: string[];
-  replaceId?: string;
-}) {
-  const { session } = useAuth();
-  const [shop, setShop] = useState("");
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!session?.access_token) return;
-    const trimmed = shop.trim().toLowerCase();
-    if (!trimmed) return;
-    const subdomain = trimmed.replace(/\.myshopify\.com$/, "");
-    const url = getOAuthAuthorizeUrl(providerId, session.access_token, {
-      scopes: oauthScopes,
-      replaceId,
-    });
-    window.location.href = `${url}&shop=${encodeURIComponent(subdomain)}`;
-    onOpenChange(false);
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Connect {providerLabel(providerId)} Store</DialogTitle>
-          <DialogDescription>
-            Enter your {providerLabel(providerId)} store subdomain to begin the
-            OAuth connection.
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-2 py-4">
-            <Label htmlFor="shop-domain">Store subdomain</Label>
-            <div className="flex items-center gap-2">
-              <Input
-                id="shop-domain"
-                placeholder="mystore"
-                value={shop}
-                onChange={(e) => setShop(e.target.value)}
-                autoFocus
-              />
-              <span className="text-muted-foreground whitespace-nowrap text-sm">
-                .myshopify.com
-              </span>
-            </div>
-            <p className="text-muted-foreground text-xs">
-              e.g. if your store URL is mystore.myshopify.com, enter
-              &quot;mystore&quot;
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!shop.trim()}>
-              <LogIn className="size-4" />
-              Continue to {providerLabel(providerId)}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function StaticCredentialRow({
-  requiredCredential,
-  storedCredentials,
-  isAlternative,
-}: {
-  requiredCredential: RequiredCredential;
-  storedCredentials: CredentialSummary[];
-  isAlternative: boolean;
-}) {
-  const [addDialogOpen, setAddDialogOpen] = useState(false);
-  const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(null);
-
-  const isConnected = storedCredentials.length > 0;
-
-  return (
-    <>
-      <div className="rounded-lg border p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
-            {isConnected ? (
-              <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
-            ) : (
-              <Circle className="text-muted-foreground size-5 shrink-0" />
-            )}
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-medium">
-                  {serviceLabel(requiredCredential.service)}
-                </p>
-                {isAlternative && (
-                  <Badge variant="outline" className="text-xs">
-                    Alternative
-                  </Badge>
-                )}
-              </div>
-              <p className="text-muted-foreground text-xs">
-                {authTypeLabel(requiredCredential.auth_type)}
-              </p>
-              {requiredCredential.instructions_url && (
-                <a
-                  href={requiredCredential.instructions_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground mt-0.5 inline-flex items-center gap-1 text-xs"
-                >
-                  <ExternalLink className="size-3" />
-                  How to get this credential
-                </a>
-              )}
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
-            <span
-              className={`text-xs font-medium ${
-                isConnected
-                  ? "text-green-600 dark:text-green-400"
-                  : "text-muted-foreground"
-              }`}
-            >
-              {isConnected ? "Connected" : "Not configured"}
-            </span>
+        {showManageButton && (
+          <div className="flex justify-end">
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setAddDialogOpen(true)}
+              onClick={() => setManageDialogOpen(true)}
             >
-              <Plus className="size-3" />
-              {isConnected ? "Add Another" : "Connect"}
+              <Settings className="size-3" />
+              Manage credentials
             </Button>
           </div>
-        </div>
-
-        {storedCredentials.length > 0 && (
-          <div className="mt-3 space-y-2 border-t pt-3">
-            {storedCredentials.map((cred) => (
-              <div
-                key={cred.id}
-                className="bg-muted/50 flex items-center justify-between rounded-md px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-sm">
-                    {cred.label ?? cred.service}
-                  </p>
-                  <p className="text-muted-foreground text-xs">
-                    Added {new Date(cred.created_at).toLocaleDateString()}
-                  </p>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => setRemoveTarget(cred)}
-                  aria-label={`Remove credential ${cred.label ?? cred.service}`}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              </div>
-            ))}
-          </div>
         )}
-      </div>
+      </CardContent>
 
-      <AddCredentialDialog
-        open={addDialogOpen}
-        onOpenChange={setAddDialogOpen}
-        credential={requiredCredential}
+      <ManageCredentialsDialog
+        open={manageDialogOpen}
+        onOpenChange={setManageDialogOpen}
+        connectorId={connectorId}
+        hasRequiredCredentials={hasRequiredCredentials}
+        hasImplicitOAuth={hasImplicitOAuth}
+        hasOAuth={hasOAuth}
+        sorted={sorted}
+        connections={connections}
+        providers={providers}
+        storedByService={storedByService}
+        matchingProvider={matchingProvider}
+        anyLoading={anyLoading}
+        error={error}
+        oauthError={oauthError}
       />
-
-      {removeTarget && (
-        <RemoveCredentialDialog
-          open
-          onOpenChange={() => setRemoveTarget(null)}
-          credential={removeTarget}
-        />
-      )}
-    </>
+    </Card>
   );
 }
 
@@ -641,9 +154,6 @@ function AgentCredentialBinding({
   const isLoading = anyLoading || bindingLoading;
   const isPending = assigning;
 
-  // Build options scoped to this connector — only show credentials whose
-  // service matches the connector ID and OAuth connections whose provider
-  // matches, so e.g. Slack creds don't appear in a Google connector dropdown.
   const scopedCredentials = credentials.filter(
     (c) => c.service === connectorId,
   );
@@ -685,9 +195,6 @@ function AgentCredentialBinding({
 
   if (isLoading) return null;
 
-  // Don't show if there are no scoped credentials, connections, or existing binding.
-  // A stale binding (pointing to a deleted credential) must still be visible
-  // so the user can reassign it.
   if (scopedCredentials.length === 0 && activeConnections.length === 0 && !binding) return null;
 
   return (

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -125,7 +125,7 @@ export function ManageCredentialsDialog({
                 cred.auth_type !== "oauth2";
 
               return (
-                <div key={cred.service}>
+                <div key={`${cred.service}:${cred.auth_type}`}>
                   {showOrSeparator && (
                     <div className="flex items-center gap-3 py-1">
                       <div className="bg-border h-px flex-1" />
@@ -561,7 +561,9 @@ function StaticCredentialRow({
       {removeTarget && (
         <RemoveCredentialDialog
           open
-          onOpenChange={() => setRemoveTarget(null)}
+          onOpenChange={(open) => {
+            if (!open) setRemoveTarget(null);
+          }}
           credential={removeTarget}
         />
       )}

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -40,6 +40,7 @@ export interface ManageCredentialsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   connectorId: string;
+  connectorLabel?: string;
   hasRequiredCredentials: boolean;
   hasImplicitOAuth: boolean;
   hasOAuth: boolean;
@@ -57,6 +58,7 @@ export function ManageCredentialsDialog({
   open,
   onOpenChange,
   connectorId,
+  connectorLabel,
   hasRequiredCredentials,
   hasImplicitOAuth,
   hasOAuth,
@@ -73,9 +75,12 @@ export function ManageCredentialsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Manage Credentials</DialogTitle>
+          <DialogTitle>
+            Manage {connectorLabel ?? "Credentials"}
+          </DialogTitle>
           <DialogDescription>
-            Connect accounts and manage credentials for this connector.
+            Connect accounts and manage credentials
+            {connectorLabel ? ` for ${connectorLabel}` : ""}.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -1,0 +1,570 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  ExternalLink,
+  Loader2,
+  LogIn,
+  Plus,
+  Trash2,
+  Unplug,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/auth/AuthContext";
+import type { CredentialSummary } from "@/hooks/useCredentials";
+import type { OAuthConnection } from "@/hooks/useOAuthConnections";
+import {
+  providerLabel,
+  getOAuthAuthorizeUrl,
+  SHOP_REQUIRED_PROVIDERS,
+} from "@/lib/oauth";
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import { serviceLabel, authTypeLabel } from "@/lib/labels";
+import { AddCredentialDialog } from "./AddCredentialDialog";
+import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
+import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
+
+export interface ManageCredentialsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connectorId: string;
+  hasRequiredCredentials: boolean;
+  hasImplicitOAuth: boolean;
+  hasOAuth: boolean;
+  sorted: RequiredCredential[];
+  connections: OAuthConnection[];
+  providers: { id: string; has_credentials: boolean }[];
+  storedByService: Map<string, CredentialSummary[]>;
+  matchingProvider: { id: string; has_credentials: boolean } | undefined;
+  anyLoading: boolean;
+  error: string | null;
+  oauthError: string | null;
+}
+
+export function ManageCredentialsDialog({
+  open,
+  onOpenChange,
+  connectorId,
+  hasRequiredCredentials,
+  hasImplicitOAuth,
+  hasOAuth,
+  sorted,
+  connections,
+  providers,
+  storedByService,
+  matchingProvider,
+  anyLoading,
+  error,
+  oauthError,
+}: ManageCredentialsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Manage Credentials</DialogTitle>
+          <DialogDescription>
+            Connect accounts and manage credentials for this connector.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!hasRequiredCredentials && !matchingProvider ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            This connector does not require any credentials.
+          </p>
+        ) : anyLoading ? (
+          <div className="flex items-center justify-center py-4">
+            <Loader2
+              className="text-muted-foreground size-5 animate-spin"
+              aria-hidden="true"
+            />
+          </div>
+        ) : error || oauthError ? (
+          <p className="text-destructive text-sm">{error ?? oauthError}</p>
+        ) : (
+          <div className="space-y-3">
+            {hasImplicitOAuth && (
+              <>
+                <OAuthCredentialRow
+                  requiredCredential={{
+                    service: connectorId,
+                    auth_type: "oauth2",
+                    oauth_provider: connectorId,
+                  }}
+                  connections={connections}
+                  providers={providers}
+                />
+                {sorted.length > 0 && (
+                  <div className="flex items-center gap-3 py-1">
+                    <div className="bg-border h-px flex-1" />
+                    <span className="text-muted-foreground text-xs font-medium uppercase">
+                      or
+                    </span>
+                    <div className="bg-border h-px flex-1" />
+                  </div>
+                )}
+              </>
+            )}
+
+            {sorted.map((cred, idx) => {
+              const prevCred = idx > 0 ? sorted[idx - 1] : undefined;
+              const showOrSeparator =
+                prevCred != null &&
+                prevCred.auth_type === "oauth2" &&
+                cred.auth_type !== "oauth2";
+
+              return (
+                <div key={cred.service}>
+                  {showOrSeparator && (
+                    <div className="flex items-center gap-3 py-1">
+                      <div className="bg-border h-px flex-1" />
+                      <span className="text-muted-foreground text-xs font-medium uppercase">
+                        or
+                      </span>
+                      <div className="bg-border h-px flex-1" />
+                    </div>
+                  )}
+                  {cred.auth_type === "oauth2" && cred.oauth_provider ? (
+                    <OAuthCredentialRow
+                      requiredCredential={cred}
+                      connections={connections}
+                      providers={providers}
+                    />
+                  ) : (
+                    <StaticCredentialRow
+                      requiredCredential={cred}
+                      storedCredentials={
+                        storedByService.get(cred.service) ?? []
+                      }
+                      isAlternative={hasOAuth}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function OAuthCredentialRow({
+  requiredCredential,
+  connections,
+  providers,
+}: {
+  requiredCredential: RequiredCredential;
+  connections: OAuthConnection[];
+  providers: { id: string; has_credentials: boolean }[];
+}) {
+  const { session } = useAuth();
+  const [shopDialogState, setShopDialogState] = useState<{
+    replaceId?: string;
+  } | null>(null);
+  const [disconnectTarget, setDisconnectTarget] = useState<{
+    id: string;
+    displayName?: string;
+  } | null>(null);
+
+  const providerId = requiredCredential.oauth_provider ?? "";
+  const providerConnections = connections.filter(
+    (c) => c.provider === providerId,
+  );
+  const activeConnections = providerConnections.filter(
+    (c) => c.status === "active",
+  );
+  const needsReauthConnection = providerConnections.find(
+    (c) => c.status === "needs_reauth",
+  );
+  const provider = providers.find((p) => p.id === providerId);
+  const hasAnyConnection = providerConnections.length > 0;
+  const isConnected = activeConnections.length > 0;
+
+  function handleConnect() {
+    if (!session?.access_token || !providerId) return;
+    if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
+      setShopDialogState({});
+      return;
+    }
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      { scopes: requiredCredential.oauth_scopes },
+    );
+  }
+
+  function handleReconnect(connectionId: string) {
+    if (!session?.access_token || !providerId) return;
+    if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
+      setShopDialogState({ replaceId: connectionId });
+      return;
+    }
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      { scopes: requiredCredential.oauth_scopes, replaceId: connectionId },
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-lg border p-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            {isConnected ? (
+              <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
+            ) : needsReauthConnection ? (
+              <AlertTriangle className="size-5 shrink-0 text-amber-500" />
+            ) : (
+              <Circle className="text-muted-foreground size-5 shrink-0" />
+            )}
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-medium">
+                  {providerLabel(providerId)}
+                </p>
+                <Badge variant="secondary" className="text-xs">
+                  OAuth
+                </Badge>
+                <Badge variant="outline" className="text-xs">
+                  Recommended
+                </Badge>
+              </div>
+              <p className="text-muted-foreground text-xs">
+                {isConnected
+                  ? `${activeConnections.length} account${activeConnections.length !== 1 ? "s" : ""} connected`
+                  : needsReauthConnection
+                    ? "Re-authorization required"
+                    : "Not connected"}
+              </p>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
+            {!hasAnyConnection && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleConnect}
+                disabled={!provider?.has_credentials}
+              >
+                <LogIn className="size-3" />
+                Connect {providerLabel(providerId)}
+              </Button>
+            )}
+            {hasAnyConnection && provider?.has_credentials && (
+              <Button variant="outline" size="sm" onClick={handleConnect}>
+                <Plus className="size-3" />
+                Add account
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {providerConnections.length > 0 && (
+          <div className="mt-3 space-y-2 border-t pt-3">
+            {providerConnections.map((conn) => (
+              <div
+                key={conn.id}
+                className="bg-muted/50 flex items-center justify-between rounded-md px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm">
+                    {conn.display_name || providerLabel(conn.provider)}
+                    {conn.instance && !conn.display_name && (
+                      <span className="text-muted-foreground ml-1">
+                        ({conn.instance})
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    {conn.status === "active"
+                      ? `Connected ${new Date(conn.connected_at).toLocaleDateString()}`
+                      : conn.status === "needs_reauth"
+                        ? "Needs re-authorization"
+                        : conn.status}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  {conn.status === "needs_reauth" ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleReconnect(conn.id)}
+                    >
+                      <LogIn className="size-3" />
+                      Re-authorize
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleReconnect(conn.id)}
+                      aria-label="Reconnect"
+                    >
+                      <LogIn className="size-3" />
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() =>
+                      setDisconnectTarget({
+                        id: conn.id,
+                        displayName: conn.display_name,
+                      })
+                    }
+                    aria-label={`Disconnect ${conn.display_name ?? providerLabel(conn.provider)}`}
+                  >
+                    <Unplug className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!hasAnyConnection && !provider?.has_credentials && (
+          <p className="text-muted-foreground mt-2 pl-8 text-xs">
+            OAuth is not available yet — ask your admin to configure{" "}
+            {providerLabel(providerId)} OAuth credentials.
+          </p>
+        )}
+      </div>
+
+      {SHOP_REQUIRED_PROVIDERS.has(providerId) && shopDialogState && (
+        <ShopDomainDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setShopDialogState(null);
+          }}
+          providerId={providerId}
+          oauthScopes={requiredCredential.oauth_scopes}
+          replaceId={shopDialogState.replaceId}
+        />
+      )}
+
+      {disconnectTarget && (
+        <DisconnectOAuthDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setDisconnectTarget(null);
+          }}
+          connectionId={disconnectTarget.id}
+          providerName={providerLabel(providerId)}
+          displayName={disconnectTarget.displayName}
+        />
+      )}
+    </>
+  );
+}
+
+function ShopDomainDialog({
+  open,
+  onOpenChange,
+  providerId,
+  oauthScopes,
+  replaceId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  providerId: string;
+  oauthScopes?: string[];
+  replaceId?: string;
+}) {
+  const { session } = useAuth();
+  const [shop, setShop] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!session?.access_token) return;
+    const trimmed = shop.trim().toLowerCase();
+    if (!trimmed) return;
+    const subdomain = trimmed.replace(/\.myshopify\.com$/, "");
+    const url = getOAuthAuthorizeUrl(providerId, session.access_token, {
+      scopes: oauthScopes,
+      replaceId,
+    });
+    window.location.href = `${url}&shop=${encodeURIComponent(subdomain)}`;
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Connect {providerLabel(providerId)} Store</DialogTitle>
+          <DialogDescription>
+            Enter your {providerLabel(providerId)} store subdomain to begin the
+            OAuth connection.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-2 py-4">
+            <Label htmlFor="shop-domain">Store subdomain</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="shop-domain"
+                placeholder="mystore"
+                value={shop}
+                onChange={(e) => setShop(e.target.value)}
+                autoFocus
+              />
+              <span className="text-muted-foreground whitespace-nowrap text-sm">
+                .myshopify.com
+              </span>
+            </div>
+            <p className="text-muted-foreground text-xs">
+              e.g. if your store URL is mystore.myshopify.com, enter
+              &quot;mystore&quot;
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!shop.trim()}>
+              <LogIn className="size-4" />
+              Continue to {providerLabel(providerId)}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StaticCredentialRow({
+  requiredCredential,
+  storedCredentials,
+  isAlternative,
+}: {
+  requiredCredential: RequiredCredential;
+  storedCredentials: CredentialSummary[];
+  isAlternative: boolean;
+}) {
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(null);
+
+  const isConnected = storedCredentials.length > 0;
+
+  return (
+    <>
+      <div className="rounded-lg border p-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            {isConnected ? (
+              <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
+            ) : (
+              <Circle className="text-muted-foreground size-5 shrink-0" />
+            )}
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-medium">
+                  {serviceLabel(requiredCredential.service)}
+                </p>
+                {isAlternative && (
+                  <Badge variant="outline" className="text-xs">
+                    Alternative
+                  </Badge>
+                )}
+              </div>
+              <p className="text-muted-foreground text-xs">
+                {authTypeLabel(requiredCredential.auth_type)}
+              </p>
+              {requiredCredential.instructions_url && (
+                <a
+                  href={requiredCredential.instructions_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-foreground mt-0.5 inline-flex items-center gap-1 text-xs"
+                >
+                  <ExternalLink className="size-3" />
+                  How to get this credential
+                </a>
+              )}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
+            <span
+              className={`text-xs font-medium ${
+                isConnected
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {isConnected ? "Connected" : "Not configured"}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAddDialogOpen(true)}
+            >
+              <Plus className="size-3" />
+              {isConnected ? "Add Another" : "Connect"}
+            </Button>
+          </div>
+        </div>
+
+        {storedCredentials.length > 0 && (
+          <div className="mt-3 space-y-2 border-t pt-3">
+            {storedCredentials.map((cred) => (
+              <div
+                key={cred.id}
+                className="bg-muted/50 flex items-center justify-between rounded-md px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm">
+                    {cred.label ?? cred.service}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Added {new Date(cred.created_at).toLocaleDateString()}
+                  </p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setRemoveTarget(cred)}
+                  aria-label={`Remove credential ${cred.label ?? cred.service}`}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <AddCredentialDialog
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        credential={requiredCredential}
+      />
+
+      {removeTarget && (
+        <RemoveCredentialDialog
+          open
+          onOpenChange={() => setRemoveTarget(null)}
+          credential={removeTarget}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
@@ -156,7 +157,10 @@ describe("ConnectorConfigPage", () => {
       screen.getByText("View all 2 available actions"),
     ).toBeInTheDocument();
 
-    // Credentials section (loads asynchronously via useCredentials)
+    // Credentials section — content is behind "Manage credentials" modal
+    const user = userEvent.setup();
+    const manageBtn = await screen.findByRole("button", { name: /Manage credentials/i });
+    await user.click(manageBtn);
     await waitFor(() => {
       expect(screen.getByText("Connected")).toBeInTheDocument();
     });
@@ -236,7 +240,11 @@ describe("ConnectorConfigPage", () => {
       return Promise.resolve({ data: {} });
     });
 
+    const user = userEvent.setup();
     renderPage();
+
+    const manageBtn = await screen.findByRole("button", { name: /Manage credentials/i });
+    await user.click(manageBtn);
 
     await waitFor(() => {
       expect(screen.getByText("Not configured")).toBeInTheDocument();

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
@@ -138,6 +138,17 @@ describe("ConnectorConfigPage", () => {
       if (path === "/v1/action-configurations") {
         return Promise.resolve({ data: mockActionConfigsResponse });
       }
+      if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
+        return Promise.resolve({
+          data: { agent_id: 42, connector_id: "github", credential_id: "cred_123", oauth_connection_id: null },
+        });
+      }
+      if (path === "/v1/oauth/connections") {
+        return Promise.resolve({ data: { connections: [] } });
+      }
+      if (path === "/v1/oauth/providers") {
+        return Promise.resolve({ data: { providers: [] } });
+      }
       return Promise.resolve({ data: {} });
     });
 
@@ -236,6 +247,17 @@ describe("ConnectorConfigPage", () => {
       }
       if (path === "/v1/credentials") {
         return Promise.resolve({ data: { credentials: [] } });
+      }
+      if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
+        return Promise.resolve({
+          data: { agent_id: 42, connector_id: "github", credential_id: null, oauth_connection_id: null },
+        });
+      }
+      if (path === "/v1/oauth/connections") {
+        return Promise.resolve({ data: { connections: [] } });
+      }
+      if (path === "/v1/oauth/providers") {
+        return Promise.resolve({ data: { providers: [] } });
       }
       return Promise.resolve({ data: {} });
     });

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorCredentialsSection.test.tsx
@@ -77,6 +77,12 @@ function setupMockGet(overrides: Record<string, unknown> = {}) {
   });
 }
 
+/** Open the "Manage credentials" modal */
+async function openManageModal(user: ReturnType<typeof userEvent.setup>) {
+  const btn = await screen.findByRole("button", { name: /Manage credentials/i });
+  await user.click(btn);
+}
+
 describe("ConnectorCredentialsSection", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -84,7 +90,7 @@ describe("ConnectorCredentialsSection", () => {
     setupAuthMocks({ authenticated: true });
   });
 
-  it("shows no credentials required message when empty", () => {
+  it("does not show manage button when no credentials required", () => {
     renderWithProviders(
       <ConnectorCredentialsSection
         agentId={42}
@@ -93,8 +99,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
     expect(
-      screen.getByText("This connector does not require any credentials."),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /Manage credentials/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows loading state", () => {
@@ -110,6 +116,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows connected status with stored credentials", async () => {
+    const user = userEvent.setup();
     setupMockGet({
       "/v1/credentials": { data: storedCredentials },
     });
@@ -122,6 +129,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText("Connected")).toBeInTheDocument();
     });
@@ -130,6 +139,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows not configured status when no credentials stored", async () => {
+    const user = userEvent.setup();
     setupMockGet();
 
     renderWithProviders(
@@ -139,6 +149,8 @@ describe("ConnectorCredentialsSection", () => {
         requiredCredentials={apiKeyCredentials}
       />,
     );
+
+    await openManageModal(user);
 
     await waitFor(() => {
       expect(screen.getByText("Not configured")).toBeInTheDocument();
@@ -157,6 +169,8 @@ describe("ConnectorCredentialsSection", () => {
         requiredCredentials={apiKeyCredentials}
       />,
     );
+
+    await openManageModal(user);
 
     await waitFor(() => {
       expect(screen.getByText("Connect")).toBeInTheDocument();
@@ -186,6 +200,8 @@ describe("ConnectorCredentialsSection", () => {
         requiredCredentials={apiKeyCredentials}
       />,
     );
+
+    await openManageModal(user);
 
     await waitFor(() => {
       expect(screen.getByText("Connect")).toBeInTheDocument();
@@ -220,6 +236,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText("Personal Access Token")).toBeInTheDocument();
     });
@@ -250,6 +268,8 @@ describe("ConnectorCredentialsSection", () => {
         requiredCredentials={apiKeyCredentials}
       />,
     );
+
+    await openManageModal(user);
 
     await waitFor(() => {
       expect(screen.getByText("Personal Access Token")).toBeInTheDocument();
@@ -285,6 +305,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText("Connect")).toBeInTheDocument();
     });
@@ -296,6 +318,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows OAuth connect button for oauth2 credential", async () => {
+    const user = userEvent.setup();
     setupMockGet();
 
     renderWithProviders(
@@ -306,6 +329,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
     });
@@ -314,6 +339,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows OAuth credential row for Slack oauth2 auth type", async () => {
+    const user = userEvent.setup();
     setupMockGet({
       "/v1/oauth/providers": {
         data: {
@@ -337,6 +363,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText("OAuth")).toBeInTheDocument();
     });
@@ -345,6 +373,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows OAuth connected status when user has connection", async () => {
+    const user = userEvent.setup();
     setupMockGet({
       "/v1/oauth/connections": {
         data: {
@@ -380,6 +409,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText(/^Connected/)).toBeInTheDocument();
     });
@@ -389,6 +420,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows re-authorization state for expired connection", async () => {
+    const user = userEvent.setup();
     setupMockGet({
       "/v1/oauth/connections": {
         data: {
@@ -419,6 +451,8 @@ describe("ConnectorCredentialsSection", () => {
       />,
     );
 
+    await openManageModal(user);
+
     await waitFor(() => {
       expect(screen.getByText("Re-authorization required")).toBeInTheDocument();
     });
@@ -426,6 +460,7 @@ describe("ConnectorCredentialsSection", () => {
   });
 
   it("shows both OAuth and API key options for mixed credentials", async () => {
+    const user = userEvent.setup();
     setupMockGet();
 
     renderWithProviders(
@@ -435,6 +470,8 @@ describe("ConnectorCredentialsSection", () => {
         requiredCredentials={mixedCredentials}
       />,
     );
+
+    await openManageModal(user);
 
     await waitFor(() => {
       expect(screen.getByText("Connect GitHub")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Extracts the inline credentials management UI (OAuth connections, static credentials, add/disconnect buttons) from the connector config page into a `ManageCredentialsDialog` modal
- Adds a "Manage credentials" button beneath the Agent Credential dropdown that opens the modal
- Keeps the Agent Credential binding dropdown inline for quick access

## Test plan

### Claude Code
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] All 721 frontend tests pass (`npm test`)
- [x] Tests updated to open modal before asserting on credential content

### OpenClaw
- [ ] Manual: open an agent connector config page, verify the credential management box is gone from inline
- [ ] Manual: "Manage credentials" button appears and opens modal with OAuth + API key rows
- [ ] Manual: sub-dialogs (add credential, disconnect, remove) still work inside the modal
- [ ] Manual: verify button is hidden when connector has no required credentials

https://claude.ai/code/session_01WkV1LRDyA2Do9vYRg3fPCE