### PR TITLE
chore: bump cli/package.json to 0.1.7

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.4",
+  "version": "0.1.7",
   "description": "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers",
   "license": "MIT",
   "type": "module",
@@ -45,7 +45,9 @@
         {
           "useESM": true,
           "diagnostics": {
-            "ignoreCodes": [151002]
+            "ignoreCodes": [
+              151002
+            ]
           }
         }
       ]


### PR DESCRIPTION
Auto-generated by `/version-tag`. Syncs `cli/package.json` version to match tag `cli/v0.1.7`.