### PR TITLE
Add x-ui schema types and parser for connector UI rendering

### DIFF
--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -288,6 +288,31 @@ describe("parseParametersSchema", () => {
       expect(result?.properties?.field?.["x-ui"]).toBeUndefined();
     });
 
+    it("rejects NaN as visible_when equals value", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          field: {
+            type: "string",
+            "x-ui": { visible_when: { field: "priority", equals: NaN } },
+          },
+        },
+      });
+
+      expect(result?.properties?.field?.["x-ui"]).toBeUndefined();
+    });
+
+    it("returns undefined x-ui when x-ui is an array", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          field: { type: "string", "x-ui": ["not", "an", "object"] },
+        },
+      });
+
+      expect(result?.properties?.field?.["x-ui"]).toBeUndefined();
+    });
+
     it("ignores visible_when with missing fields", () => {
       const result = parseParametersSchema({
         type: "object",
@@ -401,6 +426,16 @@ describe("parseParametersSchema", () => {
       const result = parseParametersSchema({
         type: "object",
         "x-ui": {},
+        properties: { a: { type: "string" } },
+      });
+
+      expect(result?.["x-ui"]).toBeUndefined();
+    });
+
+    it("returns undefined x-ui when root x-ui is an array", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        "x-ui": ["not", "valid"],
         properties: { a: { type: "string" } },
       });
 

--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseParametersSchema } from "../parameterSchema";
+import {
+  parseParametersSchema,
+  type SchemaPropertyUI,
+  type SchemaUI,
+} from "../parameterSchema";
 
 describe("parseParametersSchema", () => {
   it("parses a valid schema with properties", () => {
@@ -16,24 +20,28 @@ describe("parseParametersSchema", () => {
     expect(result).toEqual({
       type: "object",
       required: ["owner", "repo"],
+      "x-ui": undefined,
       properties: {
         owner: {
           type: "string",
           description: "Repository owner",
           enum: undefined,
           default: undefined,
+          "x-ui": undefined,
         },
         repo: {
           type: "string",
           description: "Repository name",
           enum: undefined,
           default: undefined,
+          "x-ui": undefined,
         },
         title: {
           type: "string",
           description: undefined,
           enum: undefined,
           default: undefined,
+          "x-ui": undefined,
         },
       },
     });
@@ -57,6 +65,7 @@ describe("parseParametersSchema", () => {
       description: "Merge strategy",
       enum: ["merge", "squash", "rebase"],
       default: "merge",
+      "x-ui": undefined,
     });
   });
 
@@ -118,6 +127,7 @@ describe("parseParametersSchema", () => {
         description: undefined,
         enum: undefined,
         default: undefined,
+        "x-ui": undefined,
       },
     });
   });
@@ -144,6 +154,265 @@ describe("parseParametersSchema", () => {
       description: undefined,
       enum: undefined,
       default: undefined,
+      "x-ui": undefined,
+    });
+  });
+
+  describe("x-ui property-level parsing", () => {
+    it("parses all property-level x-ui fields", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          currency: {
+            type: "string",
+            enum: ["usd", "eur", "gbp"],
+            "x-ui": {
+              widget: "select",
+              label: "Currency",
+              placeholder: "Choose currency",
+              group: "billing",
+              help_url: "https://example.com/help",
+              help_text: "Pick the billing currency",
+            },
+          },
+        },
+      });
+
+      const ui = result?.properties?.currency?.["x-ui"];
+      expect(ui).toEqual({
+        widget: "select",
+        label: "Currency",
+        placeholder: "Choose currency",
+        group: "billing",
+        help_url: "https://example.com/help",
+        help_text: "Pick the billing currency",
+      } satisfies SchemaPropertyUI);
+    });
+
+    it("parses visible_when condition", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          details: {
+            type: "string",
+            "x-ui": {
+              visible_when: { field: "mode", equals: "advanced" },
+            },
+          },
+        },
+      });
+
+      expect(result?.properties?.details?.["x-ui"]?.visible_when).toEqual({
+        field: "mode",
+        equals: "advanced",
+      });
+    });
+
+    it("ignores invalid widget values", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          field: {
+            type: "string",
+            "x-ui": { widget: "invalid_widget", label: "Valid Label" },
+          },
+        },
+      });
+
+      const ui = result?.properties?.field?.["x-ui"];
+      expect(ui?.widget).toBeUndefined();
+      expect(ui?.label).toBe("Valid Label");
+    });
+
+    it("returns undefined x-ui for empty x-ui object", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          field: { type: "string", "x-ui": {} },
+        },
+      });
+
+      expect(result?.properties?.field?.["x-ui"]).toBeUndefined();
+    });
+
+    it("returns undefined x-ui when x-ui is not an object", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          field: { type: "string", "x-ui": "not-an-object" },
+        },
+      });
+
+      expect(result?.properties?.field?.["x-ui"]).toBeUndefined();
+    });
+
+    it("ignores visible_when with missing fields", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          field: {
+            type: "string",
+            "x-ui": { visible_when: { field: "mode" } },
+          },
+        },
+      });
+
+      // visible_when is invalid (missing equals), so x-ui is empty → undefined
+      expect(result?.properties?.field?.["x-ui"]).toBeUndefined();
+    });
+
+    it("accepts all valid widget types", () => {
+      const widgets = ["text", "select", "textarea", "toggle", "number", "date"] as const;
+      for (const widget of widgets) {
+        const result = parseParametersSchema({
+          type: "object",
+          properties: {
+            field: { type: "string", "x-ui": { widget } },
+          },
+        });
+        expect(result?.properties?.field?.["x-ui"]?.widget).toBe(widget);
+      }
+    });
+  });
+
+  describe("x-ui root-level parsing", () => {
+    it("parses groups and order", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        "x-ui": {
+          groups: [
+            { id: "billing", label: "Billing", description: "Payment fields" },
+            { id: "options", label: "Options", collapsed: true },
+          ],
+          order: ["customer_id", "currency", "auto_advance"],
+        },
+        properties: {
+          customer_id: { type: "string" },
+          currency: { type: "string" },
+          auto_advance: { type: "boolean" },
+        },
+      });
+
+      const ui = result?.["x-ui"];
+      expect(ui).toEqual({
+        groups: [
+          { id: "billing", label: "Billing", description: "Payment fields" },
+          { id: "options", label: "Options", collapsed: true },
+        ],
+        order: ["customer_id", "currency", "auto_advance"],
+      } satisfies SchemaUI);
+    });
+
+    it("returns undefined x-ui when not present", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: { a: { type: "string" } },
+      });
+
+      expect(result?.["x-ui"]).toBeUndefined();
+    });
+
+    it("skips groups with missing id or label", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        "x-ui": {
+          groups: [
+            { id: "valid", label: "Valid" },
+            { id: "missing-label" },
+            { label: "Missing ID" },
+            "not-an-object",
+          ],
+        },
+        properties: { a: { type: "string" } },
+      });
+
+      expect(result?.["x-ui"]?.groups).toEqual([{ id: "valid", label: "Valid" }]);
+    });
+
+    it("filters non-string values from order array", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        "x-ui": {
+          order: ["field_a", 42, "field_b", null],
+        },
+        properties: { field_a: { type: "string" }, field_b: { type: "string" } },
+      });
+
+      expect(result?.["x-ui"]?.order).toEqual(["field_a", "field_b"]);
+    });
+
+    it("returns undefined x-ui for empty root x-ui", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        "x-ui": {},
+        properties: { a: { type: "string" } },
+      });
+
+      expect(result?.["x-ui"]).toBeUndefined();
+    });
+  });
+
+  it("parses full schema with both root and property x-ui", () => {
+    const input = {
+      type: "object",
+      required: ["customer_id"],
+      "x-ui": {
+        groups: [
+          { id: "billing", label: "Billing" },
+          { id: "options", label: "Options", collapsed: true },
+        ],
+        order: ["customer_id", "currency", "auto_advance"],
+      },
+      properties: {
+        customer_id: {
+          type: "string",
+          "x-ui": { label: "Customer", placeholder: "cus_ABC123", group: "billing" },
+        },
+        currency: {
+          type: "string",
+          enum: ["usd", "eur", "gbp"],
+          "x-ui": { widget: "select", group: "billing" },
+        },
+        auto_advance: {
+          type: "boolean",
+          "x-ui": { widget: "toggle", label: "Auto-send invoice", group: "options" },
+        },
+      },
+    };
+
+    const result = parseParametersSchema(input);
+
+    expect(result?.["x-ui"]?.groups).toHaveLength(2);
+    expect(result?.["x-ui"]?.order).toEqual(["customer_id", "currency", "auto_advance"]);
+    expect(result?.properties?.customer_id?.["x-ui"]?.label).toBe("Customer");
+    expect(result?.properties?.currency?.["x-ui"]?.widget).toBe("select");
+    expect(result?.properties?.auto_advance?.["x-ui"]?.widget).toBe("toggle");
+  });
+
+  it("preserves backwards compatibility — schemas without x-ui parse identically", () => {
+    const input = {
+      type: "object",
+      required: ["owner"],
+      properties: {
+        owner: { type: "string", description: "Repository owner" },
+      },
+    };
+
+    const result = parseParametersSchema(input);
+
+    expect(result).toEqual({
+      type: "object",
+      required: ["owner"],
+      "x-ui": undefined,
+      properties: {
+        owner: {
+          type: "string",
+          description: "Repository owner",
+          enum: undefined,
+          default: undefined,
+          "x-ui": undefined,
+        },
+      },
     });
   });
 });

--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -108,6 +108,7 @@ describe("parseParametersSchema", () => {
     expect(result).toEqual({
       type: "object",
       required: ["foo"],
+      "x-ui": undefined,
     });
   });
 
@@ -189,7 +190,7 @@ describe("parseParametersSchema", () => {
       } satisfies SchemaPropertyUI);
     });
 
-    it("parses visible_when condition", () => {
+    it("parses visible_when condition with string equals", () => {
       const result = parseParametersSchema({
         type: "object",
         properties: {
@@ -205,6 +206,44 @@ describe("parseParametersSchema", () => {
       expect(result?.properties?.details?.["x-ui"]?.visible_when).toEqual({
         field: "mode",
         equals: "advanced",
+      });
+    });
+
+    it("parses visible_when condition with boolean equals", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          details: {
+            type: "string",
+            "x-ui": {
+              visible_when: { field: "enabled", equals: true },
+            },
+          },
+        },
+      });
+
+      expect(result?.properties?.details?.["x-ui"]?.visible_when).toEqual({
+        field: "enabled",
+        equals: true,
+      });
+    });
+
+    it("parses visible_when condition with number equals", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          details: {
+            type: "string",
+            "x-ui": {
+              visible_when: { field: "priority", equals: 1 },
+            },
+          },
+        },
+      });
+
+      expect(result?.properties?.details?.["x-ui"]?.visible_when).toEqual({
+        field: "priority",
+        equals: 1,
       });
     });
 
@@ -339,6 +378,20 @@ describe("parseParametersSchema", () => {
       });
 
       expect(result?.["x-ui"]?.order).toEqual(["field_a", "field_b"]);
+    });
+
+    it("preserves root-level x-ui when properties field is missing", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        "x-ui": {
+          groups: [{ id: "main", label: "Main" }],
+          order: ["field_a"],
+        },
+      });
+
+      expect(result?.["x-ui"]?.groups).toEqual([{ id: "main", label: "Main" }]);
+      expect(result?.["x-ui"]?.order).toEqual(["field_a"]);
+      expect(result?.properties).toBeUndefined();
     });
 
     it("returns undefined x-ui for empty root x-ui", () => {

--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   parseParametersSchema,
+  getFieldLabel,
+  getOrderedFieldKeys,
+  isFieldVisible,
   type SchemaPropertyUI,
   type SchemaUI,
 } from "../parameterSchema";
@@ -440,6 +443,80 @@ describe("parseParametersSchema", () => {
     expect(result?.properties?.customer_id?.["x-ui"]?.label).toBe("Customer");
     expect(result?.properties?.currency?.["x-ui"]?.widget).toBe("select");
     expect(result?.properties?.auto_advance?.["x-ui"]?.widget).toBe("toggle");
+  });
+
+  describe("getFieldLabel", () => {
+    it("returns x-ui label when set", () => {
+      expect(getFieldLabel("customer_id", { type: "string", "x-ui": { label: "Customer" } })).toBe("Customer");
+    });
+
+    it("falls back to property key when no x-ui label", () => {
+      expect(getFieldLabel("customer_id", { type: "string" })).toBe("customer_id");
+    });
+
+    it("falls back to property key when x-ui exists but no label", () => {
+      expect(getFieldLabel("amount", { type: "number", "x-ui": { widget: "number" } })).toBe("amount");
+    });
+  });
+
+  describe("getOrderedFieldKeys", () => {
+    it("returns keys in x-ui order with remaining appended", () => {
+      const schema = parseParametersSchema({
+        type: "object",
+        "x-ui": { order: ["b", "a"] },
+        properties: { a: { type: "string" }, b: { type: "string" }, c: { type: "string" } },
+      })!;
+      expect(getOrderedFieldKeys(schema)).toEqual(["b", "a", "c"]);
+    });
+
+    it("returns original order when no x-ui order", () => {
+      const schema = parseParametersSchema({
+        type: "object",
+        properties: { x: { type: "string" }, y: { type: "string" } },
+      })!;
+      expect(getOrderedFieldKeys(schema)).toEqual(["x", "y"]);
+    });
+
+    it("skips order keys that don't exist in properties", () => {
+      const schema = parseParametersSchema({
+        type: "object",
+        "x-ui": { order: ["missing", "a"] },
+        properties: { a: { type: "string" }, b: { type: "string" } },
+      })!;
+      expect(getOrderedFieldKeys(schema)).toEqual(["a", "b"]);
+    });
+
+    it("handles schema with no properties", () => {
+      const schema = parseParametersSchema({ type: "object" })!;
+      expect(getOrderedFieldKeys(schema)).toEqual([]);
+    });
+  });
+
+  describe("isFieldVisible", () => {
+    it("returns true when no visible_when rule", () => {
+      expect(isFieldVisible({ type: "string" }, {})).toBe(true);
+    });
+
+    it("returns true when condition is met (string)", () => {
+      const prop = { type: "string", "x-ui": { visible_when: { field: "mode", equals: "advanced" as string | boolean | number } } };
+      expect(isFieldVisible(prop, { mode: "advanced" })).toBe(true);
+    });
+
+    it("returns false when condition is not met", () => {
+      const prop = { type: "string", "x-ui": { visible_when: { field: "mode", equals: "advanced" as string | boolean | number } } };
+      expect(isFieldVisible(prop, { mode: "basic" })).toBe(false);
+    });
+
+    it("returns false when referenced field is missing", () => {
+      const prop = { type: "string", "x-ui": { visible_when: { field: "mode", equals: "advanced" as string | boolean | number } } };
+      expect(isFieldVisible(prop, {})).toBe(false);
+    });
+
+    it("works with boolean condition", () => {
+      const prop = { type: "string", "x-ui": { visible_when: { field: "enabled", equals: true as string | boolean | number } } };
+      expect(isFieldVisible(prop, { enabled: true })).toBe(true);
+      expect(isFieldVisible(prop, { enabled: false })).toBe(false);
+    });
   });
 
   it("preserves backwards compatibility — schemas without x-ui parse identically", () => {

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -7,12 +7,44 @@
  * to avoid duplication.
  */
 
+/** Conditional visibility rule: show a field only when another field has a specific value. */
+export interface VisibleWhen {
+  field: string;
+  equals: string;
+}
+
+/** Property-level `x-ui` rendering hints for a single parameter. */
+export interface SchemaPropertyUI {
+  widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date";
+  label?: string;
+  placeholder?: string;
+  group?: string;
+  help_url?: string;
+  help_text?: string;
+  visible_when?: VisibleWhen;
+}
+
+/** A named group for organizing related fields in the form. */
+export interface FieldGroup {
+  id: string;
+  label: string;
+  description?: string;
+  collapsed?: boolean;
+}
+
+/** Root-level `x-ui` rendering hints for the entire parameter schema. */
+export interface SchemaUI {
+  groups?: FieldGroup[];
+  order?: string[];
+}
+
 /** JSON Schema property definition for a single action parameter. */
 export interface SchemaProperty {
   type?: string;
   description?: string;
   enum?: string[];
   default?: unknown;
+  "x-ui"?: SchemaPropertyUI;
 }
 
 /**
@@ -24,6 +56,7 @@ export interface ParametersSchema {
   type: string;
   required?: string[];
   properties?: Record<string, SchemaProperty>;
+  "x-ui"?: SchemaUI;
 }
 
 /**
@@ -63,9 +96,70 @@ export function parseParametersSchema(
           ? prop.enum.filter((e): e is string => typeof e === "string")
           : undefined,
         default: prop.default,
+        "x-ui": parsePropertyUI(prop["x-ui"]),
       };
     }
   }
 
-  return { type: "object", required, properties };
+  return { type: "object", required, properties, "x-ui": parseSchemaUI(schema["x-ui"]) };
+}
+
+const VALID_WIDGETS = new Set(["text", "select", "textarea", "toggle", "number", "date"]);
+
+/** Parse a property-level `x-ui` object, returning undefined if invalid. */
+function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as Record<string, unknown>;
+
+  const ui: SchemaPropertyUI = {};
+  if (typeof obj.widget === "string" && VALID_WIDGETS.has(obj.widget)) {
+    ui.widget = obj.widget as SchemaPropertyUI["widget"];
+  }
+  if (typeof obj.label === "string") ui.label = obj.label;
+  if (typeof obj.placeholder === "string") ui.placeholder = obj.placeholder;
+  if (typeof obj.group === "string") ui.group = obj.group;
+  if (typeof obj.help_url === "string") ui.help_url = obj.help_url;
+  if (typeof obj.help_text === "string") ui.help_text = obj.help_text;
+  if (obj.visible_when && typeof obj.visible_when === "object") {
+    const vw = obj.visible_when as Record<string, unknown>;
+    if (typeof vw.field === "string" && typeof vw.equals === "string") {
+      ui.visible_when = { field: vw.field, equals: vw.equals };
+    }
+  }
+
+  // Return undefined if no valid fields were parsed
+  if (Object.keys(ui).length === 0) return undefined;
+  return ui;
+}
+
+/** Parse a root-level `x-ui` object, returning undefined if invalid. */
+function parseSchemaUI(raw: unknown): SchemaUI | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as Record<string, unknown>;
+
+  const ui: SchemaUI = {};
+
+  if (Array.isArray(obj.groups)) {
+    const groups: FieldGroup[] = [];
+    for (const g of obj.groups) {
+      if (g && typeof g === "object") {
+        const group = g as Record<string, unknown>;
+        if (typeof group.id === "string" && typeof group.label === "string") {
+          const fg: FieldGroup = { id: group.id, label: group.label };
+          if (typeof group.description === "string") fg.description = group.description;
+          if (typeof group.collapsed === "boolean") fg.collapsed = group.collapsed;
+          groups.push(fg);
+        }
+      }
+    }
+    if (groups.length > 0) ui.groups = groups;
+  }
+
+  if (Array.isArray(obj.order)) {
+    const order = obj.order.filter((e): e is string => typeof e === "string");
+    if (order.length > 0) ui.order = order;
+  }
+
+  if (Object.keys(ui).length === 0) return undefined;
+  return ui;
 }

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -104,7 +104,50 @@ export function parseParametersSchema(
   return { type: "object", required, properties, "x-ui": parseSchemaUI(schema["x-ui"]) };
 }
 
-const VALID_WIDGETS = new Set(["text", "select", "textarea", "toggle", "number", "date"]);
+/** All valid widget type values. */
+export const VALID_WIDGETS = ["text", "select", "textarea", "toggle", "number", "date"] as const;
+
+/** Widget type as a union — useful for exhaustive switch checks. */
+export type WidgetType = (typeof VALID_WIDGETS)[number];
+
+const VALID_WIDGETS_SET = new Set<string>(VALID_WIDGETS);
+
+/**
+ * Get the display label for a schema property.
+ * Returns x-ui label if set, otherwise falls back to the property key.
+ */
+export function getFieldLabel(key: string, prop: SchemaProperty): string {
+  return prop["x-ui"]?.label ?? key;
+}
+
+/**
+ * Return property keys in the order specified by x-ui.order,
+ * with any unmentioned keys appended in their original order.
+ */
+export function getOrderedFieldKeys(schema: ParametersSchema): string[] {
+  const allKeys = Object.keys(schema.properties ?? {});
+  const order = schema["x-ui"]?.order;
+  if (!order || order.length === 0) return allKeys;
+
+  const allKeysSet = new Set(allKeys);
+  const ordered = order.filter((k) => allKeysSet.has(k));
+  const orderedSet = new Set(ordered);
+  const remaining = allKeys.filter((k) => !orderedSet.has(k));
+  return [...ordered, ...remaining];
+}
+
+/**
+ * Check whether a field should be visible given the current form values.
+ * Returns true if the field has no visible_when rule or if the condition is met.
+ */
+export function isFieldVisible(
+  prop: SchemaProperty,
+  values: Record<string, unknown>,
+): boolean {
+  const rule = prop["x-ui"]?.visible_when;
+  if (!rule) return true;
+  return values[rule.field] === rule.equals;
+}
 
 /** Parse a property-level `x-ui` object, returning undefined if invalid. */
 function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
@@ -112,7 +155,7 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
   const obj = raw as Record<string, unknown>;
 
   const ui: SchemaPropertyUI = {};
-  if (typeof obj.widget === "string" && VALID_WIDGETS.has(obj.widget)) {
+  if (typeof obj.widget === "string" && VALID_WIDGETS_SET.has(obj.widget)) {
     ui.widget = obj.widget as SchemaPropertyUI["widget"];
   }
   if (typeof obj.label === "string") ui.label = obj.label;

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -151,7 +151,7 @@ export function isFieldVisible(
 
 /** Parse a property-level `x-ui` object, returning undefined if invalid. */
 function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const obj = raw as Record<string, unknown>;
 
   const ui: SchemaPropertyUI = {};
@@ -167,7 +167,7 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
     const vw = obj.visible_when as Record<string, unknown>;
     if (
       typeof vw.field === "string" &&
-      (typeof vw.equals === "string" || typeof vw.equals === "boolean" || typeof vw.equals === "number")
+      (typeof vw.equals === "string" || typeof vw.equals === "boolean" || (typeof vw.equals === "number" && !Number.isNaN(vw.equals)))
     ) {
       ui.visible_when = { field: vw.field, equals: vw.equals as string | boolean | number };
     }
@@ -180,7 +180,7 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
 
 /** Parse a root-level `x-ui` object, returning undefined if invalid. */
 function parseSchemaUI(raw: unknown): SchemaUI | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const obj = raw as Record<string, unknown>;
 
   const ui: SchemaUI = {};

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -10,7 +10,7 @@
 /** Conditional visibility rule: show a field only when another field has a specific value. */
 export interface VisibleWhen {
   field: string;
-  equals: string;
+  equals: string | boolean | number;
 }
 
 /** Property-level `x-ui` rendering hints for a single parameter. */
@@ -79,7 +79,7 @@ export function parseParametersSchema(
 
   const rawProps = schema.properties;
   if (!rawProps || typeof rawProps !== "object") {
-    return { type: "object", required };
+    return { type: "object", required, "x-ui": parseSchemaUI(schema["x-ui"]) };
   }
 
   const properties: Record<string, SchemaProperty> = {};
@@ -122,8 +122,11 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
   if (typeof obj.help_text === "string") ui.help_text = obj.help_text;
   if (obj.visible_when && typeof obj.visible_when === "object") {
     const vw = obj.visible_when as Record<string, unknown>;
-    if (typeof vw.field === "string" && typeof vw.equals === "string") {
-      ui.visible_when = { field: vw.field, equals: vw.equals };
+    if (
+      typeof vw.field === "string" &&
+      (typeof vw.equals === "string" || typeof vw.equals === "boolean" || typeof vw.equals === "number")
+    ) {
+      ui.visible_when = { field: vw.field, equals: vw.equals as string | boolean | number };
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds TypeScript interfaces for `x-ui` vendor extensions: `SchemaPropertyUI`, `SchemaUI`, `FieldGroup`, and `VisibleWhen`
- Extends `SchemaProperty` and `ParametersSchema` to include optional `x-ui` fields
- Updates `parseParametersSchema()` to safely parse and pass through `x-ui` data from connector parameter schemas
- Adds comprehensive unit tests covering all x-ui field types, edge cases, and backwards compatibility

This is **Chunk 1** (foundation types & parser) of the connector UI rendering work described in #551.

## Test plan

### Claude Code
- [x] All 740 frontend tests pass (`make test-frontend`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Existing tests updated to account for new `x-ui` field in equality checks
- [x] New tests cover: all widget types, visible_when parsing, group/order parsing, invalid inputs, backwards compatibility

### OpenClaw
- [ ] Review the `x-ui` interface shape — are the types sufficient for Chunks 2–3?
- [ ] Confirm the parsing approach (permissive: skip invalid fields rather than reject) is acceptable

Relates to #551

https://claude.ai/code/session_016WLgKN6mJEkiGBdpL7rqkJ