### PR TITLE
Fix SQL injection in PurgeExpiredAuditEvents

### DIFF
--- a/config/plans.go
+++ b/config/plans.go
@@ -45,8 +45,8 @@ func DefaultPlanID(billingEnabled bool) string {
 }
 
 // validPlanID restricts plan IDs to alphanumeric characters and underscores.
-// This is validated at load time to prevent SQL injection when plan IDs are
-// interpolated into CASE expressions (e.g. in data_retention.go).
+// data_retention.go uses parameterized queries as the primary defense against
+// SQL injection. This regex validation is a secondary safeguard.
 var validPlanID = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 var (

--- a/db/data_retention.go
+++ b/db/data_retention.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/config"
 )
@@ -33,30 +34,51 @@ func PurgeExpiredAuditEvents(ctx context.Context, db DBTX) (int64, error) {
 		defaultRetention = freePlan.AuditRetentionDays
 	}
 
-	// Build "CASE s.plan_id WHEN 'free' THEN 7 WHEN 'pay_as_you_go' THEN 90 ELSE 7 END"
-	caseExpr := "CASE s.plan_id"
+	// Build parameterized VALUES list for plan_id → retention_days mapping.
+	// Uses ($1::text, $2::int), ($3::text, $4::int), ... to avoid interpolating
+	// plan IDs into SQL strings.
+	var valuesClauses []string
+	var args []any
+	paramIdx := 1
 	for _, p := range plans {
-		caseExpr += fmt.Sprintf(" WHEN '%s' THEN %d", p.ID, p.AuditRetentionDays)
+		valuesClauses = append(valuesClauses,
+			fmt.Sprintf("($%d::text, $%d::int)", paramIdx, paramIdx+1))
+		args = append(args, p.ID, p.AuditRetentionDays)
+		paramIdx += 2
 	}
-	caseExpr += fmt.Sprintf(" ELSE %d END", defaultRetention)
 
 	// Derive grace period days from the DowngradeGracePeriod constant so both
 	// the Go logic and the SQL query stay in sync automatically.
 	gracePeriodDays := int(DowngradeGracePeriod.Hours() / 24)
 
+	// Append remaining parameters: grace period, paid retention, default retention.
+	gracePeriodParam := paramIdx
+	paidRetentionParam := paramIdx + 1
+	defaultRetentionParam := paramIdx + 2
+	args = append(args, gracePeriodDays, PaidPlanRetentionDays(), defaultRetention)
+
 	// Pass 1: Purge events for users with a subscription, using their plan's
 	// retention period. During the downgrade grace period, use the paid plan's
 	// retention instead so users have time to export data.
-	tag1, err := db.Exec(ctx, fmt.Sprintf(`
+	query := fmt.Sprintf(`
 		DELETE FROM audit_events ae
 		USING subscriptions s
+		LEFT JOIN (VALUES %s) AS plan_retention(plan_id, retention_days)
+		    ON s.plan_id = plan_retention.plan_id
 		WHERE ae.user_id = s.user_id
 		  AND ae.created_at < now() - make_interval(days =>
 		      CASE WHEN s.downgraded_at IS NOT NULL
-		                AND s.downgraded_at > now() - interval '%d days'
-		           THEN %d
-		           ELSE %s
-		      END)`, gracePeriodDays, PaidPlanRetentionDays(), caseExpr))
+		                AND s.downgraded_at > now() - make_interval(days => $%d)
+		           THEN $%d
+		           ELSE COALESCE(plan_retention.retention_days, $%d)
+		      END)`,
+		strings.Join(valuesClauses, ", "),
+		gracePeriodParam,
+		paidRetentionParam,
+		defaultRetentionParam,
+	)
+
+	tag1, err := db.Exec(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("purge expired audit events (subscribed users): %w", err)
 	}
@@ -64,10 +86,11 @@ func PurgeExpiredAuditEvents(ctx context.Context, db DBTX) (int64, error) {
 	// Pass 2: Purge events for users without a subscription row, using the
 	// free-tier default. This is defensive — every user should have
 	// a subscription, but we don't want orphaned events to accumulate.
-	tag2, err := db.Exec(ctx, fmt.Sprintf(`
-		DELETE FROM audit_events ae
-		WHERE NOT EXISTS (SELECT 1 FROM subscriptions s WHERE s.user_id = ae.user_id)
-		  AND ae.created_at < now() - interval '%d days'`, defaultRetention))
+	tag2, err := db.Exec(ctx,
+		`DELETE FROM audit_events ae
+		 WHERE NOT EXISTS (SELECT 1 FROM subscriptions s WHERE s.user_id = ae.user_id)
+		   AND ae.created_at < now() - make_interval(days => $1)`,
+		defaultRetention)
 	if err != nil {
 		return tag1.RowsAffected(), fmt.Errorf("purge expired audit events (unsubscribed users): %w", err)
 	}


### PR DESCRIPTION
## Summary

- Replace `fmt.Sprintf` string interpolation of plan IDs in `PurgeExpiredAuditEvents` with parameterized VALUES subquery
- Both DELETE queries now use fully parameterized placeholders (`$1`, `$2`, etc.) instead of string formatting
- Update comment in `config/plans.go` to reflect that parameterized queries are the primary defense

## Context

`PurgeExpiredAuditEvents` was building a SQL CASE expression by interpolating plan IDs directly via `fmt.Sprintf(" WHEN '%s' THEN %d", p.ID, ...)`. While plan IDs were validated at config load time with `^[a-zA-Z0-9_]+$`, this violated defense-in-depth — if the validation were loosened or a new code path introduced, the interpolation could become exploitable.

The fix uses a `LEFT JOIN (VALUES ($1::text, $2::int), ...) AS plan_retention(plan_id, retention_days)` pattern so plan IDs and retention days are passed as query parameters.

## Test plan

### Claude Code
- [x] All 8 existing `TestPurgeExpiredAuditEvents` subtests pass (free plan purge, paid plan preservation/purge, no-subscription fallback, grace period preservation/expiry, SQL function variants)
- [x] `go vet ./db/... ./config/...` passes clean

### OpenClaw
- [ ] Verify the parameterized query produces identical results in staging with real subscription data
- [ ] Review that the VALUES subquery approach handles edge cases (e.g., NULL plan_id)

https://claude.ai/code/session_01XQ5SDcJEgo4AJZn1QmspvC