### PR TITLE
Add google.archive_email action

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -29,6 +29,7 @@ The credential `auth_type` is `oauth2` with `oauth_provider` set to `google` (a 
 | `drive` | `google.list_drive_files`, `google.get_drive_file`, `google.upload_drive_file`, `google.delete_drive_file`, `google.list_documents`, `google.search_drive`, `google.create_drive_folder` |
 | `calendar.events` (also used for updates/deletes) | `google.update_calendar_event`, `google.delete_calendar_event` |
 | `gmail.send` + `gmail.readonly` (both required) | `google.send_email_reply` |
+| `gmail.modify` | `google.archive_email` |
 
 Scopes follow the principle of least privilege — `calendar.events` (event-level access) is used instead of the broader `calendar` scope (full calendar management). The `drive` scope grants full Drive access; a narrower scope like `drive.file` would only allow access to files created by this app, which is too restrictive for file browsing and reading.
 
@@ -85,6 +86,7 @@ Lists recent emails from the Gmail inbox with metadata.
   "emails": [
     {
       "id": "18abc123def",
+      "thread_id": "18abc123def",
       "from": "sender@example.com",
       "to": "you@example.com",
       "subject": "Hello",
@@ -961,6 +963,34 @@ Moves a file to trash in Google Drive (soft delete — not permanent).
 
 ---
 
+### `google.archive_email`
+
+Archives a Gmail thread by removing the INBOX label from all messages in the thread. Archived emails remain accessible via search and All Mail — this matches Gmail's built-in Archive button behavior.
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `thread_id` | string | Yes | The Gmail thread ID to archive (obtained from `list_emails` `thread_id` field) |
+
+**Response:**
+
+```json
+{
+  "thread_id": "18abc123def"
+}
+```
+
+**Gmail API:** `POST /gmail/v1/users/me/threads/{id}/modify` ([docs](https://developers.google.com/gmail/api/reference/rest/v1/users.threads/modify))
+
+**Implementation notes:**
+- Uses `threads.modify` (not `messages.modify`) to atomically remove `INBOX` from all messages in the thread, matching Gmail's native Archive behavior.
+- Thread IDs are URL-encoded via `url.PathEscape` to prevent path traversal.
+
+---
+
 ## Error Handling
 
 The connector maps Google API HTTP status codes to typed connector errors:
@@ -1019,6 +1049,7 @@ The connector ships with constrained templates that demonstrate parameter lockin
 | Search Drive within folder | `search_drive` | `folder_id` locked to a specific folder |
 | Create Drive folders | `create_drive_folder` | Nothing — agent controls name and parent |
 | Reply to emails | `send_email_reply` | Nothing — agent controls thread, message, and body |
+| Archive emails | `archive_email` | Nothing — agent can archive any thread |
 
 ## Adding a New Action
 
@@ -1038,12 +1069,13 @@ Each action lives in its own file. To add one (e.g., `google.delete_calendar_eve
 ```
 connectors/google/
 ├── google.go                       # GoogleConnector struct, New(), Actions(), doJSON(), doRawGet(), wrapHTTPError(), ValidateCredentials()
-├── manifest.go                     # Manifest() — 27 action schemas and 39+ templates
+├── manifest.go                     # Manifest() — 28 action schemas and 40+ templates
 ├── docs_types.go                   # Shared Docs API types (batchUpdate request) and helpers (documentEditURL)
 ├── email_helpers.go                # buildGmailRaw() — shared RFC 2822 message builder used by send_email and send_email_reply
 ├── send_email.go                   # google.send_email action
 ├── list_emails.go                  # google.list_emails action
 ├── send_email_reply.go             # google.send_email_reply action (fetches headers, strips injection chars, sends reply)
+├── archive_email.go               # google.archive_email action (thread-level archive via threads.modify)
 ├── create_calendar_event.go        # google.create_calendar_event action
 ├── list_calendar_events.go         # google.list_calendar_events action
 ├── update_calendar_event.go        # google.update_calendar_event action (PATCH with map[string]any for explicit empty arrays)

--- a/connectors/google/archive_email.go
+++ b/connectors/google/archive_email.go
@@ -11,37 +11,36 @@ import (
 )
 
 // archiveEmailAction implements connectors.Action for google.archive_email.
-// It archives a Gmail message by removing the INBOX label via
-// POST /gmail/v1/users/me/messages/{id}/modify.
+// It archives a Gmail thread by removing the INBOX label from all messages
+// via POST /gmail/v1/users/me/threads/{id}/modify, matching Gmail's built-in
+// Archive button behavior.
 type archiveEmailAction struct {
 	conn *GoogleConnector
 }
 
 // archiveEmailParams is the user-facing parameter schema.
 type archiveEmailParams struct {
-	MessageID string `json:"message_id"`
+	ThreadID string `json:"thread_id"`
 }
 
 func (p *archiveEmailParams) validate() error {
-	if p.MessageID == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: message_id"}
+	if p.ThreadID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: thread_id"}
 	}
 	return nil
 }
 
-// gmailModifyRequest is the Gmail API request body for messages.modify.
+// gmailModifyRequest is the Gmail API request body for threads.modify / messages.modify.
 type gmailModifyRequest struct {
 	RemoveLabelIDs []string `json:"removeLabelIds"`
 }
 
-// gmailModifyResponse is the Gmail API response from messages.modify.
-type gmailModifyResponse struct {
-	ID       string   `json:"id"`
-	ThreadID string   `json:"threadId"`
-	LabelIDs []string `json:"labelIds"`
+// gmailThreadModifyResponse is the Gmail API response from threads.modify.
+type gmailThreadModifyResponse struct {
+	ID string `json:"id"`
 }
 
-// Execute archives a Gmail message by removing the INBOX label.
+// Execute archives a Gmail thread by removing the INBOX label from all messages.
 func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params archiveEmailParams
 	if err := json.Unmarshal(req.Parameters, &params); err != nil {
@@ -51,19 +50,17 @@ func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionR
 		return nil, err
 	}
 
-	modifyURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(params.MessageID) + "/modify"
+	modifyURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/threads/" + url.PathEscape(params.ThreadID) + "/modify"
 	body := gmailModifyRequest{
 		RemoveLabelIDs: []string{"INBOX"},
 	}
 
-	var resp gmailModifyResponse
+	var resp gmailThreadModifyResponse
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, modifyURL, body, &resp); err != nil {
 		return nil, err
 	}
 
 	return connectors.JSONResult(map[string]any{
-		"id":        resp.ID,
-		"thread_id": resp.ThreadID,
-		"labels":    resp.LabelIDs,
+		"thread_id": resp.ID,
 	})
 }

--- a/connectors/google/archive_email.go
+++ b/connectors/google/archive_email.go
@@ -1,0 +1,69 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// archiveEmailAction implements connectors.Action for google.archive_email.
+// It archives a Gmail message by removing the INBOX label via
+// POST /gmail/v1/users/me/messages/{id}/modify.
+type archiveEmailAction struct {
+	conn *GoogleConnector
+}
+
+// archiveEmailParams is the user-facing parameter schema.
+type archiveEmailParams struct {
+	MessageID string `json:"message_id"`
+}
+
+func (p *archiveEmailParams) validate() error {
+	if p.MessageID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: message_id"}
+	}
+	return nil
+}
+
+// gmailModifyRequest is the Gmail API request body for messages.modify.
+type gmailModifyRequest struct {
+	RemoveLabelIDs []string `json:"removeLabelIds"`
+}
+
+// gmailModifyResponse is the Gmail API response from messages.modify.
+type gmailModifyResponse struct {
+	ID       string   `json:"id"`
+	ThreadID string   `json:"threadId"`
+	LabelIDs []string `json:"labelIds"`
+}
+
+// Execute archives a Gmail message by removing the INBOX label.
+func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params archiveEmailParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	modifyURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(params.MessageID) + "/modify"
+	body := gmailModifyRequest{
+		RemoveLabelIDs: []string{"INBOX"},
+	}
+
+	var resp gmailModifyResponse
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, modifyURL, body, &resp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"id":        resp.ID,
+		"thread_id": resp.ThreadID,
+		"labels":    resp.LabelIDs,
+	})
+}

--- a/connectors/google/archive_email_test.go
+++ b/connectors/google/archive_email_test.go
@@ -16,7 +16,7 @@ func TestArchiveEmail_Success(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/gmail/v1/users/me/messages/msg-123/modify" {
+		if r.URL.Path != "/gmail/v1/users/me/threads/thread-456/modify" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
@@ -32,10 +32,8 @@ func TestArchiveEmail_Success(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(gmailModifyResponse{
-			ID:       "msg-123",
-			ThreadID: "thread-456",
-			LabelIDs: []string{"IMPORTANT"},
+		json.NewEncoder(w).Encode(gmailThreadModifyResponse{
+			ID: "thread-456",
 		})
 	}))
 	defer srv.Close()
@@ -43,7 +41,7 @@ func TestArchiveEmail_Success(t *testing.T) {
 	conn := newGmailForTest(srv.Client(), srv.URL)
 	action := &archiveEmailAction{conn: conn}
 
-	params, _ := json.Marshal(archiveEmailParams{MessageID: "msg-123"})
+	params, _ := json.Marshal(archiveEmailParams{ThreadID: "thread-456"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "google.archive_email",
@@ -58,15 +56,12 @@ func TestArchiveEmail_Success(t *testing.T) {
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	if data["id"] != "msg-123" {
-		t.Errorf("expected id 'msg-123', got %q", data["id"])
-	}
 	if data["thread_id"] != "thread-456" {
 		t.Errorf("expected thread_id 'thread-456', got %q", data["thread_id"])
 	}
 }
 
-func TestArchiveEmail_MissingMessageID(t *testing.T) {
+func TestArchiveEmail_MissingThreadID(t *testing.T) {
 	t.Parallel()
 
 	conn := New()
@@ -80,7 +75,7 @@ func TestArchiveEmail_MissingMessageID(t *testing.T) {
 		Credentials: validCreds(),
 	})
 	if err == nil {
-		t.Fatal("expected error for missing message_id")
+		t.Fatal("expected error for missing thread_id")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)
@@ -124,7 +119,7 @@ func TestArchiveEmail_AuthFailure(t *testing.T) {
 	conn := newGmailForTest(srv.Client(), srv.URL)
 	action := &archiveEmailAction{conn: conn}
 
-	params, _ := json.Marshal(archiveEmailParams{MessageID: "msg-123"})
+	params, _ := json.Marshal(archiveEmailParams{ThreadID: "thread-456"})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "google.archive_email",
@@ -151,7 +146,7 @@ func TestArchiveEmail_RateLimit(t *testing.T) {
 	conn := newGmailForTest(srv.Client(), srv.URL)
 	action := &archiveEmailAction{conn: conn}
 
-	params, _ := json.Marshal(archiveEmailParams{MessageID: "msg-123"})
+	params, _ := json.Marshal(archiveEmailParams{ThreadID: "thread-456"})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "google.archive_email",

--- a/connectors/google/archive_email_test.go
+++ b/connectors/google/archive_email_test.go
@@ -138,3 +138,30 @@ func TestArchiveEmail_AuthFailure(t *testing.T) {
 		t.Errorf("expected AuthError, got: %T (%v)", err, err)
 	}
 }
+
+func TestArchiveEmail_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &archiveEmailAction{conn: conn}
+
+	params, _ := json.Marshal(archiveEmailParams{MessageID: "msg-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.archive_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %T", err)
+	}
+}

--- a/connectors/google/archive_email_test.go
+++ b/connectors/google/archive_email_test.go
@@ -134,6 +134,31 @@ func TestArchiveEmail_AuthFailure(t *testing.T) {
 	}
 }
 
+func TestArchiveEmail_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":{"code":404,"message":"Not Found"}}`))
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &archiveEmailAction{conn: conn}
+
+	params, _ := json.Marshal(archiveEmailParams{ThreadID: "nonexistent-thread"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.archive_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
 func TestArchiveEmail_RateLimit(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/archive_email_test.go
+++ b/connectors/google/archive_email_test.go
@@ -1,0 +1,140 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestArchiveEmail_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/gmail/v1/users/me/messages/msg-123/modify" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
+			t.Errorf("expected Bearer token, got %q", got)
+		}
+
+		var body gmailModifyRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if len(body.RemoveLabelIDs) != 1 || body.RemoveLabelIDs[0] != "INBOX" {
+			t.Errorf("expected RemoveLabelIDs=[INBOX], got %v", body.RemoveLabelIDs)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailModifyResponse{
+			ID:       "msg-123",
+			ThreadID: "thread-456",
+			LabelIDs: []string{"IMPORTANT"},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &archiveEmailAction{conn: conn}
+
+	params, _ := json.Marshal(archiveEmailParams{MessageID: "msg-123"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.archive_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["id"] != "msg-123" {
+		t.Errorf("expected id 'msg-123', got %q", data["id"])
+	}
+	if data["thread_id"] != "thread-456" {
+		t.Errorf("expected thread_id 'thread-456', got %q", data["thread_id"])
+	}
+}
+
+func TestArchiveEmail_MissingMessageID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &archiveEmailAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.archive_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestArchiveEmail_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &archiveEmailAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.archive_email",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestArchiveEmail_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    401,
+				"message": "Invalid Credentials",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &archiveEmailAction{conn: conn}
+
+	params, _ := json.Marshal(archiveEmailParams{MessageID: "msg-123"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.archive_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got: %T (%v)", err, err)
+	}
+}

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -2,7 +2,7 @@
 // connector execution layer. It uses Google REST APIs (Gmail, Calendar, Slides, Sheets, Docs, Chat, Drive)
 // with plain net/http and OAuth 2.0 access tokens provided by the platform.
 //
-// The connector exposes 27 actions covering email (send, reply, list), calendar (create,
+// The connector exposes 28 actions covering email (send, reply, list, archive), calendar (create,
 // list, update, delete, meetings), Slides, Sheets, Docs, Chat, and Drive (list, get,
 // upload, delete, search, create folder).
 package google
@@ -165,6 +165,7 @@ func (c *GoogleConnector) Actions() map[string]connectors.Action {
 		"google.search_drive":          &searchDriveAction{conn: c},
 		"google.create_drive_folder":   &createDriveFolderAction{conn: c},
 		"google.send_email_reply":      &sendEmailReplyAction{conn: c},
+		"google.archive_email":         &archiveEmailAction{conn: c},
 	}
 }
 

--- a/connectors/google/google_test.go
+++ b/connectors/google/google_test.go
@@ -47,6 +47,7 @@ func TestGoogleConnector_Actions(t *testing.T) {
 		"google.search_drive",
 		"google.create_drive_folder",
 		"google.send_email_reply",
+		"google.archive_email",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -114,8 +115,8 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 	if m.Name != "Google" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Google")
 	}
-	if len(m.Actions) != 27 {
-		t.Fatalf("Manifest().Actions has %d items, want 27", len(m.Actions))
+	if len(m.Actions) != 28 {
+		t.Fatalf("Manifest().Actions has %d items, want 28", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -149,6 +150,7 @@ func TestGoogleConnector_Manifest(t *testing.T) {
 		"google.search_drive",
 		"google.create_drive_folder",
 		"google.send_email_reply",
+		"google.archive_email",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -60,8 +60,9 @@ type gmailMessageResponse struct {
 
 // emailSummary is the shape returned to the agent.
 type emailSummary struct {
-	ID      string `json:"id"`
-	From    string `json:"from,omitempty"`
+	ID       string `json:"id"`
+	ThreadID string `json:"thread_id"`
+	From     string `json:"from,omitempty"`
 	To      string `json:"to,omitempty"`
 	Subject string `json:"subject,omitempty"`
 	Snippet string `json:"snippet,omitempty"`
@@ -123,8 +124,9 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 			}
 
 			summary := emailSummary{
-				ID:      msgResp.ID,
-				Snippet: msgResp.Snippet,
+				ID:       msgResp.ID,
+				ThreadID: msgResp.ThreadID,
+				Snippet:  msgResp.Snippet,
 			}
 			for _, h := range msgResp.Payload.Headers {
 				switch h.Name {

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -63,10 +63,10 @@ type emailSummary struct {
 	ID       string `json:"id"`
 	ThreadID string `json:"thread_id"`
 	From     string `json:"from,omitempty"`
-	To      string `json:"to,omitempty"`
-	Subject string `json:"subject,omitempty"`
-	Snippet string `json:"snippet,omitempty"`
-	Date    string `json:"date,omitempty"`
+	To       string `json:"to,omitempty"`
+	Subject  string `json:"subject,omitempty"`
+	Snippet  string `json:"snippet,omitempty"`
+	Date     string `json:"date,omitempty"`
 }
 
 // maxConcurrentFetches limits concurrent Gmail API requests when fetching

--- a/connectors/google/list_emails.go
+++ b/connectors/google/list_emails.go
@@ -110,7 +110,7 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 	var wg sync.WaitGroup
 	for i, m := range listResp.Messages {
 		wg.Add(1)
-		go func(idx int, msgID string) {
+		go func(idx int, msgID, threadID string) {
 			defer wg.Done()
 
 			sem <- struct{}{}        // acquire
@@ -125,7 +125,7 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 
 			summary := emailSummary{
 				ID:       msgResp.ID,
-				ThreadID: msgResp.ThreadID,
+				ThreadID: threadID, // from list response, no need to wait for per-message fetch
 				Snippet:  msgResp.Snippet,
 			}
 			for _, h := range msgResp.Payload.Headers {
@@ -141,7 +141,7 @@ func (a *listEmailsAction) Execute(ctx context.Context, req connectors.ActionReq
 				}
 			}
 			summaries[idx] = summary
-		}(i, m.ID)
+		}(i, m.ID, m.ThreadID)
 	}
 	wg.Wait()
 

--- a/connectors/google/list_emails_test.go
+++ b/connectors/google/list_emails_test.go
@@ -71,12 +71,26 @@ func TestListEmails_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var data map[string]json.RawMessage
+	var data struct {
+		Emails []emailSummary `json:"emails"`
+	}
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	if _, ok := data["emails"]; !ok {
-		t.Error("result missing 'emails' key")
+	if len(data.Emails) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(data.Emails))
+	}
+	if data.Emails[0].ID != "msg-1" {
+		t.Errorf("expected id 'msg-1', got %q", data.Emails[0].ID)
+	}
+	if data.Emails[0].ThreadID != "thread-1" {
+		t.Errorf("expected thread_id 'thread-1', got %q", data.Emails[0].ThreadID)
+	}
+	if data.Emails[0].From != "sender@example.com" {
+		t.Errorf("expected from 'sender@example.com', got %q", data.Emails[0].From)
+	}
+	if data.Emails[0].Subject != "Test Email" {
+		t.Errorf("expected subject 'Test Email', got %q", data.Emails[0].Subject)
 	}
 }
 

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -695,6 +695,22 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "google.archive_email",
+				Name:        "Archive Email",
+				Description: "Archive a Gmail message by removing it from the inbox",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["message_id"],
+					"properties": {
+						"message_id": {
+							"type": "string",
+							"description": "The Gmail message ID to archive (obtained from list_emails)"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -703,6 +719,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				OAuthProvider: "google",
 				OAuthScopes: []string{
 					"https://www.googleapis.com/auth/gmail.send",
+						"https://www.googleapis.com/auth/gmail.modify",
 					"https://www.googleapis.com/auth/gmail.readonly",
 					"https://www.googleapis.com/auth/calendar.events",
 					"https://www.googleapis.com/auth/presentations",
@@ -985,6 +1002,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Reply to emails",
 				Description: "Agent can reply to any existing Gmail thread.",
 				Parameters:  json.RawMessage(`{"thread_id":"*","message_id":"*","body":"*"}`),
+			},
+			{
+				ID:          "tpl_google_archive_email",
+				ActionType:  "google.archive_email",
+				Name:        "Archive emails",
+				Description: "Agent can archive any Gmail message by removing it from the inbox.",
+				Parameters:  json.RawMessage(`{"message_id":"*"}`),
 			},
 		},
 	}

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -719,8 +719,6 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				OAuthProvider: "google",
 				OAuthScopes: []string{
 					"https://www.googleapis.com/auth/gmail.send",
-						"https://www.googleapis.com/auth/gmail.modify",
-					"https://www.googleapis.com/auth/gmail.readonly",
 					"https://www.googleapis.com/auth/calendar.events",
 					"https://www.googleapis.com/auth/presentations",
 					"https://www.googleapis.com/auth/spreadsheets",
@@ -728,6 +726,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 					"https://www.googleapis.com/auth/chat.spaces.readonly",
 					"https://www.googleapis.com/auth/chat.messages.create",
 					"https://www.googleapis.com/auth/drive",
+					"https://www.googleapis.com/auth/gmail.modify",
 				},
 			},
 		},

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -719,6 +719,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				OAuthProvider: "google",
 				OAuthScopes: []string{
 					"https://www.googleapis.com/auth/gmail.send",
+					"https://www.googleapis.com/auth/gmail.readonly",
 					"https://www.googleapis.com/auth/calendar.events",
 					"https://www.googleapis.com/auth/presentations",
 					"https://www.googleapis.com/auth/spreadsheets",

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -698,7 +698,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "google.archive_email",
 				Name:        "Archive Email",
-				Description: "Archive a Gmail message by removing it from the inbox",
+				Description: "Archive a Gmail message (removes from inbox; still accessible via search and All Mail)",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -1006,7 +1006,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				ID:          "tpl_google_archive_email",
 				ActionType:  "google.archive_email",
 				Name:        "Archive emails",
-				Description: "Agent can archive any Gmail message by removing it from the inbox.",
+				Description: "Agent can archive Gmail messages (removes from inbox; still accessible via search and All Mail).",
 				Parameters:  json.RawMessage(`{"message_id":"*"}`),
 			},
 		},

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -698,15 +698,15 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "google.archive_email",
 				Name:        "Archive Email",
-				Description: "Archive a Gmail message (removes from inbox; still accessible via search and All Mail)",
+				Description: "Archive a Gmail thread (removes all messages from inbox; still accessible via search and All Mail)",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["message_id"],
+					"required": ["thread_id"],
 					"properties": {
-						"message_id": {
+						"thread_id": {
 							"type": "string",
-							"description": "The Gmail message ID to archive (obtained from list_emails)"
+							"description": "The Gmail thread ID to archive (obtained from list_emails thread_id field)"
 						}
 					}
 				}`)),
@@ -1007,8 +1007,8 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				ID:          "tpl_google_archive_email",
 				ActionType:  "google.archive_email",
 				Name:        "Archive emails",
-				Description: "Agent can archive Gmail messages (removes from inbox; still accessible via search and All Mail).",
-				Parameters:  json.RawMessage(`{"message_id":"*"}`),
+				Description: "Agent can archive Gmail threads (removes from inbox; still accessible via search and All Mail).",
+				Parameters:  json.RawMessage(`{"thread_id":"*"}`),
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Adds a new `google.archive_email` action that archives Gmail messages by removing the `INBOX` label via the Gmail API `messages.modify` endpoint
- Adds the `gmail.modify` OAuth scope (required for label modifications)
- Includes manifest action definition, permission template, and 4 tests (success, missing param, invalid JSON, auth failure)

## Test plan

### Claude Code
- [x] All existing Google connector tests pass (`go test ./connectors/google/...`)
- [x] New archive email tests pass (success, validation, auth error cases)
- [x] Full project builds (`go build ./...`)

### OpenClaw
- [ ] Verify `gmail.modify` scope doesn't break existing OAuth flows for users who already authorized with `gmail.readonly` + `gmail.send`
- [ ] Manual test: archive an email via the connector and verify it disappears from inbox in Gmail UI

https://claude.ai/code/session_01AFNfhLauG41cNJMXgB4Gom