### PR TITLE
Wire standing approval execution notifications (Chunk 2E)

### DIFF
--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -220,6 +220,9 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		return
 	}
 
+	// ── Notify user of standing approval execution (fire-and-forget) ─
+	NotifyStandingApprovalExecution(r.Context(), deps, exec, agent, req.Action.Type, params)
+
 	var actionResultPtr *json.RawMessage
 	if result != nil {
 		actionResultPtr = &result.Data

--- a/api/standing_approval_notify.go
+++ b/api/standing_approval_notify.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/notify"
+)
+
+// NotifyStandingApprovalExecution dispatches an informational notification to
+// the user when an agent executes an action via a standing approval. This is
+// fire-and-forget: errors are logged, not returned, so the HTTP response is
+// never blocked by delivery latency.
+//
+// Call this after a successful RecordStandingApprovalExecutionByAgent +
+// connector execution in the standing approval path.
+func NotifyStandingApprovalExecution(ctx context.Context, deps *Deps, exec *db.StandingApprovalExecution, agent *db.Agent, actionType string, parameters json.RawMessage) {
+	if deps.Notifier == nil {
+		return
+	}
+
+	if deps.BaseURL == "" {
+		log.Printf("notify: skipping standing execution notification — BASE_URL is not configured")
+		return
+	}
+
+	// Fetch the user's profile for recipient contact info.
+	profile, err := db.GetProfileByUserID(ctx, deps.DB, exec.UserID)
+	if err != nil {
+		log.Printf("notify: standing execution: failed to fetch profile for user %s: %v", exec.UserID, err)
+		return
+	}
+
+	agentName := extractAgentName(agent)
+	activityURL := fmt.Sprintf("%s/activity", deps.BaseURL)
+
+	// Build the context JSON with execution count and max executions.
+	execContext := map[string]int{
+		"execution_count": exec.ExecutionCount,
+	}
+	if exec.MaxExecutions != nil {
+		execContext["max_executions"] = *exec.MaxExecutions
+	}
+	contextJSON, _ := json.Marshal(execContext)
+
+	// Build the action JSON with type and parameters for the notification
+	// templates (used for parameter summary in emails).
+	actionJSON := buildActionJSON(actionType, parameters)
+
+	approval := notify.Approval{
+		ApprovalID:  exec.StandingApprovalID,
+		AgentID:     exec.AgentID,
+		AgentName:   agentName,
+		Action:      actionJSON,
+		Context:     contextJSON,
+		ApprovalURL: activityURL,
+		CreatedAt:   time.Now(),
+		Type:        notify.NotificationTypeStandingExecution,
+	}
+
+	recipient := notify.Recipient{
+		UserID:   profile.ID,
+		Username: profile.Username,
+		Email:    profile.Email,
+		Phone:    profile.Phone,
+	}
+
+	deps.Notifier.Dispatch(ctx, approval, recipient)
+	log.Printf("notify: dispatched standing execution notification for SA %s to user %s", exec.StandingApprovalID, exec.UserID)
+}
+
+// buildActionJSON constructs the action JSON expected by notification templates:
+// {"type": "...", "parameters": {...}}
+func buildActionJSON(actionType string, parameters json.RawMessage) json.RawMessage {
+	action := map[string]json.RawMessage{
+		"type": mustMarshal(actionType),
+	}
+	if len(parameters) > 0 {
+		action["parameters"] = parameters
+	}
+	result, _ := json.Marshal(action)
+	return result
+}
+
+func mustMarshal(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/api/standing_approval_notify_test.go
+++ b/api/standing_approval_notify_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/notify"
+)
+
+func TestNotifyStandingApprovalExecution_NilNotifier(t *testing.T) {
+	t.Parallel()
+	// Should not panic when Notifier is nil.
+	deps := &Deps{Notifier: nil}
+	exec := &db.StandingApprovalExecution{UserID: "u1", StandingApprovalID: "sa1"}
+	agent := &db.Agent{AgentID: 1}
+	NotifyStandingApprovalExecution(context.Background(), deps, exec, agent, "test.action", nil)
+}
+
+func TestNotifyStandingApprovalExecution_EmptyBaseURL(t *testing.T) {
+	t.Parallel()
+	// Should skip when BaseURL is empty (even with a notifier).
+	deps := &Deps{
+		Notifier: notify.NewDispatcher(nil, nil),
+		BaseURL:  "",
+	}
+	exec := &db.StandingApprovalExecution{UserID: "u1", StandingApprovalID: "sa1"}
+	agent := &db.Agent{AgentID: 1}
+	NotifyStandingApprovalExecution(context.Background(), deps, exec, agent, "test.action", nil)
+}
+
+func TestBuildActionJSON_WithParameters(t *testing.T) {
+	t.Parallel()
+	params := json.RawMessage(`{"repo":"myrepo","title":"Bug fix"}`)
+	result := buildActionJSON("github.issues.create", params)
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to parse action JSON: %v", err)
+	}
+
+	var actionType string
+	if err := json.Unmarshal(parsed["type"], &actionType); err != nil {
+		t.Fatalf("failed to parse type: %v", err)
+	}
+	if actionType != "github.issues.create" {
+		t.Errorf("expected type 'github.issues.create', got: %s", actionType)
+	}
+
+	if _, ok := parsed["parameters"]; !ok {
+		t.Error("expected parameters key in action JSON")
+	}
+}
+
+func TestBuildActionJSON_WithoutParameters(t *testing.T) {
+	t.Parallel()
+	result := buildActionJSON("slack.send", nil)
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to parse action JSON: %v", err)
+	}
+
+	var actionType string
+	if err := json.Unmarshal(parsed["type"], &actionType); err != nil {
+		t.Fatalf("failed to parse type: %v", err)
+	}
+	if actionType != "slack.send" {
+		t.Errorf("expected type 'slack.send', got: %s", actionType)
+	}
+
+	if _, ok := parsed["parameters"]; ok {
+		t.Error("expected no parameters key when nil")
+	}
+}
+
+func TestBuildActionJSON_EmptyParameters(t *testing.T) {
+	t.Parallel()
+	// Empty byte slice should be treated the same as nil.
+	result := buildActionJSON("test.action", json.RawMessage{})
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to parse action JSON: %v", err)
+	}
+
+	if _, ok := parsed["parameters"]; ok {
+		t.Error("expected no parameters key for empty slice")
+	}
+}


### PR DESCRIPTION
## Summary

- Create `api/standing_approval_notify.go` with `NotifyStandingApprovalExecution()` helper that dispatches informational notifications (email, SMS, push) when an agent executes an action via a standing approval
- Wire the notification dispatch into `api/action_execute.go` after successful standing approval execution + connector execution — fire-and-forget via `deps.Notifier.Dispatch()`, never blocks the HTTP response
- No in-app banner — relies on channel-level delivery only (email, SMS, push) using the `standing_execution` notification type and templates from Phase 1B

Part of #550

## Test plan

### Claude Code
- [x] All API tests pass (`go test ./api/...`)
- [x] All notify tests pass (`go test ./notify/...`)
- [x] `make build` succeeds
- [x] New unit tests cover nil notifier, empty BaseURL, and action JSON construction

### OpenClaw
- [ ] Integration test: trigger standing approval execution and verify email/SMS/push notifications are received
- [ ] Verify no in-app banner is shown for standing execution notifications
- [ ] Review notification content matches expected format from Phase 1B templates

https://claude.ai/code/session_016HE4bE5vhcVKrBiqMPCgHR