### PR TITLE
Fix watch skill reporting vague merge status

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -300,6 +300,15 @@ This handles:
 - Auto-merging if enabled and checks pass
 - Triggering the webhook notification
 
+**After the script completes successfully (exit code 0) with `AUTO_MERGE=true`:**
+
+Check the script output for the merge result. The script prints clear signals:
+- `"[post] PR merged successfully."` → The merge completed. Report it as **merged**, not "attempted". Do NOT say "may need human approval" — if the script printed this, the PR is merged.
+- `"[post] Auto-merge failed."` → The merge failed. The script already posted a comment on the PR. Report the failure and suggest the user merge manually.
+- `"[post] Auto-merge enabled but checks did not pass."` → CI or audit failed, merge was skipped. Report which checks failed.
+
+**Do NOT hedge or use vague language like "attempted" or "may need human approval" when the script output clearly indicates success or failure.** Read the output and report what actually happened.
+
 **If the post-session script exits with code 101 (CI failure) or 102 (audit failure):**
 
 1. Read the failure logs from the file path in the script output.


### PR DESCRIPTION
## Summary
- The watch skill agent was reporting "Auto-merge attempted (may need human approval to complete)" even when the merge had already succeeded
- Added explicit instructions in SKILL.md Step 5 to read the `watch-post.sh` output signals and report the actual outcome (merged, failed, or skipped) instead of hedging with vague language

## Test plan
- [ ] Run `/watch <PR_URL> --automerge` on a PR with passing checks and verify the agent reports "PR merged" instead of "attempted"

https://claude.ai/code/session_01WQS7QWpLaGcdaYBFeZJ46J