### PR TITLE
Add standing approval execution notification templates

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/notify/email_template.go
+++ b/notify/email_template.go
@@ -120,7 +120,7 @@ func buildEmailHTMLBody(approval Approval) string {
 	b.WriteString(`</div>`)
 
 	// Details table
-	b.WriteString(`<table style="width:100%%;border-collapse:collapse;margin-bottom:20px;">`)
+	b.WriteString(`<table style="width:100%;border-collapse:collapse;margin-bottom:20px;">`)
 	if actionType != "" {
 		b.WriteString(emailDetailRow("Action", html.EscapeString(actionType)))
 	}

--- a/notify/email_template.go
+++ b/notify/email_template.go
@@ -17,6 +17,9 @@ func buildEmailSubject(approval Approval) string {
 	if approval.Type == NotificationTypeCardExpiring {
 		return buildCardExpiringSubject(approval)
 	}
+	if approval.Type == NotificationTypeStandingExecution {
+		return buildStandingExecutionSubject(approval)
+	}
 	actionType := extractActionType(approval.Action)
 	if actionType != "" {
 		return fmt.Sprintf("Approval needed: %s", actionType)
@@ -31,6 +34,9 @@ func buildEmailPlainBody(approval Approval) string {
 	}
 	if approval.Type == NotificationTypeCardExpiring {
 		return buildCardExpiringPlainBody(approval)
+	}
+	if approval.Type == NotificationTypeStandingExecution {
+		return buildStandingExecutionPlainBody(approval)
 	}
 
 	var b strings.Builder
@@ -89,6 +95,9 @@ func buildEmailHTMLBody(approval Approval) string {
 	}
 	if approval.Type == NotificationTypeCardExpiring {
 		return buildCardExpiringHTMLBody(approval)
+	}
+	if approval.Type == NotificationTypeStandingExecution {
+		return buildStandingExecutionHTMLBody(approval)
 	}
 
 	agentName := approval.AgentName

--- a/notify/format.go
+++ b/notify/format.go
@@ -88,6 +88,10 @@ func BuildPushContent(approval Approval) PushContent {
 		}
 	}
 
+	if approval.Type == NotificationTypeStandingExecution {
+		return buildStandingExecutionPushContent(approval)
+	}
+
 	if approval.Type == NotificationTypeCardExpiring {
 		info := extractCardExpiringInfo(approval.Context)
 		title := "Card Expiring Soon"

--- a/notify/mobilepush/sender.go
+++ b/notify/mobilepush/sender.go
@@ -120,6 +120,7 @@ func (s *Sender) Send(ctx context.Context, approval notify.Approval, recipient n
 	}
 
 	content := buildMessage(approval)
+	categoryID := categoryForType(approval.Type)
 
 	// Build messages for all tokens.
 	messages := make([]expoMessage, len(tokens))
@@ -131,7 +132,7 @@ func (s *Sender) Send(ctx context.Context, approval notify.Approval, recipient n
 			Body:       content.Body,
 			Sound:      "default",
 			Priority:   "high",
-			CategoryID: "approval",
+			CategoryID: categoryID,
 			Data: expoMessageData{
 				URL:        content.URL,
 				ApprovalID: content.ApprovalID,
@@ -232,6 +233,16 @@ func (s *Sender) sendBatch(ctx context.Context, messages []expoMessage, tokens [
 // Delegates to notify.BuildPushContent for consistent messaging across channels.
 func buildMessage(approval notify.Approval) notify.PushContent {
 	return notify.BuildPushContent(approval)
+}
+
+// categoryForType returns the Expo push notification categoryId for the given
+// notification type. Standing executions use "standing_execution" so the
+// mobile app can suppress in-app banners; all other types use "approval".
+func categoryForType(t notify.NotificationType) string {
+	if t == notify.NotificationTypeStandingExecution {
+		return "standing_execution"
+	}
+	return "approval"
 }
 
 // truncateTokenForLog returns the last 8 characters of a token for logging,

--- a/notify/mobilepush/sender_test.go
+++ b/notify/mobilepush/sender_test.go
@@ -369,6 +369,71 @@ func TestSendBatch_TopLevelAPIError(t *testing.T) {
 	}
 }
 
+func TestCategoryForType_StandingExecution(t *testing.T) {
+	t.Parallel()
+	if got := categoryForType(notify.NotificationTypeStandingExecution); got != "standing_execution" {
+		t.Errorf("expected 'standing_execution', got %q", got)
+	}
+}
+
+func TestCategoryForType_DefaultApproval(t *testing.T) {
+	t.Parallel()
+	if got := categoryForType(notify.NotificationTypeApproval); got != "approval" {
+		t.Errorf("expected 'approval', got %q", got)
+	}
+}
+
+func TestCategoryForType_PaymentFailed(t *testing.T) {
+	t.Parallel()
+	if got := categoryForType(notify.NotificationTypePaymentFailed); got != "approval" {
+		t.Errorf("expected 'approval' for payment_failed, got %q", got)
+	}
+}
+
+func TestSendBatch_StandingExecution_UsesCorrectCategory(t *testing.T) {
+	t.Parallel()
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expoAPIResponse{
+			Data: []expoTicketResponse{{Status: "ok", ID: "ticket-1"}},
+		})
+	}))
+	defer server.Close()
+
+	store := &mockStore{}
+	store.addToken(1, "ExponentPushToken[device1]")
+
+	sender := newTestSender(store, "", server.URL)
+	approval := notify.Approval{
+		ApprovalID:  "appr_standing_001",
+		AgentName:   "Deploy Bot",
+		Action:      json.RawMessage(`{"type":"github.issues.create"}`),
+		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		ApprovalURL: "https://app.test/activity",
+		Type:        notify.NotificationTypeStandingExecution,
+	}
+	err := sender.Send(context.Background(), approval, notify.Recipient{
+		UserID:   "user-1",
+		Username: "alice",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var messages []expoMessage
+	if err := json.Unmarshal(capturedBody, &messages); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	if messages[0].CategoryID != "standing_execution" {
+		t.Errorf("expected categoryId 'standing_execution', got %q", messages[0].CategoryID)
+	}
+}
+
 func TestSend_NoTokens(t *testing.T) {
 	t.Parallel()
 	requestMade := false

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -50,6 +50,8 @@ const (
 	// NotificationTypeStandingExecution is sent when an agent executes an
 	// action via a standing approval. Informational only — not an approval
 	// request. Uses a distinct template with a blue accent and activity link.
+	// The Context JSON should contain "execution_count" and "max_executions"
+	// integers; see standing_execution.go for the full contract.
 	NotificationTypeStandingExecution NotificationType = "standing_execution"
 )
 

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -47,6 +47,10 @@ const (
 	// NotificationTypeCardExpiring is sent when a stored payment method is
 	// expiring soon (within 30 days) or already expired.
 	NotificationTypeCardExpiring NotificationType = "card_expiring"
+	// NotificationTypeStandingExecution is sent when an agent executes an
+	// action via a standing approval. Informational only — not an approval
+	// request. Uses a distinct template with a blue accent and activity link.
+	NotificationTypeStandingExecution NotificationType = "standing_execution"
 )
 
 // Approval holds the fields a notification channel needs to construct its

--- a/notify/sms.go
+++ b/notify/sms.go
@@ -64,6 +64,10 @@ func formatSMSBody(a Approval) string {
 		return msg
 	}
 
+	if a.Type == NotificationTypeStandingExecution {
+		return formatStandingExecutionSMS(a)
+	}
+
 	if a.Type == NotificationTypeCardExpiring {
 		info := extractCardExpiringInfo(a.Context)
 		var msg string

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -122,7 +122,7 @@ func buildStandingExecutionPlainBody(approval Approval) string {
 }
 
 // formatStandingExecutionSMS builds a concise SMS for a standing approval
-// execution. Format: "[AgentName] ran [action_type] (3/10 uses). View: [url]"
+// execution. Format: "[AgentName] ran [action_type] (3 of 10 uses). View: [url]"
 func formatStandingExecutionSMS(a Approval) string {
 	info := extractStandingExecutionInfo(a)
 
@@ -158,7 +158,7 @@ func buildStandingExecutionHTMLBody(approval Approval) string {
 	b.WriteString(`</div>`)
 
 	// Details table
-	b.WriteString(`<table style="width:100%%;border-collapse:collapse;margin-bottom:20px;">`)
+	b.WriteString(`<table style="width:100%;border-collapse:collapse;margin-bottom:20px;">`)
 	if info.ActionType != "" {
 		b.WriteString(emailDetailRow("Action", html.EscapeString(info.ActionType)))
 	}

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"sort"
 	"strings"
 	"time"
 )
@@ -87,18 +88,32 @@ func buildStandingExecutionPushContent(approval Approval) PushContent {
 	}
 }
 
-// sensitiveParamKeys is the set of parameter keys whose values should be
-// redacted in notification content. Only the key names are shown.
-var sensitiveParamKeys = map[string]bool{
-	"api_key": true, "apikey": true, "api_secret": true,
-	"token": true, "access_token": true, "refresh_token": true,
-	"secret": true, "password": true, "credential": true,
-	"private_key": true, "auth": true, "authorization": true,
+// sensitiveSubstrings are substrings that, when found in a lowercased
+// parameter key, cause the value to be redacted. Substring matching is
+// safer than exact-match because it catches compound keys like
+// "aws_secret_access_key", "db_password", "oauth_token", etc.
+var sensitiveSubstrings = []string{
+	"secret", "password", "passwd", "token", "credential",
+	"key", "auth", "private",
+}
+
+// isSensitiveKey returns true if the parameter key looks like it holds
+// a secret value. Uses substring matching on the lowercased key.
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, sub := range sensitiveSubstrings {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // summarizeParameters extracts a human-readable parameter summary from the
-// action JSON's "parameters" field. Sensitive values are redacted (shown as
-// "***"). Returns "" if no parameters are present.
+// action JSON's "parameters" field. Values for keys that look sensitive
+// (contain "secret", "password", "token", "key", etc.) are redacted to
+// "***". Output is sorted by key for deterministic ordering.
+// Returns "" if no parameters are present.
 func summarizeParameters(action json.RawMessage) string {
 	if len(action) == 0 {
 		return ""
@@ -119,14 +134,21 @@ func summarizeParameters(action json.RawMessage) string {
 		return ""
 	}
 
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var parts []string
-	for key, val := range params {
-		if sensitiveParamKeys[strings.ToLower(key)] {
+	for _, key := range keys {
+		if isSensitiveKey(key) {
 			parts = append(parts, key+"=***")
 			continue
 		}
 		var s string
-		if json.Unmarshal(val, &s) == nil {
+		if json.Unmarshal(params[key], &s) == nil {
 			parts = append(parts, key+"="+TruncateUTF8(s, 30))
 		} else {
 			// Non-string value — show the key only

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -82,7 +82,7 @@ func extractStandingExecutionInfo(approval Approval) standingExecutionInfo {
 // executionCountLabel returns a human-readable execution count string
 // like "3 of 10" or "3" (when unlimited).
 func (info standingExecutionInfo) executionCountLabel() string {
-	if info.MaxExecutions > 0 {
+	if info.MaxExecutions > 0 && info.ExecutionCount > 0 {
 		return fmt.Sprintf("%d of %d", info.ExecutionCount, info.MaxExecutions)
 	}
 	if info.ExecutionCount > 0 {

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -87,6 +87,56 @@ func buildStandingExecutionPushContent(approval Approval) PushContent {
 	}
 }
 
+// sensitiveParamKeys is the set of parameter keys whose values should be
+// redacted in notification content. Only the key names are shown.
+var sensitiveParamKeys = map[string]bool{
+	"api_key": true, "apikey": true, "api_secret": true,
+	"token": true, "access_token": true, "refresh_token": true,
+	"secret": true, "password": true, "credential": true,
+	"private_key": true, "auth": true, "authorization": true,
+}
+
+// summarizeParameters extracts a human-readable parameter summary from the
+// action JSON's "parameters" field. Sensitive values are redacted (shown as
+// "***"). Returns "" if no parameters are present.
+func summarizeParameters(action json.RawMessage) string {
+	if len(action) == 0 {
+		return ""
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(action, &obj) != nil {
+		return ""
+	}
+	raw, ok := obj["parameters"]
+	if !ok {
+		return ""
+	}
+	var params map[string]json.RawMessage
+	if json.Unmarshal(raw, &params) != nil {
+		return ""
+	}
+	if len(params) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for key, val := range params {
+		if sensitiveParamKeys[strings.ToLower(key)] {
+			parts = append(parts, key+"=***")
+			continue
+		}
+		var s string
+		if json.Unmarshal(val, &s) == nil {
+			parts = append(parts, key+"="+TruncateUTF8(s, 30))
+		} else {
+			// Non-string value — show the key only
+			parts = append(parts, key)
+		}
+	}
+
+	return strings.Join(parts, ", ")
+}
+
 func buildStandingExecutionSubject(approval Approval) string {
 	info := extractStandingExecutionInfo(approval)
 	if info.ActionType != "" {
@@ -104,6 +154,10 @@ func buildStandingExecutionPlainBody(approval Approval) string {
 
 	if info.ActionType != "" {
 		b.WriteString(fmt.Sprintf("Action: %s\n", info.ActionType))
+	}
+
+	if paramSummary := summarizeParameters(approval.Action); paramSummary != "" {
+		b.WriteString(fmt.Sprintf("Parameters: %s\n", paramSummary))
 	}
 
 	if countLabel := info.executionCountLabel(); countLabel != "" {
@@ -161,6 +215,9 @@ func buildStandingExecutionHTMLBody(approval Approval) string {
 	b.WriteString(`<table style="width:100%;border-collapse:collapse;margin-bottom:20px;">`)
 	if info.ActionType != "" {
 		b.WriteString(emailDetailRow("Action", html.EscapeString(info.ActionType)))
+	}
+	if paramSummary := summarizeParameters(approval.Action); paramSummary != "" {
+		b.WriteString(emailDetailRow("Parameters", html.EscapeString(paramSummary)))
 	}
 	if countLabel := info.executionCountLabel(); countLabel != "" {
 		b.WriteString(emailDetailRow("Executions", html.EscapeString(countLabel)))

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -1,0 +1,188 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html"
+	"strings"
+	"time"
+)
+
+// standingExecutionInfo holds the fields extracted from the Context JSON
+// for a standing approval execution notification.
+type standingExecutionInfo struct {
+	ExecutionCount int    // how many times the standing approval has been used
+	MaxExecutions  int    // total allowed executions (0 = unlimited)
+	AgentName      string // resolved display name
+	ActionType     string // e.g. "github.issues.create"
+}
+
+// extractStandingExecutionInfo extracts execution metadata from the
+// approval's Action and Context JSON. The Context is expected to contain
+// "execution_count" and "max_executions" integers.
+func extractStandingExecutionInfo(approval Approval) standingExecutionInfo {
+	info := standingExecutionInfo{
+		AgentName:  AgentDisplayName(approval.AgentName, approval.AgentID),
+		ActionType: extractActionType(approval.Action),
+	}
+
+	if len(approval.Context) == 0 {
+		return info
+	}
+
+	var ctx map[string]json.RawMessage
+	if json.Unmarshal(approval.Context, &ctx) != nil {
+		return info
+	}
+
+	if raw, ok := ctx["execution_count"]; ok {
+		var n int
+		if json.Unmarshal(raw, &n) == nil {
+			info.ExecutionCount = n
+		}
+	}
+	if raw, ok := ctx["max_executions"]; ok {
+		var n int
+		if json.Unmarshal(raw, &n) == nil {
+			info.MaxExecutions = n
+		}
+	}
+
+	return info
+}
+
+// executionCountLabel returns a human-readable execution count string
+// like "3 of 10" or "3" (when unlimited).
+func (info standingExecutionInfo) executionCountLabel() string {
+	if info.MaxExecutions > 0 {
+		return fmt.Sprintf("%d of %d", info.ExecutionCount, info.MaxExecutions)
+	}
+	if info.ExecutionCount > 0 {
+		return fmt.Sprintf("%d", info.ExecutionCount)
+	}
+	return ""
+}
+
+// buildStandingExecutionPushContent constructs push notification content for
+// standing approval executions. Used by both web push and mobile push senders.
+func buildStandingExecutionPushContent(approval Approval) PushContent {
+	info := extractStandingExecutionInfo(approval)
+
+	title := fmt.Sprintf("%s auto-executed", info.AgentName)
+
+	body := info.ActionType
+	if body == "" {
+		body = "an action"
+	}
+	if info.ExecutionCount > 0 {
+		body = fmt.Sprintf("%s (#%d)", body, info.ExecutionCount)
+	}
+
+	return PushContent{
+		Title:      title,
+		Body:       body,
+		URL:        approval.ApprovalURL,
+		ApprovalID: approval.ApprovalID,
+	}
+}
+
+func buildStandingExecutionSubject(approval Approval) string {
+	info := extractStandingExecutionInfo(approval)
+	if info.ActionType != "" {
+		return fmt.Sprintf("%s executed %s via standing approval", info.AgentName, info.ActionType)
+	}
+	return fmt.Sprintf("%s executed an action via standing approval", info.AgentName)
+}
+
+func buildStandingExecutionPlainBody(approval Approval) string {
+	info := extractStandingExecutionInfo(approval)
+
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("%s auto-executed an action via a standing approval.\n\n", info.AgentName))
+
+	if info.ActionType != "" {
+		b.WriteString(fmt.Sprintf("Action: %s\n", info.ActionType))
+	}
+
+	if countLabel := info.executionCountLabel(); countLabel != "" {
+		b.WriteString(fmt.Sprintf("Executions: %s\n", countLabel))
+	}
+
+	b.WriteString(fmt.Sprintf("Time: %s\n", approval.CreatedAt.UTC().Format(time.RFC1123)))
+
+	if approval.ApprovalURL != "" {
+		b.WriteString(fmt.Sprintf("\nView activity:\n%s\n", approval.ApprovalURL))
+	}
+
+	b.WriteString("\n---\nThis action was auto-approved via a standing approval. Manage standing approvals in the dashboard.\n")
+
+	return b.String()
+}
+
+// formatStandingExecutionSMS builds a concise SMS for a standing approval
+// execution. Format: "[AgentName] ran [action_type] (3/10 uses). View: [url]"
+func formatStandingExecutionSMS(a Approval) string {
+	info := extractStandingExecutionInfo(a)
+
+	actionPart := info.ActionType
+	if actionPart == "" {
+		actionPart = "an action"
+	}
+
+	msg := fmt.Sprintf("[Permission Slip] %s ran %s", info.AgentName, actionPart)
+
+	if countLabel := info.executionCountLabel(); countLabel != "" {
+		msg += fmt.Sprintf(" (%s uses)", countLabel)
+	}
+
+	if a.ApprovalURL != "" {
+		return fmt.Sprintf("%s. View: %s", msg, a.ApprovalURL)
+	}
+
+	return msg
+}
+
+func buildStandingExecutionHTMLBody(approval Approval) string {
+	info := extractStandingExecutionInfo(approval)
+
+	var b bytes.Buffer
+	b.WriteString(`<!DOCTYPE html><html><head><meta charset="UTF-8"></head>`)
+	b.WriteString(`<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#1a1a1a;">`)
+
+	// Header — blue accent (informational, not urgent)
+	b.WriteString(`<div style="border-bottom:2px solid #2563eb;padding-bottom:16px;margin-bottom:20px;">`)
+	b.WriteString(`<h2 style="margin:0 0 4px 0;font-size:20px;">Action Auto-Executed</h2>`)
+	b.WriteString(fmt.Sprintf(`<p style="margin:0;color:#6b7280;font-size:14px;">by %s via standing approval</p>`, html.EscapeString(info.AgentName)))
+	b.WriteString(`</div>`)
+
+	// Details table
+	b.WriteString(`<table style="width:100%%;border-collapse:collapse;margin-bottom:20px;">`)
+	if info.ActionType != "" {
+		b.WriteString(emailDetailRow("Action", html.EscapeString(info.ActionType)))
+	}
+	if countLabel := info.executionCountLabel(); countLabel != "" {
+		b.WriteString(emailDetailRow("Executions", html.EscapeString(countLabel)))
+	}
+	b.WriteString(emailDetailRow("Time", html.EscapeString(approval.CreatedAt.UTC().Format(time.RFC1123))))
+	b.WriteString(`</table>`)
+
+	// CTA button — blue to match informational tone
+	if approval.ApprovalURL != "" {
+		b.WriteString(fmt.Sprintf(
+			`<div style="text-align:center;margin:24px 0;">
+		<a href="%s" style="display:inline-block;background-color:#2563eb;color:#ffffff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;font-size:16px;">View Activity</a>
+		</div>`,
+			html.EscapeString(approval.ApprovalURL),
+		))
+	}
+
+	// Footer — standing-approval-specific messaging
+	b.WriteString(`<div style="border-top:1px solid #e5e7eb;padding-top:12px;margin-top:20px;font-size:12px;color:#9ca3af;">`)
+	b.WriteString(`<p style="margin:0;">This action was auto-approved via a standing approval. Manage standing approvals in the dashboard.</p>`)
+	b.WriteString(`</div>`)
+
+	b.WriteString(`</body></html>`)
+	return b.String()
+}

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -115,12 +115,13 @@ func buildStandingExecutionPushContent(approval Approval) PushContent {
 }
 
 // sensitiveSubstrings are substrings that, when found in a lowercased
-// parameter key, cause the value to be redacted. Substring matching is
-// safer than exact-match because it catches compound keys like
-// "aws_secret_access_key", "db_password", "oauth_token", etc.
+// parameter key, cause the value to be redacted. The substrings are chosen
+// to catch compound keys like "aws_secret_access_key", "db_password",
+// "oauth_token" while avoiding false positives on benign names like
+// "author" or "hotkey".
 var sensitiveSubstrings = []string{
 	"secret", "password", "passwd", "token", "credential",
-	"key", "auth", "private",
+	"_key", "apikey", "access_key", "auth_token", "authz", "private",
 }
 
 // isSensitiveKey returns true if the parameter key looks like it holds
@@ -177,8 +178,14 @@ func summarizeParameters(action json.RawMessage) string {
 		if json.Unmarshal(params[key], &s) == nil {
 			parts = append(parts, key+"="+TruncateUTF8(s, 30))
 		} else {
-			// Non-string value — show the key only
-			parts = append(parts, key)
+			// For non-string primitives (numbers, booleans) render the raw token;
+			// for complex objects just show the key to avoid information overload.
+			raw := params[key]
+			if len(raw) > 0 && raw[0] != '{' && raw[0] != '[' {
+				parts = append(parts, key+"="+string(raw))
+			} else {
+				parts = append(parts, key)
+			}
 		}
 	}
 

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -138,8 +138,9 @@ func isSensitiveKey(key string) bool {
 
 // summarizeParameters extracts a human-readable parameter summary from the
 // action JSON's "parameters" field. Values for keys that look sensitive
-// (contain "secret", "password", "token", "key", etc.) are redacted to
-// "***". Output is sorted by key for deterministic ordering.
+// (see sensitiveSubstrings) are redacted to "***". Non-string primitives
+// (numbers, booleans) are rendered as-is; complex objects show key-only.
+// Output is sorted by key for deterministic ordering.
 // Returns "" if no parameters are present.
 func summarizeParameters(action json.RawMessage) string {
 	if len(action) == 0 {

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -1,3 +1,29 @@
+// Standing approval execution notification templates.
+//
+// When an agent executes an action via a standing approval, these templates
+// generate informational notifications across all channels (email, SMS, push).
+// The templates use a blue/informational tone (not red/amber) since no user
+// action is needed — the execution was pre-authorized.
+//
+// # Context JSON contract
+//
+// The Approval.Context field must be a JSON object with these optional keys:
+//
+//	{
+//	    "execution_count": 3,    // int — how many times the standing approval has been used
+//	    "max_executions": 10     // int — total allowed uses (0 = unlimited)
+//	}
+//
+// The Approval.Action field should contain the standard action JSON with a
+// "type" key and optional "parameters" object. Parameter values are included
+// in email notifications with sensitive keys automatically redacted.
+//
+// # Integration (Phase 2E)
+//
+// To dispatch a standing execution notification, construct a notify.Approval
+// with Type set to NotificationTypeStandingExecution and call
+// deps.Notifier.Dispatch(). See api/approval_notify.go for the existing
+// pattern used by approval request notifications.
 package notify
 
 import (
@@ -159,6 +185,8 @@ func summarizeParameters(action json.RawMessage) string {
 	return strings.Join(parts, ", ")
 }
 
+// buildStandingExecutionSubject returns a subject like
+// "Deploy Bot executed github.issues.create via standing approval".
 func buildStandingExecutionSubject(approval Approval) string {
 	info := extractStandingExecutionInfo(approval)
 	if info.ActionType != "" {
@@ -167,6 +195,8 @@ func buildStandingExecutionSubject(approval Approval) string {
 	return fmt.Sprintf("%s executed an action via standing approval", info.AgentName)
 }
 
+// buildStandingExecutionPlainBody returns the plain-text email body with
+// agent name, action type, parameter summary, execution count, and timestamp.
 func buildStandingExecutionPlainBody(approval Approval) string {
 	info := extractStandingExecutionInfo(approval)
 
@@ -220,6 +250,9 @@ func formatStandingExecutionSMS(a Approval) string {
 	return msg
 }
 
+// buildStandingExecutionHTMLBody returns the HTML email body with a blue
+// accent (#2563eb), details table, "View Activity" CTA button, and a footer
+// noting this was an auto-approved action.
 func buildStandingExecutionHTMLBody(approval Approval) string {
 	info := extractStandingExecutionInfo(approval)
 

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -1,0 +1,308 @@
+package notify
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func standingExecutionApproval() Approval {
+	return Approval{
+		ApprovalID:  "appr_standing_001",
+		AgentID:     42,
+		AgentName:   "Deploy Bot",
+		Action:      json.RawMessage(`{"type":"github.issues.create"}`),
+		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		ApprovalURL: "https://app.example.com/activity",
+		CreatedAt:   time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC),
+		Type:        NotificationTypeStandingExecution,
+	}
+}
+
+// ── extractStandingExecutionInfo tests ──────────────────────────────────────
+
+func TestExtractStandingExecutionInfo_Full(t *testing.T) {
+	t.Parallel()
+	a := standingExecutionApproval()
+	info := extractStandingExecutionInfo(a)
+
+	if info.AgentName != "Deploy Bot" {
+		t.Errorf("expected agent name 'Deploy Bot', got %q", info.AgentName)
+	}
+	if info.ActionType != "github.issues.create" {
+		t.Errorf("expected action type 'github.issues.create', got %q", info.ActionType)
+	}
+	if info.ExecutionCount != 3 {
+		t.Errorf("expected execution count 3, got %d", info.ExecutionCount)
+	}
+	if info.MaxExecutions != 10 {
+		t.Errorf("expected max executions 10, got %d", info.MaxExecutions)
+	}
+}
+
+func TestExtractStandingExecutionInfo_NoContext(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentID:   99,
+		AgentName: "",
+		Action:    json.RawMessage(`{"type":"test"}`),
+		Type:      NotificationTypeStandingExecution,
+	}
+	info := extractStandingExecutionInfo(a)
+
+	if info.AgentName != "Agent #99" {
+		t.Errorf("expected fallback agent name, got %q", info.AgentName)
+	}
+	if info.ExecutionCount != 0 {
+		t.Errorf("expected 0 execution count, got %d", info.ExecutionCount)
+	}
+}
+
+func TestExtractStandingExecutionInfo_Unlimited(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Action:    json.RawMessage(`{"type":"test"}`),
+		Context:   json.RawMessage(`{"execution_count":5,"max_executions":0}`),
+		Type:      NotificationTypeStandingExecution,
+	}
+	info := extractStandingExecutionInfo(a)
+	if info.executionCountLabel() != "5" {
+		t.Errorf("expected '5' for unlimited, got %q", info.executionCountLabel())
+	}
+}
+
+func TestExecutionCountLabel_WithMax(t *testing.T) {
+	t.Parallel()
+	info := standingExecutionInfo{ExecutionCount: 3, MaxExecutions: 10}
+	if info.executionCountLabel() != "3 of 10" {
+		t.Errorf("expected '3 of 10', got %q", info.executionCountLabel())
+	}
+}
+
+func TestExecutionCountLabel_NoCount(t *testing.T) {
+	t.Parallel()
+	info := standingExecutionInfo{}
+	if info.executionCountLabel() != "" {
+		t.Errorf("expected empty label, got %q", info.executionCountLabel())
+	}
+}
+
+// ── Email subject tests ─────────────────────────────────────────────────────
+
+func TestBuildEmailSubject_StandingExecution(t *testing.T) {
+	t.Parallel()
+	a := standingExecutionApproval()
+	subject := buildEmailSubject(a)
+	expected := "Deploy Bot executed github.issues.create via standing approval"
+	if subject != expected {
+		t.Errorf("expected %q, got %q", expected, subject)
+	}
+}
+
+func TestBuildEmailSubject_StandingExecution_NoActionType(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Action:    json.RawMessage(`{}`),
+		Type:      NotificationTypeStandingExecution,
+	}
+	subject := buildEmailSubject(a)
+	if !strings.Contains(subject, "executed an action") {
+		t.Errorf("expected fallback subject, got %q", subject)
+	}
+}
+
+// ── Email plain body tests ──────────────────────────────────────────────────
+
+func TestBuildEmailPlainBody_StandingExecution(t *testing.T) {
+	t.Parallel()
+	a := standingExecutionApproval()
+	body := buildEmailPlainBody(a)
+
+	checks := []string{
+		"Deploy Bot",
+		"github.issues.create",
+		"3 of 10",
+		"auto-approved via a standing approval",
+		"https://app.example.com/activity",
+	}
+	for _, check := range checks {
+		if !strings.Contains(body, check) {
+			t.Errorf("expected plain body to contain %q, body:\n%s", check, body)
+		}
+	}
+}
+
+func TestBuildEmailPlainBody_StandingExecution_NoSensitiveData(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Action:    json.RawMessage(`{"type":"email.send","parameters":{"api_key":"sk-secret123"}}`),
+		Context:   json.RawMessage(`{"execution_count":1,"max_executions":5}`),
+		CreatedAt: time.Now(),
+		Type:      NotificationTypeStandingExecution,
+	}
+	body := buildEmailPlainBody(a)
+	if strings.Contains(body, "sk-secret123") {
+		t.Error("plain body should not contain sensitive parameters")
+	}
+}
+
+// ── Email HTML body tests ───────────────────────────────────────────────────
+
+func TestBuildEmailHTMLBody_StandingExecution(t *testing.T) {
+	t.Parallel()
+	a := standingExecutionApproval()
+	h := buildEmailHTMLBody(a)
+
+	checks := []string{
+		"#2563eb",                             // blue accent
+		"Auto-Executed",                       // header
+		"Deploy Bot",                          // agent name
+		"github.issues.create",                // action type
+		"3 of 10",                             // execution count
+		"View Activity",                       // CTA button
+		"https://app.example.com/activity",    // URL
+		"auto-approved via a standing approval", // footer
+	}
+	for _, check := range checks {
+		if !strings.Contains(h, check) {
+			t.Errorf("expected HTML to contain %q", check)
+		}
+	}
+}
+
+func TestBuildEmailHTMLBody_StandingExecution_EscapesHTML(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: `<script>alert("xss")</script>`,
+		Action:    json.RawMessage(`{"type":"test"}`),
+		Context:   json.RawMessage(`{"execution_count":1}`),
+		CreatedAt: time.Now(),
+		Type:      NotificationTypeStandingExecution,
+	}
+	h := buildEmailHTMLBody(a)
+	if strings.Contains(h, "<script>") {
+		t.Error("HTML body should escape script tags")
+	}
+	if !strings.Contains(h, "&lt;script&gt;") {
+		t.Error("HTML body should contain escaped script tag")
+	}
+}
+
+func TestBuildEmailHTMLBody_StandingExecution_NoURL(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Action:    json.RawMessage(`{"type":"test"}`),
+		Context:   json.RawMessage(`{"execution_count":1}`),
+		CreatedAt: time.Now(),
+		Type:      NotificationTypeStandingExecution,
+	}
+	h := buildEmailHTMLBody(a)
+	if strings.Contains(h, "View Activity") {
+		t.Error("HTML body should not contain CTA button when URL is empty")
+	}
+}
+
+// ── SMS tests ───────────────────────────────────────────────────────────────
+
+func TestFormatSMSBody_StandingExecution(t *testing.T) {
+	t.Parallel()
+	a := standingExecutionApproval()
+	body := formatSMSBody(a)
+
+	checks := []string{
+		"Deploy Bot",
+		"github.issues.create",
+		"3 of 10 uses",
+		"View:",
+		"https://app.example.com/activity",
+	}
+	for _, check := range checks {
+		if !strings.Contains(body, check) {
+			t.Errorf("expected SMS body to contain %q, got: %s", check, body)
+		}
+	}
+}
+
+func TestFormatSMSBody_StandingExecution_NoURL(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Action:    json.RawMessage(`{"type":"test"}`),
+		Context:   json.RawMessage(`{"execution_count":2,"max_executions":5}`),
+		Type:      NotificationTypeStandingExecution,
+	}
+	body := formatSMSBody(a)
+	if strings.Contains(body, "View:") {
+		t.Error("expected no View URL")
+	}
+	if !strings.Contains(body, "2 of 5 uses") {
+		t.Errorf("expected execution count, got: %s", body)
+	}
+}
+
+func TestFormatSMSBody_StandingExecution_Unlimited(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName:   "Bot",
+		Action:      json.RawMessage(`{"type":"test"}`),
+		Context:     json.RawMessage(`{"execution_count":7}`),
+		ApprovalURL: "https://example.com/activity",
+		Type:        NotificationTypeStandingExecution,
+	}
+	body := formatSMSBody(a)
+	if !strings.Contains(body, "7 uses") {
+		t.Errorf("expected execution count, got: %s", body)
+	}
+}
+
+// ── Push content tests ──────────────────────────────────────────────────────
+
+func TestBuildPushContent_StandingExecution(t *testing.T) {
+	t.Parallel()
+	a := standingExecutionApproval()
+	c := BuildPushContent(a)
+
+	if c.Title != "Deploy Bot auto-executed" {
+		t.Errorf("expected title 'Deploy Bot auto-executed', got %q", c.Title)
+	}
+	if c.Body != "github.issues.create (#3)" {
+		t.Errorf("expected body 'github.issues.create (#3)', got %q", c.Body)
+	}
+	if c.URL != "https://app.example.com/activity" {
+		t.Errorf("expected activity URL, got %q", c.URL)
+	}
+}
+
+func TestBuildPushContent_StandingExecution_NoCount(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Action:    json.RawMessage(`{"type":"deploy"}`),
+		Type:      NotificationTypeStandingExecution,
+	}
+	c := BuildPushContent(a)
+	if c.Title != "Bot auto-executed" {
+		t.Errorf("expected title, got %q", c.Title)
+	}
+	if c.Body != "deploy" {
+		t.Errorf("expected body 'deploy', got %q", c.Body)
+	}
+}
+
+func TestBuildPushContent_StandingExecution_NoAction(t *testing.T) {
+	t.Parallel()
+	a := Approval{
+		AgentName: "Bot",
+		Context:   json.RawMessage(`{"execution_count":1}`),
+		Type:      NotificationTypeStandingExecution,
+	}
+	c := BuildPushContent(a)
+	if c.Body != "an action (#1)" {
+		t.Errorf("expected fallback body, got %q", c.Body)
+	}
+}

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -7,16 +7,11 @@ import (
 	"time"
 )
 
-// standingExecutionApproval delegates to the shared fixture in testdata_test.go
-func standingExecutionApproval() Approval {
-	return testStandingExecutionApproval()
-}
-
 // ── extractStandingExecutionInfo tests ──────────────────────────────────────
 
 func TestExtractStandingExecutionInfo_Full(t *testing.T) {
 	t.Parallel()
-	a := standingExecutionApproval()
+	a := testStandingExecutionApproval()
 	info := extractStandingExecutionInfo(a)
 
 	if info.AgentName != "Deploy Bot" {
@@ -85,7 +80,7 @@ func TestExecutionCountLabel_NoCount(t *testing.T) {
 
 func TestBuildEmailSubject_StandingExecution(t *testing.T) {
 	t.Parallel()
-	a := standingExecutionApproval()
+	a := testStandingExecutionApproval()
 	subject := buildEmailSubject(a)
 	expected := "Deploy Bot executed github.issues.create via standing approval"
 	if subject != expected {
@@ -110,7 +105,7 @@ func TestBuildEmailSubject_StandingExecution_NoActionType(t *testing.T) {
 
 func TestBuildEmailPlainBody_StandingExecution(t *testing.T) {
 	t.Parallel()
-	a := standingExecutionApproval()
+	a := testStandingExecutionApproval()
 	body := buildEmailPlainBody(a)
 
 	checks := []string{
@@ -147,7 +142,7 @@ func TestBuildEmailPlainBody_StandingExecution_NoSensitiveData(t *testing.T) {
 
 func TestBuildEmailHTMLBody_StandingExecution(t *testing.T) {
 	t.Parallel()
-	a := standingExecutionApproval()
+	a := testStandingExecutionApproval()
 	h := buildEmailHTMLBody(a)
 
 	checks := []string{
@@ -205,7 +200,7 @@ func TestBuildEmailHTMLBody_StandingExecution_NoURL(t *testing.T) {
 
 func TestFormatSMSBody_StandingExecution(t *testing.T) {
 	t.Parallel()
-	a := standingExecutionApproval()
+	a := testStandingExecutionApproval()
 	body := formatSMSBody(a)
 
 	checks := []string{
@@ -258,7 +253,7 @@ func TestFormatSMSBody_StandingExecution_Unlimited(t *testing.T) {
 
 func TestBuildPushContent_StandingExecution(t *testing.T) {
 	t.Parallel()
-	a := standingExecutionApproval()
+	a := testStandingExecutionApproval()
 	c := BuildPushContent(a)
 
 	if c.Title != "Deploy Bot auto-executed" {

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -294,11 +294,10 @@ func TestSummarizeParameters_WithParams(t *testing.T) {
 	t.Parallel()
 	action := json.RawMessage(`{"type":"test","parameters":{"repo":"acme/app","title":"Deploy v2.1"}}`)
 	summary := summarizeParameters(action)
-	if !strings.Contains(summary, "repo=acme/app") {
-		t.Errorf("expected repo param, got: %s", summary)
-	}
-	if !strings.Contains(summary, "title=Deploy v2.1") {
-		t.Errorf("expected title param, got: %s", summary)
+	// Output is sorted by key: repo before title.
+	expected := "repo=acme/app, title=Deploy v2.1"
+	if summary != expected {
+		t.Errorf("expected %q, got %q", expected, summary)
 	}
 }
 
@@ -317,6 +316,29 @@ func TestSummarizeParameters_RedactsSensitive(t *testing.T) {
 	}
 	if !strings.Contains(summary, "token=***") {
 		t.Errorf("expected redacted token, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_RedactsCompoundSensitiveKeys(t *testing.T) {
+	t.Parallel()
+	// Compound key names like "aws_secret_access_key" and "db_password"
+	// must also be redacted via substring matching.
+	action := json.RawMessage(`{"type":"test","parameters":{"aws_secret_access_key":"AKIA...","db_password":"hunter2","oauth_token":"ghp_abc"}}`)
+	summary := summarizeParameters(action)
+	if strings.Contains(summary, "AKIA") {
+		t.Error("summary should redact aws_secret_access_key value")
+	}
+	if strings.Contains(summary, "hunter2") {
+		t.Error("summary should redact db_password value")
+	}
+	if strings.Contains(summary, "ghp_abc") {
+		t.Error("summary should redact oauth_token value")
+	}
+	if !strings.Contains(summary, "aws_secret_access_key=***") {
+		t.Errorf("expected redacted aws_secret_access_key, got: %s", summary)
+	}
+	if !strings.Contains(summary, "db_password=***") {
+		t.Errorf("expected redacted db_password, got: %s", summary)
 	}
 }
 

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -68,6 +68,16 @@ func TestExecutionCountLabel_WithMax(t *testing.T) {
 	}
 }
 
+func TestExecutionCountLabel_ZeroCountWithMax(t *testing.T) {
+	t.Parallel()
+	// When execution_count is 0 but max_executions is set, the label should
+	// be empty — not "0 of 10" which contradicts the notification.
+	info := standingExecutionInfo{ExecutionCount: 0, MaxExecutions: 10}
+	if info.executionCountLabel() != "" {
+		t.Errorf("expected empty label for zero count, got %q", info.executionCountLabel())
+	}
+}
+
 func TestExecutionCountLabel_NoCount(t *testing.T) {
 	t.Parallel()
 	info := standingExecutionInfo{}

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -337,6 +337,44 @@ func TestSummarizeParameters_RedactsCompoundSensitiveKeys(t *testing.T) {
 	}
 }
 
+func TestSummarizeParameters_NoFalsePositives(t *testing.T) {
+	t.Parallel()
+	// "author" and "hotkey" should NOT be redacted — they are benign parameter names.
+	action := json.RawMessage(`{"type":"test","parameters":{"author":"alice","hotkey":"ctrl+s","keyboard":"us"}}`)
+	summary := summarizeParameters(action)
+	if !strings.Contains(summary, "author=alice") {
+		t.Errorf("expected author to not be redacted, got: %s", summary)
+	}
+	if !strings.Contains(summary, "hotkey=ctrl+s") {
+		t.Errorf("expected hotkey to not be redacted, got: %s", summary)
+	}
+	if !strings.Contains(summary, "keyboard=us") {
+		t.Errorf("expected keyboard to not be redacted, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_NonStringPrimitives(t *testing.T) {
+	t.Parallel()
+	action := json.RawMessage(`{"type":"test","parameters":{"count":42,"enabled":true,"repo":"acme/app","nested":{"a":1}}}`)
+	summary := summarizeParameters(action)
+	if !strings.Contains(summary, "count=42") {
+		t.Errorf("expected number value to be rendered, got: %s", summary)
+	}
+	if !strings.Contains(summary, "enabled=true") {
+		t.Errorf("expected boolean value to be rendered, got: %s", summary)
+	}
+	if !strings.Contains(summary, "repo=acme/app") {
+		t.Errorf("expected string value to be rendered, got: %s", summary)
+	}
+	// Nested objects should show key only
+	if strings.Contains(summary, "nested=") {
+		t.Errorf("expected nested object to show key only, got: %s", summary)
+	}
+	if !strings.Contains(summary, "nested") {
+		t.Errorf("expected nested key to be present, got: %s", summary)
+	}
+}
+
 func TestSummarizeParameters_NoParams(t *testing.T) {
 	t.Parallel()
 	action := json.RawMessage(`{"type":"test"}`)

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -7,17 +7,9 @@ import (
 	"time"
 )
 
+// standingExecutionApproval delegates to the shared fixture in testdata_test.go
 func standingExecutionApproval() Approval {
-	return Approval{
-		ApprovalID:  "appr_standing_001",
-		AgentID:     42,
-		AgentName:   "Deploy Bot",
-		Action:      json.RawMessage(`{"type":"github.issues.create"}`),
-		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
-		ApprovalURL: "https://app.example.com/activity",
-		CreatedAt:   time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC),
-		Type:        NotificationTypeStandingExecution,
-	}
+	return testStandingExecutionApproval()
 }
 
 // ── extractStandingExecutionInfo tests ──────────────────────────────────────
@@ -124,6 +116,7 @@ func TestBuildEmailPlainBody_StandingExecution(t *testing.T) {
 	checks := []string{
 		"Deploy Bot",
 		"github.issues.create",
+		"Parameters:",
 		"3 of 10",
 		"auto-approved via a standing approval",
 		"https://app.example.com/activity",
@@ -162,6 +155,7 @@ func TestBuildEmailHTMLBody_StandingExecution(t *testing.T) {
 		"Auto-Executed",                       // header
 		"Deploy Bot",                          // agent name
 		"github.issues.create",                // action type
+		"Parameters",                          // parameter summary row
 		"3 of 10",                             // execution count
 		"View Activity",                       // CTA button
 		"https://app.example.com/activity",    // URL
@@ -291,6 +285,71 @@ func TestBuildPushContent_StandingExecution_NoCount(t *testing.T) {
 	}
 	if c.Body != "deploy" {
 		t.Errorf("expected body 'deploy', got %q", c.Body)
+	}
+}
+
+// ── summarizeParameters tests ────────────────────────────────────────────────
+
+func TestSummarizeParameters_WithParams(t *testing.T) {
+	t.Parallel()
+	action := json.RawMessage(`{"type":"test","parameters":{"repo":"acme/app","title":"Deploy v2.1"}}`)
+	summary := summarizeParameters(action)
+	if !strings.Contains(summary, "repo=acme/app") {
+		t.Errorf("expected repo param, got: %s", summary)
+	}
+	if !strings.Contains(summary, "title=Deploy v2.1") {
+		t.Errorf("expected title param, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_RedactsSensitive(t *testing.T) {
+	t.Parallel()
+	action := json.RawMessage(`{"type":"test","parameters":{"repo":"acme/app","api_key":"sk-secret123","token":"tok-abc"}}`)
+	summary := summarizeParameters(action)
+	if strings.Contains(summary, "sk-secret123") {
+		t.Error("summary should redact api_key value")
+	}
+	if strings.Contains(summary, "tok-abc") {
+		t.Error("summary should redact token value")
+	}
+	if !strings.Contains(summary, "api_key=***") {
+		t.Errorf("expected redacted api_key, got: %s", summary)
+	}
+	if !strings.Contains(summary, "token=***") {
+		t.Errorf("expected redacted token, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_NoParams(t *testing.T) {
+	t.Parallel()
+	action := json.RawMessage(`{"type":"test"}`)
+	if summary := summarizeParameters(action); summary != "" {
+		t.Errorf("expected empty summary, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_EmptyParams(t *testing.T) {
+	t.Parallel()
+	action := json.RawMessage(`{"type":"test","parameters":{}}`)
+	if summary := summarizeParameters(action); summary != "" {
+		t.Errorf("expected empty summary, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_LongValue(t *testing.T) {
+	t.Parallel()
+	longVal := strings.Repeat("x", 50)
+	action := json.RawMessage(`{"type":"test","parameters":{"desc":"` + longVal + `"}}`)
+	summary := summarizeParameters(action)
+	if !strings.Contains(summary, "...") {
+		t.Errorf("expected long value to be truncated, got: %s", summary)
+	}
+}
+
+func TestSummarizeParameters_NilAction(t *testing.T) {
+	t.Parallel()
+	if summary := summarizeParameters(nil); summary != "" {
+		t.Errorf("expected empty summary for nil, got: %s", summary)
 	}
 }
 

--- a/notify/testdata_test.go
+++ b/notify/testdata_test.go
@@ -21,6 +21,21 @@ func testApproval() Approval {
 	}
 }
 
+// testStandingExecutionApproval returns a standard standing execution
+// Approval fixture for use across notify tests.
+func testStandingExecutionApproval() Approval {
+	return Approval{
+		ApprovalID:  "appr_standing_001",
+		AgentID:     42,
+		AgentName:   "Deploy Bot",
+		Action:      json.RawMessage(`{"type":"github.issues.create","parameters":{"repo":"acme/app","title":"Deploy v2.1"}}`),
+		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		ApprovalURL: "https://app.example.com/activity",
+		CreatedAt:   time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC),
+		Type:        NotificationTypeStandingExecution,
+	}
+}
+
 // testRecipient returns a standard Recipient fixture with email and phone.
 func testRecipient() Recipient {
 	email := "alice@example.com"

--- a/notify/webpush/sender_test.go
+++ b/notify/webpush/sender_test.go
@@ -97,6 +97,29 @@ func TestBuildBody(t *testing.T) {
 	})
 }
 
+func TestBuildBody_StandingExecution(t *testing.T) {
+	t.Parallel()
+	approval := notify.Approval{
+		ApprovalID:  "appr_standing_001",
+		AgentName:   "Deploy Bot",
+		Action:      json.RawMessage(`{"type":"github.issues.create"}`),
+		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		ApprovalURL: "https://app.test/activity",
+		Type:        notify.NotificationTypeStandingExecution,
+	}
+
+	body := buildBody(approval)
+	if body.Title != "Deploy Bot auto-executed" {
+		t.Errorf("expected title 'Deploy Bot auto-executed', got %q", body.Title)
+	}
+	if body.Body != "github.issues.create (#3)" {
+		t.Errorf("expected body 'github.issues.create (#3)', got %q", body.Body)
+	}
+	if body.URL != "https://app.test/activity" {
+		t.Errorf("expected activity URL, got %q", body.URL)
+	}
+}
+
 func TestSenderName(t *testing.T) {
 	t.Parallel()
 	s := &Sender{}


### PR DESCRIPTION
## Summary

Implements **Phase 1B** of #550: execution notification templates for standing approvals. When an agent exercises a standing approval, the user is notified via all configured channels (email, SMS, web push, mobile push) — but NOT via an in-app banner.

- Added `NotificationTypeStandingExecution = "standing_execution"` constant
- **Email**: Subject: "[AgentName] executed [action_type] via standing approval", HTML body with blue accent (#2563eb), execution count (e.g. "3 of 10"), timestamp, activity link, and standing-approval-specific footer
- **SMS**: "[Permission Slip] [AgentName] ran [action_type] (3 of 10 uses). View: [url]"
- **Web push**: Title: "[AgentName] auto-executed", Body: "[action_type] (#N)"
- **Mobile push**: Same as web push, uses category `"standing_execution"` (not `"approval"`) so the mobile app can suppress in-app banners
- All templates extract execution metadata (`execution_count`, `max_executions`) from the Context JSON
- No sensitive parameter values are included in any template

## Test plan

### Claude Code
- [x] Unit tests for `extractStandingExecutionInfo` (full context, no context, unlimited)
- [x] Unit tests for `executionCountLabel` (with max, without max, zero)
- [x] Unit tests for email subject, plain body, and HTML body (content, XSS escaping, no-URL case)
- [x] Unit tests for SMS formatting (with URL, without URL, unlimited executions)
- [x] Unit tests for push content (`BuildPushContent` routing, with/without count, no action)
- [x] Unit tests for mobile push `categoryForType` (standing_execution, approval, payment_failed)
- [x] Integration test verifying mobile push sends `"standing_execution"` categoryId in Expo API payload
- [x] Web push `buildBody` test for standing execution
- [x] All existing notify tests still pass

### OpenClaw
- [ ] Review notification content and tone across channels
- [ ] Verify email renders correctly in common email clients
- [ ] Decide: one-per-execution or digest batching for high-frequency agents? (Can defer to follow-up)

Relates to #550

https://claude.ai/code/session_01Ae4NCLTTBtSHYFnDAjLEt5