### PR TITLE
Support free-form prompts in yolo skill

### DIFF
--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -1,30 +1,35 @@
 ---
 name: yolo
-description: Autonomously implement a GitHub issue end-to-end — do the work, open a PR, and watch it through to merge. Use when the user wants to hand off an issue completely.
-argument-hint: "<ISSUE_URL> [--scope \"<heading>\"]"
+description: Autonomously implement a GitHub issue or a free-form prompt end-to-end — do the work, open a PR, and watch it through to merge. Use when the user wants to hand off an issue or task completely.
+argument-hint: "<ISSUE_URL|prompt text> [--scope \"<heading>\"]"
 ---
 
-# YOLO — Autonomous Issue Implementation
+# YOLO — Autonomous Implementation
 
-Takes a GitHub issue URL, implements the work described in it, opens a pull request, and hands off to `/watch --automerge` to shepherd it through review to merge.
+Takes a GitHub issue URL **or a free-form prompt**, implements the work described, opens a pull request, and hands off to `/watch --automerge` to shepherd it through review to merge.
 
-Optionally accepts a `--scope` flag to limit work to a specific section of the issue (e.g., `--scope "Chunk 1A"` or `--scope "Phase 4"`). When scoped, only the content under that heading is implemented — everything else is ignored.
+Optionally accepts a `--scope` flag to limit work to a specific section of the issue (e.g., `--scope "Chunk 1A"` or `--scope "Phase 4"`). When scoped, only the content under that heading is implemented — everything else is ignored. The `--scope` flag is only valid when an issue URL is provided.
 
 ## Setup
 
 Parse the arguments from: `$ARGUMENTS`
 
-Extract the issue URL and any flags. The format is: `<ISSUE_URL> [--scope "<heading>"]`
+Determine whether the input is an **issue URL** or a **free-form prompt**:
 
-Extract the issue number from the URL (e.g., `https://github.com/supersuit-tech/permission-slip/issues/42` → `42`).
+- **Issue URL mode**: The first argument matches a GitHub issue URL pattern (e.g., `https://github.com/.../issues/N` or just a `#N` issue reference). Extract the URL/number and any `--scope` flag.
+- **Prompt mode**: The arguments do NOT start with a GitHub issue URL. Treat the entire `$ARGUMENTS` string (minus any flags) as the task description.
 
 Set these variables:
-- `ISSUE_URL` — the full issue URL
-- `ISSUE_NUMBER` — the extracted issue number
-- `SCOPE` — the value of `--scope` if provided, empty string otherwise
+- `MODE` — either `issue` or `prompt`
+- `ISSUE_URL` — the full issue URL (issue mode only, empty in prompt mode)
+- `ISSUE_NUMBER` — the extracted issue number (issue mode only, empty in prompt mode)
+- `TASK_DESCRIPTION` — the free-form prompt text (prompt mode only, empty in issue mode)
+- `SCOPE` — the value of `--scope` if provided, empty string otherwise (issue mode only)
 - `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
 
-## Step 1: Fetch and Understand the Issue
+## Step 1: Understand the Work
+
+### Issue Mode
 
 Fetch the issue details:
 
@@ -34,7 +39,7 @@ GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh issue view "$ISSUE_
 
 Read the issue thoroughly.
 
-### Scoped Execution
+#### Scoped Execution
 
 If `SCOPE` is set, find the section of the issue body whose heading matches the scope value. The match is **case-insensitive** and looks for any markdown heading (`#`, `##`, `###`, etc.) that contains the scope text. For example, `--scope "Chunk 1A"` matches `## Chunk 1A`, `### Chunk 1A — Database Layer`, etc.
 
@@ -42,26 +47,41 @@ Extract only the content under that heading (up to the next heading of equal or 
 
 If no matching heading is found, abort with a comment on the issue: "Could not find a section matching `<SCOPE>` in the issue body."
 
-### Understanding the Work
+### Prompt Mode
+
+The task description IS your scope of work. Read it carefully.
+
+If the prompt is unclear or too vague to implement confidently, tell the user what's ambiguous and stop. Do NOT guess at ambiguous requirements.
+
+### Understanding the Work (Both Modes)
 
 Identify:
-- **What needs to be built or changed** — the core deliverable (from the scoped section if `SCOPE` is set, otherwise the full issue)
-- **Acceptance criteria** — any checklist items, requirements, or success conditions within scope
+- **What needs to be built or changed** — the core deliverable
+- **Acceptance criteria** — any checklist items, requirements, or success conditions
 - **Scope boundaries** — what's explicitly out of scope or deferred
 - **Related files** — any files, endpoints, or components mentioned
 
-If the issue (or scoped section) is unclear or too vague to implement confidently, post a comment on the issue asking for clarification and stop. Do NOT guess at ambiguous requirements.
+If the task is unclear or too vague to implement confidently, post a comment on the issue (issue mode) or tell the user (prompt mode) asking for clarification and stop. Do NOT guess at ambiguous requirements.
 
 ## Step 2: Create a Feature Branch
 
-Create a descriptive branch name based on the issue:
+Create a descriptive branch name:
 
+**Issue mode:**
 ```bash
 BRANCH="issue-${ISSUE_NUMBER}-<short-kebab-description>"
 git checkout -b "$BRANCH"
 ```
 
-The branch name should be concise but descriptive (e.g., `issue-42-add-user-avatars`). When `SCOPE` is set, incorporate it into the branch name (e.g., `issue-42-chunk-1a-database-layer`).
+When `SCOPE` is set, incorporate it into the branch name (e.g., `issue-42-chunk-1a-database-layer`).
+
+**Prompt mode:**
+```bash
+BRANCH="<short-kebab-description>"
+git checkout -b "$BRANCH"
+```
+
+Pick a concise, descriptive branch name based on the task (e.g., `add-user-avatars`, `fix-login-redirect`).
 
 ## Step 3: Plan and Implement
 
@@ -79,7 +99,7 @@ Then implement the changes. Follow these principles:
 - **Keep diffs minimal** — only touch lines directly related to the task.
 - **Follow CLAUDE.md guidelines** — especially around API layer, component architecture, migrations, and testing.
 
-### Checklist Tracking
+### Checklist Tracking (Issue Mode Only)
 
 If the issue body contains checklist items (`- [ ] ...`), check them off as you complete each one. When `SCOPE` is set, **only check off items within the scoped section** — do not touch checklist items in other sections:
 
@@ -117,7 +137,9 @@ Push the branch:
 git push -u origin "$BRANCH"
 ```
 
-Create the PR, linking it to the issue. When `SCOPE` is set, include the scope in the PR title (e.g., "Add user avatars (Chunk 1A)") and use `Part of #N` instead of `Closes #N` since a scoped run only completes a portion of the issue:
+Create the PR. The body format differs based on mode:
+
+**Issue mode** — link to the issue. When `SCOPE` is set, include the scope in the PR title (e.g., "Add user avatars (Chunk 1A)") and use `Part of #N` instead of `Closes #N`:
 
 ```bash
 GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr create \
@@ -128,6 +150,32 @@ GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr create \
 <1-3 bullet points describing the changes>
 
 <"Closes" if unscoped, "Part of" if scoped> #<ISSUE_NUMBER>
+
+## Test plan
+
+### Claude Code
+- [ ] <items Claude Code can verify autonomously>
+
+### OpenClaw
+- [ ] <items requiring human judgment>
+
+https://claude.ai/code
+PREOF
+)" \
+  --head "$BRANCH"
+```
+
+**Prompt mode** — no issue to link, so include the original prompt for context:
+
+```bash
+GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr create \
+  --title "<concise PR title>" \
+  --body "$(cat <<'PREOF'
+## Summary
+
+<1-3 bullet points describing the changes>
+
+> **Task:** <original prompt text, quoted>
 
 ## Test plan
 
@@ -160,8 +208,9 @@ Use the `Skill` tool to invoke the watch skill, passing `--automerge --no-notify
 - **Never ask for human input during implementation** — make your best judgment and implement.
 - **Commit frequently** — small, logical commits with clear messages.
 - **Run tests before pushing** — never push broken code.
-- **Check off issue checklist items in real time** — don't wait until the end.
-- **Link the PR to the issue** — use `Closes #N` in the PR body so the issue auto-closes on merge.
+- **Check off issue checklist items in real time** (issue mode) — don't wait until the end.
+- **Link the PR to the issue** (issue mode) — use `Closes #N` in the PR body so the issue auto-closes on merge.
+- **Include the original prompt in the PR body** (prompt mode) — so reviewers have context on what was requested.
 - **Follow all CLAUDE.md guidelines** — especially around migrations, API types, component architecture, and merge conflict minimization.
 - **Post-task review** — before opening the PR, run all five review passes from CLAUDE.md (self-review, senior engineer lens, maintainability, code quality, documentation).
 - **Do NOT trigger the webhook notification** — the `/yolo` skill is fully autonomous end-to-end. Do not call the `trigger-webhook.yml` workflow at any point during this skill. The `--no-notify` flag on `/watch` handles suppressing the notification from the watch post-session as well.


### PR DESCRIPTION
## Summary

- The `/yolo` skill now accepts either a GitHub issue URL **or** a free-form prompt as input
- In prompt mode, it skips issue-specific steps (fetching, checklist tracking, issue linking) and includes the original prompt in the PR body for reviewer context
- All existing issue-based functionality is preserved unchanged

## Test plan

### Claude Code
- [ ] Verify `/yolo <issue-url>` still works as before
- [ ] Verify `/yolo do this stuff` triggers prompt mode

### Manual Testing
- [ ] Run `/yolo` with a multi-line prompt and confirm the PR body includes the quoted prompt

https://claude.ai/code/session_01MFEJxKUY3fWakeSSUZwrdw