### PR TITLE
Set default model to Sonnet 4.6

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "model": "claude-sonnet-4-6"
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` to set the default model to `claude-sonnet-4-6` for all Claude Code sessions in this repo
- Reduces cost by defaulting to Sonnet instead of Opus for routine tasks

## Test plan
- [ ] Start a new Claude Code session on this repo and verify it defaults to Sonnet 4.6

https://claude.ai/code/session_01P8E22F7jdZewuonAjQunCJ