### PR TITLE
Add semantic badge variants (Phase 1B)

### DIFF
--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -26,7 +26,8 @@ const badgeVariants = cva(
         "success-soft":
           "border-success/20 bg-success/10 text-success [a&]:hover:bg-success/15",
         "warning-soft":
-          "border-warning/20 bg-warning/10 text-warning [a&]:hover:bg-warning/15",
+        "warning-soft":
+          "border-warning/20 bg-warning/10 text-warning/80 [a&]:hover:bg-warning/15",
         "info-soft":
           "border-info/20 bg-info/10 text-info [a&]:hover:bg-info/15",
         "destructive-soft":

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -18,11 +18,11 @@ const badgeVariants = cva(
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         success:
-          "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90",
+          "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90 dark:bg-success/60",
         warning:
-          "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90",
+          "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90 dark:bg-warning/60",
         info:
-          "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90",
+          "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90 dark:bg-info/60",
         "success-soft":
           "border-success/20 bg-success/10 text-success [a&]:hover:bg-success/15",
         "warning-soft":

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -18,11 +18,11 @@ const badgeVariants = cva(
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         success:
-          "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90 dark:bg-success/60",
+          "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/60",
         warning:
-          "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90 dark:bg-warning/60",
+          "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90 focus-visible:ring-warning/20 dark:focus-visible:ring-warning/40 dark:bg-warning/60",
         info:
-          "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90 dark:bg-info/60",
+          "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90 focus-visible:ring-info/20 dark:focus-visible:ring-info/40 dark:bg-info/60",
         "success-soft":
           "border-success/20 bg-success/10 text-success [a&]:hover:bg-success/15",
         "warning-soft":

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -17,6 +17,20 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        success:
+          "border-transparent bg-success text-success-foreground [a&]:hover:bg-success/90",
+        warning:
+          "border-transparent bg-warning text-warning-foreground [a&]:hover:bg-warning/90",
+        info:
+          "border-transparent bg-info text-info-foreground [a&]:hover:bg-info/90",
+        "success-soft":
+          "border-success/20 bg-success/10 text-success [a&]:hover:bg-success/15",
+        "warning-soft":
+          "border-warning/20 bg-warning/10 text-warning [a&]:hover:bg-warning/15",
+        "info-soft":
+          "border-info/20 bg-info/10 text-info [a&]:hover:bg-info/15",
+        "destructive-soft":
+          "border-destructive/20 bg-destructive/10 text-destructive [a&]:hover:bg-destructive/15",
       },
     },
     defaultVariants: {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

- Adds 7 new CVA badge variants to `badge.tsx`: `success`, `warning`, `info`, `success-soft`, `warning-soft`, `info-soft`, `destructive-soft`
- Solid variants use semantic color tokens from Phase 1A (green/amber/blue backgrounds)
- Soft variants use tinted backgrounds (`bg-*/10`) with low-opacity borders (`border-*/20`) and colored text — designed for risk badges and status indicators

Part of #610

## Test plan

### Claude Code
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 905 frontend tests pass (`make test-frontend`)

### Manual Testing
- [ ] Verify solid badge variants (success, warning, info) render correctly in light & dark mode
- [ ] Verify soft badge variants render with tinted backgrounds and colored text
- [ ] Confirm hover states work on all new variants

https://claude.ai/code/session_01M6WwPBQonYwXVWQb9V18yC