### PR TITLE
Use design system tokens in PendingApprovalsBanner (Phase 2D)

### DIFF
--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -99,7 +99,7 @@ export function PendingApprovalsBanner() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200">
+      <div className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-sm text-foreground">
         Could not load pending approvals.{" "}
         <button
           type="button"

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -38,7 +38,7 @@ function ApprovalBannerItem({
     <button
       type="button"
       onClick={() => onOpenDialog(approval, agentDisplayName)}
-      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-blue-300 bg-blue-50 px-4 py-3 text-left text-sm text-blue-900 shadow-sm transition-colors hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950/50 dark:text-blue-200 dark:hover:bg-blue-950/70"
+      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-info/30 bg-info/5 px-4 py-3 text-left text-sm text-foreground shadow-sm transition-colors hover:bg-info/10"
       aria-label={`Pending approval: ${approval.action.type} from ${agentDisplayName}`}
     >
       <Bot className="size-5 shrink-0" />


### PR DESCRIPTION
## Summary

- Replace hardcoded `border-blue-300 bg-blue-50 text-blue-900` (plus dark mode variants) with design system tokens: `border-info/30 bg-info/5 text-foreground hover:bg-info/10`
- Removes 5 hardcoded dark-mode overrides (`dark:border-blue-700`, `dark:bg-blue-950/50`, `dark:text-blue-200`, `dark:hover:bg-blue-950/70`) — the CSS variable tokens handle both modes automatically
- The hover state now uses `hover:bg-info/10` (slightly more opaque than the idle `bg-info/5`) for a subtle interactive feel

Part of #610

## Test plan

### Claude Code
- [x] `make test-frontend` passes (905 tests)
- [x] `make build` (frontend) passes with no TypeScript errors

### Manual Testing
- [ ] Visual QA: Dashboard pending approvals banner in both light and dark mode
- [ ] Confirm the info-tinted background reads clearly against surrounding content

https://claude.ai/code/session_011pgHKiuu1bMRKWRfcRFy3C