### PR TITLE
Revert: Set default model to Sonnet 4.6

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,0 @@
-{
-  "model": "claude-sonnet-4-6"
-}


### PR DESCRIPTION
## Summary
- Reverts PR #617 which set the default Claude Code model to Sonnet 4.6
- The model override didn't work as intended — sessions were still using Opus

## Test plan
### Claude Code
- [ ] Verify `.claude/settings.json` is removed after merge

### Manual Testing
- [ ] Start a new Claude Code session and confirm default model behavior is restored

https://claude.ai/code/session_01BQ5dNJM7f5wX9GdTuKi6bW