### PR TITLE
CLI: Add status command and make async the default for request

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@permission-slip/cli",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0"

--- a/cli/src/commands/request-status.ts
+++ b/cli/src/commands/request-status.ts
@@ -42,6 +42,9 @@ export function requestStatusCommand(program: Command): void {
         const client = new ApiClient({ serverUrl: opts.server, agentId });
 
         if (!opts.wait) {
+          if (opts.timeout !== "120") {
+            process.stderr.write("Warning: --timeout has no effect with --no-wait\n");
+          }
           // --no-wait: single check, return immediately.
           const result = await client.approvalStatus(opts.approvalId);
           output(result, outputOpts);

--- a/cli/src/commands/request-status.ts
+++ b/cli/src/commands/request-status.ts
@@ -1,9 +1,11 @@
 /**
  * permission-slip request-status --approval-id <id> [--server <url>]
  *
- * Checks the status of a previously submitted approval request. By default,
- * blocks until the approval reaches a terminal state. Pass --no-wait for a
- * single status check.
+ * Checks the status of a previously submitted approval request.
+ * Returns the current status immediately by default. Pass --wait to block
+ * until the approval reaches a terminal state.
+ *
+ * Deprecated: prefer `permission-slip status <approval_id>` instead.
  */
 
 import type { Command } from "commander";
@@ -15,7 +17,7 @@ import { pollUntilResolved, parseTimeout } from "../util/poll.js";
 export function requestStatusCommand(program: Command): void {
   program
     .command("request-status")
-    .description("Check the status of an approval request")
+    .description("Check approval status (deprecated: use 'status <approval_id>' instead)")
     .requiredOption("--approval-id <id>", "Approval ID returned by the request command")
     .option(
       "--server <url>",
@@ -23,14 +25,14 @@ export function requestStatusCommand(program: Command): void {
       "https://app.permissionslip.dev",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
-    .option("--no-wait", "Return immediately without waiting for resolution")
-    .option("--timeout <seconds>", "Max seconds to wait for resolution (default: 120)", "120")
+    .option("--wait", "Block until the approval reaches a terminal state")
+    .option("--timeout <seconds>", "Max seconds to wait when using --wait (default: 120)", "120")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       approvalId: string;
       server: string;
       agentId?: string;
-      wait: boolean;
+      wait?: boolean;
       timeout: string;
       pretty?: boolean;
     }) => {
@@ -40,13 +42,13 @@ export function requestStatusCommand(program: Command): void {
         const client = new ApiClient({ serverUrl: opts.server, agentId });
 
         if (!opts.wait) {
-          // Single check, no waiting.
+          // Default: single check, return immediately.
           const result = await client.approvalStatus(opts.approvalId);
           output(result, outputOpts);
           return;
         }
 
-        // Wait for terminal state.
+        // --wait: block until terminal state.
         const timeoutSeconds = parseTimeout(opts.timeout);
 
         process.stderr.write(`Waiting for approval ${opts.approvalId}...\n`);

--- a/cli/src/commands/request-status.ts
+++ b/cli/src/commands/request-status.ts
@@ -1,9 +1,9 @@
 /**
  * permission-slip request-status --approval-id <id> [--server <url>]
  *
- * Checks the status of a previously submitted approval request.
- * Returns the current status immediately by default. Pass --wait to block
- * until the approval reaches a terminal state.
+ * Checks the status of a previously submitted approval request. Blocks by
+ * default until the approval reaches a terminal state (preserving backward
+ * compatibility). Pass --no-wait for a single status check.
  *
  * Deprecated: prefer `permission-slip status <approval_id>` instead.
  */
@@ -25,14 +25,14 @@ export function requestStatusCommand(program: Command): void {
       "https://app.permissionslip.dev",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
-    .option("--wait", "Block until the approval reaches a terminal state")
-    .option("--timeout <seconds>", "Max seconds to wait when using --wait (default: 120)", "120")
+    .option("--no-wait", "Return immediately without waiting for resolution")
+    .option("--timeout <seconds>", "Max seconds to wait for resolution (default: 120)", "120")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       approvalId: string;
       server: string;
       agentId?: string;
-      wait?: boolean;
+      wait: boolean;
       timeout: string;
       pretty?: boolean;
     }) => {
@@ -42,13 +42,13 @@ export function requestStatusCommand(program: Command): void {
         const client = new ApiClient({ serverUrl: opts.server, agentId });
 
         if (!opts.wait) {
-          // Default: single check, return immediately.
+          // --no-wait: single check, return immediately.
           const result = await client.approvalStatus(opts.approvalId);
           output(result, outputOpts);
           return;
         }
 
-        // --wait: block until terminal state.
+        // Default: block until terminal state (backward compatible).
         const timeoutSeconds = parseTimeout(opts.timeout);
 
         process.stderr.write(`Waiting for approval ${opts.approvalId}...\n`);

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -69,9 +69,10 @@ export function requestCommand(program: Command): void {
             {
               ...result,
               next_step:
-                "Approval requested. To check the result once approved, run: " +
-                `permission-slip status ${shellQuote(result.approval_id)}` +
-                (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : ""),
+                "Approval requested. To wait for the result, run: " +
+                `permission-slip status --wait ${shellQuote(result.approval_id)}` +
+                (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : "") +
+                " (omit --wait for a single status snapshot)",
             },
             outputOpts,
           );

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -63,6 +63,9 @@ export function requestCommand(program: Command): void {
 
         const result = await client.requestApproval(opts.action, params, context);
 
+        if (!opts.wait && opts.timeout !== "120") {
+          process.stderr.write("Warning: --timeout has no effect without --wait\n");
+        }
         if (!opts.wait) {
           // Default: return immediately with next_step hint.
           output(

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -1,9 +1,9 @@
 /**
  * permission-slip request --action <action_id> [--params '{}'] [--server <url>]
  *
- * Requests one-off approval for an action. By default, blocks until the
- * approval is resolved (approved/denied/cancelled/expired) and returns the
- * execution result. Pass --no-wait for fire-and-forget behavior.
+ * Requests one-off approval for an action. Returns immediately by default
+ * with the approval_id and a next_step hint. Pass --wait to block until
+ * the approval is resolved.
  */
 
 import type { Command } from "commander";
@@ -27,8 +27,8 @@ export function requestCommand(program: Command): void {
       "https://app.permissionslip.dev",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
-    .option("--no-wait", "Return immediately without waiting for approval")
-    .option("--timeout <seconds>", "Max seconds to wait for approval (default: 120)", "120")
+    .option("--wait", "Block until the approval is resolved (default: return immediately)")
+    .option("--timeout <seconds>", "Max seconds to wait when using --wait (default: 120)", "120")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       action: string;
@@ -37,7 +37,7 @@ export function requestCommand(program: Command): void {
       riskLevel?: string;
       server: string;
       agentId?: string;
-      wait: boolean;
+      wait?: boolean;
       timeout: string;
       pretty?: boolean;
     }) => {
@@ -64,23 +64,21 @@ export function requestCommand(program: Command): void {
         const result = await client.requestApproval(opts.action, params, context);
 
         if (!opts.wait) {
-          // Fire-and-forget: output immediately with next_step hint.
+          // Default: return immediately with next_step hint.
           output(
             {
               ...result,
               next_step:
-                "Your request is pending approval. Once approved, the action will execute automatically — no further action is needed from you. " +
-                "To wait for the outcome, run: " +
-                `permission-slip request-status --approval-id ${shellQuote(result.approval_id)}` +
-                (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : "") +
-                " (this blocks until resolved; add --no-wait for a single status check)",
+                "Approval requested. To check the result once approved, run: " +
+                `permission-slip status ${shellQuote(result.approval_id)}` +
+                (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : ""),
             },
             outputOpts,
           );
           return;
         }
 
-        // Wait for approval resolution.
+        // --wait: block until approval resolution.
         const timeoutSeconds = parseTimeout(opts.timeout);
 
         process.stderr.write(

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -61,11 +61,12 @@ export function requestCommand(program: Command): void {
               }
             : undefined;
 
-        const result = await client.requestApproval(opts.action, params, context);
-
         if (!opts.wait && opts.timeout !== "120") {
           process.stderr.write("Warning: --timeout has no effect without --wait\n");
         }
+
+        const result = await client.requestApproval(opts.action, params, context);
+
         if (!opts.wait) {
           // Default: return immediately with next_step hint.
           output(

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -49,6 +49,9 @@ export function statusCommand(program: Command): void {
         }
 
         // Approval status check.
+        if (!opts.wait && opts.timeout !== "120") {
+          process.stderr.write("Warning: --timeout has no effect without --wait\n");
+        }
         if (opts.wait) {
           const timeoutSeconds = parseTimeout(opts.timeout);
           process.stderr.write(`Waiting for approval ${approvalId}...\n`);

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -42,6 +42,9 @@ export function statusCommand(program: Command): void {
           if (opts.wait) {
             process.stderr.write("Warning: --wait has no effect without an approval_id (shows registration state)\n");
           }
+          if (opts.timeout !== "120") {
+            process.stderr.write("Warning: --timeout has no effect without an approval_id\n");
+          }
           // No approval_id: show registration state.
           const result = await client.status();
           output(result, outputOpts);

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,36 +1,71 @@
 /**
- * permission-slip status [--server <url>]
+ * permission-slip status [<approval_id>] [--server <url>]
  *
- * Shows the current registration state for the agent on the given server.
+ * Without an approval_id: shows the current registration state.
+ * With an approval_id: checks the status of a previously submitted approval
+ * request. Returns the current status and, if approved, the execution result.
  */
 
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
 import { findRegistration } from "../config/store.js";
 import { output, type OutputOptions } from "../output.js";
+import { pollUntilResolved, parseTimeout } from "../util/poll.js";
 
 export function statusCommand(program: Command): void {
   program
     .command("status")
-    .description("Show current registration state")
+    .description("Show registration state, or check approval status with an approval_id")
+    .argument("[approval_id]", "Approval ID to check (omit for registration status)")
     .option(
       "--server <url>",
       "Permission Slip server URL",
       "https://app.permissionslip.dev",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
+    .option("--wait", "Block until the approval reaches a terminal state")
+    .option("--timeout <seconds>", "Max seconds to wait when using --wait (default: 120)", "120")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
-    .action(async (opts: {
+    .action(async (approvalId: string | undefined, opts: {
       server: string;
       agentId?: string;
+      wait?: boolean;
+      timeout: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
         const agentId = resolveAgentId(opts.server, opts.agentId);
         const client = new ApiClient({ serverUrl: opts.server, agentId });
-        const result = await client.status();
-        output(result, outputOpts);
+
+        if (!approvalId) {
+          // No approval_id: show registration state.
+          const result = await client.status();
+          output(result, outputOpts);
+          return;
+        }
+
+        // Approval status check.
+        if (opts.wait) {
+          const timeoutSeconds = parseTimeout(opts.timeout);
+          process.stderr.write(`Waiting for approval ${approvalId}...\n`);
+          const result = await pollUntilResolved({
+            approvalId,
+            client,
+            timeoutSeconds,
+            onPoll: ({ elapsed, timeout }) => {
+              process.stderr.write(`Still waiting... ${elapsed}s / ${timeout}s\n`);
+            },
+          });
+          output(result, outputOpts);
+          if (result.timed_out) {
+            process.exitCode = 2;
+          }
+        } else {
+          // Single check, return immediately.
+          const result = await client.approvalStatus(approvalId);
+          output(result, outputOpts);
+        }
       } catch (err) {
         output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
         process.exit(1);

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -39,6 +39,9 @@ export function statusCommand(program: Command): void {
         const client = new ApiClient({ serverUrl: opts.server, agentId });
 
         if (!approvalId) {
+          if (opts.wait) {
+            process.stderr.write("Warning: --wait has no effect without an approval_id (shows registration state)\n");
+          }
           // No approval_id: show registration state.
           const result = await client.status();
           output(result, outputOpts);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,7 +8,7 @@
  * Commands:
  *   register      Generate keys and register with a Permission Slip server
  *   verify        Complete registration with the confirmation code
- *   status        Show current registration state
+ *   status        Show registration state, or check approval status
  *   capabilities  List available action configurations and standing approvals
  *   connectors    List available connectors
  *   request        Request approval for an action (auto-executes on approval)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -419,10 +419,15 @@ The Permission Slip CLI returns immediately by default with an `approval_id` and
 # Default: returns immediately with approval_id
 permission-slip request --action email.send --params '{"to":["alice@example.com"]}'
 
-# Check result later:
+# Check result (single snapshot):
 permission-slip status <approval_id>
 
-# Block until resolved (up to 120s):
+# Fire-and-forget, then block later when ready:
+APPROVAL_ID=$(permission-slip request --action email.send --params '{}' | jq -r '.approval_id')
+# ... do other work ...
+permission-slip status --wait "$APPROVAL_ID"
+
+# Block from the start (up to 120s):
 permission-slip request --action email.send --params '{}' --wait
 
 # Block with custom timeout:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -413,17 +413,20 @@ The user receives a notification and reviews the request on their dashboard.
 
 The user reviews and approves (or denies) the request. After approving, they see a confirmation code and share it with you.
 
-You can poll `GET /approvals/{id}/status` to check for approval resolution. The Permission Slip CLI does this automatically — by default, `permission-slip request` blocks until the approval is resolved (approved, denied, cancelled, or expired) or the `--timeout` elapses. Pass `--no-wait` if you prefer fire-and-forget behavior.
+The Permission Slip CLI returns immediately by default with an `approval_id` and a `next_step` hint. Use `permission-slip status <approval_id>` to check the result once the user has approved. Pass `--wait` to `request` if you prefer blocking behavior.
 
 ```bash
-# Default: blocks until resolved (up to 120s)
+# Default: returns immediately with approval_id
 permission-slip request --action email.send --params '{"to":["alice@example.com"]}'
 
-# Fire-and-forget:
-permission-slip request --action email.send --params '{}' --no-wait
+# Check result later:
+permission-slip status <approval_id>
 
-# Custom timeout:
-permission-slip request --action email.send --params '{}' --timeout 30
+# Block until resolved (up to 120s):
+permission-slip request --action email.send --params '{}' --wait
+
+# Block with custom timeout:
+permission-slip request --action email.send --params '{}' --wait --timeout 30
 ```
 
 Alternatively, the user can share the approval confirmation code out-of-band (paste it in chat, set it in your config, etc.).

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

- **`request` now returns immediately by default** with `approval_id`, `approval_url`, `status`, and `next_step` — agents stay responsive while waiting for human approval
- **Added `status <approval_id>` command** for checking approval status (single check by default, `--wait` to poll until resolved)
- **`--wait` flag** opts into the old blocking/polling behavior on both `request` and `status`
- **`request-status` kept as deprecated alias** — existing scripts won't break

Closes #578

## Test plan

### Claude Code
- [x] Verify CLI builds cleanly (`cd cli && npm run build`)
- [x] Verify `permission-slip request --help` shows `--wait` instead of `--no-wait`
- [x] Verify `permission-slip status --help` shows the `[approval_id]` argument
- [x] Verify `permission-slip request-status --help` shows deprecation notice

### OpenClaw
- [ ] End-to-end test: run `request`, get approval_id, then `status <id>` to check result
- [ ] Verify backward compat: `request --wait` still blocks and polls as before
- [ ] Verify `status` without args still shows registration state

https://claude.ai/code/session_01X6zdkZJ7VYBmQHTeFiyZR9