### PR TITLE
Move mobile tests out of CI into separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,33 +71,10 @@ jobs:
       - name: Run frontend tests
         run: make test-frontend
 
-  mobile:
-    name: Mobile Tests & Typecheck
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: mobile/package-lock.json
-
-      - name: Install dependencies
-        run: cd mobile && npm ci
-
-      - name: Type-check
-        run: make mobile-typecheck
-
-      - name: Run mobile tests
-        run: make mobile-test
-
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [backend, frontend, mobile]
+    needs: [backend, frontend]
 
     steps:
       - uses: actions/checkout@v4
@@ -121,7 +98,7 @@ jobs:
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [backend, frontend, mobile, build]
+    needs: [backend, frontend, build]
     if: ${{ failure() && github.event_name == 'push' }}
     steps:
       - name: Send Twilio SMS

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,29 @@
+name: Mobile CI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  mobile:
+    name: Mobile Tests & Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: cd mobile && npm ci
+
+      - name: Type-check
+        run: make mobile-typecheck
+
+      - name: Run mobile tests
+        run: make mobile-test


### PR DESCRIPTION
## Summary
- Removes the `mobile` job from `ci.yml` so mobile failures no longer block Fly.io deployments
- Creates `.github/workflows/mobile-ci.yml` as a standalone workflow (runs on push to `main` and `workflow_dispatch`)
- Mobile deploys use tags, not CI, so there's no reason for mobile to gate the deploy pipeline

## Test plan
### Claude Code
- [ ] Trigger CI workflow and verify it passes without the mobile job
- [ ] Verify `deploy.yml` still gates on CI success (unchanged)

### OpenClaw
- [ ] Confirm mobile-ci.yml runs independently and appears in Actions tab