### PR TITLE
Fix Fly.io deploy: copy config/ into Docker frontend stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG SENTRY_PROJECT
 COPY shared/ /app/shared/
 
 # Copy config directory (frontend/src/config/plans.ts imports @config/plans.json)
-COPY config/ /app/config/
+COPY config/plans.json /app/config/plans.json
 
 # Copy frontend source and build
 COPY frontend/ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ ARG SENTRY_PROJECT
 # Copy shared validation config (imported by frontend/src/lib/validation.ts)
 COPY shared/ /app/shared/
 
+# Copy config directory (frontend/src/config/plans.ts imports @config/plans.json)
+COPY config/ /app/config/
+
 # Copy frontend source and build
 COPY frontend/ ./
 RUN npm run build


### PR DESCRIPTION
## Summary

- Fly.io deploys have been failing since PR #542 added `frontend/src/config/plans.ts`, which imports `@config/plans.json` (resolved via Vite alias to `../config/plans.json`)
- The Dockerfile's frontend build stage never copies `config/` into the container, so the Vite build fails when it can't resolve the import
- Every deploy since ~March 14 15:00 UTC has failed with exit code 1
- Fix: add `COPY config/ /app/config/` to the frontend build stage, matching the existing pattern for `shared/` and `spec/`

## Test plan

### Claude Code
- [ ] Verify CI passes

### Manual Testing
- [ ] Confirm next deploy to Fly.io succeeds after merge

https://claude.ai/code/session_013Gkf7SbWwsHQTSGb4CJWYv