### PR TITLE
Move Always Allow to approval screen, skip wizard steps

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -169,8 +169,20 @@ export function CreateStandingApprovalDialog({
     setAgentId(initialAgentId ?? "");
     setSelectedConfigId(initialActionType ? CUSTOM_ACTION_SENTINEL : "");
     setCustomActionType(initialActionType ?? "");
-    setParamValues({});
-    setParamModes({});
+    if (hasInitialContext && initialConstraints) {
+      const values: Record<string, string> = {};
+      const modes: Record<string, ParamMode> = {};
+      for (const [key, value] of Object.entries(initialConstraints)) {
+        if (value === "*") { values[key] = "*"; modes[key] = "wildcard"; }
+        else if (isPatternWrapper(value)) { values[key] = value.$pattern; modes[key] = "pattern"; }
+        else { values[key] = value === null || value === undefined ? "" : String(value); modes[key] = "fixed"; }
+      }
+      setParamValues(values);
+      setParamModes(modes);
+    } else {
+      setParamValues({});
+      setParamModes({});
+    }
     setManualConstraintsJson(
       hasInitialContext && initialConstraints
         ? JSON.stringify(initialConstraints, null, 2)

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -84,7 +84,9 @@ export function CreateStandingApprovalDialog({
 }: CreateStandingApprovalDialogProps) {
   const { createStandingApproval, isPending } = useCreateStandingApproval();
 
-  const [step, setStep] = useState<Step>(1);
+  // Skip straight to constraints when agent + action are pre-filled
+  const hasInitialContext = !!(initialAgentId && initialActionType);
+  const [step, setStep] = useState<Step>(hasInitialContext ? 3 : 1);
   const [agentId, setAgentId] = useState<number | "">(initialAgentId ?? "");
   const [selectedConfigId, setSelectedConfigId] = useState<string>(
     initialActionType ? CUSTOM_ACTION_SENTINEL : "",
@@ -92,9 +94,33 @@ export function CreateStandingApprovalDialog({
   const [customActionType, setCustomActionType] = useState(
     initialActionType ?? "",
   );
-  const [paramValues, setParamValues] = useState<Record<string, string>>({});
-  const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
-  const [manualConstraintsJson, setManualConstraintsJson] = useState("");
+  // Pre-populate constraint form values when initial constraints are provided
+  const [paramValues, setParamValues] = useState<Record<string, string>>(() => {
+    if (!hasInitialContext || !initialConstraints) return {};
+    const values: Record<string, string> = {};
+    for (const [key, value] of Object.entries(initialConstraints)) {
+      if (value === "*") values[key] = "*";
+      else if (isPatternWrapper(value)) values[key] = value.$pattern;
+      else if (value === null || value === undefined) values[key] = "";
+      else values[key] = String(value);
+    }
+    return values;
+  });
+  const [paramModes, setParamModes] = useState<Record<string, ParamMode>>(() => {
+    if (!hasInitialContext || !initialConstraints) return {};
+    const modes: Record<string, ParamMode> = {};
+    for (const [key, value] of Object.entries(initialConstraints)) {
+      if (value === "*") modes[key] = "wildcard";
+      else if (isPatternWrapper(value)) modes[key] = "pattern";
+      else modes[key] = "fixed";
+    }
+    return modes;
+  });
+  const [manualConstraintsJson, setManualConstraintsJson] = useState(
+    hasInitialContext && initialConstraints
+      ? JSON.stringify(initialConstraints, null, 2)
+      : "",
+  );
   const [maxExecutions, setMaxExecutions] = useState("");
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
@@ -139,13 +165,17 @@ export function CreateStandingApprovalDialog({
   }, [activeConfigs]);
 
   function resetForm() {
-    setStep(1);
+    setStep(hasInitialContext ? 3 : 1);
     setAgentId(initialAgentId ?? "");
     setSelectedConfigId(initialActionType ? CUSTOM_ACTION_SENTINEL : "");
     setCustomActionType(initialActionType ?? "");
     setParamValues({});
     setParamModes({});
-    setManualConstraintsJson("");
+    setManualConstraintsJson(
+      hasInitialContext && initialConstraints
+        ? JSON.stringify(initialConstraints, null, 2)
+        : "",
+    );
     setMaxExecutions("");
     setExpiresAt(defaultExpiresAt());
   }
@@ -250,8 +280,9 @@ export function CreateStandingApprovalDialog({
   }
 
   function handleBack() {
-    if (step === 2) setStep(1);
-    else if (step === 3) setStep(2);
+    const minStep = hasInitialContext ? 3 : 1;
+    if (step === 2 && minStep <= 1) setStep(1);
+    else if (step === 3 && minStep <= 2) setStep(2);
     else if (step === 4) setStep(3);
   }
 
@@ -337,12 +368,14 @@ export function CreateStandingApprovalDialog({
         <DialogHeader>
           <DialogTitle>Create Standing Approval</DialogTitle>
           <DialogDescription>
-            Step {step} of 4: {STEP_LABELS[step]}
+            {hasInitialContext
+              ? `Step ${step - 2} of 2: ${STEP_LABELS[step]}`
+              : `Step ${step} of 4: ${STEP_LABELS[step]}`}
           </DialogDescription>
         </DialogHeader>
 
         <div className="flex items-center gap-1 px-1">
-          {([1, 2, 3, 4] as Step[]).map((s) => (
+          {(hasInitialContext ? [3, 4] as Step[] : [1, 2, 3, 4] as Step[]).map((s) => (
             <div
               key={s}
               className={`h-1.5 flex-1 rounded-full transition-colors ${
@@ -415,7 +448,7 @@ export function CreateStandingApprovalDialog({
           )}
 
           <DialogFooter className="gap-2 sm:gap-0">
-            {step > 1 && (
+            {step > (hasInitialContext ? 3 : 1) && (
               <Button
                 type="button"
                 variant="outline"

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -116,13 +116,14 @@ export function ReviewApprovalDialog({
   const [standingDialogOpen, setStandingDialogOpen] = useState(false);
   const [standingApprovalCreated, setStandingApprovalCreated] = useState(false);
   const [autoCloseBlocked, setAutoCloseBlocked] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"approve" | "alwaysAllow" | null>(null);
   const isApproved = approveResult !== null;
-  const { approveApproval, isPending: isApproving } = useApproveApproval();
+  const { approveApproval } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
   const { schema, actionName } = useActionSchema(approval.action.type);
   const remaining = useCountdown(approval.expires_at);
   const isExpired = remaining <= 0;
-  const isBusy = isApproving || isDenying;
+  const isBusy = pendingAction !== null || isDenying;
 
   // Data for "Always Allow This"
   const { agents } = useAgents();
@@ -149,11 +150,14 @@ export function ReviewApprovalDialog({
   }, [isApproved, autoCloseBlocked, onOpenChange]);
 
   const handleApprove = useCallback(async () => {
+    setPendingAction("approve");
     try {
       const result = await approveApproval(approval.approval_id);
       setApproveResult(result);
     } catch {
       toast.error("Failed to approve request. Please try again.");
+    } finally {
+      setPendingAction(null);
     }
   }, [approveApproval, approval.approval_id]);
 
@@ -168,7 +172,7 @@ export function ReviewApprovalDialog({
   }, [denyApproval, approval.approval_id, onOpenChange]);
 
   const handleAlwaysAllow = useCallback(async () => {
-    // Approve the request first, then open the standing approval wizard
+    setPendingAction("alwaysAllow");
     try {
       const result = await approveApproval(approval.approval_id);
       setApproveResult(result);
@@ -176,6 +180,8 @@ export function ReviewApprovalDialog({
       setStandingDialogOpen(true);
     } catch {
       toast.error("Failed to approve request. Please try again.");
+    } finally {
+      setPendingAction(null);
     }
   }, [approveApproval, approval.approval_id]);
 
@@ -193,6 +199,7 @@ export function ReviewApprovalDialog({
       setApproveResult(null);
       setStandingApprovalCreated(false);
       setAutoCloseBlocked(false);
+      setPendingAction(null);
     }
     onOpenChange(nextOpen);
   }
@@ -346,9 +353,9 @@ export function ReviewApprovalDialog({
                 variant="secondary"
                 disabled={isBusy || isExpired}
                 onClick={handleAlwaysAllow}
-                aria-label={isApproving ? "Approving and creating rule…" : undefined}
+                aria-label={pendingAction === "alwaysAllow" ? "Approving and creating rule…" : undefined}
               >
-                {isApproving ? (
+                {pendingAction === "alwaysAllow" ? (
                   <Loader2 className="size-4 animate-spin" />
                 ) : (
                   <>
@@ -362,9 +369,9 @@ export function ReviewApprovalDialog({
               size="lg"
               disabled={isBusy || isExpired}
               onClick={handleApprove}
-              aria-label={isApproving ? "Approving request…" : undefined}
+              aria-label={pendingAction === "approve" ? "Approving request…" : undefined}
             >
-              {isApproving ? (
+              {pendingAction === "approve" ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : (
                 "Approve"

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -177,7 +177,9 @@ export function ReviewApprovalDialog({
       const result = await approveApproval(approval.approval_id);
       setApproveResult(result);
       setAutoCloseBlocked(true);
-      setStandingDialogOpen(true);
+      if (result.execution_status !== "error") {
+        setStandingDialogOpen(true);
+      }
     } catch {
       toast.error("Failed to approve request. Please try again.");
     } finally {

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -167,10 +167,17 @@ export function ReviewApprovalDialog({
     }
   }, [denyApproval, approval.approval_id, onOpenChange]);
 
-  function handleAlwaysAllow() {
-    setAutoCloseBlocked(true);
-    setStandingDialogOpen(true);
-  }
+  const handleAlwaysAllow = useCallback(async () => {
+    // Approve the request first, then open the standing approval wizard
+    try {
+      const result = await approveApproval(approval.approval_id);
+      setApproveResult(result);
+      setAutoCloseBlocked(true);
+      setStandingDialogOpen(true);
+    } catch {
+      toast.error("Failed to approve request. Please try again.");
+    }
+  }, [approveApproval, approval.approval_id]);
 
   function handleStandingDialogChange(nextOpen: boolean) {
     setStandingDialogOpen(nextOpen);
@@ -317,16 +324,6 @@ export function ReviewApprovalDialog({
             >
               Done
             </Button>
-            {showAlwaysAllow && !standingApprovalCreated && approveResult?.execution_status === "success" && (
-              <Button
-                size="lg"
-                variant="secondary"
-                onClick={handleAlwaysAllow}
-              >
-                <ShieldCheck className="mr-1 size-4" />
-                Always Allow This
-              </Button>
-            )}
           </DialogFooter>
         ) : (
           <DialogFooter>
@@ -343,6 +340,24 @@ export function ReviewApprovalDialog({
                 "Deny"
               )}
             </Button>
+            {showAlwaysAllow && (
+              <Button
+                size="lg"
+                variant="secondary"
+                disabled={isBusy || isExpired}
+                onClick={handleAlwaysAllow}
+                aria-label={isApproving ? "Approving and creating rule…" : undefined}
+              >
+                {isApproving ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <>
+                    <ShieldCheck className="mr-1 size-4" />
+                    Always Allow
+                  </>
+                )}
+              </Button>
+            )}
             <Button
               size="lg"
               disabled={isBusy || isExpired}

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -298,7 +298,7 @@ describe("CreateStandingApprovalDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("accepts initial props for pre-populated flow", () => {
+  it("accepts initial props and skips to constraints step", () => {
     render(
       <CreateStandingApprovalDialog
         agents={mockAgents}
@@ -311,9 +311,9 @@ describe("CreateStandingApprovalDialog", () => {
       { wrapper },
     );
 
-    // Agent should be pre-selected
-    const select = screen.getByLabelText("Agent") as HTMLSelectElement;
-    expect(select.value).toBe("1");
+    // Should skip to step 3 (constraints), shown as step 1 of 2
+    expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Set Constraints/)).toBeInTheDocument();
   });
 
   it("filters out deactivated agents", () => {

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -74,22 +74,10 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     wrapper = createAuthWrapper();
   });
 
-  it("shows 'Always Allow This' button after successful approval when action has parameters", async () => {
+  it("shows 'Always Allow' button on the approval screen when action has parameters", async () => {
     setupMocks();
     const approval = makeApproval();
 
-    mockPost.mockResolvedValueOnce({
-      data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC-123",
-        execution_status: "success",
-        execution_result: null,
-      },
-    });
-
-    const user = userEvent.setup();
     render(
       <ReviewApprovalDialog
         approval={approval}
@@ -100,36 +88,20 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    // Click approve
-    await user.click(screen.getByText("Approve"));
-
-    // Wait for success banner
+    // "Always Allow" button should be visible alongside Approve/Deny
     await waitFor(() => {
-      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+      expect(screen.getByText("Always Allow")).toBeInTheDocument();
     });
-
-    // "Always Allow This" button should be visible
-    expect(screen.getByText("Always Allow This")).toBeInTheDocument();
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+    expect(screen.getByText("Deny")).toBeInTheDocument();
   });
 
-  it("does NOT show 'Always Allow This' when action has no parameters", async () => {
+  it("does NOT show 'Always Allow' when action has no parameters", () => {
     setupMocks();
     const approval = makeApproval({
       action: { type: "system.noop", version: "1", parameters: {} },
     });
 
-    mockPost.mockResolvedValueOnce({
-      data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC-123",
-        execution_status: "success",
-        execution_result: null,
-      },
-    });
-
-    const user = userEvent.setup();
     render(
       <ReviewApprovalDialog
         approval={approval}
@@ -140,16 +112,10 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    await user.click(screen.getByText("Approve"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
-    });
-
-    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
+    expect(screen.queryByText("Always Allow")).not.toBeInTheDocument();
   });
 
-  it("does NOT show 'Always Allow This' when a standing approval already exists for agent+action", async () => {
+  it("does NOT show 'Always Allow' when a standing approval already exists for agent+action", async () => {
     setupMocks({
       standingApprovals: [
         { agent_id: 1, action_type: "email.send" },
@@ -157,18 +123,6 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     });
     const approval = makeApproval();
 
-    mockPost.mockResolvedValueOnce({
-      data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC-123",
-        execution_status: "success",
-        execution_result: null,
-      },
-    });
-
-    const user = userEvent.setup();
     render(
       <ReviewApprovalDialog
         approval={approval}
@@ -179,86 +133,16 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    await user.click(screen.getByText("Approve"));
-
+    // Wait for standing approvals to load, then verify button is absent
     await waitFor(() => {
-      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+      // Standing approvals have loaded (no loading state)
+      expect(screen.getByText("Approve")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
+    expect(screen.queryByText("Always Allow")).not.toBeInTheDocument();
   });
 
-  it("does NOT show 'Always Allow This' when execution_status is 'pending'", async () => {
-    setupMocks();
-    const approval = makeApproval();
-
-    mockPost.mockResolvedValueOnce({
-      data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC-123",
-        execution_status: "pending",
-        execution_result: null,
-      },
-    });
-
-    const user = userEvent.setup();
-    render(
-      <ReviewApprovalDialog
-        approval={approval}
-        agentDisplayName="Test Bot"
-        open={true}
-        onOpenChange={vi.fn()}
-      />,
-      { wrapper },
-    );
-
-    await user.click(screen.getByText("Approve"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Request Approved")).toBeInTheDocument();
-    });
-
-    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
-  });
-
-  it("does NOT show 'Always Allow This' when execution_status is 'error'", async () => {
-    setupMocks();
-    const approval = makeApproval();
-
-    mockPost.mockResolvedValueOnce({
-      data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC-123",
-        execution_status: "error",
-        execution_result: { execution_error: "Connection failed" },
-      },
-    });
-
-    const user = userEvent.setup();
-    render(
-      <ReviewApprovalDialog
-        approval={approval}
-        agentDisplayName="Test Bot"
-        open={true}
-        onOpenChange={vi.fn()}
-      />,
-      { wrapper },
-    );
-
-    await user.click(screen.getByText("Approve"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Execution Failed")).toBeInTheDocument();
-    });
-
-    expect(screen.queryByText("Always Allow This")).not.toBeInTheDocument();
-  });
-
-  it("opens CreateStandingApprovalDialog when 'Always Allow This' is clicked", async () => {
+  it("approves request and opens CreateStandingApprovalDialog when 'Always Allow' is clicked", async () => {
     setupMocks();
     const approval = makeApproval();
 
@@ -284,17 +168,19 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    await user.click(screen.getByText("Approve"));
-
+    // Click "Always Allow" from the pre-approval screen
     await waitFor(() => {
-      expect(screen.getByText("Always Allow This")).toBeInTheDocument();
+      expect(screen.getByText("Always Allow")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Always Allow This"));
+    await user.click(screen.getByText("Always Allow"));
 
-    // The CreateStandingApprovalDialog should open
+    // The CreateStandingApprovalDialog should open (skipping to constraints step)
     await waitFor(() => {
       expect(screen.getByText("Create Standing Approval")).toBeInTheDocument();
     });
+
+    // Should show step 1 of 2 (constraints), not step 1 of 4
+    expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -183,4 +183,44 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     // Should show step 1 of 2 (constraints), not step 1 of 4
     expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
   });
+
+  it("does NOT open standing approval wizard when execution fails after 'Always Allow'", async () => {
+    setupMocks();
+    const approval = makeApproval();
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        approval_id: approval.approval_id,
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        confirmation_code: "ABC-123",
+        execution_status: "error",
+        execution_result: { execution_error: "Connection failed" },
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={approval}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Always Allow")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Always Allow"));
+
+    // Should show execution failure, NOT the standing approval wizard
+    await waitFor(() => {
+      expect(screen.getByText("Execution Failed")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Create Standing Approval")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Moved the "Always Allow" button from the post-approval success screen to the initial approval screen (alongside Deny and Approve), fixing the flash where the button was only visible for ~1 second before auto-close dismissed it
- Clicking "Always Allow" now approves the request first, then opens the standing approval wizard with agent, action type, and constraints pre-filled
- The wizard skips steps 1-2 (Pick Agent / Pick Action) when launched from an approval, showing a condensed 2-step flow (Set Constraints → Set Limits)

## Test plan

### Claude Code
- [x] All 861 frontend tests pass
- [x] TypeScript compilation clean (no errors)
- [x] Updated ReviewApprovalDialog tests to verify Always Allow appears on pre-approval screen
- [x] Updated CreateStandingApprovalDialog test to verify step-skipping behavior

### Manual Testing
- [ ] Verify "Always Allow" button appears alongside Deny/Approve on the approval screen
- [ ] Verify clicking "Always Allow" approves the request and opens the standing approval wizard
- [ ] Verify the wizard starts at "Set Constraints" (step 1 of 2) with params pre-filled from the request
- [ ] Verify the wizard's Back button doesn't navigate to steps 1-2 when launched from an approval
- [ ] Verify the regular "Approve" button still works as before (shows success, auto-closes after 3s)

https://claude.ai/code/session_012xXGF6dRydrTZ5SrhwFAFW