### PR TITLE
Clarify free request allowance on billing page

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -429,8 +429,9 @@ func handleGetUsage(deps *Deps) http.HandlerFunc {
 			PeriodEnd:   sub.CurrentPeriodEnd,
 		}
 
-		// Determine included request allowance from the plan.
-		included := 0
+		// Determine included request allowance.
+		// Paid plans get the same free allowance as the free tier (250 requests).
+		included := int(pstripe.FreeRequestAllowance())
 		if sub.Plan.MaxRequestsPerMonth != nil {
 			included = *sub.Plan.MaxRequestsPerMonth
 		}

--- a/frontend/src/pages/billing/RequestUsageBar.tsx
+++ b/frontend/src/pages/billing/RequestUsageBar.tsx
@@ -1,9 +1,72 @@
+import { PRICE_PER_REQUEST } from "./constants";
+
 interface RequestUsageBarProps {
   total: number;
   limit: number | null;
+  /** Free request allowance for paid plans (e.g. 250). */
+  included?: number;
 }
 
-export function RequestUsageBar({ total, limit }: RequestUsageBarProps) {
+/**
+ * Segmented bar for paid plans showing free vs billed requests.
+ * Green portion = free allowance, amber = billed overage.
+ */
+function PaidRequestBar({ total, included }: { total: number; included: number }) {
+  const overage = Math.max(0, total - included);
+  const hasOverage = overage > 0;
+
+  // Bar is measured against included allowance (e.g. 250).
+  // When under: green bar grows toward 100%.
+  // When over: green fills 100%, amber extends proportionally.
+  const freePercent = Math.min((total / included) * 100, 100);
+  // Overage segment as proportion of total (so bar width stays readable).
+  const overagePercent = hasOverage ? (overage / total) * 100 : 0;
+  const freeSegmentPercent = hasOverage ? 100 - overagePercent : freePercent;
+
+  const label = hasOverage
+    ? `${total.toLocaleString()} total (${overage.toLocaleString()} billed)`
+    : `${total.toLocaleString()} / ${included.toLocaleString()} free`;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">Requests this period</span>
+        <span className="text-muted-foreground tabular-nums">{label}</span>
+      </div>
+      <div
+        className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuenow={total}
+        aria-valuemin={0}
+        aria-valuemax={included}
+        aria-label={`Requests: ${label}`}
+      >
+        <div
+          className="h-full rounded-l-full bg-primary transition-all"
+          style={{ width: `${freeSegmentPercent}%` }}
+        />
+        {hasOverage && (
+          <div
+            className="h-full rounded-r-full bg-amber-500 transition-all"
+            style={{ width: `${overagePercent}%` }}
+          />
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {hasOverage
+          ? `${included.toLocaleString()} free + ${overage.toLocaleString()} at ${PRICE_PER_REQUEST}/request`
+          : `First ${included.toLocaleString()} requests/month are free, then ${PRICE_PER_REQUEST}/request`}
+      </p>
+    </div>
+  );
+}
+
+export function RequestUsageBar({ total, limit, included }: RequestUsageBarProps) {
+  // Paid plan with free allowance: show segmented bar.
+  if (limit === null && included != null && included > 0) {
+    return <PaidRequestBar total={total} included={included} />;
+  }
+
   const isUnlimited = limit === null;
   const percentage = isUnlimited
     ? 0

--- a/frontend/src/pages/billing/RequestUsageBar.tsx
+++ b/frontend/src/pages/billing/RequestUsageBar.tsx
@@ -36,7 +36,7 @@ function PaidRequestBar({ total, included }: { total: number; included: number }
       <div
         className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted"
         role="progressbar"
-        aria-valuenow={total}
+        aria-valuenow={Math.min(total, included)}
         aria-valuemin={0}
         aria-valuemax={included}
         aria-label={`Requests: ${label}`}

--- a/frontend/src/pages/billing/UsageDashboard.tsx
+++ b/frontend/src/pages/billing/UsageDashboard.tsx
@@ -86,6 +86,7 @@ export function UsageDashboard({ plan, subscription }: UsageDashboardProps) {
             <RequestUsageBar
               total={usage.requests.total}
               limit={plan.max_requests_per_month ?? null}
+              included={usage.requests.included}
             />
 
             <div className="grid grid-cols-2 gap-4">
@@ -118,6 +119,11 @@ export function UsageDashboard({ plan, subscription }: UsageDashboardProps) {
                   </p>
                   <p className="text-lg font-semibold tabular-nums">
                     {formatCents(totalCostCents)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {usage.requests.overage > 0
+                      ? `${usage.requests.overage.toLocaleString()} requests billed`
+                      : `${Math.max(0, usage.requests.included - usage.requests.total).toLocaleString()} free requests remaining`}
                   </p>
                 </div>
               )}

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -83,7 +83,9 @@ function PaidRequestRow({ current, included }: { current: number; included: numb
         )}
       </div>
       <p className="text-xs text-muted-foreground">
-        Then {PRICE_PER_REQUEST}/request
+        {hasOverage
+          ? `${allowance.toLocaleString()} free + ${overage.toLocaleString()} at ${PRICE_PER_REQUEST}/request`
+          : `First ${allowance.toLocaleString()} requests/month are free, then ${PRICE_PER_REQUEST}/request`}
       </p>
     </div>
   );

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Plan, UsageSummary } from "@/hooks/useBillingPlan";
+import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { FREE_REQUEST_ALLOWANCE, PRICE_PER_REQUEST } from "./constants";
 
 interface UsageSummaryCardProps {
@@ -53,12 +54,11 @@ function UsageRow({ label, current, limit }: UsageRowProps) {
 }
 
 /** Request usage row for paid plans — shows progress against the free allowance. */
-function PaidRequestRow({ current }: { current: number }) {
-  const allowance = FREE_REQUEST_ALLOWANCE;
+function PaidRequestRow({ current, included }: { current: number; included: number }) {
+  const allowance = included;
   const overage = Math.max(0, current - allowance);
   const hasOverage = overage > 0;
   const percentage = Math.min((current / allowance) * 100, 100);
-  const isNearLimit = percentage >= 80;
 
   const label = hasOverage
     ? `${current.toLocaleString()} total (${overage.toLocaleString()} billed)`
@@ -70,11 +70,9 @@ function PaidRequestRow({ current }: { current: number }) {
         <span className="font-medium">Requests</span>
         <span className="text-muted-foreground tabular-nums">{label}</span>
       </div>
-      <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={allowance} aria-label={`Requests: ${label}`}>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={Math.min(current, allowance)} aria-valuemin={0} aria-valuemax={allowance} aria-label={`Requests: ${label}`}>
         <div
-          className={`h-full rounded-l-full transition-all ${
-            hasOverage ? "bg-primary" : isNearLimit ? "bg-amber-500" : "bg-primary"
-          }`}
+          className="h-full rounded-l-full transition-all bg-primary"
           style={{ width: `${hasOverage ? ((allowance / current) * 100) : percentage}%` }}
         />
         {hasOverage && (
@@ -93,6 +91,9 @@ function PaidRequestRow({ current }: { current: number }) {
 
 export function UsageSummaryCard({ usage, plan }: UsageSummaryCardProps) {
   const isPaid = plan.id !== "free";
+  const { usage: usageDetail } = useBillingUsage();
+  // Use server-provided included value, fall back to config constant.
+  const included = usageDetail?.requests.included ?? FREE_REQUEST_ALLOWANCE;
 
   return (
     <Card>
@@ -108,7 +109,7 @@ export function UsageSummaryCard({ usage, plan }: UsageSummaryCardProps) {
       <CardContent>
         <div className="space-y-4">
           {isPaid ? (
-            <PaidRequestRow current={usage.requests} />
+            <PaidRequestRow current={usage.requests} included={included} />
           ) : (
             <UsageRow
               label="Requests"

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Plan, UsageSummary } from "@/hooks/useBillingPlan";
+import { FREE_REQUEST_ALLOWANCE, PRICE_PER_REQUEST } from "./constants";
 
 interface UsageSummaryCardProps {
   usage: UsageSummary;
@@ -51,7 +52,48 @@ function UsageRow({ label, current, limit }: UsageRowProps) {
   );
 }
 
+/** Request usage row for paid plans — shows progress against the free allowance. */
+function PaidRequestRow({ current }: { current: number }) {
+  const allowance = FREE_REQUEST_ALLOWANCE;
+  const overage = Math.max(0, current - allowance);
+  const hasOverage = overage > 0;
+  const percentage = Math.min((current / allowance) * 100, 100);
+  const isNearLimit = percentage >= 80;
+
+  const label = hasOverage
+    ? `${current.toLocaleString()} total (${overage.toLocaleString()} billed)`
+    : `${current.toLocaleString()} / ${allowance.toLocaleString()} free`;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">Requests</span>
+        <span className="text-muted-foreground tabular-nums">{label}</span>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={allowance} aria-label={`Requests: ${label}`}>
+        <div
+          className={`h-full rounded-l-full transition-all ${
+            hasOverage ? "bg-primary" : isNearLimit ? "bg-amber-500" : "bg-primary"
+          }`}
+          style={{ width: `${hasOverage ? ((allowance / current) * 100) : percentage}%` }}
+        />
+        {hasOverage && (
+          <div
+            className="h-full rounded-r-full bg-amber-500 transition-all"
+            style={{ width: `${(overage / current) * 100}%` }}
+          />
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Then {PRICE_PER_REQUEST}/request
+      </p>
+    </div>
+  );
+}
+
 export function UsageSummaryCard({ usage, plan }: UsageSummaryCardProps) {
+  const isPaid = plan.id !== "free";
+
   return (
     <Card>
       <CardHeader>
@@ -65,11 +107,15 @@ export function UsageSummaryCard({ usage, plan }: UsageSummaryCardProps) {
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          <UsageRow
-            label="Requests"
-            current={usage.requests}
-            limit={plan.max_requests_per_month ?? null}
-          />
+          {isPaid ? (
+            <PaidRequestRow current={usage.requests} />
+          ) : (
+            <UsageRow
+              label="Requests"
+              current={usage.requests}
+              limit={plan.max_requests_per_month ?? null}
+            />
+          )}
           <UsageRow
             label="Agents"
             current={usage.agents}

--- a/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -10,6 +10,7 @@ import {
   paidPlanResponse,
   usageDetailResponse,
   freeUsageDetailResponse,
+  paidUnderAllowanceUsageResponse,
   invoicesResponse,
   agentsResponse,
   overLimitPaidPlanResponse,
@@ -21,7 +22,7 @@ vi.mock("../../../api/client");
 
 function mockBillingApi(
   planResponse: typeof freePlanResponse | typeof paidPlanResponse,
-  usageResponse: typeof usageDetailResponse | typeof freeUsageDetailResponse = usageDetailResponse,
+  usageResponse: typeof usageDetailResponse | typeof freeUsageDetailResponse | typeof paidUnderAllowanceUsageResponse = usageDetailResponse,
 ) {
   setupAuthMocks({ authenticated: true });
   mockGet.mockImplementation((url: string) => {
@@ -270,7 +271,7 @@ describe("BillingPage", () => {
       expect(screen.getByText("Pay-as-you-go")).toBeInTheDocument();
     });
 
-    it("shows unlimited usage for paid plan", async () => {
+    it("shows unlimited usage for paid plan resources", async () => {
       mockBillingApi(paidPlanResponse);
 
       render(<BillingPage />, { wrapper });
@@ -278,8 +279,22 @@ describe("BillingPage", () => {
       await waitFor(() => {
         expect(screen.getByText("Usage")).toBeInTheDocument();
       });
+      // Agents, Standing Approvals, Credentials show "Unlimited"
       const unlimitedTexts = screen.getAllByText(/Unlimited/);
       expect(unlimitedTexts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows free request allowance for paid plan", async () => {
+      mockBillingApi(paidPlanResponse);
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Usage")).toBeInTheDocument();
+      });
+      // Paid plan shows requests against the 250 free allowance with billed count
+      expect(screen.getByText(/billed/)).toBeInTheDocument();
+      expect(screen.getByText(/\$0.005\/request/)).toBeInTheDocument();
     });
 
     it("does not show upgrade CTA for paid plan", async () => {
@@ -513,8 +528,31 @@ describe("BillingPage", () => {
       await waitFor(() => {
         expect(screen.getByText("Estimated cost")).toBeInTheDocument();
       });
-      // $2.71 requests + $0.05 SMS = $2.76 (shown in both UsageDashboard and PlanDetailsCard)
-      expect(screen.getAllByText("$2.76").length).toBeGreaterThanOrEqual(1);
+      // $6.46 requests + $0.05 SMS = $6.51 (shown in both UsageDashboard and PlanDetailsCard)
+      expect(screen.getAllByText("$6.51").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows free requests remaining when under allowance", async () => {
+      mockBillingApi(paidPlanResponse, paidUnderAllowanceUsageResponse);
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Estimated cost")).toBeInTheDocument();
+      });
+      expect(screen.getAllByText("$0.00").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText(/free requests remaining/)).toBeInTheDocument();
+    });
+
+    it("shows billed requests count when over allowance", async () => {
+      mockBillingApi(paidPlanResponse);
+
+      render(<BillingPage />, { wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Estimated cost")).toBeInTheDocument();
+      });
+      expect(screen.getByText(/requests billed/)).toBeInTheDocument();
     });
 
     it("shows days remaining in billing period", async () => {

--- a/frontend/src/pages/billing/__tests__/fixtures.ts
+++ b/frontend/src/pages/billing/__tests__/fixtures.ts
@@ -84,12 +84,25 @@ export const atLimitPaidPlanResponse = {
 export const usageDetailResponse = {
   period_start: "2026-03-01T00:00:00Z",
   period_end: "2026-04-01T00:00:00Z",
-  requests: { total: 1542, included: 1000, overage: 542, cost_cents: 271 },
+  requests: { total: 1542, included: 250, overage: 1292, cost_cents: 646 },
   sms: { total: 5, cost_cents: 5 },
   breakdown: {
     by_agent: { "1": 500, "2": 1042 },
     by_connector: { gmail: 300, stripe: 1242 },
     by_action_type: { "email.send": 300, "payment.create": 1242 },
+  },
+};
+
+/** Paid plan usage under the free allowance (no overage). */
+export const paidUnderAllowanceUsageResponse = {
+  period_start: "2026-03-01T00:00:00Z",
+  period_end: "2026-04-01T00:00:00Z",
+  requests: { total: 80, included: 250, overage: 0, cost_cents: 0 },
+  sms: { total: 0, cost_cents: 0 },
+  breakdown: {
+    by_agent: { "1": 80 },
+    by_connector: {},
+    by_action_type: {},
   },
 };
 

--- a/frontend/src/pages/billing/constants.ts
+++ b/frontend/src/pages/billing/constants.ts
@@ -1,7 +1,7 @@
 import { freePlan, paidPlan, formatLimit } from "@/config/plans";
 
 /** Number of free requests included per month for all plans. */
-export const FREE_REQUEST_ALLOWANCE = freePlan.max_requests_per_month;
+export const FREE_REQUEST_ALLOWANCE: number = freePlan.max_requests_per_month ?? 250;
 
 /** Formatted per-request price string (e.g. "$0.005"). */
 export const PRICE_PER_REQUEST = `$${(paidPlan.price_per_request_millicents / 100_000).toFixed(3)}`;

--- a/frontend/src/pages/billing/constants.ts
+++ b/frontend/src/pages/billing/constants.ts
@@ -1,5 +1,11 @@
 import { freePlan, paidPlan, formatLimit } from "@/config/plans";
 
+/** Number of free requests included per month for all plans. */
+export const FREE_REQUEST_ALLOWANCE = freePlan.max_requests_per_month;
+
+/** Formatted per-request price string (e.g. "$0.005"). */
+export const PRICE_PER_REQUEST = `$${(paidPlan.price_per_request_millicents / 100_000).toFixed(3)}`;
+
 /** Features included in the paid (Pay-as-you-go) plan. */
 export const PAID_PLAN_FEATURES = [
   "Unlimited agents",


### PR DESCRIPTION
## Summary
- **Backend**: Fixed `/v1/billing/usage` to return `included: 250` for paid plans (was returning 0, even though Stripe billing correctly applies a 250 free request allowance)
- **Frontend**: Replaced "Requests: X / Unlimited" (no progress bar) with a segmented progress bar showing usage against the 250 free allowance — green for free, amber for billed overage
- **Frontend**: Added pricing context text ("First 250 requests/month are free, then $0.005/request") and enriched the estimated cost card with "X free requests remaining" or "X requests billed" subtext

## Test plan

### Claude Code
- [x] All 726 frontend tests pass (`make test-frontend`)
- [x] TypeScript compilation clean (`npx tsc --noEmit`)
- [x] Test fixtures updated: `included` corrected from 1000 to 250, added `paidUnderAllowanceUsageResponse` fixture
- [x] New test cases: paid plan free allowance display, free requests remaining, billed requests count

### OpenClaw
- [ ] Visual review: check billing page on mobile and desktop for paid user under 250 requests
- [ ] Visual review: check billing page for paid user over 250 requests (overage segment + cost)
- [ ] Verify backend returns `included: 250` for paid plans via API call
- [ ] Confirm free plan billing page is unchanged

https://claude.ai/code/session_01Fz3eP81d3UMm9dJdq4rKds