### PR TITLE
Move payment methods from billing settings to agent page

### DIFF
--- a/api/agent_payment_methods.go
+++ b/api/agent_payment_methods.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// --- Response types ---
+
+type agentPaymentMethodResponse struct {
+	AgentID         int64     `json:"agent_id"`
+	PaymentMethodID string    `json:"payment_method_id"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+type assignAgentPaymentMethodRequest struct {
+	PaymentMethodID string `json:"payment_method_id"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentPaymentMethodRoutes)
+}
+
+// RegisterAgentPaymentMethodRoutes adds agent payment method endpoints to the mux.
+func RegisterAgentPaymentMethodRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /agents/{agent_id}/payment-method", requireProfile(handleGetAgentPaymentMethod(deps)))
+	mux.Handle("PUT /agents/{agent_id}/payment-method", requireProfile(handleAssignAgentPaymentMethod(deps)))
+	mux.Handle("DELETE /agents/{agent_id}/payment-method", requireProfile(handleRemoveAgentPaymentMethod(deps)))
+}
+
+// ── GET /agents/{agent_id}/payment-method ───────────────────────────────────
+
+func handleGetAgentPaymentMethod(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		binding, err := db.GetAgentPaymentMethod(r.Context(), deps.DB, agentID)
+		if err != nil {
+			log.Printf("[%s] GetAgentPaymentMethod: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get payment method assignment"))
+			return
+		}
+
+		if binding == nil {
+			RespondJSON(w, http.StatusOK, map[string]interface{}{
+				"agent_id":          agentID,
+				"payment_method_id": nil,
+			})
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, agentPaymentMethodResponse{
+			AgentID:         binding.AgentID,
+			PaymentMethodID: binding.PaymentMethodID,
+			CreatedAt:       binding.CreatedAt,
+		})
+	}
+}
+
+// ── PUT /agents/{agent_id}/payment-method ───────────────────────────────────
+
+func handleAssignAgentPaymentMethod(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		var req assignAgentPaymentMethodRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		if req.PaymentMethodID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "payment_method_id is required"))
+			return
+		}
+
+		// Verify the payment method belongs to the user.
+		pm, err := db.GetPaymentMethodByID(r.Context(), deps.DB, userID, req.PaymentMethodID)
+		if err != nil {
+			log.Printf("[%s] AssignAgentPaymentMethod: pm lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify payment method"))
+			return
+		}
+		if pm == nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Payment method not found"))
+			return
+		}
+
+		binding, err := db.AssignAgentPaymentMethod(r.Context(), deps.DB, agentID, req.PaymentMethodID)
+		if err != nil {
+			log.Printf("[%s] AssignAgentPaymentMethod: upsert: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign payment method"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, agentPaymentMethodResponse{
+			AgentID:         binding.AgentID,
+			PaymentMethodID: binding.PaymentMethodID,
+			CreatedAt:       binding.CreatedAt,
+		})
+	}
+}
+
+// ── DELETE /agents/{agent_id}/payment-method ────────────────────────────────
+
+func handleRemoveAgentPaymentMethod(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		deleted, err := db.RemoveAgentPaymentMethod(r.Context(), deps.DB, agentID)
+		if err != nil {
+			log.Printf("[%s] RemoveAgentPaymentMethod: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to remove payment method assignment"))
+			return
+		}
+		if !deleted {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrPaymentMethodNotFound, "No payment method assigned to this agent"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+	}
+}

--- a/api/agent_payment_methods_test.go
+++ b/api/agent_payment_methods_test.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestGetAgentPaymentMethod_NoAssignment(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "apmapi_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/payment-method", agentID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp["payment_method_id"] != nil {
+		t.Errorf("expected null payment_method_id, got %v", resp["payment_method_id"])
+	}
+}
+
+func TestAssignAgentPaymentMethod(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "apmassign_"+uid[:8])
+
+	pm, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                uid,
+		StripePaymentMethodID: "pm_api_" + uid[:8],
+		Brand:                 "visa",
+		Last4:                 "4242",
+		ExpMonth:              12,
+		ExpYear:               2028,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod: %v", err)
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body, _ := json.Marshal(map[string]string{"payment_method_id": pm.ID})
+	r := authenticatedRequestWithBody(t, http.MethodPut, fmt.Sprintf("/agents/%d/payment-method", agentID), uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp agentPaymentMethodResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.PaymentMethodID != pm.ID {
+		t.Errorf("expected payment_method_id=%s, got %s", pm.ID, resp.PaymentMethodID)
+	}
+	if resp.AgentID != agentID {
+		t.Errorf("expected agent_id=%d, got %d", agentID, resp.AgentID)
+	}
+}
+
+func TestAssignAgentPaymentMethod_OtherUserPM(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+	otherUID := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "apmown_"+uid[:8])
+	testhelper.InsertUser(t, tx, otherUID, "apmoth_"+otherUID[:8])
+
+	pm, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                otherUID,
+		StripePaymentMethodID: "pm_other_" + otherUID[:8],
+		Brand:                 "visa",
+		Last4:                 "9999",
+		ExpMonth:              12,
+		ExpYear:               2028,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod: %v", err)
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body, _ := json.Marshal(map[string]string{"payment_method_id": pm.ID})
+	r := authenticatedRequestWithBody(t, http.MethodPut, fmt.Sprintf("/agents/%d/payment-method", agentID), uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for other user's PM, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRemoveAgentPaymentMethod(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "apmrm_"+uid[:8])
+
+	pm, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                uid,
+		StripePaymentMethodID: "pm_rm_" + uid[:8],
+		Brand:                 "visa",
+		Last4:                 "4242",
+		ExpMonth:              12,
+		ExpYear:               2028,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod: %v", err)
+	}
+
+	_, err = db.AssignAgentPaymentMethod(ctx, tx, agentID, pm.ID)
+	if err != nil {
+		t.Fatalf("AssignAgentPaymentMethod: %v", err)
+	}
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodDelete, fmt.Sprintf("/agents/%d/payment-method", agentID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify it's gone.
+	binding, err := db.GetAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("GetAgentPaymentMethod: %v", err)
+	}
+	if binding != nil {
+		t.Fatal("expected nil after removal")
+	}
+}
+
+func TestRemoveAgentPaymentMethod_NotFound(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "apmnf_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodDelete, fmt.Sprintf("/agents/%d/payment-method", agentID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeletePaymentMethod_ReturnsAffectedAgents(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "pmaffect_"+uid[:8])
+	agentID1 := testhelper.InsertAgent(t, tx, uid)
+	agentID2 := testhelper.InsertAgent(t, tx, uid)
+
+	pm, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                uid,
+		StripePaymentMethodID: "pm_affect_" + uid[:8],
+		Brand:                 "visa",
+		Last4:                 "4242",
+		ExpMonth:              12,
+		ExpYear:               2028,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod: %v", err)
+	}
+
+	_, _ = db.AssignAgentPaymentMethod(ctx, tx, agentID1, pm.ID)
+	_, _ = db.AssignAgentPaymentMethod(ctx, tx, agentID2, pm.ID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodDelete, fmt.Sprintf("/payment-methods/%s", pm.ID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp deletePaymentMethodResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if !resp.Deleted {
+		t.Error("expected deleted=true")
+	}
+	if resp.AffectedAgents != 2 {
+		t.Errorf("expected affected_agents=2, got %d", resp.AffectedAgents)
+	}
+}
+
+// authenticatedRequestWithBody creates a request with a JSON body and auth.
+func authenticatedRequestWithBody(t *testing.T, method, path, userID string, body []byte) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// Copy auth header from authenticatedRequest.
+	authReq := authenticatedRequest(t, method, path, userID)
+	req.Header.Set("Authorization", authReq.Header.Get("Authorization"))
+	return req
+}

--- a/api/payment_methods.go
+++ b/api/payment_methods.go
@@ -55,7 +55,8 @@ type updatePaymentMethodRequest struct {
 }
 
 type deletePaymentMethodResponse struct {
-	Deleted bool `json:"deleted"`
+	Deleted        bool `json:"deleted"`
+	AffectedAgents int  `json:"affected_agents"`
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -447,6 +448,15 @@ func handleDeletePaymentMethod(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Count affected agents before deletion (cascade will remove bindings).
+		affectedAgents, err := db.CountAgentsByPaymentMethod(r.Context(), deps.DB, pmID)
+		if err != nil {
+			log.Printf("[%s] DeletePaymentMethod: count agents: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			// Non-fatal — continue with deletion.
+			affectedAgents = 0
+		}
+
 		// Detach from Stripe customer (best-effort — we still delete locally even if this fails).
 		if deps.Stripe != nil {
 			if _, err := deps.Stripe.DetachPaymentMethod(r.Context(), pm.StripePaymentMethodID); err != nil {
@@ -467,6 +477,6 @@ func handleDeletePaymentMethod(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		RespondJSON(w, http.StatusOK, deletePaymentMethodResponse{Deleted: true})
+		RespondJSON(w, http.StatusOK, deletePaymentMethodResponse{Deleted: true, AffectedAgents: affectedAgents})
 	}
 }

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -1041,6 +1041,42 @@ func seedUserHasEverything(ctx context.Context, tx db.DBTX, supa *supabaseClient
 	}
 
 	// ---------------------------------------------------------------
+	// Payment methods — two cards for the "has everything" user
+	// ---------------------------------------------------------------
+	exec(ctx, tx,
+		`INSERT INTO payment_methods (id, user_id, stripe_payment_method_id, label, brand, last4, exp_month, exp_year, is_default, per_transaction_limit, monthly_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, 5000, 50000)`,
+		"00000000-0000-0000-0000-000000000090", userHasEverything,
+		"pm_seed_visa_4242", "Work Visa", "visa", "4242", 12, 2028)
+
+	exec(ctx, tx,
+		`INSERT INTO payment_methods (id, user_id, stripe_payment_method_id, label, brand, last4, exp_month, exp_year, is_default)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, false)`,
+		"00000000-0000-0000-0000-000000000091", userHasEverything,
+		"pm_seed_mc_5555", "Personal MC", "mastercard", "5555", 6, 2027)
+
+	fmt.Println("  ✓ payment_methods seeded")
+
+	// ---------------------------------------------------------------
+	// Agent payment method assignments — bind cards to agents
+	// ---------------------------------------------------------------
+	agentPMs := []struct {
+		agentID         int64
+		paymentMethodID string
+	}{
+		{claude, "00000000-0000-0000-0000-000000000090"},
+		{github, "00000000-0000-0000-0000-000000000090"},
+		{slack, "00000000-0000-0000-0000-000000000091"},
+		{sentry, "00000000-0000-0000-0000-000000000090"},
+	}
+	for _, apm := range agentPMs {
+		exec(ctx, tx,
+			`INSERT INTO agent_payment_methods (agent_id, payment_method_id) VALUES ($1, $2)`,
+			apm.agentID, apm.paymentMethodID)
+	}
+	fmt.Println("  ✓ agent_payment_methods seeded")
+
+	// ---------------------------------------------------------------
 	// Approvals — pending (3, 24h expiry so they survive dev sessions)
 	// ---------------------------------------------------------------
 	exec(ctx, tx,

--- a/db/agent_payment_methods.go
+++ b/db/agent_payment_methods.go
@@ -37,7 +37,7 @@ func AssignAgentPaymentMethod(ctx context.Context, db DBTX, agentID int64, payme
 	err := db.QueryRow(ctx,
 		`INSERT INTO agent_payment_methods (agent_id, payment_method_id)
 		 VALUES ($1, $2)
-		 ON CONFLICT (agent_id) DO UPDATE SET payment_method_id = EXCLUDED.payment_method_id, created_at = now()
+		 ON CONFLICT (agent_id) DO UPDATE SET payment_method_id = EXCLUDED.payment_method_id
 		 RETURNING agent_id, payment_method_id, created_at`,
 		agentID, paymentMethodID).Scan(&apm.AgentID, &apm.PaymentMethodID, &apm.CreatedAt)
 	if err != nil {

--- a/db/agent_payment_methods.go
+++ b/db/agent_payment_methods.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// AgentPaymentMethod represents the binding between an agent and a payment method.
+type AgentPaymentMethod struct {
+	AgentID         int64     `json:"agent_id"`
+	PaymentMethodID string    `json:"payment_method_id"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// GetAgentPaymentMethod returns the payment method assignment for an agent, or nil if none.
+func GetAgentPaymentMethod(ctx context.Context, db DBTX, agentID int64) (*AgentPaymentMethod, error) {
+	var apm AgentPaymentMethod
+	err := db.QueryRow(ctx,
+		`SELECT agent_id, payment_method_id, created_at
+		 FROM agent_payment_methods WHERE agent_id = $1`,
+		agentID).Scan(&apm.AgentID, &apm.PaymentMethodID, &apm.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &apm, nil
+}
+
+// AssignAgentPaymentMethod upserts the payment method for an agent.
+func AssignAgentPaymentMethod(ctx context.Context, db DBTX, agentID int64, paymentMethodID string) (*AgentPaymentMethod, error) {
+	var apm AgentPaymentMethod
+	err := db.QueryRow(ctx,
+		`INSERT INTO agent_payment_methods (agent_id, payment_method_id)
+		 VALUES ($1, $2)
+		 ON CONFLICT (agent_id) DO UPDATE SET payment_method_id = EXCLUDED.payment_method_id, created_at = now()
+		 RETURNING agent_id, payment_method_id, created_at`,
+		agentID, paymentMethodID).Scan(&apm.AgentID, &apm.PaymentMethodID, &apm.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &apm, nil
+}
+
+// RemoveAgentPaymentMethod deletes the payment method assignment for an agent.
+// Returns true if a row was deleted.
+func RemoveAgentPaymentMethod(ctx context.Context, db DBTX, agentID int64) (bool, error) {
+	tag, err := db.Exec(ctx,
+		`DELETE FROM agent_payment_methods WHERE agent_id = $1`,
+		agentID)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// CountAgentsByPaymentMethod returns the number of agents using a given payment method.
+func CountAgentsByPaymentMethod(ctx context.Context, db DBTX, paymentMethodID string) (int, error) {
+	var count int
+	err := db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM agent_payment_methods WHERE payment_method_id = $1`,
+		paymentMethodID).Scan(&count)
+	return count, err
+}

--- a/db/agent_payment_methods_test.go
+++ b/db/agent_payment_methods_test.go
@@ -1,0 +1,171 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+)
+
+func TestAgentPaymentMethodCRUD(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "apm_"+uid[:8])
+	agentID := testhelper.InsertAgent(t, tx, uid)
+
+	// Create a payment method.
+	pm, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                uid,
+		StripePaymentMethodID: "pm_apm_" + uid[:8],
+		Brand:                 "visa",
+		Last4:                 "4242",
+		ExpMonth:              12,
+		ExpYear:               2028,
+		IsDefault:             true,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod: %v", err)
+	}
+
+	// Get should return nil initially.
+	got, err := db.GetAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("GetAgentPaymentMethod: %v", err)
+	}
+	if got != nil {
+		t.Fatal("expected nil before assignment")
+	}
+
+	// Assign.
+	assigned, err := db.AssignAgentPaymentMethod(ctx, tx, agentID, pm.ID)
+	if err != nil {
+		t.Fatalf("AssignAgentPaymentMethod: %v", err)
+	}
+	if assigned.AgentID != agentID {
+		t.Errorf("expected agent_id=%d, got %d", agentID, assigned.AgentID)
+	}
+	if assigned.PaymentMethodID != pm.ID {
+		t.Errorf("expected payment_method_id=%s, got %s", pm.ID, assigned.PaymentMethodID)
+	}
+
+	// Get should return the assignment.
+	got, err = db.GetAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("GetAgentPaymentMethod after assign: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil after assignment")
+	}
+	if got.PaymentMethodID != pm.ID {
+		t.Errorf("got payment_method_id=%s, want %s", got.PaymentMethodID, pm.ID)
+	}
+
+	// Count should be 1.
+	count, err := db.CountAgentsByPaymentMethod(ctx, tx, pm.ID)
+	if err != nil {
+		t.Fatalf("CountAgentsByPaymentMethod: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected count=1, got %d", count)
+	}
+
+	// Re-assign with a second payment method (upsert).
+	pm2, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                uid,
+		StripePaymentMethodID: "pm_apm2_" + uid[:8],
+		Brand:                 "mastercard",
+		Last4:                 "5555",
+		ExpMonth:              6,
+		ExpYear:               2027,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod 2: %v", err)
+	}
+
+	reassigned, err := db.AssignAgentPaymentMethod(ctx, tx, agentID, pm2.ID)
+	if err != nil {
+		t.Fatalf("AssignAgentPaymentMethod (upsert): %v", err)
+	}
+	if reassigned.PaymentMethodID != pm2.ID {
+		t.Errorf("expected pm2 after upsert, got %s", reassigned.PaymentMethodID)
+	}
+
+	// Old PM count should be 0, new PM count should be 1.
+	count, err = db.CountAgentsByPaymentMethod(ctx, tx, pm.ID)
+	if err != nil {
+		t.Fatalf("CountAgentsByPaymentMethod pm1: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected count=0 for pm1 after reassign, got %d", count)
+	}
+
+	// Remove.
+	deleted, err := db.RemoveAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("RemoveAgentPaymentMethod: %v", err)
+	}
+	if !deleted {
+		t.Error("expected deleted=true")
+	}
+
+	// Get should return nil after removal.
+	got, err = db.GetAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("GetAgentPaymentMethod after remove: %v", err)
+	}
+	if got != nil {
+		t.Fatal("expected nil after removal")
+	}
+
+	// Remove again should return false.
+	deleted, err = db.RemoveAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("RemoveAgentPaymentMethod again: %v", err)
+	}
+	if deleted {
+		t.Error("expected deleted=false on second removal")
+	}
+}
+
+func TestAgentPaymentMethodCascadeOnPMDelete(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "apmcas_"+uid[:8])
+	agentID := testhelper.InsertAgent(t, tx, uid)
+
+	pm, err := db.CreatePaymentMethod(ctx, tx, &db.PaymentMethod{
+		UserID:                uid,
+		StripePaymentMethodID: "pm_cas_" + uid[:8],
+		Brand:                 "visa",
+		Last4:                 "1111",
+		ExpMonth:              3,
+		ExpYear:               2029,
+	})
+	if err != nil {
+		t.Fatalf("CreatePaymentMethod: %v", err)
+	}
+
+	_, err = db.AssignAgentPaymentMethod(ctx, tx, agentID, pm.ID)
+	if err != nil {
+		t.Fatalf("AssignAgentPaymentMethod: %v", err)
+	}
+
+	// Delete the payment method — should cascade and remove the agent binding.
+	_, err = db.DeletePaymentMethod(ctx, tx, uid, pm.ID)
+	if err != nil {
+		t.Fatalf("DeletePaymentMethod: %v", err)
+	}
+
+	got, err := db.GetAgentPaymentMethod(ctx, tx, agentID)
+	if err != nil {
+		t.Fatalf("GetAgentPaymentMethod after PM delete: %v", err)
+	}
+	if got != nil {
+		t.Fatal("expected nil after payment method cascade delete")
+	}
+}

--- a/db/migrations/20260315030430_add_agent_payment_methods.sql
+++ b/db/migrations/20260315030430_add_agent_payment_methods.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+
+-- Join table linking agents to payment methods.
+-- Each agent can have at most one assigned payment method (PRIMARY KEY on agent_id),
+-- but one payment method can be shared across multiple agents.
+CREATE TABLE agent_payment_methods (
+    agent_id          BIGINT      NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+    payment_method_id UUID        NOT NULL REFERENCES payment_methods(id) ON DELETE CASCADE,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (agent_id)
+);
+
+CREATE INDEX idx_agent_payment_methods_pm ON agent_payment_methods(payment_method_id);
+
+ALTER TABLE agent_payment_methods ENABLE ROW LEVEL SECURITY;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_backend') THEN
+        CREATE POLICY app_backend_all ON agent_payment_methods
+            FOR ALL TO app_backend USING (true) WITH CHECK (true);
+        GRANT SELECT, INSERT, UPDATE, DELETE ON agent_payment_methods TO app_backend;
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP TABLE IF EXISTS agent_payment_methods;

--- a/frontend/src/hooks/useAgentPaymentMethod.ts
+++ b/frontend/src/hooks/useAgentPaymentMethod.ts
@@ -1,0 +1,116 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type AgentPaymentMethodResponse =
+  components["schemas"]["AgentPaymentMethodResponse"];
+
+export function useAgentPaymentMethod(agentId: number) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const query = useQuery({
+    queryKey: ["agent-payment-method", agentId],
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.GET(
+        "/v1/agents/{agent_id}/payment-method",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { path: { agent_id: agentId } },
+        },
+      );
+      if (error) throw new Error("Failed to load agent payment method");
+      return data;
+    },
+    enabled: !!accessToken && agentId > 0,
+  });
+
+  return {
+    binding: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load payment method assignment."
+      : null,
+  };
+}
+
+export function useAssignAgentPaymentMethod() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      agentId,
+      paymentMethodId,
+    }: {
+      agentId: number;
+      paymentMethodId: string;
+    }) => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.PUT(
+        "/v1/agents/{agent_id}/payment-method",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { path: { agent_id: agentId } },
+          body: { payment_method_id: paymentMethodId },
+        },
+      );
+      if (error) {
+        const msg =
+          (error as { error?: { message?: string } }).error?.message ??
+          "Failed to assign payment method";
+        throw new Error(msg);
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-payment-method", variables.agentId],
+      });
+    },
+  });
+
+  return {
+    assign: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export function useRemoveAgentPaymentMethod() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ agentId }: { agentId: number }) => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.DELETE(
+        "/v1/agents/{agent_id}/payment-method",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { path: { agent_id: agentId } },
+        },
+      );
+      if (error) {
+        const msg =
+          (error as { error?: { message?: string } }).error?.message ??
+          "Failed to remove payment method";
+        throw new Error(msg);
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-payment-method", variables.agentId],
+      });
+    },
+  });
+
+  return {
+    remove: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/lib/paymentMethodUtils.ts
+++ b/frontend/src/lib/paymentMethodUtils.ts
@@ -1,0 +1,16 @@
+export function formatBrand(brand: string): string {
+  const brands: Record<string, string> = {
+    visa: "Visa",
+    mastercard: "Mastercard",
+    amex: "Amex",
+    discover: "Discover",
+    diners: "Diners",
+    jcb: "JCB",
+    unionpay: "UnionPay",
+  };
+  return brands[brand] ?? brand;
+}
+
+export function formatExpiry(month: number, year: number): string {
+  return `${String(month).padStart(2, "0")}/${String(year).slice(-2)}`;
+}

--- a/frontend/src/pages/agents/AgentConfigPage.tsx
+++ b/frontend/src/pages/agents/AgentConfigPage.tsx
@@ -6,6 +6,7 @@ import { useAgentConnectors } from "@/hooks/useAgentConnectors";
 import { AgentInfoSection } from "./AgentInfoSection";
 import { AgentConnectorsSection } from "./AgentConnectorsSection";
 
+import { AgentPaymentMethodSection } from "./AgentPaymentMethodSection";
 import { DeactivateSection } from "./DeactivateSection";
 
 export function AgentConfigPage() {
@@ -65,6 +66,7 @@ export function AgentConfigPage() {
         isLoading={connectorsLoading}
         error={connectorsError}
       />
+      <AgentPaymentMethodSection agentId={agentId} />
       {agent.status !== "deactivated" && (
         <DeactivateSection agentId={agent.agent_id} />
       )}

--- a/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
+++ b/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
@@ -1,0 +1,195 @@
+import { useState } from "react";
+import { CreditCard, Loader2, Settings } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { usePaymentMethods } from "@/hooks/usePaymentMethods";
+import type { PaymentMethod } from "@/hooks/usePaymentMethods";
+import {
+  useAgentPaymentMethod,
+  useAssignAgentPaymentMethod,
+} from "@/hooks/useAgentPaymentMethod";
+import { ManagePaymentMethodsDialog } from "./ManagePaymentMethodsDialog";
+
+interface AgentPaymentMethodSectionProps {
+  agentId: number;
+}
+
+function formatBrand(brand: string): string {
+  const brands: Record<string, string> = {
+    visa: "Visa",
+    mastercard: "Mastercard",
+    amex: "Amex",
+    discover: "Discover",
+    diners: "Diners",
+    jcb: "JCB",
+    unionpay: "UnionPay",
+  };
+  return brands[brand] ?? brand;
+}
+
+function formatExpiry(month: number, year: number): string {
+  return `${String(month).padStart(2, "0")}/${String(year).slice(-2)}`;
+}
+
+const selectClassName =
+  "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
+
+export function AgentPaymentMethodSection({
+  agentId,
+}: AgentPaymentMethodSectionProps) {
+  const [manageDialogOpen, setManageDialogOpen] = useState(false);
+
+  const {
+    paymentMethods,
+    isLoading: pmLoading,
+    error: pmError,
+  } = usePaymentMethods();
+  const {
+    binding,
+    isLoading: bindingLoading,
+    error: bindingError,
+  } = useAgentPaymentMethod(agentId);
+  const { assign, isPending: assigning } = useAssignAgentPaymentMethod();
+
+  const isLoading = pmLoading || bindingLoading;
+  const error = pmError ?? bindingError;
+
+  const currentValue = binding?.payment_method_id ?? "";
+
+  async function handleChange(value: string) {
+    if (assigning || !value) return;
+
+    try {
+      await assign({ agentId, paymentMethodId: value });
+      toast.success("Payment method assigned to this agent.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to assign payment method.",
+      );
+    }
+  }
+
+  function cardLabel(pm: PaymentMethod): string {
+    const brand = formatBrand(pm.brand);
+    const base = pm.label
+      ? `${pm.label} — ${brand} ••${pm.last4}`
+      : `${brand} ••${pm.last4}`;
+    return `${base} (exp ${formatExpiry(pm.exp_month, pm.exp_year)})`;
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <CreditCard className="size-5" />
+            Payment Method
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div
+              className="flex items-center justify-center py-8"
+              role="status"
+              aria-label="Loading payment method"
+            >
+              <Loader2
+                className="text-muted-foreground size-6 animate-spin"
+                aria-hidden="true"
+              />
+            </div>
+          ) : error ? (
+            <p className="text-destructive text-sm">{error}</p>
+          ) : paymentMethods.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <CreditCard className="text-muted-foreground mb-3 size-10" />
+              <p className="text-muted-foreground mb-3 text-sm">
+                No payment methods stored yet. Add a card to enable
+                agent-initiated purchases.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setManageDialogOpen(true)}
+              >
+                <Settings className="size-3" />
+                Add payment method
+              </Button>
+            </div>
+          ) : (
+            <>
+              <div className="mb-4 rounded-lg border p-3">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Label
+                      htmlFor="agent-payment-method-select"
+                      className="text-sm font-medium"
+                    >
+                      Assigned Payment Method
+                    </Label>
+                    {currentValue ? (
+                      <Badge
+                        variant="secondary"
+                        className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                      >
+                        Assigned
+                      </Badge>
+                    ) : (
+                      <Badge variant="destructive">Not set</Badge>
+                    )}
+                  </div>
+                  <p className="text-muted-foreground text-xs">
+                    {currentValue
+                      ? "This agent uses the selected payment method for purchases."
+                      : "Select a payment method for this agent to use for purchases."}
+                  </p>
+                  <select
+                    id="agent-payment-method-select"
+                    className={selectClassName}
+                    value={currentValue}
+                    onChange={(e) => handleChange(e.target.value)}
+                    disabled={assigning}
+                  >
+                    {!currentValue && (
+                      <option value="">Select a payment method…</option>
+                    )}
+                    {paymentMethods.map((pm) => (
+                      <option key={pm.id} value={pm.id}>
+                        {cardLabel(pm)}
+                        {pm.is_default ? " (default)" : ""}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="flex justify-end">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setManageDialogOpen(true)}
+                >
+                  <Settings className="size-3" />
+                  Manage payment methods
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <ManagePaymentMethodsDialog
+        open={manageDialogOpen}
+        onOpenChange={setManageDialogOpen}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
+++ b/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
@@ -15,28 +15,13 @@ import type { PaymentMethod } from "@/hooks/usePaymentMethods";
 import {
   useAgentPaymentMethod,
   useAssignAgentPaymentMethod,
+  useRemoveAgentPaymentMethod,
 } from "@/hooks/useAgentPaymentMethod";
+import { formatBrand, formatExpiry } from "@/lib/paymentMethodUtils";
 import { ManagePaymentMethodsDialog } from "./ManagePaymentMethodsDialog";
 
 interface AgentPaymentMethodSectionProps {
   agentId: number;
-}
-
-function formatBrand(brand: string): string {
-  const brands: Record<string, string> = {
-    visa: "Visa",
-    mastercard: "Mastercard",
-    amex: "Amex",
-    discover: "Discover",
-    diners: "Diners",
-    jcb: "JCB",
-    unionpay: "UnionPay",
-  };
-  return brands[brand] ?? brand;
-}
-
-function formatExpiry(month: number, year: number): string {
-  return `${String(month).padStart(2, "0")}/${String(year).slice(-2)}`;
 }
 
 const selectClassName =
@@ -58,21 +43,28 @@ export function AgentPaymentMethodSection({
     error: bindingError,
   } = useAgentPaymentMethod(agentId);
   const { assign, isPending: assigning } = useAssignAgentPaymentMethod();
+  const { remove, isPending: removing } = useRemoveAgentPaymentMethod();
 
   const isLoading = pmLoading || bindingLoading;
   const error = pmError ?? bindingError;
+  const busy = assigning || removing;
 
   const currentValue = binding?.payment_method_id ?? "";
 
   async function handleChange(value: string) {
-    if (assigning || !value) return;
+    if (busy) return;
 
     try {
-      await assign({ agentId, paymentMethodId: value });
-      toast.success("Payment method assigned to this agent.");
+      if (value === "") {
+        await remove({ agentId });
+        toast.success("Payment method unassigned from this agent.");
+      } else {
+        await assign({ agentId, paymentMethodId: value });
+        toast.success("Payment method assigned to this agent.");
+      }
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to assign payment method.",
+        err instanceof Error ? err.message : "Failed to update payment method.",
       );
     }
   }
@@ -156,11 +148,13 @@ export function AgentPaymentMethodSection({
                     className={selectClassName}
                     value={currentValue}
                     onChange={(e) => handleChange(e.target.value)}
-                    disabled={assigning}
+                    disabled={busy}
                   >
-                    {!currentValue && (
-                      <option value="">Select a payment method…</option>
-                    )}
+                    <option value="">
+                      {currentValue
+                        ? "None (unassigned)"
+                        : "Select a payment method…"}
+                    </option>
                     {paymentMethods.map((pm) => (
                       <option key={pm.id} value={pm.id}>
                         {cardLabel(pm)}

--- a/frontend/src/pages/agents/ManagePaymentMethodsDialog.tsx
+++ b/frontend/src/pages/agents/ManagePaymentMethodsDialog.tsx
@@ -28,23 +28,7 @@ import {
 import { AddCardDialog } from "../settings/AddCardDialog";
 import { SpendingLimitsDialog } from "../settings/SpendingLimitsDialog";
 import type { PaymentMethod } from "@/hooks/usePaymentMethods";
-
-function formatExpiry(month: number, year: number): string {
-  return `${String(month).padStart(2, "0")}/${String(year).slice(-2)}`;
-}
-
-function formatBrand(brand: string): string {
-  const brands: Record<string, string> = {
-    visa: "Visa",
-    mastercard: "Mastercard",
-    amex: "Amex",
-    discover: "Discover",
-    diners: "Diners",
-    jcb: "JCB",
-    unionpay: "UnionPay",
-  };
-  return brands[brand] ?? brand;
-}
+import { formatBrand, formatExpiry } from "@/lib/paymentMethodUtils";
 
 type ExpiryStatus = "expired" | "expiring_soon" | "ok";
 
@@ -155,8 +139,14 @@ export function ManagePaymentMethodsDialog({
 
   async function handleDelete(pm: PaymentMethod) {
     try {
-      await deletePaymentMethod(pm.id);
-      toast.success(`Card ending in ${pm.last4} removed.`);
+      const result = await deletePaymentMethod(pm.id);
+      if (result?.affected_agents && result.affected_agents > 0) {
+        toast.success(
+          `Card ending in ${pm.last4} removed. ${result.affected_agents} agent(s) had their payment method unassigned.`,
+        );
+      } else {
+        toast.success(`Card ending in ${pm.last4} removed.`);
+      }
     } catch {
       toast.error("Failed to remove payment method.");
     }

--- a/frontend/src/pages/agents/ManagePaymentMethodsDialog.tsx
+++ b/frontend/src/pages/agents/ManagePaymentMethodsDialog.tsx
@@ -1,0 +1,323 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CreditCard,
+  Loader2,
+  Pencil,
+  Plus,
+  Star,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { formatCents } from "@/lib/utils";
+import {
+  usePaymentMethods,
+  useDeletePaymentMethod,
+  useUpdatePaymentMethod,
+} from "@/hooks/usePaymentMethods";
+import { InlineConfirmButton } from "@/components/InlineConfirmButton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { AddCardDialog } from "../settings/AddCardDialog";
+import { SpendingLimitsDialog } from "../settings/SpendingLimitsDialog";
+import type { PaymentMethod } from "@/hooks/usePaymentMethods";
+
+function formatExpiry(month: number, year: number): string {
+  return `${String(month).padStart(2, "0")}/${String(year).slice(-2)}`;
+}
+
+function formatBrand(brand: string): string {
+  const brands: Record<string, string> = {
+    visa: "Visa",
+    mastercard: "Mastercard",
+    amex: "Amex",
+    discover: "Discover",
+    diners: "Diners",
+    jcb: "JCB",
+    unionpay: "UnionPay",
+  };
+  return brands[brand] ?? brand;
+}
+
+type ExpiryStatus = "expired" | "expiring_soon" | "ok";
+
+function getExpiryStatus(expMonth: number, expYear: number): ExpiryStatus {
+  const now = new Date();
+  const currentMonth = now.getMonth() + 1;
+  const currentYear = now.getFullYear();
+
+  if (
+    expYear < currentYear ||
+    (expYear === currentYear && expMonth < currentMonth)
+  ) {
+    return "expired";
+  }
+
+  const expiryDate = new Date(expYear, expMonth, 0);
+  const daysUntilExpiry = Math.ceil(
+    (expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  if (daysUntilExpiry <= 30) {
+    return "expiring_soon";
+  }
+
+  return "ok";
+}
+
+function ExpiryBadge({
+  expMonth,
+  expYear,
+}: {
+  expMonth: number;
+  expYear: number;
+}) {
+  const status = getExpiryStatus(expMonth, expYear);
+
+  if (status === "expired") {
+    return (
+      <Badge variant="destructive" className="text-xs">
+        Expired
+      </Badge>
+    );
+  }
+
+  if (status === "expiring_soon") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-yellow-500 text-xs text-yellow-600 dark:text-yellow-400"
+      >
+        <AlertTriangle className="mr-1 size-3" />
+        Expiring soon
+      </Badge>
+    );
+  }
+
+  return null;
+}
+
+function SpendProgressBar({
+  monthlySpend,
+  monthlyLimit,
+}: {
+  monthlySpend: number;
+  monthlyLimit: number;
+}) {
+  const pct = Math.min((monthlySpend / monthlyLimit) * 100, 100);
+  const remaining = Math.max(monthlyLimit - monthlySpend, 0);
+
+  let barColor = "bg-blue-500";
+  if (pct >= 85) barColor = "bg-red-500";
+  else if (pct >= 60) barColor = "bg-yellow-500";
+
+  return (
+    <div className="mt-1.5 space-y-1">
+      <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {formatCents(monthlySpend)} of {formatCents(monthlyLimit)} used
+        {remaining > 0 && ` · ${formatCents(remaining)} remaining`}
+      </p>
+    </div>
+  );
+}
+
+export interface ManagePaymentMethodsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ManagePaymentMethodsDialog({
+  open,
+  onOpenChange,
+}: ManagePaymentMethodsDialogProps) {
+  const { paymentMethods, maxAllowed, isLoading, error } = usePaymentMethods();
+  const { deletePaymentMethod, isLoading: isDeleting } =
+    useDeletePaymentMethod();
+  const { updatePaymentMethod } = useUpdatePaymentMethod();
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [limitsDialogPM, setLimitsDialogPM] = useState<PaymentMethod | null>(
+    null,
+  );
+
+  const atCardLimit = maxAllowed > 0 && paymentMethods.length >= maxAllowed;
+
+  async function handleDelete(pm: PaymentMethod) {
+    try {
+      await deletePaymentMethod(pm.id);
+      toast.success(`Card ending in ${pm.last4} removed.`);
+    } catch {
+      toast.error("Failed to remove payment method.");
+    }
+  }
+
+  async function handleSetDefault(pm: PaymentMethod) {
+    try {
+      await updatePaymentMethod({ id: pm.id, is_default: true });
+      toast.success(`Card ending in ${pm.last4} set as default.`);
+    } catch {
+      toast.error("Failed to set default payment method.");
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <CreditCard className="text-muted-foreground size-5" />
+              <DialogTitle>Payment Methods</DialogTitle>
+              {paymentMethods.length > 0 && (
+                <Badge variant="outline" className="ml-1">
+                  {paymentMethods.length}
+                  {maxAllowed > 0 && `/${maxAllowed}`}
+                </Badge>
+              )}
+            </div>
+            <DialogDescription>
+              Manage stored payment methods for agent-initiated purchases.
+            </DialogDescription>
+          </DialogHeader>
+
+          {isLoading ? (
+            <div
+              className="flex items-center justify-center py-8"
+              role="status"
+              aria-label="Loading payment methods"
+            >
+              <Loader2 className="text-muted-foreground size-5 animate-spin" />
+            </div>
+          ) : error ? (
+            <p className="text-destructive text-sm">{error}</p>
+          ) : paymentMethods.length === 0 ? (
+            <p className="text-muted-foreground py-4 text-center text-sm">
+              No payment methods stored yet. Add a card so agents can make
+              purchases on your behalf.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {paymentMethods.map((pm) => (
+                <div
+                  key={pm.id}
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      {pm.label ? (
+                        <p className="text-sm font-medium">{pm.label}</p>
+                      ) : (
+                        <p className="text-sm font-medium">
+                          {formatBrand(pm.brand)} ending in {pm.last4}
+                        </p>
+                      )}
+                      {pm.is_default && (
+                        <Badge variant="secondary" className="text-xs">
+                          Default
+                        </Badge>
+                      )}
+                      <ExpiryBadge
+                        expMonth={pm.exp_month}
+                        expYear={pm.exp_year}
+                      />
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      {pm.label
+                        ? `${formatBrand(pm.brand)} ending in ${pm.last4} · `
+                        : ""}
+                      Expires {formatExpiry(pm.exp_month, pm.exp_year)}
+                      {pm.per_transaction_limit != null &&
+                        ` · Per-tx limit: ${formatCents(pm.per_transaction_limit)}`}
+                    </p>
+                    {pm.monthly_limit != null && pm.monthly_spend != null && (
+                      <SpendProgressBar
+                        monthlySpend={pm.monthly_spend}
+                        monthlyLimit={pm.monthly_limit}
+                      />
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title={
+                        pm.is_default
+                          ? "Default payment method"
+                          : "Set as default"
+                      }
+                      onClick={() => !pm.is_default && handleSetDefault(pm)}
+                      disabled={pm.is_default}
+                    >
+                      <Star
+                        className={`size-4 ${pm.is_default ? "fill-yellow-400 text-yellow-400" : "text-muted-foreground"}`}
+                      />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setLimitsDialogPM(pm)}
+                    >
+                      <Pencil className="mr-1 size-3" />
+                      Edit
+                    </Button>
+                    <InlineConfirmButton
+                      confirmLabel="Remove"
+                      isProcessing={isDeleting}
+                      onConfirm={() => handleDelete(pm)}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Remove card ending in ${pm.last4}`}
+                      >
+                        <Trash2 className="text-muted-foreground size-4" />
+                      </Button>
+                    </InlineConfirmButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="flex justify-end pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAddDialogOpen(true)}
+              disabled={atCardLimit}
+              title={
+                atCardLimit
+                  ? `Maximum of ${maxAllowed} payment methods reached`
+                  : undefined
+              }
+            >
+              <Plus className="size-4" />
+              Add Card
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AddCardDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
+
+      {limitsDialogPM && (
+        <SpendingLimitsDialog
+          paymentMethod={limitsDialogPM}
+          open={!!limitsDialogPM}
+          onOpenChange={(o) => !o && setLimitsDialogPM(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/agents/__tests__/AgentPaymentMethodSection.test.tsx
+++ b/frontend/src/pages/agents/__tests__/AgentPaymentMethodSection.test.tsx
@@ -1,0 +1,167 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderWithProviders } from "../../../test-helpers";
+import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
+import { mockGet } from "../../../api/__mocks__/client";
+import { AgentPaymentMethodSection } from "../AgentPaymentMethodSection";
+
+vi.mock("../../../lib/supabaseClient");
+vi.mock("../../../api/client");
+
+// Helper to set up standard mock responses
+function setupMocks({
+  paymentMethods = [] as Array<{
+    id: string;
+    brand: string;
+    last4: string;
+    exp_month: number;
+    exp_year: number;
+    is_default: boolean;
+    label?: string;
+    created_at: string;
+    updated_at: string;
+  }>,
+  binding = { agent_id: 42, payment_method_id: null as string | null },
+}: {
+  paymentMethods?: Array<{
+    id: string;
+    brand: string;
+    last4: string;
+    exp_month: number;
+    exp_year: number;
+    is_default: boolean;
+    label?: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+  binding?: { agent_id: number; payment_method_id: string | null };
+} = {}) {
+  mockGet.mockImplementation(
+    (path: string) => {
+      if (path === "/v1/payment-methods") {
+        return Promise.resolve({
+          data: { payment_methods: paymentMethods, max_allowed: 10 },
+        });
+      }
+      if (path === "/v1/agents/{agent_id}/payment-method") {
+        return Promise.resolve({ data: binding });
+      }
+      return Promise.resolve({ data: {} });
+    },
+  );
+}
+
+describe("AgentPaymentMethodSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("shows loading state", () => {
+    mockGet.mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+    expect(
+      screen.getByRole("status", { name: "Loading payment method" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no payment methods exist", async () => {
+    setupMocks();
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No payment methods stored yet/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows dropdown with payment methods", async () => {
+    setupMocks({
+      paymentMethods: [
+        {
+          id: "pm-1",
+          brand: "visa",
+          last4: "4242",
+          exp_month: 12,
+          exp_year: 2028,
+          is_default: true,
+          label: "Work Visa",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "pm-2",
+          brand: "mastercard",
+          last4: "5555",
+          exp_month: 6,
+          exp_year: 2027,
+          is_default: false,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Not set")).toBeInTheDocument();
+    });
+
+    const select = screen.getByRole("combobox");
+    expect(select).toBeInTheDocument();
+    // Should have "Select a payment method…" placeholder + 2 options
+    const options = select.querySelectorAll("option");
+    expect(options.length).toBe(3);
+  });
+
+  it("shows Assigned badge when payment method is set", async () => {
+    setupMocks({
+      paymentMethods: [
+        {
+          id: "pm-1",
+          brand: "visa",
+          last4: "4242",
+          exp_month: 12,
+          exp_year: 2028,
+          is_default: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      binding: { agent_id: 42, payment_method_id: "pm-1" },
+    });
+
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Assigned")).toBeInTheDocument();
+    });
+  });
+
+  it("shows manage button", async () => {
+    setupMocks({
+      paymentMethods: [
+        {
+          id: "pm-1",
+          brand: "visa",
+          last4: "4242",
+          exp_month: 12,
+          exp_year: 2028,
+          is_default: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Manage payment methods"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/settings/BillingSettingsPage.tsx
+++ b/frontend/src/pages/settings/BillingSettingsPage.tsx
@@ -12,7 +12,6 @@ import { PlanDetailsCard } from "../billing/PlanDetailsCard";
 import { BillingPageSkeleton } from "../billing/BillingPageSkeleton";
 import { UpgradeSuccessBanner } from "../billing/UpgradeSuccessBanner";
 import { activateUpgrade } from "../billing/activateUpgrade";
-import { PaymentMethodSection } from "./PaymentMethodSection";
 import { DataRetentionSection } from "./DataRetentionSection";
 
 const RETRY_DELAYS = [1000, 2000, 3000];
@@ -118,8 +117,7 @@ export function BillingSettingsPage() {
         </>
       ) : null}
 
-      {/* These sections manage their own loading/error states independently of the billing plan. */}
-      <PaymentMethodSection />
+      {/* Data retention manages its own loading/error state independently of the billing plan. */}
       <DataRetentionSection />
     </>
   );

--- a/spec/openapi/components/paths/agent_payment_methods.yaml
+++ b/spec/openapi/components/paths/agent_payment_methods.yaml
@@ -1,0 +1,78 @@
+agentPaymentMethod:
+  get:
+    operationId: getAgentPaymentMethod
+    summary: Get agent payment method
+    description: |
+      Returns the payment method assigned to this agent, or null if none is assigned.
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+    responses:
+      '200':
+        description: Payment method assignment retrieved
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_payment_methods.yaml#/AgentPaymentMethodResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+  put:
+    operationId: assignAgentPaymentMethod
+    summary: Assign payment method to agent
+    description: |
+      Assigns a payment method to this agent. If the agent already has a payment
+      method assigned, it is replaced. The payment method must belong to the
+      authenticated user.
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/agent_payment_methods.yaml#/AssignAgentPaymentMethodRequest'
+    responses:
+      '200':
+        description: Payment method assigned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_payment_methods.yaml#/AgentPaymentMethodResponse'
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+  delete:
+    operationId: removeAgentPaymentMethod
+    summary: Remove payment method from agent
+    description: |
+      Removes the payment method assignment from this agent. Does not delete
+      the payment method itself.
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+    responses:
+      '200':
+        description: Payment method assignment removed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_payment_methods.yaml#/RemoveAgentPaymentMethodResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'

--- a/spec/openapi/components/schemas/agent_payment_methods.yaml
+++ b/spec/openapi/components/schemas/agent_payment_methods.yaml
@@ -1,0 +1,36 @@
+AgentPaymentMethodResponse:
+  type: object
+  required:
+    - agent_id
+    - payment_method_id
+  properties:
+    agent_id:
+      type: integer
+      format: int64
+    payment_method_id:
+      type: string
+      format: uuid
+      nullable: true
+      description: The assigned payment method ID, or null if none is assigned
+    created_at:
+      type: string
+      format: date-time
+
+AssignAgentPaymentMethodRequest:
+  type: object
+  required:
+    - payment_method_id
+  properties:
+    payment_method_id:
+      type: string
+      format: uuid
+      description: The payment method to assign to this agent
+
+RemoveAgentPaymentMethodResponse:
+  type: object
+  required:
+    - status
+  properties:
+    status:
+      type: string
+      enum: [removed]

--- a/spec/openapi/components/schemas/payment_methods.yaml
+++ b/spec/openapi/components/schemas/payment_methods.yaml
@@ -141,7 +141,12 @@ DeletePaymentMethodResponse:
   type: object
   required:
     - deleted
+    - affected_agents
   properties:
     deleted:
       type: boolean
       description: Always true on successful deletion
+    affected_agents:
+      type: integer
+      minimum: 0
+      description: Number of agents that had this payment method assigned (bindings are cascade-deleted)

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -6138,6 +6138,84 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/payment-method:
+    get:
+      operationId: getAgentPaymentMethod
+      summary: Get agent payment method
+      description: |
+        Returns the payment method assigned to this agent, or null if none is assigned.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+      responses:
+        '200':
+          description: Payment method assignment retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPaymentMethodResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: assignAgentPaymentMethod
+      summary: Assign payment method to agent
+      description: |
+        Assigns a payment method to this agent. If the agent already has a payment
+        method assigned, it is replaced. The payment method must belong to the
+        authenticated user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignAgentPaymentMethodRequest'
+      responses:
+        '200':
+          description: Payment method assigned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPaymentMethodResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: removeAgentPaymentMethod
+      summary: Remove payment method from agent
+      description: |
+        Removes the payment method assignment from this agent. Does not delete
+        the payment method itself.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+      responses:
+        '200':
+          description: Payment method assignment removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveAgentPaymentMethodResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /v1/payment-methods:
     get:
       tags:
@@ -10814,6 +10892,41 @@ components:
           format: date-time
           description: When the BYOA credentials were deleted
           example: '2026-03-05T15:00:00Z'
+    AgentPaymentMethodResponse:
+      type: object
+      required:
+        - agent_id
+        - payment_method_id
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+        payment_method_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The assigned payment method ID, or null if none is assigned
+        created_at:
+          type: string
+          format: date-time
+    AssignAgentPaymentMethodRequest:
+      type: object
+      required:
+        - payment_method_id
+      properties:
+        payment_method_id:
+          type: string
+          format: uuid
+          description: The payment method to assign to this agent
+    RemoveAgentPaymentMethodResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - removed
     PaymentMethod:
       type: object
       description: |
@@ -10952,10 +11065,15 @@ components:
       type: object
       required:
         - deleted
+        - affected_agents
       properties:
         deleted:
           type: boolean
           description: Always true on successful deletion
+        affected_agents:
+          type: integer
+          minimum: 0
+          description: Number of agents that had this payment method assigned (bindings are cascade-deleted)
     ConfigResponse:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -310,6 +310,9 @@ paths:
   /v1/oauth/provider-configs/{provider}:
     $ref: './components/paths/oauth.yaml#/oauthProviderConfigByProvider'
 
+  /v1/agents/{agent_id}/payment-method:
+    $ref: './components/paths/agent_payment_methods.yaml#/agentPaymentMethod'
+
   /v1/payment-methods:
     $ref: './components/paths/payment_methods.yaml#/paymentMethods'
 
@@ -609,6 +612,14 @@ components:
       $ref: './components/schemas/oauth.yaml#/OAuthProviderConfigListResponse'
     OAuthProviderConfigDeleteResponse:
       $ref: './components/schemas/oauth.yaml#/OAuthProviderConfigDeleteResponse'
+
+    # Agent Payment Methods
+    AgentPaymentMethodResponse:
+      $ref: './components/schemas/agent_payment_methods.yaml#/AgentPaymentMethodResponse'
+    AssignAgentPaymentMethodRequest:
+      $ref: './components/schemas/agent_payment_methods.yaml#/AssignAgentPaymentMethodRequest'
+    RemoveAgentPaymentMethodResponse:
+      $ref: './components/schemas/agent_payment_methods.yaml#/RemoveAgentPaymentMethodResponse'
 
     # Payment Methods
     PaymentMethod:


### PR DESCRIPTION
## Summary

- Add `agent_payment_methods` join table with migration, DB layer (CRUD + count), and API endpoints (GET/PUT/DELETE `/v1/agents/{agent_id}/payment-method`)
- Build `AgentPaymentMethodSection` component with dropdown assignment, status badge, and `ManagePaymentMethodsDialog` for full card management (add/edit/delete/set default)
- Remove `PaymentMethodSection` from billing settings page, add frontend hooks, OpenAPI spec, seed data, and comprehensive backend + frontend tests

Closes #594

## Test plan

### Claude Code
- [x] Backend DB tests pass (`go test ./db/...`)
- [x] Backend API tests pass (`go test ./api/...`)
- [x] Frontend tests pass (856/856)
- [x] TypeScript typecheck passes
- [x] Frontend build succeeds

### OpenClaw
- [ ] Verify payment method dropdown appears on agent config page
- [ ] Test assigning/removing a payment method from an agent
- [ ] Test "Manage payment methods" dialog (add/edit/delete cards)
- [ ] Verify payment methods section is removed from billing settings
- [ ] Test cascade behavior when deleting a PM assigned to multiple agents

https://claude.ai/code