### PR TITLE
Clarify BYOA OAuth rationale and surface setup inline

### DIFF
--- a/api/oauth_byoa.go
+++ b/api/oauth_byoa.go
@@ -1,9 +1,14 @@
 // BYOA (Bring Your Own OAuth App) endpoints.
 //
 // These endpoints let users register their own OAuth client credentials for
-// any provider declared in a connector manifest. This is essential for:
-//   - Providers that don't have platform-level credentials (e.g. Salesforce)
-//   - Self-hosted deployments where users bring their own Google/Microsoft apps
+// any provider declared in a connector manifest. This is needed when a
+// connector's OAuth provider has no platform-level credentials — i.e. the
+// manifest declares endpoints and scopes but no client ID/secret (e.g.
+// Salesforce, X/Twitter). Users create an OAuth app in the provider's
+// developer console, then enter the client ID and secret here.
+//
+// Self-hosted deployments do NOT need BYOA — they should set provider
+// credentials via environment variables (GOOGLE_CLIENT_ID, etc.) instead.
 //
 // Provider resolution order: platform-level built-in → user-level BYOA config.
 // BYOA credentials are merged into the existing provider config (preserving

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -699,15 +699,21 @@ The X connector requires these scopes:
 2. On the connector's configuration page, enter your **Client ID** and **Client Secret** from the X Developer Portal
 3. Connect your X account via the credential configuration section
 
-## Self-Hosted BYOA Setup
+## BYOA (Bring Your Own App) Setup
 
-For self-hosted deployments without platform-level OAuth credentials, users configure their own OAuth apps through the connector configuration UI:
+Some connectors use OAuth providers that don't have platform-level credentials — for example, Salesforce, X/Twitter, or any external connector that declares its own OAuth provider in a manifest. These connectors require you to create your own OAuth app in the provider's developer console and supply the client credentials.
 
-1. Follow the Google or Microsoft setup steps above to create an OAuth app
-2. In Permission Slip, navigate to an agent's configuration page and click the relevant connector card
-3. On the connector's configuration page, enter your Client ID and Client Secret
-4. The credentials are encrypted and stored in the vault
-5. You can now connect your account via the credential configuration section
+**Self-hosted deployments** do NOT need BYOA for providers like Google or Microsoft. Set those credentials via environment variables (`GOOGLE_CLIENT_ID`, `MICROSOFT_CLIENT_ID`, etc.) instead — see the sections above.
+
+### When is BYOA required?
+
+When you open a connector's credential management dialog and the OAuth section shows an "OAuth app setup required" banner, that provider needs BYOA. The banner walks you through the setup:
+
+1. **Create an OAuth app** in the provider's developer console (linked from the banner)
+2. **Enter your Client ID and Client Secret** in the configuration form
+3. **Connect your account** — the Connect button becomes available after credentials are saved
+
+Credentials are encrypted in the vault and never stored in plaintext.
 
 ## External Connector OAuth
 
@@ -735,7 +741,7 @@ External connectors can declare their own OAuth providers in `connector.json`:
 }
 ```
 
-The platform reads `oauth_providers` from the manifest and registers them in the provider registry. Users then supply their own OAuth app credentials via the BYOA configuration in Settings.
+The platform reads `oauth_providers` from the manifest and registers them in the provider registry. Users then supply their own OAuth app credentials via the BYOA setup banner that appears in the connector's credential management dialog.
 
 For more details on creating external connectors, see [Creating Connectors](creating-connectors.md).
 

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -6,6 +6,31 @@
 export { providerLabel } from "@/lib/labels";
 
 /**
+ * Developer console URLs for OAuth providers that may need BYOA setup.
+ * Used by the BYOASetupBanner to link users to the right place when they
+ * need to create an OAuth app.
+ */
+export const PROVIDER_DEV_CONSOLE_URLS: Record<string, string> = {
+  atlassian: "https://developer.atlassian.com/console/myapps/",
+  datadog: "https://app.datadoghq.com/oauth/manage",
+  dropbox: "https://www.dropbox.com/developers/apps",
+  figma: "https://www.figma.com/developers/apps",
+  github: "https://github.com/settings/developers",
+  google: "https://console.cloud.google.com/apis/credentials",
+  hubspot: "https://developers.hubspot.com/",
+  linear: "https://linear.app/settings/api",
+  meta: "https://developers.facebook.com/apps/",
+  microsoft: "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
+  notion: "https://www.notion.so/my-integrations",
+  pagerduty: "https://developer.pagerduty.com/apps/",
+  salesforce: "https://login.salesforce.com/",
+  shopify: "https://partners.shopify.com/",
+  square: "https://developer.squareup.com/apps",
+  stripe: "https://dashboard.stripe.com/apikeys",
+  x: "https://developer.x.com/en/portal/dashboard",
+};
+
+/**
  * Providers that require a shop subdomain to construct per-shop OAuth URLs.
  * When a provider is in this set, the UI prompts the user for their store
  * subdomain (e.g. "mystore") which is appended as `&shop=mystore` to the

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -21,7 +21,7 @@ export const PROVIDER_DEV_CONSOLE_URLS: Partial<Record<string, string>> = {
   datadog: "https://app.datadoghq.com/oauth/manage",
   dropbox: "https://www.dropbox.com/developers/apps",
   figma: "https://www.figma.com/developers/apps",
-  hubspot: "https://developers.hubspot.com/docs/api/oauth/tokens",
+  hubspot: "https://app.hubspot.com/developer/",
   linear: "https://linear.app/settings/api",
   meta: "https://developers.facebook.com/apps/",
   notion: "https://www.notion.so/my-integrations",

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -23,10 +23,10 @@ export const PROVIDER_DEV_CONSOLE_URLS: Record<string, string> = {
   microsoft: "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
   notion: "https://www.notion.so/my-integrations",
   pagerduty: "https://developer.pagerduty.com/apps/",
-  salesforce: "https://login.salesforce.com/",
+  salesforce: "https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm",
   shopify: "https://partners.shopify.com/",
   square: "https://developer.squareup.com/apps",
-  stripe: "https://dashboard.stripe.com/apikeys",
+  stripe: "https://dashboard.stripe.com/settings/applications",
   x: "https://developer.x.com/en/portal/dashboard",
 };
 

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -24,7 +24,7 @@ export const PROVIDER_DEV_CONSOLE_URLS: Record<string, string> = {
   notion: "https://www.notion.so/my-integrations",
   pagerduty: "https://developer.pagerduty.com/apps/",
   salesforce: "https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm",
-  shopify: "https://partners.shopify.com/",
+  shopify: "https://help.shopify.com/en/manual/apps/app-types/custom-apps",
   square: "https://developer.squareup.com/apps",
   stripe: "https://dashboard.stripe.com/settings/applications",
   x: "https://developer.x.com/en/portal/dashboard",

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -9,18 +9,21 @@ export { providerLabel } from "@/lib/labels";
  * Developer console URLs for OAuth providers that may need BYOA setup.
  * Used by the BYOASetupBanner to link users to the right place when they
  * need to create an OAuth app.
+ *
+ * Only includes providers that realistically need BYOA. Built-in providers
+ * (Google, Microsoft, GitHub, etc.) are omitted because they should always
+ * have platform-level credentials via env vars — if they show up without
+ * credentials, the generic fallback text in BYOASetupBanner is more
+ * appropriate than directing users to create their own OAuth app.
  */
 export const PROVIDER_DEV_CONSOLE_URLS: Partial<Record<string, string>> = {
   atlassian: "https://developer.atlassian.com/console/myapps/",
   datadog: "https://app.datadoghq.com/oauth/manage",
   dropbox: "https://www.dropbox.com/developers/apps",
   figma: "https://www.figma.com/developers/apps",
-  github: "https://github.com/settings/developers",
-  google: "https://console.cloud.google.com/apis/credentials",
   hubspot: "https://developers.hubspot.com/docs/api/oauth/tokens",
   linear: "https://linear.app/settings/api",
   meta: "https://developers.facebook.com/apps/",
-  microsoft: "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
   notion: "https://www.notion.so/my-integrations",
   pagerduty: "https://developer.pagerduty.com/apps/",
   salesforce: "https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm",

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -10,14 +10,14 @@ export { providerLabel } from "@/lib/labels";
  * Used by the BYOASetupBanner to link users to the right place when they
  * need to create an OAuth app.
  */
-export const PROVIDER_DEV_CONSOLE_URLS: Record<string, string> = {
+export const PROVIDER_DEV_CONSOLE_URLS: Partial<Record<string, string>> = {
   atlassian: "https://developer.atlassian.com/console/myapps/",
   datadog: "https://app.datadoghq.com/oauth/manage",
   dropbox: "https://www.dropbox.com/developers/apps",
   figma: "https://www.figma.com/developers/apps",
   github: "https://github.com/settings/developers",
   google: "https://console.cloud.google.com/apis/credentials",
-  hubspot: "https://developers.hubspot.com/",
+  hubspot: "https://developers.hubspot.com/docs/api/oauth/tokens",
   linear: "https://linear.app/settings/api",
   meta: "https://developers.facebook.com/apps/",
   microsoft: "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",

--- a/frontend/src/pages/agents/connectors/BYOASetupBanner.tsx
+++ b/frontend/src/pages/agents/connectors/BYOASetupBanner.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { AlertTriangle, ExternalLink, KeyRound, LogIn } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { providerLabel, PROVIDER_DEV_CONSOLE_URLS } from "@/lib/oauth";
+import { BYOAConfigDialog } from "@/pages/settings/BYOAConfigDialog";
+
+interface BYOASetupBannerProps {
+  providerId: string;
+}
+
+export function BYOASetupBanner({ providerId }: BYOASetupBannerProps) {
+  const [configDialogOpen, setConfigDialogOpen] = useState(false);
+  const label = providerLabel(providerId);
+  const devConsoleUrl = PROVIDER_DEV_CONSOLE_URLS[providerId];
+
+  return (
+    <>
+      <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950/50">
+        <div className="mb-3 flex items-center gap-2">
+          <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
+          <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            OAuth app setup required
+          </p>
+        </div>
+        <p className="mb-3 text-xs text-amber-700 dark:text-amber-300">
+          {label} requires you to create your own OAuth app and enter the
+          credentials before you can connect.
+        </p>
+        <ol className="space-y-3 text-sm">
+          <li className="flex items-start gap-3">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-amber-200 text-xs font-bold text-amber-800 dark:bg-amber-800 dark:text-amber-200">
+              1
+            </span>
+            <div>
+              <p className="font-medium text-amber-900 dark:text-amber-100">
+                Create an OAuth app
+              </p>
+              {devConsoleUrl ? (
+                <a
+                  href={devConsoleUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-0.5 inline-flex items-center gap-1 text-xs text-amber-700 underline hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+                >
+                  <ExternalLink className="size-3" />
+                  Open {label} developer console
+                </a>
+              ) : (
+                <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
+                  Visit the {label} developer portal to create an OAuth
+                  application.
+                </p>
+              )}
+            </div>
+          </li>
+          <li className="flex items-start gap-3">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-amber-200 text-xs font-bold text-amber-800 dark:bg-amber-800 dark:text-amber-200">
+              2
+            </span>
+            <div>
+              <p className="font-medium text-amber-900 dark:text-amber-100">
+                Enter your Client ID and Client Secret
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-1.5"
+                onClick={() => setConfigDialogOpen(true)}
+              >
+                <KeyRound className="size-3" />
+                Configure credentials
+              </Button>
+            </div>
+          </li>
+          <li className="flex items-start gap-3">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-amber-200 text-xs font-bold text-amber-800 dark:bg-amber-800 dark:text-amber-200">
+              3
+            </span>
+            <div>
+              <p className="font-medium text-amber-900 dark:text-amber-100">
+                Connect your account
+              </p>
+              <p className="mt-0.5 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+                <LogIn className="size-3" />
+                Available after credentials are saved
+              </p>
+            </div>
+          </li>
+        </ol>
+      </div>
+
+      <BYOAConfigDialog
+        open={configDialogOpen}
+        onOpenChange={setConfigDialogOpen}
+        provider={providerId}
+        providerLabel={label}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -35,6 +35,7 @@ import { serviceLabel, authTypeLabel } from "@/lib/labels";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
+import { BYOASetupBanner } from "./BYOASetupBanner";
 
 export interface ManageCredentialsDialogProps {
   open: boolean;
@@ -373,10 +374,7 @@ function OAuthCredentialRow({
         )}
 
         {!hasAnyConnection && !provider?.has_credentials && (
-          <p className="text-muted-foreground mt-2 pl-8 text-xs">
-            OAuth is not available yet — ask your admin to configure{" "}
-            {providerLabel(providerId)} OAuth credentials.
-          </p>
+          <BYOASetupBanner providerId={providerId} />
         )}
       </div>
 

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -373,7 +373,7 @@ function OAuthCredentialRow({
           </div>
         )}
 
-        {!hasAnyConnection && !provider?.has_credentials && (
+        {!hasAnyConnection && provider != null && !provider.has_credentials && (
           <BYOASetupBanner providerId={providerId} />
         )}
       </div>

--- a/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
@@ -124,7 +124,7 @@ describe("BYOASetupBanner", () => {
     });
     expect(link).toHaveAttribute(
       "href",
-      "https://login.salesforce.com/",
+      "https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm",
     );
     expect(link).toHaveAttribute("target", "_blank");
   });
@@ -209,6 +209,98 @@ describe("BYOASetupBanner", () => {
         },
       });
     });
+  });
+
+  it("hides banner and enables Connect after saving credentials", async () => {
+    const user = userEvent.setup();
+
+    // Track calls to the providers endpoint so we can switch the response
+    // after the BYOA config save triggers a React Query invalidation.
+    let providerCallCount = 0;
+    const defaults: Record<string, unknown> = {
+      "/v1/credentials": { data: { credentials: [] } },
+      "/v1/oauth/connections": { data: { connections: [] } },
+      "/v1/oauth/provider-configs": { data: { configs: [] } },
+    };
+    mockGet.mockImplementation((path: string, ..._args: unknown[]) => {
+      if (
+        path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential"
+      ) {
+        return Promise.resolve({
+          data: {
+            agent_id: 42,
+            connector_id: "salesforce",
+            credential_id: null,
+            oauth_connection_id: null,
+          },
+        });
+      }
+      if (path === "/v1/oauth/providers") {
+        providerCallCount++;
+        // After the first fetch, return has_credentials: true
+        // (simulating React Query refetch after invalidation)
+        const hasCredentials = providerCallCount > 1;
+        return Promise.resolve({
+          data: {
+            providers: [
+              {
+                id: "salesforce",
+                has_credentials: hasCredentials,
+                source: hasCredentials ? "byoa" : "manifest",
+              },
+            ],
+          },
+        });
+      }
+      const match = defaults[path];
+      if (match) return Promise.resolve(match);
+      return Promise.resolve({ data: {} });
+    });
+
+    mockPost.mockResolvedValue({
+      data: {
+        provider: "salesforce",
+        created_at: "2026-03-15T10:00:00Z",
+      },
+    });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    // Banner should be visible initially
+    await waitFor(() => {
+      expect(
+        screen.getByText("OAuth app setup required"),
+      ).toBeInTheDocument();
+    });
+
+    // Save credentials through the dialog
+    await user.click(
+      screen.getByRole("button", { name: /Configure credentials/ }),
+    );
+    await user.type(screen.getByLabelText("Client ID"), "my-client-id");
+    await user.type(screen.getByLabelText("Client Secret"), "my-secret");
+    await user.click(screen.getByRole("button", { name: "Save Credentials" }));
+
+    // After save + React Query invalidation, banner should disappear
+    // and Connect button should be enabled
+    await waitFor(() => {
+      expect(
+        screen.queryByText("OAuth app setup required"),
+      ).not.toBeInTheDocument();
+    });
+
+    const connectBtn = screen.getByRole("button", {
+      name: /Connect Salesforce/,
+    });
+    expect(connectBtn).not.toBeDisabled();
   });
 
   it("does not show banner when provider has credentials", async () => {

--- a/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
@@ -1,0 +1,247 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderWithProviders } from "../../../../test-helpers";
+import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
+import {
+  mockGet,
+  mockPost,
+  resetClientMocks,
+} from "../../../../api/__mocks__/client";
+import { ConnectorCredentialsSection } from "../ConnectorCredentialsSection";
+
+vi.mock("../../../../lib/supabaseClient");
+vi.mock("../../../../api/client");
+
+const salesforceOAuth = [
+  {
+    service: "salesforce",
+    auth_type: "oauth2" as const,
+    oauth_provider: "salesforce",
+    oauth_scopes: ["api", "refresh_token"],
+  },
+];
+
+function setupMockGet(overrides: Record<string, unknown> = {}) {
+  const defaults: Record<string, unknown> = {
+    "/v1/credentials": { data: { credentials: [] } },
+    "/v1/oauth/connections": { data: { connections: [] } },
+    "/v1/oauth/providers": {
+      data: {
+        providers: [
+          { id: "salesforce", has_credentials: false, source: "manifest" },
+        ],
+      },
+    },
+    ...overrides,
+  };
+  mockGet.mockImplementation((path: string, ..._args: unknown[]) => {
+    if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
+      return Promise.resolve({
+        data: {
+          agent_id: 42,
+          connector_id: "salesforce",
+          credential_id: null,
+          oauth_connection_id: null,
+        },
+      });
+    }
+    const match = defaults[path];
+    if (match) return Promise.resolve(match);
+    return Promise.resolve({ data: {} });
+  });
+}
+
+async function openManageModal(user: ReturnType<typeof userEvent.setup>) {
+  const btn = await screen.findByRole("button", {
+    name: /Manage credentials/i,
+  });
+  await user.click(btn);
+}
+
+describe("BYOASetupBanner", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("shows BYOA setup banner when provider has_credentials is false", async () => {
+    const user = userEvent.setup();
+    setupMockGet();
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("OAuth app setup required"),
+      ).toBeInTheDocument();
+    });
+
+    // Verify step-by-step guide is shown
+    expect(screen.getByText("Create an OAuth app")).toBeInTheDocument();
+    expect(
+      screen.getByText("Enter your Client ID and Client Secret"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Connect your account")).toBeInTheDocument();
+
+    // Connect button should be disabled
+    expect(
+      screen.getByRole("button", { name: /Connect Salesforce/ }),
+    ).toBeDisabled();
+  });
+
+  it("shows developer console link for known providers", async () => {
+    const user = userEvent.setup();
+    setupMockGet();
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("OAuth app setup required"),
+      ).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole("link", {
+      name: /Open Salesforce developer console/,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://login.salesforce.com/",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("opens BYOAConfigDialog from the banner", async () => {
+    const user = userEvent.setup();
+    setupMockGet();
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("OAuth app setup required"),
+      ).toBeInTheDocument();
+    });
+
+    // Click the configure credentials button in the banner
+    await user.click(
+      screen.getByRole("button", { name: /Configure credentials/ }),
+    );
+
+    // BYOAConfigDialog should appear
+    expect(
+      screen.getByText("Configure Salesforce OAuth App"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Client ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Client Secret")).toBeInTheDocument();
+  });
+
+  it("saves BYOA credentials through the config dialog", async () => {
+    const user = userEvent.setup();
+    setupMockGet();
+    mockPost.mockResolvedValue({
+      data: {
+        provider: "salesforce",
+        created_at: "2026-03-15T10:00:00Z",
+      },
+    });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("OAuth app setup required"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /Configure credentials/ }),
+    );
+
+    await user.type(screen.getByLabelText("Client ID"), "test-client-id");
+    await user.type(
+      screen.getByLabelText("Client Secret"),
+      "test-client-secret",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Credentials" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/v1/oauth/provider-configs", {
+        headers: { Authorization: "Bearer token" },
+        body: {
+          provider: "salesforce",
+          client_id: "test-client-id",
+          client_secret: "test-client-secret",
+        },
+      });
+    });
+  });
+
+  it("does not show banner when provider has credentials", async () => {
+    const user = userEvent.setup();
+    setupMockGet({
+      "/v1/oauth/providers": {
+        data: {
+          providers: [
+            { id: "salesforce", has_credentials: true, source: "byoa" },
+          ],
+        },
+      },
+    });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Connect Salesforce/ }),
+      ).toBeInTheDocument();
+    });
+
+    // Banner should NOT be shown
+    expect(
+      screen.queryByText("OAuth app setup required"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
@@ -209,6 +209,13 @@ describe("BYOASetupBanner", () => {
         },
       });
     });
+
+    // Dialog should close after successful save
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Configure Salesforce OAuth App"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("hides banner and enables Connect after saving credentials", async () => {

--- a/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
@@ -310,6 +310,35 @@ describe("BYOASetupBanner", () => {
     expect(connectBtn).not.toBeDisabled();
   });
 
+  it("does not show banner when provider is absent from list", async () => {
+    const user = userEvent.setup();
+    setupMockGet({
+      "/v1/oauth/providers": {
+        data: { providers: [] },
+      },
+    });
+
+    renderWithProviders(
+      <ConnectorCredentialsSection
+        agentId={42}
+        connectorId="salesforce"
+        requiredCredentials={salesforceOAuth}
+      />,
+    );
+
+    await openManageModal(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Connect Salesforce/ }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("OAuth app setup required"),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not show banner when provider has credentials", async () => {
     const user = userEvent.setup();
     setupMockGet({

--- a/frontend/src/pages/settings/OAuthProviderSection.tsx
+++ b/frontend/src/pages/settings/OAuthProviderSection.tsx
@@ -65,8 +65,8 @@ export function OAuthProviderSection() {
           </div>
           <CardDescription>
             Configure your own OAuth client credentials for providers that
-            aren&apos;t pre-configured. Required for self-hosted deployments or
-            custom providers.
+            aren&apos;t pre-configured on this platform (e.g. Salesforce,
+            X/Twitter).
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Summary

- **Narrowed BYOA rationale**: Removed self-hosted as a use case (env vars handle that). BYOA is now clearly scoped to connectors whose OAuth provider lacks platform-level credentials (e.g. Salesforce, X/Twitter).
- **Added BYOASetupBanner**: When a connector needs BYOA, the credential dialog now shows a prominent amber banner with a 3-step guide: (1) create an OAuth app (with link to the provider's developer console), (2) enter client ID and secret, (3) connect your account.
- **Updated docs and comments**: `api/oauth_byoa.go` header, `docs/oauth-setup.md` BYOA section, and `OAuthProviderSection` description all reflect the narrower scope.

> **Task:** Clarify BYOA OAuth rationale in docs/comments and wire up the BYOA setup UI inline in the connector credentials flow

## Test plan

### Claude Code
- [x] Frontend tests pass (851/851)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Verify BYOASetupBanner renders when `has_credentials` is false
- [x] Verify BYOAConfigDialog opens from the banner and saves correctly
- [x] Verify Connect button enables after BYOA credentials are saved (React Query invalidation)

### Manual Testing
- [ ] Open a connector that needs BYOA (e.g. Salesforce) and verify the banner is prominent and clear
- [ ] Confirm dev console links work for each provider
- [ ] Verify dark mode styling of the amber banner looks good

https://claude.ai/code/session_01XXNQgTTX1P4iTXgYUsETx7