### PR TITLE
Redesign standing approval creation as multi-step dialog (Chunk 2D)

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -185,8 +185,10 @@ export function CreateStandingApprovalDialog({
       }
       if (selectedConfig) {
         initConstraintsFromRecord(selectedConfig.parameters);
+        setManualConstraintsJson("");
       } else if (initialConstraints && isCustomAction) {
         initConstraintsFromRecord(initialConstraints);
+        setManualConstraintsJson(JSON.stringify(initialConstraints, null, 2));
       } else {
         setParamValues({});
         setParamModes({});

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -1,9 +1,7 @@
-import { type FormEvent, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { type FormEvent, useState, useMemo } from "react";
+import { Loader2, ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -13,13 +11,39 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useCreateStandingApproval } from "@/hooks/useCreateStandingApproval";
+import { useActionConfigs } from "@/hooks/useActionConfigs";
+import { useActionSchema } from "@/hooks/useActionSchema";
+import type { ActionConfiguration } from "@/hooks/useActionConfigs";
 import type { Agent } from "@/hooks/useAgents";
+import {
+  buildParametersFromForm,
+  isPatternWrapper,
+  type ParamMode,
+} from "@/pages/agents/connectors/ActionConfigFormFields";
+import {
+  CUSTOM_ACTION_SENTINEL,
+  StepPickAgent,
+  StepPickAction,
+  StepConstraints,
+  StepLimits,
+} from "./StandingApprovalSteps";
 
-interface CreateStandingApprovalDialogProps {
+export interface CreateStandingApprovalDialogProps {
   agents: Agent[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialAgentId?: number;
+  initialActionType?: string;
+  initialConstraints?: Record<string, unknown>;
 }
+
+type Step = 1 | 2 | 3 | 4;
+const STEP_LABELS: Record<Step, string> = {
+  1: "Pick Agent",
+  2: "Pick Action",
+  3: "Set Constraints",
+  4: "Set Limits",
+};
 
 function defaultExpiresAt(): string {
   const d = new Date();
@@ -28,58 +52,229 @@ function defaultExpiresAt(): string {
   return local.toISOString().slice(0, 16);
 }
 
+/**
+ * Returns true when at least one parameter constraint is non-wildcard.
+ */
+function hasNonWildcardConstraint(
+  paramValues: Record<string, string>,
+  paramModes: Record<string, ParamMode>,
+): boolean {
+  for (const key of Object.keys(paramValues)) {
+    const mode = paramModes[key] ?? "fixed";
+    if (mode !== "wildcard") {
+      const value = paramValues[key];
+      if (value !== undefined && value !== "") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function CreateStandingApprovalDialog({
   agents,
   open,
   onOpenChange,
+  initialAgentId,
+  initialActionType,
+  initialConstraints,
 }: CreateStandingApprovalDialogProps) {
   const { createStandingApproval, isPending } = useCreateStandingApproval();
 
-  const [agentId, setAgentId] = useState<number | "">("");
-  const [actionType, setActionType] = useState("");
-  const [actionVersion, setActionVersion] = useState("1");
-  const [constraintsJson, setConstraintsJson] = useState("");
+  const [step, setStep] = useState<Step>(1);
+  const [agentId, setAgentId] = useState<number | "">(initialAgentId ?? "");
+  const [selectedConfigId, setSelectedConfigId] = useState<string>("");
+  const [customActionType, setCustomActionType] = useState(
+    initialActionType ?? "",
+  );
+  const [paramValues, setParamValues] = useState<Record<string, string>>({});
+  const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
+  const [manualConstraintsJson, setManualConstraintsJson] = useState("");
   const [maxExecutions, setMaxExecutions] = useState("");
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
   const activeAgents = agents.filter((a) => a.status !== "deactivated");
 
+  const { configs, isLoading: configsLoading } = useActionConfigs(
+    typeof agentId === "number" ? agentId : 0,
+  );
+
+  const activeConfigs = useMemo(
+    () => configs.filter((c) => c.status === "active"),
+    [configs],
+  );
+
+  const selectedConfig = useMemo(
+    () =>
+      selectedConfigId && selectedConfigId !== CUSTOM_ACTION_SENTINEL
+        ? activeConfigs.find((c) => c.id === selectedConfigId) ?? null
+        : null,
+    [activeConfigs, selectedConfigId],
+  );
+
+  const isCustomAction = selectedConfigId === CUSTOM_ACTION_SENTINEL;
+
+  const effectiveActionType = selectedConfig
+    ? selectedConfig.action_type
+    : customActionType;
+
+  const { schema: fetchedSchema, isLoading: schemaLoading } =
+    useActionSchema(effectiveActionType);
+
+  const configSchema = useMemo(
+    () => fetchedSchema,
+    [fetchedSchema],
+  );
+
+  const configsByConnector = useMemo(() => {
+    const groups: Record<string, ActionConfiguration[]> = {};
+    for (const config of activeConfigs) {
+      const key = config.connector_id;
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(config);
+    }
+    return groups;
+  }, [activeConfigs]);
+
   function resetForm() {
-    setAgentId("");
-    setActionType("");
-    setActionVersion("1");
-    setConstraintsJson("");
+    setStep(1);
+    setAgentId(initialAgentId ?? "");
+    setSelectedConfigId("");
+    setCustomActionType(initialActionType ?? "");
+    setParamValues({});
+    setParamModes({});
+    setManualConstraintsJson("");
     setMaxExecutions("");
     setExpiresAt(defaultExpiresAt());
+  }
+
+  function initConstraintsFromRecord(record: Record<string, unknown>) {
+    const values: Record<string, string> = {};
+    const modes: Record<string, ParamMode> = {};
+    for (const [key, value] of Object.entries(record)) {
+      if (value === "*") {
+        values[key] = "*";
+        modes[key] = "wildcard";
+      } else if (isPatternWrapper(value)) {
+        values[key] = value.$pattern;
+        modes[key] = "pattern";
+      } else if (value === null || value === undefined) {
+        values[key] = "";
+        modes[key] = "fixed";
+      } else {
+        values[key] = String(value);
+        modes[key] = "fixed";
+      }
+    }
+    setParamValues(values);
+    setParamModes(modes);
+  }
+
+  function handleNext() {
+    if (step === 1) {
+      if (!agentId) {
+        toast.error("Please select an agent");
+        return;
+      }
+      setStep(2);
+    } else if (step === 2) {
+      if (!selectedConfigId) {
+        toast.error("Please select an action configuration or choose custom");
+        return;
+      }
+      if (isCustomAction && !customActionType.trim()) {
+        toast.error("Please enter an action type");
+        return;
+      }
+      if (selectedConfig) {
+        initConstraintsFromRecord(selectedConfig.parameters);
+      } else if (initialConstraints && isCustomAction) {
+        initConstraintsFromRecord(initialConstraints);
+      } else {
+        setParamValues({});
+        setParamModes({});
+        setManualConstraintsJson("");
+      }
+      setStep(3);
+    } else if (step === 3) {
+      if (isCustomAction && !configSchema) {
+        try {
+          const parsed = JSON.parse(manualConstraintsJson) as Record<
+            string,
+            unknown
+          >;
+          if (
+            parsed === null ||
+            typeof parsed !== "object" ||
+            Array.isArray(parsed)
+          ) {
+            toast.error("Constraints must be a JSON object");
+            return;
+          }
+          const allWildcard = Object.values(parsed).every((v) => v === "*");
+          if (Object.keys(parsed).length === 0 || allWildcard) {
+            toast.error(
+              "At least one parameter constraint must be non-wildcard",
+            );
+            return;
+          }
+        } catch {
+          toast.error("Constraints must be valid JSON");
+          return;
+        }
+      } else {
+        if (!hasNonWildcardConstraint(paramValues, paramModes)) {
+          toast.error(
+            "At least one parameter constraint must be non-wildcard",
+          );
+          return;
+        }
+      }
+      setStep(4);
+    }
+  }
+
+  function handleBack() {
+    if (step === 2) setStep(1);
+    else if (step === 3) setStep(2);
+    else if (step === 4) setStep(3);
   }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
 
-    if (!agentId || !actionType || !expiresAt) {
+    if (!agentId || !effectiveActionType || !expiresAt) {
       toast.error("Please fill in all required fields");
       return;
     }
 
     let constraints: Record<string, unknown>;
-    try {
-      constraints = JSON.parse(constraintsJson) as Record<string, unknown>;
-    } catch {
-      toast.error("Constraints must be valid JSON");
-      return;
-    }
 
-    if (constraints === null || typeof constraints !== "object" || Array.isArray(constraints)) {
-      toast.error("Constraints must be a JSON object");
-      return;
+    if (isCustomAction && !configSchema) {
+      try {
+        constraints = JSON.parse(manualConstraintsJson) as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        toast.error("Constraints must be valid JSON");
+        return;
+      }
+    } else {
+      constraints = buildParametersFromForm(
+        paramValues,
+        configSchema?.properties,
+        paramModes,
+      );
     }
 
     try {
       await createStandingApproval({
         agent_id: agentId,
-        action_type: actionType,
-        action_version: actionVersion || "1",
+        action_type: effectiveActionType,
+        action_version: "1",
         constraints,
+        source_action_configuration_id: selectedConfig?.id,
         max_executions: maxExecutions ? Number(maxExecutions) : null,
         expires_at: new Date(expiresAt).toISOString(),
       });
@@ -95,6 +290,8 @@ export function CreateStandingApprovalDialog({
     }
   }
 
+  const canCreate = !isPending && !!agentId && !!effectiveActionType && !!expiresAt;
+
   return (
     <Dialog
       open={open}
@@ -103,110 +300,100 @@ export function CreateStandingApprovalDialog({
         onOpenChange(v);
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Create Standing Approval</DialogTitle>
           <DialogDescription>
-            Pre-authorize an agent to execute an action type without per-request
-            approval.
+            Step {step} of 4: {STEP_LABELS[step]}
           </DialogDescription>
         </DialogHeader>
 
+        <div className="flex items-center gap-1 px-1">
+          {([1, 2, 3, 4] as Step[]).map((s) => (
+            <div
+              key={s}
+              className={`h-1.5 flex-1 rounded-full transition-colors ${
+                s <= step ? "bg-primary" : "bg-muted"
+              }`}
+            />
+          ))}
+        </div>
+
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="sa-agent">Agent</Label>
-            <select
-              id="sa-agent"
-              value={agentId}
-              onChange={(e) => setAgentId(e.target.value === "" ? "" : Number(e.target.value))}
-              className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-              required
-            >
-              <option value="">Select an agent</option>
-              {activeAgents.map((a) => (
-                <option key={a.agent_id} value={a.agent_id}>
-                  {a.agent_id}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="sa-action-type">Action Type</Label>
-            <Input
-              id="sa-action-type"
-              placeholder="e.g. email.send"
-              value={actionType}
-              onChange={(e) => setActionType(e.target.value)}
-              required
+          {step === 1 && (
+            <StepPickAgent
+              agentId={agentId}
+              onAgentChange={(id) => {
+                setAgentId(id);
+                setSelectedConfigId("");
+                setParamValues({});
+                setParamModes({});
+              }}
+              activeAgents={activeAgents}
             />
-          </div>
+          )}
 
-          <div className="space-y-2">
-            <Label htmlFor="sa-constraints">Constraints (JSON)</Label>
-            <Input
-              id="sa-constraints"
-              placeholder='{"recipient_pattern": "*@mycompany.com"}'
-              value={constraintsJson}
-              onChange={(e) => setConstraintsJson(e.target.value)}
-              required
+          {step === 2 && (
+            <StepPickAction
+              selectedConfigId={selectedConfigId}
+              onConfigChange={setSelectedConfigId}
+              customActionType={customActionType}
+              onCustomActionTypeChange={setCustomActionType}
+              configsByConnector={configsByConnector}
+              configsLoading={configsLoading}
+              isCustomAction={isCustomAction}
             />
-            <p className="text-muted-foreground text-xs">
-              Parameter constraints for this standing approval. At least one
-              non-wildcard constraint is required.
-            </p>
-          </div>
+          )}
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="sa-action-version">Version</Label>
-              <Input
-                id="sa-action-version"
-                placeholder="1"
-                value={actionVersion}
-                onChange={(e) => setActionVersion(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="sa-max-executions">Max Executions</Label>
-              <Input
-                id="sa-max-executions"
-                type="number"
-                min="1"
-                step="1"
-                placeholder="Unlimited"
-                value={maxExecutions}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  if (value === "") {
-                    setMaxExecutions("");
-                    return;
-                  }
-                  const intValue = parseInt(value, 10);
-                  if (Number.isNaN(intValue) || intValue < 1) {
-                    return;
-                  }
-                  setMaxExecutions(String(intValue));
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="sa-expires-at">Expires At</Label>
-            <Input
-              id="sa-expires-at"
-              type="datetime-local"
-              value={expiresAt}
-              onChange={(e) => setExpiresAt(e.target.value)}
-              required
+          {step === 3 && (
+            <StepConstraints
+              isCustomAction={isCustomAction}
+              configSchema={configSchema}
+              schemaLoading={schemaLoading}
+              paramValues={paramValues}
+              paramModes={paramModes}
+              onParamValueChange={(key, value) =>
+                setParamValues((prev) => ({ ...prev, [key]: value }))
+              }
+              onParamModeChange={(key, mode) =>
+                setParamModes((prev) => ({ ...prev, [key]: mode }))
+              }
+              manualConstraintsJson={manualConstraintsJson}
+              onManualConstraintsJsonChange={setManualConstraintsJson}
+              isPending={isPending}
             />
-            <p className="text-muted-foreground text-xs">
-              Maximum 90 days from now.
-            </p>
-          </div>
+          )}
 
-          <DialogFooter>
+          {step === 4 && (
+            <StepLimits
+              maxExecutions={maxExecutions}
+              onMaxExecutionsChange={(value) => {
+                if (value === "") {
+                  setMaxExecutions("");
+                  return;
+                }
+                const intValue = parseInt(value, 10);
+                if (Number.isNaN(intValue) || intValue < 1) return;
+                setMaxExecutions(String(intValue));
+              }}
+              expiresAt={expiresAt}
+              onExpiresAtChange={setExpiresAt}
+            />
+          )}
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            {step > 1 && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleBack}
+                disabled={isPending}
+              >
+                <ChevronLeft className="size-4" />
+                Back
+              </Button>
+            )}
+            <div className="flex-1" />
             <Button
               type="button"
               variant="secondary"
@@ -218,10 +405,21 @@ export function CreateStandingApprovalDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Loader2 className="animate-spin" />}
-              Create
-            </Button>
+            {step < 4 ? (
+              <Button type="button" onClick={handleNext}>
+                Next
+                <ChevronRight className="size-4" />
+              </Button>
+            ) : (
+              <Button type="submit" disabled={!canCreate}>
+                {isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Check className="size-4" />
+                )}
+                Create
+              </Button>
+            )}
           </DialogFooter>
         </form>
       </DialogContent>

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -194,7 +194,10 @@ export function CreateStandingApprovalDialog({
       }
       setStep(3);
     } else if (step === 3) {
-      if (isCustomAction && !configSchema) {
+      // Use manual JSON path when no schema properties are available —
+      // matches the rendering condition in StepConstraints.
+      const useManualJson = !configSchema?.properties;
+      if (useManualJson) {
         try {
           const parsed = JSON.parse(manualConstraintsJson) as Record<
             string,
@@ -247,7 +250,10 @@ export function CreateStandingApprovalDialog({
 
     let constraints: Record<string, unknown>;
 
-    if (isCustomAction && !configSchema) {
+    // Use manual JSON path when no schema properties are available —
+    // matches the rendering condition in StepConstraints.
+    const useManualJson = !configSchema?.properties;
+    if (useManualJson) {
       try {
         constraints = JSON.parse(manualConstraintsJson) as Record<
           string,
@@ -357,7 +363,6 @@ export function CreateStandingApprovalDialog({
 
           {step === 3 && (
             <StepConstraints
-              isCustomAction={isCustomAction}
               configSchema={configSchema}
               schemaLoading={schemaLoading}
               paramValues={paramValues}

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -194,6 +194,10 @@ export function CreateStandingApprovalDialog({
       }
       setStep(3);
     } else if (step === 3) {
+      if (schemaLoading) {
+        toast.error("Please wait for the parameter schema to finish loading");
+        return;
+      }
       // Use manual JSON path when no schema properties are available —
       // matches the rendering condition in StepConstraints.
       const useManualJson = !configSchema?.properties;
@@ -342,6 +346,7 @@ export function CreateStandingApprovalDialog({
               onAgentChange={(id) => {
                 setAgentId(id);
                 setSelectedConfigId("");
+                setCustomActionType(initialActionType ?? "");
                 setParamValues({});
                 setParamModes({});
               }}
@@ -421,7 +426,11 @@ export function CreateStandingApprovalDialog({
               Cancel
             </Button>
             {step < 4 ? (
-              <Button type="button" onClick={handleNext}>
+              <Button
+                type="button"
+                onClick={handleNext}
+                disabled={step === 3 && schemaLoading}
+              >
                 Next
                 <ChevronRight className="size-4" />
               </Button>

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -175,6 +175,10 @@ export function CreateStandingApprovalDialog({
       }
       setStep(2);
     } else if (step === 2) {
+      if (configsLoading) {
+        toast.error("Please wait for configurations to finish loading");
+        return;
+      }
       if (!selectedConfigId) {
         toast.error("Please select an action configuration or choose custom");
         return;
@@ -431,7 +435,10 @@ export function CreateStandingApprovalDialog({
               <Button
                 type="button"
                 onClick={handleNext}
-                disabled={step === 3 && schemaLoading}
+                disabled={
+                  (step === 2 && configsLoading) ||
+                  (step === 3 && schemaLoading)
+                }
               >
                 Next
                 <ChevronRight className="size-4" />

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -121,10 +121,7 @@ export function CreateStandingApprovalDialog({
   const { schema: fetchedSchema, isLoading: schemaLoading } =
     useActionSchema(effectiveActionType);
 
-  const configSchema = useMemo(
-    () => fetchedSchema,
-    [fetchedSchema],
-  );
+  const configSchema = fetchedSchema;
 
   const configsByConnector = useMemo(() => {
     const groups: Record<string, ActionConfiguration[]> = {};
@@ -258,6 +255,19 @@ export function CreateStandingApprovalDialog({
         >;
       } catch {
         toast.error("Constraints must be valid JSON");
+        return;
+      }
+      if (
+        constraints === null ||
+        typeof constraints !== "object" ||
+        Array.isArray(constraints)
+      ) {
+        toast.error("Constraints must be a JSON object");
+        return;
+      }
+      const allWildcard = Object.values(constraints).every((v) => v === "*");
+      if (Object.keys(constraints).length === 0 || allWildcard) {
+        toast.error("At least one parameter constraint must be non-wildcard");
         return;
       }
     } else {

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -83,7 +83,9 @@ export function CreateStandingApprovalDialog({
 
   const [step, setStep] = useState<Step>(1);
   const [agentId, setAgentId] = useState<number | "">(initialAgentId ?? "");
-  const [selectedConfigId, setSelectedConfigId] = useState<string>("");
+  const [selectedConfigId, setSelectedConfigId] = useState<string>(
+    initialActionType ? CUSTOM_ACTION_SENTINEL : "",
+  );
   const [customActionType, setCustomActionType] = useState(
     initialActionType ?? "",
   );
@@ -136,7 +138,7 @@ export function CreateStandingApprovalDialog({
   function resetForm() {
     setStep(1);
     setAgentId(initialAgentId ?? "");
-    setSelectedConfigId("");
+    setSelectedConfigId(initialActionType ? CUSTOM_ACTION_SENTINEL : "");
     setCustomActionType(initialActionType ?? "");
     setParamValues({});
     setParamModes({});
@@ -252,6 +254,7 @@ export function CreateStandingApprovalDialog({
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    if (step !== 4) return;
 
     if (!agentId || !effectiveActionType || !expiresAt) {
       toast.error("Please fill in all required fields");

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -1,0 +1,267 @@
+import { Loader2, Info } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ActionConfiguration } from "@/hooks/useActionConfigs";
+import type { Agent } from "@/hooks/useAgents";
+import { getAgentDisplayName } from "@/lib/agents";
+import type { ParametersSchema } from "@/lib/parameterSchema";
+import { ActionConfigParameterFields } from "@/pages/agents/connectors/ActionConfigParameterFields";
+import type { ParamMode } from "@/pages/agents/connectors/ActionConfigFormFields";
+
+export const CUSTOM_ACTION_SENTINEL = "__custom__";
+
+const selectClassName =
+  "border-input bg-background ring-offset-background focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
+export function StepPickAgent({
+  agentId,
+  onAgentChange,
+  activeAgents,
+}: {
+  agentId: number | "";
+  onAgentChange: (id: number | "") => void;
+  activeAgents: Agent[];
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="sa-agent">Agent</Label>
+      <select
+        id="sa-agent"
+        value={agentId}
+        onChange={(e) =>
+          onAgentChange(e.target.value === "" ? "" : Number(e.target.value))
+        }
+        className={selectClassName}
+      >
+        <option value="">Select an agent</option>
+        {activeAgents.map((a) => (
+          <option key={a.agent_id} value={a.agent_id}>
+            {getAgentDisplayName(a)}
+          </option>
+        ))}
+      </select>
+      <p className="text-muted-foreground text-xs">
+        Choose which agent this standing approval applies to.
+      </p>
+    </div>
+  );
+}
+
+export function StepPickAction({
+  selectedConfigId,
+  onConfigChange,
+  customActionType,
+  onCustomActionTypeChange,
+  configsByConnector,
+  configsLoading,
+  isCustomAction,
+}: {
+  selectedConfigId: string;
+  onConfigChange: (id: string) => void;
+  customActionType: string;
+  onCustomActionTypeChange: (value: string) => void;
+  configsByConnector: Record<string, ActionConfiguration[]>;
+  configsLoading: boolean;
+  isCustomAction: boolean;
+}) {
+  const connectorIds = Object.keys(configsByConnector);
+
+  return (
+    <div className="space-y-3">
+      <Label htmlFor="sa-config">Action Configuration</Label>
+      {configsLoading ? (
+        <div className="flex items-center gap-2 py-2">
+          <Loader2 className="size-4 animate-spin" />
+          <span className="text-muted-foreground text-sm">
+            Loading configurations...
+          </span>
+        </div>
+      ) : (
+        <>
+          <select
+            id="sa-config"
+            value={selectedConfigId}
+            onChange={(e) => onConfigChange(e.target.value)}
+            className={selectClassName}
+          >
+            <option value="">Select an action configuration...</option>
+            {connectorIds.map((connId) => (
+              <optgroup key={connId} label={connId}>
+                {configsByConnector[connId]?.map((config) => (
+                  <option key={config.id} value={config.id}>
+                    {config.name} ({config.action_type})
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+            <option value={CUSTOM_ACTION_SENTINEL}>
+              Custom action type...
+            </option>
+          </select>
+          <p className="text-muted-foreground text-xs">
+            Select an action configuration to pre-populate constraints, or
+            choose &quot;Custom action type&quot; for manual entry.
+          </p>
+        </>
+      )}
+
+      {isCustomAction && (
+        <div className="space-y-2">
+          <Label htmlFor="sa-custom-action">Action Type</Label>
+          <Input
+            id="sa-custom-action"
+            placeholder="e.g. github.create_issue"
+            value={customActionType}
+            onChange={(e) => onCustomActionTypeChange(e.target.value)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function StepConstraints({
+  isCustomAction,
+  configSchema,
+  schemaLoading,
+  paramValues,
+  paramModes,
+  onParamValueChange,
+  onParamModeChange,
+  manualConstraintsJson,
+  onManualConstraintsJsonChange,
+  isPending,
+}: {
+  isCustomAction: boolean;
+  configSchema: ParametersSchema | null;
+  schemaLoading: boolean;
+  paramValues: Record<string, string>;
+  paramModes: Record<string, ParamMode>;
+  onParamValueChange: (key: string, value: string) => void;
+  onParamModeChange: (key: string, mode: ParamMode) => void;
+  manualConstraintsJson: string;
+  onManualConstraintsJsonChange: (value: string) => void;
+  isPending: boolean;
+}) {
+  if (schemaLoading) {
+    return (
+      <div className="flex items-center gap-2 py-4">
+        <Loader2 className="size-4 animate-spin" />
+        <span className="text-muted-foreground text-sm">
+          Loading parameter schema...
+        </span>
+      </div>
+    );
+  }
+
+  const showSchemaFields = configSchema?.properties && !isCustomAction;
+  const showManualJson = isCustomAction && !configSchema?.properties;
+
+  return (
+    <div className="space-y-3">
+      <div className="bg-muted/50 flex items-start gap-2 rounded-md p-3">
+        <Info className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+        <p className="text-muted-foreground text-xs">
+          Standing approvals require parameter constraints. At least one
+          parameter must be Fixed or Pattern — not all wildcards.
+        </p>
+      </div>
+
+      {showSchemaFields ? (
+        <div className="space-y-2">
+          <Label>Constraints</Label>
+          <ActionConfigParameterFields
+            parametersSchema={configSchema}
+            values={paramValues}
+            onValueChange={onParamValueChange}
+            modes={paramModes}
+            onModeChange={onParamModeChange}
+            disabled={isPending}
+          />
+        </div>
+      ) : showManualJson ? (
+        <div className="space-y-2">
+          <Label htmlFor="sa-manual-constraints">Constraints (JSON)</Label>
+          <textarea
+            id="sa-manual-constraints"
+            className="border-input bg-background ring-offset-background focus-visible:ring-ring flex min-h-[100px] w-full rounded-md border px-3 py-2 font-mono text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder={'{\n  "recipient": "*@mycompany.com",\n  "subject": "*"\n}'}
+            value={manualConstraintsJson}
+            onChange={(e) => onManualConstraintsJsonChange(e.target.value)}
+            disabled={isPending}
+          />
+          <p className="text-muted-foreground text-xs">
+            Enter parameter constraints as a JSON object. Use{" "}
+            <code className="font-mono">&quot;*&quot;</code> for wildcard
+            parameters, but at least one must be non-wildcard.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Label>Constraints</Label>
+          {configSchema?.properties ? (
+            <ActionConfigParameterFields
+              parametersSchema={configSchema}
+              values={paramValues}
+              onValueChange={onParamValueChange}
+              modes={paramModes}
+              onModeChange={onParamModeChange}
+              disabled={isPending}
+            />
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              No parameter schema found for this action. Enter constraints
+              manually as JSON below.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function StepLimits({
+  maxExecutions,
+  onMaxExecutionsChange,
+  expiresAt,
+  onExpiresAtChange,
+}: {
+  maxExecutions: string;
+  onMaxExecutionsChange: (value: string) => void;
+  expiresAt: string;
+  onExpiresAtChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="sa-max-executions">Max Executions</Label>
+        <Input
+          id="sa-max-executions"
+          type="number"
+          min="1"
+          step="1"
+          placeholder="Unlimited"
+          value={maxExecutions}
+          onChange={(e) => onMaxExecutionsChange(e.target.value)}
+        />
+        <p className="text-muted-foreground text-xs">
+          Leave empty for unlimited executions.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="sa-expires-at">Expires At</Label>
+        <Input
+          id="sa-expires-at"
+          type="datetime-local"
+          value={expiresAt}
+          onChange={(e) => onExpiresAtChange(e.target.value)}
+          required
+        />
+        <p className="text-muted-foreground text-xs">
+          Maximum 90 days from now.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -121,7 +121,6 @@ export function StepPickAction({
 }
 
 export function StepConstraints({
-  isCustomAction,
   configSchema,
   schemaLoading,
   paramValues,
@@ -132,7 +131,6 @@ export function StepConstraints({
   onManualConstraintsJsonChange,
   isPending,
 }: {
-  isCustomAction: boolean;
   configSchema: ParametersSchema | null;
   schemaLoading: boolean;
   paramValues: Record<string, string>;
@@ -154,9 +152,6 @@ export function StepConstraints({
     );
   }
 
-  const showSchemaFields = configSchema?.properties && !isCustomAction;
-  const showManualJson = isCustomAction && !configSchema?.properties;
-
   return (
     <div className="space-y-3">
       <div className="bg-muted/50 flex items-start gap-2 rounded-md p-3">
@@ -167,7 +162,7 @@ export function StepConstraints({
         </p>
       </div>
 
-      {showSchemaFields ? (
+      {configSchema?.properties ? (
         <div className="space-y-2">
           <Label>Constraints</Label>
           <ActionConfigParameterFields
@@ -179,9 +174,13 @@ export function StepConstraints({
             disabled={isPending}
           />
         </div>
-      ) : showManualJson ? (
+      ) : (
         <div className="space-y-2">
           <Label htmlFor="sa-manual-constraints">Constraints (JSON)</Label>
+          <p className="text-muted-foreground text-xs">
+            No parameter schema found for this action. Enter constraints
+            manually as a JSON object.
+          </p>
           <textarea
             id="sa-manual-constraints"
             className="border-input bg-background ring-offset-background focus-visible:ring-ring flex min-h-[100px] w-full rounded-md border px-3 py-2 font-mono text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
@@ -191,39 +190,9 @@ export function StepConstraints({
             disabled={isPending}
           />
           <p className="text-muted-foreground text-xs">
-            Enter parameter constraints as a JSON object. Use{" "}
-            <code className="font-mono">&quot;*&quot;</code> for wildcard
+            Use <code className="font-mono">&quot;*&quot;</code> for wildcard
             parameters, but at least one must be non-wildcard.
           </p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <Label>Constraints</Label>
-          {configSchema?.properties ? (
-            <ActionConfigParameterFields
-              parametersSchema={configSchema}
-              values={paramValues}
-              onValueChange={onParamValueChange}
-              modes={paramModes}
-              onModeChange={onParamModeChange}
-              disabled={isPending}
-            />
-          ) : (
-            <>
-              <p className="text-muted-foreground text-sm">
-                No parameter schema found for this action. Enter constraints
-                manually as JSON.
-              </p>
-              <textarea
-                id="sa-manual-constraints-fallback"
-                className="border-input bg-background ring-offset-background focus-visible:ring-ring flex min-h-[100px] w-full rounded-md border px-3 py-2 font-mono text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                placeholder={'{\n  "param": "value"\n}'}
-                value={manualConstraintsJson}
-                onChange={(e) => onManualConstraintsJsonChange(e.target.value)}
-                disabled={isPending}
-              />
-            </>
-          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -209,10 +209,20 @@ export function StepConstraints({
               disabled={isPending}
             />
           ) : (
-            <p className="text-muted-foreground text-sm">
-              No parameter schema found for this action. Enter constraints
-              manually as JSON below.
-            </p>
+            <>
+              <p className="text-muted-foreground text-sm">
+                No parameter schema found for this action. Enter constraints
+                manually as JSON.
+              </p>
+              <textarea
+                id="sa-manual-constraints-fallback"
+                className="border-input bg-background ring-offset-background focus-visible:ring-ring flex min-h-[100px] w-full rounded-md border px-3 py-2 font-mono text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder={'{\n  "param": "value"\n}'}
+                value={manualConstraintsJson}
+                onChange={(e) => onManualConstraintsJsonChange(e.target.value)}
+                disabled={isPending}
+              />
+            </>
           )}
         </div>
       )}

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -1,0 +1,343 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import { mockGet, resetClientMocks } from "../../../api/__mocks__/client";
+import { CreateStandingApprovalDialog } from "../CreateStandingApprovalDialog";
+import type { Agent } from "../../../hooks/useAgents";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+const mockAgents: Agent[] = [
+  {
+    agent_id: 1,
+    status: "registered",
+    metadata: { name: "Test Bot" },
+    confirmation_code: null,
+    expires_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    agent_id: 2,
+    status: "registered",
+    metadata: { name: "Deploy Bot" },
+    confirmation_code: null,
+    expires_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const mockConfigs = [
+  {
+    id: "ac_config1",
+    agent_id: 1,
+    connector_id: "github",
+    action_type: "github.create_issue",
+    parameters: { repo: "supersuit-tech/webapp", title: "*", body: "*" },
+    status: "active" as const,
+    name: "Create bug issues",
+    description: "Create issues in the webapp repo",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+function setupMocks() {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string, opts?: { params?: { query?: { agent_id?: number } } }) => {
+    if (url === "/v1/action-configurations") {
+      const agentId = opts?.params?.query?.agent_id;
+      if (agentId === 1) {
+        return Promise.resolve({ data: { data: mockConfigs } });
+      }
+      return Promise.resolve({ data: { data: [] } });
+    }
+    if (url === "/v1/connectors/github") {
+      return Promise.resolve({
+        data: {
+          id: "github",
+          name: "GitHub",
+          actions: [
+            {
+              action_type: "github.create_issue",
+              name: "Create Issue",
+              parameters_schema: {
+                type: "object",
+                properties: {
+                  repo: { type: "string", description: "Repository" },
+                  title: { type: "string", description: "Issue title" },
+                  body: { type: "string", description: "Issue body" },
+                },
+                required: ["repo"],
+              },
+            },
+          ],
+        },
+      });
+    }
+    return Promise.resolve({ data: {} });
+  });
+}
+
+describe("CreateStandingApprovalDialog", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+    setupMocks();
+  });
+
+  it("renders step 1 with agent dropdown", () => {
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByText("Create Standing Approval")).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of 4/)).toBeInTheDocument();
+    expect(screen.getByText("Test Bot")).toBeInTheDocument();
+    expect(screen.getByText("Deploy Bot")).toBeInTheDocument();
+  });
+
+  it("shows agent display names instead of IDs", () => {
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Should show display names, not just IDs
+    expect(screen.getByText("Test Bot")).toBeInTheDocument();
+    expect(screen.getByText("Deploy Bot")).toBeInTheDocument();
+  });
+
+  it("navigates to step 2 after selecting an agent", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Select agent
+    await user.selectOptions(screen.getByLabelText("Agent"), "1");
+    // Click Next
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when trying to advance without selecting agent", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.click(screen.getByText("Next"));
+    // Should still be on step 1
+    expect(screen.getByText(/Step 1 of 4/)).toBeInTheDocument();
+  });
+
+  it("shows action configs grouped by connector on step 2", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Select agent
+    await user.selectOptions(screen.getByLabelText("Agent"), "1");
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+    });
+
+    // Wait for configs to load
+    await waitFor(() => {
+      expect(
+        screen.getByText("Create bug issues (github.create_issue)"),
+      ).toBeInTheDocument();
+    });
+
+    // Custom option should be present
+    expect(screen.getByText("Custom action type...")).toBeInTheDocument();
+  });
+
+  it("shows custom action type input when custom is selected", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.selectOptions(screen.getByLabelText("Agent"), "1");
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+    });
+
+    // Select custom action type
+    await user.selectOptions(
+      screen.getByLabelText("Action Configuration"),
+      "__custom__",
+    );
+
+    expect(screen.getByLabelText("Action Type")).toBeInTheDocument();
+  });
+
+  it("navigates back from step 2 to step 1", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.selectOptions(screen.getByLabelText("Agent"), "1");
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Back"));
+
+    expect(screen.getByText(/Step 1 of 4/)).toBeInTheDocument();
+  });
+
+  it("resets form on dialog close", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+      { wrapper },
+    );
+
+    await user.selectOptions(screen.getByLabelText("Agent"), "1");
+    await user.click(screen.getByText("Cancel"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows helper message about constraints on step 3", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Navigate to step 3
+    await user.selectOptions(screen.getByLabelText("Agent"), "1");
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+    });
+
+    // Wait for configs and select one
+    await waitFor(() => {
+      expect(
+        screen.getByText("Create bug issues (github.create_issue)"),
+      ).toBeInTheDocument();
+    });
+
+    await user.selectOptions(
+      screen.getByLabelText("Action Configuration"),
+      "ac_config1",
+    );
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 3 of 4/)).toBeInTheDocument();
+    });
+
+    // Helper message should be visible
+    expect(
+      screen.getByText(/Standing approvals require parameter constraints/),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts initial props for pre-populated flow", () => {
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+        initialAgentId={1}
+        initialActionType="email.send"
+        initialConstraints={{ recipient: "*@mycompany.com" }}
+      />,
+      { wrapper },
+    );
+
+    // Agent should be pre-selected
+    const select = screen.getByLabelText("Agent") as HTMLSelectElement;
+    expect(select.value).toBe("1");
+  });
+
+  it("filters out deactivated agents", () => {
+    const agentsWithDeactivated: Agent[] = [
+      ...mockAgents,
+      {
+        agent_id: 3,
+        status: "deactivated",
+        metadata: { name: "Old Bot" },
+        confirmation_code: null,
+        expires_at: null,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    render(
+      <CreateStandingApprovalDialog
+        agents={agentsWithDeactivated}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.queryByText("Old Bot")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the single-form standing approval creation dialog with a 4-step wizard: Pick Agent → Pick Action Configuration → Set Constraints → Set Limits
- Links standing approvals to existing action configurations for pre-populated constraints, with a "Custom action type" fallback for manual entry
- Enforces that at least one parameter constraint is non-wildcard (frontend validation) before allowing creation
- Passes `source_action_configuration_id` through to the API for traceability
- Adds `initialAgentId`, `initialActionType`, and `initialConstraints` props for the "Approve & Always Allow" flow (Phase 3G)
- Splits step components into `StandingApprovalSteps.tsx` for maintainability and merge conflict reduction

Part of #550

## Test plan

### Claude Code
- [x] All 91 frontend test files pass (769 tests)
- [x] TypeScript compilation passes with no errors
- [x] New test file covers: step navigation, agent dropdown with display names, action config grouping, custom action type input, back navigation, form reset, constraint helper message, initial props, deactivated agent filtering

### OpenClaw
- [ ] Review the multi-step dialog UX — does the flow feel intuitive?
- [ ] Verify constraint modes (Fixed/Pattern/Wildcard) make sense for standing approvals
- [ ] Decide: should users be able to loosen constraints beyond the action config, or only tighten?

https://claude.ai/code/session_01AGTGCynk66BJVndxmodYNm