### PR TITLE
feat: Approve & Always Allow flow (Chunk 3G)

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -35,6 +35,8 @@ export interface CreateStandingApprovalDialogProps {
   initialAgentId?: number;
   initialActionType?: string;
   initialConstraints?: Record<string, unknown>;
+  /** Called after a standing approval is successfully created. */
+  onCreated?: () => void;
 }
 
 type Step = 1 | 2 | 3 | 4;
@@ -78,6 +80,7 @@ export function CreateStandingApprovalDialog({
   initialAgentId,
   initialActionType,
   initialConstraints,
+  onCreated,
 }: CreateStandingApprovalDialogProps) {
   const { createStandingApproval, isPending } = useCreateStandingApproval();
 
@@ -309,7 +312,11 @@ export function CreateStandingApprovalDialog({
       });
       toast.success("Standing approval created");
       resetForm();
-      onOpenChange(false);
+      if (onCreated) {
+        onCreated();
+      } else {
+        onOpenChange(false);
+      }
     } catch (err) {
       toast.error(
         err instanceof Error

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -312,11 +312,8 @@ export function CreateStandingApprovalDialog({
       });
       toast.success("Standing approval created");
       resetForm();
-      if (onCreated) {
-        onCreated();
-      } else {
-        onOpenChange(false);
-      }
+      onOpenChange(false);
+      onCreated?.();
     } catch (err) {
       toast.error(
         err instanceof Error

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useEffect } from "react";
-import { Loader2, Clock, Bot, AlertTriangle, CheckCircle, XCircle } from "lucide-react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { Loader2, Clock, Bot, AlertTriangle, CheckCircle, XCircle, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,8 +14,11 @@ import type { ApproveResult } from "@/hooks/useApproveApproval";
 import { useDenyApproval } from "@/hooks/useDenyApproval";
 import { useActionSchema } from "@/hooks/useActionSchema";
 import type { ApprovalSummary } from "@/hooks/useApprovals";
+import { useAgents } from "@/hooks/useAgents";
+import { useStandingApprovals } from "@/hooks/useStandingApprovals";
 import { ActionPreviewSummary } from "@/components/ActionPreviewSummary";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
+import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import {
   useCountdown,
   formatCountdown,
@@ -87,6 +90,22 @@ function ExecutionStatusBanner({ result }: { result: ApproveResult }) {
   );
 }
 
+/**
+ * Derive initial constraints from an approval's action parameters.
+ * Each parameter becomes a "fixed" constraint by default.
+ */
+function deriveConstraintsFromParams(
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const constraints: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(parameters)) {
+    // Keep the raw value — CreateStandingApprovalDialog's
+    // initConstraintsFromRecord handles type coercion.
+    constraints[key] = value ?? "";
+  }
+  return constraints;
+}
+
 export function ReviewApprovalDialog({
   approval,
   agentDisplayName,
@@ -94,6 +113,9 @@ export function ReviewApprovalDialog({
   onOpenChange,
 }: ReviewApprovalDialogProps) {
   const [approveResult, setApproveResult] = useState<ApproveResult | null>(null);
+  const [standingDialogOpen, setStandingDialogOpen] = useState(false);
+  const [standingApprovalCreated, setStandingApprovalCreated] = useState(false);
+  const autoCloseBlocked = useRef(false);
   const isApproved = approveResult !== null;
   const { approveApproval, isPending: isApproving } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
@@ -102,9 +124,25 @@ export function ReviewApprovalDialog({
   const isExpired = remaining <= 0;
   const isBusy = isApproving || isDenying;
 
-  // Auto-close dialog after successful approval
+  // Data for "Always Allow This"
+  const { agents } = useAgents();
+  const { standingApprovals } = useStandingApprovals();
+  const params = approval.action.parameters as Record<string, unknown>;
+  const hasParams = Object.keys(params).length > 0;
+  const hasExistingStandingApproval = useMemo(
+    () =>
+      standingApprovals.some(
+        (sa) =>
+          sa.agent_id === approval.agent_id &&
+          sa.action_type === approval.action.type,
+      ),
+    [standingApprovals, approval.agent_id, approval.action.type],
+  );
+  const showAlwaysAllow = hasParams && !hasExistingStandingApproval;
+
+  // Auto-close dialog after successful approval (unless user is creating standing approval)
   useEffect(() => {
-    if (!isApproved) return;
+    if (!isApproved || autoCloseBlocked.current) return;
     const timer = setTimeout(() => onOpenChange(false), SUCCESS_AUTO_CLOSE_MS);
     return () => clearTimeout(timer);
   }, [isApproved, onOpenChange]);
@@ -128,9 +166,25 @@ export function ReviewApprovalDialog({
     }
   }, [denyApproval, approval.approval_id, onOpenChange]);
 
+  function handleAlwaysAllow() {
+    autoCloseBlocked.current = true;
+    setStandingDialogOpen(true);
+  }
+
+  function handleStandingDialogChange(nextOpen: boolean) {
+    setStandingDialogOpen(nextOpen);
+    if (!nextOpen) {
+      // If the standing approval was successfully created,
+      // show combined success and close after a delay.
+      // If not, just let the user continue viewing the approval result.
+    }
+  }
+
   function handleClose(nextOpen: boolean) {
     if (!nextOpen) {
       setApproveResult(null);
+      setStandingApprovalCreated(false);
+      autoCloseBlocked.current = false;
     }
     onOpenChange(nextOpen);
   }
@@ -145,6 +199,14 @@ export function ReviewApprovalDialog({
         {isApproved ? (
           <div className="space-y-6 py-4" role="status" aria-live="polite">
             <ExecutionStatusBanner result={approveResult} />
+            {standingApprovalCreated && (
+              <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-950/30">
+                <ShieldCheck className="size-4 shrink-0 text-green-600 dark:text-green-400" aria-hidden="true" />
+                <p className="text-sm text-green-800 dark:text-green-300">
+                  Standing approval created. Future matching requests will be auto-approved.
+                </p>
+              </div>
+            )}
           </div>
         ) : (
           <div className="space-y-4 sm:space-y-6">
@@ -246,7 +308,7 @@ export function ReviewApprovalDialog({
         )}
 
         {isApproved ? (
-          <DialogFooter>
+          <DialogFooter className="gap-2 sm:gap-0">
             <Button
               variant="outline"
               size="lg"
@@ -254,6 +316,16 @@ export function ReviewApprovalDialog({
             >
               Done
             </Button>
+            {showAlwaysAllow && !standingApprovalCreated && (
+              <Button
+                size="lg"
+                variant="secondary"
+                onClick={handleAlwaysAllow}
+              >
+                <ShieldCheck className="mr-1 size-4" />
+                Always Allow This
+              </Button>
+            )}
           </DialogFooter>
         ) : (
           <DialogFooter>
@@ -285,6 +357,20 @@ export function ReviewApprovalDialog({
           </DialogFooter>
         )}
       </DialogContent>
+
+      {/* Standing approval creation dialog — opened by "Always Allow This" */}
+      <CreateStandingApprovalDialog
+        agents={agents}
+        open={standingDialogOpen}
+        onOpenChange={handleStandingDialogChange}
+        onCreated={() => {
+          setStandingApprovalCreated(true);
+          setStandingDialogOpen(false);
+        }}
+        initialAgentId={approval.agent_id}
+        initialActionType={approval.action.type}
+        initialConstraints={deriveConstraintsFromParams(params)}
+      />
     </Dialog>
   );
 }

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { Loader2, Clock, Bot, AlertTriangle, CheckCircle, XCircle, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -115,7 +115,7 @@ export function ReviewApprovalDialog({
   const [approveResult, setApproveResult] = useState<ApproveResult | null>(null);
   const [standingDialogOpen, setStandingDialogOpen] = useState(false);
   const [standingApprovalCreated, setStandingApprovalCreated] = useState(false);
-  const autoCloseBlocked = useRef(false);
+  const [autoCloseBlocked, setAutoCloseBlocked] = useState(false);
   const isApproved = approveResult !== null;
   const { approveApproval, isPending: isApproving } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
@@ -142,10 +142,10 @@ export function ReviewApprovalDialog({
 
   // Auto-close dialog after successful approval (unless user is creating standing approval)
   useEffect(() => {
-    if (!isApproved || autoCloseBlocked.current) return;
+    if (!isApproved || autoCloseBlocked) return;
     const timer = setTimeout(() => onOpenChange(false), SUCCESS_AUTO_CLOSE_MS);
     return () => clearTimeout(timer);
-  }, [isApproved, onOpenChange]);
+  }, [isApproved, autoCloseBlocked, onOpenChange]);
 
   const handleApprove = useCallback(async () => {
     try {
@@ -167,24 +167,19 @@ export function ReviewApprovalDialog({
   }, [denyApproval, approval.approval_id, onOpenChange]);
 
   function handleAlwaysAllow() {
-    autoCloseBlocked.current = true;
+    setAutoCloseBlocked(true);
     setStandingDialogOpen(true);
   }
 
   function handleStandingDialogChange(nextOpen: boolean) {
     setStandingDialogOpen(nextOpen);
-    if (!nextOpen) {
-      // If the standing approval was successfully created,
-      // show combined success and close after a delay.
-      // If not, just let the user continue viewing the approval result.
-    }
   }
 
   function handleClose(nextOpen: boolean) {
     if (!nextOpen) {
       setApproveResult(null);
       setStandingApprovalCreated(false);
-      autoCloseBlocked.current = false;
+      setAutoCloseBlocked(false);
     }
     onOpenChange(nextOpen);
   }
@@ -312,7 +307,7 @@ export function ReviewApprovalDialog({
             <Button
               variant="outline"
               size="lg"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleClose(false)}
             >
               Done
             </Button>
@@ -363,10 +358,7 @@ export function ReviewApprovalDialog({
         agents={agents}
         open={standingDialogOpen}
         onOpenChange={handleStandingDialogChange}
-        onCreated={() => {
-          setStandingApprovalCreated(true);
-          setStandingDialogOpen(false);
-        }}
+        onCreated={() => setStandingApprovalCreated(true)}
         initialAgentId={approval.agent_id}
         initialActionType={approval.action.type}
         initialConstraints={deriveConstraintsFromParams(params)}

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -126,6 +126,7 @@ export function ReviewApprovalDialog({
 
   // Data for "Always Allow This"
   const { agents } = useAgents();
+  // API defaults to status=active, so only active standing approvals are returned
   const { standingApprovals, isLoading: standingApprovalsLoading } = useStandingApprovals();
   const params = approval.action.parameters as Record<string, unknown>;
   const hasParams = Object.keys(params).length > 0;
@@ -311,7 +312,7 @@ export function ReviewApprovalDialog({
             >
               Done
             </Button>
-            {showAlwaysAllow && !standingApprovalCreated && approveResult?.execution_status !== "error" && (
+            {showAlwaysAllow && !standingApprovalCreated && approveResult?.execution_status === "success" && (
               <Button
                 size="lg"
                 variant="secondary"
@@ -353,16 +354,18 @@ export function ReviewApprovalDialog({
         )}
       </DialogContent>
 
-      {/* Standing approval creation dialog — opened by "Always Allow This" */}
-      <CreateStandingApprovalDialog
-        agents={agents}
-        open={standingDialogOpen}
-        onOpenChange={handleStandingDialogChange}
-        onCreated={() => setStandingApprovalCreated(true)}
-        initialAgentId={approval.agent_id}
-        initialActionType={approval.action.type}
-        initialConstraints={deriveConstraintsFromParams(params)}
-      />
+      {/* Standing approval creation dialog — only mounted when needed */}
+      {standingDialogOpen && (
+        <CreateStandingApprovalDialog
+          agents={agents}
+          open={standingDialogOpen}
+          onOpenChange={handleStandingDialogChange}
+          onCreated={() => setStandingApprovalCreated(true)}
+          initialAgentId={approval.agent_id}
+          initialActionType={approval.action.type}
+          initialConstraints={deriveConstraintsFromParams(params)}
+        />
+      )}
     </Dialog>
   );
 }

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -126,7 +126,7 @@ export function ReviewApprovalDialog({
 
   // Data for "Always Allow This"
   const { agents } = useAgents();
-  const { standingApprovals } = useStandingApprovals();
+  const { standingApprovals, isLoading: standingApprovalsLoading } = useStandingApprovals();
   const params = approval.action.parameters as Record<string, unknown>;
   const hasParams = Object.keys(params).length > 0;
   const hasExistingStandingApproval = useMemo(
@@ -138,7 +138,7 @@ export function ReviewApprovalDialog({
       ),
     [standingApprovals, approval.agent_id, approval.action.type],
   );
-  const showAlwaysAllow = hasParams && !hasExistingStandingApproval;
+  const showAlwaysAllow = hasParams && !standingApprovalsLoading && !hasExistingStandingApproval;
 
   // Auto-close dialog after successful approval (unless user is creating standing approval)
   useEffect(() => {
@@ -311,7 +311,7 @@ export function ReviewApprovalDialog({
             >
               Done
             </Button>
-            {showAlwaysAllow && !standingApprovalCreated && (
+            {showAlwaysAllow && !standingApprovalCreated && approveResult?.execution_status !== "error" && (
               <Button
                 size="lg"
                 variant="secondary"

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -174,6 +174,11 @@ export function ReviewApprovalDialog({
 
   function handleStandingDialogChange(nextOpen: boolean) {
     setStandingDialogOpen(nextOpen);
+    if (!nextOpen && !standingApprovalCreated) {
+      // SA wizard was dismissed without creating — unblock auto-close
+      // so the user can click Done or let the dialog close naturally.
+      setAutoCloseBlocked(false);
+    }
   }
 
   function handleClose(nextOpen: boolean) {

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -188,6 +188,76 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
   });
 
+  it("does NOT show 'Always Allow This' when execution_status is 'pending'", async () => {
+    setupMocks();
+    const approval = makeApproval();
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "pending",
+        execution_result: null,
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Request Approved")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'Always Allow This' when execution_status is 'error'", async () => {
+    setupMocks();
+    const approval = makeApproval();
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "error",
+        execution_result: { execution_error: "Connection failed" },
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Execution Failed")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
+  });
+
   it("opens CreateStandingApprovalDialog when 'Always Allow This' is clicked", async () => {
     setupMocks();
     const approval = makeApproval();

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -1,0 +1,230 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../test-helpers";
+import { mockGet, mockPost, resetClientMocks } from "../../../api/__mocks__/client";
+import { ReviewApprovalDialog } from "../ReviewApprovalDialog";
+import type { ApprovalSummary } from "../../../hooks/useApprovals";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+const futureDate = new Date(Date.now() + 600_000).toISOString();
+
+function makeApproval(overrides?: Partial<ApprovalSummary>): ApprovalSummary {
+  return {
+    approval_id: "appr_test123",
+    agent_id: 1,
+    action: {
+      type: "email.send",
+      version: "1",
+      parameters: { recipient: "user@example.com", subject: "Hello" },
+    },
+    context: {
+      description: "Send an email",
+      risk_level: "low",
+    },
+    status: "pending",
+    expires_at: futureDate,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as ApprovalSummary;
+}
+
+const mockAgents = [
+  {
+    agent_id: 1,
+    status: "registered" as const,
+    metadata: { name: "Test Bot" },
+    confirmation_code: null,
+    expires_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+function setupMocks({
+  standingApprovals = [] as Array<{ agent_id: number; action_type: string }>,
+} = {}) {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/agents") {
+      return Promise.resolve({ data: { data: mockAgents } });
+    }
+    if (url === "/v1/standing-approvals") {
+      return Promise.resolve({ data: { data: standingApprovals } });
+    }
+    if (url === "/v1/action-configurations") {
+      return Promise.resolve({ data: { data: [] } });
+    }
+    // Connector/schema lookups
+    if (url.startsWith("/v1/connectors/")) {
+      return Promise.resolve({ data: { id: "email", name: "Email", actions: [] } });
+    }
+    return Promise.resolve({ data: {} });
+  });
+}
+
+describe("ReviewApprovalDialog — Always Allow This", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+  });
+
+  it("shows 'Always Allow This' button after successful approval when action has parameters", async () => {
+    setupMocks();
+    const approval = makeApproval();
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "success",
+        execution_result: null,
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Click approve
+    await user.click(screen.getByText("Approve"));
+
+    // Wait for success banner
+    await waitFor(() => {
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+    });
+
+    // "Always Allow This" button should be visible
+    expect(screen.getByText("Always Allow This")).toBeInTheDocument();
+  });
+
+  it("does NOT show 'Always Allow This' when action has no parameters", async () => {
+    setupMocks();
+    const approval = makeApproval({
+      action: { type: "system.noop", version: "1", parameters: {} },
+    });
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "success",
+        execution_result: null,
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'Always Allow This' when a standing approval already exists for agent+action", async () => {
+    setupMocks({
+      standingApprovals: [
+        { agent_id: 1, action_type: "email.send" },
+      ],
+    });
+    const approval = makeApproval();
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "success",
+        execution_result: null,
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
+  });
+
+  it("opens CreateStandingApprovalDialog when 'Always Allow This' is clicked", async () => {
+    setupMocks();
+    const approval = makeApproval();
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "success",
+        execution_result: null,
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Always Allow This")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Always Allow This"));
+
+    // The CreateStandingApprovalDialog should open
+    await waitFor(() => {
+      expect(screen.getByText("Create Standing Approval")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- After a successful one-off approval, adds an "Always Allow This" button that opens `CreateStandingApprovalDialog` pre-populated with the approval's agent, action type, and parameters (each as a Fixed constraint by default)
- Only shows the button when the action has parameters AND no active standing approval already exists for that agent + action type
- Adds combined success state banner ("Standing approval created. Future matching requests will be auto-approved.") with graceful degradation — approval success is always visible regardless of standing approval outcome
- Adds `onCreated` callback to `CreateStandingApprovalDialog` so callers can react to successful creation without the dialog closing itself

Part of #550

## Test plan

### Claude Code
- [x] All 94 frontend test files pass (819 tests)
- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] New test file covers: button visibility with/without params, button hidden when SA exists, opens CreateStandingApprovalDialog on click

### OpenClaw
- [ ] Review button placement — separate button alongside Done vs dropdown under Approve
- [ ] Review whether single-request params make good standing approval defaults
- [ ] Gate behind plan tier?

https://claude.ai/code/session_01RxovXHMBYrAmgQpzt63WT8