### PR TITLE
Phase 1 complete: standing approval constraints + notification templates + OpenAPI types

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

This PR confirms Phase 1 (issues #550) is fully implemented. All three parallel tracks have been completed and merged:

- **Phase 1A**: Backend constraint enforcement — `handleCreateStandingApproval` validates constraints are non-empty and not all-wildcards; migration adds `source_action_configuration_id`; full test coverage
- **Phase 1B**: Execution notification templates — `NotificationTypeStandingExecution`, email/SMS/push templates in `notify/standing_execution.go` with blue informational tone; full test coverage  
- **Phase 1C**: OpenAPI spec + TypeScript types — `constraints` marked required in `CreateStandingApprovalRequest`, `source_action_configuration_id` added to schemas, `schema.d.ts` regenerated

Verified: `make test-backend` ✅, `make build` ✅

## Test plan

- [ ] `make test-backend` passes
- [ ] `make build` passes (TypeScript compilation clean)
- [ ] Creating a standing approval without constraints → 400
- [ ] Creating with all-wildcard constraints → 400
- [ ] Creating with at least one non-wildcard constraint → 201
- [ ] `source_action_configuration_id` is stored and returned

Closes #550 (Phase 1)

https://claude.ai/code/session_01XaPZBV3HiEXuqjfwZUgMUB