### PR TITLE
Scrub sensitive execution data with 30-minute TTL

### DIFF
--- a/background_scrub.go
+++ b/background_scrub.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/supersuit-tech/permission-slip-web/api"
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+func init() {
+	RegisterBackgroundJob(BackgroundJob{
+		Name: "scrub sensitive execution data",
+		Start: func(ctx context.Context, deps *api.Deps, logger *slog.Logger) <-chan struct{} {
+			if deps.DB == nil {
+				return nil
+			}
+			return startScrubExecutionData(ctx, deps.DB, logger)
+		},
+	})
+}
+
+// startScrubExecutionData runs db.ScrubSensitiveExecutionData on a recurring
+// ticker, scrubbing execution_result, action parameters, and standing approval
+// execution parameters older than 30 minutes. Returns a channel that is closed
+// when the goroutine exits for clean shutdown coordination.
+func startScrubExecutionData(ctx context.Context, pool db.DBTX, logger *slog.Logger) <-chan struct{} {
+	interval := scrubInterval(logger)
+	logger.Info("scrub execution data: scheduled", "interval", interval.String())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		// Run once immediately on startup to catch up after downtime.
+		runScrubExecutionData(ctx, pool, logger)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info("scrub execution data: stopped")
+				return
+			case <-ticker.C:
+				runScrubExecutionData(ctx, pool, logger)
+			}
+		}
+	}()
+	return done
+}
+
+// runScrubExecutionData executes a single scrub pass with a 60-second timeout.
+func runScrubExecutionData(ctx context.Context, pool db.DBTX, logger *slog.Logger) {
+	scrubCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	scrubbed, err := db.ScrubSensitiveExecutionData(scrubCtx, pool)
+	if err != nil {
+		if ctx.Err() != nil {
+			logger.Info("scrub execution data: cancelled", "error", err)
+			return
+		}
+		logger.Error("scrub execution data: failed", "error", err)
+		sentry.CaptureException(err)
+	} else if scrubbed > 0 {
+		logger.Info("scrub execution data: completed", "rows_scrubbed", scrubbed)
+	} else {
+		logger.Debug("scrub execution data: completed", "rows_scrubbed", 0)
+	}
+}
+
+// scrubInterval returns the scrub ticker interval from the
+// SCRUB_EXECUTION_DATA_INTERVAL env var, defaulting to 5 minutes.
+// Values below 1 minute are rejected to prevent resource exhaustion.
+func scrubInterval(logger *slog.Logger) time.Duration {
+	const minInterval = time.Minute
+
+	if v := os.Getenv("SCRUB_EXECUTION_DATA_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err == nil && d >= minInterval {
+			return d
+		}
+		logger.Warn("invalid SCRUB_EXECUTION_DATA_INTERVAL, using default 5m",
+			"value", v, "error", err, "min", minInterval.String())
+	}
+	return 5 * time.Minute
+}

--- a/background_scrub.go
+++ b/background_scrub.go
@@ -85,8 +85,13 @@ func scrubInterval(logger *slog.Logger) time.Duration {
 		if err == nil && d >= minInterval {
 			return d
 		}
-		logger.Warn("invalid SCRUB_EXECUTION_DATA_INTERVAL, using default 5m",
-			"value", v, "error", err, "min", minInterval.String())
+		if err != nil {
+			logger.Warn("invalid SCRUB_EXECUTION_DATA_INTERVAL, using default 5m",
+				"value", v, "error", err, "min", minInterval.String())
+		} else {
+			logger.Warn("SCRUB_EXECUTION_DATA_INTERVAL is below minimum, using default 5m",
+				"value", v, "min", minInterval.String())
+		}
 	}
 	return 5 * time.Minute
 }

--- a/db/migrations/20260315002453_scrub_sensitive_execution_data.sql
+++ b/db/migrations/20260315002453_scrub_sensitive_execution_data.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+
+-- SQL function to scrub sensitive execution data older than 30 minutes.
+-- Targets three columns across two tables:
+--   1. approvals.execution_result → NULL
+--   2. approvals.action → {"type":"<original_type>"} (parameters stripped)
+--   3. standing_approval_executions.parameters → NULL
+--
+-- Only scrubs resolved approvals (approved/denied/cancelled) or executed ones.
+-- Pending approvals keep their action parameters so approvers can review them.
+-- Idempotent: WHERE clauses skip already-scrubbed rows.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION scrub_sensitive_execution_data() RETURNS void
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+AS $$
+DECLARE
+    approvals_count bigint;
+    executions_count bigint;
+BEGIN
+    -- Scrub approvals: NULL out execution_result, strip action to type-only.
+    -- Only target resolved approvals with executed_at older than 30 minutes.
+    UPDATE approvals
+    SET execution_result = NULL,
+        action = jsonb_build_object('type', action->>'type')
+    WHERE executed_at IS NOT NULL
+      AND executed_at < now() - interval '30 minutes'
+      AND status IN ('approved', 'denied', 'cancelled')
+      AND (execution_result IS NOT NULL
+           OR action != jsonb_build_object('type', action->>'type'));
+    GET DIAGNOSTICS approvals_count = ROW_COUNT;
+
+    -- Scrub standing_approval_executions: NULL out parameters.
+    UPDATE standing_approval_executions
+    SET parameters = NULL
+    WHERE executed_at < now() - interval '30 minutes'
+      AND parameters IS NOT NULL;
+    GET DIAGNOSTICS executions_count = ROW_COUNT;
+
+    IF approvals_count + executions_count > 0 THEN
+        RAISE LOG 'scrub_sensitive_execution_data: scrubbed % approvals, % standing_approval_executions',
+            approvals_count, executions_count;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+-- Schedule every 5 minutes for redundancy alongside the Go background ticker.
+SELECT try_cron_schedule(
+    'scrub_sensitive_execution_data',
+    '*/5 * * * *',
+    'SELECT scrub_sensitive_execution_data()'
+);
+
+-- +goose Down
+
+SELECT try_cron_unschedule('scrub_sensitive_execution_data');
+DROP FUNCTION IF EXISTS scrub_sensitive_execution_data();

--- a/db/migrations/20260315002453_scrub_sensitive_execution_data.sql
+++ b/db/migrations/20260315002453_scrub_sensitive_execution_data.sql
@@ -23,12 +23,12 @@ BEGIN
     -- Only target resolved approvals with executed_at older than 30 minutes.
     UPDATE approvals
     SET execution_result = NULL,
-        action = jsonb_build_object('type', action->>'type')
+        action = action - 'parameters'
     WHERE executed_at IS NOT NULL
       AND executed_at < now() - interval '30 minutes'
       AND status IN ('approved', 'denied', 'cancelled')
       AND (execution_result IS NOT NULL
-           OR action != jsonb_build_object('type', action->>'type'));
+           OR action ? 'parameters');
     GET DIAGNOSTICS approvals_count = ROW_COUNT;
 
     -- Scrub standing_approval_executions: NULL out parameters.

--- a/db/scrub_execution_data.go
+++ b/db/scrub_execution_data.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// ScrubSensitiveExecutionData nullifies sensitive execution data that is older
+// than 30 minutes. This covers three columns:
+//
+//   - approvals.execution_result → NULL
+//   - approvals.action → {"type":"<original>"} (parameters stripped, type preserved)
+//   - standing_approval_executions.parameters → NULL
+//
+// Only resolved approvals (approved/denied/cancelled) are scrubbed; pending
+// approvals keep their action parameters so approvers can still review them.
+// The function is idempotent — already-scrubbed rows are skipped via WHERE clauses.
+//
+// Returns the total number of rows updated across both tables.
+func ScrubSensitiveExecutionData(ctx context.Context, d DBTX) (int64, error) {
+	// Scrub approvals: NULL out execution_result, strip action to type-only.
+	tag1, err := d.Exec(ctx, `
+		UPDATE approvals
+		SET execution_result = NULL,
+		    action = jsonb_build_object('type', action->>'type')
+		WHERE executed_at IS NOT NULL
+		  AND executed_at < now() - interval '30 minutes'
+		  AND status IN ('approved', 'denied', 'cancelled')
+		  AND (execution_result IS NOT NULL
+		       OR action != jsonb_build_object('type', action->>'type'))`)
+	if err != nil {
+		return 0, fmt.Errorf("scrub approvals: %w", err)
+	}
+
+	// Scrub standing_approval_executions: NULL out parameters.
+	tag2, err := d.Exec(ctx, `
+		UPDATE standing_approval_executions
+		SET parameters = NULL
+		WHERE executed_at < now() - interval '30 minutes'
+		  AND parameters IS NOT NULL`)
+	if err != nil {
+		return tag1.RowsAffected(), fmt.Errorf("scrub standing_approval_executions: %w", err)
+	}
+
+	return tag1.RowsAffected() + tag2.RowsAffected(), nil
+}

--- a/db/scrub_execution_data.go
+++ b/db/scrub_execution_data.go
@@ -39,7 +39,7 @@ func ScrubSensitiveExecutionData(ctx context.Context, d DBTX) (int64, error) {
 		WHERE executed_at < now() - interval '30 minutes'
 		  AND parameters IS NOT NULL`)
 	if err != nil {
-		return tag1.RowsAffected(), fmt.Errorf("scrub standing_approval_executions: %w", err)
+		return 0, fmt.Errorf("scrub standing_approval_executions: %w", err)
 	}
 
 	return tag1.RowsAffected() + tag2.RowsAffected(), nil

--- a/db/scrub_execution_data.go
+++ b/db/scrub_execution_data.go
@@ -22,12 +22,12 @@ func ScrubSensitiveExecutionData(ctx context.Context, d DBTX) (int64, error) {
 	tag1, err := d.Exec(ctx, `
 		UPDATE approvals
 		SET execution_result = NULL,
-		    action = jsonb_build_object('type', action->>'type')
+		    action = action - 'parameters'
 		WHERE executed_at IS NOT NULL
 		  AND executed_at < now() - interval '30 minutes'
 		  AND status IN ('approved', 'denied', 'cancelled')
 		  AND (execution_result IS NOT NULL
-		       OR action != jsonb_build_object('type', action->>'type'))`)
+		       OR action ? 'parameters')`)
 	if err != nil {
 		return 0, fmt.Errorf("scrub approvals: %w", err)
 	}

--- a/db/scrub_execution_data_test.go
+++ b/db/scrub_execution_data_test.go
@@ -53,16 +53,20 @@ func TestScrubSensitiveExecutionData(t *testing.T) {
 			t.Errorf("expected action type 'test.action', got %q", actionType)
 		}
 
-		// Verify parameters were stripped from action.
+		// Verify parameters were stripped but other keys preserved.
 		var actionParams *string
+		var actionVersion *string
 		err = tx.QueryRow(ctx,
-			`SELECT action->>'parameters' FROM approvals WHERE approval_id = $1`,
-			approvalID).Scan(&actionParams)
+			`SELECT action->>'parameters', action->>'version' FROM approvals WHERE approval_id = $1`,
+			approvalID).Scan(&actionParams, &actionVersion)
 		if err != nil {
 			t.Fatalf("query error: %v", err)
 		}
 		if actionParams != nil {
 			t.Errorf("expected action parameters to be stripped, got %s", *actionParams)
+		}
+		if actionVersion == nil || *actionVersion != "1" {
+			t.Errorf("expected action version '1' to be preserved, got %v", actionVersion)
 		}
 	})
 

--- a/db/scrub_execution_data_test.go
+++ b/db/scrub_execution_data_test.go
@@ -1,0 +1,302 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestScrubSensitiveExecutionData(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("ScrubsOldApprovalExecutionData", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		approvalID := testhelper.GenerateID(t, "appr_")
+
+		// Insert a resolved approval with execution data older than 30 minutes.
+		testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "approved")
+		testhelper.MustExec(t, tx,
+			`UPDATE approvals SET
+				execution_status = 'success',
+				execution_result = '{"data":"sensitive"}',
+				executed_at = now() - interval '1 hour'
+			 WHERE approval_id = $1`, approvalID)
+
+		scrubbed, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scrubbed != 1 {
+			t.Errorf("expected 1 scrubbed row, got %d", scrubbed)
+		}
+
+		// Verify execution_result is NULL and action is type-only.
+		var execResult *string
+		var actionType string
+		err = tx.QueryRow(ctx,
+			`SELECT execution_result::text, action->>'type' FROM approvals WHERE approval_id = $1`,
+			approvalID).Scan(&execResult, &actionType)
+		if err != nil {
+			t.Fatalf("query error: %v", err)
+		}
+		if execResult != nil {
+			t.Errorf("expected NULL execution_result, got %s", *execResult)
+		}
+		if actionType != "test.action" {
+			t.Errorf("expected action type 'test.action', got %q", actionType)
+		}
+
+		// Verify parameters were stripped from action.
+		var actionParams *string
+		err = tx.QueryRow(ctx,
+			`SELECT action->>'parameters' FROM approvals WHERE approval_id = $1`,
+			approvalID).Scan(&actionParams)
+		if err != nil {
+			t.Fatalf("query error: %v", err)
+		}
+		if actionParams != nil {
+			t.Errorf("expected action parameters to be stripped, got %s", *actionParams)
+		}
+	})
+
+	t.Run("PreservesRecentApprovalData", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		approvalID := testhelper.GenerateID(t, "appr_")
+
+		// Insert a resolved approval with execution data only 10 minutes old.
+		testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "approved")
+		testhelper.MustExec(t, tx,
+			`UPDATE approvals SET
+				execution_status = 'success',
+				execution_result = '{"data":"sensitive"}',
+				executed_at = now() - interval '10 minutes'
+			 WHERE approval_id = $1`, approvalID)
+
+		scrubbed, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scrubbed != 0 {
+			t.Errorf("expected 0 scrubbed rows, got %d", scrubbed)
+		}
+
+		// Verify execution_result is still present.
+		var execResult *string
+		err = tx.QueryRow(ctx,
+			`SELECT execution_result::text FROM approvals WHERE approval_id = $1`,
+			approvalID).Scan(&execResult)
+		if err != nil {
+			t.Fatalf("query error: %v", err)
+		}
+		if execResult == nil {
+			t.Error("expected execution_result to be preserved, got NULL")
+		}
+	})
+
+	t.Run("PreservesPendingApprovalAction", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		approvalID := testhelper.GenerateID(t, "appr_")
+
+		// Insert a pending approval — should NOT be scrubbed regardless of age.
+		testhelper.InsertApproval(t, tx, approvalID, agentID, uid)
+
+		scrubbed, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scrubbed != 0 {
+			t.Errorf("expected 0 scrubbed rows for pending approval, got %d", scrubbed)
+		}
+	})
+
+	t.Run("ScrubsOldStandingApprovalExecutionParams", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		saID := testhelper.GenerateID(t, "sa_")
+		testhelper.InsertStandingApproval(t, tx, saID, agentID, uid)
+		testhelper.InsertStandingApprovalExecutionWithParams(t, tx, saID, []byte(`{"key":"sensitive_value"}`))
+
+		// Backdate the execution to 1 hour ago.
+		testhelper.MustExec(t, tx,
+			`UPDATE standing_approval_executions SET executed_at = now() - interval '1 hour'
+			 WHERE standing_approval_id = $1`, saID)
+
+		scrubbed, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scrubbed != 1 {
+			t.Errorf("expected 1 scrubbed row, got %d", scrubbed)
+		}
+
+		// Verify parameters are NULL.
+		var params *string
+		err = tx.QueryRow(ctx,
+			`SELECT parameters::text FROM standing_approval_executions WHERE standing_approval_id = $1`,
+			saID).Scan(&params)
+		if err != nil {
+			t.Fatalf("query error: %v", err)
+		}
+		if params != nil {
+			t.Errorf("expected NULL parameters, got %s", *params)
+		}
+	})
+
+	t.Run("PreservesRecentStandingApprovalExecutionParams", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		saID := testhelper.GenerateID(t, "sa_")
+		testhelper.InsertStandingApproval(t, tx, saID, agentID, uid)
+		testhelper.InsertStandingApprovalExecutionWithParams(t, tx, saID, []byte(`{"key":"sensitive_value"}`))
+
+		// Execution is recent (default now()) — should not be scrubbed.
+		scrubbed, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scrubbed != 0 {
+			t.Errorf("expected 0 scrubbed rows, got %d", scrubbed)
+		}
+	})
+
+	t.Run("IdempotentOnAlreadyScrubbed", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		approvalID := testhelper.GenerateID(t, "appr_")
+
+		// Insert and scrub once.
+		testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "approved")
+		testhelper.MustExec(t, tx,
+			`UPDATE approvals SET
+				execution_status = 'success',
+				execution_result = '{"data":"sensitive"}',
+				executed_at = now() - interval '1 hour'
+			 WHERE approval_id = $1`, approvalID)
+
+		_, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("first scrub error: %v", err)
+		}
+
+		// Second scrub should find nothing to do.
+		scrubbed, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("second scrub error: %v", err)
+		}
+		if scrubbed != 0 {
+			t.Errorf("expected 0 rows on idempotent re-scrub, got %d", scrubbed)
+		}
+	})
+
+	t.Run("PreservesExecutionStatus", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		approvalID := testhelper.GenerateID(t, "appr_")
+
+		testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "denied")
+		testhelper.MustExec(t, tx,
+			`UPDATE approvals SET
+				execution_status = 'error',
+				execution_result = '{"error":"something failed"}',
+				executed_at = now() - interval '2 hours'
+			 WHERE approval_id = $1`, approvalID)
+
+		_, err := db.ScrubSensitiveExecutionData(ctx, tx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// execution_status and executed_at should remain intact.
+		var execStatus string
+		var executedAt *string
+		err = tx.QueryRow(ctx,
+			`SELECT execution_status, executed_at::text FROM approvals WHERE approval_id = $1`,
+			approvalID).Scan(&execStatus, &executedAt)
+		if err != nil {
+			t.Fatalf("query error: %v", err)
+		}
+		if execStatus != "error" {
+			t.Errorf("expected execution_status 'error', got %q", execStatus)
+		}
+		if executedAt == nil {
+			t.Error("expected executed_at to be preserved, got NULL")
+		}
+	})
+}
+
+func TestScrubSensitiveExecutionData_SQLFunction(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("ScrubsViaSQL", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		approvalID := testhelper.GenerateID(t, "appr_")
+
+		testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "approved")
+		testhelper.MustExec(t, tx,
+			`UPDATE approvals SET
+				execution_status = 'success',
+				execution_result = '{"data":"sensitive"}',
+				executed_at = now() - interval '1 hour'
+			 WHERE approval_id = $1`, approvalID)
+
+		// Call the SQL function directly.
+		_, err := tx.Exec(ctx, "SELECT scrub_sensitive_execution_data()")
+		if err != nil {
+			t.Fatalf("SQL function error: %v", err)
+		}
+
+		// Verify scrubbed.
+		var execResult *string
+		var actionType string
+		err = tx.QueryRow(ctx,
+			`SELECT execution_result::text, action->>'type' FROM approvals WHERE approval_id = $1`,
+			approvalID).Scan(&execResult, &actionType)
+		if err != nil {
+			t.Fatalf("query error: %v", err)
+		}
+		if execResult != nil {
+			t.Errorf("expected NULL execution_result, got %s", *execResult)
+		}
+		if actionType != "test.action" {
+			t.Errorf("expected action type 'test.action', got %q", actionType)
+		}
+	})
+}
+
+func TestScrubSensitiveExecutionData_PgCronJob(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	testhelper.RequirePgCronJob(t, tx, "scrub_sensitive_execution_data")
+}

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -223,6 +223,11 @@ function ApprovalContent({
           </pre>
         </div>
       )}
+      {executionStatus && !executionResult && (
+        <p className="text-muted-foreground text-xs italic">
+          Execution details are automatically removed after 30 minutes.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -227,6 +227,7 @@ function ApprovalContent({
         </div>
       )}
       {executionStatus && !executionResult && executedAt &&
+        Object.keys(parameters).length === 0 &&
         new Date(executedAt).getTime() < Date.now() - 30 * 60 * 1000 && (
         <p className="text-muted-foreground text-xs italic">
           Execution details are automatically removed after 30 minutes.

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -134,6 +134,7 @@ function ApprovalDetails({ approvalId }: { approvalId: string }) {
       executionStatus={approval.execution_status ?? undefined}
       executionError={executionError}
       executionResult={executionResult}
+      executedAt={approval.executed_at ?? undefined}
     />
   );
 }
@@ -146,6 +147,7 @@ function ApprovalContent({
   executionStatus,
   executionError,
   executionResult,
+  executedAt,
 }: {
   actionType: string;
   parameters: Record<string, unknown>;
@@ -154,6 +156,7 @@ function ApprovalContent({
   executionStatus?: string;
   executionError?: string;
   executionResult?: Record<string, unknown>;
+  executedAt?: string;
 }) {
   const { schema, actionName } = useActionSchema(actionType);
 
@@ -223,7 +226,8 @@ function ApprovalContent({
           </pre>
         </div>
       )}
-      {executionStatus && !executionResult && (
+      {executionStatus && !executionResult && executedAt &&
+        new Date(executedAt).getTime() < Date.now() - 30 * 60 * 1000 && (
         <p className="text-muted-foreground text-xs italic">
           Execution details are automatically removed after 30 minutes.
         </p>


### PR DESCRIPTION
## Summary

- Adds a 30-minute TTL scrub for three sensitive JSONB columns: `approvals.execution_result` (→ NULL), `approvals.action` (→ type-only), and `standing_approval_executions.parameters` (→ NULL)
- Two-layer enforcement: Go background ticker (5-min default) + pg_cron SQL function (every 5 min) for redundancy
- Only scrubs resolved approvals (approved/denied/cancelled); pending approvals retain action parameters for approver review

Closes #583

## Test plan

### Claude Code
- [x] Database integration tests pass (7 Go tests + SQL function test)
- [x] Frontend typecheck passes
- [x] Frontend tests pass (851 tests)
- [x] Full Go build passes
- [x] Verify migration applies cleanly in CI

### Manual Testing
- [ ] Verify scrubbed data hint displays correctly in Activity detail sheet when execution_result is null but execution_status is present
- [ ] Confirm pending approvals still show full action parameters in dashboard
- [ ] Test background scrub job starts and logs correctly on server boot

https://claude.ai/code