### PR TITLE
Remove disable-model-invocation from watch skill

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: watch
 description: Poll a GitHub PR for new comments and PR reviews and act on them autonomously. Use when the user wants to monitor a PR for feedback and have Claude implement requested changes automatically.
-disable-model-invocation: true
 argument-hint: "[PR_URL] [--automerge] [--max-turns <N>]"
 ---
 


### PR DESCRIPTION
## Summary

- The watch skill had `disable-model-invocation: true` in its frontmatter, which prevented it from being invoked programmatically via the Skill tool
- The yolo skill's Step 6 uses the Skill tool to call `/watch --automerge`, so this flag was silently blocking the handoff — yolo would complete its PR but never start watching it
- Removed the flag so watch can be invoked by both users and other skills/agents

## Test plan

### Claude Code
- [ ] Verify watch skill appears in available skills list after the change
- [ ] Run yolo on a test issue and confirm it successfully invokes /watch at Step 6

### OpenClaw
- [ ] Confirm /watch still works correctly when invoked directly by a user

https://claude.ai/code/session_01R8jSqRb4RvKKfaB4fjDzpV