### PR TITLE
Delete API key credentials when removing a connector

### DIFF
--- a/api/agent_connector_credentials.go
+++ b/api/agent_connector_credentials.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// --- Response types ---
+
+type assignCredentialRequest struct {
+	CredentialID      *string `json:"credential_id,omitempty"`
+	OAuthConnectionID *string `json:"oauth_connection_id,omitempty"`
+}
+
+type agentConnectorCredentialResponse struct {
+	AgentID           int64   `json:"agent_id"`
+	ConnectorID       string  `json:"connector_id"`
+	CredentialID      *string `json:"credential_id,omitempty"`
+	OAuthConnectionID *string `json:"oauth_connection_id,omitempty"`
+}
+
+func handleAssignAgentConnectorCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		var req assignCredentialRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		// Exactly one of credential_id or oauth_connection_id must be provided.
+		if (req.CredentialID == nil) == (req.OAuthConnectionID == nil) {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "provide exactly one of credential_id or oauth_connection_id"))
+			return
+		}
+
+		// Validate ownership and service match for static credentials.
+		if req.CredentialID != nil {
+			cred, err := db.GetCredentialByID(r.Context(), deps.DB, *req.CredentialID)
+			if err != nil {
+				log.Printf("[%s] AssignCredential: credential check: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify credential"))
+				return
+			}
+			if cred == nil || cred.UserID != userID {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Credential not found"))
+				return
+			}
+			if cred.Service != connectorID {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					fmt.Sprintf("credential service %q does not match connector %q", cred.Service, connectorID)))
+				return
+			}
+		}
+		if req.OAuthConnectionID != nil {
+			conn, err := db.GetOAuthConnectionByID(r.Context(), deps.DB, *req.OAuthConnectionID)
+			if err != nil {
+				log.Printf("[%s] AssignCredential: oauth check: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify OAuth connection"))
+				return
+			}
+			if conn == nil || conn.UserID != userID {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "OAuth connection not found"))
+				return
+			}
+			if conn.Provider != connectorID {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					fmt.Sprintf("OAuth connection provider %q does not match connector %q", conn.Provider, connectorID)))
+				return
+			}
+		}
+
+		bindingID, err := generatePrefixedID("acc_", 16)
+		if err != nil {
+			log.Printf("[%s] AssignCredential: generate ID: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign credential"))
+			return
+		}
+
+		binding, err := db.UpsertAgentConnectorCredential(r.Context(), deps.DB, db.UpsertAgentConnectorCredentialParams{
+			ID:                bindingID,
+			AgentID:           agentID,
+			ConnectorID:       connectorID,
+			ApproverID:        userID,
+			CredentialID:      req.CredentialID,
+			OAuthConnectionID: req.OAuthConnectionID,
+		})
+		if err != nil {
+			log.Printf("[%s] AssignCredential: upsert: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign credential"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
+			AgentID:           binding.AgentID,
+			ConnectorID:       binding.ConnectorID,
+			CredentialID:      binding.CredentialID,
+			OAuthConnectionID: binding.OAuthConnectionID,
+		})
+	}
+}
+
+func handleRemoveAgentConnectorCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		deleted, err := db.DeleteAgentConnectorCredential(r.Context(), deps.DB, agentID, userID, connectorID)
+		if err != nil {
+			log.Printf("[%s] RemoveCredential: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to remove credential binding"))
+			return
+		}
+		if !deleted {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrCredentialNotFound, "No credential binding found"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+	}
+}
+
+func handleGetAgentConnectorCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		binding, err := db.GetAgentConnectorCredential(r.Context(), deps.DB, agentID, connectorID)
+		if err != nil {
+			log.Printf("[%s] GetCredentialBinding: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get credential binding"))
+			return
+		}
+		if binding == nil {
+			RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
+				AgentID:     agentID,
+				ConnectorID: connectorID,
+			})
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
+			AgentID:           binding.AgentID,
+			ConnectorID:       binding.ConnectorID,
+			CredentialID:      binding.CredentialID,
+			OAuthConnectionID: binding.OAuthConnectionID,
+		})
+	}
+}

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -1,13 +1,14 @@
 package api
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/vault"
 )
 
 // --- Response types ---
@@ -139,76 +140,33 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 
 		deleteCredentials := r.URL.Query().Get("delete_credentials") == "true"
 
-		if deleteCredentials {
-			// Wrap in a transaction so connector disable + credential delete are atomic.
-			tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
-			if err != nil {
-				log.Printf("[%s] DisableAgentConnector: begin tx: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
-				return
-			}
-			if owned {
-				defer db.RollbackTx(r.Context(), tx) //nolint:errcheck // best-effort cleanup
-			}
+		// When deleting credentials, wrap everything in a transaction so
+		// connector disable + credential delete + vault delete are atomic.
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] DisableAgentConnector: begin tx: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx) //nolint:errcheck // best-effort cleanup
+		}
 
-			// Look up credential binding before disabling (cascade will delete the binding row).
-			credBinding, err := db.GetAgentConnectorCredential(r.Context(), tx, agentID, connectorID)
+		// Look up credential binding before disabling — the cascade from
+		// agent_connectors → agent_connector_credentials will remove it.
+		var credBinding *db.AgentConnectorCredential
+		if deleteCredentials {
+			credBinding, err = db.GetAgentConnectorCredential(r.Context(), tx, agentID, connectorID)
 			if err != nil {
 				log.Printf("[%s] DisableAgentConnector: get credential: %v", TraceID(r.Context()), err)
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
 				return
 			}
-
-			result, err := db.DisableAgentConnector(r.Context(), tx, agentID, userID, connectorID)
-			if err != nil {
-				log.Printf("[%s] DisableAgentConnector: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
-				return
-			}
-			if result == nil {
-				RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not enabled for this agent"))
-				return
-			}
-
-			// Delete the credential and its vault secret if one was assigned.
-			if credBinding != nil && credBinding.CredentialID != nil {
-				deleteResult, err := db.DeleteCredential(r.Context(), tx, *credBinding.CredentialID, userID)
-				if err != nil {
-					var credErr *db.CredentialError
-					if !errors.As(err, &credErr) || credErr.Code != db.CredentialErrNotFound {
-						log.Printf("[%s] DisableAgentConnector: delete credential: %v", TraceID(r.Context()), err)
-						RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
-						return
-					}
-				} else if deps.Vault != nil {
-					if err := deps.Vault.DeleteSecret(r.Context(), tx, deleteResult.VaultSecretID); err != nil {
-						log.Printf("[%s] DisableAgentConnector: vault delete: %v", TraceID(r.Context()), err)
-						RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
-						return
-					}
-				}
-			}
-
-			if owned {
-				if err := db.CommitTx(r.Context(), tx); err != nil {
-					log.Printf("[%s] DisableAgentConnector: commit: %v", TraceID(r.Context()), err)
-					RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
-					return
-				}
-			}
-
-			RespondJSON(w, http.StatusOK, disableAgentConnectorResponse{
-				AgentID:                  result.AgentID,
-				ConnectorID:              result.ConnectorID,
-				DisabledAt:               result.DisabledAt,
-				RevokedStandingApprovals: result.RevokedStandingApprovals,
-			})
-			return
 		}
 
 		// Delete is scoped by approver_id: returns nil for both "agent not found"
 		// and "connector not enabled" to avoid leaking agent existence.
-		result, err := db.DisableAgentConnector(r.Context(), deps.DB, agentID, userID, connectorID)
+		result, err := db.DisableAgentConnector(r.Context(), tx, agentID, userID, connectorID)
 		if err != nil {
 			log.Printf("[%s] DisableAgentConnector: %v", TraceID(r.Context()), err)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
@@ -217,6 +175,22 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 		if result == nil {
 			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not enabled for this agent"))
 			return
+		}
+
+		if deleteCredentials && credBinding != nil && credBinding.CredentialID != nil {
+			if err := deleteCredentialAndVault(r.Context(), tx, *credBinding.CredentialID, userID, deps.Vault); err != nil {
+				log.Printf("[%s] DisableAgentConnector: delete credential: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
+				return
+			}
+		}
+
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] DisableAgentConnector: commit: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+				return
+			}
 		}
 
 		RespondJSON(w, http.StatusOK, disableAgentConnectorResponse{
@@ -228,185 +202,19 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 	}
 }
 
-// --- Credential binding ---
-
-type assignCredentialRequest struct {
-	CredentialID      *string `json:"credential_id,omitempty"`
-	OAuthConnectionID *string `json:"oauth_connection_id,omitempty"`
-}
-
-type agentConnectorCredentialResponse struct {
-	AgentID           int64   `json:"agent_id"`
-	ConnectorID       string  `json:"connector_id"`
-	CredentialID      *string `json:"credential_id,omitempty"`
-	OAuthConnectionID *string `json:"oauth_connection_id,omitempty"`
-}
-
-func handleAssignAgentConnectorCredential(deps *Deps) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		userID := Profile(r.Context()).ID
-
-		agentID, ok := parsePathAgentID(w, r)
-		if !ok {
-			return
+// deleteCredentialAndVault deletes a credential row and its associated vault
+// secret atomically within d. NotFound is treated as a no-op (idempotent).
+func deleteCredentialAndVault(ctx context.Context, d db.DBTX, credID, userID string, v vault.VaultStore) error {
+	result, err := db.DeleteCredential(ctx, d, credID, userID)
+	if err != nil {
+		var credErr *db.CredentialError
+		if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
+			return nil // already gone; nothing to do
 		}
-		connectorID := r.PathValue("connector_id")
-		if connectorID == "" {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
-			return
-		}
-
-		if !requireAgentOwnership(w, r, deps, agentID, userID) {
-			return
-		}
-
-		var req assignCredentialRequest
-		if !DecodeJSONOrReject(w, r, &req) {
-			return
-		}
-
-		// Exactly one of credential_id or oauth_connection_id must be provided.
-		if (req.CredentialID == nil) == (req.OAuthConnectionID == nil) {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "provide exactly one of credential_id or oauth_connection_id"))
-			return
-		}
-
-		// Validate ownership and service match for static credentials.
-		if req.CredentialID != nil {
-			cred, err := db.GetCredentialByID(r.Context(), deps.DB, *req.CredentialID)
-			if err != nil {
-				log.Printf("[%s] AssignCredential: credential check: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify credential"))
-				return
-			}
-			if cred == nil || cred.UserID != userID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Credential not found"))
-				return
-			}
-			if cred.Service != connectorID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
-					fmt.Sprintf("credential service %q does not match connector %q", cred.Service, connectorID)))
-				return
-			}
-		}
-		if req.OAuthConnectionID != nil {
-			conn, err := db.GetOAuthConnectionByID(r.Context(), deps.DB, *req.OAuthConnectionID)
-			if err != nil {
-				log.Printf("[%s] AssignCredential: oauth check: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify OAuth connection"))
-				return
-			}
-			if conn == nil || conn.UserID != userID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "OAuth connection not found"))
-				return
-			}
-			if conn.Provider != connectorID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
-					fmt.Sprintf("OAuth connection provider %q does not match connector %q", conn.Provider, connectorID)))
-				return
-			}
-		}
-
-		bindingID, err := generatePrefixedID("acc_", 16)
-		if err != nil {
-			log.Printf("[%s] AssignCredential: generate ID: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign credential"))
-			return
-		}
-
-		binding, err := db.UpsertAgentConnectorCredential(r.Context(), deps.DB, db.UpsertAgentConnectorCredentialParams{
-			ID:                bindingID,
-			AgentID:           agentID,
-			ConnectorID:       connectorID,
-			ApproverID:        userID,
-			CredentialID:      req.CredentialID,
-			OAuthConnectionID: req.OAuthConnectionID,
-		})
-		if err != nil {
-			log.Printf("[%s] AssignCredential: upsert: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign credential"))
-			return
-		}
-
-		RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
-			AgentID:           binding.AgentID,
-			ConnectorID:       binding.ConnectorID,
-			CredentialID:      binding.CredentialID,
-			OAuthConnectionID: binding.OAuthConnectionID,
-		})
+		return err
 	}
-}
-
-func handleRemoveAgentConnectorCredential(deps *Deps) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		userID := Profile(r.Context()).ID
-
-		agentID, ok := parsePathAgentID(w, r)
-		if !ok {
-			return
-		}
-		connectorID := r.PathValue("connector_id")
-		if connectorID == "" {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
-			return
-		}
-
-		if !requireAgentOwnership(w, r, deps, agentID, userID) {
-			return
-		}
-
-		deleted, err := db.DeleteAgentConnectorCredential(r.Context(), deps.DB, agentID, userID, connectorID)
-		if err != nil {
-			log.Printf("[%s] RemoveCredential: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to remove credential binding"))
-			return
-		}
-		if !deleted {
-			RespondError(w, r, http.StatusNotFound, NotFound(ErrCredentialNotFound, "No credential binding found"))
-			return
-		}
-
-		RespondJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+	if v != nil {
+		return v.DeleteSecret(ctx, d, result.VaultSecretID)
 	}
-}
-
-func handleGetAgentConnectorCredential(deps *Deps) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		userID := Profile(r.Context()).ID
-
-		agentID, ok := parsePathAgentID(w, r)
-		if !ok {
-			return
-		}
-		connectorID := r.PathValue("connector_id")
-		if connectorID == "" {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
-			return
-		}
-
-		if !requireAgentOwnership(w, r, deps, agentID, userID) {
-			return
-		}
-
-		binding, err := db.GetAgentConnectorCredential(r.Context(), deps.DB, agentID, connectorID)
-		if err != nil {
-			log.Printf("[%s] GetCredentialBinding: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get credential binding"))
-			return
-		}
-		if binding == nil {
-			RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
-				AgentID:     agentID,
-				ConnectorID: connectorID,
-			})
-			return
-		}
-
-		RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
-			AgentID:           binding.AgentID,
-			ConnectorID:       binding.ConnectorID,
-			CredentialID:      binding.CredentialID,
-			OAuthConnectionID: binding.OAuthConnectionID,
-		})
-	}
+	return nil
 }

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -141,13 +141,15 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 
 		if deleteCredentials {
 			// Wrap in a transaction so connector disable + credential delete are atomic.
-			tx, _, err := db.BeginOrContinue(r.Context(), deps.DB)
+			tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
 			if err != nil {
 				log.Printf("[%s] DisableAgentConnector: begin tx: %v", TraceID(r.Context()), err)
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
 				return
 			}
-			defer db.RollbackTx(r.Context(), tx) //nolint:errcheck
+			if owned {
+				defer db.RollbackTx(r.Context(), tx) //nolint:errcheck // best-effort cleanup
+			}
 
 			// Look up credential binding before disabling (cascade will delete the binding row).
 			credBinding, err := db.GetAgentConnectorCredential(r.Context(), tx, agentID, connectorID)
@@ -187,10 +189,12 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 				}
 			}
 
-			if err := db.CommitTx(r.Context(), tx); err != nil {
-				log.Printf("[%s] DisableAgentConnector: commit: %v", TraceID(r.Context()), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
-				return
+			if owned {
+				if err := db.CommitTx(r.Context(), tx); err != nil {
+					log.Printf("[%s] DisableAgentConnector: commit: %v", TraceID(r.Context()), err)
+					RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+					return
+				}
 			}
 
 			RespondJSON(w, http.StatusOK, disableAgentConnectorResponse{

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -137,6 +137,71 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		deleteCredentials := r.URL.Query().Get("delete_credentials") == "true"
+
+		if deleteCredentials {
+			// Wrap in a transaction so connector disable + credential delete are atomic.
+			tx, _, err := db.BeginOrContinue(r.Context(), deps.DB)
+			if err != nil {
+				log.Printf("[%s] DisableAgentConnector: begin tx: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+				return
+			}
+			defer db.RollbackTx(r.Context(), tx) //nolint:errcheck
+
+			// Look up credential binding before disabling (cascade will delete the binding row).
+			credBinding, err := db.GetAgentConnectorCredential(r.Context(), tx, agentID, connectorID)
+			if err != nil {
+				log.Printf("[%s] DisableAgentConnector: get credential: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+				return
+			}
+
+			result, err := db.DisableAgentConnector(r.Context(), tx, agentID, userID, connectorID)
+			if err != nil {
+				log.Printf("[%s] DisableAgentConnector: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+				return
+			}
+			if result == nil {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not enabled for this agent"))
+				return
+			}
+
+			// Delete the credential and its vault secret if one was assigned.
+			if credBinding != nil && credBinding.CredentialID != nil {
+				deleteResult, err := db.DeleteCredential(r.Context(), tx, *credBinding.CredentialID, userID)
+				if err != nil {
+					var credErr *db.CredentialError
+					if !errors.As(err, &credErr) || credErr.Code != db.CredentialErrNotFound {
+						log.Printf("[%s] DisableAgentConnector: delete credential: %v", TraceID(r.Context()), err)
+						RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
+						return
+					}
+				} else if deps.Vault != nil {
+					if err := deps.Vault.DeleteSecret(r.Context(), tx, deleteResult.VaultSecretID); err != nil {
+						log.Printf("[%s] DisableAgentConnector: vault delete: %v", TraceID(r.Context()), err)
+						RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
+						return
+					}
+				}
+			}
+
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] DisableAgentConnector: commit: %v", TraceID(r.Context()), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+				return
+			}
+
+			RespondJSON(w, http.StatusOK, disableAgentConnectorResponse{
+				AgentID:                  result.AgentID,
+				ConnectorID:              result.ConnectorID,
+				DisabledAt:               result.DisabledAt,
+				RevokedStandingApprovals: result.RevokedStandingApprovals,
+			})
+			return
+		}
+
 		// Delete is scoped by approver_id: returns nil for both "agent not found"
 		// and "connector not enabled" to avoid leaking agent existence.
 		result, err := db.DisableAgentConnector(r.Context(), deps.DB, agentID, userID, connectorID)

--- a/api/agent_connectors_test.go
+++ b/api/agent_connectors_test.go
@@ -1,13 +1,16 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	"github.com/supersuit-tech/permission-slip-web/vault"
 )
 
 // ── GET /agents/{agent_id}/connectors ───────────────────────────────────────
@@ -414,5 +417,60 @@ func TestDisableAgentConnector_RevokesStandingApprovals(t *testing.T) {
 	resp := decodeDisableAgentConnectorResponse(t, w.Body.Bytes())
 	if resp.RevokedStandingApprovals != 1 {
 		t.Errorf("expected 1 revoked standing approval, got %d", resp.RevokedStandingApprovals)
+	}
+}
+
+func TestDisableAgentConnector_DeleteCredentials(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	mockVault := vault.NewMockVaultStore()
+	vaultSecretID, err := mockVault.CreateSecret(context.Background(), tx, "cred_test", []byte("secret"))
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultSecretID)
+	if _, err = db.UpsertAgentConnectorCredential(context.Background(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID:           testhelper.GenerateID(t, "acc_"),
+		AgentID:      agentID,
+		ConnectorID:  connID,
+		ApproverID:   uid,
+		CredentialID: &credID,
+	}); err != nil {
+		t.Fatalf("UpsertAgentConnectorCredential: %v", err)
+	}
+
+	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodDelete,
+		fmt.Sprintf("/agents/%d/connectors/%s?delete_credentials=true", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Credential row should be gone.
+	exists, err := db.CredentialBelongsToUser(context.Background(), tx, credID, uid)
+	if err != nil {
+		t.Fatalf("CredentialBelongsToUser: %v", err)
+	}
+	if exists {
+		t.Error("expected credential to be deleted, but it still exists")
+	}
+
+	// Vault secret should be gone.
+	if mockVault.SecretCount() != 0 {
+		t.Errorf("expected 0 vault secrets after remove, got %d", mockVault.SecretCount())
 	}
 }

--- a/api/agent_connectors_test.go
+++ b/api/agent_connectors_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -431,14 +430,14 @@ func TestDisableAgentConnector_DeleteCredentials(t *testing.T) {
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
 
 	mockVault := vault.NewMockVaultStore()
-	vaultSecretID, err := mockVault.CreateSecret(context.Background(), tx, "cred_test", []byte("secret"))
+	vaultSecretID, err := mockVault.CreateSecret(t.Context(), tx, "cred_test", []byte("secret"))
 	if err != nil {
 		t.Fatalf("CreateSecret: %v", err)
 	}
 
 	credID := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, connID, vaultSecretID)
-	if _, err = db.UpsertAgentConnectorCredential(context.Background(), tx, db.UpsertAgentConnectorCredentialParams{
+	if _, err = db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
 		ID:           testhelper.GenerateID(t, "acc_"),
 		AgentID:      agentID,
 		ConnectorID:  connID,
@@ -461,7 +460,7 @@ func TestDisableAgentConnector_DeleteCredentials(t *testing.T) {
 	}
 
 	// Credential row should be gone.
-	exists, err := db.CredentialBelongsToUser(context.Background(), tx, credID, uid)
+	exists, err := db.CredentialBelongsToUser(t.Context(), tx, credID, uid)
 	if err != nil {
 		t.Fatalf("CredentialBelongsToUser: %v", err)
 	}

--- a/api/agent_connectors_test.go
+++ b/api/agent_connectors_test.go
@@ -473,3 +473,30 @@ func TestDisableAgentConnector_DeleteCredentials(t *testing.T) {
 		t.Errorf("expected 0 vault secrets after remove, got %d", mockVault.SecretCount())
 	}
 }
+
+// TestDisableAgentConnector_DeleteCredentials_NoBinding verifies that
+// delete_credentials=true succeeds even when no credential is bound —
+// the connector is disabled and the no-op case is handled gracefully.
+func TestDisableAgentConnector_DeleteCredentials_NoBinding(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	// No credential binding inserted.
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodDelete,
+		fmt.Sprintf("/agents/%d/connectors/%s?delete_credentials=true", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/frontend/src/hooks/__tests__/useDisableAgentConnector.test.tsx
+++ b/frontend/src/hooks/__tests__/useDisableAgentConnector.test.tsx
@@ -46,6 +46,7 @@ describe("useDisableAgentConnector", () => {
         headers: { Authorization: "Bearer token" },
         params: {
           path: { agent_id: 42, connector_id: "gmail" },
+          query: {},
         },
       },
     );

--- a/frontend/src/hooks/__tests__/useDisableAgentConnector.test.tsx
+++ b/frontend/src/hooks/__tests__/useDisableAgentConnector.test.tsx
@@ -59,6 +59,41 @@ describe("useDisableAgentConnector", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it("sends delete_credentials=true when deleteCredentials is set", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockDelete.mockResolvedValue({
+      data: {
+        agent_id: 42,
+        connector_id: "github",
+        disabled_at: "2026-02-18T12:00:00Z",
+        revoked_standing_approvals: 0,
+      },
+    });
+
+    const { result } = renderHook(() => useDisableAgentConnector(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.disableConnector({
+        agentId: 42,
+        connectorId: "github",
+        deleteCredentials: true,
+      });
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/v1/agents/{agent_id}/connectors/{connector_id}",
+      {
+        headers: { Authorization: "Bearer token" },
+        params: {
+          path: { agent_id: 42, connector_id: "github" },
+          query: { delete_credentials: true },
+        },
+      },
+    );
+  });
+
   it("throws when not authenticated", async () => {
     setupAuthMocks({ authenticated: false });
 

--- a/frontend/src/hooks/useDisableAgentConnector.ts
+++ b/frontend/src/hooks/useDisableAgentConnector.ts
@@ -9,6 +9,7 @@ type DisableResponse =
 interface DisableArgs {
   agentId: number;
   connectorId: string;
+  deleteCredentials?: boolean;
 }
 
 export function useDisableAgentConnector() {
@@ -16,7 +17,7 @@ export function useDisableAgentConnector() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async ({ agentId, connectorId }: DisableArgs) => {
+    mutationFn: async ({ agentId, connectorId, deleteCredentials }: DisableArgs) => {
       if (!session?.access_token) {
         throw new Error("Not authenticated");
       }
@@ -27,6 +28,7 @@ export function useDisableAgentConnector() {
           headers: { Authorization: `Bearer ${session.access_token}` },
           params: {
             path: { agent_id: agentId, connector_id: connectorId },
+            query: deleteCredentials ? { delete_credentials: true } : {},
           },
         },
       );

--- a/frontend/src/hooks/useDisableAgentConnector.ts
+++ b/frontend/src/hooks/useDisableAgentConnector.ts
@@ -35,10 +35,16 @@ export function useDisableAgentConnector() {
       if (error) throw new Error("Failed to disable connector");
       return data as DisableResponse;
     },
-    onSuccess: (_data, { agentId }) => {
+    onSuccess: (_data, { agentId, connectorId, deleteCredentials }) => {
       queryClient.invalidateQueries({
         queryKey: ["agent-connectors", agentId],
       });
+      if (deleteCredentials) {
+        queryClient.invalidateQueries({ queryKey: ["credentials"] });
+        queryClient.invalidateQueries({
+          queryKey: ["agent-connector-credential", agentId, connectorId],
+        });
+      }
     },
   });
 

--- a/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
@@ -6,6 +6,7 @@ import { useAgent } from "@/hooks/useAgent";
 import { useActionConfigs } from "@/hooks/useActionConfigs";
 import { useConnectorDetail } from "@/hooks/useConnectorDetail";
 import { useAgentConnectors } from "@/hooks/useAgentConnectors";
+import { useAgentConnectorCredential } from "@/hooks/useAgentConnectorCredential";
 import { ConnectorOverviewSection } from "./ConnectorOverviewSection";
 import { ConnectorActionsDialog } from "./ConnectorActionsDialog";
 import { ActionConfigurationsSection } from "./ActionConfigurationsSection";
@@ -44,6 +45,11 @@ export function ConnectorConfigPage() {
     isLoading: configsLoading,
     error: configsError,
   } = useActionConfigs(agentId);
+
+  const { binding: credentialBinding } = useAgentConnectorCredential(
+    agentId,
+    connectorId ?? "",
+  );
 
   const connectorConfigs = configs.filter((c) => c.connector_id === connectorId);
 
@@ -169,6 +175,7 @@ export function ConnectorConfigPage() {
             (c) => c.auth_type === "oauth2" && c.oauth_provider,
           )?.oauth_provider
         }
+        oauthConnectionId={credentialBinding?.oauth_connection_id ?? undefined}
       />
     </div>
   );

--- a/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
@@ -176,6 +176,7 @@ export function ConnectorConfigPage() {
           )?.oauth_provider
         }
         oauthConnectionId={credentialBinding?.oauth_connection_id ?? undefined}
+        hasApiKeyCredential={!!credentialBinding?.credential_id}
       />
     </div>
   );

--- a/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
+++ b/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
@@ -29,6 +29,8 @@ interface DisableConnectorSectionProps {
   oauthProvider?: string;
   /** Active OAuth connection ID for this connector. Required to actually disconnect OAuth on Remove. */
   oauthConnectionId?: string;
+  /** Whether an API key credential is currently assigned — when true, Remove also deletes it. */
+  hasApiKeyCredential?: boolean;
 }
 
 export function DisableConnectorSection({
@@ -37,6 +39,7 @@ export function DisableConnectorSection({
   connectorName,
   oauthProvider,
   oauthConnectionId,
+  hasApiKeyCredential = false,
 }: DisableConnectorSectionProps) {
   const [disableConfirmOpen, setDisableConfirmOpen] = useState(false);
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
@@ -133,7 +136,7 @@ export function DisableConnectorSection({
             </Button>
           </div>
 
-          {oauthProvider && (
+          {(oauthProvider || hasApiKeyCredential) && (
             <>
               <div className="border-t" />
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -142,10 +145,20 @@ export function DisableConnectorSection({
                     Remove this connector
                   </p>
                   <p className="text-muted-foreground text-xs">
-                    Disable the connector, disconnect the{" "}
-                    {providerLabel(oauthProvider)} OAuth connection, and
-                    permanently delete any saved API keys. You will need to
-                    re-authorize and re-add credentials when re-enabling.
+                    {oauthProvider ? (
+                      <>
+                        Disable the connector, disconnect the{" "}
+                        {providerLabel(oauthProvider)} OAuth connection, and
+                        permanently delete any saved API keys. You will need to
+                        re-authorize and re-add credentials when re-enabling.
+                      </>
+                    ) : (
+                      <>
+                        Disable the connector and permanently delete the saved
+                        API key. You will need to re-add credentials when
+                        re-enabling.
+                      </>
+                    )}
                   </p>
                 </div>
                 <Button
@@ -201,12 +214,23 @@ export function DisableConnectorSection({
           <DialogHeader>
             <DialogTitle>Remove {connectorName}</DialogTitle>
             <DialogDescription>
-              This will disable the <strong>{connectorName}</strong> connector,
-              disconnect the{" "}
-              <strong>{providerLabel(oauthProvider ?? "")}</strong> OAuth
-              connection, and permanently delete any saved API keys. Standing
-              approvals will be revoked. You will need to re-authorize and
-              re-add credentials when re-enabling.
+              {oauthProvider ? (
+                <>
+                  This will disable the <strong>{connectorName}</strong>{" "}
+                  connector, disconnect the{" "}
+                  <strong>{providerLabel(oauthProvider)}</strong> OAuth
+                  connection, and permanently delete any saved API keys.
+                  Standing approvals will be revoked. You will need to
+                  re-authorize and re-add credentials when re-enabling.
+                </>
+              ) : (
+                <>
+                  This will disable the <strong>{connectorName}</strong>{" "}
+                  connector and permanently delete the saved API key. Standing
+                  approvals will be revoked. You will need to re-add credentials
+                  when re-enabling.
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
+++ b/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
@@ -64,10 +64,10 @@ export function DisableConnectorSection({
   async function handleRemove() {
     setIsRemoving(true);
     try {
-      // Step 1: disable the connector
+      // Step 1: disable the connector and delete any API key credentials.
       let disableResult: Awaited<ReturnType<typeof disableConnector>>;
       try {
-        disableResult = await disableConnector({ agentId, connectorId });
+        disableResult = await disableConnector({ agentId, connectorId, deleteCredentials: true });
       } catch {
         toast.error("Failed to disable connector");
         return;
@@ -138,9 +138,10 @@ export function DisableConnectorSection({
                     Remove this connector
                   </p>
                   <p className="text-muted-foreground text-xs">
-                    Disable the connector and disconnect the{" "}
-                    {providerLabel(oauthProvider)} OAuth connection. You will
-                    need to re-authorize when re-enabling.
+                    Disable the connector, disconnect the{" "}
+                    {providerLabel(oauthProvider)} OAuth connection, and
+                    permanently delete any saved API keys. You will need to
+                    re-authorize and re-add credentials when re-enabling.
                   </p>
                 </div>
                 <Button
@@ -196,11 +197,12 @@ export function DisableConnectorSection({
           <DialogHeader>
             <DialogTitle>Remove {connectorName}</DialogTitle>
             <DialogDescription>
-              This will disable the <strong>{connectorName}</strong> connector
-              and disconnect the{" "}
+              This will disable the <strong>{connectorName}</strong> connector,
+              disconnect the{" "}
               <strong>{providerLabel(oauthProvider ?? "")}</strong> OAuth
-              connection. Standing approvals will be revoked and you will need
-              to re-authorize OAuth when re-enabling.
+              connection, and permanently delete any saved API keys. Standing
+              approvals will be revoked. You will need to re-authorize and
+              re-add credentials when re-enabling.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
+++ b/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
@@ -27,6 +27,8 @@ interface DisableConnectorSectionProps {
   connectorName: string;
   /** OAuth provider ID — when set, shows a "Remove" option that also disconnects OAuth. */
   oauthProvider?: string;
+  /** Active OAuth connection ID for this connector. Required to actually disconnect OAuth on Remove. */
+  oauthConnectionId?: string;
 }
 
 export function DisableConnectorSection({
@@ -34,6 +36,7 @@ export function DisableConnectorSection({
   connectorId,
   connectorName,
   oauthProvider,
+  oauthConnectionId,
 }: DisableConnectorSectionProps) {
   const [disableConfirmOpen, setDisableConfirmOpen] = useState(false);
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
@@ -73,26 +76,27 @@ export function DisableConnectorSection({
         return;
       }
 
-      // Step 2: disconnect OAuth (best-effort — connector is already disabled).
-      // The Remove button is only rendered when oauthProvider is set, so this
-      // branch is always taken. The assertion guards against future refactors.
-      if (!oauthProvider) {
-        throw new Error("handleRemove called without oauthProvider");
-      }
       const revoked = disableResult.revoked_standing_approvals;
       const revokedSuffix =
         revoked > 0
           ? ` ${revoked} standing approval${revoked === 1 ? "" : "s"} revoked.`
           : "";
-      try {
-        await disconnect(oauthProvider);
-        toast.success(
-          `Connector removed and OAuth disconnected.${revokedSuffix}`,
-        );
-      } catch {
-        toast.warning(
-          `Connector disabled, but OAuth disconnect failed.${revokedSuffix} You can disconnect manually from Settings.`,
-        );
+
+      // Step 2: disconnect OAuth (best-effort — connector is already disabled).
+      // oauthConnectionId is the specific connection to disconnect; skip if not bound.
+      if (oauthConnectionId) {
+        try {
+          await disconnect(oauthConnectionId);
+          toast.success(
+            `Connector removed and OAuth disconnected.${revokedSuffix}`,
+          );
+        } catch {
+          toast.warning(
+            `Connector disabled and API keys deleted, but OAuth disconnect failed.${revokedSuffix} You can disconnect manually from Settings.`,
+          );
+        }
+      } else {
+        toast.success(`Connector removed.${revokedSuffix}`);
       }
 
       setRemoveConfirmOpen(false);

--- a/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
+++ b/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
@@ -25,11 +25,25 @@ interface DisableConnectorSectionProps {
   agentId: number;
   connectorId: string;
   connectorName: string;
-  /** OAuth provider ID — when set, shows a "Remove" option that also disconnects OAuth. */
+  /**
+   * OAuth provider ID (e.g. "github") from the connector spec.
+   * When set, the "Remove" option is shown and its description mentions
+   * disconnecting OAuth. Does NOT drive the actual disconnect call —
+   * see `oauthConnectionId` for that.
+   */
   oauthProvider?: string;
-  /** Active OAuth connection ID for this connector. Required to actually disconnect OAuth on Remove. */
+  /**
+   * The specific OAuth connection ID currently bound to this connector
+   * (e.g. "oconn_abc123"). Passed to `useDisconnectOAuth` on Remove so
+   * the correct connection is disconnected. If undefined, the OAuth
+   * disconnect step is skipped silently.
+   */
   oauthConnectionId?: string;
-  /** Whether an API key credential is currently assigned — when true, Remove also deletes it. */
+  /**
+   * True when an API key credential is assigned to this connector.
+   * When true (and `oauthProvider` is not set), the "Remove" option is
+   * shown so the user can permanently delete the saved API key.
+   */
   hasApiKeyCredential?: boolean;
 }
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/bundled.yaml
+++ b/spec/openapi/bundled.yaml
@@ -1446,6 +1446,20 @@ paths:
         forgotten standing approvals from silently reactivating if the connector
         is re-enabled later.
 
+        ### Disabling vs. Removing
+
+        By default this endpoint **disables** the connector — it removes the
+        agent-connector association but leaves the user's credentials (API keys)
+        and OAuth connections intact so the connector can be re-enabled without
+        re-entering credentials.
+
+        Pass `?delete_credentials=true` to also **permanently delete** the API
+        key credential assigned to this connector. The credential row and its
+        encrypted vault secret are deleted in the same database transaction, so
+        the operation is fully atomic — either everything succeeds or nothing
+        changes. OAuth connections are unaffected by this flag and must be
+        disconnected separately via `DELETE /v1/oauth/connections/{connection_id}`.
+
         Uses session authentication (Supabase JWT).
       tags:
         - Agents
@@ -1458,9 +1472,16 @@ paths:
           in: query
           required: false
           description: |
-            When true, permanently delete any API key credentials associated with
-            this connector in addition to disabling it. OAuth connections are not
-            affected by this flag (they are managed separately).
+            When `true`, permanently delete the API key credential assigned to
+            this connector (both the credential record and its encrypted vault
+            secret) as part of the same atomic operation. Defaults to `false`.
+
+            Use this when you want a full "remove" — disabling the connector
+            **and** discarding saved API keys — rather than a temporary disable
+            that preserves credentials for re-enabling later.
+
+            OAuth connections are **not** affected by this flag. To disconnect
+            OAuth, call `DELETE /v1/oauth/connections/{connection_id}` separately.
           schema:
             type: boolean
       responses:

--- a/spec/openapi/bundled.yaml
+++ b/spec/openapi/bundled.yaml
@@ -1454,6 +1454,15 @@ paths:
       parameters:
         - $ref: '#/components/parameters/AgentId'
         - $ref: '#/components/parameters/ConnectorId'
+        - name: delete_credentials
+          in: query
+          required: false
+          description: |
+            When true, permanently delete any API key credentials associated with
+            this connector in addition to disabling it. OAuth connections are not
+            affected by this flag (they are managed separately).
+          schema:
+            type: boolean
       responses:
         '200':
           description: Connector disabled for agent
@@ -5647,6 +5656,13 @@ paths:
             type: array
             items:
               type: string
+        - name: replace
+          in: query
+          required: false
+          description: |
+            ID of an existing OAuth connection to replace (reconnect flow). When set, the specified connection is deleted and replaced by the new one after successful authorization. When omitted, a new connection is created alongside any existing ones for the same provider. The connection must belong to the authenticated user and the same provider being authorized.
+          schema:
+            type: string
       responses:
         '307':
           description: Redirects to the OAuth provider's authorization endpoint
@@ -5745,13 +5761,24 @@ paths:
                 $ref: '#/components/schemas/OAuthConnectionListResponse'
               example:
                 connections:
-                  - provider: google
+                  - id: oconn_abc123
+                    provider: google
                     scopes:
                       - openid
                       - https://www.googleapis.com/auth/userinfo.email
                     status: active
                     connected_at: '2026-03-05T10:00:00Z'
-                  - provider: microsoft
+                    display_name: user@gmail.com
+                  - id: oconn_def456
+                    provider: google
+                    scopes:
+                      - openid
+                      - https://www.googleapis.com/auth/gmail.send
+                    status: active
+                    connected_at: '2026-03-06T09:00:00Z'
+                    display_name: work@company.com
+                  - id: oconn_ghi789
+                    provider: microsoft
                     scopes:
                       - openid
                       - offline_access
@@ -5766,16 +5793,18 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-  /v1/oauth/connections/{provider}:
+  /v1/oauth/connections/{connection_id}:
     delete:
       operationId: deleteOAuthConnection
-      summary: Disconnect OAuth Provider
+      summary: Disconnect OAuth Connection
       description: |
-        Disconnects an OAuth provider for the authenticated user. Deletes the
-        OAuth connection row and removes the encrypted tokens from the vault.
+        Disconnects a specific OAuth connection by its ID. Deletes the
+        OAuth connection row, removes the encrypted tokens from the vault,
+        and cascades to remove any agent-connector credential bindings that
+        reference this connection.
 
         After disconnection, any connector actions that depend on this OAuth
-        provider will fail until the user re-authorizes.
+        connection will fail until the user connects a new account.
 
         ## Security
 
@@ -5786,10 +5815,10 @@ paths:
       security:
         - SupabaseSession: []
       parameters:
-        - name: provider
+        - name: connection_id
           in: path
           required: true
-          description: The OAuth provider ID to disconnect
+          description: The OAuth connection ID to disconnect (e.g. "oconn_abc123")
           schema:
             type: string
       responses:
@@ -10512,6 +10541,11 @@ components:
           description: |
             For providers with per-instance OAuth URLs (e.g. Zendesk, Shopify), the instance identifier — subdomain for Zendesk (e.g. "mycompany.zendesk.com") or shop domain for Shopify (e.g. "mystore.myshopify.com"). Omitted for providers with static OAuth endpoints (e.g. Google, Slack).
           example: mycompany.zendesk.com
+        display_name:
+          type: string
+          description: |
+            A human-readable identifier for this connection, typically the authenticated user's email address. Omitted when no identifying information is available.
+          example: user@example.com
     OAuthConnectionListResponse:
       type: object
       required:

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -133,6 +133,20 @@ agentConnectorById:
       forgotten standing approvals from silently reactivating if the connector
       is re-enabled later.
 
+      ### Disabling vs. Removing
+
+      By default this endpoint **disables** the connector — it removes the
+      agent-connector association but leaves the user's credentials (API keys)
+      and OAuth connections intact so the connector can be re-enabled without
+      re-entering credentials.
+
+      Pass `?delete_credentials=true` to also **permanently delete** the API
+      key credential assigned to this connector. The credential row and its
+      encrypted vault secret are deleted in the same database transaction, so
+      the operation is fully atomic — either everything succeeds or nothing
+      changes. OAuth connections are unaffected by this flag and must be
+      disconnected separately via `DELETE /v1/oauth/connections/{connection_id}`.
+
       Uses session authentication (Supabase JWT).
 
     tags:
@@ -148,9 +162,16 @@ agentConnectorById:
         in: query
         required: false
         description: |
-          When true, permanently delete any API key credentials associated with
-          this connector in addition to disabling it. OAuth connections are not
-          affected by this flag (they are managed separately).
+          When `true`, permanently delete the API key credential assigned to
+          this connector (both the credential record and its encrypted vault
+          secret) as part of the same atomic operation. Defaults to `false`.
+
+          Use this when you want a full "remove" — disabling the connector
+          **and** discarding saved API keys — rather than a temporary disable
+          that preserves credentials for re-enabling later.
+
+          OAuth connections are **not** affected by this flag. To disconnect
+          OAuth, call `DELETE /v1/oauth/connections/{connection_id}` separately.
         schema:
           type: boolean
 

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -144,6 +144,15 @@ agentConnectorById:
     parameters:
       - $ref: '../parameters/common.yaml#/AgentId'
       - $ref: '../parameters/common.yaml#/ConnectorId'
+      - name: delete_credentials
+        in: query
+        required: false
+        description: |
+          When true, permanently delete any API key credentials associated with
+          this connector in addition to disabling it. OAuth connections are not
+          affected by this flag (they are managed separately).
+        schema:
+          type: boolean
 
     responses:
       '200':

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1454,6 +1454,15 @@ paths:
       parameters:
         - $ref: '#/components/parameters/AgentId'
         - $ref: '#/components/parameters/ConnectorId'
+        - name: delete_credentials
+          in: query
+          required: false
+          description: |
+            When true, permanently delete any API key credentials associated with
+            this connector in addition to disabling it. OAuth connections are not
+            affected by this flag (they are managed separately).
+          schema:
+            type: boolean
       responses:
         '200':
           description: Connector disabled for agent

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1446,6 +1446,20 @@ paths:
         forgotten standing approvals from silently reactivating if the connector
         is re-enabled later.
 
+        ### Disabling vs. Removing
+
+        By default this endpoint **disables** the connector — it removes the
+        agent-connector association but leaves the user's credentials (API keys)
+        and OAuth connections intact so the connector can be re-enabled without
+        re-entering credentials.
+
+        Pass `?delete_credentials=true` to also **permanently delete** the API
+        key credential assigned to this connector. The credential row and its
+        encrypted vault secret are deleted in the same database transaction, so
+        the operation is fully atomic — either everything succeeds or nothing
+        changes. OAuth connections are unaffected by this flag and must be
+        disconnected separately via `DELETE /v1/oauth/connections/{connection_id}`.
+
         Uses session authentication (Supabase JWT).
       tags:
         - Agents
@@ -1458,9 +1472,16 @@ paths:
           in: query
           required: false
           description: |
-            When true, permanently delete any API key credentials associated with
-            this connector in addition to disabling it. OAuth connections are not
-            affected by this flag (they are managed separately).
+            When `true`, permanently delete the API key credential assigned to
+            this connector (both the credential record and its encrypted vault
+            secret) as part of the same atomic operation. Defaults to `false`.
+
+            Use this when you want a full "remove" — disabling the connector
+            **and** discarding saved API keys — rather than a temporary disable
+            that preserves credentials for re-enabling later.
+
+            OAuth connections are **not** affected by this flag. To disconnect
+            OAuth, call `DELETE /v1/oauth/connections/{connection_id}` separately.
           schema:
             type: boolean
       responses:


### PR DESCRIPTION
## Summary

- Removing a connector now permanently deletes any saved API key credentials (and vault secrets) associated with that connector, in addition to disabling it and disconnecting OAuth
- Added `?delete_credentials=true` query param to `DELETE /v1/agents/{agent_id}/connectors/{connector_id}`; the "Remove" flow sends this flag, while "Disable" does not (credentials are preserved)
- Updated the description text and confirmation dialog on the Remove button to mention API key deletion alongside OAuth disconnection

## Test plan

- [ ] Remove a connector that has an API key credential assigned → verify the credential is deleted from the credentials list
- [ ] Remove a connector with no credential assigned → verify it still works (no errors)
- [ ] Disable a connector → verify the credential is still present (preserved)
- [ ] New backend test: `TestDisableAgentConnector_DeleteCredentials` covers the credential + vault secret deletion path

### Claude Code
- [x] Added `TestDisableAgentConnector_DeleteCredentials` backend test
- [x] Updated `useDisableAgentConnector` hook test for new params shape

### OpenClaw
- [ ] Verify the updated UI copy reads well across all connector types

https://claude.ai/code/session_01La1yyXXGjFJp1gNNrdGjw6