### PR TITLE
CLI: Add --poll flag for non-blocking approval polling with timeout

### DIFF
--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -27,7 +27,13 @@ function parsePollInterval(value: string): number {
     );
     return DEFAULT_POLL_INTERVAL;
   }
-  return Math.max(MIN_POLL_INTERVAL, Math.min(parsed, MAX_POLL_INTERVAL));
+  const clamped = Math.max(MIN_POLL_INTERVAL, Math.min(parsed, MAX_POLL_INTERVAL));
+  if (clamped !== parsed) {
+    process.stderr.write(
+      `Warning: --poll-interval value "${value}" out of range [${MIN_POLL_INTERVAL}, ${MAX_POLL_INTERVAL}], using ${clamped}s\n`,
+    );
+  }
+  return clamped;
 }
 
 export function requestCommand(program: Command): void {

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -3,7 +3,8 @@
  *
  * Requests one-off approval for an action. Returns immediately by default
  * with the approval_id and a next_step hint. Pass --wait to block until
- * the approval is resolved.
+ * the approval is resolved, or --poll to poll at a regular interval with
+ * a configurable timeout (ideal for agents).
  */
 
 import type { Command } from "commander";
@@ -12,6 +13,22 @@ import { resolveAgentId } from "./status.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
 import { pollUntilResolved, parseTimeout } from "../util/poll.js";
+
+const DEFAULT_POLL_INTERVAL = 5;
+const MIN_POLL_INTERVAL = 1;
+const MAX_POLL_INTERVAL = 300;
+
+/** Parses and clamps --poll-interval to a valid range. */
+function parsePollInterval(value: string): number {
+  const parsed = Number(value);
+  if (isNaN(parsed) || parsed <= 0) {
+    process.stderr.write(
+      `Warning: invalid --poll-interval value "${value}", using default ${DEFAULT_POLL_INTERVAL}s\n`,
+    );
+    return DEFAULT_POLL_INTERVAL;
+  }
+  return Math.max(MIN_POLL_INTERVAL, Math.min(parsed, MAX_POLL_INTERVAL));
+}
 
 export function requestCommand(program: Command): void {
   program
@@ -29,6 +46,9 @@ export function requestCommand(program: Command): void {
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--wait", "Block until the approval is resolved (default: return immediately)")
     .option("--timeout <seconds>", "Max seconds to wait when using --wait (default: 120)", "120")
+    .option("--poll", "Submit and poll for approval at a regular interval (default: return immediately)")
+    .option("--poll-interval <seconds>", "Seconds between polls when using --poll (default: 5)", "5")
+    .option("--poll-timeout <seconds>", "Max seconds to poll before giving up (default: 600)", "600")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       action: string;
@@ -39,6 +59,9 @@ export function requestCommand(program: Command): void {
       agentId?: string;
       wait?: boolean;
       timeout: string;
+      poll?: boolean;
+      pollInterval: string;
+      pollTimeout: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
@@ -61,13 +84,23 @@ export function requestCommand(program: Command): void {
               }
             : undefined;
 
-        if (!opts.wait && opts.timeout !== "120") {
+        if (opts.wait && opts.poll) {
+          throw new Error("--wait and --poll are mutually exclusive. Use one or the other.");
+        }
+
+        if (!opts.wait && !opts.poll && opts.timeout !== "120") {
           process.stderr.write("Warning: --timeout has no effect without --wait\n");
+        }
+        if (!opts.poll && opts.pollInterval !== "5") {
+          process.stderr.write("Warning: --poll-interval has no effect without --poll\n");
+        }
+        if (!opts.poll && opts.pollTimeout !== "600") {
+          process.stderr.write("Warning: --poll-timeout has no effect without --poll\n");
         }
 
         const result = await client.requestApproval(opts.action, params, context);
 
-        if (!opts.wait) {
+        if (!opts.wait && !opts.poll) {
           // Default: return immediately with next_step hint.
           output(
             {
@@ -80,6 +113,41 @@ export function requestCommand(program: Command): void {
             },
             outputOpts,
           );
+          return;
+        }
+
+        if (opts.poll) {
+          // --poll: submit and poll at a regular interval.
+          const pollInterval = parsePollInterval(opts.pollInterval);
+          const timeoutSeconds = parseTimeout(opts.pollTimeout);
+
+          process.stderr.write(
+            `Polling for approval every ${pollInterval}s (timeout ${timeoutSeconds}s)... Approve at ${result.approval_url}\n`,
+          );
+
+          const statusResult = await pollUntilResolved({
+            approvalId: result.approval_id,
+            client,
+            timeoutSeconds,
+            fixedIntervalSeconds: pollInterval,
+            onPoll: ({ elapsed, timeout }) => {
+              process.stderr.write(
+                `Polling... ${elapsed}s / ${timeout}s\n`,
+              );
+            },
+          });
+
+          output(
+            {
+              ...statusResult,
+              approval_url: result.approval_url,
+            },
+            outputOpts,
+          );
+
+          if (statusResult.timed_out) {
+            process.exitCode = 2;
+          }
           return;
         }
 

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -88,7 +88,7 @@ export function requestCommand(program: Command): void {
           throw new Error("--wait and --poll are mutually exclusive. Use one or the other.");
         }
 
-        if (!opts.wait && !opts.poll && opts.timeout !== "120") {
+        if (!opts.wait && opts.timeout !== "120") {
           process.stderr.write("Warning: --timeout has no effect without --wait\n");
         }
         // Note: these comparisons miss the case where the flag is explicitly passed

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -91,6 +91,8 @@ export function requestCommand(program: Command): void {
         if (!opts.wait && !opts.poll && opts.timeout !== "120") {
           process.stderr.write("Warning: --timeout has no effect without --wait\n");
         }
+        // Note: these comparisons miss the case where the flag is explicitly passed
+        // with its default value, but this is consistent with the --timeout guard.
         if (!opts.poll && opts.pollInterval !== "5") {
           process.stderr.write("Warning: --poll-interval has no effect without --poll\n");
         }
@@ -119,7 +121,11 @@ export function requestCommand(program: Command): void {
         if (opts.poll) {
           // --poll: submit and poll at a regular interval.
           const pollInterval = parsePollInterval(opts.pollInterval);
-          const timeoutSeconds = parseTimeout(opts.pollTimeout);
+          const timeoutSeconds = parseTimeout(
+            opts.pollTimeout,
+            undefined,
+            { flagName: "--poll-timeout", defaultTimeout: 600 },
+          );
 
           process.stderr.write(
             `Polling for approval every ${pollInterval}s (timeout ${timeoutSeconds}s)... Approve at ${result.approval_url}\n`,

--- a/cli/src/util/poll.ts
+++ b/cli/src/util/poll.ts
@@ -28,13 +28,19 @@ const MIN_TIMEOUT = 1;
 const MAX_TIMEOUT = 86400;
 
 /** Parses and clamps a timeout string to a valid range. Warns on invalid input. */
-export function parseTimeout(value: string | undefined, warn: (msg: string) => void = (msg) => process.stderr.write(msg)): number {
+export function parseTimeout(
+  value: string | undefined,
+  warn: (msg: string) => void = (msg) => process.stderr.write(msg),
+  options?: { flagName?: string; defaultTimeout?: number },
+): number {
+  const flagName = options?.flagName ?? "--timeout";
+  const defaultVal = options?.defaultTimeout ?? DEFAULT_TIMEOUT;
   const parsed = Number(value);
   if (value !== undefined && (isNaN(parsed) || parsed <= 0)) {
-    warn(`Warning: invalid --timeout value "${value}", using default ${DEFAULT_TIMEOUT}s\n`);
-    return DEFAULT_TIMEOUT;
+    warn(`Warning: invalid ${flagName} value "${value}", using default ${defaultVal}s\n`);
+    return defaultVal;
   }
-  return Math.max(MIN_TIMEOUT, Math.min(parsed || DEFAULT_TIMEOUT, MAX_TIMEOUT));
+  return Math.max(MIN_TIMEOUT, Math.min(parsed || defaultVal, MAX_TIMEOUT));
 }
 
 function sleep(ms: number): Promise<void> {

--- a/cli/src/util/poll.ts
+++ b/cli/src/util/poll.ts
@@ -72,7 +72,7 @@ export async function pollUntilResolved(
   const start = Date.now();
   const deadline = start + opts.timeoutSeconds * 1000;
   const useFixedInterval = opts.fixedIntervalSeconds !== undefined;
-  let interval = useFixedInterval ? opts.fixedIntervalSeconds! * 1000 : 2000;
+  let interval = useFixedInterval ? Math.max(1, opts.fixedIntervalSeconds!) * 1000 : 2000;
   const maxInterval = 5000; // cap at 5 seconds (only used with backoff)
 
   while (Date.now() < deadline) {

--- a/cli/src/util/poll.ts
+++ b/cli/src/util/poll.ts
@@ -15,6 +15,8 @@ export interface PollOptions {
   client: ApiClient;
   /** Maximum seconds to wait before returning. */
   timeoutSeconds: number;
+  /** Fixed polling interval in seconds. When set, disables exponential backoff. */
+  fixedIntervalSeconds?: number;
   /** Called after each poll while still pending. Use for progress messages. */
   onPoll?: (info: { status: string; elapsed: number; timeout: number }) => void;
 }
@@ -63,8 +65,9 @@ export async function pollUntilResolved(
 ): Promise<ApprovalStatusResult & { timed_out?: boolean }> {
   const start = Date.now();
   const deadline = start + opts.timeoutSeconds * 1000;
-  let interval = 2000; // start at 2 seconds
-  const maxInterval = 5000; // cap at 5 seconds
+  const useFixedInterval = opts.fixedIntervalSeconds !== undefined;
+  let interval = useFixedInterval ? opts.fixedIntervalSeconds! * 1000 : 2000;
+  const maxInterval = 5000; // cap at 5 seconds (only used with backoff)
 
   while (Date.now() < deadline) {
     try {
@@ -88,7 +91,9 @@ export async function pollUntilResolved(
     if (remaining <= 0) break;
 
     await sleep(Math.min(interval, remaining));
-    interval = Math.min(Math.ceil(interval * 1.5), maxInterval);
+    if (!useFixedInterval) {
+      interval = Math.min(Math.ceil(interval * 1.5), maxInterval);
+    }
   }
 
   // Final check after timeout — also protected from transient errors.

--- a/cli/tests/poll.test.ts
+++ b/cli/tests/poll.test.ts
@@ -409,4 +409,20 @@ describe("parseTimeout", () => {
     parseTimeout("30", (msg) => warnings.push(msg));
     expect(warnings).toHaveLength(0);
   });
+
+  it("uses custom flag name in warning", () => {
+    const warnings: string[] = [];
+    parseTimeout("bad", (msg) => warnings.push(msg), { flagName: "--poll-timeout" });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("invalid --poll-timeout");
+    expect(warnings[0]).not.toContain("invalid --timeout ");
+  });
+
+  it("uses custom default timeout", () => {
+    expect(parseTimeout(undefined, noop, { defaultTimeout: 600 })).toBe(600);
+  });
+
+  it("uses custom default on invalid value", () => {
+    expect(parseTimeout("bad", noop, { defaultTimeout: 600 })).toBe(600);
+  });
 });

--- a/cli/tests/poll.test.ts
+++ b/cli/tests/poll.test.ts
@@ -280,6 +280,59 @@ describe("pollUntilResolved", () => {
     expect(typeof pollCalls[0]!.elapsed).toBe("number");
   });
 
+  it("uses fixed interval when fixedIntervalSeconds is set", async () => {
+    let callCount = 0;
+    const mock = jest.fn<() => Promise<ApprovalStatusResult>>(async () => {
+      callCount++;
+      if (callCount >= 4) {
+        return makeResult({ status: "approved", execution_status: "success" });
+      }
+      return makeResult({ status: "pending" });
+    });
+    const client = { approvalStatus: mock } as unknown as ApiClient;
+
+    const promise = pollUntilResolved({
+      approvalId: "appr_test123",
+      client,
+      timeoutSeconds: 60,
+      fixedIntervalSeconds: 5,
+    });
+
+    // Poll 1 (immediate) → pending → sleep 5s
+    await jest.advanceTimersByTimeAsync(5000);
+    // Poll 2 → pending → sleep 5s (fixed, no backoff)
+    await jest.advanceTimersByTimeAsync(5000);
+    // Poll 3 → pending → sleep 5s (still fixed)
+    await jest.advanceTimersByTimeAsync(5000);
+    // Poll 4 → approved
+
+    const result = await promise;
+
+    expect(result.status).toBe("approved");
+    expect(result.timed_out).toBeUndefined();
+    expect(mock.mock.calls.length).toBe(4);
+  });
+
+  it("fixed interval polls respect timeout", async () => {
+    const pending = makeResult({ status: "pending" });
+    const { client } = makeMockClient([pending]);
+
+    const promise = pollUntilResolved({
+      approvalId: "appr_test123",
+      client,
+      timeoutSeconds: 7,
+      fixedIntervalSeconds: 5,
+    });
+
+    // Advance past timeout
+    await jest.advanceTimersByTimeAsync(10000);
+
+    const result = await promise;
+
+    expect(result.status).toBe("pending");
+    expect(result.timed_out).toBe(true);
+  });
+
   it("propagates non-transient errors immediately", async () => {
     const mock = jest.fn<() => Promise<ApprovalStatusResult>>(async () => {
       throw new PermissionSlipApiError(401, {

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -432,6 +432,13 @@ permission-slip request --action email.send --params '{}' --wait
 
 # Block with custom timeout:
 permission-slip request --action email.send --params '{}' --wait --timeout 30
+
+# Agent-friendly: poll at a fixed interval (default 5s), exit code 2 on timeout (default 600s):
+permission-slip request --action email.send --params '{}' --poll
+
+# Custom poll interval and timeout:
+permission-slip request --action email.send --params '{}' \
+  --poll --poll-interval 10 --poll-timeout 120
 ```
 
 Alternatively, the user can share the approval confirmation code out-of-band (paste it in chat, set it in your config, etc.).


### PR DESCRIPTION
## Summary

- Adds `--poll`, `--poll-interval`, and `--poll-timeout` flags to the `request` command for agent-friendly non-blocking approval polling
- `--poll` uses a fixed interval (default 5s) instead of exponential backoff, with a longer default timeout (600s vs 120s for `--wait`)
- Prints the approval URL immediately to stderr, then polls and returns JSON result on resolution or clean exit code 2 on timeout

Closes #601

## Test plan

### Claude Code
- [x] All existing poll tests pass (53/53)
- [x] Two new tests: fixed interval polling resolves correctly; fixed interval respects timeout
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### Manual Testing
- [ ] Run `permission-slip request --action test --poll` against a live server and approve/deny
- [ ] Verify `--poll-interval 10` uses 10s between polls
- [ ] Verify `--poll-timeout 30` exits with code 2 after 30s if not resolved
- [ ] Verify `--wait` and `--poll` together produces a clear error
- [ ] Verify `--poll-interval` without `--poll` prints a warning

https://claude.ai/code