### PR TITLE
Use soft badge variants for risk level (Phase 2C)

### DIFF
--- a/frontend/src/pages/dashboard/approval-components.tsx
+++ b/frontend/src/pages/dashboard/approval-components.tsx
@@ -86,10 +86,10 @@ export function RiskBadge({ level }: { level?: "low" | "medium" | "high" | null 
 
   const variant =
     level === "high"
-      ? "destructive"
+      ? "destructive-soft"
       : level === "medium"
-        ? "outline"
-        : "secondary";
+        ? "warning-soft"
+        : "success-soft";
 
   return (
     <Badge variant={variant} className="rounded-full text-[10px] capitalize">


### PR DESCRIPTION
## Summary

- Updates `RiskBadge` in `approval-components.tsx` to use soft badge variants
- `high` → `destructive-soft`, `medium` → `warning-soft`, `low` → `success-soft`
- Softer visual weight for risk indicators — less alarming, more intentional

Part of #610

## Test plan

### Claude Code
- [x] `make test-frontend` passes (905 tests)
- [x] `cd frontend && npm run build` passes with no TypeScript errors

### Manual Testing
- [ ] Visual QA: confirm soft badge styles render correctly for high/medium/low risk in the approvals UI (light + dark mode)

https://claude.ai/code/session_01TCCpMjLBKNB1q1GDpWsa1C