### PR TITLE
Standing approval spec: require constraints, add action_configuration_id

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -38,6 +38,7 @@ export function CreateStandingApprovalDialog({
   const [agentId, setAgentId] = useState<number | "">("");
   const [actionType, setActionType] = useState("");
   const [actionVersion, setActionVersion] = useState("1");
+  const [constraintsJson, setConstraintsJson] = useState("");
   const [maxExecutions, setMaxExecutions] = useState("");
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
@@ -47,6 +48,7 @@ export function CreateStandingApprovalDialog({
     setAgentId("");
     setActionType("");
     setActionVersion("1");
+    setConstraintsJson("");
     setMaxExecutions("");
     setExpiresAt(defaultExpiresAt());
   }
@@ -59,11 +61,27 @@ export function CreateStandingApprovalDialog({
       return;
     }
 
+    let constraints: Record<string, unknown>;
+    try {
+      constraints = constraintsJson
+        ? (JSON.parse(constraintsJson) as Record<string, unknown>)
+        : {};
+    } catch {
+      toast.error("Constraints must be valid JSON");
+      return;
+    }
+
+    if (typeof constraints !== "object" || Array.isArray(constraints)) {
+      toast.error("Constraints must be a JSON object");
+      return;
+    }
+
     try {
       await createStandingApproval({
         agent_id: agentId,
         action_type: actionType,
         action_version: actionVersion || "1",
+        constraints,
         max_executions: maxExecutions ? Number(maxExecutions) : null,
         expires_at: new Date(expiresAt).toISOString(),
       });
@@ -124,6 +142,21 @@ export function CreateStandingApprovalDialog({
               onChange={(e) => setActionType(e.target.value)}
               required
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="sa-constraints">Constraints (JSON)</Label>
+            <Input
+              id="sa-constraints"
+              placeholder='{"recipient_pattern": "*@mycompany.com"}'
+              value={constraintsJson}
+              onChange={(e) => setConstraintsJson(e.target.value)}
+              required
+            />
+            <p className="text-muted-foreground text-xs">
+              Parameter constraints for this standing approval. At least one
+              non-wildcard constraint is required.
+            </p>
           </div>
 
           <div className="grid grid-cols-2 gap-4">

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -63,15 +63,13 @@ export function CreateStandingApprovalDialog({
 
     let constraints: Record<string, unknown>;
     try {
-      constraints = constraintsJson
-        ? (JSON.parse(constraintsJson) as Record<string, unknown>)
-        : {};
+      constraints = JSON.parse(constraintsJson) as Record<string, unknown>;
     } catch {
       toast.error("Constraints must be valid JSON");
       return;
     }
 
-    if (typeof constraints !== "object" || Array.isArray(constraints)) {
+    if (constraints === null || typeof constraints !== "object" || Array.isArray(constraints)) {
       toast.error("Constraints must be a JSON object");
       return;
     }

--- a/spec/openapi/components/paths/standing_approvals.yaml
+++ b/spec/openapi/components/paths/standing_approvals.yaml
@@ -83,6 +83,7 @@ listStandingApprovals:
                   expires_at: "2026-02-21T00:00:00Z"
                   created_at: "2026-02-14T10:30:00Z"
                   revoked_at: null
+                  source_action_configuration_id: null
                 - standing_approval_id: "sa_def456"
                   agent_id: 42
                   user_id: "alice"
@@ -98,6 +99,7 @@ listStandingApprovals:
                   expires_at: "2026-05-15T00:00:00Z"
                   created_at: "2026-02-14T10:35:00Z"
                   revoked_at: null
+                  source_action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
               has_more: true
               next_cursor: "2026-02-14T10:30:00.000000000Z,sa_abc123"
 
@@ -226,6 +228,7 @@ userListStandingApprovals:
                   expires_at: "2026-02-21T00:00:00Z"
                   created_at: "2026-02-14T10:30:00Z"
                   revoked_at: null
+                  source_action_configuration_id: null
               has_more: false
 
       '400':
@@ -293,6 +296,7 @@ createStandingApproval:
             action_version: "1"
             constraints:
               recipient_pattern: "*@mycompany.com"
+            action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
             max_executions: 100
             expires_at: "2026-03-14T00:00:00Z"
 

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -46,6 +46,7 @@ StandingApprovalListResponse:
         expires_at: "2026-02-21T00:00:00Z"
         created_at: "2026-02-14T10:30:00Z"
         revoked_at: null
+        source_action_configuration_id: null
     has_more: false
 
 StandingApproval:
@@ -55,6 +56,7 @@ StandingApproval:
     - agent_id
     - user_id
     - action_type
+    - constraints
     - status
     - execution_count
     - starts_at
@@ -184,6 +186,18 @@ StandingApproval:
         `null` if not revoked.
       example: null
 
+    source_action_configuration_id:
+      type: string
+      pattern: '^ac_[a-f0-9]{32}$'
+      maxLength: 36
+      nullable: true
+      description: |
+        The action configuration this standing approval was derived from, if any.
+        Nullable — `null` when the standing approval was created with a custom
+        action type rather than from an existing configuration. The referenced
+        configuration may have been deleted since creation.
+      example: null
+
   example:
     standing_approval_id: "sa_abc123"
     agent_id: 42
@@ -200,6 +214,7 @@ StandingApproval:
     expires_at: "2026-02-21T00:00:00Z"
     created_at: "2026-02-14T10:30:00Z"
     revoked_at: null
+    source_action_configuration_id: null
 
 UserStandingApprovalListResponse:
   type: object
@@ -242,6 +257,7 @@ UserStandingApprovalListResponse:
         expires_at: "2026-02-21T00:00:00Z"
         created_at: "2026-02-14T10:30:00Z"
         revoked_at: null
+        source_action_configuration_id: null
     has_more: false
 
 CreateStandingApprovalRequest:
@@ -249,6 +265,7 @@ CreateStandingApprovalRequest:
   required:
     - agent_id
     - action_type
+    - constraints
     - expires_at
   properties:
     agent_id:
@@ -274,10 +291,25 @@ CreateStandingApprovalRequest:
     constraints:
       type: object
       additionalProperties: true
-      description: Constraint boundaries for this standing approval.
+      description: |
+        Constraint boundaries for this standing approval. Required and must
+        contain at least one non-wildcard parameter constraint. A standing
+        approval without parameter constraints is a blank check — the backend
+        rejects empty constraints or constraints where every value is a
+        wildcard (`"*"`).
       example:
         recipient_pattern: "*@mycompany.com"
         max_recipients: 5
+
+    action_configuration_id:
+      type: string
+      pattern: '^ac_[a-f0-9]{32}$'
+      maxLength: 36
+      description: |
+        Optional reference to the action configuration this standing approval
+        was derived from. When provided, the backend records it for traceability.
+        No foreign-key enforcement — the configuration may be deleted later.
+      example: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
 
     max_executions:
       type: integer
@@ -304,6 +336,7 @@ CreateStandingApprovalRequest:
     action_version: "1"
     constraints:
       recipient_pattern: "*@mycompany.com"
+    action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
     max_executions: 100
     expires_at: "2026-03-14T00:00:00Z"
 

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -190,7 +190,7 @@ StandingApproval:
     source_action_configuration_id:
       type: string
       pattern: '^ac_[a-f0-9]{32}$'
-      maxLength: 36
+      maxLength: 35
       nullable: true
       description: |
         The action configuration this standing approval was derived from, if any.
@@ -305,7 +305,7 @@ CreateStandingApprovalRequest:
     action_configuration_id:
       type: string
       pattern: '^ac_[a-f0-9]{32}$'
-      maxLength: 36
+      maxLength: 35
       description: |
         Optional reference to the action configuration this standing approval
         was derived from. When provided, the backend records it for traceability.

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -62,6 +62,7 @@ StandingApproval:
     - starts_at
     - expires_at
     - created_at
+    - source_action_configuration_id
   properties:
     standing_approval_id:
       type: string

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7849,6 +7849,7 @@ components:
         - starts_at
         - expires_at
         - created_at
+        - source_action_configuration_id
       properties:
         standing_approval_id:
           type: string

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7964,7 +7964,7 @@ components:
         source_action_configuration_id:
           type: string
           pattern: ^ac_[a-f0-9]{32}$
-          maxLength: 36
+          maxLength: 35
           nullable: true
           description: |
             The action configuration this standing approval was derived from, if any.
@@ -8220,7 +8220,7 @@ components:
         action_configuration_id:
           type: string
           pattern: ^ac_[a-f0-9]{32}$
-          maxLength: 36
+          maxLength: 35
           description: |
             Optional reference to the action configuration this standing approval
             was derived from. When provided, the backend records it for traceability.

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -3997,6 +3997,7 @@ paths:
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
                     revoked_at: null
+                    source_action_configuration_id: null
                   - standing_approval_id: sa_def456
                     agent_id: 42
                     user_id: alice
@@ -4012,6 +4013,7 @@ paths:
                     expires_at: '2026-05-15T00:00:00Z'
                     created_at: '2026-02-14T10:35:00Z'
                     revoked_at: null
+                    source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
                 has_more: true
                 next_cursor: 2026-02-14T10:30:00.000000000Z,sa_abc123
         '400':
@@ -4125,6 +4127,7 @@ paths:
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
                     revoked_at: null
+                    source_action_configuration_id: null
                 has_more: false
         '400':
           description: Invalid query parameters
@@ -4182,6 +4185,7 @@ paths:
               action_version: '1'
               constraints:
                 recipient_pattern: '*@mycompany.com'
+              action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
               max_executions: 100
               expires_at: '2026-03-14T00:00:00Z'
       responses:
@@ -7839,6 +7843,7 @@ components:
         - agent_id
         - user_id
         - action_type
+        - constraints
         - status
         - execution_count
         - starts_at
@@ -7955,6 +7960,17 @@ components:
             ISO 8601 timestamp (RFC 3339 format, UTC) when this standing approval was revoked.
             `null` if not revoked.
           example: null
+        source_action_configuration_id:
+          type: string
+          pattern: ^ac_[a-f0-9]{32}$
+          maxLength: 36
+          nullable: true
+          description: |
+            The action configuration this standing approval was derived from, if any.
+            Nullable — `null` when the standing approval was created with a custom
+            action type rather than from an existing configuration. The referenced
+            configuration may have been deleted since creation.
+          example: null
       example:
         standing_approval_id: sa_abc123
         agent_id: 42
@@ -7971,6 +7987,7 @@ components:
         expires_at: '2026-02-21T00:00:00Z'
         created_at: '2026-02-14T10:30:00Z'
         revoked_at: null
+        source_action_configuration_id: null
     StandingApprovalExecuteRequest:
       type: object
       required:
@@ -8118,6 +8135,7 @@ components:
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
             revoked_at: null
+            source_action_configuration_id: null
         has_more: false
     UserStandingApprovalListResponse:
       type: object
@@ -8159,12 +8177,14 @@ components:
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
             revoked_at: null
+            source_action_configuration_id: null
         has_more: false
     CreateStandingApprovalRequest:
       type: object
       required:
         - agent_id
         - action_type
+        - constraints
         - expires_at
       properties:
         agent_id:
@@ -8187,10 +8207,24 @@ components:
         constraints:
           type: object
           additionalProperties: true
-          description: Constraint boundaries for this standing approval.
+          description: |
+            Constraint boundaries for this standing approval. Required and must
+            contain at least one non-wildcard parameter constraint. A standing
+            approval without parameter constraints is a blank check — the backend
+            rejects empty constraints or constraints where every value is a
+            wildcard (`"*"`).
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
+        action_configuration_id:
+          type: string
+          pattern: ^ac_[a-f0-9]{32}$
+          maxLength: 36
+          description: |
+            Optional reference to the action configuration this standing approval
+            was derived from. When provided, the backend records it for traceability.
+            No foreign-key enforcement — the configuration may be deleted later.
+          example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         max_executions:
           type: integer
           minimum: 1
@@ -8213,6 +8247,7 @@ components:
         action_version: '1'
         constraints:
           recipient_pattern: '*@mycompany.com'
+        action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         max_executions: 100
         expires_at: '2026-03-14T00:00:00Z'
     RevokeStandingApprovalResponse:


### PR DESCRIPTION
## Summary

Phase 1C of #550 (Standing Approval UI/UX). This PR does **not** close the issue — it covers only the OpenAPI spec + type generation phase.

- Mark `constraints` as **required** on `POST /v1/standing-approvals/create` and on the `StandingApproval` response schema
- Add optional `action_configuration_id` field to the create request (tracks which action config a standing approval was derived from)
- Add `source_action_configuration_id` to the `StandingApproval` response schema (nullable, for traceability)
- Update the bundled spec (`openapi.bundle.yaml`) and all examples
- Update `CreateStandingApprovalDialog.tsx` to pass `constraints` (simple JSON input field — Phase 2D will rewrite the full dialog)

Related to #550

## Test plan

### Claude Code
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Frontend tests pass (`make test-frontend` — 726 tests, 90 files)
- [x] Frontend build succeeds (`npm run build`)
- [x] Bundled spec regenerates cleanly (`make bundle`)
- [x] Generated types include new fields (`action_configuration_id`, `source_action_configuration_id`, required `constraints`)

### OpenClaw
- [ ] Verify spec changes align with Phase 1A backend implementation expectations
- [ ] Confirm `source_action_configuration_id` naming convention is acceptable

https://claude.ai/code/session_01L49nE3bNL757Zx4heqG9nW