### PR TITLE
Add google.read_email action for Gmail connector

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -19,7 +19,7 @@ The credential `auth_type` is `oauth2` with `oauth_provider` set to `google` (a 
 | Scope | Used by |
 |-------|---------|
 | `gmail.send` | `google.send_email` |
-| `gmail.readonly` | `google.list_emails` |
+| `gmail.readonly` | `google.list_emails`, `google.read_email` |
 | `calendar.events` | `google.create_calendar_event`, `google.list_calendar_events`, `google.create_meeting` |
 | `presentations` | `google.create_presentation`, `google.get_presentation`, `google.add_slide` |
 | `spreadsheets` | `google.sheets_read_range`, `google.sheets_write_range`, `google.sheets_append_rows`, `google.sheets_list_sheets` |
@@ -85,6 +85,7 @@ Lists recent emails from the Gmail inbox with metadata.
   "emails": [
     {
       "id": "18abc123def",
+      "thread_id": "18abc123def",
       "from": "sender@example.com",
       "to": "you@example.com",
       "subject": "Hello",
@@ -98,7 +99,68 @@ Lists recent emails from the Gmail inbox with metadata.
 
 **Gmail API:** `GET /gmail/v1/users/me/messages` + `GET /gmail/v1/users/me/messages/{id}` ([docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list))
 
-The action first lists message IDs matching the query, then fetches metadata (From, To, Subject, Date headers and snippet) for each message.
+The action first lists message IDs matching the query, then fetches metadata (From, To, Subject, Date headers and snippet) for each message. Each email includes a `thread_id` to enable seamless list → read → reply workflows.
+
+---
+
+### `google.read_email`
+
+Fetches a single email by message ID and returns the full body, headers, labels, and attachment metadata.
+
+**Risk level:** low
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `message_id` | string | Yes | The Gmail message ID (from `list_emails` or other source) |
+
+**Response:**
+
+```json
+{
+  "id": "18abc123def",
+  "thread_id": "thread123",
+  "from": "sender@example.com",
+  "to": "recipient@example.com",
+  "cc": "cc@example.com",
+  "subject": "Project Update",
+  "date": "Mon, 14 Mar 2026 10:00:00 -0500",
+  "snippet": "Here is the latest update on...",
+  "labels": ["INBOX", "UNREAD"],
+  "content_type": "text/plain",
+  "body": "Full email body text...",
+  "attachments": [
+    {
+      "filename": "report.pdf",
+      "mime_type": "application/pdf",
+      "size": 12345,
+      "part_id": "1",
+      "attachment_id": "ANGjdJ8..."
+    }
+  ]
+}
+```
+
+**Gmail API:** `GET /gmail/v1/users/me/messages/{id}?format=full` ([docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get))
+
+**Typical workflow:** `list_emails` → `read_email` (using the `id` from the list) → `send_email_reply` (using `thread_id` and `id`).
+
+**Body extraction:**
+- For multipart messages, `text/plain` is preferred over `text/html`.
+- The MIME part tree is walked recursively (depth-limited to 20) to find the best text body.
+- Bodies exceeding 1 MB are truncated at a valid UTF-8 boundary with a `[truncated]` marker.
+
+**Attachment metadata:**
+- Filenames are extracted from `Content-Disposition` headers, falling back to `Content-Type` `name=` parameter.
+- RFC 5987 extended filenames (`filename*=UTF-8''encoded%20name`) are supported and take priority per RFC 6266.
+- Only UTF-8 encoded filenames are decoded; other charsets are skipped to avoid producing invalid strings.
+- The `attachment_id` field can be used with `GET /gmail/v1/users/me/messages/{messageId}/attachments/{attachmentId}` to download content.
+
+**Security notes:**
+- Header names are matched case-insensitively per RFC 5322.
+- MIME tree recursion is capped at depth 20 to prevent stack overflow from crafted deeply-nested messages.
+- Base64url decoding tries raw (no padding) first since that's the Gmail API format, with padded fallback.
 
 ---
 
@@ -1018,6 +1080,7 @@ The connector ships with constrained templates that demonstrate parameter lockin
 | Search Drive files | `search_drive` | Nothing — agent controls query, type, folder |
 | Search Drive within folder | `search_drive` | `folder_id` locked to a specific folder |
 | Create Drive folders | `create_drive_folder` | Nothing — agent controls name and parent |
+| Read any email | `read_email` | Nothing — agent controls message ID |
 | Reply to emails | `send_email_reply` | Nothing — agent controls thread, message, and body |
 
 ## Adding a New Action
@@ -1038,11 +1101,12 @@ Each action lives in its own file. To add one (e.g., `google.delete_calendar_eve
 ```
 connectors/google/
 ├── google.go                       # GoogleConnector struct, New(), Actions(), doJSON(), doRawGet(), wrapHTTPError(), ValidateCredentials()
-├── manifest.go                     # Manifest() — 27 action schemas and 39+ templates
+├── manifest.go                     # Manifest() — 28 action schemas and 40+ templates
 ├── docs_types.go                   # Shared Docs API types (batchUpdate request) and helpers (documentEditURL)
 ├── email_helpers.go                # buildGmailRaw() — shared RFC 2822 message builder used by send_email and send_email_reply
 ├── send_email.go                   # google.send_email action
 ├── list_emails.go                  # google.list_emails action
+├── read_email.go                   # google.read_email action (full body, headers, attachment metadata, MIME tree walking)
 ├── send_email_reply.go             # google.send_email_reply action (fetches headers, strips injection chars, sends reply)
 ├── create_calendar_event.go        # google.create_calendar_event action
 ├── list_calendar_events.go         # google.list_calendar_events action
@@ -1075,6 +1139,7 @@ connectors/google/
 ├── helpers_test.go                 # Shared test helpers (validCreds)
 ├── send_email_test.go              # Send email action tests (including MIME injection, base64 encoding)
 ├── list_emails_test.go             # List emails action tests
+├── read_email_test.go              # Read email tests (MIME parsing, attachments, RFC 5987, depth limit, edge cases)
 ├── send_email_reply_test.go        # Send email reply tests (thread validation, header injection, Re: prefix)
 ├── create_calendar_event_test.go   # Create event tests (including time validation, URL encoding)
 ├── list_calendar_events_test.go    # List events action tests

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -2,7 +2,7 @@
 // connector execution layer. It uses Google REST APIs (Gmail, Calendar, Slides, Sheets, Docs, Chat, Drive)
 // with plain net/http and OAuth 2.0 access tokens provided by the platform.
 //
-// The connector exposes 27 actions covering email (send, reply, list), calendar (create,
+// The connector exposes 28 actions covering email (send, reply, read, list), calendar (create,
 // list, update, delete, meetings), Slides, Sheets, Docs, Chat, and Drive (list, get,
 // upload, delete, search, create folder).
 package google
@@ -165,6 +165,7 @@ func (c *GoogleConnector) Actions() map[string]connectors.Action {
 		"google.search_drive":          &searchDriveAction{conn: c},
 		"google.create_drive_folder":   &createDriveFolderAction{conn: c},
 		"google.send_email_reply":      &sendEmailReplyAction{conn: c},
+		"google.read_email":            &readEmailAction{conn: c},
 	}
 }
 

--- a/connectors/google/google_test.go
+++ b/connectors/google/google_test.go
@@ -47,6 +47,7 @@ func TestGoogleConnector_Actions(t *testing.T) {
 		"google.search_drive",
 		"google.create_drive_folder",
 		"google.send_email_reply",
+		"google.read_email",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -114,8 +115,8 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 	if m.Name != "Google" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Google")
 	}
-	if len(m.Actions) != 27 {
-		t.Fatalf("Manifest().Actions has %d items, want 27", len(m.Actions))
+	if len(m.Actions) != 28 {
+		t.Fatalf("Manifest().Actions has %d items, want 28", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -149,6 +150,7 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 		"google.search_drive",
 		"google.create_drive_folder",
 		"google.send_email_reply",
+		"google.read_email",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -60,12 +60,13 @@ type gmailMessageResponse struct {
 
 // emailSummary is the shape returned to the agent.
 type emailSummary struct {
-	ID      string `json:"id"`
-	From    string `json:"from,omitempty"`
-	To      string `json:"to,omitempty"`
-	Subject string `json:"subject,omitempty"`
-	Snippet string `json:"snippet,omitempty"`
-	Date    string `json:"date,omitempty"`
+	ID       string `json:"id"`
+	ThreadID string `json:"thread_id"`
+	From     string `json:"from,omitempty"`
+	To       string `json:"to,omitempty"`
+	Subject  string `json:"subject,omitempty"`
+	Snippet  string `json:"snippet,omitempty"`
+	Date     string `json:"date,omitempty"`
 }
 
 // maxConcurrentFetches limits concurrent Gmail API requests when fetching
@@ -123,8 +124,9 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 			}
 
 			summary := emailSummary{
-				ID:      msgResp.ID,
-				Snippet: msgResp.Snippet,
+				ID:       msgResp.ID,
+				ThreadID: msgResp.ThreadID,
+				Snippet:  msgResp.Snippet,
 			}
 			for _, h := range msgResp.Payload.Headers {
 				switch h.Name {

--- a/connectors/google/list_emails_test.go
+++ b/connectors/google/list_emails_test.go
@@ -71,12 +71,20 @@ func TestListEmails_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var data map[string]json.RawMessage
+	var data struct {
+		Emails []emailSummary `json:"emails"`
+	}
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	if _, ok := data["emails"]; !ok {
-		t.Error("result missing 'emails' key")
+	if len(data.Emails) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(data.Emails))
+	}
+	if data.Emails[0].ThreadID != "thread-1" {
+		t.Errorf("expected thread_id 'thread-1', got %q", data.Emails[0].ThreadID)
+	}
+	if data.Emails[0].From != "sender@example.com" {
+		t.Errorf("expected from 'sender@example.com', got %q", data.Emails[0].From)
 	}
 }
 

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -672,6 +672,22 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
+				ActionType:  "google.read_email",
+				Name:        "Read Email",
+				Description: "Read a single email message from Gmail by message ID, returning the full body, headers, and attachment metadata",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["message_id"],
+					"properties": {
+						"message_id": {
+							"type": "string",
+							"description": "The Gmail message ID to read (from list_emails results)"
+						}
+					}
+				}`)),
+			},
+			{
 				ActionType:  "google.send_email_reply",
 				Name:        "Reply to Email",
 				Description: "Reply to an existing Gmail thread",
@@ -978,6 +994,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Create Drive folders",
 				Description: "Agent can create folders anywhere in Google Drive.",
 				Parameters:  json.RawMessage(`{"name":"*","parent_id":"*"}`),
+			},
+			{
+				ID:          "tpl_google_read_email",
+				ActionType:  "google.read_email",
+				Name:        "Read any email",
+				Description: "Agent can read the full content of any email by message ID.",
+				Parameters:  json.RawMessage(`{"message_id":"*"}`),
 			},
 			{
 				ID:          "tpl_google_send_email_reply",

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -13,9 +13,15 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
-// maxEmailBodySize caps the decoded email body at 1 MB to prevent memory
-// issues with large messages. Bodies exceeding this are truncated.
-const maxEmailBodySize = 1024 * 1024
+const (
+	// maxEmailBodySize caps the decoded email body at 1 MB to prevent memory
+	// issues with large messages. Bodies exceeding this are truncated.
+	maxEmailBodySize = 1024 * 1024
+
+	// maxMIMEDepth limits recursion depth when walking MIME part trees to
+	// prevent stack overflow from crafted deeply-nested messages.
+	maxMIMEDepth = 20
+)
 
 // readEmailAction implements connectors.Action for google.read_email.
 // It fetches a single email by message ID and returns the full body,
@@ -125,8 +131,8 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 		}
 	}
 
-	// Extract body and attachments from the MIME tree.
-	body, contentType := extractBody(&msg.Payload)
+	// Extract body and attachments from the MIME tree (depth-limited).
+	body, contentType := extractBody(&msg.Payload, 0)
 	detail.Body = body
 	detail.ContentType = contentType
 	detail.Attachments = extractAttachments(&msg.Payload)
@@ -136,8 +142,13 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 
 // extractBody walks the MIME part tree and returns the best text body.
 // It prefers text/plain over text/html. For multipart messages it recurses
-// into alternative/mixed/related parts.
-func extractBody(part *gmailMessagePart) (body, contentType string) {
+// into alternative/mixed/related parts. Recursion is capped at maxMIMEDepth
+// to prevent stack overflow from crafted deeply-nested messages.
+func extractBody(part *gmailMessagePart, depth int) (body, contentType string) {
+	if depth > maxMIMEDepth {
+		return "", "text/plain"
+	}
+
 	// Single-part message with body data.
 	if part.Body.Data != "" && strings.HasPrefix(part.MimeType, "text/") {
 		decoded := decodeBase64URL(part.Body.Data)
@@ -149,7 +160,7 @@ func extractBody(part *gmailMessagePart) (body, contentType string) {
 	for i := range part.Parts {
 		p := &part.Parts[i]
 		if strings.HasPrefix(p.MimeType, "multipart/") {
-			b, ct := extractBody(p)
+			b, ct := extractBody(p, depth+1)
 			if b != "" {
 				if ct == "text/plain" {
 					return b, ct
@@ -177,14 +188,17 @@ func extractBody(part *gmailMessagePart) (body, contentType string) {
 // extractAttachments collects attachment metadata from the MIME part tree.
 func extractAttachments(part *gmailMessagePart) []gmailAttachmentInfo {
 	var attachments []gmailAttachmentInfo
-	collectAttachments(part, &attachments)
+	collectAttachments(part, &attachments, 0)
 	if len(attachments) == 0 {
 		return nil
 	}
 	return attachments
 }
 
-func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo) {
+func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo, depth int) {
+	if depth > maxMIMEDepth {
+		return
+	}
 	if part.Body.AttachmentID != "" {
 		info := gmailAttachmentInfo{
 			MimeType: part.MimeType,
@@ -208,7 +222,7 @@ func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo) {
 		*out = append(*out, info)
 	}
 	for i := range part.Parts {
-		collectAttachments(&part.Parts[i], out)
+		collectAttachments(&part.Parts[i], out, depth+1)
 	}
 }
 
@@ -232,11 +246,12 @@ func parseFilename(headerValue string) string {
 }
 
 // decodeBase64URL decodes a base64url-encoded string (Gmail API format).
+// Gmail uses raw (no padding) base64url, so we try that first. Padded
+// encoding is tried as a fallback for edge cases.
 func decodeBase64URL(s string) string {
-	b, err := base64.URLEncoding.DecodeString(s)
+	b, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
-		// Gmail uses raw (no padding) base64url.
-		b, err = base64.RawURLEncoding.DecodeString(s)
+		b, err = base64.URLEncoding.DecodeString(s)
 		if err != nil {
 			return s // return as-is if decoding fails
 		}

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -1,0 +1,235 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// maxEmailBodySize caps the decoded email body at 1 MB to prevent memory
+// issues with large messages. Bodies exceeding this are truncated.
+const maxEmailBodySize = 1024 * 1024
+
+// readEmailAction implements connectors.Action for google.read_email.
+// It fetches a single email by message ID and returns the full body,
+// headers, and attachment metadata.
+type readEmailAction struct {
+	conn *GoogleConnector
+}
+
+// readEmailParams is the user-facing parameter schema.
+type readEmailParams struct {
+	MessageID string `json:"message_id"`
+}
+
+func (p *readEmailParams) validate() error {
+	if p.MessageID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: message_id"}
+	}
+	return nil
+}
+
+// gmailFullMessage is the Gmail API response from messages.get with format=full.
+type gmailFullMessage struct {
+	ID           string           `json:"id"`
+	ThreadID     string           `json:"threadId"`
+	LabelIDs     []string         `json:"labelIds"`
+	Snippet      string           `json:"snippet"`
+	InternalDate string           `json:"internalDate"`
+	Payload      gmailMessagePart `json:"payload"`
+}
+
+// gmailMessagePart represents a MIME message part in the Gmail API response.
+type gmailMessagePart struct {
+	MimeType string `json:"mimeType"`
+	Headers  []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	} `json:"headers"`
+	Body struct {
+		AttachmentID string `json:"attachmentId"`
+		Size         int    `json:"size"`
+		Data         string `json:"data"`
+	} `json:"body"`
+	Parts []gmailMessagePart `json:"parts"`
+}
+
+// emailFullDetail is the shape returned to the agent.
+type emailFullDetail struct {
+	ID          string               `json:"id"`
+	ThreadID    string               `json:"thread_id"`
+	From        string               `json:"from,omitempty"`
+	To          string               `json:"to,omitempty"`
+	Cc          string               `json:"cc,omitempty"`
+	Subject     string               `json:"subject,omitempty"`
+	Date        string               `json:"date,omitempty"`
+	Labels      []string             `json:"labels,omitempty"`
+	ContentType string               `json:"content_type"`
+	Body        string               `json:"body"`
+	Attachments []gmailAttachmentInfo `json:"attachments,omitempty"`
+}
+
+// gmailAttachmentInfo describes an attachment without including its content.
+type gmailAttachmentInfo struct {
+	Filename    string `json:"filename"`
+	MimeType    string `json:"mime_type"`
+	Size        int    `json:"size"`
+	PartID      string `json:"part_id,omitempty"`
+}
+
+// Execute fetches a single email by message ID and returns its full content.
+func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params readEmailParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	var msg gmailFullMessage
+	msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(params.MessageID) + "?format=full"
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, msgURL, nil, &msg); err != nil {
+		return nil, err
+	}
+
+	detail := emailFullDetail{
+		ID:       msg.ID,
+		ThreadID: msg.ThreadID,
+		Labels:   msg.LabelIDs,
+	}
+
+	// Extract headers from the top-level payload.
+	for _, h := range msg.Payload.Headers {
+		switch h.Name {
+		case "From":
+			detail.From = h.Value
+		case "To":
+			detail.To = h.Value
+		case "Cc":
+			detail.Cc = h.Value
+		case "Subject":
+			detail.Subject = h.Value
+		case "Date":
+			detail.Date = h.Value
+		}
+	}
+
+	// Extract body and attachments from the MIME tree.
+	body, contentType := extractBody(&msg.Payload)
+	detail.Body = body
+	detail.ContentType = contentType
+	detail.Attachments = extractAttachments(&msg.Payload)
+
+	return connectors.JSONResult(detail)
+}
+
+// extractBody walks the MIME part tree and returns the best text body.
+// It prefers text/plain over text/html. For multipart messages it recurses
+// into alternative/mixed/related parts.
+func extractBody(part *gmailMessagePart) (body, contentType string) {
+	// Single-part message with body data.
+	if part.Body.Data != "" && strings.HasPrefix(part.MimeType, "text/") {
+		decoded := decodeBase64URL(part.Body.Data)
+		return truncateEmailBody(decoded), part.MimeType
+	}
+
+	// Multipart: recurse into parts.
+	var htmlBody string
+	for i := range part.Parts {
+		p := &part.Parts[i]
+		if strings.HasPrefix(p.MimeType, "multipart/") {
+			b, ct := extractBody(p)
+			if b != "" {
+				if ct == "text/plain" {
+					return b, ct
+				}
+				htmlBody = b
+				contentType = ct
+			}
+			continue
+		}
+		if p.Body.Data != "" && p.MimeType == "text/plain" {
+			return truncateEmailBody(decodeBase64URL(p.Body.Data)), "text/plain"
+		}
+		if p.Body.Data != "" && p.MimeType == "text/html" {
+			htmlBody = truncateEmailBody(decodeBase64URL(p.Body.Data))
+			contentType = "text/html"
+		}
+	}
+
+	if htmlBody != "" {
+		return htmlBody, contentType
+	}
+	return "", "text/plain"
+}
+
+// extractAttachments collects attachment metadata from the MIME part tree.
+func extractAttachments(part *gmailMessagePart) []gmailAttachmentInfo {
+	var attachments []gmailAttachmentInfo
+	collectAttachments(part, &attachments)
+	if len(attachments) == 0 {
+		return nil
+	}
+	return attachments
+}
+
+func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo) {
+	if part.Body.AttachmentID != "" {
+		info := gmailAttachmentInfo{
+			MimeType: part.MimeType,
+			Size:     part.Body.Size,
+		}
+		// Extract filename from Content-Disposition or part headers.
+		for _, h := range part.Headers {
+			if strings.EqualFold(h.Name, "Content-Disposition") {
+				if fn := parseFilename(h.Value); fn != "" {
+					info.Filename = fn
+				}
+			}
+		}
+		*out = append(*out, info)
+	}
+	for i := range part.Parts {
+		collectAttachments(&part.Parts[i], out)
+	}
+}
+
+// parseFilename extracts a filename from a Content-Disposition header value.
+func parseFilename(disposition string) string {
+	for _, param := range strings.Split(disposition, ";") {
+		param = strings.TrimSpace(param)
+		if strings.HasPrefix(strings.ToLower(param), "filename=") {
+			name := param[len("filename="):]
+			return strings.Trim(name, `"`)
+		}
+	}
+	return ""
+}
+
+// decodeBase64URL decodes a base64url-encoded string (Gmail API format).
+func decodeBase64URL(s string) string {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		// Gmail uses raw (no padding) base64url.
+		b, err = base64.RawURLEncoding.DecodeString(s)
+		if err != nil {
+			return s // return as-is if decoding fails
+		}
+	}
+	return string(b)
+}
+
+// truncateEmailBody limits body content to maxEmailBodySize.
+func truncateEmailBody(s string) string {
+	if len(s) > maxEmailBodySize {
+		return s[:maxEmailBodySize] + "\n[truncated]"
+	}
+	return s
+}

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -47,6 +48,7 @@ type gmailFullMessage struct {
 
 // gmailMessagePart represents a MIME message part in the Gmail API response.
 type gmailMessagePart struct {
+	PartID   string `json:"partId"`
 	MimeType string `json:"mimeType"`
 	Headers  []struct {
 		Name  string `json:"name"`
@@ -107,18 +109,18 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 		Labels:   msg.LabelIDs,
 	}
 
-	// Extract headers from the top-level payload.
+	// Extract headers from the top-level payload (case-insensitive per RFC 5322).
 	for _, h := range msg.Payload.Headers {
-		switch h.Name {
-		case "From":
+		switch strings.ToLower(h.Name) {
+		case "from":
 			detail.From = h.Value
-		case "To":
+		case "to":
 			detail.To = h.Value
-		case "Cc":
+		case "cc":
 			detail.Cc = h.Value
-		case "Subject":
+		case "subject":
 			detail.Subject = h.Value
-		case "Date":
+		case "date":
 			detail.Date = h.Value
 		}
 	}
@@ -187,10 +189,17 @@ func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo) {
 		info := gmailAttachmentInfo{
 			MimeType: part.MimeType,
 			Size:     part.Body.Size,
+			PartID:   part.PartID,
 		}
-		// Extract filename from Content-Disposition or part headers.
+		// Extract filename from Content-Disposition, falling back to
+		// Content-Type name= (used by some older mailers).
 		for _, h := range part.Headers {
 			if strings.EqualFold(h.Name, "Content-Disposition") {
+				if fn := parseFilename(h.Value); fn != "" {
+					info.Filename = fn
+				}
+			}
+			if info.Filename == "" && strings.EqualFold(h.Name, "Content-Type") {
 				if fn := parseFilename(h.Value); fn != "" {
 					info.Filename = fn
 				}
@@ -203,12 +212,19 @@ func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo) {
 	}
 }
 
-// parseFilename extracts a filename from a Content-Disposition header value.
-func parseFilename(disposition string) string {
-	for _, param := range strings.Split(disposition, ";") {
+// parseFilename extracts a filename from a Content-Disposition or Content-Type
+// header value. Checks for both filename= (Content-Disposition) and name=
+// (Content-Type) parameters.
+func parseFilename(headerValue string) string {
+	for _, param := range strings.Split(headerValue, ";") {
 		param = strings.TrimSpace(param)
-		if strings.HasPrefix(strings.ToLower(param), "filename=") {
+		lower := strings.ToLower(param)
+		if strings.HasPrefix(lower, "filename=") {
 			name := param[len("filename="):]
+			return strings.Trim(name, `"`)
+		}
+		if strings.HasPrefix(lower, "name=") {
+			name := param[len("name="):]
 			return strings.Trim(name, `"`)
 		}
 	}
@@ -228,10 +244,16 @@ func decodeBase64URL(s string) string {
 	return string(b)
 }
 
-// truncateEmailBody limits body content to maxEmailBodySize.
+// truncateEmailBody limits body content to maxEmailBodySize, cutting at a
+// valid UTF-8 boundary to avoid splitting multi-byte runes.
 func truncateEmailBody(s string) string {
-	if len(s) > maxEmailBodySize {
-		return s[:maxEmailBodySize] + "\n[truncated]"
+	if len(s) <= maxEmailBodySize {
+		return s
 	}
-	return s
+	// Walk backwards from the limit to avoid splitting a multi-byte rune.
+	i := maxEmailBodySize
+	for i > 0 && !utf8.RuneStart(s[i]) {
+		i--
+	}
+	return s[:i] + "\n[truncated]"
 }

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -86,7 +86,7 @@ type emailFullDetail struct {
 
 // gmailAttachmentInfo describes an attachment without including its content.
 type gmailAttachmentInfo struct {
-	Filename     string `json:"filename"`
+	Filename     string `json:"filename,omitempty"`
 	MimeType     string `json:"mime_type"`
 	Size         int    `json:"size"`
 	PartID       string `json:"part_id,omitempty"`

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -227,22 +227,49 @@ func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo, dept
 }
 
 // parseFilename extracts a filename from a Content-Disposition or Content-Type
-// header value. Checks for both filename= (Content-Disposition) and name=
-// (Content-Type) parameters.
+// header value. Checks filename=, filename*= (RFC 5987), name=, and name*=.
 func parseFilename(headerValue string) string {
+	var plainName string
 	for _, param := range strings.Split(headerValue, ";") {
 		param = strings.TrimSpace(param)
 		lower := strings.ToLower(param)
-		if strings.HasPrefix(lower, "filename=") {
-			name := param[len("filename="):]
-			return strings.Trim(name, `"`)
+
+		// RFC 5987 extended filenames (filename*=UTF-8''encoded%20name)
+		// take priority over plain filenames per RFC 6266.
+		if strings.HasPrefix(lower, "filename*=") {
+			if fn := decodeRFC5987(param[len("filename*="):]); fn != "" {
+				return fn
+			}
 		}
-		if strings.HasPrefix(lower, "name=") {
-			name := param[len("name="):]
-			return strings.Trim(name, `"`)
+		if strings.HasPrefix(lower, "name*=") {
+			if fn := decodeRFC5987(param[len("name*="):]); fn != "" {
+				return fn
+			}
+		}
+
+		if strings.HasPrefix(lower, "filename=") {
+			plainName = strings.Trim(param[len("filename="):], `"`)
+		}
+		if plainName == "" && strings.HasPrefix(lower, "name=") {
+			plainName = strings.Trim(param[len("name="):], `"`)
 		}
 	}
-	return ""
+	return plainName
+}
+
+// decodeRFC5987 decodes a RFC 5987 encoded value like "UTF-8''caf%C3%A9.pdf".
+// Returns empty string if the format is unrecognized.
+func decodeRFC5987(value string) string {
+	// Format: charset'language'encoded_value
+	parts := strings.SplitN(value, "'", 3)
+	if len(parts) != 3 {
+		return ""
+	}
+	decoded, err := url.PathUnescape(parts[2])
+	if err != nil {
+		return ""
+	}
+	return decoded
 }
 
 // decodeBase64URL decodes a base64url-encoded string (Gmail API format).

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -69,6 +69,7 @@ type emailFullDetail struct {
 	Cc          string               `json:"cc,omitempty"`
 	Subject     string               `json:"subject,omitempty"`
 	Date        string               `json:"date,omitempty"`
+	Snippet     string               `json:"snippet,omitempty"`
 	Labels      []string             `json:"labels,omitempty"`
 	ContentType string               `json:"content_type"`
 	Body        string               `json:"body"`
@@ -102,6 +103,7 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	detail := emailFullDetail{
 		ID:       msg.ID,
 		ThreadID: msg.ThreadID,
+		Snippet:  msg.Snippet,
 		Labels:   msg.LabelIDs,
 	}
 

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -86,10 +86,11 @@ type emailFullDetail struct {
 
 // gmailAttachmentInfo describes an attachment without including its content.
 type gmailAttachmentInfo struct {
-	Filename    string `json:"filename"`
-	MimeType    string `json:"mime_type"`
-	Size        int    `json:"size"`
-	PartID      string `json:"part_id,omitempty"`
+	Filename     string `json:"filename"`
+	MimeType     string `json:"mime_type"`
+	Size         int    `json:"size"`
+	PartID       string `json:"part_id,omitempty"`
+	AttachmentID string `json:"attachment_id,omitempty"`
 }
 
 // Execute fetches a single email by message ID and returns its full content.
@@ -201,9 +202,10 @@ func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo, dept
 	}
 	if part.Body.AttachmentID != "" {
 		info := gmailAttachmentInfo{
-			MimeType: part.MimeType,
-			Size:     part.Body.Size,
-			PartID:   part.PartID,
+			MimeType:     part.MimeType,
+			Size:         part.Body.Size,
+			PartID:       part.PartID,
+			AttachmentID: part.Body.AttachmentID,
 		}
 		// Extract filename from Content-Disposition, falling back to
 		// Content-Type name= (used by some older mailers).
@@ -258,11 +260,15 @@ func parseFilename(headerValue string) string {
 }
 
 // decodeRFC5987 decodes a RFC 5987 encoded value like "UTF-8''caf%C3%A9.pdf".
-// Returns empty string if the format is unrecognized.
+// Only UTF-8 charset is supported; other charsets (e.g. ISO-8859-1) return ""
+// to avoid producing invalid UTF-8 strings.
 func decodeRFC5987(value string) string {
 	// Format: charset'language'encoded_value
 	parts := strings.SplitN(value, "'", 3)
 	if len(parts) != 3 {
+		return ""
+	}
+	if !strings.EqualFold(parts[0], "UTF-8") {
 		return ""
 	}
 	decoded, err := url.PathUnescape(parts[2])

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -1,0 +1,407 @@
+package google
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestReadEmail_Success(t *testing.T) {
+	t.Parallel()
+
+	plainBody := base64.RawURLEncoding.EncodeToString([]byte("Hello, this is the email body."))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Query().Get("format") != "full" {
+			t.Errorf("expected format=full, got %s", r.URL.Query().Get("format"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-123",
+			ThreadID: "thread-456",
+			LabelIDs: []string{"INBOX", "UNREAD"},
+			Snippet:  "Hello, this is",
+			Payload: gmailMessagePart{
+				MimeType: "text/plain",
+				Headers: []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				}{
+					{Name: "From", Value: "sender@example.com"},
+					{Name: "To", Value: "recipient@example.com"},
+					{Name: "Subject", Value: "Test Email"},
+					{Name: "Date", Value: "Mon, 14 Mar 2026 10:00:00 -0500"},
+				},
+				Body: struct {
+					AttachmentID string `json:"attachmentId"`
+					Size         int    `json:"size"`
+					Data         string `json:"data"`
+				}{
+					Data: plainBody,
+					Size: 29,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail emailFullDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if detail.ID != "msg-123" {
+		t.Errorf("expected ID msg-123, got %s", detail.ID)
+	}
+	if detail.ThreadID != "thread-456" {
+		t.Errorf("expected ThreadID thread-456, got %s", detail.ThreadID)
+	}
+	if detail.From != "sender@example.com" {
+		t.Errorf("expected From sender@example.com, got %s", detail.From)
+	}
+	if detail.Subject != "Test Email" {
+		t.Errorf("expected Subject 'Test Email', got %s", detail.Subject)
+	}
+	if detail.Body != "Hello, this is the email body." {
+		t.Errorf("expected body content, got %q", detail.Body)
+	}
+	if detail.ContentType != "text/plain" {
+		t.Errorf("expected content_type text/plain, got %s", detail.ContentType)
+	}
+}
+
+func TestReadEmail_MultipartMessage(t *testing.T) {
+	t.Parallel()
+
+	plainBody := base64.RawURLEncoding.EncodeToString([]byte("Plain text version"))
+	htmlBody := base64.RawURLEncoding.EncodeToString([]byte("<p>HTML version</p>"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-multi",
+			ThreadID: "thread-1",
+			Payload: gmailMessagePart{
+				MimeType: "multipart/alternative",
+				Parts: []gmailMessagePart{
+					{
+						MimeType: "text/plain",
+						Body: struct {
+							AttachmentID string `json:"attachmentId"`
+							Size         int    `json:"size"`
+							Data         string `json:"data"`
+						}{Data: plainBody},
+					},
+					{
+						MimeType: "text/html",
+						Body: struct {
+							AttachmentID string `json:"attachmentId"`
+							Size         int    `json:"size"`
+							Data         string `json:"data"`
+						}{Data: htmlBody},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-multi"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail emailFullDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	// Should prefer text/plain over text/html.
+	if detail.ContentType != "text/plain" {
+		t.Errorf("expected text/plain, got %s", detail.ContentType)
+	}
+	if detail.Body != "Plain text version" {
+		t.Errorf("expected plain text body, got %q", detail.Body)
+	}
+}
+
+func TestReadEmail_WithAttachments(t *testing.T) {
+	t.Parallel()
+
+	plainBody := base64.RawURLEncoding.EncodeToString([]byte("See attached."))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-attach",
+			ThreadID: "thread-2",
+			Payload: gmailMessagePart{
+				MimeType: "multipart/mixed",
+				Parts: []gmailMessagePart{
+					{
+						MimeType: "text/plain",
+						Body: struct {
+							AttachmentID string `json:"attachmentId"`
+							Size         int    `json:"size"`
+							Data         string `json:"data"`
+						}{Data: plainBody},
+					},
+					{
+						MimeType: "application/pdf",
+						Headers: []struct {
+							Name  string `json:"name"`
+							Value string `json:"value"`
+						}{
+							{Name: "Content-Disposition", Value: `attachment; filename="report.pdf"`},
+						},
+						Body: struct {
+							AttachmentID string `json:"attachmentId"`
+							Size         int    `json:"size"`
+							Data         string `json:"data"`
+						}{
+							AttachmentID: "att-001",
+							Size:         12345,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-attach"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail emailFullDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if len(detail.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(detail.Attachments))
+	}
+	att := detail.Attachments[0]
+	if att.Filename != "report.pdf" {
+		t.Errorf("expected filename report.pdf, got %s", att.Filename)
+	}
+	if att.MimeType != "application/pdf" {
+		t.Errorf("expected mime_type application/pdf, got %s", att.MimeType)
+	}
+	if att.Size != 12345 {
+		t.Errorf("expected size 12345, got %d", att.Size)
+	}
+}
+
+func TestReadEmail_MissingMessageID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestReadEmail_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &readEmailAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestReadEmail_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 401, "message": "Invalid Credentials"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T", err)
+	}
+}
+
+func TestReadEmail_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 404, "message": "Requested entity was not found."},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "nonexistent"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
+func TestExtractBody_PlainTextPreferred(t *testing.T) {
+	t.Parallel()
+
+	plainData := base64.RawURLEncoding.EncodeToString([]byte("plain"))
+	htmlData := base64.RawURLEncoding.EncodeToString([]byte("<b>html</b>"))
+
+	part := &gmailMessagePart{
+		MimeType: "multipart/alternative",
+		Parts: []gmailMessagePart{
+			{MimeType: "text/html", Body: struct {
+				AttachmentID string `json:"attachmentId"`
+				Size         int    `json:"size"`
+				Data         string `json:"data"`
+			}{Data: htmlData}},
+			{MimeType: "text/plain", Body: struct {
+				AttachmentID string `json:"attachmentId"`
+				Size         int    `json:"size"`
+				Data         string `json:"data"`
+			}{Data: plainData}},
+		},
+	}
+
+	body, ct := extractBody(part)
+	if ct != "text/plain" {
+		t.Errorf("expected text/plain, got %s", ct)
+	}
+	if body != "plain" {
+		t.Errorf("expected 'plain', got %q", body)
+	}
+}
+
+func TestExtractBody_FallbackToHTML(t *testing.T) {
+	t.Parallel()
+
+	htmlData := base64.RawURLEncoding.EncodeToString([]byte("<b>html only</b>"))
+
+	part := &gmailMessagePart{
+		MimeType: "multipart/alternative",
+		Parts: []gmailMessagePart{
+			{MimeType: "text/html", Body: struct {
+				AttachmentID string `json:"attachmentId"`
+				Size         int    `json:"size"`
+				Data         string `json:"data"`
+			}{Data: htmlData}},
+		},
+	}
+
+	body, ct := extractBody(part)
+	if ct != "text/html" {
+		t.Errorf("expected text/html, got %s", ct)
+	}
+	if body != "<b>html only</b>" {
+		t.Errorf("expected html body, got %q", body)
+	}
+}
+
+func TestParseFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`attachment; filename="report.pdf"`, "report.pdf"},
+		{`attachment; filename=report.pdf`, "report.pdf"},
+		{`inline`, ""},
+		{``, ""},
+	}
+
+	for _, tt := range tests {
+		got := parseFilename(tt.input)
+		if got != tt.want {
+			t.Errorf("parseFilename(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -488,3 +488,96 @@ func TestParseFilename(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeRFC5987_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"valid UTF-8", "UTF-8''hello%20world.pdf", "hello world.pdf"},
+		{"empty language tag", "UTF-8'en'doc.pdf", "doc.pdf"},
+		{"missing single quotes", "UTF-8hello.pdf", ""},
+		{"only one single quote", "UTF-8'hello.pdf", ""},
+		{"invalid percent encoding", "UTF-8''bad%ZZvalue", ""},
+		{"empty value after quotes", "UTF-8''", ""},
+		{"empty input", "", ""},
+	}
+
+	for _, tt := range tests {
+		got := decodeRFC5987(tt.input)
+		if got != tt.want {
+			t.Errorf("decodeRFC5987[%s](%q) = %q, want %q", tt.name, tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestDecodeBase64URL_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	// Raw base64url (no padding) — standard Gmail format.
+	raw := base64.RawURLEncoding.EncodeToString([]byte("test data"))
+	if got := decodeBase64URL(raw); got != "test data" {
+		t.Errorf("raw base64url: got %q, want %q", got, "test data")
+	}
+
+	// Padded base64url — fallback path.
+	padded := base64.URLEncoding.EncodeToString([]byte("padded data"))
+	if got := decodeBase64URL(padded); got != "padded data" {
+		t.Errorf("padded base64url: got %q, want %q", got, "padded data")
+	}
+
+	// Totally invalid base64 — returned as-is.
+	invalid := "not-valid-base64!!!"
+	if got := decodeBase64URL(invalid); got != invalid {
+		t.Errorf("invalid base64: got %q, want %q (as-is)", got, invalid)
+	}
+}
+
+func TestTruncateEmailBody_UTF8Boundary(t *testing.T) {
+	t.Parallel()
+
+	// Short body — no truncation.
+	short := "hello"
+	if got := truncateEmailBody(short); got != short {
+		t.Errorf("short body: got %q, want %q", got, short)
+	}
+
+	// Empty body.
+	if got := truncateEmailBody(""); got != "" {
+		t.Errorf("empty body: got %q, want empty", got)
+	}
+}
+
+func TestExtractBody_DepthLimit(t *testing.T) {
+	t.Parallel()
+
+	plainData := base64.RawURLEncoding.EncodeToString([]byte("deep body"))
+
+	// Create a part at exactly the depth limit — should still return empty
+	// because the body is nested beyond maxMIMEDepth.
+	part := &gmailMessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []gmailMessagePart{
+			{
+				MimeType: "text/plain",
+				Body: struct {
+					AttachmentID string `json:"attachmentId"`
+					Size         int    `json:"size"`
+					Data         string `json:"data"`
+				}{Data: plainData},
+			},
+		},
+	}
+
+	// At depth maxMIMEDepth+1, extractBody should bail out.
+	body, ct := extractBody(part, maxMIMEDepth+1)
+	if body != "" {
+		t.Errorf("expected empty body at max depth, got %q", body)
+	}
+	if ct != "text/plain" {
+		t.Errorf("expected text/plain fallback, got %s", ct)
+	}
+}

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -475,6 +475,8 @@ func TestParseFilename(t *testing.T) {
 		{`attachment; filename=report.pdf`, "report.pdf"},
 		{`application/pdf; name="invoice.pdf"`, "invoice.pdf"},
 		{`application/pdf; name=invoice.pdf`, "invoice.pdf"},
+		{`attachment; filename*=UTF-8''caf%C3%A9%20menu.pdf`, "café menu.pdf"},
+		{`attachment; filename="fallback.pdf"; filename*=UTF-8''preferred.pdf`, "preferred.pdf"},
 		{`inline`, ""},
 		{``, ""},
 	}

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -181,6 +181,7 @@ func TestReadEmail_WithAttachments(t *testing.T) {
 						}{Data: plainBody},
 					},
 					{
+						PartID:   "1",
 						MimeType: "application/pdf",
 						Headers: []struct {
 							Name  string `json:"name"`
@@ -234,6 +235,81 @@ func TestReadEmail_WithAttachments(t *testing.T) {
 	}
 	if att.Size != 12345 {
 		t.Errorf("expected size 12345, got %d", att.Size)
+	}
+	if att.PartID != "1" {
+		t.Errorf("expected part_id '1', got %q", att.PartID)
+	}
+}
+
+func TestReadEmail_AttachmentFilenameFromContentType(t *testing.T) {
+	t.Parallel()
+
+	plainBody := base64.RawURLEncoding.EncodeToString([]byte("See attached."))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-ct-name",
+			ThreadID: "thread-3",
+			Payload: gmailMessagePart{
+				MimeType: "multipart/mixed",
+				Parts: []gmailMessagePart{
+					{
+						MimeType: "text/plain",
+						Body: struct {
+							AttachmentID string `json:"attachmentId"`
+							Size         int    `json:"size"`
+							Data         string `json:"data"`
+						}{Data: plainBody},
+					},
+					{
+						MimeType: "application/pdf",
+						Headers: []struct {
+							Name  string `json:"name"`
+							Value string `json:"value"`
+						}{
+							// No Content-Disposition; filename in Content-Type name= instead.
+							{Name: "Content-Type", Value: `application/pdf; name="invoice.pdf"`},
+						},
+						Body: struct {
+							AttachmentID string `json:"attachmentId"`
+							Size         int    `json:"size"`
+							Data         string `json:"data"`
+						}{
+							AttachmentID: "att-002",
+							Size:         5000,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-ct-name"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail emailFullDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if len(detail.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(detail.Attachments))
+	}
+	if detail.Attachments[0].Filename != "invoice.pdf" {
+		t.Errorf("expected filename 'invoice.pdf' from Content-Type fallback, got %q", detail.Attachments[0].Filename)
 	}
 }
 
@@ -397,6 +473,8 @@ func TestParseFilename(t *testing.T) {
 	}{
 		{`attachment; filename="report.pdf"`, "report.pdf"},
 		{`attachment; filename=report.pdf`, "report.pdf"},
+		{`application/pdf; name="invoice.pdf"`, "invoice.pdf"},
+		{`application/pdf; name=invoice.pdf`, "invoice.pdf"},
 		{`inline`, ""},
 		{``, ""},
 	}

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -430,7 +430,7 @@ func TestExtractBody_PlainTextPreferred(t *testing.T) {
 		},
 	}
 
-	body, ct := extractBody(part)
+	body, ct := extractBody(part, 0)
 	if ct != "text/plain" {
 		t.Errorf("expected text/plain, got %s", ct)
 	}
@@ -455,7 +455,7 @@ func TestExtractBody_FallbackToHTML(t *testing.T) {
 		},
 	}
 
-	body, ct := extractBody(part)
+	body, ct := extractBody(part, 0)
 	if ct != "text/html" {
 		t.Errorf("expected text/html, got %s", ct)
 	}

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -90,6 +90,9 @@ func TestReadEmail_Success(t *testing.T) {
 	if detail.ContentType != "text/plain" {
 		t.Errorf("expected content_type text/plain, got %s", detail.ContentType)
 	}
+	if detail.Snippet != "Hello, this is" {
+		t.Errorf("expected snippet 'Hello, this is', got %q", detail.Snippet)
+	}
 }
 
 func TestReadEmail_MultipartMessage(t *testing.T) {

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -239,6 +239,9 @@ func TestReadEmail_WithAttachments(t *testing.T) {
 	if att.PartID != "1" {
 		t.Errorf("expected part_id '1', got %q", att.PartID)
 	}
+	if att.AttachmentID != "att-001" {
+		t.Errorf("expected attachment_id 'att-001', got %q", att.AttachmentID)
+	}
 }
 
 func TestReadEmail_AttachmentFilenameFromContentType(t *testing.T) {
@@ -504,6 +507,7 @@ func TestDecodeRFC5987_EdgeCases(t *testing.T) {
 		{"invalid percent encoding", "UTF-8''bad%ZZvalue", ""},
 		{"empty value after quotes", "UTF-8''", ""},
 		{"empty input", "", ""},
+		{"non-UTF-8 charset rejected", "ISO-8859-1''caf%E9.pdf", ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Adds a new `google.read_email` action that fetches a single email by message ID via Gmail API (`messages.get` with `format=full`)
- Returns full body text (preferring text/plain over text/html), headers (From, To, Cc, Subject, Date), labels, and attachment metadata
- Includes a "Read any email" standing approval template

## Test plan

### Claude Code
- [x] Unit tests for success, multipart messages, attachments, missing params, invalid JSON, auth failure, and 404
- [x] Unit tests for `extractBody` (plain text preference, HTML fallback) and `parseFilename`
- [x] Updated `google_test.go` action count (27 → 28) and manifest/action list assertions
- [x] `go vet` passes clean

### OpenClaw
- [ ] Manual test with a real Gmail account to verify full email body retrieval
- [ ] Verify attachment metadata looks correct for emails with multiple attachments
- [ ] Confirm the action appears in the UI action picker after seeding

https://claude.ai/code/session_017JMyzAuSHAiDbmhriX3n9f