### PR TITLE
Make PR URL optional in /watch skill

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -2,7 +2,7 @@
 name: watch
 description: Poll a GitHub PR for new comments and PR reviews and act on them autonomously. Use when the user wants to monitor a PR for feedback and have Claude implement requested changes automatically.
 disable-model-invocation: true
-argument-hint: "<PR_URL> [--automerge] [--max-turns <N>]"
+argument-hint: "[PR_URL] [--automerge] [--max-turns <N>]"
 ---
 
 # Watch PR for Comments and Reviews
@@ -40,12 +40,20 @@ Agent (this skill)     — Only invoked when reasoning is needed
 
 Parse the arguments from: `$ARGUMENTS`
 
-Extract the PR URL and any flags. The format is: `<PR_URL> [--automerge] [--max-turns <N>]`
+Extract any PR URL and flags. The format is: `[PR_URL] [--automerge] [--max-turns <N>]`
+
+The PR URL is **optional**. If not provided, detect it automatically from the current branch:
+
+```bash
+PR_URL=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+```
+
+If auto-detection fails (no PR exists for the current branch), abort with a clear error message.
 
 Parse the PR number from the URL (e.g., `https://github.com/supersuit-tech/permission-slip/pull/123` → `123`).
 
 Set these variables for the session:
-- `PR_URL` — the PR URL extracted from the arguments
+- `PR_URL` — the PR URL (from arguments or auto-detected from current branch)
 - `PR_NUMBER` — the extracted PR number
 - `AUTO_MERGE` — `true` if `--automerge` was passed, `false` otherwise
 - `MAX_TURNS` — the value of `--max-turns` if passed, `0` otherwise (0 = unlimited)

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -3,7 +3,7 @@
 # Handles all mechanical bookkeeping (fetching, deduplication, idle timeout)
 # and only invokes the Claude agent when there's actionable work.
 #
-# Usage: bash watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>] [--max-turns <N>]
+# Usage: bash watch-poll.sh [PR_URL] [--automerge] [--work-dir <path>] [--max-turns <N>]
 #
 # Options:
 #   --automerge       Enable auto-merge after checks pass
@@ -26,20 +26,33 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Arguments
 # ---------------------------------------------------------------------------
-PR_URL="${1:?Usage: watch-poll.sh <PR_URL> [--automerge] [--work-dir <path>] [--max-turns <N>]}"
+PR_URL=""
 AUTO_MERGE=false
 EXISTING_WORK_DIR=""
 MAX_TURNS=0  # 0 = unlimited
 
-shift
+# Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --automerge) AUTO_MERGE=true; shift ;;
     --work-dir) EXISTING_WORK_DIR="$2"; shift 2 ;;
     --max-turns) MAX_TURNS="$2"; shift 2 ;;
+    https://*) PR_URL="$1"; shift ;;
     *) shift ;;
   esac
 done
+
+# Auto-detect PR URL from current branch if not provided
+if [[ -z "$PR_URL" ]]; then
+  echo "[setup] No PR URL provided, detecting from current branch..."
+  PR_URL=$(GH_HOST="${GH_HOST:-github.com}" GH_REPO="${GH_REPO:-supersuit-tech/permission-slip}" gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+  if [[ -z "$PR_URL" ]]; then
+    echo "ERROR: No PR URL provided and could not detect a PR for the current branch." >&2
+    echo "Either pass a PR URL or run this from a branch with an open PR." >&2
+    exit 1
+  fi
+  echo "[setup] Detected PR: ${PR_URL}"
+fi
 
 PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
 if [[ -z "$PR_NUMBER" ]]; then

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -4,7 +4,7 @@
 # Invoked after the polling loop ends (idle timeout) and the agent has
 # finished all its work.
 #
-# Usage: bash watch-post.sh <PR_URL> [--automerge]
+# Usage: bash watch-post.sh [PR_URL] [--automerge]
 #
 # This script handles steps 11-13 from the original SKILL.md:
 #   11. Trigger CI and audit, wait, fix failures (signals agent for fixes)
@@ -16,10 +16,27 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Arguments
 # ---------------------------------------------------------------------------
-PR_URL="${1:?Usage: watch-post.sh <PR_URL> [--automerge]}"
+PR_URL=""
 AUTO_MERGE=false
-if [[ "${2:-}" == "--automerge" ]]; then
-  AUTO_MERGE=true
+
+# Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --automerge) AUTO_MERGE=true; shift ;;
+    https://*) PR_URL="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+
+# Auto-detect PR URL from current branch if not provided
+if [[ -z "$PR_URL" ]]; then
+  echo "[post] No PR URL provided, detecting from current branch..."
+  PR_URL=$(GH_HOST="${GH_HOST:-github.com}" GH_REPO="${GH_REPO:-supersuit-tech/permission-slip}" gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+  if [[ -z "$PR_URL" ]]; then
+    echo "ERROR: No PR URL provided and could not detect a PR for the current branch." >&2
+    exit 1
+  fi
+  echo "[post] Detected PR: ${PR_URL}"
 fi
 
 PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')


### PR DESCRIPTION
## Summary

- Makes the PR URL argument optional in the `/watch` command — it now auto-detects the PR from the current branch using `gh pr view` when no URL is provided
- Explicitly passing a PR URL still works exactly as before (fully backwards-compatible)
- Updated all three watch skill files: `SKILL.md`, `watch-poll.sh`, and `watch-post.sh`

## Test plan

### Claude Code
- [ ] Verify `/watch` works without a PR URL when on a branch with an open PR
- [ ] Verify `/watch <url>` still works with an explicit PR URL
- [ ] Verify clear error message when no URL provided and no PR exists for current branch

### OpenClaw
- [ ] Manual smoke test of `/watch` in a real session to confirm auto-detection works end-to-end

https://claude.ai/code/session_01TCbE4Y8KaXZtnfWcseVdxg