### PR TITLE
Make --automerge the default for /watch skill

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: watch
 description: Poll a GitHub PR for new comments and PR reviews and act on them autonomously. Use when the user wants to monitor a PR for feedback and have Claude implement requested changes automatically.
-argument-hint: "[PR_URL] [--automerge] [--max-turns <N>] [--no-notify]"
+argument-hint: "[PR_URL] [--no-automerge] [--max-turns <N>] [--no-notify]"
 ---
 
 # Watch PR for Comments and Reviews
@@ -39,7 +39,7 @@ Agent (this skill)     — Only invoked when reasoning is needed
 
 Parse the arguments from: `$ARGUMENTS`
 
-Extract any PR URL and flags. The format is: `[PR_URL] [--automerge] [--max-turns <N>] [--no-notify]`
+Extract any PR URL and flags. The format is: `[PR_URL] [--no-automerge] [--max-turns <N>] [--no-notify]`
 
 The PR URL is **optional**. If not provided, detect it automatically from the current branch:
 
@@ -54,7 +54,7 @@ Parse the PR number from the URL (e.g., `https://github.com/supersuit-tech/permi
 Set these variables for the session:
 - `PR_URL` — the PR URL (from arguments or auto-detected from current branch)
 - `PR_NUMBER` — the extracted PR number
-- `AUTO_MERGE` — `true` if `--automerge` was passed, `false` otherwise
+- `AUTO_MERGE` — `true` by default, `false` if `--no-automerge` was passed
 - `MAX_TURNS` — the value of `--max-turns` if passed, `0` otherwise (0 = unlimited)
 - `NO_NOTIFY` — `true` if `--no-notify` was passed, `false` otherwise
 - `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
@@ -68,11 +68,11 @@ The agent orchestrates the session by running the shell scripts and only doing A
 
 ```bash
 # First run (no --work-dir):
-bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") $([[ "$MAX_TURNS" -gt 0 ]] && echo "--max-turns $MAX_TURNS") 2>&1
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$MAX_TURNS" -gt 0 ]] && echo "--max-turns $MAX_TURNS") 2>&1
 # Capture WORK_DIR from the session context JSON in the output.
 
 # Subsequent runs (reuse WORK_DIR to preserve state):
-bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") $([[ "$MAX_TURNS" -gt 0 ]] && echo "--max-turns $MAX_TURNS") --work-dir "$WORK_DIR" 2>&1
+bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$MAX_TURNS" -gt 0 ]] && echo "--max-turns $MAX_TURNS") --work-dir "$WORK_DIR" 2>&1
 ```
 
 The script handles:
@@ -299,7 +299,7 @@ After the agent finishes processing work items, go back to **Step 1** and run th
 When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has already been posted by the script. Run the post-session script:
 
 ```bash
-bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "true" ]] && echo "--automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") 2>&1
+bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") 2>&1
 ```
 
 This handles:

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -3,10 +3,10 @@
 # Handles all mechanical bookkeeping (fetching, deduplication, idle timeout)
 # and only invokes the Claude agent when there's actionable work.
 #
-# Usage: bash watch-poll.sh [PR_URL] [--automerge] [--work-dir <path>] [--max-turns <N>]
+# Usage: bash watch-poll.sh [PR_URL] [--no-automerge] [--work-dir <path>] [--max-turns <N>]
 #
 # Options:
-#   --automerge       Enable auto-merge after checks pass
+#   --no-automerge    Disable auto-merge (enabled by default)
 #   --work-dir <path> Reuse an existing work directory (preserves state
 #                     across invocations: last-seen IDs, action log, cache)
 #   --max-turns <N>   Maximum number of agent turns before ending the session.
@@ -27,14 +27,15 @@ set -euo pipefail
 # Arguments
 # ---------------------------------------------------------------------------
 PR_URL=""
-AUTO_MERGE=false
+AUTO_MERGE=true
 EXISTING_WORK_DIR=""
 MAX_TURNS=0  # 0 = unlimited
 
 # Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --automerge) AUTO_MERGE=true; shift ;;
+    --automerge) AUTO_MERGE=true; shift ;;  # kept for backwards compat
+    --no-automerge) AUTO_MERGE=false; shift ;;
     --work-dir) EXISTING_WORK_DIR="$2"; shift 2 ;;
     --max-turns) MAX_TURNS="$2"; shift 2 ;;
     https://*) PR_URL="$1"; shift ;;

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -4,7 +4,7 @@
 # Invoked after the polling loop ends (idle timeout) and the agent has
 # finished all its work.
 #
-# Usage: bash watch-post.sh [PR_URL] [--automerge]
+# Usage: bash watch-post.sh [PR_URL] [--no-automerge]
 #
 # This script handles steps 11-13 from the original SKILL.md:
 #   11. Trigger CI and audit, wait, fix failures (signals agent for fixes)
@@ -17,13 +17,14 @@ set -euo pipefail
 # Arguments
 # ---------------------------------------------------------------------------
 PR_URL=""
-AUTO_MERGE=false
+AUTO_MERGE=true
 NO_NOTIFY=false
 
 # Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --automerge) AUTO_MERGE=true; shift ;;
+    --automerge) AUTO_MERGE=true; shift ;;  # kept for backwards compat
+    --no-automerge) AUTO_MERGE=false; shift ;;
     --no-notify) NO_NOTIFY=true; shift ;;
     https://*) PR_URL="$1"; shift ;;
     *) shift ;;

--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<ISSUE_URL|prompt text> [--scope \"<heading>\"]"
 
 # YOLO — Autonomous Implementation
 
-Takes a GitHub issue URL **or a free-form prompt**, implements the work described, opens a pull request, and hands off to `/watch --automerge` to shepherd it through review to merge.
+Takes a GitHub issue URL **or a free-form prompt**, implements the work described, opens a pull request, and hands off to `/watch` to shepherd it through review to merge.
 
 Optionally accepts a `--scope` flag to limit work to a specific section of the issue (e.g., `--scope "Chunk 1A"` or `--scope "Phase 4"`). When scoped, only the content under that heading is implemented — everything else is ignored. The `--scope` flag is only valid when an issue URL is provided.
 
@@ -195,13 +195,13 @@ Capture the PR URL from the output.
 
 ## Step 6: Hand Off to /watch
 
-Invoke the `/watch` skill with `--automerge --no-notify` to monitor the PR through review and merge it when ready. The `--no-notify` flag suppresses the webhook notification since `/yolo` is a fully autonomous flow — no human ping needed. Since `/watch` auto-detects the PR from the current branch, you don't need to pass the URL explicitly — just the flags:
+Invoke the `/watch` skill with `--no-notify` to monitor the PR through review and merge it when ready. Auto-merge is enabled by default, so no flag is needed. The `--no-notify` flag suppresses the webhook notification since `/yolo` is a fully autonomous flow — no human ping needed. Since `/watch` auto-detects the PR from the current branch, you don't need to pass the URL explicitly — just the flags:
 
 ```
-/watch --automerge --no-notify
+/watch --no-notify
 ```
 
-Use the `Skill` tool to invoke the watch skill, passing `--automerge --no-notify` as the argument. The watch skill will detect the PR from the current branch automatically.
+Use the `Skill` tool to invoke the watch skill, passing `--no-notify` as the argument. The watch skill will detect the PR from the current branch automatically.
 
 ## Important Rules
 


### PR DESCRIPTION
## Summary

- Flips the `/watch` skill default so auto-merge is **enabled by default** — no more forgetting `--automerge`
- Adds `--no-automerge` flag to opt out when you want to prevent auto-merge
- Keeps the old `--automerge` flag for backwards compatibility (now a no-op)
- Updates `/yolo` skill to drop the now-redundant `--automerge` flag

## Test plan

### Claude Code
- [ ] Verify `/watch` without flags defaults to auto-merge enabled
- [ ] Verify `/watch --no-automerge` disables auto-merge
- [ ] Verify `/watch --automerge` still works (backwards compat)

### Manual Testing
- [ ] Run `/watch` on a real PR and confirm it auto-merges on success
- [ ] Run `/watch --no-automerge` and confirm it skips the merge step

https://claude.ai/code/session_01V9nS4Z3suXoVE5ZvmonhNK