### PR TITLE
Add CODEOWNERS for infra/dependency file reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Require @chiedo's approval for infrastructure, dependency, and CI files
+Dockerfile @chiedo
+go.mod @chiedo
+go.sum @chiedo
+Makefile @chiedo
+.github/workflows/ @chiedo


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring @chiedo's approval when PRs touch:
  - `Dockerfile`
  - `go.mod` / `go.sum`
  - `Makefile`
  - `.github/workflows/` (all CI/CD pipelines)

## Manual Testing

- [ ] Enable "Require review from Code Owners" in branch protection settings for `main` (Settings > Branches > Branch protection rules)
- [ ] Verify a PR touching `Dockerfile` requests @chiedo as a reviewer
- [ ] Verify a PR that doesn't touch any listed files does not require @chiedo's review

https://claude.ai/code/session_01XkFR8BqRrJSU78ntbcCtwL