### PR TITLE
Condense agent detail header and clarify payment method

### DIFF
--- a/frontend/src/pages/agents/AgentInfoSection.tsx
+++ b/frontend/src/pages/agents/AgentInfoSection.tsx
@@ -119,32 +119,17 @@ export function AgentInfoSection({ agent }: { agent: AgentDetail }) {
         </div>
       </CardHeader>
       <CardContent>
-        <dl className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
-          <InfoItem label="Agent ID" value={String(agent.agent_id)} />
-          <InfoItem label="Status" value={agent.status} />
-          <InfoItem
-            label="Registered"
-            value={
-              agent.registered_at
-                ? new Date(agent.registered_at).toLocaleDateString()
-                : "—"
-            }
-          />
-          <InfoItem
-            label="Last Active"
-            value={formatRelativeTime(agent.last_active_at)}
-          />
-        </dl>
+        <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+          <span>
+            Registered{" "}
+            {agent.registered_at
+              ? new Date(agent.registered_at).toLocaleDateString()
+              : "—"}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>Active {formatRelativeTime(agent.last_active_at)}</span>
+        </div>
       </CardContent>
     </Card>
-  );
-}
-
-function InfoItem({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <dt className="text-muted-foreground font-medium">{label}</dt>
-      <dd className="mt-0.5">{value}</dd>
-    </div>
   );
 }

--- a/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
+++ b/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
@@ -81,10 +81,19 @@ export function AgentPaymentMethodSection({
     <>
       <Card>
         <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <CardTitle className="flex items-center gap-2">
-            <CreditCard className="size-5" />
-            Payment Method
-          </CardTitle>
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <CreditCard className="size-5" />
+              Payment Method
+              <Badge variant="secondary" className="text-xs font-normal">
+                Optional
+              </Badge>
+            </CardTitle>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Only needed if you want this agent to use connector actions that
+              make purchases.
+            </p>
+          </div>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -104,8 +113,8 @@ export function AgentPaymentMethodSection({
             <div className="flex flex-col items-center justify-center py-8 text-center">
               <CreditCard className="text-muted-foreground mb-3 size-10" />
               <p className="text-muted-foreground mb-3 text-sm">
-                No payment methods stored yet. Add a card to enable
-                agent-initiated purchases.
+                No payment methods added yet. You only need a payment method if
+                this agent will use connector actions that make purchases.
               </p>
               <Button
                 variant="outline"
@@ -140,8 +149,8 @@ export function AgentPaymentMethodSection({
                   </div>
                   <p className="text-muted-foreground text-xs">
                     {currentValue
-                      ? "This agent uses the selected payment method for purchases."
-                      : "Select a payment method for this agent to use for purchases."}
+                      ? "This agent will use the selected payment method for purchases."
+                      : "No payment method assigned. Only needed if this agent uses connector actions that make purchases."}
                   </p>
                   <select
                     id="agent-payment-method-select"

--- a/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
+++ b/frontend/src/pages/agents/AgentPaymentMethodSection.tsx
@@ -144,7 +144,7 @@ export function AgentPaymentMethodSection({
                         Assigned
                       </Badge>
                     ) : (
-                      <Badge variant="destructive">Not set</Badge>
+                      <Badge variant="secondary">Not set</Badge>
                     )}
                   </div>
                   <p className="text-muted-foreground text-xs">

--- a/frontend/src/pages/agents/__tests__/AgentPaymentMethodSection.test.tsx
+++ b/frontend/src/pages/agents/__tests__/AgentPaymentMethodSection.test.tsx
@@ -71,7 +71,7 @@ describe("AgentPaymentMethodSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/No payment methods stored yet/),
+        screen.getByText(/No payment methods added yet/),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/pages/agents/__tests__/AgentPaymentMethodSection.test.tsx
+++ b/frontend/src/pages/agents/__tests__/AgentPaymentMethodSection.test.tsx
@@ -140,6 +140,43 @@ describe("AgentPaymentMethodSection", () => {
     });
   });
 
+  it("shows Optional badge and subtitle in card header", async () => {
+    setupMocks();
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Optional")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Only needed if you want this agent/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows unassigned description when payment methods exist but none assigned", async () => {
+    setupMocks({
+      paymentMethods: [
+        {
+          id: "pm-1",
+          brand: "visa",
+          last4: "4242",
+          exp_month: 12,
+          exp_year: 2028,
+          is_default: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    renderWithProviders(<AgentPaymentMethodSection agentId={42} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No payment method assigned/),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("shows manage button", async () => {
     setupMocks({
       paymentMethods: [

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- Condensed the agent info section by removing redundant Agent ID and Status fields (status badge is already in the header). Registered date and Last Active now display as a compact inline line with a dot separator, saving significant vertical space on mobile.
- Added an "Optional" badge and descriptive subtitle to the Payment Method section, making it clear this is only needed if the agent uses connector actions that make purchases. Updated all empty/unassigned state copy to reinforce this.

## Test plan

### Claude Code
- [x] Frontend tests pass (`make test-frontend` — 856/856 passing)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### Manual Testing
- [ ] Load the agent detail page on mobile — verify the header is visually more compact
- [ ] Verify "Optional" badge appears next to "Payment Method" title
- [ ] Check the payment section description copy makes it clear this is not required
- [ ] Verify the empty state (no payment methods) shows updated copy
- [ ] Verify the unassigned state (has methods, none selected) shows updated copy

https://claude.ai/code/session_01GNH6SeN43zuoqbaKdTU8ax