### PR TITLE
Show human-readable resource details in approval modals for Google connector

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -209,17 +209,18 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 		// Best-effort: resolve human-readable resource details for the action.
 		var resourceDetails []byte
 		if deps.Connectors != nil {
-			connectorID := connectorIDFromActionType(actionType)
-			if conn, ok := deps.Connectors.Get(connectorID); ok {
-				if resolver, ok := conn.(connectors.ResourceDetailResolver); ok {
-					resolveCtx, resolveCancel := context.WithTimeout(r.Context(), 5*time.Second)
-					details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, connectorID))
-					resolveCancel()
-					if resolveErr != nil {
-						log.Printf("[%s] ResolveResourceDetails: %v", TraceID(r.Context()), resolveErr)
-					} else if details != nil {
-						if encoded, encErr := json.Marshal(details); encErr == nil {
-							resourceDetails = encoded
+			if cid := strings.SplitN(actionType, ".", 2); len(cid) == 2 {
+				if conn, ok := deps.Connectors.Get(cid[0]); ok {
+					if resolver, ok := conn.(connectors.ResourceDetailResolver); ok {
+						resolveCtx, resolveCancel := context.WithTimeout(r.Context(), 5*time.Second)
+						details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0]))
+						resolveCancel()
+						if resolveErr != nil {
+							log.Printf("[%s] ResolveResourceDetails: %v", TraceID(r.Context()), resolveErr)
+						} else if details != nil {
+							if encoded, encErr := json.Marshal(details); encErr == nil {
+								resourceDetails = encoded
+							}
 						}
 					}
 				}

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -206,13 +206,34 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Best-effort: resolve human-readable resource details for the action.
+		var resourceDetails []byte
+		if deps.Connectors != nil {
+			connectorID := connectorIDFromActionType(actionType)
+			if conn, ok := deps.Connectors.Get(connectorID); ok {
+				if resolver, ok := conn.(connectors.ResourceDetailResolver); ok {
+					resolveCtx, resolveCancel := context.WithTimeout(r.Context(), 5*time.Second)
+					details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, connectorID))
+					resolveCancel()
+					if resolveErr != nil {
+						log.Printf("[%s] ResolveResourceDetails: %v", TraceID(r.Context()), resolveErr)
+					} else if details != nil {
+						if encoded, encErr := json.Marshal(details); encErr == nil {
+							resourceDetails = encoded
+						}
+					}
+				}
+			}
+		}
+
 		approval, err := db.InsertApproval(r.Context(), deps.DB, db.InsertApprovalParams{
-			ApprovalID: approvalID,
-			AgentID:    agent.AgentID,
-			ApproverID: agent.ApproverID,
-			Action:     req.Action,
-			Context:    req.Context,
-			ExpiresAt:  expiresAt,
+			ApprovalID:      approvalID,
+			AgentID:         agent.AgentID,
+			ApproverID:      agent.ApproverID,
+			Action:          req.Action,
+			Context:         req.Context,
+			ResourceDetails: resourceDetails,
+			ExpiresAt:       expiresAt,
 		}, req.RequestID)
 		if err != nil {
 			var apprErr *db.ApprovalError
@@ -342,6 +363,22 @@ func handleAgentApprovalStatus(deps *Deps) http.HandlerFunc {
 // handleAgentApprovalError is an alias for the shared handleApprovalError
 // in approvals.go. Both dashboard and agent endpoints use the same mapping.
 var handleAgentApprovalError = handleApprovalError
+
+// resolveCredentialsForResolver is a best-effort credential resolver for the
+// ResourceDetailResolver call. It mirrors the credential resolution logic from
+// connector execution but returns empty credentials on any failure (since
+// resource detail resolution is non-fatal).
+func resolveCredentialsForResolver(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID string) connectors.Credentials {
+	reqCreds, err := db.GetRequiredCredentialsByActionType(ctx, deps.DB, actionType)
+	if err != nil || len(reqCreds) == 0 {
+		return connectors.NewCredentials(nil)
+	}
+	creds, err := resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, reqCreds)
+	if err != nil {
+		return connectors.NewCredentials(nil)
+	}
+	return creds
+}
 
 // emitApprovalRequestAuditEvent writes an audit event for a new approval request.
 // Only the action type is persisted — parameters are redacted.

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -17,16 +17,17 @@ import (
 // Response types for the dashboard approval endpoints.
 
 type approvalResponse struct {
-	ApprovalID  string     `json:"approval_id"`
-	AgentID     int64      `json:"agent_id"`
-	Action      any        `json:"action"`
-	Context     any        `json:"context"`
-	Status      string     `json:"status"`
-	ExpiresAt   time.Time  `json:"expires_at"`
-	ApprovedAt  *time.Time `json:"approved_at,omitempty"`
-	DeniedAt    *time.Time `json:"denied_at,omitempty"`
-	CancelledAt *time.Time `json:"cancelled_at,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
+	ApprovalID      string     `json:"approval_id"`
+	AgentID         int64      `json:"agent_id"`
+	Action          any        `json:"action"`
+	Context         any        `json:"context"`
+	Status          string     `json:"status"`
+	ResourceDetails any        `json:"resource_details,omitempty"`
+	ExpiresAt       time.Time  `json:"expires_at"`
+	ApprovedAt      *time.Time `json:"approved_at,omitempty"`
+	DeniedAt        *time.Time `json:"denied_at,omitempty"`
+	CancelledAt     *time.Time `json:"cancelled_at,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
 }
 
 type approvalListResponse struct {
@@ -380,6 +381,12 @@ func toApprovalResponse(a db.Approval) approvalResponse {
 			resp.Context = ctx
 		} else {
 			log.Printf("WARNING: corrupt context JSONB for approval %s: %v", a.ApprovalID, err)
+		}
+	}
+	if len(a.ResourceDetails) > 0 {
+		var details any
+		if err := json.Unmarshal(a.ResourceDetails, &details); err == nil {
+			resp.ResourceDetails = details
 		}
 	}
 

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -61,6 +61,7 @@ type approvalDetailResponse struct {
 	ExecutionStatus *string    `json:"execution_status,omitempty"`
 	ExecutionResult any        `json:"execution_result,omitempty"`
 	ExecutedAt      *time.Time `json:"executed_at,omitempty"`
+	ResourceDetails any        `json:"resource_details,omitempty"`
 	ExpiresAt       time.Time  `json:"expires_at"`
 	ApprovedAt      *time.Time `json:"approved_at,omitempty"`
 	DeniedAt        *time.Time `json:"denied_at,omitempty"`
@@ -417,6 +418,12 @@ func toApprovalDetailResponse(a db.Approval) approvalDetailResponse {
 		var result any
 		if err := json.Unmarshal(a.ExecutionResult, &result); err == nil {
 			resp.ExecutionResult = result
+		}
+	}
+	if len(a.ResourceDetails) > 0 {
+		var details any
+		if err := json.Unmarshal(a.ResourceDetails, &details); err == nil {
+			resp.ResourceDetails = details
 		}
 	}
 

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -81,6 +81,17 @@ type ActionResult struct {
 	Data json.RawMessage // service-specific response payload
 }
 
+// ResourceDetailResolver is optionally implemented by connectors that can
+// look up human-readable details for resources referenced by opaque IDs.
+// Called when an approval request is created, before the approval is stored.
+// Errors are non-fatal — the approval is stored without details on failure.
+type ResourceDetailResolver interface {
+	// ResolveResourceDetails fetches human-readable metadata for the resources
+	// referenced by the action parameters. Returns a map of display-friendly
+	// fields (e.g., {"title": "Q1 Planning", "start_time": "2026-03-15T14:00:00Z"}).
+	ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds Credentials) (map[string]any, error)
+}
+
 // ManifestProvider is optionally implemented by connectors that can
 // describe their metadata declaratively. All built-in and external
 // connectors implement this. The server uses it to auto-seed DB rows

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -205,8 +205,20 @@ func (c *GoogleConnector) resolveEmail(ctx context.Context, creds connectors.Cre
 
 	messageID := p.MessageID
 	if messageID == "" && p.ThreadID != "" {
-		// For archive, we need to get the first message of the thread
-		messageID = p.ThreadID // Gmail thread ID == first message ID
+		// Fetch the thread to get the first message's ID.
+		// Thread IDs and message IDs are separate namespaces in Gmail.
+		var thread struct {
+			Messages []struct {
+				ID string `json:"id"`
+			} `json:"messages"`
+		}
+		threadURL := c.gmailBaseURL + "/gmail/v1/users/me/threads/" + url.PathEscape(p.ThreadID) + "?format=metadata&fields=" + url.QueryEscape("messages(id)")
+		if err := c.doJSON(ctx, creds, http.MethodGet, threadURL, nil, &thread); err != nil {
+			return nil, err
+		}
+		if len(thread.Messages) > 0 {
+			messageID = thread.Messages[0].ID
+		}
 	}
 	if messageID == "" {
 		return nil, fmt.Errorf("missing message_id or thread_id")
@@ -247,6 +259,9 @@ func (c *GoogleConnector) fetchEmailMetadata(ctx context.Context, creds connecto
 		case "From":
 			details["from"] = h.Value
 		}
+	}
+	if len(details) == 0 {
+		return nil, nil
 	}
 	return details, nil
 }

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -1,0 +1,252 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// ResolveResourceDetails fetches human-readable metadata for resources
+// referenced by opaque IDs in Google action parameters. Each action type
+// maps to a specific Google API GET call. Errors are non-fatal — the caller
+// stores the approval without details on failure.
+func (c *GoogleConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	// Calendar
+	case "google.delete_calendar_event", "google.update_calendar_event":
+		return c.resolveCalendarEvent(ctx, creds, params)
+
+	// Drive
+	case "google.delete_drive_file", "google.get_drive_file":
+		return c.resolveDriveFile(ctx, creds, params)
+
+	// Docs
+	case "google.get_document", "google.update_document":
+		return c.resolveDocument(ctx, creds, params)
+
+	// Sheets
+	case "google.sheets_read_range", "google.sheets_write_range",
+		"google.sheets_append_rows", "google.sheets_list_sheets":
+		return c.resolveSpreadsheet(ctx, creds, params)
+
+	// Slides
+	case "google.get_presentation", "google.add_slide":
+		return c.resolvePresentation(ctx, creds, params)
+
+	// Gmail
+	case "google.read_email", "google.archive_email":
+		return c.resolveEmail(ctx, creds, params)
+	case "google.send_email_reply":
+		return c.resolveEmailReply(ctx, creds, params)
+
+	default:
+		return nil, nil
+	}
+}
+
+// ── Calendar ────────────────────────────────────────────────────────────────
+
+func (c *GoogleConnector) resolveCalendarEvent(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		EventID    string `json:"event_id"`
+		CalendarID string `json:"calendar_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.EventID == "" {
+		return nil, fmt.Errorf("missing event_id")
+	}
+	if p.CalendarID == "" {
+		p.CalendarID = "primary"
+	}
+
+	var resp struct {
+		Summary string `json:"summary"`
+		Start   struct {
+			DateTime string `json:"dateTime"`
+			Date     string `json:"date"`
+		} `json:"start"`
+		End struct {
+			DateTime string `json:"dateTime"`
+			Date     string `json:"date"`
+		} `json:"end"`
+	}
+	getURL := c.calendarBaseURL + "/calendars/" + url.PathEscape(p.CalendarID) + "/events/" + url.PathEscape(p.EventID) + "?fields=summary,start,end"
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	details := map[string]any{"title": resp.Summary}
+	startTime := resp.Start.DateTime
+	if startTime == "" {
+		startTime = resp.Start.Date
+	}
+	endTime := resp.End.DateTime
+	if endTime == "" {
+		endTime = resp.End.Date
+	}
+	if startTime != "" {
+		details["start_time"] = startTime
+	}
+	if endTime != "" {
+		details["end_time"] = endTime
+	}
+	return details, nil
+}
+
+// ── Drive ───────────────────────────────────────────────────────────────────
+
+func (c *GoogleConnector) resolveDriveFile(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		FileID string `json:"file_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.FileID == "" {
+		return nil, fmt.Errorf("missing file_id")
+	}
+
+	var resp struct {
+		Name     string `json:"name"`
+		MimeType string `json:"mimeType"`
+	}
+	getURL := c.driveBaseURL + "/drive/v3/files/" + url.PathEscape(p.FileID) + "?fields=" + url.QueryEscape("name,mimeType")
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"file_name": resp.Name,
+		"mime_type": resp.MimeType,
+	}, nil
+}
+
+// ── Docs ────────────────────────────────────────────────────────────────────
+
+func (c *GoogleConnector) resolveDocument(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		DocumentID string `json:"document_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.DocumentID == "" {
+		return nil, fmt.Errorf("missing document_id")
+	}
+
+	var resp struct {
+		Title string `json:"title"`
+	}
+	getURL := c.docsBaseURL + "/v1/documents/" + url.PathEscape(p.DocumentID) + "?fields=title"
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{"title": resp.Title}, nil
+}
+
+// ── Sheets ──────────────────────────────────────────────────────────────────
+
+func (c *GoogleConnector) resolveSpreadsheet(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		SpreadsheetID string `json:"spreadsheet_id"`
+		Range         string `json:"range"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.SpreadsheetID == "" {
+		return nil, fmt.Errorf("missing spreadsheet_id")
+	}
+
+	var resp struct {
+		Properties struct {
+			Title string `json:"title"`
+		} `json:"properties"`
+	}
+	getURL := c.sheetsBaseURL + "/spreadsheets/" + url.PathEscape(p.SpreadsheetID) + "?fields=" + url.QueryEscape("properties.title")
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	details := map[string]any{"title": resp.Properties.Title}
+	if p.Range != "" {
+		details["range"] = p.Range
+	}
+	return details, nil
+}
+
+// ── Slides ──────────────────────────────────────────────────────────────────
+
+func (c *GoogleConnector) resolvePresentation(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		PresentationID string `json:"presentation_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.PresentationID == "" {
+		return nil, fmt.Errorf("missing presentation_id")
+	}
+
+	var resp struct {
+		Title string `json:"title"`
+	}
+	getURL := c.slidesBaseURL + "/v1/presentations/" + url.PathEscape(p.PresentationID) + "?fields=title"
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{"title": resp.Title}, nil
+}
+
+// ── Gmail ───────────────────────────────────────────────────────────────────
+
+func (c *GoogleConnector) resolveEmail(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	// read_email uses message_id; archive_email uses thread_id and fetches first message
+	var p struct {
+		MessageID string `json:"message_id"`
+		ThreadID  string `json:"thread_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+
+	messageID := p.MessageID
+	if messageID == "" && p.ThreadID != "" {
+		// For archive, we need to get the first message of the thread
+		messageID = p.ThreadID // Gmail thread ID == first message ID
+	}
+	if messageID == "" {
+		return nil, fmt.Errorf("missing message_id or thread_id")
+	}
+
+	return c.fetchEmailMetadata(ctx, creds, messageID)
+}
+
+func (c *GoogleConnector) resolveEmailReply(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		MessageID string `json:"message_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.MessageID == "" {
+		return nil, fmt.Errorf("missing message_id")
+	}
+	return c.fetchEmailMetadata(ctx, creds, p.MessageID)
+}
+
+func (c *GoogleConnector) fetchEmailMetadata(ctx context.Context, creds connectors.Credentials, messageID string) (map[string]any, error) {
+	var resp struct {
+		Payload struct {
+			Headers []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"headers"`
+		} `json:"payload"`
+	}
+	getURL := c.gmailBaseURL + "/gmail/v1/users/me/messages/" + url.PathEscape(messageID) + "?format=metadata&metadataHeaders=Subject&metadataHeaders=From"
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	details := map[string]any{}
+	for _, h := range resp.Payload.Headers {
+		switch h.Name {
+		case "Subject":
+			details["subject"] = h.Value
+		case "From":
+			details["from"] = h.Value
+		}
+	}
+	return details, nil
+}

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -221,7 +221,11 @@ func (c *GoogleConnector) resolveEmail(ctx context.Context, creds connectors.Cre
 		}
 	}
 	if messageID == "" {
+		if p.ThreadID != "" {
+			return nil, fmt.Errorf("thread %q has no messages", p.ThreadID)
+		}
 		return nil, fmt.Errorf("missing message_id or thread_id")
+	}
 	}
 
 	return c.fetchEmailMetadata(ctx, creds, messageID)

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -212,7 +212,7 @@ func (c *GoogleConnector) resolveEmail(ctx context.Context, creds connectors.Cre
 				ID string `json:"id"`
 			} `json:"messages"`
 		}
-		threadURL := c.gmailBaseURL + "/gmail/v1/users/me/threads/" + url.PathEscape(p.ThreadID) + "?format=metadata&fields=" + url.QueryEscape("messages(id)")
+		threadURL := c.gmailBaseURL + "/gmail/v1/users/me/threads/" + url.PathEscape(p.ThreadID) + "?fields=" + url.QueryEscape("messages(id)")
 		if err := c.doJSON(ctx, creds, http.MethodGet, threadURL, nil, &thread); err != nil {
 			return nil, err
 		}

--- a/connectors/google/resolve_resource_details_test.go
+++ b/connectors/google/resolve_resource_details_test.go
@@ -1,0 +1,270 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// testResolveServer creates an httptest.Server that routes requests by path prefix
+// and returns the corresponding JSON body. Returns the server and a GoogleConnector
+// pointed at it.
+func testResolveServer(t *testing.T, routes map[string]string) (*httptest.Server, *GoogleConnector) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for prefix, body := range routes {
+			if len(r.URL.Path) >= len(prefix) && r.URL.Path[:len(prefix)] == prefix {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(body))
+				return
+			}
+		}
+		t.Errorf("unexpected request path: %s", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	conn := &GoogleConnector{
+		client:          srv.Client(),
+		gmailBaseURL:    srv.URL,
+		calendarBaseURL: srv.URL,
+		slidesBaseURL:   srv.URL,
+		sheetsBaseURL:   srv.URL,
+		docsBaseURL:     srv.URL,
+		driveBaseURL:    srv.URL,
+	}
+	return srv, conn
+}
+
+func TestResolveResourceDetails_CalendarEvent(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/calendars/": `{"summary":"Q1 Planning","start":{"dateTime":"2026-03-15T14:00:00Z"},"end":{"dateTime":"2026-03-15T15:00:00Z"}}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"event_id": "evt123", "calendar_id": "primary"})
+
+	for _, actionType := range []string{"google.delete_calendar_event", "google.update_calendar_event"} {
+		details, err := conn.ResolveResourceDetails(context.Background(), actionType, params, validCreds())
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", actionType, err)
+		}
+		if details["title"] != "Q1 Planning" {
+			t.Errorf("%s: expected title 'Q1 Planning', got %v", actionType, details["title"])
+		}
+		if details["start_time"] != "2026-03-15T14:00:00Z" {
+			t.Errorf("%s: expected start_time, got %v", actionType, details["start_time"])
+		}
+		if details["end_time"] != "2026-03-15T15:00:00Z" {
+			t.Errorf("%s: expected end_time, got %v", actionType, details["end_time"])
+		}
+	}
+}
+
+func TestResolveResourceDetails_CalendarEvent_AllDayEvent(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/calendars/": `{"summary":"Company Holiday","start":{"date":"2026-12-25"},"end":{"date":"2026-12-26"}}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"event_id": "evt_allday"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.delete_calendar_event", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["start_time"] != "2026-12-25" {
+		t.Errorf("expected date-only start_time, got %v", details["start_time"])
+	}
+}
+
+func TestResolveResourceDetails_DriveFile(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/drive/v3/files/": `{"name":"Budget 2026.xlsx","mimeType":"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"file_id": "f123"})
+
+	for _, actionType := range []string{"google.delete_drive_file", "google.get_drive_file"} {
+		details, err := conn.ResolveResourceDetails(context.Background(), actionType, params, validCreds())
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", actionType, err)
+		}
+		if details["file_name"] != "Budget 2026.xlsx" {
+			t.Errorf("%s: expected file_name, got %v", actionType, details["file_name"])
+		}
+		if details["mime_type"] == nil {
+			t.Errorf("%s: expected mime_type", actionType)
+		}
+	}
+}
+
+func TestResolveResourceDetails_Document(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/v1/documents/": `{"title":"Project Spec"}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"document_id": "doc123"})
+
+	for _, actionType := range []string{"google.get_document", "google.update_document"} {
+		details, err := conn.ResolveResourceDetails(context.Background(), actionType, params, validCreds())
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", actionType, err)
+		}
+		if details["title"] != "Project Spec" {
+			t.Errorf("%s: expected title 'Project Spec', got %v", actionType, details["title"])
+		}
+	}
+}
+
+func TestResolveResourceDetails_Spreadsheet(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/spreadsheets/": `{"properties":{"title":"Budget Tracker"}}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"spreadsheet_id": "s123", "range": "Sheet1!A1:B5"})
+
+	for _, actionType := range []string{"google.sheets_read_range", "google.sheets_write_range", "google.sheets_append_rows", "google.sheets_list_sheets"} {
+		details, err := conn.ResolveResourceDetails(context.Background(), actionType, params, validCreds())
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", actionType, err)
+		}
+		if details["title"] != "Budget Tracker" {
+			t.Errorf("%s: expected title 'Budget Tracker', got %v", actionType, details["title"])
+		}
+		// sheets_list_sheets doesn't have a range param
+		if actionType != "google.sheets_list_sheets" {
+			if details["range"] != "Sheet1!A1:B5" {
+				t.Errorf("%s: expected range, got %v", actionType, details["range"])
+			}
+		}
+	}
+}
+
+func TestResolveResourceDetails_Presentation(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/v1/presentations/": `{"title":"Q1 Review Deck"}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"presentation_id": "p123"})
+
+	for _, actionType := range []string{"google.get_presentation", "google.add_slide"} {
+		details, err := conn.ResolveResourceDetails(context.Background(), actionType, params, validCreds())
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", actionType, err)
+		}
+		if details["title"] != "Q1 Review Deck" {
+			t.Errorf("%s: expected title 'Q1 Review Deck', got %v", actionType, details["title"])
+		}
+	}
+}
+
+func TestResolveResourceDetails_Email(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/gmail/v1/users/me/messages/": `{"payload":{"headers":[{"name":"Subject","value":"Weekly Update"},{"name":"From","value":"alice@example.com"}]}}`,
+	})
+	defer srv.Close()
+
+	// read_email uses message_id
+	params, _ := json.Marshal(map[string]string{"message_id": "msg123"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.read_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("read_email: unexpected error: %v", err)
+	}
+	if details["subject"] != "Weekly Update" {
+		t.Errorf("read_email: expected subject 'Weekly Update', got %v", details["subject"])
+	}
+	if details["from"] != "alice@example.com" {
+		t.Errorf("read_email: expected from 'alice@example.com', got %v", details["from"])
+	}
+
+	// archive_email uses thread_id
+	params, _ = json.Marshal(map[string]string{"thread_id": "thread123"})
+	details, err = conn.ResolveResourceDetails(context.Background(), "google.archive_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("archive_email: unexpected error: %v", err)
+	}
+	if details["subject"] != "Weekly Update" {
+		t.Errorf("archive_email: expected subject, got %v", details["subject"])
+	}
+}
+
+func TestResolveResourceDetails_EmailReply(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/gmail/v1/users/me/messages/": `{"payload":{"headers":[{"name":"Subject","value":"Re: Budget Discussion"}]}}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"message_id": "msg456"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.send_email_reply", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["subject"] != "Re: Budget Discussion" {
+		t.Errorf("expected subject, got %v", details["subject"])
+	}
+}
+
+func TestResolveResourceDetails_UnknownAction(t *testing.T) {
+	conn := New()
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.unknown_action", []byte(`{}`), validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != nil {
+		t.Errorf("expected nil details for unknown action, got %v", details)
+	}
+}
+
+func TestResolveResourceDetails_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":{"message":"Not Found","code":404}}`))
+	}))
+	defer srv.Close()
+
+	conn := newCalendarForTest(srv.Client(), srv.URL)
+	params, _ := json.Marshal(map[string]string{"event_id": "deleted_event"})
+	_, err := conn.ResolveResourceDetails(context.Background(), "google.delete_calendar_event", params, validCreds())
+	if err == nil {
+		t.Fatal("expected error for 404 API response")
+	}
+}
+
+func TestResolveResourceDetails_MissingParams(t *testing.T) {
+	conn := New()
+
+	// Missing event_id
+	params, _ := json.Marshal(map[string]string{})
+	_, err := conn.ResolveResourceDetails(context.Background(), "google.delete_calendar_event", params, validCreds())
+	if err == nil {
+		t.Error("expected error for missing event_id")
+	}
+
+	// Missing file_id
+	_, err = conn.ResolveResourceDetails(context.Background(), "google.delete_drive_file", params, validCreds())
+	if err == nil {
+		t.Error("expected error for missing file_id")
+	}
+
+	// Missing document_id
+	_, err = conn.ResolveResourceDetails(context.Background(), "google.get_document", params, validCreds())
+	if err == nil {
+		t.Error("expected error for missing document_id")
+	}
+
+	// Missing spreadsheet_id
+	_, err = conn.ResolveResourceDetails(context.Background(), "google.sheets_read_range", params, validCreds())
+	if err == nil {
+		t.Error("expected error for missing spreadsheet_id")
+	}
+
+	// Missing presentation_id
+	_, err = conn.ResolveResourceDetails(context.Background(), "google.get_presentation", params, validCreds())
+	if err == nil {
+		t.Error("expected error for missing presentation_id")
+	}
+}

--- a/connectors/google/resolve_resource_details_test.go
+++ b/connectors/google/resolve_resource_details_test.go
@@ -165,6 +165,7 @@ func TestResolveResourceDetails_Presentation(t *testing.T) {
 func TestResolveResourceDetails_Email(t *testing.T) {
 	srv, conn := testResolveServer(t, map[string]string{
 		"/gmail/v1/users/me/messages/": `{"payload":{"headers":[{"name":"Subject","value":"Weekly Update"},{"name":"From","value":"alice@example.com"}]}}`,
+		"/gmail/v1/users/me/threads/":  `{"messages":[{"id":"msg_from_thread"}]}`,
 	})
 	defer srv.Close()
 
@@ -181,7 +182,7 @@ func TestResolveResourceDetails_Email(t *testing.T) {
 		t.Errorf("read_email: expected from 'alice@example.com', got %v", details["from"])
 	}
 
-	// archive_email uses thread_id
+	// archive_email uses thread_id — fetches thread first, then message
 	params, _ = json.Marshal(map[string]string{"thread_id": "thread123"})
 	details, err = conn.ResolveResourceDetails(context.Background(), "google.archive_email", params, validCreds())
 	if err != nil {

--- a/db/agent_approvals.go
+++ b/db/agent_approvals.go
@@ -14,12 +14,13 @@ const DefaultApprovalTTL = 10 * time.Minute
 
 // InsertApprovalParams holds the parameters for creating a new approval.
 type InsertApprovalParams struct {
-	ApprovalID string
-	AgentID    int64
-	ApproverID string
-	Action     []byte // raw JSONB
-	Context    []byte // raw JSONB
-	ExpiresAt  time.Time
+	ApprovalID      string
+	AgentID         int64
+	ApproverID      string
+	Action          []byte // raw JSONB
+	Context         []byte // raw JSONB
+	ResourceDetails []byte // raw JSONB — human-readable resource metadata (optional)
+	ExpiresAt       time.Time
 }
 
 // InsertApproval creates a new pending approval row. It also inserts the
@@ -50,10 +51,10 @@ func InsertApproval(ctx context.Context, d DBTX, p InsertApprovalParams, request
 	}
 
 	row := tx.QueryRow(ctx,
-		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, status, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, 'pending', $6)
+		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, resource_details, status, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7)
 		 RETURNING `+approvalColumns,
-		p.ApprovalID, p.AgentID, p.ApproverID, p.Action, p.Context, p.ExpiresAt,
+		p.ApprovalID, p.AgentID, p.ApproverID, p.Action, p.Context, p.ResourceDetails, p.ExpiresAt,
 	)
 	appr, err := scanApproval(row)
 	if err != nil {

--- a/db/approvals.go
+++ b/db/approvals.go
@@ -19,9 +19,10 @@ type Approval struct {
 	Context         []byte // raw JSONB
 	Status          string
 	ExecutionStatus *string
-	ExecutionResult []byte // raw JSONB
-	ExecutedAt      *time.Time
-	ExpiresAt       time.Time
+	ExecutionResult  []byte // raw JSONB
+	ExecutedAt       *time.Time
+	ResourceDetails  []byte // raw JSONB — human-readable resource metadata
+	ExpiresAt        time.Time
 	ApprovedAt      *time.Time
 	DeniedAt        *time.Time
 	CancelledAt     *time.Time
@@ -31,7 +32,7 @@ type Approval struct {
 // approvalColumns is the canonical column list for SELECT on the approvals table.
 // Keep in sync with scanApproval.
 const approvalColumns = `approval_id, agent_id, approver_id, action, context,
-	status, execution_status, execution_result, executed_at,
+	status, execution_status, execution_result, executed_at, resource_details,
 	expires_at, approved_at, denied_at, cancelled_at, created_at`
 
 // ApprovalCursor identifies the position of the last item on a page,
@@ -53,7 +54,7 @@ func scanApproval(row pgx.Row) (*Approval, error) {
 	var a Approval
 	err := row.Scan(
 		&a.ApprovalID, &a.AgentID, &a.ApproverID, &a.Action, &a.Context,
-		&a.Status, &a.ExecutionStatus, &a.ExecutionResult, &a.ExecutedAt,
+		&a.Status, &a.ExecutionStatus, &a.ExecutionResult, &a.ExecutedAt, &a.ResourceDetails,
 		&a.ExpiresAt, &a.ApprovedAt, &a.DeniedAt, &a.CancelledAt, &a.CreatedAt,
 	)
 	if err != nil {
@@ -68,7 +69,7 @@ func scanApprovalWithMeta(row pgx.Row) (*Approval, []byte, error) {
 	var agentMeta []byte
 	err := row.Scan(
 		&a.ApprovalID, &a.AgentID, &a.ApproverID, &a.Action, &a.Context,
-		&a.Status, &a.ExecutionStatus, &a.ExecutionResult, &a.ExecutedAt,
+		&a.Status, &a.ExecutionStatus, &a.ExecutionResult, &a.ExecutedAt, &a.ResourceDetails,
 		&a.ExpiresAt, &a.ApprovedAt, &a.DeniedAt, &a.CancelledAt, &a.CreatedAt,
 		&agentMeta,
 	)

--- a/db/migrations/20260315153426_add_approval_resource_details.sql
+++ b/db/migrations/20260315153426_add_approval_resource_details.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE approvals ADD COLUMN resource_details JSONB;
+
+-- +goose Down
+ALTER TABLE approvals DROP COLUMN IF EXISTS resource_details;

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -463,9 +463,12 @@ function formatDateTime(iso: string): string {
   try {
     const date = new Date(iso);
     if (isNaN(date.getTime())) return iso;
+    const now = new Date();
+    const sameYear = date.getFullYear() === now.getFullYear();
     return date.toLocaleString(undefined, {
       month: "short",
       day: "numeric",
+      year: sameYear ? undefined : "numeric",
       hour: "numeric",
       minute: "2-digit",
     });

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -461,6 +461,22 @@ function strVal(v: unknown): string | null {
 /** Formats an ISO datetime string for display in summaries. */
 function formatDateTime(iso: string): string {
   try {
+    // Date-only strings (all-day events) use "YYYY-MM-DD". Parsing them with
+    // `new Date()` treats them as UTC midnight, which shifts the displayed date
+    // by one day in UTC-negative timezones. Format them without a time component
+    // by splitting the string directly to avoid any timezone conversion.
+    const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(iso);
+    if (isDateOnly) {
+      const [year, month, day] = iso.split("-").map(Number);
+      const date = new Date(year!, month! - 1, day!);
+      const now = new Date();
+      const sameYear = date.getFullYear() === now.getFullYear();
+      return date.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: sameYear ? undefined : "numeric",
+      });
+    }
     const date = new Date(iso);
     if (isNaN(date.getTime())) return iso;
     const now = new Date();

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -45,6 +45,8 @@ interface ActionPreviewSummaryProps {
   actionName: string | null;
   /** Display template from the connector manifest, e.g. "Send email to {{to}}". */
   displayTemplate?: string | null;
+  /** Resource details resolved at approval creation time. */
+  resourceDetails?: Record<string, unknown> | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,8 +109,9 @@ export function ActionPreviewSummary({
   schema,
   actionName,
   displayTemplate,
+  resourceDetails,
 }: ActionPreviewSummaryProps) {
-  const parts = buildParts(actionType, parameters, schema, actionName, displayTemplate);
+  const parts = buildParts(actionType, parameters, schema, actionName, displayTemplate, resourceDetails);
 
   return (
     <p className="text-sm leading-relaxed" data-testid="action-preview-summary">
@@ -127,8 +130,9 @@ export function buildSummary(
   schema: ParametersSchema | null,
   actionName: string | null,
   displayTemplate?: string | null,
+  resourceDetails?: Record<string, unknown> | null,
 ): string {
-  return renderPlain(buildParts(actionType, parameters, schema, actionName, displayTemplate));
+  return renderPlain(buildParts(actionType, parameters, schema, actionName, displayTemplate, resourceDetails));
 }
 
 /**
@@ -141,6 +145,7 @@ function buildParts(
   schema: ParametersSchema | null,
   actionName: string | null,
   displayTemplate?: string | null,
+  resourceDetails?: Record<string, unknown> | null,
 ): SummaryPart[] {
   // 1. Try display template from manifest.
   if (displayTemplate) {
@@ -148,10 +153,10 @@ function buildParts(
     if (templateParts) return templateParts;
   }
 
-  // 2. Try action-specific describer.
+  // 2. Try action-specific describer (with resource details).
   const formatter = ACTION_DESCRIBERS[actionType];
   if (formatter) {
-    const result = formatter(parameters);
+    const result = formatter(parameters, resourceDetails ?? undefined);
     if (result) return result;
   }
 
@@ -167,7 +172,7 @@ function buildParts(
  * Returns structured summary parts for a specific action type,
  * or null to fall through to the generic schema-based summary.
  */
-type ActionDescriber = (params: Record<string, unknown>) => SummaryPart[] | null;
+type ActionDescriber = (params: Record<string, unknown>, resourceDetails?: Record<string, unknown>) => SummaryPart[] | null;
 
 /** Registry of action-type-specific formatters. Keyed by action_type string. */
 const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
@@ -231,6 +236,129 @@ const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
     const desc = strVal(params.description);
     const parts: SummaryPart[] = [text("Charge "), val(formatted)];
     if (desc) parts.push(text(" for "), val(desc));
+    return parts;
+  },
+
+  // ── Google Calendar ─────────────────────────────────────────────
+
+  "google.delete_calendar_event": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    const parts: SummaryPart[] = [text("Delete event "), val(title)];
+    const startTime = strVal(rd?.start_time);
+    if (startTime) parts.push(text(" on "), val(formatDateTime(startTime)));
+    return parts;
+  },
+
+  "google.update_calendar_event": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    const parts: SummaryPart[] = [text("Update event "), val(title)];
+    const startTime = strVal(rd?.start_time);
+    if (startTime) parts.push(text(" on "), val(formatDateTime(startTime)));
+    return parts;
+  },
+
+  // ── Google Drive ────────────────────────────────────────────────
+
+  "google.delete_drive_file": (_params, rd) => {
+    const name = strVal(rd?.file_name);
+    if (!name) return null;
+    return [text("Delete file "), val(name)];
+  },
+
+  "google.get_drive_file": (_params, rd) => {
+    const name = strVal(rd?.file_name);
+    if (!name) return null;
+    return [text("Get file "), val(name)];
+  },
+
+  // ── Google Docs ─────────────────────────────────────────────────
+
+  "google.get_document": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    return [text("Get document "), val(title)];
+  },
+
+  "google.update_document": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    return [text("Update document "), val(title)];
+  },
+
+  // ── Google Sheets ───────────────────────────────────────────────
+
+  "google.sheets_read_range": (params, rd) => {
+    const title = strVal(rd?.title);
+    const range = strVal(rd?.range) ?? strVal(params.range);
+    if (!title) return null;
+    const parts: SummaryPart[] = [text("Read "), val(title)];
+    if (range) parts.push(text(" range "), val(range));
+    return parts;
+  },
+
+  "google.sheets_write_range": (params, rd) => {
+    const title = strVal(rd?.title);
+    const range = strVal(rd?.range) ?? strVal(params.range);
+    if (!title) return null;
+    const parts: SummaryPart[] = [text("Write to "), val(title)];
+    if (range) parts.push(text(" range "), val(range));
+    return parts;
+  },
+
+  "google.sheets_append_rows": (params, rd) => {
+    const title = strVal(rd?.title);
+    const range = strVal(rd?.range) ?? strVal(params.range);
+    if (!title) return null;
+    const parts: SummaryPart[] = [text("Append rows to "), val(title)];
+    if (range) parts.push(text(" range "), val(range));
+    return parts;
+  },
+
+  "google.sheets_list_sheets": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    return [text("List sheets in "), val(title)];
+  },
+
+  // ── Google Slides ───────────────────────────────────────────────
+
+  "google.get_presentation": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    return [text("Get presentation "), val(title)];
+  },
+
+  "google.add_slide": (_params, rd) => {
+    const title = strVal(rd?.title);
+    if (!title) return null;
+    return [text("Add slide to "), val(title)];
+  },
+
+  // ── Gmail ───────────────────────────────────────────────────────
+
+  "google.read_email": (_params, rd) => {
+    const subject = strVal(rd?.subject);
+    if (!subject) return null;
+    const parts: SummaryPart[] = [text("Read email "), val(subject)];
+    const from = strVal(rd?.from);
+    if (from) parts.push(text(" from "), val(from));
+    return parts;
+  },
+
+  "google.send_email_reply": (_params, rd) => {
+    const subject = strVal(rd?.subject);
+    if (!subject) return null;
+    return [text("Reply to "), val(subject)];
+  },
+
+  "google.archive_email": (_params, rd) => {
+    const subject = strVal(rd?.subject);
+    if (!subject) return null;
+    const parts: SummaryPart[] = [text("Archive email "), val(subject)];
+    const from = strVal(rd?.from);
+    if (from) parts.push(text(" from "), val(from));
     return parts;
   },
 };
@@ -328,6 +456,22 @@ function pickHighlights(
 function strVal(v: unknown): string | null {
   if (typeof v === "string" && v.length > 0) return v;
   return null;
+}
+
+/** Formats an ISO datetime string for display in summaries. */
+function formatDateTime(iso: string): string {
+  try {
+    const date = new Date(iso);
+    if (isNaN(date.getTime())) return iso;
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
 }
 
 function formatRecipients(v: unknown): string | null {

--- a/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
+++ b/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
@@ -222,6 +222,164 @@ describe("buildSummary", () => {
     });
   });
 
+  // ── Google Calendar ─────────────────────────────────────────────
+
+  describe("google.delete_calendar_event", () => {
+    it("shows event title and time from resource details", () => {
+      const result = buildSummary(
+        "google.delete_calendar_event",
+        { event_id: "evt123" },
+        null,
+        null,
+        undefined,
+        { title: "Q1 Planning", start_time: "2026-03-15T14:00:00Z" },
+      );
+      expect(result).toContain("Delete event");
+      expect(result).toContain("Q1 Planning");
+    });
+
+    it("falls back to generic when no resource details", () => {
+      const result = buildSummary(
+        "google.delete_calendar_event",
+        { event_id: "evt123" },
+        null,
+        "Delete Calendar Event",
+      );
+      expect(result).toContain("Delete Calendar Event");
+    });
+  });
+
+  describe("google.update_calendar_event", () => {
+    it("shows event title from resource details", () => {
+      const result = buildSummary(
+        "google.update_calendar_event",
+        { event_id: "evt123", summary: "New Title" },
+        null,
+        null,
+        undefined,
+        { title: "Old Title", start_time: "2026-03-15T14:00:00Z" },
+      );
+      expect(result).toContain("Update event");
+      expect(result).toContain("Old Title");
+    });
+  });
+
+  // ── Google Drive ────────────────────────────────────────────────
+
+  describe("google.delete_drive_file", () => {
+    it("shows file name from resource details", () => {
+      const result = buildSummary(
+        "google.delete_drive_file",
+        { file_id: "f123" },
+        null,
+        null,
+        undefined,
+        { file_name: "Budget 2026.xlsx" },
+      );
+      expect(result).toBe(`Delete file ${q("Budget 2026.xlsx")}`);
+    });
+  });
+
+  // ── Google Docs ─────────────────────────────────────────────────
+
+  describe("google.get_document", () => {
+    it("shows document title from resource details", () => {
+      const result = buildSummary(
+        "google.get_document",
+        { document_id: "doc123" },
+        null,
+        null,
+        undefined,
+        { title: "Project Spec" },
+      );
+      expect(result).toBe(`Get document ${q("Project Spec")}`);
+    });
+  });
+
+  // ── Google Sheets ───────────────────────────────────────────────
+
+  describe("google.sheets_read_range", () => {
+    it("shows spreadsheet name and range", () => {
+      const result = buildSummary(
+        "google.sheets_read_range",
+        { spreadsheet_id: "s123", range: "Sheet1!A1:B5" },
+        null,
+        null,
+        undefined,
+        { title: "Budget Tracker", range: "Sheet1!A1:B5" },
+      );
+      expect(result).toContain("Read");
+      expect(result).toContain("Budget Tracker");
+      expect(result).toContain("Sheet1!A1:B5");
+    });
+  });
+
+  // ── Google Slides ───────────────────────────────────────────────
+
+  describe("google.get_presentation", () => {
+    it("shows presentation title", () => {
+      const result = buildSummary(
+        "google.get_presentation",
+        { presentation_id: "p123" },
+        null,
+        null,
+        undefined,
+        { title: "Q1 Review Deck" },
+      );
+      expect(result).toBe(`Get presentation ${q("Q1 Review Deck")}`);
+    });
+  });
+
+  // ── Gmail ───────────────────────────────────────────────────────
+
+  describe("google.read_email", () => {
+    it("shows subject and sender", () => {
+      const result = buildSummary(
+        "google.read_email",
+        { message_id: "msg123" },
+        null,
+        null,
+        undefined,
+        { subject: "Weekly Update", from: "alice@example.com" },
+      );
+      expect(result).toContain("Read email");
+      expect(result).toContain("Weekly Update");
+      expect(result).toContain("alice@example.com");
+    });
+  });
+
+  describe("google.archive_email", () => {
+    it("shows subject and sender", () => {
+      const result = buildSummary(
+        "google.archive_email",
+        { thread_id: "t123" },
+        null,
+        null,
+        undefined,
+        { subject: "Old Thread", from: "bob@example.com" },
+      );
+      expect(result).toContain("Archive email");
+      expect(result).toContain("Old Thread");
+      expect(result).toContain("bob@example.com");
+    });
+  });
+
+  describe("google.send_email_reply", () => {
+    it("shows original subject", () => {
+      const result = buildSummary(
+        "google.send_email_reply",
+        { message_id: "msg456" },
+        null,
+        null,
+        undefined,
+        { subject: "Re: Budget Discussion" },
+      );
+      expect(result).toBe(`Reply to ${q("Re: Budget Discussion")}`);
+    });
+  });
+
+  // ── Existing describers still work ──────────────────────────────
+
   describe("generic / unknown action types", () => {
     it("uses actionName when available", () => {
       const schema: ParametersSchema = {

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -124,6 +124,7 @@ function ApprovalDetails({ approvalId }: { approvalId: string }) {
   const description = typeof context?.description === "string" ? context.description : null;
   const executionResult = approval.execution_result as Record<string, unknown> | undefined;
   const executionError = typeof executionResult?.error === "string" ? executionResult.error : undefined;
+  const resourceDetails = approval.resource_details as Record<string, unknown> | undefined;
 
   return (
     <ApprovalContent
@@ -135,6 +136,7 @@ function ApprovalDetails({ approvalId }: { approvalId: string }) {
       executionError={executionError}
       executionResult={executionResult}
       executedAt={approval.executed_at ?? undefined}
+      resourceDetails={resourceDetails}
     />
   );
 }
@@ -148,6 +150,7 @@ function ApprovalContent({
   executionError,
   executionResult,
   executedAt,
+  resourceDetails,
 }: {
   actionType: string;
   parameters: Record<string, unknown>;
@@ -157,6 +160,7 @@ function ApprovalContent({
   executionError?: string;
   executionResult?: Record<string, unknown>;
   executedAt?: string;
+  resourceDetails?: Record<string, unknown>;
 }) {
   const { schema, actionName, displayTemplate } = useActionSchema(actionType);
 
@@ -191,6 +195,7 @@ function ApprovalContent({
                   schema={schema}
                   actionName={actionName}
                   displayTemplate={displayTemplate}
+                  resourceDetails={resourceDetails}
                 />
               </div>
             )}

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -30,6 +30,8 @@ function ApprovalBannerItem({
     approval.action.parameters as Record<string, unknown>,
     null,
     null,
+    undefined,
+    approval.resource_details as Record<string, unknown> | undefined,
   );
 
   return (

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -281,6 +281,7 @@ export function ReviewApprovalDialog({
                   schema={schema}
                   actionName={actionName}
                   displayTemplate={displayTemplate}
+                  resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
                 />
               </div>
             </div>

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -257,6 +257,19 @@ ApprovalSummary:
       format: date-time
       description: When the approval request was created
       example: "2026-02-11T13:20:00Z"
+    resource_details:
+      type: object
+      nullable: true
+      description: |
+        Human-readable metadata for resources referenced by opaque IDs in the
+        action parameters. Populated at request time via the connector's
+        ResourceDetailResolver. Null when the connector doesn't support
+        resource resolution or the lookup failed.
+      additionalProperties: true
+      example:
+        title: "Q1 Planning Meeting"
+        start_time: "2026-03-15T14:00:00Z"
+        end_time: "2026-03-15T15:00:00Z"
     execution_status:
       allOf:
         - $ref: './shared.yaml#/ExecutionStatus'

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -6957,6 +6957,19 @@ components:
           format: date-time
           description: When the approval request was created
           example: '2026-02-11T13:20:00Z'
+        resource_details:
+          type: object
+          nullable: true
+          description: |
+            Human-readable metadata for resources referenced by opaque IDs in the
+            action parameters. Populated at request time via the connector's
+            ResourceDetailResolver. Null when the connector doesn't support
+            resource resolution or the lookup failed.
+          additionalProperties: true
+          example:
+            title: Q1 Planning Meeting
+            start_time: '2026-03-15T14:00:00Z'
+            end_time: '2026-03-15T15:00:00Z'
         execution_status:
           allOf:
             - $ref: '#/components/schemas/ExecutionStatus'


### PR DESCRIPTION
## Summary

- Add `ResourceDetailResolver` optional connector interface and `resource_details` JSONB column on approvals table
- Implement Google connector resolver for 15 action types (Calendar, Drive, Docs, Sheets, Slides, Gmail) — makes lightweight API calls at approval-request time to fetch human-readable metadata
- Add Google-specific `ACTION_DESCRIBERS` entries and thread `resource_details` through `ReviewApprovalDialog`, `PendingApprovalsBanner`, and `ActivityDetailSheet`
- Add comprehensive Go tests (11 test cases) and frontend tests for all new describers

Closes #605

## Test plan

### Claude Code
- [x] Go tests pass (`go test ./connectors/google/ -v -run TestResolve` — 11 tests)
- [x] Frontend tests pass (`make test-frontend` — 905 tests, 99 files)
- [x] Go build compiles (`go build ./connectors/google/ ./api/ ./db/`)
- [x] Frontend build succeeds (`make build-frontend`)

### OpenClaw
- [ ] Verify resource details appear in ReviewApprovalDialog for Google actions (Calendar, Drive, Docs, Sheets, Slides, Gmail)
- [ ] Verify PendingApprovalsBanner shows enriched summaries
- [ ] Verify ActivityDetailSheet displays resource_details
- [ ] Test fallback behavior when resource details are unavailable (e.g., deleted resource, revoked credentials)

https://claude.ai/code