### PR TITLE
UI polish: Phase 2 semantic colors & component improvements

### DIFF
--- a/frontend/src/components/AgentStatusBadge.tsx
+++ b/frontend/src/components/AgentStatusBadge.tsx
@@ -2,21 +2,22 @@ import { Badge } from "@/components/ui/badge";
 
 const STATUS_CONFIG: Record<
   string,
-  { variant: "default" | "secondary" | "destructive"; label: string }
+  { dotColor: string; label: string }
 > = {
-  registered: { variant: "default", label: "Active" },
-  pending: { variant: "secondary", label: "Pending" },
-  deactivated: { variant: "destructive", label: "Deactivated" },
+  registered: { dotColor: "bg-success", label: "Active" },
+  pending: { dotColor: "bg-warning", label: "Pending" },
+  deactivated: { dotColor: "bg-destructive", label: "Deactivated" },
 };
 
 export function AgentStatusBadge({ status }: { status: string }) {
   const config = STATUS_CONFIG[status] ?? {
-    variant: "secondary" as const,
+    dotColor: "bg-muted-foreground",
     label: status,
   };
 
   return (
-    <Badge variant={config.variant} className="rounded-full">
+    <Badge variant="outline" className="gap-1.5 rounded-full">
+      <span className={`size-2 rounded-full ${config.dotColor}`} />
       {config.label}
     </Badge>
   );

--- a/frontend/src/lib/auditEvents.tsx
+++ b/frontend/src/lib/auditEvents.tsx
@@ -41,20 +41,20 @@ export const ACTION_EVENT_TYPES =
 
 interface OutcomeStyle {
   label: string;
-  variant: "default" | "secondary" | "destructive" | "outline";
+  variant: "default" | "secondary" | "destructive" | "outline" | "success" | "warning" | "info";
   Icon: typeof CheckCircle2;
 }
 
 export const OUTCOME_CONFIG: Record<string, OutcomeStyle> = {
-  approved: { label: "Approved", variant: "default", Icon: CheckCircle2 },
+  approved: { label: "Approved", variant: "success", Icon: CheckCircle2 },
   denied: { label: "Denied", variant: "destructive", Icon: XCircle },
   cancelled: { label: "Cancelled", variant: "outline", Icon: Ban },
-  auto_executed: { label: "Auto-executed", variant: "secondary", Icon: Zap },
-  registered: { label: "Registered", variant: "default", Icon: Bot },
+  auto_executed: { label: "Auto-executed", variant: "info", Icon: Zap },
+  registered: { label: "Registered", variant: "success", Icon: Bot },
   deactivated: { label: "Deactivated", variant: "destructive", Icon: Power },
-  pending: { label: "Pending", variant: "outline", Icon: Clock },
-  expired: { label: "Expired", variant: "secondary", Icon: TimerOff },
-  charged: { label: "Charged", variant: "default", Icon: CreditCard },
+  pending: { label: "Pending", variant: "warning", Icon: Clock },
+  expired: { label: "Expired", variant: "outline", Icon: TimerOff },
+  charged: { label: "Charged", variant: "info", Icon: CreditCard },
 };
 
 /** All outcome values (derived from OUTCOME_CONFIG) plus "all", for the full activity page. */

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -99,7 +99,7 @@ export function PendingApprovalsBanner() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200">
+      <div className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-sm text-foreground">
         Could not load pending approvals.{" "}
         <button
           type="button"

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -38,7 +38,7 @@ function ApprovalBannerItem({
     <button
       type="button"
       onClick={() => onOpenDialog(approval, agentDisplayName)}
-      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-blue-300 bg-blue-50 px-4 py-3 text-left text-sm text-blue-900 shadow-sm transition-colors hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-950/70"
+      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-info/30 bg-info/5 px-4 py-3 text-left text-sm text-foreground shadow-sm transition-colors hover:bg-info/10"
       aria-label={`Pending approval: ${approval.action.type} from ${agentDisplayName}`}
     >
       <Bot className="size-5 shrink-0" />

--- a/frontend/src/pages/dashboard/approval-components.tsx
+++ b/frontend/src/pages/dashboard/approval-components.tsx
@@ -86,10 +86,10 @@ export function RiskBadge({ level }: { level?: "low" | "medium" | "high" | null 
 
   const variant =
     level === "high"
-      ? "destructive"
+      ? "destructive-soft"
       : level === "medium"
-        ? "outline"
-        : "secondary";
+        ? "warning-soft"
+        : "success-soft";
 
   return (
     <Badge variant={variant} className="rounded-full text-[10px] capitalize">


### PR DESCRIPTION
## Summary

- **2A:** Outcome badges now use semantic colors — approved (green/success), pending (amber/warning), auto_executed/charged (blue/info) — instead of generic purple/grey
- **2B:** Agent status badges switched to GitHub-style outline pills with colored dot indicators (green=active, amber=pending, red=deactivated)
- **2C:** Risk badges use soft variants (destructive-soft, warning-soft, success-soft) for gentler visual weight
- **2D:** Pending approval banner replaces hardcoded blue Tailwind classes with design system `info` tokens for consistent theming

Part of #610

## Test plan

### Claude Code
- [x] All 905 frontend tests pass
- [x] TypeScript compiles with no errors
- [x] Badge variant types align with CVA config

### Manual Testing
- [ ] Visual QA: Dashboard pending approvals banner renders with info token colors in light & dark mode
- [ ] Visual QA: Outcome badges show correct semantic colors (green approved, amber pending, blue auto-executed)
- [ ] Visual QA: Agent status badges show colored dots with outline style
- [ ] Visual QA: Risk badges show soft tinted variants

https://claude.ai/code