### PR TITLE
Fix Slack connector HTTP error handling in doPost

### DIFF
--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -278,18 +278,18 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 	}
 	defer resp.Body.Close()
 
-	// Slack returns 429 for rate limiting with a Retry-After header.
-	if resp.StatusCode == http.StatusTooManyRequests {
-		retryAfter := connectors.ParseRetryAfter(resp.Header.Get("Retry-After"), defaultRetryAfter)
-		return &connectors.RateLimitError{
-			Message:    "Slack API rate limit exceeded",
-			RetryAfter: retryAfter,
-		}
-	}
-
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	// Handle HTTP-level errors before attempting JSON unmarshal.
+	// Slack normally returns 200 with {"ok": false} for app-level errors,
+	// but can return non-200 for rate limits, auth failures, and server errors.
+	if resp.StatusCode != http.StatusOK {
+		if err := checkHTTPStatus(resp.StatusCode, resp.Header, respBody); err != nil {
+			return err
+		}
 	}
 
 	if err := json.Unmarshal(respBody, dest); err != nil {
@@ -358,6 +358,46 @@ func mapSlackError(slackErr string) error {
 		return &connectors.ExternalError{
 			StatusCode: 200,
 			Message:    fmt.Sprintf("Slack API error: %s", slackErr),
+		}
+	}
+}
+
+// checkHTTPStatus maps non-200 HTTP status codes to typed connector errors.
+// Slack normally returns 200 with {"ok": false} for application-level errors,
+// but returns standard HTTP status codes for rate limits, auth failures, and
+// server errors — especially when the request never reaches the API handler.
+func checkHTTPStatus(statusCode int, header http.Header, body []byte) error {
+	// Try to extract a Slack error string from the response body.
+	var env slackResponse
+	msg := ""
+	if json.Unmarshal(body, &env) == nil && env.Error != "" {
+		msg = env.Error
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized:
+		if msg == "" {
+			msg = "invalid or expired token"
+		}
+		return &connectors.AuthError{Message: fmt.Sprintf("Slack auth error: %s", msg)}
+	case http.StatusForbidden:
+		if msg == "" {
+			msg = "permission denied"
+		}
+		return &connectors.AuthError{Message: fmt.Sprintf("Slack permission denied: %s", msg)}
+	case http.StatusTooManyRequests:
+		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
+		return &connectors.RateLimitError{
+			Message:    "Slack API rate limit exceeded",
+			RetryAfter: retryAfter,
+		}
+	default:
+		if msg == "" {
+			msg = fmt.Sprintf("HTTP %d", statusCode)
+		}
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Slack API error: %s", msg),
 		}
 	}
 }

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -286,7 +286,7 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 	// Handle HTTP-level errors before attempting JSON unmarshal.
 	// Slack normally returns 200 with {"ok": false} for app-level errors,
 	// but can return non-200 for rate limits, auth failures, and server errors.
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return checkHTTPStatus(resp.StatusCode, resp.Header, respBody)
 	}
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -287,9 +287,7 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 	// Slack normally returns 200 with {"ok": false} for app-level errors,
 	// but can return non-200 for rate limits, auth failures, and server errors.
 	if resp.StatusCode != http.StatusOK {
-		if err := checkHTTPStatus(resp.StatusCode, resp.Header, respBody); err != nil {
-			return err
-		}
+		return checkHTTPStatus(resp.StatusCode, resp.Header, respBody)
 	}
 
 	if err := json.Unmarshal(respBody, dest); err != nil {

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -384,6 +384,7 @@ func checkHTTPStatus(statusCode int, header http.Header, body []byte) error {
 		}
 		return &connectors.AuthError{Message: fmt.Sprintf("Slack permission denied: %s", msg)}
 	case http.StatusTooManyRequests:
+		// Body message intentionally unused; rate-limit errors only need RetryAfter.
 		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), defaultRetryAfter)
 		return &connectors.RateLimitError{
 			Message:    "Slack API rate limit exceeded",

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -319,8 +320,11 @@ func TestCheckHTTPStatus(t *testing.T) {
 					t.Errorf("RetryAfter = %v, want %v (default)", rle.RetryAfter, defaultRetryAfter)
 				}
 			case "external":
-				if !connectors.IsExternalError(err) {
+				var ee *connectors.ExternalError
+				if !errors.As(err, &ee) {
 					t.Errorf("expected ExternalError, got %T: %v", err, err)
+				} else if ee.StatusCode != tt.statusCode {
+					t.Errorf("StatusCode = %d, want %d", ee.StatusCode, tt.statusCode)
 				}
 			}
 		})
@@ -387,8 +391,11 @@ func TestDoPost_HTTPErrors(t *testing.T) {
 					t.Errorf("RetryAfter = %v, want 60s", rle.RetryAfter)
 				}
 			case "external":
-				if !connectors.IsExternalError(err) {
+				var ee *connectors.ExternalError
+				if !errors.As(err, &ee) {
 					t.Errorf("expected ExternalError, got %T: %v", err, err)
+				} else if ee.StatusCode != tt.statusCode {
+					t.Errorf("StatusCode = %d, want %d", ee.StatusCode, tt.statusCode)
 				}
 			}
 		})

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -1,6 +1,8 @@
 package slack
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -244,6 +246,140 @@ func TestValidateUserID(t *testing.T) {
 			err := validateUserID(tt.userID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateUserID(%q) error = %v, wantErr %v", tt.userID, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantType   string // "auth", "rate_limit", "external"
+	}{
+		{
+			name:       "401 with Slack error",
+			statusCode: 401,
+			body:       `{"ok":false,"error":"invalid_auth"}`,
+			wantType:   "auth",
+		},
+		{
+			name:       "401 without body",
+			statusCode: 401,
+			body:       ``,
+			wantType:   "auth",
+		},
+		{
+			name:       "403 permission denied",
+			statusCode: 403,
+			body:       `{"ok":false,"error":"missing_scope"}`,
+			wantType:   "auth",
+		},
+		{
+			name:       "429 rate limited",
+			statusCode: 429,
+			body:       `{"ok":false,"error":"ratelimited"}`,
+			wantType:   "rate_limit",
+		},
+		{
+			name:       "500 server error",
+			statusCode: 500,
+			body:       `internal server error`,
+			wantType:   "external",
+		},
+		{
+			name:       "503 service unavailable with JSON",
+			statusCode: 503,
+			body:       `{"ok":false,"error":"service_unavailable"}`,
+			wantType:   "external",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkHTTPStatus(tt.statusCode, http.Header{}, []byte(tt.body))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			switch tt.wantType {
+			case "auth":
+				if !connectors.IsAuthError(err) {
+					t.Errorf("expected AuthError, got %T: %v", err, err)
+				}
+			case "rate_limit":
+				if !connectors.IsRateLimitError(err) {
+					t.Errorf("expected RateLimitError, got %T: %v", err, err)
+				}
+			case "external":
+				if !connectors.IsExternalError(err) {
+					t.Errorf("expected ExternalError, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestDoPost_HTTPErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantType   string
+	}{
+		{
+			name:       "401 returns AuthError",
+			statusCode: 401,
+			body:       `{"ok":false,"error":"invalid_auth"}`,
+			wantType:   "auth",
+		},
+		{
+			name:       "429 returns RateLimitError",
+			statusCode: 429,
+			body:       `{"ok":false,"error":"ratelimited"}`,
+			wantType:   "rate_limit",
+		},
+		{
+			name:       "500 returns ExternalError",
+			statusCode: 500,
+			body:       `not json`,
+			wantType:   "external",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			c := newForTest(srv.Client(), srv.URL)
+			var dest slackResponse
+			err := c.doPost(t.Context(), "test.method", validCreds(), map[string]string{}, &dest)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			switch tt.wantType {
+			case "auth":
+				if !connectors.IsAuthError(err) {
+					t.Errorf("expected AuthError, got %T: %v", err, err)
+				}
+			case "rate_limit":
+				if !connectors.IsRateLimitError(err) {
+					t.Errorf("expected RateLimitError, got %T: %v", err, err)
+				}
+			case "external":
+				if !connectors.IsExternalError(err) {
+					t.Errorf("expected ExternalError, got %T: %v", err, err)
+				}
 			}
 		})
 	}

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -356,6 +357,9 @@ func TestDoPost_HTTPErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.statusCode == http.StatusTooManyRequests {
+					w.Header().Set("Retry-After", "60")
+				}
 				w.WriteHeader(tt.statusCode)
 				w.Write([]byte(tt.body))
 			}))
@@ -373,8 +377,11 @@ func TestDoPost_HTTPErrors(t *testing.T) {
 					t.Errorf("expected AuthError, got %T: %v", err, err)
 				}
 			case "rate_limit":
-				if !connectors.IsRateLimitError(err) {
+				var rle *connectors.RateLimitError
+				if !connectors.AsRateLimitError(err, &rle) {
 					t.Errorf("expected RateLimitError, got %T: %v", err, err)
+				} else if rle.RetryAfter != 60*time.Second {
+					t.Errorf("RetryAfter = %v, want 60s", rle.RetryAfter)
 				}
 			case "external":
 				if !connectors.IsExternalError(err) {

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -312,8 +312,11 @@ func TestCheckHTTPStatus(t *testing.T) {
 					t.Errorf("expected AuthError, got %T: %v", err, err)
 				}
 			case "rate_limit":
-				if !connectors.IsRateLimitError(err) {
+				var rle *connectors.RateLimitError
+				if !connectors.AsRateLimitError(err, &rle) {
 					t.Errorf("expected RateLimitError, got %T: %v", err, err)
+				} else if rle.RetryAfter != defaultRetryAfter {
+					t.Errorf("RetryAfter = %v, want %v (default)", rle.RetryAfter, defaultRetryAfter)
 				}
 			case "external":
 				if !connectors.IsExternalError(err) {

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -309,8 +309,11 @@ func TestCheckHTTPStatus(t *testing.T) {
 			}
 			switch tt.wantType {
 			case "auth":
-				if !connectors.IsAuthError(err) {
+				var ae *connectors.AuthError
+				if !errors.As(err, &ae) {
 					t.Errorf("expected AuthError, got %T: %v", err, err)
+				} else if ae.Message == "" {
+					t.Error("AuthError.Message is empty")
 				}
 			case "rate_limit":
 				var rle *connectors.RateLimitError
@@ -380,8 +383,11 @@ func TestDoPost_HTTPErrors(t *testing.T) {
 			}
 			switch tt.wantType {
 			case "auth":
-				if !connectors.IsAuthError(err) {
+				var ae *connectors.AuthError
+				if !errors.As(err, &ae) {
 					t.Errorf("expected AuthError, got %T: %v", err, err)
+				} else if ae.Message == "" {
+					t.Error("AuthError.Message is empty")
 				}
 			case "rate_limit":
 				var rle *connectors.RateLimitError


### PR DESCRIPTION
## Summary
- Add `checkHTTPStatus` to Slack connector's `doPost` to handle non-200 HTTP responses (401, 403, 429, 5xx) with proper typed errors before attempting JSON unmarshal
- Matches the pattern used by the working Google connector's `checkResponse`
- Previously, non-200/non-429 responses (e.g., 500 server errors with non-JSON body) produced a confusing "failed to decode Slack API response" instead of a clear error

## Test plan
### Claude Code
- [x] Added `TestCheckHTTPStatus` covering 401 (with/without body), 403, 429, 500, 503
- [x] Added `TestDoPost_HTTPErrors` integration tests with httptest servers for 401, 429, 500
- [x] All 65 existing Slack connector tests pass
- [x] Build compiles cleanly

### OpenClaw
- [ ] Manually test with a real Slack workspace to verify error messages on expired tokens
- [ ] Verify rate limiting behavior matches expectations in production

https://claude.ai/code/session_01Uty5Z7CSeLdpjvu84TYqvs