### PR TITLE
Add x-ui manifest validation for connector rendering hints

### DIFF
--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -359,6 +359,17 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		propertyKeys[k] = true
 	}
 
+	// Extract the "required" array so we can check for visible_when + required conflicts.
+	requiredFields := make(map[string]bool)
+	if raw, ok := s["required"]; ok {
+		var required []string
+		if err := json.Unmarshal(raw, &required); err == nil {
+			for _, f := range required {
+				requiredFields[f] = true
+			}
+		}
+	}
+
 	// Parse root-level x-ui.
 	var rootUI struct {
 		Groups []struct {
@@ -403,6 +414,7 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 	sort.Strings(sortedProps)
 
 	// First pass: collect visible_when targets for cycle detection.
+	// Maps each property to the field it depends on for visibility.
 	visibleWhenTarget := make(map[string]string) // property → field it depends on
 	for _, propName := range sortedProps {
 		var prop struct {
@@ -416,6 +428,34 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			continue
 		}
 		visibleWhenTarget[propName] = prop.XUI.VisibleWhen.Field
+	}
+
+	// Detect visible_when dependency cycles of any length (A→B→C→A).
+	// Walk the chain from each node; if we revisit the start, it's a cycle.
+	for _, start := range sortedProps {
+		if _, ok := visibleWhenTarget[start]; !ok {
+			continue
+		}
+		visited := map[string]bool{start: true}
+		cur := visibleWhenTarget[start]
+		for cur != "" {
+			if cur == start {
+				// Build the cycle path for a readable error message.
+				path := start
+				c := visibleWhenTarget[start]
+				for c != start {
+					path += " → " + c
+					c = visibleWhenTarget[c]
+				}
+				path += " → " + start
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema has a visible_when dependency cycle: %s", actionIdx, path)
+			}
+			if visited[cur] {
+				break // dead end or sub-cycle not involving start
+			}
+			visited[cur] = true
+			cur = visibleWhenTarget[cur]
+		}
 	}
 
 	// Validate property-level x-ui.
@@ -454,19 +494,19 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			if prop.XUI.VisibleWhen.Field == "" {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires a \"field\" key", actionIdx, propName)
 			}
-			if prop.XUI.VisibleWhen.Field == propName {
-				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field must not reference the property itself", actionIdx, propName)
-			}
-			// Detect mutual dependency cycles (A depends on B, B depends on A).
-			if target, ok := visibleWhenTarget[prop.XUI.VisibleWhen.Field]; ok && target == propName {
-				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s and %s have mutual visible_when dependency — neither can ever be visible", actionIdx, propName, prop.XUI.VisibleWhen.Field)
-			}
+			// Self-references and cycles are caught by the general cycle
+			// detector above, so no separate self-reference check needed.
 			if !propertyKeys[prop.XUI.VisibleWhen.Field] {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
 			}
 			// len == 0 means the key was absent; null unmarshal produces []byte("null").
 			if len(prop.XUI.VisibleWhen.Equals) == 0 {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires an \"equals\" key", actionIdx, propName)
+			}
+			// A field with visible_when can be hidden, so it should not be in "required".
+			// JSON Schema validation would reject the submission when the field is hidden.
+			if requiredFields[propName] {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s has visible_when but is also listed in \"required\" — hidden fields cannot satisfy required validation", actionIdx, propName)
 			}
 		}
 	}

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -379,11 +379,16 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			}
 			groupIDs[g.ID] = true
 		}
-		// Validate x-ui.order references existing property keys.
+		// Validate x-ui.order references existing property keys with no duplicates.
+		orderSeen := make(map[string]bool, len(rootUI.Order))
 		for _, field := range rootUI.Order {
 			if !propertyKeys[field] {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui.order references unknown property %q", actionIdx, field)
 			}
+			if orderSeen[field] {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui.order contains duplicate entry %q", actionIdx, field)
+			}
+			orderSeen[field] = true
 		}
 	}
 
@@ -394,7 +399,8 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 				Widget      string `json:"widget"`
 				Group       string `json:"group"`
 				VisibleWhen *struct {
-					Field string `json:"field"`
+					Field  string `json:"field"`
+					Equals *json.RawMessage `json:"equals"`
 				} `json:"visible_when"`
 			} `json:"x-ui"`
 		}
@@ -405,13 +411,21 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			continue
 		}
 		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
-			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q is not a valid widget type", actionIdx, propName, prop.XUI.Widget)
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, textarea, toggle, number, date", actionIdx, propName, prop.XUI.Widget)
 		}
 		if prop.XUI.Group != "" && !groupIDs[prop.XUI.Group] {
 			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.group %q does not match any defined group in x-ui.groups", actionIdx, propName, prop.XUI.Group)
 		}
-		if prop.XUI.VisibleWhen != nil && prop.XUI.VisibleWhen.Field != "" && !propertyKeys[prop.XUI.VisibleWhen.Field] {
-			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
+		if prop.XUI.VisibleWhen != nil {
+			if prop.XUI.VisibleWhen.Field == "" {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires a \"field\" key", actionIdx, propName)
+			}
+			if !propertyKeys[prop.XUI.VisibleWhen.Field] {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
+			}
+			if prop.XUI.VisibleWhen.Equals == nil {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires an \"equals\" key", actionIdx, propName)
+			}
 		}
 	}
 

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -400,8 +400,8 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 				Group       string `json:"group"`
 				HelpURL     string `json:"help_url"`
 				VisibleWhen *struct {
-					Field  string           `json:"field"`
-					Equals *json.RawMessage `json:"equals"`
+					Field  string          `json:"field"`
+					Equals json.RawMessage `json:"equals"`
 				} `json:"visible_when"`
 			} `json:"x-ui"`
 		}
@@ -433,7 +433,8 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			if !propertyKeys[prop.XUI.VisibleWhen.Field] {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
 			}
-			if prop.XUI.VisibleWhen.Equals == nil {
+			// len == 0 means the key was absent; null unmarshal produces []byte("null").
+			if len(prop.XUI.VisibleWhen.Equals) == 0 {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires an \"equals\" key", actionIdx, propName)
 			}
 		}

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -374,6 +374,9 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			if g.ID == "" {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui.groups contains entry with empty id", actionIdx)
 			}
+			if groupIDs[g.ID] {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui.groups contains duplicate id %q", actionIdx, g.ID)
+			}
 			groupIDs[g.ID] = true
 		}
 		// Validate x-ui.order references existing property keys.

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
@@ -392,8 +393,34 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		}
 	}
 
+	// Sort property keys for deterministic validation order. Unlike other
+	// validators that iterate slices, we iterate a map — sorting ensures
+	// error messages are consistent across runs.
+	sortedProps := make([]string, 0, len(properties))
+	for k := range properties {
+		sortedProps = append(sortedProps, k)
+	}
+	sort.Strings(sortedProps)
+
+	// First pass: collect visible_when targets for cycle detection.
+	visibleWhenTarget := make(map[string]string) // property → field it depends on
+	for _, propName := range sortedProps {
+		var prop struct {
+			XUI *struct {
+				VisibleWhen *struct {
+					Field string `json:"field"`
+				} `json:"visible_when"`
+			} `json:"x-ui"`
+		}
+		if err := json.Unmarshal(properties[propName], &prop); err != nil || prop.XUI == nil || prop.XUI.VisibleWhen == nil {
+			continue
+		}
+		visibleWhenTarget[propName] = prop.XUI.VisibleWhen.Field
+	}
+
 	// Validate property-level x-ui.
-	for propName, propRaw := range properties {
+	for _, propName := range sortedProps {
+		propRaw := properties[propName]
 		var prop struct {
 			XUI *struct {
 				Widget      string `json:"widget"`
@@ -429,6 +456,10 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			}
 			if prop.XUI.VisibleWhen.Field == propName {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field must not reference the property itself", actionIdx, propName)
+			}
+			// Detect mutual dependency cycles (A depends on B, B depends on A).
+			if target, ok := visibleWhenTarget[prop.XUI.VisibleWhen.Field]; ok && target == propName {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s and %s have mutual visible_when dependency — neither can ever be visible", actionIdx, propName, prop.XUI.VisibleWhen.Field)
 			}
 			if !propertyKeys[prop.XUI.VisibleWhen.Field] {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -81,6 +81,16 @@ var validRiskLevels = map[string]bool{
 	"high":   true,
 }
 
+// validWidgets are the allowed values for x-ui.widget on schema properties.
+var validWidgets = map[string]bool{
+	"text":     true,
+	"select":   true,
+	"textarea": true,
+	"toggle":   true,
+	"number":   true,
+	"date":     true,
+}
+
 // validAuthTypes are the allowed values for credential auth types.
 // Must match the CHECK constraint on connector_required_credentials.auth_type.
 var validAuthTypes = map[string]bool{
@@ -182,6 +192,15 @@ func (m *ConnectorManifest) Validate() error {
 		}
 		if a.RiskLevel != "" && !validRiskLevels[a.RiskLevel] {
 			return fmt.Errorf("manifest validation: actions[%d].risk_level %q must be low, medium, or high", i, a.RiskLevel)
+		}
+	}
+
+	// Validate x-ui hints in parameters_schema (optional).
+	for i, a := range m.Actions {
+		if len(a.ParametersSchema) > 0 {
+			if err := validateParametersSchemaUI(a.ParametersSchema, i); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -310,6 +329,86 @@ func (m *ConnectorManifest) Validate() error {
 	for i, c := range m.RequiredCredentials {
 		if c.AuthType == "oauth2" && !knownProviders[c.OAuthProvider] {
 			return fmt.Errorf("manifest validation: required_credentials[%d].oauth_provider %q is not a built-in provider and not declared in oauth_providers", i, c.OAuthProvider)
+		}
+	}
+
+	return nil
+}
+
+// validateParametersSchemaUI validates x-ui rendering hints embedded in a
+// parameters_schema. It checks that widget values, group references, field
+// ordering, and visible_when references are all consistent and valid.
+func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
+	// Parse the schema into a generic map.
+	var s map[string]json.RawMessage
+	if err := json.Unmarshal(schema, &s); err != nil {
+		// Not a JSON object — nothing to validate here (other validation handles this).
+		return nil
+	}
+
+	// Extract property keys.
+	var properties map[string]json.RawMessage
+	if raw, ok := s["properties"]; ok {
+		if err := json.Unmarshal(raw, &properties); err != nil {
+			return nil // malformed properties — not our concern here
+		}
+	}
+	propertyKeys := make(map[string]bool, len(properties))
+	for k := range properties {
+		propertyKeys[k] = true
+	}
+
+	// Parse root-level x-ui.
+	var rootUI struct {
+		Groups []struct {
+			ID string `json:"id"`
+		} `json:"groups"`
+		Order []string `json:"order"`
+	}
+	groupIDs := make(map[string]bool)
+	if raw, ok := s["x-ui"]; ok {
+		if err := json.Unmarshal(raw, &rootUI); err != nil {
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui is not a valid object: %w", actionIdx, err)
+		}
+		for _, g := range rootUI.Groups {
+			if g.ID == "" {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui.groups contains entry with empty id", actionIdx)
+			}
+			groupIDs[g.ID] = true
+		}
+		// Validate x-ui.order references existing property keys.
+		for _, field := range rootUI.Order {
+			if !propertyKeys[field] {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema x-ui.order references unknown property %q", actionIdx, field)
+			}
+		}
+	}
+
+	// Validate property-level x-ui.
+	for propName, propRaw := range properties {
+		var prop struct {
+			XUI *struct {
+				Widget      string `json:"widget"`
+				Group       string `json:"group"`
+				VisibleWhen *struct {
+					Field string `json:"field"`
+				} `json:"visible_when"`
+			} `json:"x-ui"`
+		}
+		if err := json.Unmarshal(propRaw, &prop); err != nil {
+			continue // not our concern
+		}
+		if prop.XUI == nil {
+			continue
+		}
+		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q is not a valid widget type", actionIdx, propName, prop.XUI.Widget)
+		}
+		if prop.XUI.Group != "" && !groupIDs[prop.XUI.Group] {
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.group %q does not match any defined group in x-ui.groups", actionIdx, propName, prop.XUI.Group)
+		}
+		if prop.XUI.VisibleWhen != nil && prop.XUI.VisibleWhen.Field != "" && !propertyKeys[prop.XUI.VisibleWhen.Field] {
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
 		}
 	}
 

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -427,6 +427,9 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			if prop.XUI.VisibleWhen.Field == "" {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires a \"field\" key", actionIdx, propName)
 			}
+			if prop.XUI.VisibleWhen.Field == propName {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field must not reference the property itself", actionIdx, propName)
+			}
 			if !propertyKeys[prop.XUI.VisibleWhen.Field] {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
 			}

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -398,8 +398,9 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			XUI *struct {
 				Widget      string `json:"widget"`
 				Group       string `json:"group"`
+				HelpURL     string `json:"help_url"`
 				VisibleWhen *struct {
-					Field  string `json:"field"`
+					Field  string           `json:"field"`
 					Equals *json.RawMessage `json:"equals"`
 				} `json:"visible_when"`
 			} `json:"x-ui"`
@@ -412,6 +413,12 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		}
 		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
 			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, textarea, toggle, number, date", actionIdx, propName, prop.XUI.Widget)
+		}
+		if prop.XUI.HelpURL != "" {
+			field := fmt.Sprintf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.help_url", actionIdx, propName)
+			if err := validateURL(prop.XUI.HelpURL, field, "http", "https"); err != nil {
+				return err
+			}
 		}
 		if prop.XUI.Group != "" && !groupIDs[prop.XUI.Group] {
 			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.group %q does not match any defined group in x-ui.groups", actionIdx, propName, prop.XUI.Group)

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -427,7 +427,11 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		if err := json.Unmarshal(properties[propName], &prop); err != nil || prop.XUI == nil || prop.XUI.VisibleWhen == nil {
 			continue
 		}
-		visibleWhenTarget[propName] = prop.XUI.VisibleWhen.Field
+		// Only record valid references — skip empty fields and self-references
+		// so the cycle detector operates on semantically valid edges only.
+		if vwField := prop.XUI.VisibleWhen.Field; vwField != "" && vwField != propName {
+			visibleWhenTarget[propName] = vwField
+		}
 	}
 
 	// Detect visible_when dependency cycles of any length (A→B→C→A).
@@ -481,6 +485,15 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
 			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, textarea, toggle, number, date", actionIdx, propName, prop.XUI.Widget)
 		}
+		// A "select" widget needs enum values to populate the dropdown.
+		if prop.XUI.Widget == "select" {
+			var propObj map[string]json.RawMessage
+			if err := json.Unmarshal(propRaw, &propObj); err == nil {
+				if _, hasEnum := propObj["enum"]; !hasEnum {
+					return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget \"select\" requires an \"enum\" array on the property", actionIdx, propName)
+				}
+			}
+		}
 		if prop.XUI.HelpURL != "" {
 			field := fmt.Sprintf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.help_url", actionIdx, propName)
 			if err := validateURL(prop.XUI.HelpURL, field, "http", "https"); err != nil {
@@ -494,8 +507,9 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			if prop.XUI.VisibleWhen.Field == "" {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when requires a \"field\" key", actionIdx, propName)
 			}
-			// Self-references and cycles are caught by the general cycle
-			// detector above, so no separate self-reference check needed.
+			if prop.XUI.VisibleWhen.Field == propName {
+				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field must not reference the property itself", actionIdx, propName)
+			}
 			if !propertyKeys[prop.XUI.VisibleWhen.Field] {
 				return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.visible_when.field %q references unknown property", actionIdx, propName, prop.XUI.VisibleWhen.Field)
 			}

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -686,7 +686,7 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 		{
 			"visible_when self-reference",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"field":"f","equals":"val"}}}}}`,
-			`dependency cycle: f`,
+			`must not reference the property itself`,
 		},
 		{
 			"visible_when mutual dependency (A↔B)",
@@ -697,6 +697,11 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			"visible_when 3-node cycle (A→B→C→A)",
 			`{"type":"object","properties":{"a":{"type":"string","x-ui":{"visible_when":{"field":"c","equals":"x"}}},"b":{"type":"string","x-ui":{"visible_when":{"field":"a","equals":"y"}}},"c":{"type":"string","x-ui":{"visible_when":{"field":"b","equals":"z"}}}}}`,
 			`dependency cycle`,
+		},
+		{
+			"select widget without enum",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"widget":"select"}}}}`,
+			`widget "select" requires an "enum" array`,
 		},
 		{
 			"visible_when on required field",
@@ -757,6 +762,11 @@ func TestParseManifest_XUIAllWidgetTypes(t *testing.T) {
 	// All valid widget types should be accepted.
 	for _, widget := range []string{"text", "select", "textarea", "toggle", "number", "date"} {
 		t.Run(widget, func(t *testing.T) {
+			// "select" requires an enum array on the property.
+			propExtra := ""
+			if widget == "select" {
+				propExtra = `, "enum": ["a", "b"]`
+			}
 			input := fmt.Sprintf(`{
 				"id": "x",
 				"name": "X",
@@ -766,11 +776,11 @@ func TestParseManifest_XUIAllWidgetTypes(t *testing.T) {
 					"parameters_schema": {
 						"type": "object",
 						"properties": {
-							"f": {"type": "string", "x-ui": {"widget": %q}}
+							"f": {"type": "string"%s, "x-ui": {"widget": %q}}
 						}
 					}
 				}]
-			}`, widget)
+			}`, propExtra, widget)
 			_, err := ParseManifest([]byte(input))
 			if err != nil {
 				t.Fatalf("widget %q should be valid, got: %v", widget, err)

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -655,6 +655,10 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			"root x-ui groups with empty id",
 			`{"type":"object","x-ui":{"groups":[{"id":"","label":"Empty"}]},"properties":{"f":{"type":"string"}}}`,
 		},
+		{
+			"duplicate group id",
+			`{"type":"object","x-ui":{"groups":[{"id":"billing","label":"Billing"},{"id":"billing","label":"Billing 2"}]},"properties":{"f":{"type":"string"}}}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -659,6 +659,18 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			"duplicate group id",
 			`{"type":"object","x-ui":{"groups":[{"id":"billing","label":"Billing"},{"id":"billing","label":"Billing 2"}]},"properties":{"f":{"type":"string"}}}`,
 		},
+		{
+			"duplicate order entry",
+			`{"type":"object","x-ui":{"order":["name","name"]},"properties":{"name":{"type":"string"}}}`,
+		},
+		{
+			"visible_when missing field key",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"equals":"val"}}}}}`,
+		},
+		{
+			"visible_when missing equals key",
+			`{"type":"object","properties":{"a":{"type":"string"},"f":{"type":"string","x-ui":{"visible_when":{"field":"a"}}}}}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -696,6 +696,30 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 	}
 }
 
+func TestParseManifest_XUIVisibleWhenEqualsNull(t *testing.T) {
+	// visible_when with equals: null should be valid (means "show when field is unset").
+	input := `{
+		"id": "x",
+		"name": "X",
+		"actions": [{
+			"action_type": "x.do",
+			"name": "Do",
+			"parameters_schema": {
+				"type": "object",
+				"properties": {
+					"a": {"type": "string"},
+					"b": {"type": "string", "x-ui": {"visible_when": {"field": "a", "equals": null}}}
+				}
+			}
+		}]
+	}`
+
+	_, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("visible_when with equals:null should be valid, got: %v", err)
+	}
+}
+
 func TestParseManifest_XUIAllWidgetTypes(t *testing.T) {
 	// All valid widget types should be accepted.
 	for _, widget := range []string{"text", "select", "textarea", "toggle", "number", "date"} {

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -676,6 +676,10 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"field":"f","equals":"val"}}}}}`,
 		},
 		{
+			"visible_when mutual dependency",
+			`{"type":"object","properties":{"a":{"type":"string","x-ui":{"visible_when":{"field":"b","equals":"x"}}},"b":{"type":"string","x-ui":{"visible_when":{"field":"a","equals":"y"}}}}}`,
+		},
+		{
 			"help_url with javascript scheme",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"help_url":"javascript:alert(1)"}}}}`,
 		},

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -672,6 +672,10 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			`{"type":"object","properties":{"a":{"type":"string"},"f":{"type":"string","x-ui":{"visible_when":{"field":"a"}}}}}`,
 		},
 		{
+			"visible_when self-reference",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"field":"f","equals":"val"}}}}}`,
+		},
+		{
 			"help_url with javascript scheme",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"help_url":"javascript:alert(1)"}}}}`,
 		},

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -529,3 +529,167 @@ func TestManifestValidation_ReservedAuthorizeParams(t *testing.T) {
 		})
 	}
 }
+
+// ── x-ui Validation ─────────────────────────────────────────────────────
+
+func TestParseManifest_ValidXUI(t *testing.T) {
+	input := `{
+		"id": "x",
+		"name": "X",
+		"actions": [{
+			"action_type": "x.do",
+			"name": "Do",
+			"parameters_schema": {
+				"type": "object",
+				"x-ui": {
+					"groups": [
+						{"id": "main", "label": "Main Settings"},
+						{"id": "advanced", "label": "Advanced", "collapsed": true}
+					],
+					"order": ["name", "email", "notify"]
+				},
+				"properties": {
+					"name": {
+						"type": "string",
+						"x-ui": {"label": "Full Name", "placeholder": "John Doe", "group": "main", "widget": "text"}
+					},
+					"email": {
+						"type": "string",
+						"x-ui": {"label": "Email", "group": "main", "help_url": "https://example.com/help"}
+					},
+					"notify": {
+						"type": "boolean",
+						"x-ui": {"widget": "toggle", "group": "advanced", "visible_when": {"field": "email", "equals": "set"}}
+					}
+				}
+			}
+		}]
+	}`
+
+	_, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseManifest_XUIWithoutGroups(t *testing.T) {
+	// x-ui on properties without root groups or order should be fine
+	// as long as no group references are made.
+	input := `{
+		"id": "x",
+		"name": "X",
+		"actions": [{
+			"action_type": "x.do",
+			"name": "Do",
+			"parameters_schema": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string",
+						"x-ui": {"label": "Name", "widget": "text", "placeholder": "Enter name"}
+					}
+				}
+			}
+		}]
+	}`
+
+	_, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseManifest_NoXUI(t *testing.T) {
+	// Schema without any x-ui should pass validation (backwards compatible).
+	input := `{
+		"id": "x",
+		"name": "X",
+		"actions": [{
+			"action_type": "x.do",
+			"name": "Do",
+			"parameters_schema": {
+				"type": "object",
+				"properties": {
+					"name": {"type": "string"}
+				}
+			}
+		}]
+	}`
+
+	_, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseManifest_XUIValidationErrors(t *testing.T) {
+	base := func(schema string) string {
+		return fmt.Sprintf(`{"id":"x","name":"X","actions":[{"action_type":"x.do","name":"Do","parameters_schema":%s}]}`, schema)
+	}
+
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{
+			"invalid widget type",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"widget":"slider"}}}}`,
+		},
+		{
+			"group references undefined group",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"group":"missing"}}}}`,
+		},
+		{
+			"group references undefined group with other groups defined",
+			`{"type":"object","x-ui":{"groups":[{"id":"billing","label":"Billing"}]},"properties":{"f":{"type":"string","x-ui":{"group":"shipping"}}}}`,
+		},
+		{
+			"order references unknown property",
+			`{"type":"object","x-ui":{"order":["name","nonexistent"]},"properties":{"name":{"type":"string"}}}`,
+		},
+		{
+			"visible_when references unknown property",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"field":"ghost","equals":"val"}}}}}`,
+		},
+		{
+			"root x-ui groups with empty id",
+			`{"type":"object","x-ui":{"groups":[{"id":"","label":"Empty"}]},"properties":{"f":{"type":"string"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := base(tt.schema)
+			_, err := ParseManifest([]byte(input))
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseManifest_XUIAllWidgetTypes(t *testing.T) {
+	// All valid widget types should be accepted.
+	for _, widget := range []string{"text", "select", "textarea", "toggle", "number", "date"} {
+		t.Run(widget, func(t *testing.T) {
+			input := fmt.Sprintf(`{
+				"id": "x",
+				"name": "X",
+				"actions": [{
+					"action_type": "x.do",
+					"name": "Do",
+					"parameters_schema": {
+						"type": "object",
+						"properties": {
+							"f": {"type": "string", "x-ui": {"widget": %q}}
+						}
+					}
+				}]
+			}`, widget)
+			_, err := ParseManifest([]byte(input))
+			if err != nil {
+				t.Fatalf("widget %q should be valid, got: %v", widget, err)
+			}
+		})
+	}
+}

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -628,64 +629,89 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		schema string
+		name    string
+		schema  string
+		wantSub string // substring that must appear in the error message
 	}{
 		{
 			"invalid widget type",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"widget":"slider"}}}}`,
+			`widget "slider" must be one of`,
 		},
 		{
 			"group references undefined group",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"group":"missing"}}}}`,
+			`group "missing" does not match any defined group`,
 		},
 		{
 			"group references undefined group with other groups defined",
 			`{"type":"object","x-ui":{"groups":[{"id":"billing","label":"Billing"}]},"properties":{"f":{"type":"string","x-ui":{"group":"shipping"}}}}`,
+			`group "shipping" does not match any defined group`,
 		},
 		{
 			"order references unknown property",
 			`{"type":"object","x-ui":{"order":["name","nonexistent"]},"properties":{"name":{"type":"string"}}}`,
+			`order references unknown property "nonexistent"`,
 		},
 		{
 			"visible_when references unknown property",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"field":"ghost","equals":"val"}}}}}`,
+			`visible_when.field "ghost" references unknown property`,
 		},
 		{
 			"root x-ui groups with empty id",
 			`{"type":"object","x-ui":{"groups":[{"id":"","label":"Empty"}]},"properties":{"f":{"type":"string"}}}`,
+			`groups contains entry with empty id`,
 		},
 		{
 			"duplicate group id",
 			`{"type":"object","x-ui":{"groups":[{"id":"billing","label":"Billing"},{"id":"billing","label":"Billing 2"}]},"properties":{"f":{"type":"string"}}}`,
+			`groups contains duplicate id "billing"`,
 		},
 		{
 			"duplicate order entry",
 			`{"type":"object","x-ui":{"order":["name","name"]},"properties":{"name":{"type":"string"}}}`,
+			`order contains duplicate entry "name"`,
 		},
 		{
 			"visible_when missing field key",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"equals":"val"}}}}}`,
+			`visible_when requires a "field" key`,
 		},
 		{
 			"visible_when missing equals key",
 			`{"type":"object","properties":{"a":{"type":"string"},"f":{"type":"string","x-ui":{"visible_when":{"field":"a"}}}}}`,
+			`visible_when requires an "equals" key`,
 		},
 		{
 			"visible_when self-reference",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"visible_when":{"field":"f","equals":"val"}}}}}`,
+			`dependency cycle: f`,
 		},
 		{
-			"visible_when mutual dependency",
+			"visible_when mutual dependency (A↔B)",
 			`{"type":"object","properties":{"a":{"type":"string","x-ui":{"visible_when":{"field":"b","equals":"x"}}},"b":{"type":"string","x-ui":{"visible_when":{"field":"a","equals":"y"}}}}}`,
+			`dependency cycle`,
+		},
+		{
+			"visible_when 3-node cycle (A→B→C→A)",
+			`{"type":"object","properties":{"a":{"type":"string","x-ui":{"visible_when":{"field":"c","equals":"x"}}},"b":{"type":"string","x-ui":{"visible_when":{"field":"a","equals":"y"}}},"c":{"type":"string","x-ui":{"visible_when":{"field":"b","equals":"z"}}}}}`,
+			`dependency cycle`,
+		},
+		{
+			"visible_when on required field",
+			`{"type":"object","required":["f"],"properties":{"a":{"type":"string"},"f":{"type":"string","x-ui":{"visible_when":{"field":"a","equals":"show"}}}}}`,
+			`has visible_when but is also listed in "required"`,
 		},
 		{
 			"help_url with javascript scheme",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"help_url":"javascript:alert(1)"}}}}`,
+			`must use http or https scheme`,
 		},
 		{
 			"help_url with no host",
 			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"help_url":"https://"}}}}`,
+			`must include a host`,
 		},
 	}
 
@@ -694,7 +720,10 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			input := base(tt.schema)
 			_, err := ParseManifest([]byte(input))
 			if err == nil {
-				t.Error("expected error, got nil")
+				t.Fatal("expected error, got nil")
+			}
+			if tt.wantSub != "" && !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q does not contain expected substring %q", err.Error(), tt.wantSub)
 			}
 		})
 	}

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -671,6 +671,14 @@ func TestParseManifest_XUIValidationErrors(t *testing.T) {
 			"visible_when missing equals key",
 			`{"type":"object","properties":{"a":{"type":"string"},"f":{"type":"string","x-ui":{"visible_when":{"field":"a"}}}}}`,
 		},
+		{
+			"help_url with javascript scheme",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"help_url":"javascript:alert(1)"}}}}`,
+		},
+		{
+			"help_url with no host",
+			`{"type":"object","properties":{"f":{"type":"string","x-ui":{"help_url":"https://"}}}}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/custom-connectors.md
+++ b/docs/custom-connectors.md
@@ -260,6 +260,7 @@ The server validates `x-ui` hints during manifest parsing. Invalid schemas are r
 | Rule | Error if violated |
 |------|-------------------|
 | `widget` must be one of: `text`, `select`, `textarea`, `toggle`, `number`, `date` | Lists valid widget types |
+| `widget: "select"` requires an `enum` array on the property | Names the property missing enum |
 | `group` must reference a group defined in root `x-ui.groups` | Names the unrecognized group |
 | `x-ui.groups` entries must have unique, non-empty `id` values | Names the duplicate |
 | `x-ui.order` entries must reference existing property keys, no duplicates | Names the unknown/duplicate field |

--- a/docs/custom-connectors.md
+++ b/docs/custom-connectors.md
@@ -253,6 +253,20 @@ This renders:
 | `required_credentials[].auth_type` | `api_key`, `basic`, or `custom` |
 | `required_credentials[].instructions_url` | URL to human-readable credential setup docs (optional, must be http/https, max 2048 chars) |
 
+**`x-ui` validation rules:**
+
+The server validates `x-ui` hints during manifest parsing. Invalid schemas are rejected at startup with descriptive error messages:
+
+| Rule | Error if violated |
+|------|-------------------|
+| `widget` must be one of: `text`, `select`, `textarea`, `toggle`, `number`, `date` | Lists valid widget types |
+| `group` must reference a group defined in root `x-ui.groups` | Names the unrecognized group |
+| `x-ui.groups` entries must have unique, non-empty `id` values | Names the duplicate |
+| `x-ui.order` entries must reference existing property keys, no duplicates | Names the unknown/duplicate field |
+| `visible_when.field` must reference an existing property (not itself) | Names the invalid reference |
+| `visible_when` must include both `field` and `equals` keys | Identifies which key is missing |
+| `help_url` must use `http` or `https` scheme | Prevents `javascript:` XSS |
+
 ### Makefile
 
 Your `Makefile` must have a `build` target that produces an executable named `connector` in the repo root:

--- a/docs/custom-connectors.md
+++ b/docs/custom-connectors.md
@@ -265,6 +265,8 @@ The server validates `x-ui` hints during manifest parsing. Invalid schemas are r
 | `x-ui.order` entries must reference existing property keys, no duplicates | Names the unknown/duplicate field |
 | `visible_when.field` must reference an existing property (not itself) | Names the invalid reference |
 | `visible_when` must include both `field` and `equals` keys | Identifies which key is missing |
+| `visible_when` fields must not be in `required` | Hidden fields can't satisfy required validation |
+| `visible_when` dependencies must not form cycles (any length) | Shows the full cycle path (e.g. A → B → C → A) |
 | `help_url` must use `http` or `https` scheme | Prevents `javascript:` XSS |
 
 ### Makefile

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

- Adds `validateParametersSchemaUI()` to the connector manifest `Validate()` function, which validates `x-ui` rendering hints embedded in `parameters_schema`
- Validates that `x-ui.widget` values are in the allowed set (`text`, `select`, `textarea`, `toggle`, `number`, `date`)
- Validates that `x-ui.group` references match a defined group in root `x-ui.groups`
- Validates that `x-ui.order` field names match actual property keys
- Validates that `visible_when.field` references an existing property
- Adds comprehensive tests for all validation rules (valid schemas, invalid schemas, all widget types)
- Backwards compatible — schemas without `x-ui` continue to pass validation unchanged

## Test plan

### Claude Code
- [x] All existing connectors package tests pass
- [x] New x-ui validation tests pass (12 test cases)
- [x] Build compiles successfully

### OpenClaw
- [ ] Review validation error messages for clarity
- [ ] Confirm the allowed widget set matches what the frontend supports (Chunk 2)

Relates to #551

https://claude.ai/code/session_01BiiCso5K7bQqAjLgN84RxJ