### PR TITLE
Standing approval display improvements (Phase 2F)

### DIFF
--- a/frontend/src/hooks/useActionConfigMap.ts
+++ b/frontend/src/hooks/useActionConfigMap.ts
@@ -7,6 +7,9 @@ import type { ActionConfiguration } from "./useActionConfigs";
 /**
  * Fetches action configurations for multiple agents and returns
  * a Map keyed by config ID for quick lookups.
+ *
+ * Uses TanStack Query v5 `combine` to produce a stable return value
+ * that only recalculates when query data actually changes.
  */
 export function useActionConfigMap(agentIds: number[]) {
   const { session } = useAuth();
@@ -22,7 +25,7 @@ export function useActionConfigMap(agentIds: number[]) {
     [agentIds],
   );
 
-  const results = useQueries({
+  return useQueries({
     queries: uniqueIds.map((agentId) => ({
       queryKey: ["action-configs", agentId],
       queryFn: async () => {
@@ -37,20 +40,17 @@ export function useActionConfigMap(agentIds: number[]) {
       },
       enabled: !!accessToken,
     })),
-  });
-
-  const configMap = useMemo(() => {
-    const map = new Map<string, ActionConfiguration>();
-    for (const result of results) {
-      const configs = result.data?.data;
-      if (configs) {
-        for (const config of configs) {
-          map.set(config.id, config);
+    combine: (results) => {
+      const map = new Map<string, ActionConfiguration>();
+      for (const result of results) {
+        const configs = result.data?.data;
+        if (configs) {
+          for (const config of configs) {
+            map.set(config.id, config);
+          }
         }
       }
-    }
-    return map;
-  }, [results]);
-
-  return configMap;
+      return map;
+    },
+  });
 }

--- a/frontend/src/hooks/useActionConfigMap.ts
+++ b/frontend/src/hooks/useActionConfigMap.ts
@@ -1,0 +1,56 @@
+import { useMemo, useRef } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { ActionConfiguration } from "./useActionConfigs";
+
+/**
+ * Fetches action configurations for multiple agents and returns
+ * a Map keyed by config ID for quick lookups.
+ */
+export function useActionConfigMap(agentIds: number[]) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const uniqueIds = useMemo(
+    () => [...new Set(agentIds.filter((id) => id > 0))],
+    [agentIds],
+  );
+
+  const results = useQueries({
+    queries: uniqueIds.map((agentId) => ({
+      queryKey: ["action-configs", agentId],
+      queryFn: async () => {
+        const token = tokenRef.current;
+        if (!token) throw new Error("Missing access token");
+        const { data, error } = await client.GET("/v1/action-configurations", {
+          headers: { Authorization: `Bearer ${token}` },
+          params: { query: { agent_id: agentId } },
+        });
+        if (error) throw new Error("Failed to load action configurations");
+        return data;
+      },
+      enabled: !!accessToken,
+    })),
+  });
+
+  const configMap = useMemo(() => {
+    const map = new Map<string, ActionConfiguration>();
+    for (const result of results) {
+      const configs = result.data?.data;
+      if (configs) {
+        for (const config of configs) {
+          map.set(config.id, config);
+        }
+      }
+    }
+    return map;
+  }, [results]);
+
+  return configMap;
+}

--- a/frontend/src/lib/constraints.ts
+++ b/frontend/src/lib/constraints.ts
@@ -1,0 +1,9 @@
+/** Check if a stored parameter value is a $pattern wrapper object. */
+export function isPatternWrapper(value: unknown): value is { $pattern: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "$pattern" in value &&
+    typeof (value as Record<string, unknown>).$pattern === "string"
+  );
+}

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -186,12 +186,5 @@ export function buildParametersFromForm(
   return parameters;
 }
 
-/** Check if a stored parameter value is a $pattern wrapper object. */
-export function isPatternWrapper(value: unknown): value is { $pattern: string } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "$pattern" in value &&
-    typeof (value as Record<string, unknown>).$pattern === "string"
-  );
-}
+// Re-exported from shared lib for backward compatibility.
+export { isPatternWrapper } from "@/lib/constraints";

--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import { TableRow, TableCell } from "@/components/ui/table";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
-import { isPatternWrapper, WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
+import { isPatternWrapper } from "@/lib/constraints";
+import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 
 interface ActionConfigRowProps {
   config: ActionConfiguration;

--- a/frontend/src/pages/agents/connectors/TemplatePicker.tsx
+++ b/frontend/src/pages/agents/connectors/TemplatePicker.tsx
@@ -1,7 +1,7 @@
 import { Check, FileText, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
-import { isPatternWrapper } from "./ActionConfigFormFields";
+import { isPatternWrapper } from "@/lib/constraints";
 
 interface TemplatePickerProps {
   templates: ActionConfigTemplate[];

--- a/frontend/src/pages/dashboard/ConstraintsSummary.tsx
+++ b/frontend/src/pages/dashboard/ConstraintsSummary.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { Asterisk, Lock, Regex } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { isPatternWrapper } from "@/pages/agents/connectors/ActionConfigFormFields";
+
+/** Maximum number of constraints shown before collapsing with "+N more". */
+const VISIBLE_LIMIT = 2;
+
+/** Maximum characters for a constraint value before truncating. */
+const VALUE_TRUNCATE_LENGTH = 24;
+
+type ConstraintMode = "fixed" | "pattern" | "wildcard";
+
+interface ParsedConstraint {
+  name: string;
+  mode: ConstraintMode;
+  value: string;
+}
+
+function parseConstraints(
+  constraints: Record<string, unknown> | null | undefined,
+): ParsedConstraint[] {
+  if (!constraints || typeof constraints !== "object") return [];
+  return Object.entries(constraints).map(([name, raw]) => {
+    if (raw === "*") {
+      return { name, mode: "wildcard" as const, value: "*" };
+    }
+    if (isPatternWrapper(raw)) {
+      return { name, mode: "pattern" as const, value: raw.$pattern };
+    }
+    return { name, mode: "fixed" as const, value: String(raw) };
+  });
+}
+
+const modeIcon: Record<ConstraintMode, React.ReactNode> = {
+  fixed: <Lock className="size-3" />,
+  pattern: <Regex className="size-3" />,
+  wildcard: <Asterisk className="size-3" />,
+};
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max - 1) + "\u2026";
+}
+
+function ConstraintBadge({ constraint }: { constraint: ParsedConstraint }) {
+  const displayValue =
+    constraint.mode === "wildcard"
+      ? "any"
+      : truncate(constraint.value, VALUE_TRUNCATE_LENGTH);
+
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 font-mono text-xs"
+      title={`${constraint.name}: ${constraint.value} (${constraint.mode})`}
+    >
+      {modeIcon[constraint.mode]}
+      <span className="font-sans font-medium">{constraint.name}</span>
+      <span className="text-muted-foreground">{displayValue}</span>
+    </Badge>
+  );
+}
+
+interface ConstraintsSummaryProps {
+  constraints: Record<string, unknown> | null | undefined;
+}
+
+export function ConstraintsSummary({ constraints }: ConstraintsSummaryProps) {
+  const [expanded, setExpanded] = useState(false);
+  const parsed = parseConstraints(constraints);
+
+  if (parsed.length === 0) {
+    return (
+      <span className="text-muted-foreground text-xs italic">
+        No constraints
+      </span>
+    );
+  }
+
+  const visible = expanded ? parsed : parsed.slice(0, VISIBLE_LIMIT);
+  const remaining = parsed.length - VISIBLE_LIMIT;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {visible.map((c) => (
+        <ConstraintBadge key={c.name} constraint={c} />
+      ))}
+      {!expanded && remaining > 0 && (
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+          onClick={() => setExpanded(true)}
+        >
+          +{remaining} more
+        </button>
+      )}
+      {expanded && parsed.length > VISIBLE_LIMIT && (
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+          onClick={() => setExpanded(false)}
+        >
+          show less
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/ConstraintsSummary.tsx
+++ b/frontend/src/pages/dashboard/ConstraintsSummary.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Asterisk, Lock, Regex } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { isPatternWrapper } from "@/pages/agents/connectors/ActionConfigFormFields";
+import { isPatternWrapper } from "@/lib/constraints";
 
 /** Maximum number of constraints shown before collapsing with "+N more". */
 const VISIBLE_LIMIT = 2;

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Loader2, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LimitBadge } from "@/components/LimitBadge";
@@ -23,10 +23,14 @@ import {
   useStandingApprovals,
   type StandingApproval,
 } from "@/hooks/useStandingApprovals";
-import { useAgents } from "@/hooks/useAgents";
+import { useAgents, type Agent } from "@/hooks/useAgents";
+import type { ActionConfiguration } from "@/hooks/useActionConfigs";
+import { useActionConfigMap } from "@/hooks/useActionConfigMap";
 import { useResourceLimit } from "@/hooks/useResourceLimit";
+import { getAgentDisplayName } from "@/lib/agents";
 import { RevokeStandingApprovalDialog } from "./RevokeStandingApprovalDialog";
 import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
+import { ConstraintsSummary } from "./ConstraintsSummary";
 
 function formatExpiresIn(expiresAt: string | null | undefined): string {
   if (!expiresAt) return "\u2014";
@@ -69,18 +73,57 @@ function ExecutionBadge({
   );
 }
 
+function resolveAgentName(
+  agentId: number,
+  agentMap: Map<number, Agent>,
+): string {
+  const agent = agentMap.get(agentId);
+  return agent ? getAgentDisplayName(agent) : `Agent ${agentId}`;
+}
+
+function resolveActionConfigName(
+  sourceId: string | null | undefined,
+  configMap: Map<string, ActionConfiguration>,
+): string | null {
+  if (!sourceId) return null;
+  const config = configMap.get(sourceId);
+  return config?.name ?? null;
+}
+
 function StandingApprovalRow({
   sa,
   onRevoke,
+  agentMap,
+  configMap,
 }: {
   sa: StandingApproval;
   onRevoke: (sa: StandingApproval) => void;
+  agentMap: Map<number, Agent>;
+  configMap: Map<string, ActionConfiguration>;
 }) {
+  const agentName = resolveAgentName(sa.agent_id, agentMap);
+  const configName = resolveActionConfigName(
+    sa.source_action_configuration_id,
+    configMap,
+  );
+
   return (
     <TableRow>
-      <TableCell className="font-medium">{sa.action_type}</TableCell>
+      <TableCell className="font-medium">
+        <div>
+          <span>{sa.action_type}</span>
+          {configName && (
+            <span className="text-muted-foreground block text-xs">
+              {configName}
+            </span>
+          )}
+        </div>
+      </TableCell>
       <TableCell className="max-w-[200px] truncate text-xs">
-        {sa.agent_id}
+        {agentName}
+      </TableCell>
+      <TableCell>
+        <ConstraintsSummary constraints={sa.constraints} />
       </TableCell>
       <TableCell>
         <ExecutionBadge
@@ -124,6 +167,18 @@ export function StandingApprovalsCard() {
   const { standingApprovals, isLoading, error, refetch } =
     useStandingApprovals();
   const { agents } = useAgents();
+  const agentIds = useMemo(
+    () => standingApprovals.map((sa) => sa.agent_id),
+    [standingApprovals],
+  );
+  const configMap = useActionConfigMap(agentIds);
+  const agentMap = useMemo(() => {
+    const map = new Map<number, Agent>();
+    for (const agent of agents) {
+      map.set(agent.agent_id, agent);
+    }
+    return map;
+  }, [agents]);
   const {
     max: maxStandingApprovals,
     current: standingApprovalCount,
@@ -167,6 +222,8 @@ export function StandingApprovalsCard() {
           <StandingApprovalsTable
             approvals={standingApprovals}
             onRevoke={(sa) => setRevokeTarget(sa)}
+            agentMap={agentMap}
+            configMap={configMap}
           />
         )}
       </CardContent>
@@ -209,13 +266,17 @@ export function StandingApprovalsCard() {
 function StandingApprovalsTable({
   approvals,
   onRevoke,
+  agentMap,
+  configMap,
 }: {
   approvals: StandingApproval[];
   onRevoke: (sa: StandingApproval) => void;
+  agentMap: Map<number, Agent>;
+  configMap: Map<string, ActionConfiguration>;
 }) {
   return (
     <div className="-mx-3 overflow-x-auto sm:mx-0">
-      <div className="min-w-[480px] overflow-hidden rounded-lg sm:min-w-0">
+      <div className="min-w-[600px] overflow-hidden rounded-lg sm:min-w-0">
         <Table>
           <TableHeader>
             <TableRow className="border-none bg-primary hover:bg-primary">
@@ -224,6 +285,9 @@ function StandingApprovalsTable({
               </TableHead>
               <TableHead className="font-semibold text-primary-foreground">
                 Agent
+              </TableHead>
+              <TableHead className="font-semibold text-primary-foreground">
+                Constraints
               </TableHead>
               <TableHead className="font-semibold text-primary-foreground">
                 Executions
@@ -242,6 +306,8 @@ function StandingApprovalsTable({
                 key={sa.standing_approval_id}
                 sa={sa}
                 onRevoke={onRevoke}
+                agentMap={agentMap}
+                configMap={configMap}
               />
             ))}
           </TableBody>

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -168,7 +168,10 @@ export function StandingApprovalsCard() {
     useStandingApprovals();
   const { agents } = useAgents();
   const agentIds = useMemo(
-    () => standingApprovals.map((sa) => sa.agent_id),
+    () =>
+      standingApprovals
+        .filter((sa) => !!sa.source_action_configuration_id)
+        .map((sa) => sa.agent_id),
     [standingApprovals],
   );
   const configMap = useActionConfigMap(agentIds);

--- a/frontend/src/pages/dashboard/__tests__/ConstraintsSummary.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ConstraintsSummary.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ConstraintsSummary } from "../ConstraintsSummary";
+
+describe("ConstraintsSummary", () => {
+  it("renders 'No constraints' when constraints is null", () => {
+    render(<ConstraintsSummary constraints={null} />);
+    expect(screen.getByText("No constraints")).toBeInTheDocument();
+  });
+
+  it("renders 'No constraints' when constraints is empty object", () => {
+    render(<ConstraintsSummary constraints={{}} />);
+    expect(screen.getByText("No constraints")).toBeInTheDocument();
+  });
+
+  it("renders fixed constraint with Lock icon and value", () => {
+    render(<ConstraintsSummary constraints={{ repo: "my-repo" }} />);
+    expect(screen.getByText("repo")).toBeInTheDocument();
+    expect(screen.getByText("my-repo")).toBeInTheDocument();
+  });
+
+  it("renders wildcard constraint showing 'any'", () => {
+    render(<ConstraintsSummary constraints={{ subject: "*" }} />);
+    expect(screen.getByText("subject")).toBeInTheDocument();
+    expect(screen.getByText("any")).toBeInTheDocument();
+  });
+
+  it("renders pattern constraint with $pattern wrapper", () => {
+    render(
+      <ConstraintsSummary
+        constraints={{ to: { $pattern: "*@mycompany.com" } }}
+      />,
+    );
+    expect(screen.getByText("to")).toBeInTheDocument();
+    expect(screen.getByText("*@mycompany.com")).toBeInTheDocument();
+  });
+
+  it("truncates long values", () => {
+    const longValue = "a".repeat(30);
+    render(<ConstraintsSummary constraints={{ field: longValue }} />);
+    // Should be truncated (23 chars + ellipsis)
+    expect(screen.queryByText(longValue)).not.toBeInTheDocument();
+  });
+
+  it("shows '+N more' when more than 2 constraints", () => {
+    render(
+      <ConstraintsSummary
+        constraints={{
+          repo: "my-repo",
+          branch: "main",
+          owner: "me",
+          label: "bug",
+        }}
+      />,
+    );
+    expect(screen.getByText("repo")).toBeInTheDocument();
+    expect(screen.getByText("branch")).toBeInTheDocument();
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+    // Hidden constraints
+    expect(screen.queryByText("owner")).not.toBeInTheDocument();
+  });
+
+  it("expands to show all constraints on click", () => {
+    render(
+      <ConstraintsSummary
+        constraints={{
+          repo: "my-repo",
+          branch: "main",
+          owner: "me",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByText("+1 more"));
+    expect(screen.getByText("owner")).toBeInTheDocument();
+    expect(screen.getByText("show less")).toBeInTheDocument();
+  });
+
+  it("collapses back on 'show less' click", () => {
+    render(
+      <ConstraintsSummary
+        constraints={{
+          repo: "my-repo",
+          branch: "main",
+          owner: "me",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByText("+1 more"));
+    fireEvent.click(screen.getByText("show less"));
+    expect(screen.queryByText("owner")).not.toBeInTheDocument();
+    expect(screen.getByText("+1 more")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
@@ -16,6 +16,31 @@ const mockStandingApprovals = [
     execution_count: 3,
     max_executions: 10,
     expires_at: null,
+    constraints: { to: { $pattern: "*@mycompany.com" }, subject: "*" },
+    source_action_configuration_id: "ac_config1",
+  },
+];
+
+const mockAgents = [
+  {
+    agent_id: 1,
+    status: "registered" as const,
+    metadata: { name: "Email Bot" } as Record<string, unknown> | null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const mockActionConfigs = [
+  {
+    id: "ac_config1",
+    agent_id: 1,
+    connector_id: "gmail",
+    action_type: "email.send",
+    parameters: {},
+    status: "active" as const,
+    name: "Send company emails",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
   },
 ];
 
@@ -36,6 +61,8 @@ const freePlanResponse = {
 function mockApiFetch(
   standingApprovals = mockStandingApprovals,
   billingPlan = freePlanResponse,
+  agents = mockAgents,
+  actionConfigs = mockActionConfigs,
 ) {
   setupAuthMocks({ authenticated: true });
   mockGet.mockImplementation((url: string) => {
@@ -45,8 +72,11 @@ function mockApiFetch(
     if (url === "/v1/standing-approvals") {
       return Promise.resolve({ data: { data: standingApprovals } });
     }
+    if (url === "/v1/action-configurations") {
+      return Promise.resolve({ data: { data: actionConfigs } });
+    }
     // agents endpoint
-    return Promise.resolve({ data: { data: [], has_more: false } });
+    return Promise.resolve({ data: { data: agents, has_more: false } });
   });
 }
 
@@ -99,6 +129,60 @@ describe("StandingApprovalsCard", () => {
 
     await waitFor(() => {
       expect(screen.getByText("10 standing approvals")).toBeInTheDocument();
+    });
+  });
+
+  it("shows agent display name from metadata", async () => {
+    mockApiFetch();
+
+    render(<StandingApprovalsCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Email Bot")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Constraints column header", async () => {
+    mockApiFetch();
+
+    render(<StandingApprovalsCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Constraints")).toBeInTheDocument();
+    });
+  });
+
+  it("shows constraint badges for standing approvals", async () => {
+    mockApiFetch();
+
+    render(<StandingApprovalsCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("to")).toBeInTheDocument();
+      expect(screen.getByText("subject")).toBeInTheDocument();
+    });
+  });
+
+  it("shows source action config name when available", async () => {
+    mockApiFetch();
+
+    render(<StandingApprovalsCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Send company emails")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to Agent ID when no metadata name", async () => {
+    const agentsNoName = [
+      { agent_id: 1, status: "registered" as const, metadata: null as Record<string, unknown> | null, created_at: "2026-01-01T00:00:00Z" },
+    ];
+    mockApiFetch(mockStandingApprovals, freePlanResponse, agentsNoName);
+
+    render(<StandingApprovalsCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent 1")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
@@ -185,4 +185,15 @@ describe("StandingApprovalsCard", () => {
       expect(screen.getByText("Agent 1")).toBeInTheDocument();
     });
   });
+
+  it("shows no config subtitle when source config is not found", async () => {
+    mockApiFetch(mockStandingApprovals, freePlanResponse, mockAgents, []);
+
+    render(<StandingApprovalsCard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Send company emails")).not.toBeInTheDocument();
+      expect(screen.getByText("email.send")).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `ConstraintsSummary` component with compact constraint badges (Lock/Regex/Asterisk icons, value truncation, expandable "+N more")
- Add Constraints column to standing approvals table and show agent display names from metadata instead of raw IDs
- Show source action config name when available, with `useActionConfigMap` hook for efficient multi-agent config lookups

Part of #550

## Test plan

### Claude Code
- [x] ConstraintsSummary unit tests (9 tests: null/empty, fixed/pattern/wildcard modes, truncation, expand/collapse)
- [x] StandingApprovalsCard integration tests (8 tests: constraint badges, agent names, config names, fallback to Agent ID)
- [x] TypeScript compilation passes (`tsc -b`)
- [x] Full frontend test suite passes (`make test-frontend`)

### OpenClaw
- [ ] Review constraint summary — clear enough at a glance?
- [ ] Decide detail view format: expandable row vs. sheet vs. dialog
- [ ] Visual QA on mobile breakpoints (table min-width increased to 600px)

https://claude.ai/code/session_01GiTsn2gJ7RQFQXvfTfUgHG