### PR TITLE
feat(ui): semantic outcome colors for audit event badges (phase 2A)

### DIFF
--- a/frontend/src/lib/auditEvents.tsx
+++ b/frontend/src/lib/auditEvents.tsx
@@ -10,7 +10,8 @@ import {
   CreditCard,
   HelpCircle,
 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { Badge, badgeVariants } from "@/components/ui/badge";
+import type { VariantProps } from "class-variance-authority";
 import {
   TableRow,
   TableCell,
@@ -41,7 +42,7 @@ export const ACTION_EVENT_TYPES =
 
 interface OutcomeStyle {
   label: string;
-  variant: "default" | "secondary" | "destructive" | "outline" | "success" | "warning" | "info" | "success-soft" | "warning-soft" | "info-soft" | "destructive-soft";
+  variant: NonNullable<VariantProps<typeof badgeVariants>["variant"]>;
   Icon: typeof CheckCircle2;
 }
 

--- a/frontend/src/lib/auditEvents.tsx
+++ b/frontend/src/lib/auditEvents.tsx
@@ -41,20 +41,20 @@ export const ACTION_EVENT_TYPES =
 
 interface OutcomeStyle {
   label: string;
-  variant: "default" | "secondary" | "destructive" | "outline";
+  variant: "default" | "secondary" | "destructive" | "outline" | "success" | "warning" | "info" | "success-soft" | "warning-soft" | "info-soft" | "destructive-soft";
   Icon: typeof CheckCircle2;
 }
 
 export const OUTCOME_CONFIG: Record<string, OutcomeStyle> = {
-  approved: { label: "Approved", variant: "default", Icon: CheckCircle2 },
+  approved: { label: "Approved", variant: "success", Icon: CheckCircle2 },
   denied: { label: "Denied", variant: "destructive", Icon: XCircle },
   cancelled: { label: "Cancelled", variant: "outline", Icon: Ban },
-  auto_executed: { label: "Auto-executed", variant: "secondary", Icon: Zap },
-  registered: { label: "Registered", variant: "default", Icon: Bot },
+  auto_executed: { label: "Auto-executed", variant: "info", Icon: Zap },
+  registered: { label: "Registered", variant: "success", Icon: Bot },
   deactivated: { label: "Deactivated", variant: "destructive", Icon: Power },
-  pending: { label: "Pending", variant: "outline", Icon: Clock },
-  expired: { label: "Expired", variant: "secondary", Icon: TimerOff },
-  charged: { label: "Charged", variant: "default", Icon: CreditCard },
+  pending: { label: "Pending", variant: "warning", Icon: Clock },
+  expired: { label: "Expired", variant: "outline", Icon: TimerOff },
+  charged: { label: "Charged", variant: "info", Icon: CreditCard },
 };
 
 /** All outcome values (derived from OUTCOME_CONFIG) plus "all", for the full activity page. */

--- a/frontend/src/lib/auditEvents.tsx
+++ b/frontend/src/lib/auditEvents.tsx
@@ -10,7 +10,7 @@ import {
   CreditCard,
   HelpCircle,
 } from "lucide-react";
-import { Badge, badgeVariants } from "@/components/ui/badge";
+import { Badge, type badgeVariants } from "@/components/ui/badge";
 import type { VariantProps } from "class-variance-authority";
 import {
   TableRow,


### PR DESCRIPTION
## Summary

- Maps audit outcome badges to semantic colors: `approved`/`registered` → `success` (green), `pending` → `warning` (amber), `auto_executed`/`charged` → `info` (blue)
- Keeps `denied`/`deactivated` → `destructive`, `cancelled`/`expired` → `outline`
- Expands `OutcomeStyle` variant type union to include all badge variants from phase 1B

Part of #610

## Test plan

### Claude Code
- [x] `make test-frontend` passes (905 tests)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

### Manual Testing
- [ ] Visual QA: approved events show green badge, denied show red, pending show amber, auto-executed show blue
- [ ] Check both light and dark mode on the Activity page and Dashboard

https://claude.ai/code/session_018h2Lxvxhj9PncRFbzCj4rX