### PR TITLE
Fix token dropdown: show all credentials with custom labels

### DIFF
--- a/frontend/src/lib/__tests__/providers.test.ts
+++ b/frontend/src/lib/__tests__/providers.test.ts
@@ -27,6 +27,11 @@ describe("serviceLabel", () => {
     expect(serviceLabel("github_pat")).toBe("GitHub Personal Access Token");
   });
 
+  it("falls back to provider label for bare provider IDs", () => {
+    expect(serviceLabel("github")).toBe("GitHub");
+    expect(serviceLabel("slack")).toBe("Slack");
+  });
+
   it("falls back to raw service ID for unknown services", () => {
     expect(serviceLabel("some-service")).toBe("some-service");
   });

--- a/frontend/src/lib/labels.ts
+++ b/frontend/src/lib/labels.ts
@@ -46,10 +46,11 @@ const SERVICE_LABELS: Record<string, string> = {
 
 /**
  * Returns a human-readable label for a credential service identifier.
- * Falls back to the raw service ID if no explicit label is defined.
+ * Falls back to providerLabel() for proper casing when service IDs match
+ * provider IDs (e.g. "github" → "GitHub").
  */
 export function serviceLabel(service: string): string {
-  return SERVICE_LABELS[service] ?? service;
+  return SERVICE_LABELS[service] ?? PROVIDER_LABELS[service] ?? service;
 }
 
 const AUTH_TYPE_LABELS: Record<string, string> = {

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Settings } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -38,8 +38,9 @@ export function ConnectorCredentialsSection({
 }: ConnectorCredentialsSectionProps) {
   // Collect all service IDs from required credentials so the dropdown can
   // include credentials stored under any of them (e.g. "github" + "github_pat").
-  const credentialServiceIds = new Set(
-    requiredCredentials.map((rc) => rc.service),
+  const credentialServiceIds = useMemo(
+    () => new Set(requiredCredentials.map((rc) => rc.service)),
+    [requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
 

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -39,8 +39,8 @@ export function ConnectorCredentialsSection({
   // Collect all service IDs from required credentials so the dropdown can
   // include credentials stored under any of them (e.g. "github" + "github_pat").
   const credentialServiceIds = useMemo(
-    () => new Set(requiredCredentials.map((rc) => rc.service)),
-    [requiredCredentials],
+    () => new Set([connectorId, ...requiredCredentials.map((rc) => rc.service)]),
+    [connectorId, requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
 

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -36,6 +36,11 @@ export function ConnectorCredentialsSection({
   connectorId,
   requiredCredentials,
 }: ConnectorCredentialsSectionProps) {
+  // Collect all service IDs from required credentials so the dropdown can
+  // include credentials stored under any of them (e.g. "github" + "github_pat").
+  const credentialServiceIds = new Set(
+    requiredCredentials.map((rc) => rc.service),
+  );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
 
   const hasRequiredCredentials = requiredCredentials.length > 0;
@@ -92,6 +97,7 @@ export function ConnectorCredentialsSection({
         <AgentCredentialBinding
           agentId={agentId}
           connectorId={connectorId}
+          credentialServiceIds={credentialServiceIds}
           credentials={credentials}
           connections={connections}
           anyLoading={anyLoading}
@@ -138,12 +144,14 @@ const selectClassName =
 function AgentCredentialBinding({
   agentId,
   connectorId,
+  credentialServiceIds,
   credentials,
   connections,
   anyLoading,
 }: {
   agentId: number;
   connectorId: string;
+  credentialServiceIds: Set<string>;
   credentials: CredentialSummary[];
   connections: OAuthConnection[];
   anyLoading: boolean;
@@ -157,7 +165,7 @@ function AgentCredentialBinding({
   const isPending = assigning;
 
   const scopedCredentials = credentials.filter(
-    (c) => c.service === connectorId,
+    (c) => credentialServiceIds.has(c.service),
   );
   const activeConnections = connections.filter(
     (c) => c.status === "active" && c.id && c.provider === connectorId,
@@ -241,9 +249,10 @@ function AgentCredentialBinding({
           ))}
           {scopedCredentials.map((cred) => (
             <option key={`cred:${cred.id}`} value={`cred:${cred.id}`}>
-              {serviceLabel(cred.service)}
-              {cred.label ? ` — ${cred.label}` : ""} (added{" "}
-              {new Date(cred.created_at).toLocaleDateString()})
+              {cred.label
+                ? `${cred.label} — ${serviceLabel(cred.service)}`
+                : serviceLabel(cred.service)}{" "}
+              (added {new Date(cred.created_at).toLocaleDateString()})
             </option>
           ))}
         </select>

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -71,6 +71,12 @@ export function ManageCredentialsDialog({
   error,
   oauthError,
 }: ManageCredentialsDialogProps) {
+  // True when connectorId is already a static required credential service —
+  // skip orphan merging to avoid showing the same credentials in two rows.
+  const connectorIdIsExplicitService = sorted.some(
+    (c) => c.auth_type !== "oauth2" && c.service === connectorId,
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
@@ -141,9 +147,6 @@ export function ManageCredentialsDialog({
                 !sorted
                   .slice(0, idx)
                   .some((c) => c.auth_type !== "oauth2");
-              const connectorIdIsExplicitService = sorted.some(
-                (c) => c.auth_type !== "oauth2" && c.service === connectorId,
-              );
               let storedCredentials =
                 storedByService.get(cred.service) ?? [];
               if (

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -71,10 +71,12 @@ export function ManageCredentialsDialog({
   error,
   oauthError,
 }: ManageCredentialsDialogProps) {
-  // True when connectorId is already a static required credential service —
-  // skip orphan merging to avoid showing the same credentials in two rows.
+  // Precompute loop-invariant values used inside sorted.map().
   const connectorIdIsExplicitService = sorted.some(
     (c) => c.auth_type !== "oauth2" && c.service === connectorId,
+  );
+  const firstStaticIdx = sorted.findIndex(
+    (c) => c.auth_type !== "oauth2",
   );
 
   return (
@@ -142,11 +144,7 @@ export function ManageCredentialsDialog({
               // with service "github" instead of "github_pat").
               // Skip if connectorId is already an explicit static service
               // to avoid showing the same credentials in two rows.
-              const isFirstStatic =
-                cred.auth_type !== "oauth2" &&
-                !sorted
-                  .slice(0, idx)
-                  .some((c) => c.auth_type !== "oauth2");
+              const isFirstStatic = idx === firstStaticIdx;
               let storedCredentials =
                 storedByService.get(cred.service) ?? [];
               if (

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -134,16 +134,22 @@ export function ManageCredentialsDialog({
               // connectorId itself — these are "orphans" that don't match
               // any specific required credential service (e.g. a PAT stored
               // with service "github" instead of "github_pat").
+              // Skip if connectorId is already an explicit static service
+              // to avoid showing the same credentials in two rows.
               const isFirstStatic =
                 cred.auth_type !== "oauth2" &&
                 !sorted
                   .slice(0, idx)
                   .some((c) => c.auth_type !== "oauth2");
+              const connectorIdIsExplicitService = sorted.some(
+                (c) => c.auth_type !== "oauth2" && c.service === connectorId,
+              );
               let storedCredentials =
                 storedByService.get(cred.service) ?? [];
               if (
                 isFirstStatic &&
                 connectorId !== cred.service &&
+                !connectorIdIsExplicitService &&
                 storedByService.has(connectorId)
               ) {
                 const seenIds = new Set(storedCredentials.map((c) => c.id));

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -129,6 +129,32 @@ export function ManageCredentialsDialog({
                 prevCred.auth_type === "oauth2" &&
                 cred.auth_type !== "oauth2";
 
+              // Collect stored credentials for this row. For the first
+              // static row, also include credentials stored under the
+              // connectorId itself — these are "orphans" that don't match
+              // any specific required credential service (e.g. a PAT stored
+              // with service "github" instead of "github_pat").
+              const isFirstStatic =
+                cred.auth_type !== "oauth2" &&
+                !sorted
+                  .slice(0, idx)
+                  .some((c) => c.auth_type !== "oauth2");
+              let storedCredentials =
+                storedByService.get(cred.service) ?? [];
+              if (
+                isFirstStatic &&
+                connectorId !== cred.service &&
+                storedByService.has(connectorId)
+              ) {
+                const seenIds = new Set(storedCredentials.map((c) => c.id));
+                const orphans = (
+                  storedByService.get(connectorId) ?? []
+                ).filter((c) => !seenIds.has(c.id));
+                if (orphans.length > 0) {
+                  storedCredentials = [...storedCredentials, ...orphans];
+                }
+              }
+
               return (
                 <div key={`${cred.service}:${cred.auth_type}`}>
                   {showOrSeparator && (
@@ -149,9 +175,7 @@ export function ManageCredentialsDialog({
                   ) : (
                     <StaticCredentialRow
                       requiredCredential={cred}
-                      storedCredentials={
-                        storedByService.get(cred.service) ?? []
-                      }
+                      storedCredentials={storedCredentials}
                       isAlternative={hasOAuth}
                     />
                   )}


### PR DESCRIPTION
## Summary
- Fixed credential dropdown filtering to include all service IDs from required credentials (e.g. both `github` and `github_pat`), not just the connectorId. This was causing PAT credentials to not appear in the dropdown.
- Custom labels now lead in the dropdown text (e.g. `Key 500 — GitHub Personal Access Token`) instead of being appended after the service type, matching how OAuth shows display names.
- `serviceLabel()` now falls back to provider labels for proper casing (`github` → `GitHub`).

## Test plan
### Claude Code
- [x] Frontend TypeScript compiles clean
- [x] All 722 frontend tests pass (including new `serviceLabel` fallback test)

### OpenClaw
- [ ] Verify on the connector page that all stored API keys appear in the agent credential dropdown
- [ ] Confirm custom labels (e.g. "Key 500") are shown prominently in the dropdown
- [ ] Check that OAuth entries still display correctly with their display names

https://claude.ai/code/session_01JQkFrD7VaA45pbYyk9AXq3