### PR TITLE
Fix billing payment method display

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -236,6 +236,14 @@ func handleGetBillingPlan(deps *Deps) http.HandlerFunc {
 			Subscription: newBillingSubscription(sub),
 		}
 
+		// Check actual payment methods rather than relying on Stripe customer ID.
+		if pmCount, err := db.CountPaymentMethodsByUser(r.Context(), deps.DB, profile.ID); err != nil {
+			log.Printf("[%s] GetBillingPlan: count payment methods: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+		} else {
+			resp.Subscription.HasPaymentMethod = pmCount > 0
+		}
+
 		// Gather usage counts (non-fatal — return zeros on error).
 		usage, err := db.GetCurrentPeriodUsage(r.Context(), deps.DB, profile.ID)
 		if err != nil {
@@ -294,6 +302,14 @@ func handleGetSubscription(deps *Deps) http.HandlerFunc {
 			PlanName:            sub.Plan.Name,
 			billingSubscription: newBillingSubscription(sub),
 			PlanLimits:          newPlanLimits(&sub.Plan),
+		}
+
+		// Check actual payment methods rather than relying on Stripe customer ID.
+		if pmCount, err := db.CountPaymentMethodsByUser(r.Context(), deps.DB, profile.ID); err != nil {
+			log.Printf("[%s] GetSubscription: count payment methods: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+		} else {
+			resp.HasPaymentMethod = pmCount > 0
 		}
 
 		// Attach current period usage if available (non-fatal — subscription

--- a/api/billing.go
+++ b/api/billing.go
@@ -150,7 +150,7 @@ func newBillingSubscription(sub *db.SubscriptionWithPlan) billingSubscription {
 		Status:             string(sub.Status),
 		CurrentPeriodStart: sub.CurrentPeriodStart,
 		CurrentPeriodEnd:   sub.CurrentPeriodEnd,
-		HasPaymentMethod:   sub.StripeCustomerID != nil,
+		HasPaymentMethod:   false,
 		CanUpgrade:         sub.PlanID == db.PlanFree,
 		CanDowngrade:       sub.PlanID == db.PlanPayAsYouGo,
 		GracePeriodEndsAt:  sub.GracePeriodEndsAt(),

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -148,17 +148,13 @@ func TestGetBillingPlan_ZeroUsage(t *testing.T) {
 func TestGetBillingPlan_PaidPlan(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
-	ctx := context.Background()
 	uid := testhelper.GenerateUID(t)
 
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	// Set Stripe customer ID to verify has_payment_method.
-	customerID := "cus_test_plan"
-	if _, err := db.UpdateSubscriptionStripe(ctx, tx, uid, &customerID, nil); err != nil {
-		t.Fatalf("UpdateSubscriptionStripe: %v", err)
-	}
+	// Insert a payment method to verify has_payment_method.
+	testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{IsDefault: true})
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
 	router := NewRouter(deps)
@@ -185,7 +181,7 @@ func TestGetBillingPlan_PaidPlan(t *testing.T) {
 		t.Error("expected can_downgrade=true for paid plan")
 	}
 	if !resp.Subscription.HasPaymentMethod {
-		t.Error("expected has_payment_method=true when stripe_customer_id is set")
+		t.Error("expected has_payment_method=true when payment method exists")
 	}
 }
 
@@ -349,20 +345,16 @@ func TestCreateCheckout_AlreadyPaid(t *testing.T) {
 	}
 }
 
-func TestGetSubscription_HasPaymentMethodWhenStripeCustomerSet(t *testing.T) {
+func TestGetSubscription_HasPaymentMethodWhenPaymentMethodExists(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
-	ctx := context.Background()
 	uid := testhelper.GenerateUID(t)
 
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	// Set Stripe customer ID.
-	customerID := "cus_test_payment"
-	if _, err := db.UpdateSubscriptionStripe(ctx, tx, uid, &customerID, nil); err != nil {
-		t.Fatalf("UpdateSubscriptionStripe: %v", err)
-	}
+	// Insert a payment method.
+	testhelper.InsertPaymentMethod(t, tx, uid, testhelper.PaymentMethodOpts{IsDefault: true})
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
 	router := NewRouter(deps)
@@ -380,7 +372,7 @@ func TestGetSubscription_HasPaymentMethodWhenStripeCustomerSet(t *testing.T) {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 	if !resp.HasPaymentMethod {
-		t.Error("expected has_payment_method=true when stripe_customer_id is set")
+		t.Error("expected has_payment_method=true when payment method exists")
 	}
 	if resp.CanUpgrade {
 		t.Error("expected can_upgrade=false for pay_as_you_go plan")


### PR DESCRIPTION
## Summary
- Fixed `has_payment_method` in both `/billing/plan` and `/billing/subscription` endpoints to query the `payment_methods` table instead of checking `stripe_customer_id`
- A Stripe customer ID can exist without any payment methods attached, causing the billing page to incorrectly show "None" for paid plan users
- Updated tests to insert actual payment methods instead of relying on Stripe customer ID

## Test plan
### Claude Code
- [x] Backend tests pass (`TestGetBillingPlan_PaidPlan`, `TestGetSubscription_HasPaymentMethodWhenPaymentMethodExists`)
- [x] All billing/subscription tests pass

### OpenClaw
- [ ] Verify billing page shows payment method correctly for paid plan users
- [ ] Verify free plan users still see "None" for payment method

https://claude.ai/code/session_01K9p3hxNTnLV4iyeQvs9mLT