### PR TITLE
feat(ui): nav polish — softer inactive item styling (Phase 3D)

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -63,7 +63,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   "pb-1 font-medium",
                   isActive
                     ? "border-b-2 border-secondary text-foreground"
-                    : "text-muted-foreground"
+                    : "text-foreground/50 hover:text-foreground transition-colors"
                 )}
               >
                 <Link to={item.path} aria-current={isActive ? "page" : undefined} className="inline-flex items-center gap-1.5">

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -63,7 +63,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   "pb-1 font-medium",
                   isActive
                     ? "border-b-2 border-secondary text-foreground"
-                    : "text-foreground/50 hover:text-foreground transition-colors"
+                    : "text-foreground/50 hover:text-foreground focus-visible:text-foreground transition-colors"
                 )}
               >
                 <Link to={item.path} aria-current={isActive ? "page" : undefined} className="inline-flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

- Switches inactive nav items from `text-muted-foreground` to `text-foreground/50 hover:text-foreground transition-colors`
- Gives the nav a more refined GitHub/Linear feel: items are subtly dimmed at rest and smoothly reveal on hover, vs. the flat grey they were before
- Active items retain their existing `border-b-2 border-secondary text-foreground` treatment unchanged

Part of #610

## Test plan

### Claude Code
- [x] `make test-frontend` passes (99 test files, 905 tests)
- [x] `npm run build` passes with no TypeScript errors

### Manual Testing
- [ ] Verify inactive nav items appear at ~50% opacity and animate to full foreground on hover
- [ ] Confirm active nav item styling (underline + full foreground) is unchanged
- [ ] Test in both light and dark mode

https://claude.ai/code/session_01CHJuWGnAWF9LwoEfcDXJyw