### PR TITLE
Add format parameter to google.read_email action

### DIFF
--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -688,7 +688,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "string",
 							"enum": ["full", "metadata", "minimal"],
 							"default": "full",
-							"description": "The format to return the message in (defaults to full)"
+							"description": "Controls how much of the message is returned. 'full' (default) returns headers, body, and attachment metadata. 'metadata' returns headers only (no body). 'minimal' returns only ID, labels, and snippet."
 						}
 					}
 				}`)),

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -683,6 +683,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"message_id": {
 							"type": "string",
 							"description": "The Gmail message ID to read (from list_emails results)"
+						},
+						"format": {
+							"type": "string",
+							"enum": ["full", "metadata", "minimal"],
+							"default": "full",
+							"description": "The format to return the message in (defaults to full)"
 						}
 					}
 				}`)),

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -96,8 +96,8 @@ type emailFullDetail struct {
 	Date        string               `json:"date,omitempty"`
 	Snippet     string               `json:"snippet,omitempty"`
 	Labels      []string             `json:"labels,omitempty"`
-	ContentType string               `json:"content_type"`
-	Body        string               `json:"body"`
+	ContentType string               `json:"content_type,omitempty"`
+	Body        string               `json:"body,omitempty"`
 	Attachments []gmailAttachmentInfo `json:"attachments,omitempty"`
 }
 
@@ -151,9 +151,13 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	}
 
 	// Extract body and attachments from the MIME tree (depth-limited).
+	// Only set content_type when a body is present to avoid misleading
+	// consumers for metadata/minimal formats that return no body data.
 	body, contentType := extractBody(&msg.Payload, 0)
-	detail.Body = body
-	detail.ContentType = contentType
+	if body != "" {
+		detail.Body = body
+		detail.ContentType = contentType
+	}
 	detail.Attachments = extractAttachments(&msg.Payload)
 
 	return connectors.JSONResult(detail)

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -33,13 +33,30 @@ type readEmailAction struct {
 // readEmailParams is the user-facing parameter schema.
 type readEmailParams struct {
 	MessageID string `json:"message_id"`
+	Format    string `json:"format,omitempty"`
+}
+
+// validFormats are the allowed values for the format parameter.
+var validFormats = map[string]bool{
+	"full":     true,
+	"metadata": true,
+	"minimal":  true,
 }
 
 func (p *readEmailParams) validate() error {
 	if p.MessageID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: message_id"}
 	}
+	if p.Format != "" && !validFormats[p.Format] {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid format: %q (must be full, metadata, or minimal)", p.Format)}
+	}
 	return nil
+}
+
+func (p *readEmailParams) normalize() {
+	if p.Format == "" {
+		p.Format = "full"
+	}
 }
 
 // gmailFullMessage is the Gmail API response from messages.get with format=full.
@@ -102,9 +119,10 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	if err := params.validate(); err != nil {
 		return nil, err
 	}
+	params.normalize()
 
 	var msg gmailFullMessage
-	msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(params.MessageID) + "?format=full"
+	msgURL := a.conn.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(params.MessageID) + "?format=" + params.Format
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, msgURL, nil, &msg); err != nil {
 		return nil, err
 	}

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -150,15 +150,16 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 		}
 	}
 
-	// Extract body and attachments from the MIME tree (depth-limited).
-	// Only set content_type when a body is present to avoid misleading
-	// consumers for metadata/minimal formats that return no body data.
-	body, contentType := extractBody(&msg.Payload, 0)
-	if body != "" {
-		detail.Body = body
-		detail.ContentType = contentType
+	// Only extract body and attachments for format=full. The metadata and
+	// minimal formats return no body data or MIME parts from the Gmail API.
+	if params.Format == "full" {
+		body, contentType := extractBody(&msg.Payload, 0)
+		if body != "" {
+			detail.Body = body
+			detail.ContentType = contentType
+		}
+		detail.Attachments = extractAttachments(&msg.Payload)
 	}
-	detail.Attachments = extractAttachments(&msg.Payload)
 
 	return connectors.JSONResult(detail)
 }

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -316,6 +316,165 @@ func TestReadEmail_AttachmentFilenameFromContentType(t *testing.T) {
 	}
 }
 
+func TestReadEmail_FormatMetadata(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Query().Get("format") != "metadata" {
+			t.Errorf("expected format=metadata, got %s", r.URL.Query().Get("format"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-meta",
+			ThreadID: "thread-meta",
+			LabelIDs: []string{"INBOX"},
+			Snippet:  "Hello snippet",
+			Payload: gmailMessagePart{
+				MimeType: "text/plain",
+				Headers: []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				}{
+					{Name: "From", Value: "meta@example.com"},
+					{Name: "Subject", Value: "Metadata Only"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-meta", Format: "metadata"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail emailFullDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if detail.ID != "msg-meta" {
+		t.Errorf("expected ID msg-meta, got %s", detail.ID)
+	}
+	if detail.From != "meta@example.com" {
+		t.Errorf("expected From meta@example.com, got %s", detail.From)
+	}
+	if detail.Subject != "Metadata Only" {
+		t.Errorf("expected Subject 'Metadata Only', got %s", detail.Subject)
+	}
+}
+
+func TestReadEmail_FormatMinimal(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("format") != "minimal" {
+			t.Errorf("expected format=minimal, got %s", r.URL.Query().Get("format"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-min",
+			ThreadID: "thread-min",
+			LabelIDs: []string{"INBOX", "UNREAD"},
+			Snippet:  "Short snippet",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-min", Format: "minimal"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var detail emailFullDetail
+	if err := json.Unmarshal(result.Data, &detail); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if detail.ID != "msg-min" {
+		t.Errorf("expected ID msg-min, got %s", detail.ID)
+	}
+	if detail.ThreadID != "thread-min" {
+		t.Errorf("expected ThreadID thread-min, got %s", detail.ThreadID)
+	}
+}
+
+func TestReadEmail_DefaultFormatIsFull(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("format") != "full" {
+			t.Errorf("expected format=full (default), got %s", r.URL.Query().Get("format"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailFullMessage{
+			ID:       "msg-default",
+			ThreadID: "thread-default",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &readEmailAction{conn: conn}
+
+	// No format specified — should default to "full".
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-default"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadEmail_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &readEmailAction{conn: conn}
+
+	params, _ := json.Marshal(readEmailParams{MessageID: "msg-123", Format: "raw"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.read_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
 func TestReadEmail_MissingMessageID(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -369,6 +369,9 @@ func TestReadEmail_FormatMetadata(t *testing.T) {
 	if detail.ID != "msg-meta" {
 		t.Errorf("expected ID msg-meta, got %s", detail.ID)
 	}
+	if detail.ThreadID != "thread-meta" {
+		t.Errorf("expected ThreadID thread-meta, got %s", detail.ThreadID)
+	}
 	if len(detail.Labels) != 1 || detail.Labels[0] != "INBOX" {
 		t.Errorf("expected Labels [INBOX], got %v", detail.Labels)
 	}

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -375,6 +375,9 @@ func TestReadEmail_FormatMetadata(t *testing.T) {
 	if detail.Subject != "Metadata Only" {
 		t.Errorf("expected Subject 'Metadata Only', got %s", detail.Subject)
 	}
+	if detail.Snippet != "Hello snippet" {
+		t.Errorf("expected Snippet 'Hello snippet', got %q", detail.Snippet)
+	}
 	if detail.Body != "" {
 		t.Errorf("expected empty Body for format=metadata, got %q", detail.Body)
 	}
@@ -425,6 +428,9 @@ func TestReadEmail_FormatMinimal(t *testing.T) {
 	}
 	if detail.ThreadID != "thread-min" {
 		t.Errorf("expected ThreadID thread-min, got %s", detail.ThreadID)
+	}
+	if detail.Snippet != "Short snippet" {
+		t.Errorf("expected Snippet 'Short snippet', got %q", detail.Snippet)
 	}
 	if detail.Body != "" {
 		t.Errorf("expected empty Body for format=minimal, got %q", detail.Body)

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -369,6 +369,9 @@ func TestReadEmail_FormatMetadata(t *testing.T) {
 	if detail.ID != "msg-meta" {
 		t.Errorf("expected ID msg-meta, got %s", detail.ID)
 	}
+	if len(detail.Labels) != 1 || detail.Labels[0] != "INBOX" {
+		t.Errorf("expected Labels [INBOX], got %v", detail.Labels)
+	}
 	if detail.From != "meta@example.com" {
 		t.Errorf("expected From meta@example.com, got %s", detail.From)
 	}
@@ -428,6 +431,9 @@ func TestReadEmail_FormatMinimal(t *testing.T) {
 	}
 	if detail.ThreadID != "thread-min" {
 		t.Errorf("expected ThreadID thread-min, got %s", detail.ThreadID)
+	}
+	if len(detail.Labels) != 2 || detail.Labels[0] != "INBOX" || detail.Labels[1] != "UNREAD" {
+		t.Errorf("expected Labels [INBOX UNREAD], got %v", detail.Labels)
 	}
 	if detail.Snippet != "Short snippet" {
 		t.Errorf("expected Snippet 'Short snippet', got %q", detail.Snippet)

--- a/connectors/google/read_email_test.go
+++ b/connectors/google/read_email_test.go
@@ -375,6 +375,12 @@ func TestReadEmail_FormatMetadata(t *testing.T) {
 	if detail.Subject != "Metadata Only" {
 		t.Errorf("expected Subject 'Metadata Only', got %s", detail.Subject)
 	}
+	if detail.Body != "" {
+		t.Errorf("expected empty Body for format=metadata, got %q", detail.Body)
+	}
+	if detail.ContentType != "" {
+		t.Errorf("expected empty ContentType for format=metadata, got %q", detail.ContentType)
+	}
 }
 
 func TestReadEmail_FormatMinimal(t *testing.T) {
@@ -419,6 +425,12 @@ func TestReadEmail_FormatMinimal(t *testing.T) {
 	}
 	if detail.ThreadID != "thread-min" {
 		t.Errorf("expected ThreadID thread-min, got %s", detail.ThreadID)
+	}
+	if detail.Body != "" {
+		t.Errorf("expected empty Body for format=minimal, got %q", detail.Body)
+	}
+	if detail.ContentType != "" {
+		t.Errorf("expected empty ContentType for format=minimal, got %q", detail.ContentType)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds an optional `format` parameter (`full`, `metadata`, `minimal`) to `google.read_email`, defaulting to `full`
- The existing `google.read_email` action already provides the full email reading capability requested as `google.get_email` in the issue — the only gap was the `format` parameter flexibility
- Includes validation for invalid format values and comprehensive test coverage for all three formats

Closes #573

## Test plan

### Claude Code
- [x] All existing read_email tests pass
- [x] New tests for format=metadata, format=minimal, default format=full, and invalid format
- [x] Full Google connector test suite passes
- [x] Go build succeeds

### OpenClaw
- [ ] Verify the format parameter works correctly against the live Gmail API
- [ ] Confirm the issue description's intent is fully satisfied by enhancing `read_email` rather than adding a separate `get_email` action

https://claude.ai/code/session_01AaxXbdBjxkXqC6gB6rEwxY