### PR TITLE
Suppress webhook notification for /yolo skill

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: watch
 description: Poll a GitHub PR for new comments and PR reviews and act on them autonomously. Use when the user wants to monitor a PR for feedback and have Claude implement requested changes automatically.
-argument-hint: "[PR_URL] [--automerge] [--max-turns <N>]"
+argument-hint: "[PR_URL] [--automerge] [--max-turns <N>] [--no-notify]"
 ---
 
 # Watch PR for Comments and Reviews
@@ -39,7 +39,7 @@ Agent (this skill)     — Only invoked when reasoning is needed
 
 Parse the arguments from: `$ARGUMENTS`
 
-Extract any PR URL and flags. The format is: `[PR_URL] [--automerge] [--max-turns <N>]`
+Extract any PR URL and flags. The format is: `[PR_URL] [--automerge] [--max-turns <N>] [--no-notify]`
 
 The PR URL is **optional**. If not provided, detect it automatically from the current branch:
 
@@ -56,6 +56,7 @@ Set these variables for the session:
 - `PR_NUMBER` — the extracted PR number
 - `AUTO_MERGE` — `true` if `--automerge` was passed, `false` otherwise
 - `MAX_TURNS` — the value of `--max-turns` if passed, `0` otherwise (0 = unlimited)
+- `NO_NOTIFY` — `true` if `--no-notify` was passed, `false` otherwise
 - `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
 - `SKILL_DIR` — the directory containing this skill file (`.claude/skills/watch`)
 
@@ -298,7 +299,7 @@ After the agent finishes processing work items, go back to **Step 1** and run th
 When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has already been posted by the script. Run the post-session script:
 
 ```bash
-bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") 2>&1
+bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") 2>&1
 ```
 
 This handles:

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -18,11 +18,13 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 PR_URL=""
 AUTO_MERGE=false
+NO_NOTIFY=false
 
 # Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --automerge) AUTO_MERGE=true; shift ;;
+    --no-notify) NO_NOTIFY=true; shift ;;
     https://*) PR_URL="$1"; shift ;;
     *) shift ;;
   esac
@@ -168,10 +170,14 @@ elif [[ "$AUTO_MERGE" == "true" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Trigger webhook notification
+# Trigger webhook notification (skipped with --no-notify)
 # ---------------------------------------------------------------------------
-echo "[post] Triggering webhook notification..."
-gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
+if [[ "$NO_NOTIFY" == "true" ]]; then
+  echo "[post] Skipping webhook notification (--no-notify)."
+else
+  echo "[post] Triggering webhook notification..."
+  gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
+fi
 
 echo ""
 echo "POST_COMPLETE"

--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -147,13 +147,13 @@ Capture the PR URL from the output.
 
 ## Step 6: Hand Off to /watch
 
-Invoke the `/watch` skill with `--automerge` to monitor the PR through review and merge it when ready. Since `/watch` auto-detects the PR from the current branch, you don't need to pass the URL explicitly — just the flags:
+Invoke the `/watch` skill with `--automerge --no-notify` to monitor the PR through review and merge it when ready. The `--no-notify` flag suppresses the webhook notification since `/yolo` is a fully autonomous flow — no human ping needed. Since `/watch` auto-detects the PR from the current branch, you don't need to pass the URL explicitly — just the flags:
 
 ```
-/watch --automerge
+/watch --automerge --no-notify
 ```
 
-Use the `Skill` tool to invoke the watch skill, passing `--automerge` as the argument. The watch skill will detect the PR from the current branch automatically.
+Use the `Skill` tool to invoke the watch skill, passing `--automerge --no-notify` as the argument. The watch skill will detect the PR from the current branch automatically.
 
 ## Important Rules
 
@@ -164,3 +164,4 @@ Use the `Skill` tool to invoke the watch skill, passing `--automerge` as the arg
 - **Link the PR to the issue** — use `Closes #N` in the PR body so the issue auto-closes on merge.
 - **Follow all CLAUDE.md guidelines** — especially around migrations, API types, component architecture, and merge conflict minimization.
 - **Post-task review** — before opening the PR, run all five review passes from CLAUDE.md (self-review, senior engineer lens, maintainability, code quality, documentation).
+- **Do NOT trigger the webhook notification** — the `/yolo` skill is fully autonomous end-to-end. Do not call the `trigger-webhook.yml` workflow at any point during this skill. The `--no-notify` flag on `/watch` handles suppressing the notification from the watch post-session as well.


### PR DESCRIPTION
## Summary

- Adds a `--no-notify` flag to `watch-post.sh` that skips the webhook notification trigger
- Updates `/watch` SKILL.md to document and pass through the new flag
- Updates `/yolo` SKILL.md to pass `--no-notify` when invoking `/watch`, and explicitly prohibits webhook triggers during the yolo flow

The `/yolo` skill is fully autonomous — it implements an issue, opens a PR, and shepherds it through review to merge. Notifying the user at the end is unnecessary noise since the whole point is hands-off execution.

## Test plan

### Claude Code
- [ ] Verify `watch-post.sh` respects `--no-notify` flag (skips webhook trigger)
- [ ] Verify `watch-post.sh` still triggers webhook when `--no-notify` is not passed

### OpenClaw
- [ ] Run `/yolo` on a test issue and confirm no webhook notification is received

https://claude.ai/code/session_0143LtZ37bBChgurZhMu7SWG