### PR TITLE
Add ParameterFieldWidget component (Chunk 2)

### DIFF
--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -1,0 +1,198 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { ExternalLink } from "lucide-react";
+import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
+
+export interface ParameterFieldWidgetProps {
+  /** The parameter key (used for id, fallback label). */
+  paramKey: string;
+  /** The schema property definition. */
+  property: SchemaProperty;
+  /** Current string value of the field. */
+  value: string;
+  /** Callback when the value changes. */
+  onChange: (value: string) => void;
+  /** Whether the field is disabled. */
+  disabled?: boolean;
+  /** Extra className for the input element. */
+  className?: string;
+}
+
+/**
+ * Renders the correct input widget for a parameter based on its `x-ui.widget`
+ * hint. Falls back to a plain text `<Input>` when no widget is specified.
+ */
+export function ParameterFieldWidget({
+  paramKey,
+  property,
+  value,
+  onChange,
+  disabled,
+  className,
+}: ParameterFieldWidgetProps) {
+  const ui = property["x-ui"];
+  const widget: WidgetType = ui?.widget ?? "text";
+  const placeholder = ui?.placeholder;
+  const inputId = `param-${paramKey}`;
+
+  return (
+    <div className="space-y-1">
+      {renderWidget(widget, {
+        inputId,
+        value,
+        onChange,
+        disabled,
+        placeholder,
+        className,
+        enumValues: property.enum,
+      })}
+      <FieldHints ui={ui} />
+    </div>
+  );
+}
+
+interface WidgetRenderProps {
+  inputId: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  enumValues?: string[];
+}
+
+function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
+  switch (widget) {
+    case "select":
+      return <SelectWidget {...props} />;
+    case "textarea":
+      return <TextareaWidget {...props} />;
+    case "toggle":
+      return <ToggleWidget {...props} />;
+    case "number":
+      return <NumberWidget {...props} />;
+    case "date":
+      return <DateWidget {...props} />;
+    case "text":
+    default:
+      return <TextWidget {...props} />;
+  }
+}
+
+function TextWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
+  return (
+    <Input
+      id={inputId}
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
+function SelectWidget({ inputId, value, onChange, disabled, enumValues }: WidgetRenderProps) {
+  return (
+    <select
+      id={inputId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className="border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50"
+      data-testid={`select-${inputId}`}
+    >
+      <option value="">Select…</option>
+      {(enumValues ?? []).map((opt) => (
+        <option key={opt} value={opt}>
+          {opt}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function TextareaWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
+  return (
+    <textarea
+      id={inputId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      placeholder={placeholder}
+      rows={3}
+      className={`border-input bg-background ring-ring/50 w-full rounded-md border px-3 py-2 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 ${className ?? ""}`}
+      data-testid={`textarea-${inputId}`}
+    />
+  );
+}
+
+function ToggleWidget({ inputId, value, onChange, disabled }: WidgetRenderProps) {
+  const checked = value === "true";
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <Switch
+        id={inputId}
+        checked={checked}
+        onCheckedChange={(next) => onChange(String(next))}
+        disabled={disabled}
+      />
+      <Label htmlFor={inputId} className="text-muted-foreground text-sm">
+        {checked ? "Enabled" : "Disabled"}
+      </Label>
+    </div>
+  );
+}
+
+function NumberWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
+  return (
+    <Input
+      id={inputId}
+      type="number"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
+function DateWidget({ inputId, value, onChange, disabled, className }: WidgetRenderProps) {
+  return (
+    <Input
+      id={inputId}
+      type="date"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className={className}
+    />
+  );
+}
+
+/** Renders help_text and help_url hints below the input. */
+function FieldHints({ ui }: { ui?: SchemaPropertyUI }) {
+  if (!ui?.help_text && !ui?.help_url) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2">
+      {ui.help_text && (
+        <p className="text-muted-foreground text-xs">{ui.help_text}</p>
+      )}
+      {ui.help_url && (
+        <a
+          href={ui.help_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline"
+        >
+          Docs
+          <ExternalLink className="size-3" />
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -94,7 +94,7 @@ function TextWidget({ inputId, value, onChange, disabled, placeholder, className
   );
 }
 
-function SelectWidget({ inputId, value, onChange, disabled, enumValues, className }: WidgetRenderProps) {
+function SelectWidget({ inputId, value, onChange, disabled, placeholder, enumValues, className }: WidgetRenderProps) {
   return (
     <select
       id={inputId}
@@ -104,7 +104,7 @@ function SelectWidget({ inputId, value, onChange, disabled, enumValues, classNam
       className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
       data-testid={`select-${inputId}`}
     >
-      <option value="">Select…</option>
+      <option value="">{placeholder ?? "Select…"}</option>
       {(enumValues ?? []).map((opt) => (
         <option key={opt} value={opt}>
           {opt}

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -161,7 +161,7 @@ function NumberWidget({ inputId, value, onChange, disabled, placeholder, classNa
   );
 }
 
-function DateWidget({ inputId, value, onChange, disabled, className }: WidgetRenderProps) {
+function DateWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
   return (
     <Input
       id={inputId}
@@ -169,6 +169,7 @@ function DateWidget({ inputId, value, onChange, disabled, className }: WidgetRen
       value={value}
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
+      placeholder={placeholder}
       className={className}
     />
   );

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -105,7 +105,7 @@ function SelectWidget({ inputId, value, onChange, disabled, placeholder, enumVal
       data-testid={`select-${inputId}`}
     >
       <option value="">{placeholder ?? "Select…"}</option>
-      {(enumValues ?? []).map((opt) => (
+      {(enumValues ?? []).filter((opt) => opt !== "").map((opt) => (
         <option key={opt} value={opt}>
           {opt}
         </option>

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -94,14 +94,14 @@ function TextWidget({ inputId, value, onChange, disabled, placeholder, className
   );
 }
 
-function SelectWidget({ inputId, value, onChange, disabled, enumValues }: WidgetRenderProps) {
+function SelectWidget({ inputId, value, onChange, disabled, enumValues, className }: WidgetRenderProps) {
   return (
     <select
       id={inputId}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
-      className="border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50"
+      className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
       data-testid={`select-${inputId}`}
     >
       <option value="">Select…</option>
@@ -123,7 +123,7 @@ function TextareaWidget({ inputId, value, onChange, disabled, placeholder, class
       disabled={disabled}
       placeholder={placeholder}
       rows={3}
-      className={`border-input bg-background ring-ring/50 w-full rounded-md border px-3 py-2 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 ${className ?? ""}`}
+      className={`border-input bg-background ring-ring/50 w-full rounded-md border px-3 py-2 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
       data-testid={`textarea-${inputId}`}
     />
   );
@@ -184,7 +184,7 @@ function FieldHints({ ui }: { ui?: SchemaPropertyUI }) {
       )}
       {ui.help_url && (
         <a
-          href={ui.help_url}
+          href={/^https?:\/\//i.test(ui.help_url) ? ui.help_url : "#"}
           target="_blank"
           rel="noopener noreferrer"
           className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline"

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -129,7 +129,7 @@ function TextareaWidget({ inputId, value, onChange, disabled, placeholder, class
   );
 }
 
-function ToggleWidget({ inputId, value, onChange, disabled }: WidgetRenderProps) {
+function ToggleWidget({ inputId, value, onChange, disabled, className }: WidgetRenderProps) {
   const checked = value === "true";
   return (
     <div className="flex items-center gap-2 py-1">
@@ -138,6 +138,7 @@ function ToggleWidget({ inputId, value, onChange, disabled }: WidgetRenderProps)
         checked={checked}
         onCheckedChange={(next) => onChange(String(next))}
         disabled={disabled}
+        className={className}
       />
       <Label htmlFor={inputId} className="text-muted-foreground text-sm">
         {checked ? "Enabled" : "Disabled"}
@@ -175,16 +176,18 @@ function DateWidget({ inputId, value, onChange, disabled, className }: WidgetRen
 
 /** Renders help_text and help_url hints below the input. */
 function FieldHints({ ui }: { ui?: SchemaPropertyUI }) {
-  if (!ui?.help_text && !ui?.help_url) return null;
+  const validHelpUrl =
+    ui?.help_url && /^https?:\/\//i.test(ui.help_url) ? ui.help_url : null;
+  if (!ui?.help_text && !validHelpUrl) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-x-2">
-      {ui.help_text && (
+      {ui?.help_text && (
         <p className="text-muted-foreground text-xs">{ui.help_text}</p>
       )}
-      {ui.help_url && /^https?:\/\//i.test(ui.help_url) && (
+      {validHelpUrl && (
         <a
-          href={ui.help_url}
+          href={validHelpUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline"

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -182,9 +182,9 @@ function FieldHints({ ui }: { ui?: SchemaPropertyUI }) {
       {ui.help_text && (
         <p className="text-muted-foreground text-xs">{ui.help_text}</p>
       )}
-      {ui.help_url && (
+      {ui.help_url && /^https?:\/\//i.test(ui.help_url) && (
         <a
-          href={/^https?:\/\//i.test(ui.help_url) ? ui.help_url : "#"}
+          href={ui.help_url}
           target="_blank"
           rel="noopener noreferrer"
           className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline"

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -1,5 +1,4 @@
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { ExternalLink } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
@@ -140,9 +139,9 @@ function ToggleWidget({ inputId, value, onChange, disabled, className }: WidgetR
         disabled={disabled}
         className={className}
       />
-      <Label htmlFor={inputId} className="text-muted-foreground text-sm">
+      <span className="text-muted-foreground text-sm" aria-hidden="true">
         {checked ? "Enabled" : "Disabled"}
-      </Label>
+      </span>
     </div>
   );
 }

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -178,6 +178,15 @@ describe("ParameterFieldWidget", () => {
 
       expect(screen.getByPlaceholderText("0")).toBeInTheDocument();
     });
+
+    it("fires onChange when typed into", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(numberProp);
+
+      await user.type(screen.getByRole("spinbutton"), "5");
+
+      expect(onChange).toHaveBeenCalledWith("5");
+    });
   });
 
   describe("date widget", () => {
@@ -232,6 +241,16 @@ describe("ParameterFieldWidget", () => {
       expect(screen.getByRole("link", { name: /docs/i })).toBeInTheDocument();
     });
 
+    it("sanitizes non-http help_url to '#'", () => {
+      renderWidget({
+        type: "string",
+        "x-ui": { help_url: "javascript:alert(1)" },
+      });
+
+      const link = screen.getByRole("link", { name: /docs/i });
+      expect(link).toHaveAttribute("href", "#");
+    });
+
     it("renders nothing when no hints provided", () => {
       const { container } = renderWidget({ type: "string" });
 
@@ -268,6 +287,40 @@ describe("ParameterFieldWidget", () => {
       );
 
       expect(screen.getByRole("switch")).toBeDisabled();
+    });
+
+    it("disables the textarea when disabled", () => {
+      renderWidget(
+        { type: "string", "x-ui": { widget: "textarea" } },
+        "",
+        vi.fn(),
+        true,
+      );
+
+      expect(screen.getByTestId("textarea-param-test_field")).toBeDisabled();
+    });
+
+    it("disables the number input when disabled", () => {
+      renderWidget(
+        { type: "number", "x-ui": { widget: "number" } },
+        "",
+        vi.fn(),
+        true,
+      );
+
+      expect(screen.getByRole("spinbutton")).toBeDisabled();
+    });
+
+    it("disables the date input when disabled", () => {
+      renderWidget(
+        { type: "string", "x-ui": { widget: "date" } },
+        "",
+        vi.fn(),
+        true,
+      );
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input).toBeDisabled();
     });
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -232,6 +232,9 @@ describe("ParameterFieldWidget", () => {
       await user.type(input, "2025-06-01");
 
       expect(onChange).toHaveBeenCalled();
+      // Verify the handler forwards a string (not undefined/hardcoded)
+      const lastCall = onChange.mock.calls.at(-1)?.[0] as unknown;
+      expect(typeof lastCall).toBe("string");
     });
   });
 

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -161,13 +161,22 @@ describe("ParameterFieldWidget", () => {
       expect(screen.getByText("Enabled")).toBeInTheDocument();
     });
 
-    it("fires onChange with 'true'/'false' strings", async () => {
+    it("fires onChange with 'true' when toggled on", async () => {
       const user = userEvent.setup();
       const { onChange } = renderWidget(toggleProp, "false");
 
       await user.click(screen.getByRole("switch"));
 
       expect(onChange).toHaveBeenCalledWith("true");
+    });
+
+    it("fires onChange with 'false' when toggled off", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(toggleProp, "true");
+
+      await user.click(screen.getByRole("switch"));
+
+      expect(onChange).toHaveBeenCalledWith("false");
     });
   });
 

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -86,6 +86,17 @@ describe("ParameterFieldWidget", () => {
       expect(screen.getByText("Select…")).toBeInTheDocument();
     });
 
+    it("uses x-ui.placeholder as default option text", () => {
+      renderWidget({
+        type: "string",
+        enum: ["usd", "eur"],
+        "x-ui": { widget: "select", placeholder: "Choose a currency" },
+      });
+
+      expect(screen.getByText("Choose a currency")).toBeInTheDocument();
+      expect(screen.queryByText("Select…")).not.toBeInTheDocument();
+    });
+
     it("fires onChange when an option is selected", async () => {
       const user = userEvent.setup();
       const { onChange } = renderWidget(selectProp);

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -214,6 +214,16 @@ describe("ParameterFieldWidget", () => {
       expect(input).toBeInTheDocument();
       expect(input.type).toBe("date");
     });
+
+    it("fires onChange when a date is entered", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(dateProp);
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      await user.type(input, "2025-06-01");
+
+      expect(onChange).toHaveBeenCalled();
+    });
   });
 
   describe("help hints", () => {
@@ -252,14 +262,13 @@ describe("ParameterFieldWidget", () => {
       expect(screen.getByRole("link", { name: /docs/i })).toBeInTheDocument();
     });
 
-    it("sanitizes non-http help_url to '#'", () => {
+    it("does not render link for non-http help_url", () => {
       renderWidget({
         type: "string",
         "x-ui": { help_url: "javascript:alert(1)" },
       });
 
-      const link = screen.getByRole("link", { name: /docs/i });
-      expect(link).toHaveAttribute("href", "#");
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
     });
 
     it("renders nothing when no hints provided", () => {

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -233,7 +233,8 @@ describe("ParameterFieldWidget", () => {
 
       expect(onChange).toHaveBeenCalled();
       // Verify the handler forwards a string (not undefined/hardcoded)
-      const lastCall = onChange.mock.calls.at(-1)?.[0] as unknown;
+      const calls = onChange.mock.calls;
+      const lastCall = calls[calls.length - 1]?.[0] as unknown;
       expect(typeof lastCall).toBe("string");
     });
   });

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -1,0 +1,273 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders } from "../../../../test-helpers";
+import { ParameterFieldWidget } from "../ParameterFieldWidget";
+import type { SchemaProperty } from "@/lib/parameterSchema";
+
+vi.mock("../../../../lib/supabaseClient");
+
+function renderWidget(
+  property: SchemaProperty,
+  value = "",
+  onChange = vi.fn(),
+  disabled = false,
+) {
+  return {
+    onChange,
+    ...renderWithProviders(
+      <ParameterFieldWidget
+        paramKey="test_field"
+        property={property}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+      />,
+    ),
+  };
+}
+
+describe("ParameterFieldWidget", () => {
+  describe("text widget (default)", () => {
+    it("renders a text input when no x-ui widget is specified", () => {
+      renderWidget({ type: "string" });
+
+      const input = screen.getByRole("textbox");
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute("type", "text");
+    });
+
+    it("renders a text input when x-ui.widget is 'text'", () => {
+      renderWidget({ type: "string", "x-ui": { widget: "text" } });
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("type", "text");
+    });
+
+    it("uses x-ui.placeholder", () => {
+      renderWidget({
+        type: "string",
+        "x-ui": { placeholder: "Enter customer ID" },
+      });
+
+      expect(screen.getByPlaceholderText("Enter customer ID")).toBeInTheDocument();
+    });
+
+    it("fires onChange when typed into", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget({ type: "string" });
+
+      await user.type(screen.getByRole("textbox"), "a");
+
+      expect(onChange).toHaveBeenCalledWith("a");
+    });
+  });
+
+  describe("select widget", () => {
+    const selectProp: SchemaProperty = {
+      type: "string",
+      enum: ["usd", "eur", "gbp"],
+      "x-ui": { widget: "select" },
+    };
+
+    it("renders a select element with enum options", () => {
+      renderWidget(selectProp);
+
+      const select = screen.getByTestId("select-param-test_field");
+      expect(select.tagName).toBe("SELECT");
+      expect(screen.getByText("usd")).toBeInTheDocument();
+      expect(screen.getByText("eur")).toBeInTheDocument();
+      expect(screen.getByText("gbp")).toBeInTheDocument();
+    });
+
+    it("includes a placeholder option", () => {
+      renderWidget(selectProp);
+
+      expect(screen.getByText("Select…")).toBeInTheDocument();
+    });
+
+    it("fires onChange when an option is selected", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(selectProp);
+
+      await user.selectOptions(
+        screen.getByTestId("select-param-test_field"),
+        "eur",
+      );
+
+      expect(onChange).toHaveBeenCalledWith("eur");
+    });
+  });
+
+  describe("textarea widget", () => {
+    const textareaProp: SchemaProperty = {
+      type: "string",
+      "x-ui": { widget: "textarea", placeholder: "Enter description" },
+    };
+
+    it("renders a textarea element", () => {
+      renderWidget(textareaProp);
+
+      const textarea = screen.getByTestId("textarea-param-test_field");
+      expect(textarea.tagName).toBe("TEXTAREA");
+    });
+
+    it("applies placeholder", () => {
+      renderWidget(textareaProp);
+
+      expect(screen.getByPlaceholderText("Enter description")).toBeInTheDocument();
+    });
+
+    it("fires onChange when typed into", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(textareaProp);
+
+      await user.type(
+        screen.getByTestId("textarea-param-test_field"),
+        "x",
+      );
+
+      expect(onChange).toHaveBeenCalledWith("x");
+    });
+  });
+
+  describe("toggle widget", () => {
+    const toggleProp: SchemaProperty = {
+      type: "boolean",
+      "x-ui": { widget: "toggle" },
+    };
+
+    it("renders a switch component", () => {
+      renderWidget(toggleProp, "false");
+
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+      expect(screen.getByText("Disabled")).toBeInTheDocument();
+    });
+
+    it("shows Enabled when value is 'true'", () => {
+      renderWidget(toggleProp, "true");
+
+      expect(screen.getByText("Enabled")).toBeInTheDocument();
+    });
+
+    it("fires onChange with 'true'/'false' strings", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(toggleProp, "false");
+
+      await user.click(screen.getByRole("switch"));
+
+      expect(onChange).toHaveBeenCalledWith("true");
+    });
+  });
+
+  describe("number widget", () => {
+    const numberProp: SchemaProperty = {
+      type: "number",
+      "x-ui": { widget: "number", placeholder: "0" },
+    };
+
+    it("renders a number input", () => {
+      renderWidget(numberProp);
+
+      const input = screen.getByRole("spinbutton");
+      expect(input).toHaveAttribute("type", "number");
+    });
+
+    it("applies placeholder", () => {
+      renderWidget(numberProp);
+
+      expect(screen.getByPlaceholderText("0")).toBeInTheDocument();
+    });
+  });
+
+  describe("date widget", () => {
+    const dateProp: SchemaProperty = {
+      type: "string",
+      "x-ui": { widget: "date" },
+    };
+
+    it("renders a date input", () => {
+      renderWidget(dateProp);
+
+      // Date inputs don't have a specific role; query by id
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input).toBeInTheDocument();
+      expect(input.type).toBe("date");
+    });
+  });
+
+  describe("help hints", () => {
+    it("renders help_text below the input", () => {
+      renderWidget({
+        type: "string",
+        "x-ui": { help_text: "Use the Stripe customer ID format" },
+      });
+
+      expect(
+        screen.getByText("Use the Stripe customer ID format"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a help_url link", () => {
+      renderWidget({
+        type: "string",
+        "x-ui": { help_url: "https://example.com/docs" },
+      });
+
+      const link = screen.getByRole("link", { name: /docs/i });
+      expect(link).toHaveAttribute("href", "https://example.com/docs");
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+
+    it("renders both help_text and help_url together", () => {
+      renderWidget({
+        type: "string",
+        "x-ui": {
+          help_text: "Some help",
+          help_url: "https://example.com",
+        },
+      });
+
+      expect(screen.getByText("Some help")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /docs/i })).toBeInTheDocument();
+    });
+
+    it("renders nothing when no hints provided", () => {
+      const { container } = renderWidget({ type: "string" });
+
+      // Only the input should be present, no hint paragraphs
+      expect(container.querySelectorAll("p")).toHaveLength(0);
+      expect(container.querySelectorAll("a")).toHaveLength(0);
+    });
+  });
+
+  describe("disabled state", () => {
+    it("disables the text input when disabled", () => {
+      renderWidget({ type: "string" }, "", vi.fn(), true);
+
+      expect(screen.getByRole("textbox")).toBeDisabled();
+    });
+
+    it("disables the select when disabled", () => {
+      renderWidget(
+        { type: "string", enum: ["a"], "x-ui": { widget: "select" } },
+        "",
+        vi.fn(),
+        true,
+      );
+
+      expect(screen.getByTestId("select-param-test_field")).toBeDisabled();
+    });
+
+    it("disables the toggle when disabled", () => {
+      renderWidget(
+        { type: "boolean", "x-ui": { widget: "toggle" } },
+        "false",
+        vi.fn(),
+        true,
+      );
+
+      expect(screen.getByRole("switch")).toBeDisabled();
+    });
+  });
+});

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

- Adds `ParameterFieldWidget` component that renders the correct input widget based on `x-ui.widget` value from parameter schemas
- Supports all six widget types: text (default), select, textarea, toggle, number, date
- Renders `help_text` and `help_url` hints below inputs; falls back to plain `<Input>` when no `x-ui` is specified
- Includes comprehensive test coverage for all widget types, help hints, and disabled state (23 tests)

Part of #551

## Test plan

### Claude Code
- [x] All frontend tests pass (781 tests, 91 files)
- [x] TypeScript compilation passes with no errors
- [x] Each widget type has test coverage for rendering and interaction
- [x] Disabled state tested for text, select, and toggle widgets
- [x] Help text and help URL rendering tested

### OpenClaw
- [ ] Visual review of widget rendering in browser
- [ ] Verify toggle widget UX feels natural with string-based value ("true"/"false")
- [ ] Review select widget styling matches design system

https://claude.ai/code/session_01DSeJbJQFgFWs4nfdyTdvoJ