### PR TITLE
Fix payment methods UI: prominent nickname, clear edit button

### DIFF
--- a/api/payment_methods.go
+++ b/api/payment_methods.go
@@ -49,6 +49,7 @@ type updatePaymentMethodRequest struct {
 	IsDefault           *bool   `json:"is_default,omitempty"`
 	PerTransactionLimit *int    `json:"per_transaction_limit,omitempty"`
 	MonthlyLimit        *int    `json:"monthly_limit,omitempty"`
+	ClearLabel          *bool   `json:"clear_label,omitempty"`
 	ClearPerTxLimit     *bool   `json:"clear_per_transaction_limit,omitempty"`
 	ClearMonthlyLimit   *bool   `json:"clear_monthly_limit,omitempty"`
 }
@@ -386,6 +387,9 @@ func handleUpdatePaymentMethod(deps *Deps) http.HandlerFunc {
 		}
 		if req.MonthlyLimit != nil {
 			params.MonthlyLimit = req.MonthlyLimit
+		}
+		if req.ClearLabel != nil && *req.ClearLabel {
+			params.ClearLabel = true
 		}
 		if req.ClearPerTxLimit != nil && *req.ClearPerTxLimit {
 			params.ClearPerTxLimit = true

--- a/db/payment_methods.go
+++ b/db/payment_methods.go
@@ -127,6 +127,7 @@ type UpdatePaymentMethodParams struct {
 	IsDefault           *bool
 	PerTransactionLimit *int  // use pointer-to-nil pattern: nil = don't change, non-nil = set (value can be 0 to clear)
 	MonthlyLimit        *int
+	ClearLabel          bool // when true, sets label to ''
 	ClearPerTxLimit     bool // when true, sets per_transaction_limit to NULL
 	ClearMonthlyLimit   bool // when true, sets monthly_limit to NULL
 }
@@ -135,7 +136,10 @@ type UpdatePaymentMethodParams struct {
 func UpdatePaymentMethod(ctx context.Context, db DBTX, userID, paymentMethodID string, params UpdatePaymentMethodParams) (*PaymentMethod, error) {
 	pm, err := scanPaymentMethod(db.QueryRow(ctx,
 		`UPDATE payment_methods SET
-			label = COALESCE($3, label),
+			label = CASE
+				WHEN $9 THEN ''
+				ELSE COALESCE($3, label)
+			END,
 			is_default = COALESCE($4, is_default),
 			per_transaction_limit = CASE
 				WHEN $7 THEN NULL
@@ -154,6 +158,7 @@ func UpdatePaymentMethod(ctx context.Context, db DBTX, userID, paymentMethodID s
 		params.Label, params.IsDefault,
 		params.PerTransactionLimit, params.MonthlyLimit,
 		params.ClearPerTxLimit, params.ClearMonthlyLimit,
+		params.ClearLabel,
 	))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil

--- a/frontend/src/hooks/usePaymentMethods.ts
+++ b/frontend/src/hooks/usePaymentMethods.ts
@@ -125,6 +125,7 @@ export function useUpdatePaymentMethod() {
       is_default?: boolean;
       per_transaction_limit?: number | null;
       monthly_limit?: number | null;
+      clear_label?: boolean;
       clear_per_transaction_limit?: boolean;
       clear_monthly_limit?: boolean;
     }) => {

--- a/frontend/src/pages/settings/PaymentMethodSection.tsx
+++ b/frontend/src/pages/settings/PaymentMethodSection.tsx
@@ -3,6 +3,7 @@ import {
   AlertTriangle,
   CreditCard,
   Loader2,
+  Pencil,
   Plus,
   Star,
   Trash2,
@@ -225,9 +226,13 @@ export function PaymentMethodSection() {
                 >
                   <div className="min-w-0 flex-1 space-y-0.5">
                     <div className="flex items-center gap-2">
-                      <p className="text-sm font-medium">
-                        {formatBrand(pm.brand)} ending in {pm.last4}
-                      </p>
+                      {pm.label ? (
+                        <p className="text-sm font-medium">{pm.label}</p>
+                      ) : (
+                        <p className="text-sm font-medium">
+                          {formatBrand(pm.brand)} ending in {pm.last4}
+                        </p>
+                      )}
                       {pm.is_default && (
                         <Badge variant="secondary" className="text-xs">
                           Default
@@ -239,7 +244,9 @@ export function PaymentMethodSection() {
                       />
                     </div>
                     <p className="text-muted-foreground text-xs">
-                      {pm.label ? `${pm.label} · ` : ""}
+                      {pm.label
+                        ? `${formatBrand(pm.brand)} ending in ${pm.last4} · `
+                        : ""}
                       Expires {formatExpiry(pm.exp_month, pm.exp_year)}
                       {pm.per_transaction_limit != null &&
                         ` · Per-tx limit: ${formatCents(pm.per_transaction_limit)}`}
@@ -268,11 +275,12 @@ export function PaymentMethodSection() {
                       />
                     </Button>
                     <Button
-                      variant="ghost"
+                      variant="outline"
                       size="sm"
                       onClick={() => setLimitsDialogPM(pm)}
                     >
-                      Limits
+                      <Pencil className="mr-1 size-3" />
+                      Edit
                     </Button>
                     <InlineConfirmButton
                       confirmLabel="Remove"

--- a/frontend/src/pages/settings/SpendingLimitsDialog.tsx
+++ b/frontend/src/pages/settings/SpendingLimitsDialog.tsx
@@ -86,10 +86,10 @@ export function SpendingLimitsDialog({
           !monthlyDollars && paymentMethod.monthly_limit != null,
       });
 
-      toast.success("Spending limits updated.");
+      toast.success("Card settings updated.");
       onOpenChange(false);
     } catch {
-      toast.error("Failed to update spending limits.");
+      toast.error("Failed to update card settings.");
     }
   }
 
@@ -98,24 +98,27 @@ export function SpendingLimitsDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            Spending Limits &mdash; {paymentMethod.last4}
+            Card Settings &mdash; {paymentMethod.last4}
           </DialogTitle>
           <DialogDescription>
-            Set optional spending limits to control how much agents can charge to
-            this card. Leave blank for no limit.
+            Rename this card and set optional spending limits to control how much
+            agents can charge. Leave limits blank for no limit.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
           <div className="space-y-2">
-            <Label htmlFor="pm-label">Label</Label>
+            <Label htmlFor="pm-label">Card Nickname</Label>
             <Input
               id="pm-label"
-              placeholder="e.g. Personal Visa"
+              placeholder="e.g. Personal Visa, Groceries Card"
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               disabled={isLoading}
             />
+            <p className="text-muted-foreground text-xs">
+              A friendly name to identify this card at a glance.
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/pages/settings/SpendingLimitsDialog.tsx
+++ b/frontend/src/pages/settings/SpendingLimitsDialog.tsx
@@ -78,6 +78,7 @@ export function SpendingLimitsDialog({
       await updatePaymentMethod({
         id: paymentMethod.id,
         label: label || undefined,
+        clear_label: !label && !!paymentMethod.label,
         per_transaction_limit: perTxCents,
         monthly_limit: monthlyCents,
         clear_per_transaction_limit:
@@ -98,7 +99,8 @@ export function SpendingLimitsDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            Card Settings &mdash; {paymentMethod.last4}
+            Card Settings &mdash;{" "}
+            {paymentMethod.label ?? paymentMethod.last4}
           </DialogTitle>
           <DialogDescription>
             Rename this card and set optional spending limits to control how much

--- a/spec/openapi/components/schemas/payment_methods.yaml
+++ b/spec/openapi/components/schemas/payment_methods.yaml
@@ -127,6 +127,9 @@ UpdatePaymentMethodRequest:
       description: |
         Monthly spend limit in cents (rolling 30-day window). Must be >= per_transaction_limit
         if both are set. Set to a value to create/update the limit.
+    clear_label:
+      type: boolean
+      description: Set to true to remove the card nickname/label
     clear_per_transaction_limit:
       type: boolean
       description: Set to true to remove the per-transaction limit entirely

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -10894,6 +10894,9 @@ components:
           description: |
             Monthly spend limit in cents (rolling 30-day window). Must be >= per_transaction_limit
             if both are set. Set to a value to create/update the limit.
+        clear_label:
+          type: boolean
+          description: Set to true to remove the card nickname/label
         clear_per_transaction_limit:
           type: boolean
           description: Set to true to remove the per-transaction limit entirely


### PR DESCRIPTION
## Summary
- Card nickname is now the primary identifier when set — displayed as the bold card name, with brand/last4 details moved to the secondary line
- Replaced the ambiguous ghost "Limits" text with a clearly styled outline "Edit" button with a pencil icon
- Renamed the dialog from "Spending Limits" to "Card Settings" with updated description so it's obvious you can rename the card there
- Added helper text to the nickname field for discoverability

## Test plan

### Claude Code
- [x] Frontend tests pass (851/851)
- [x] TypeScript compiles cleanly

### Manual Testing
- [ ] Verify card with a nickname shows nickname as primary text and card details as secondary
- [ ] Verify card without a nickname shows brand/last4 as primary text
- [ ] Verify "Edit" button is visually distinct and opens the Card Settings dialog
- [ ] Verify renaming a card via the dialog updates the card display
- [ ] Verify spending limits still save correctly from the renamed dialog

https://claude.ai/code/session_01Nr58cgcEMpwcsYcJhhMmqo