### PR TITLE
Fix billing detail row spacing on narrow screens

### DIFF
--- a/frontend/src/pages/billing/DetailRow.tsx
+++ b/frontend/src/pages/billing/DetailRow.tsx
@@ -13,9 +13,9 @@ interface DetailRowProps {
  */
 export function DetailRow({ label, children }: DetailRowProps) {
   return (
-    <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
       <span className="text-sm font-medium shrink-0">{label}</span>
-      <div className="text-sm text-muted-foreground text-right">{children}</div>
+      <div className="text-sm text-muted-foreground text-right ms-auto">{children}</div>
     </div>
   );
 }

--- a/frontend/src/pages/billing/DetailRow.tsx
+++ b/frontend/src/pages/billing/DetailRow.tsx
@@ -15,7 +15,7 @@ export function DetailRow({ label, children }: DetailRowProps) {
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
       <span className="text-sm font-medium shrink-0">{label}</span>
-      <div className="text-sm text-muted-foreground text-right ms-auto">{children}</div>
+      <div className="text-sm text-right ms-auto">{children}</div>
     </div>
   );
 }

--- a/frontend/src/pages/billing/DetailRow.tsx
+++ b/frontend/src/pages/billing/DetailRow.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+interface DetailRowProps {
+  label: string;
+  children: ReactNode;
+}
+
+/**
+ * A label–value row for billing detail cards.
+ *
+ * Uses flex-wrap so that long values (e.g. pricing descriptions) wrap
+ * below the label on narrow screens instead of colliding with it.
+ */
+export function DetailRow({ label, children }: DetailRowProps) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+      <span className="text-sm font-medium shrink-0">{label}</span>
+      <div className="text-sm text-muted-foreground text-right">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -46,7 +46,7 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
           <div className="rounded-lg border p-4 space-y-3">
             <DetailRow label="Plan">
               <div className="flex items-center gap-2">
-                <span className="text-foreground">{plan.name}</span>
+                <span>{plan.name}</span>
                 <Badge variant={isFree ? "outline" : "default"}>
                   {isFree ? "Free" : "Pay-as-you-go"}
                 </Badge>
@@ -54,15 +54,17 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
             </DetailRow>
             {!isFree && pricing && (
               <DetailRow label="Pricing">
-                {pricing.free_request_allowance.toLocaleString()} requests/month included, then {pricing.price_per_request_display}/request
+                <span className="text-muted-foreground">{pricing.free_request_allowance.toLocaleString()} requests/month included, then {pricing.price_per_request_display}/request</span>
               </DetailRow>
             )}
             <DetailRow label="Status">
               <StatusBadge status={subscription.status} />
             </DetailRow>
             <DetailRow label="Billing Period">
-              {formatDate(subscription.current_period_start)} &ndash;{" "}
-              {formatDate(subscription.current_period_end)}
+              <span className="text-muted-foreground">
+                {formatDate(subscription.current_period_start)} &ndash;{" "}
+                {formatDate(subscription.current_period_end)}
+              </span>
             </DetailRow>
           </div>
           {subscription.status === "past_due" && (

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { BillingPricing, Plan, Subscription } from "@/hooks/useBillingPlan";
+import { DetailRow } from "./DetailRow";
 import { formatDate } from "./formatters";
 
 interface PlanCardProps {
@@ -43,34 +44,26 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
       <CardContent>
         <div className="space-y-4">
           <div className="rounded-lg border p-4 space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">Plan</span>
+            <DetailRow label="Plan">
               <div className="flex items-center gap-2">
-                <span className="text-sm">{plan.name}</span>
+                <span>{plan.name}</span>
                 <Badge variant={isFree ? "outline" : "default"}>
                   {isFree ? "Free" : "Pay-as-you-go"}
                 </Badge>
               </div>
-            </div>
+            </DetailRow>
             {!isFree && pricing && (
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium">Pricing</span>
-                <span className="text-sm text-muted-foreground">
-                  {pricing.free_request_allowance.toLocaleString()} requests/month included, then {pricing.price_per_request_display}/request
-                </span>
-              </div>
+              <DetailRow label="Pricing">
+                {pricing.free_request_allowance.toLocaleString()} requests/month included, then {pricing.price_per_request_display}/request
+              </DetailRow>
             )}
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">Status</span>
+            <DetailRow label="Status">
               <StatusBadge status={subscription.status} />
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">Billing Period</span>
-              <span className="text-sm text-muted-foreground">
-                {formatDate(subscription.current_period_start)} &ndash;{" "}
-                {formatDate(subscription.current_period_end)}
-              </span>
-            </div>
+            </DetailRow>
+            <DetailRow label="Billing Period">
+              {formatDate(subscription.current_period_start)} &ndash;{" "}
+              {formatDate(subscription.current_period_end)}
+            </DetailRow>
           </div>
           {subscription.status === "past_due" && (
             <p className="text-sm text-destructive">

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -46,7 +46,7 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
           <div className="rounded-lg border p-4 space-y-3">
             <DetailRow label="Plan">
               <div className="flex items-center gap-2">
-                <span>{plan.name}</span>
+                <span className="text-foreground">{plan.name}</span>
                 <Badge variant={isFree ? "outline" : "default"}>
                   {isFree ? "Free" : "Pay-as-you-go"}
                 </Badge>

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -18,6 +18,7 @@ import { useBillingPortal } from "@/hooks/useBillingPortal";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { useBillingInvoices } from "@/hooks/useBillingInvoices";
 import type { Subscription, UsageSummary } from "@/hooks/useBillingPlan";
+import { DetailRow } from "./DetailRow";
 import { formatCents, formatDate, isStripeUrl } from "./formatters";
 import { DowngradeConfirmDialog } from "./DowngradeConfirmDialog";
 
@@ -45,8 +46,7 @@ function ManageSubscriptionLink() {
   const { openPortal, isLoading } = useBillingPortal();
 
   return (
-    <div className="flex items-center justify-between">
-      <span className="text-sm font-medium">Subscription</span>
+    <DetailRow label="Subscription">
       <Button
         variant="link"
         size="sm"
@@ -66,7 +66,7 @@ function ManageSubscriptionLink() {
         )}
         Manage on Stripe
       </Button>
-    </div>
+    </DetailRow>
   );
 }
 
@@ -186,10 +186,9 @@ export function PlanDetailsCard({ subscription, usage }: PlanDetailsCardProps) {
       <CardContent>
         <div className="space-y-4">
           <div className="rounded-lg border p-4 space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">Estimated Cost (this month)</span>
+            <DetailRow label="Estimated Cost (this month)">
               <CostEstimate />
-            </div>
+            </DetailRow>
             {subscription.can_downgrade && <ManageSubscriptionLink />}
           </div>
 

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -138,7 +138,7 @@ export function UsageSummaryCard({ usage, plan, pricing }: UsageSummaryCardProps
             limit={plan.max_credentials ?? null}
           />
           <DetailRow label="Audit Retention">
-            {plan.audit_retention_days} days
+            <span className="text-muted-foreground">{plan.audit_retention_days} days</span>
           </DetailRow>
         </div>
       </CardContent>

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -9,6 +9,7 @@ import {
 import type { BillingPricing, Plan, UsageSummary } from "@/hooks/useBillingPlan";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { FREE_REQUEST_ALLOWANCE, PRICE_PER_REQUEST } from "./constants";
+import { DetailRow } from "./DetailRow";
 
 interface UsageSummaryCardProps {
   usage: UsageSummary;
@@ -136,12 +137,9 @@ export function UsageSummaryCard({ usage, plan, pricing }: UsageSummaryCardProps
             current={usage.credentials}
             limit={plan.max_credentials ?? null}
           />
-          <div className="flex items-center justify-between text-sm">
-            <span className="font-medium">Audit Retention</span>
-            <span className="text-muted-foreground">
-              {plan.audit_retention_days} days
-            </span>
-          </div>
+          <DetailRow label="Audit Retention">
+            {plan.audit_retention_days} days
+          </DetailRow>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

- Extract a reusable `DetailRow` component (`flex-wrap` + `gap-x-4 gap-y-1` + `shrink-0` label) that gracefully wraps long values below the label on narrow screens instead of cramming them side-by-side
- Apply `DetailRow` across `PlanCard`, `PlanDetailsCard`, and `UsageSummaryCard` to fix the "Pricing" row clutter and prevent similar issues in any future detail rows
- The component uses `items-baseline` alignment and `text-right` for values, keeping the layout clean on both wide and narrow viewports

> **Task:** Fix the styling on the billing page under current plan. Where "250 requests/month included, then $0.005/request" is terribly cluttered right next to the pricing label, ideally in a way that generalizes and prevents this from happening in the future and fixes other places where this happens

## Test plan

### Claude Code
- [x] All frontend tests pass
- [x] TypeScript compiles without errors

### Manual Testing
- [ ] Verify the "Pricing" row in the Current Plan card wraps properly on mobile
- [ ] Verify other detail rows (Plan, Status, Billing Period, Estimated Cost, Audit Retention) still look correct on both mobile and desktop

https://claude.ai/code