### PR TITLE
Enforce constraints on standing approval creation (Phase 1A)

### DIFF
--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -72,6 +72,9 @@ const (
 	// Parameter validation (request-time, distinct from execution-time invalid_parameters)
 	ErrMissingRequiredParameters ErrorCode = "missing_required_parameters"
 
+	// Standing approval constraint validation
+	ErrInvalidConstraints ErrorCode = "invalid_constraints"
+
 	// 429 Too Many Requests (quota)
 	ErrMonthlyQuotaExceeded ErrorCode = "monthly_quota_exceeded"
 )

--- a/api/plan_limits_test.go
+++ b/api/plan_limits_test.go
@@ -33,6 +33,7 @@ func TestCreateStandingApproval_FreePlan_AtLimit_Returns403(t *testing.T) {
 	body := fmt.Sprintf(`{
 		"agent_id": %d,
 		"action_type": "test.action",
+		"constraints": {"channel": "#test"},
 		"expires_at": "%s"
 	}`, agentID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
 
@@ -82,6 +83,7 @@ func TestCreateStandingApproval_FreePlan_UnderLimit_Succeeds(t *testing.T) {
 	body := fmt.Sprintf(`{
 		"agent_id": %d,
 		"action_type": "test.action",
+		"constraints": {"channel": "#test"},
 		"expires_at": "%s"
 	}`, agentID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
 
@@ -113,6 +115,7 @@ func TestCreateStandingApproval_PaidPlan_NoLimit(t *testing.T) {
 	body := fmt.Sprintf(`{
 		"agent_id": %d,
 		"action_type": "test.action",
+		"constraints": {"channel": "#test"},
 		"expires_at": "%s"
 	}`, agentID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
 
@@ -139,6 +142,7 @@ func TestCreateStandingApproval_NoSubscription_NoLimit(t *testing.T) {
 	body := fmt.Sprintf(`{
 		"agent_id": %d,
 		"action_type": "test.action",
+		"constraints": {"channel": "#test"},
 		"expires_at": "%s"
 	}`, agentID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
 
@@ -455,6 +459,7 @@ func TestCreateStandingApproval_RevokedDoNotCountTowardLimit(t *testing.T) {
 	body := fmt.Sprintf(`{
 		"agent_id": %d,
 		"action_type": "test.action",
+		"constraints": {"channel": "#test"},
 		"expires_at": "%s"
 	}`, agentID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
 

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -493,7 +493,7 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 		var s string
 		if json.Unmarshal(v, &s) != nil || s != "*" {
 			allWildcard = false
-			break
+			// No break — must continue iterating to check remaining values for null.
 		}
 	}
 	if allWildcard {

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -204,7 +204,11 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 
 		constraintsBytes, err := validateStandingApprovalConstraints(req.Constraints)
 		if err != nil {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
+			resp := BadRequest(ErrInvalidConstraints, err.Error())
+			resp.Error.Details = map[string]any{
+				"hint": "Provide a JSON object with at least one non-wildcard constraint, e.g. {\"repo\": \"my-org/my-repo\", \"title\": \"*\"}",
+			}
+			RespondError(w, r, http.StatusBadRequest, resp)
 			return
 		}
 

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -484,12 +484,11 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 	}
 
 	// Check that at least one constraint value is not a wildcard ("*").
-	// JSON null is treated as wildcard-equivalent (no constraint on that key).
+	// Null values are rejected outright — use "*" for a wildcard or omit the key.
 	allWildcard := true
 	for _, v := range obj {
-		// Treat JSON null as a wildcard-equivalent (unconstrained).
 		if string(v) == "null" {
-			continue
+			return nil, errors.New("constraint values must not be null; use \"*\" for a wildcard or omit the key entirely")
 		}
 		var s string
 		if json.Unmarshal(v, &s) != nil || s != "*" {

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -17,19 +17,20 @@ import (
 // Response types for the dashboard standing approval endpoints.
 
 type standingApprovalResponse struct {
-	StandingApprovalID string     `json:"standing_approval_id"`
-	AgentID            int64      `json:"agent_id"`
-	UserID             string     `json:"user_id"`
-	ActionType         string     `json:"action_type"`
-	ActionVersion      string     `json:"action_version"`
-	Constraints        any        `json:"constraints"`
-	Status             string     `json:"status"`
-	MaxExecutions      *int       `json:"max_executions"`
-	ExecutionCount     int        `json:"execution_count"`
-	StartsAt           time.Time  `json:"starts_at"`
-	ExpiresAt          time.Time  `json:"expires_at"`
-	CreatedAt          time.Time  `json:"created_at"`
-	RevokedAt          *time.Time `json:"revoked_at,omitempty"`
+	StandingApprovalID          string     `json:"standing_approval_id"`
+	AgentID                     int64      `json:"agent_id"`
+	UserID                      string     `json:"user_id"`
+	ActionType                  string     `json:"action_type"`
+	ActionVersion               string     `json:"action_version"`
+	Constraints                 any        `json:"constraints"`
+	SourceActionConfigurationID *string    `json:"source_action_configuration_id"`
+	Status                      string     `json:"status"`
+	MaxExecutions               *int       `json:"max_executions"`
+	ExecutionCount              int        `json:"execution_count"`
+	StartsAt                    time.Time  `json:"starts_at"`
+	ExpiresAt                   time.Time  `json:"expires_at"`
+	CreatedAt                   time.Time  `json:"created_at"`
+	RevokedAt                   *time.Time `json:"revoked_at,omitempty"`
 }
 
 type standingApprovalListResponse struct {
@@ -45,13 +46,14 @@ type revokeStandingApprovalResponse struct {
 }
 
 type createStandingApprovalRequest struct {
-	AgentID       int64           `json:"agent_id" validate:"gt=0"`
-	ActionType    string          `json:"action_type" validate:"required"`
-	ActionVersion string          `json:"action_version"`
-	Constraints   json.RawMessage `json:"constraints"`
-	MaxExecutions *int            `json:"max_executions" validate:"omitempty,gte=1"`
-	StartsAt      *time.Time      `json:"starts_at"`
-	ExpiresAt     time.Time       `json:"expires_at" validate:"required"`
+	AgentID                int64           `json:"agent_id" validate:"gt=0"`
+	ActionType             string          `json:"action_type" validate:"required"`
+	ActionVersion          string          `json:"action_version"`
+	Constraints            json.RawMessage `json:"constraints"`
+	ActionConfigurationID  *string         `json:"action_configuration_id"`
+	MaxExecutions          *int            `json:"max_executions" validate:"omitempty,gte=1"`
+	StartsAt               *time.Time      `json:"starts_at"`
+	ExpiresAt              time.Time       `json:"expires_at" validate:"required"`
 }
 
 type executeStandingApprovalRequest struct {
@@ -200,13 +202,14 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		var constraintsBytes []byte
 		if err := ValidateJSONObject(req.Constraints); err != nil {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "constraints must be a JSON object"))
 			return
 		}
-		if len(req.Constraints) > 0 && string(req.Constraints) != "null" {
-			constraintsBytes = req.Constraints
+		constraintsBytes, err := validateStandingApprovalConstraints(req.Constraints)
+		if err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
+			return
 		}
 
 		// Wrap limit check + insert in a transaction with an advisory lock
@@ -233,15 +236,16 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 		}
 
 		sa, err := db.CreateStandingApproval(r.Context(), tx, db.CreateStandingApprovalParams{
-			StandingApprovalID: saID,
-			AgentID:            req.AgentID,
-			UserID:             profile.ID,
-			ActionType:         req.ActionType,
-			ActionVersion:      req.ActionVersion,
-			Constraints:        constraintsBytes,
-			MaxExecutions:      req.MaxExecutions,
-			StartsAt:           startsAt,
-			ExpiresAt:          req.ExpiresAt,
+			StandingApprovalID:          saID,
+			AgentID:                     req.AgentID,
+			UserID:                      profile.ID,
+			ActionType:                  req.ActionType,
+			ActionVersion:               req.ActionVersion,
+			Constraints:                 constraintsBytes,
+			SourceActionConfigurationID: req.ActionConfigurationID,
+			MaxExecutions:               req.MaxExecutions,
+			StartsAt:                    startsAt,
+			ExpiresAt:                   req.ExpiresAt,
 		})
 		if err != nil {
 			var saErr *db.StandingApprovalError
@@ -419,18 +423,19 @@ func emitStandingApprovalAuditEvent(ctx context.Context, d db.DBTX, userID strin
 
 func toStandingApprovalResponse(sa db.StandingApproval) standingApprovalResponse {
 	resp := standingApprovalResponse{
-		StandingApprovalID: sa.StandingApprovalID,
-		AgentID:            sa.AgentID,
-		UserID:             sa.UserID,
-		ActionType:         sa.ActionType,
-		ActionVersion:      sa.ActionVersion,
-		Status:             sa.Status,
-		MaxExecutions:      sa.MaxExecutions,
-		ExecutionCount:     sa.ExecutionCount,
-		StartsAt:           sa.StartsAt,
-		ExpiresAt:          sa.ExpiresAt,
-		CreatedAt:          sa.CreatedAt,
-		RevokedAt:          sa.RevokedAt,
+		StandingApprovalID:          sa.StandingApprovalID,
+		AgentID:                     sa.AgentID,
+		UserID:                      sa.UserID,
+		ActionType:                  sa.ActionType,
+		ActionVersion:               sa.ActionVersion,
+		SourceActionConfigurationID: sa.SourceActionConfigurationID,
+		Status:                      sa.Status,
+		MaxExecutions:               sa.MaxExecutions,
+		ExecutionCount:              sa.ExecutionCount,
+		StartsAt:                    sa.StartsAt,
+		ExpiresAt:                   sa.ExpiresAt,
+		CreatedAt:                   sa.CreatedAt,
+		RevokedAt:                   sa.RevokedAt,
 	}
 
 	if len(sa.Constraints) > 0 {
@@ -443,4 +448,43 @@ func toStandingApprovalResponse(sa db.StandingApproval) standingApprovalResponse
 	}
 
 	return resp
+}
+
+// validateStandingApprovalConstraints checks that constraints are present, non-empty,
+// and contain at least one non-wildcard value. Returns the raw bytes to store, or an
+// error describing why the constraints are invalid.
+//
+// Rules:
+//   - null, empty, or {} → rejected (constraints are required)
+//   - all values are "*" → rejected (at least one must be Fixed or Pattern)
+//   - valid otherwise → returns the raw bytes
+func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
+	// Null or absent.
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, errors.New("constraints are required for standing approvals")
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, errors.New("constraints must be a JSON object")
+	}
+
+	if len(obj) == 0 {
+		return nil, errors.New("constraints are required for standing approvals")
+	}
+
+	// Check that at least one constraint value is not a wildcard ("*").
+	allWildcard := true
+	for _, v := range obj {
+		var s string
+		if json.Unmarshal(v, &s) != nil || s != "*" {
+			allWildcard = false
+			break
+		}
+	}
+	if allWildcard {
+		return nil, errors.New("at least one constraint must be a non-wildcard value")
+	}
+
+	return raw, nil
 }

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -484,8 +484,13 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 	}
 
 	// Check that at least one constraint value is not a wildcard ("*").
+	// JSON null is treated as wildcard-equivalent (no constraint on that key).
 	allWildcard := true
 	for _, v := range obj {
+		// Treat JSON null as a wildcard-equivalent (unconstrained).
+		if string(v) == "null" {
+			continue
+		}
 		var s string
 		if json.Unmarshal(v, &s) != nil || s != "*" {
 			allWildcard = false

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -50,7 +50,7 @@ type createStandingApprovalRequest struct {
 	ActionType             string          `json:"action_type" validate:"required"`
 	ActionVersion          string          `json:"action_version"`
 	Constraints            json.RawMessage `json:"constraints"`
-	ActionConfigurationID  *string         `json:"action_configuration_id"`
+	SourceActionConfigurationID *string     `json:"source_action_configuration_id"`
 	MaxExecutions          *int            `json:"max_executions" validate:"omitempty,gte=1"`
 	StartsAt               *time.Time      `json:"starts_at"`
 	ExpiresAt              time.Time       `json:"expires_at" validate:"required"`
@@ -202,10 +202,6 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		if err := ValidateJSONObject(req.Constraints); err != nil {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "constraints must be a JSON object"))
-			return
-		}
 		constraintsBytes, err := validateStandingApprovalConstraints(req.Constraints)
 		if err != nil {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
@@ -242,7 +238,7 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			ActionType:                  req.ActionType,
 			ActionVersion:               req.ActionVersion,
 			Constraints:                 constraintsBytes,
-			SourceActionConfigurationID: req.ActionConfigurationID,
+			SourceActionConfigurationID: req.SourceActionConfigurationID,
 			MaxExecutions:               req.MaxExecutions,
 			StartsAt:                    startsAt,
 			ExpiresAt:                   req.ExpiresAt,
@@ -450,11 +446,12 @@ func toStandingApprovalResponse(sa db.StandingApproval) standingApprovalResponse
 	return resp
 }
 
-// validateStandingApprovalConstraints checks that constraints are present, non-empty,
-// and contain at least one non-wildcard value. Returns the raw bytes to store, or an
-// error describing why the constraints are invalid.
+// validateStandingApprovalConstraints is the single validation point for standing
+// approval constraints. It checks type, presence, and content. Returns the raw
+// bytes to store, or an error describing why the constraints are invalid.
 //
 // Rules:
+//   - non-object JSON (array, string, number) → rejected
 //   - null, empty, or {} → rejected (constraints are required)
 //   - all values are "*" → rejected (at least one must be Fixed or Pattern)
 //   - valid otherwise → returns the raw bytes

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -77,6 +77,10 @@ var validStandingApprovalStatusFilters = map[string]bool{
 
 var actionVersionPattern = regexp.MustCompile(`^\d+$`)
 
+// maxActionConfigIDLength is the maximum length for source_action_configuration_id.
+// Generated IDs are ~35 chars (prefix + 32 hex); 128 is generous headroom.
+const maxActionConfigIDLength = 128
+
 func init() {
 	RegisterRouteGroup(RegisterStandingApprovalRoutes)
 }
@@ -199,6 +203,11 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 		if err != nil {
 			log.Printf("[%s] CreateStandingApproval: generate ID: %v", TraceID(r.Context()), err)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+			return
+		}
+
+		if req.SourceActionConfigurationID != nil && len(*req.SourceActionConfigurationID) > maxActionConfigIDLength {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id exceeds maximum length"))
 			return
 		}
 

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -206,8 +206,8 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		if req.SourceActionConfigurationID != nil && len(*req.SourceActionConfigurationID) > maxActionConfigIDLength {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id exceeds maximum length"))
+		if req.SourceActionConfigurationID != nil && (len(*req.SourceActionConfigurationID) == 0 || len(*req.SourceActionConfigurationID) > maxActionConfigIDLength) {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id must be between 1 and 128 characters"))
 			return
 		}
 

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -572,7 +572,7 @@ func TestCreateStandingApproval_AgentNotFound(t *testing.T) {
 	router := NewRouter(deps)
 
 	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	body := fmt.Sprintf(`{"agent_id": 99999999, "action_type": "email.send", "expires_at": "%s"}`, expiresAt)
+	body := fmt.Sprintf(`{"agent_id": 99999999, "action_type": "email.send", "constraints": {"to": "test@example.com"}, "expires_at": "%s"}`, expiresAt)
 	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
 	w := httptest.NewRecorder()
 
@@ -597,7 +597,7 @@ func TestCreateStandingApproval_OtherUsersAgent(t *testing.T) {
 	router := NewRouter(deps)
 
 	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "expires_at": "%s"}`, agentID, expiresAt)
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {"to": "test@example.com"}, "expires_at": "%s"}`, agentID, expiresAt)
 	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid2, body)
 	w := httptest.NewRecorder()
 
@@ -728,15 +728,15 @@ func TestCreateStandingApproval_ConstraintsNull(t *testing.T) {
 
 	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
 
-	// Explicit null should be treated as "not provided" and succeed.
+	// Explicit null should be rejected — constraints are required.
 	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": null, "expires_at": "%s"}`, agentID, expiresAt)
 	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201 for null constraints, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for null constraints, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -760,6 +760,135 @@ func TestCreateStandingApproval_ConstraintsTooLarge(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_ConstraintsOmitted(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Omitting constraints entirely should be rejected.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for omitted constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_ConstraintsEmptyObject(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Empty object {} should be rejected — at least one constraint is required.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {}, "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_ConstraintsAllWildcard(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// All-wildcard constraints should be rejected.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {"to": "*", "subject": "*"}, "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for all-wildcard constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_ConstraintsMixedWildcardAndFixed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Mix of wildcard and fixed — should succeed because at least one is non-wildcard.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {"to": "user@example.com", "subject": "*"}, "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for mixed constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_WithActionConfigurationID(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Include an action_configuration_id — should be stored and returned.
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "email.send",
+		"constraints": {"to": "user@example.com"},
+		"action_configuration_id": "ac-test-123",
+		"expires_at": "%s"
+	}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp standingApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.SourceActionConfigurationID == nil || *resp.SourceActionConfigurationID != "ac-test-123" {
+		t.Errorf("expected source_action_configuration_id 'ac-test-123', got %v", resp.SourceActionConfigurationID)
 	}
 }
 

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -855,7 +855,7 @@ func TestCreateStandingApproval_ConstraintsMixedWildcardAndFixed(t *testing.T) {
 	}
 }
 
-func TestCreateStandingApproval_WithActionConfigurationID(t *testing.T) {
+func TestCreateStandingApproval_WithSourceActionConfigurationID(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -871,7 +871,7 @@ func TestCreateStandingApproval_WithActionConfigurationID(t *testing.T) {
 		"agent_id": %d,
 		"action_type": "email.send",
 		"constraints": {"to": "user@example.com"},
-		"action_configuration_id": "ac-test-123",
+		"source_action_configuration_id": "ac-test-123",
 		"expires_at": "%s"
 	}`, agentID, expiresAt)
 	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -892,6 +892,63 @@ func TestCreateStandingApproval_WithSourceActionConfigurationID(t *testing.T) {
 	}
 }
 
+func TestCreateStandingApproval_SourceActionConfigIDEmpty(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "email.send",
+		"constraints": {"to": "user@example.com"},
+		"source_action_configuration_id": "",
+		"expires_at": "%s"
+	}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_SourceActionConfigIDTooLong(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	longID := strings.Repeat("a", 129)
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "email.send",
+		"constraints": {"to": "user@example.com"},
+		"source_action_configuration_id": "%s",
+		"expires_at": "%s"
+	}`, agentID, longID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestCreateStandingApproval_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -855,6 +855,52 @@ func TestCreateStandingApproval_ConstraintsMixedWildcardAndFixed(t *testing.T) {
 	}
 }
 
+func TestCreateStandingApproval_ConstraintsAllNull(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// All null values should be treated as wildcards and rejected.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {"repo": null, "title": null}, "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for all-null constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateStandingApproval_ConstraintsNullAndWildcard(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Mix of null and wildcard — all are effectively unconstrained, should be rejected.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {"repo": null, "title": "*"}, "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for null+wildcard constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestCreateStandingApproval_WithSourceActionConfigurationID(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -901,6 +901,29 @@ func TestCreateStandingApproval_ConstraintsNullAndWildcard(t *testing.T) {
 	}
 }
 
+func TestCreateStandingApproval_ConstraintsNullWithFixed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Null mixed with a fixed value — null values are rejected outright.
+	body := fmt.Sprintf(`{"agent_id": %d, "action_type": "email.send", "constraints": {"repo": null, "title": "my-title"}, "expires_at": "%s"}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for null+fixed constraints, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestCreateStandingApproval_WithSourceActionConfigurationID(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -1242,10 +1242,11 @@ func seedUserHasEverything(ctx context.Context, tx db.DBTX, supa *supabaseClient
 		now.Add(27*24*time.Hour))
 
 	exec(ctx, tx,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at, expired_at)
-		 VALUES ($1, $2, $3, $4, 'expired', $5, $6, $6)`,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, constraints, starts_at, expires_at, expired_at)
+		 VALUES ($1, $2, $3, $4, 'expired', $5, $6, $7, $7)`,
 		"sa-everything-expired", github, userHasEverything,
 		"github.merge_pr",
+		`{"pr": "supersuit-tech/permission-slip#123"}`,
 		now.Add(-60*24*time.Hour),
 		now.Add(-30*24*time.Hour))
 

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -866,10 +866,11 @@ func seedUserHasActivity(ctx context.Context, tx db.DBTX, supa *supabaseClient) 
 
 	// 1 active standing approval
 	exec(ctx, tx,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at)
-		 VALUES ($1, $2, $3, $4, 'active', $5, $6)`,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, constraints, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, 'active', $5, $6, $7)`,
 		"sa-activity-1", agentCI, userHasActivity,
 		"github.create_issue",
+		`{"repo": "supersuit-tech/ci-actions"}`,
 		now.Add(-7*24*time.Hour),
 		now.Add(23*24*time.Hour))
 
@@ -1222,18 +1223,21 @@ func seedUserHasEverything(ctx context.Context, tx db.DBTX, supa *supabaseClient
 	// Standing approvals (2 active, 1 expired)
 	// ---------------------------------------------------------------
 	exec(ctx, tx,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, max_executions, starts_at, expires_at)
-		 VALUES ($1, $2, $3, $4, 'active', $5, $6, $7)`,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, max_executions, constraints, source_action_configuration_id, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9)`,
 		"sa-everything-1", claude, userHasEverything,
 		"github.create_issue", 100,
+		`{"repo": "supersuit-tech/permission-slip", "title": "*"}`,
+		"ac-claude-create-issue",
 		now.Add(-7*24*time.Hour),
 		now.Add(23*24*time.Hour))
 
 	exec(ctx, tx,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at)
-		 VALUES ($1, $2, $3, $4, 'active', $5, $6)`,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, constraints, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, 'active', $5, $6, $7)`,
 		"sa-everything-2", slack, userHasEverything,
 		"slack.send_message",
+		`{"channel": "#engineering"}`,
 		now.Add(-3*24*time.Hour),
 		now.Add(27*24*time.Hour))
 

--- a/db/migrations/20260314185338_add_source_config_to_standing_approvals.sql
+++ b/db/migrations/20260314185338_add_source_config_to_standing_approvals.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Tracks which action configuration a standing approval was derived from.
+-- Nullable because existing approvals predate this column and the source
+-- config may be deleted after the standing approval is created (no FK).
+ALTER TABLE standing_approvals
+    ADD COLUMN source_action_configuration_id text;
+
+-- +goose Down
+ALTER TABLE standing_approvals
+    DROP COLUMN IF EXISTS source_action_configuration_id;

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -12,27 +12,28 @@ import (
 
 // StandingApproval represents a row from the standing_approvals table.
 type StandingApproval struct {
-	StandingApprovalID string
-	AgentID            int64
-	UserID             string
-	ActionType         string
-	ActionVersion      string
-	Constraints        []byte // raw JSONB
-	Status             string
-	MaxExecutions      *int
-	ExecutionCount     int
-	StartsAt           time.Time
-	ExpiresAt          time.Time
-	CreatedAt          time.Time
-	RevokedAt          *time.Time
-	ExpiredAt          *time.Time
-	ExhaustedAt        *time.Time
+	StandingApprovalID          string
+	AgentID                     int64
+	UserID                      string
+	ActionType                  string
+	ActionVersion               string
+	Constraints                 []byte // raw JSONB
+	SourceActionConfigurationID *string
+	Status                      string
+	MaxExecutions               *int
+	ExecutionCount              int
+	StartsAt                    time.Time
+	ExpiresAt                   time.Time
+	CreatedAt                   time.Time
+	RevokedAt                   *time.Time
+	ExpiredAt                   *time.Time
+	ExhaustedAt                 *time.Time
 }
 
 // standingApprovalColumns is the canonical column list for SELECT on the standing_approvals table.
 // Keep in sync with scanStandingApproval.
 const standingApprovalColumns = `standing_approval_id, agent_id, user_id, action_type, action_version,
-	constraints, status, max_executions, execution_count,
+	constraints, source_action_configuration_id, status, max_executions, execution_count,
 	starts_at, expires_at, created_at, revoked_at, expired_at, exhausted_at`
 
 // MaxStandingApprovalListSize is the maximum number of standing approvals returned per page.
@@ -60,7 +61,7 @@ func scanStandingApproval(row pgx.Row) (*StandingApproval, error) {
 	var sa StandingApproval
 	err := row.Scan(
 		&sa.StandingApprovalID, &sa.AgentID, &sa.UserID, &sa.ActionType, &sa.ActionVersion,
-		&sa.Constraints, &sa.Status, &sa.MaxExecutions, &sa.ExecutionCount,
+		&sa.Constraints, &sa.SourceActionConfigurationID, &sa.Status, &sa.MaxExecutions, &sa.ExecutionCount,
 		&sa.StartsAt, &sa.ExpiresAt, &sa.CreatedAt, &sa.RevokedAt, &sa.ExpiredAt, &sa.ExhaustedAt,
 	)
 	if err != nil {
@@ -108,15 +109,16 @@ const (
 
 // CreateStandingApprovalParams holds the parameters for creating a standing approval.
 type CreateStandingApprovalParams struct {
-	StandingApprovalID string
-	AgentID            int64
-	UserID             string
-	ActionType         string
-	ActionVersion      string
-	Constraints        []byte // raw JSONB, may be nil
-	MaxExecutions      *int
-	StartsAt           time.Time
-	ExpiresAt          time.Time
+	StandingApprovalID          string
+	AgentID                     int64
+	UserID                      string
+	ActionType                  string
+	ActionVersion               string
+	Constraints                 []byte // raw JSONB, may be nil
+	SourceActionConfigurationID *string
+	MaxExecutions               *int
+	StartsAt                    time.Time
+	ExpiresAt                   time.Time
 }
 
 // CreateStandingApproval inserts a new standing approval with status 'active'.
@@ -129,12 +131,12 @@ func CreateStandingApproval(ctx context.Context, db DBTX, p CreateStandingApprov
 			SELECT 1 FROM agents WHERE agent_id = $2 AND approver_id = $3
 		)
 		INSERT INTO standing_approvals
-		   (standing_approval_id, agent_id, user_id, action_type, action_version, constraints, status, max_executions, starts_at, expires_at)
-		 SELECT $1, $2, $3, $4, $5, $6, 'active', $7, $8, $9
+		   (standing_approval_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, status, max_executions, starts_at, expires_at)
+		 SELECT $1, $2, $3, $4, $5, $6, $7, 'active', $8, $9, $10
 		 WHERE EXISTS (SELECT 1 FROM agent_check)
 		 RETURNING `+standingApprovalColumns,
 		p.StandingApprovalID, p.AgentID, p.UserID, p.ActionType, p.ActionVersion,
-		p.Constraints, p.MaxExecutions, p.StartsAt, p.ExpiresAt,
+		p.Constraints, p.SourceActionConfigurationID, p.MaxExecutions, p.StartsAt, p.ExpiresAt,
 	)
 	sa, err := scanStandingApproval(row)
 	if err != nil {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/components/paths/standing_approvals.yaml
+++ b/spec/openapi/components/paths/standing_approvals.yaml
@@ -278,6 +278,10 @@ createStandingApproval:
       the authenticated user. The standing approval becomes active immediately
       (or at `starts_at` if specified).
 
+      **Constraints are required.** The `constraints` object must be non-empty and
+      contain at least one non-wildcard (`"*"`) value. This prevents "blank check"
+      standing approvals that auto-approve any parameters.
+
     tags:
       - Standing Approvals
 
@@ -296,7 +300,7 @@ createStandingApproval:
             action_version: "1"
             constraints:
               recipient_pattern: "*@mycompany.com"
-            action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+            source_action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
             max_executions: 100
             expires_at: "2026-03-14T00:00:00Z"
 
@@ -309,17 +313,35 @@ createStandingApproval:
               $ref: '../schemas/standing_approvals.yaml#/StandingApproval'
 
       '400':
-        description: Invalid request (validation errors, duration exceeds 90 days, etc.)
+        description: |
+          Invalid request. Common causes:
+          - Missing or empty `constraints` (`invalid_constraints`)
+          - All constraint values are wildcards (`invalid_constraints`)
+          - Duration exceeds 90 days (`invalid_request`)
+          - Invalid field values (`invalid_request`)
         content:
           application/json:
             schema:
               $ref: '../schemas/errors.yaml#/ErrorResponse'
-            example:
-              error:
-                code: "invalid_request"
-                message: "Duration exceeds maximum of 90 days"
-                retryable: false
-                trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+            examples:
+              invalid_constraints:
+                summary: Constraints are required
+                value:
+                  error:
+                    code: "invalid_constraints"
+                    message: "constraints are required for standing approvals"
+                    retryable: false
+                    details:
+                      hint: "Provide a JSON object with at least one non-wildcard constraint, e.g. {\"repo\": \"my-org/my-repo\", \"title\": \"*\"}"
+                    trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+              duration_exceeded:
+                summary: Duration exceeds maximum
+                value:
+                  error:
+                    code: "invalid_request"
+                    message: "Duration exceeds maximum of 90 days"
+                    retryable: false
+                    trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
 
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -304,12 +304,14 @@ CreateStandingApprovalRequest:
 
     source_action_configuration_id:
       type: string
-      pattern: '^ac_[a-f0-9]{32}$'
       maxLength: 128
       description: |
         Optional reference to the action configuration this standing approval
         was derived from. When provided, the backend records it for traceability.
         No foreign-key enforcement — the configuration may be deleted later.
+        Expected format: `ac_` prefix followed by 32 hex characters (e.g.,
+        `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
+        enforce the pattern — only non-empty and max 128 characters.
       example: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
 
     max_executions:

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -305,6 +305,7 @@ CreateStandingApprovalRequest:
 
     source_action_configuration_id:
       type: string
+      minLength: 1
       maxLength: 128
       description: |
         Optional reference to the action configuration this standing approval

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -302,10 +302,10 @@ CreateStandingApprovalRequest:
         recipient_pattern: "*@mycompany.com"
         max_recipients: 5
 
-    action_configuration_id:
+    source_action_configuration_id:
       type: string
       pattern: '^ac_[a-f0-9]{32}$'
-      maxLength: 35
+      maxLength: 128
       description: |
         Optional reference to the action configuration this standing approval
         was derived from. When provided, the backend records it for traceability.
@@ -337,7 +337,7 @@ CreateStandingApprovalRequest:
     action_version: "1"
     constraints:
       recipient_pattern: "*@mycompany.com"
-    action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+    source_action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
     max_executions: 100
     expires_at: "2026-03-14T00:00:00Z"
 

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -189,14 +189,15 @@ StandingApproval:
 
     source_action_configuration_id:
       type: string
-      pattern: '^ac_[a-f0-9]{32}$'
-      maxLength: 35
+      maxLength: 128
       nullable: true
       description: |
         The action configuration this standing approval was derived from, if any.
         Nullable — `null` when the standing approval was created with a custom
         action type rather than from an existing configuration. The referenced
         configuration may have been deleted since creation.
+        Expected format: `ac_` prefix followed by 32 hex characters, but the
+        backend does not enforce the pattern.
       example: null
 
   example:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4169,6 +4169,10 @@ paths:
         Create a new standing approval for an agent. The agent must belong to
         the authenticated user. The standing approval becomes active immediately
         (or at `starts_at` if specified).
+
+        **Constraints are required.** The `constraints` object must be non-empty and
+        contain at least one non-wildcard (`"*"`) value. This prevents "blank check"
+        standing approvals that auto-approve any parameters.
       tags:
         - Standing Approvals
       security:
@@ -4185,7 +4189,7 @@ paths:
               action_version: '1'
               constraints:
                 recipient_pattern: '*@mycompany.com'
-              action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+              source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
               max_executions: 100
               expires_at: '2026-03-14T00:00:00Z'
       responses:
@@ -4196,17 +4200,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/StandingApproval'
         '400':
-          description: Invalid request (validation errors, duration exceeds 90 days, etc.)
+          description: |
+            Invalid request. Common causes:
+            - Missing or empty `constraints` (`invalid_constraints`)
+            - All constraint values are wildcards (`invalid_constraints`)
+            - Duration exceeds 90 days (`invalid_request`)
+            - Invalid field values (`invalid_request`)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: invalid_request
-                  message: Duration exceeds maximum of 90 days
-                  retryable: false
-                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+              examples:
+                invalid_constraints:
+                  summary: Constraints are required
+                  value:
+                    error:
+                      code: invalid_constraints
+                      message: constraints are required for standing approvals
+                      retryable: false
+                      details:
+                        hint: 'Provide a JSON object with at least one non-wildcard constraint, e.g. {"repo": "my-org/my-repo", "title": "*"}'
+                      trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+                duration_exceeded:
+                  summary: Duration exceeds maximum
+                  value:
+                    error:
+                      code: invalid_request
+                      message: Duration exceeds maximum of 90 days
+                      retryable: false
+                      trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -7963,14 +7985,15 @@ components:
           example: null
         source_action_configuration_id:
           type: string
-          pattern: ^ac_[a-f0-9]{32}$
-          maxLength: 35
+          maxLength: 128
           nullable: true
           description: |
             The action configuration this standing approval was derived from, if any.
             Nullable — `null` when the standing approval was created with a custom
             action type rather than from an existing configuration. The referenced
             configuration may have been deleted since creation.
+            Expected format: `ac_` prefix followed by 32 hex characters, but the
+            backend does not enforce the pattern.
           example: null
       example:
         standing_approval_id: sa_abc123
@@ -8217,14 +8240,17 @@ components:
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
-        action_configuration_id:
+        source_action_configuration_id:
           type: string
-          pattern: ^ac_[a-f0-9]{32}$
-          maxLength: 35
+          minLength: 1
+          maxLength: 128
           description: |
             Optional reference to the action configuration this standing approval
             was derived from. When provided, the backend records it for traceability.
             No foreign-key enforcement — the configuration may be deleted later.
+            Expected format: `ac_` prefix followed by 32 hex characters (e.g.,
+            `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
+            enforce the pattern — only non-empty and max 128 characters.
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         max_executions:
           type: integer
@@ -8248,7 +8274,7 @@ components:
         action_version: '1'
         constraints:
           recipient_pattern: '*@mycompany.com'
-        action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+        source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         max_executions: 100
         expires_at: '2026-03-14T00:00:00Z'
     RevokeStandingApprovalResponse:


### PR DESCRIPTION
## Summary

- Standing approvals now **require non-empty parameter constraints** with at least one non-wildcard value — prevents "blank check" approvals that auto-approve any parameters
- Added `source_action_configuration_id` column to `standing_approvals` to track which action config a standing approval was derived from (nullable, no FK — config may be deleted later)
- Updated API request/response structs, DB layer, seed data, and tests

Part of #550 (Phase 1A: Backend constraint enforcement)

## Test plan

### Claude Code
- [x] Constraint validation: null → 400
- [x] Constraint validation: omitted → 400
- [x] Constraint validation: empty `{}` → 400
- [x] Constraint validation: all-wildcard `{"a": "*", "b": "*"}` → 400
- [x] Constraint validation: mixed wildcard + fixed → 201
- [x] Constraint validation: valid constraints → 201
- [x] `action_configuration_id` round-trips through create → response
- [x] Existing tests updated (plan limits, agent-not-found) to include constraints
- [x] `go test ./api/...` passes
- [x] `go test ./db/...` passes
- [x] `go build ./api ./db ./cmd/seed` succeeds

### OpenClaw
- [ ] Decide migration plan for existing standing approvals with no constraints — grandfather or flag for user review?
- [ ] Confirm: should ALL-wildcard constraints be rejected, or is that acceptable?

https://claude.ai/code/session_01SFegDqGT2oCVFDA4deyJPX