### PR TITLE
Replace heavy purple table headers with subtle muted style (Phase 3A)

### DIFF
--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -156,22 +156,14 @@ export function ActivityPage() {
             <div className="min-w-[480px] overflow-hidden rounded-lg sm:min-w-0">
             <Table>
               <TableHeader>
-                <TableRow className="border-none bg-primary hover:bg-primary">
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Timestamp
-                  </TableHead>
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Agent
-                  </TableHead>
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Action
-                  </TableHead>
-                  <TableHead className="font-semibold text-primary-foreground">
-                    Outcome
-                  </TableHead>
+                <TableRow className="border-none bg-muted/50 hover:bg-muted/50">
+                  <TableHead>Timestamp</TableHead>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>Outcome</TableHead>
                 </TableRow>
               </TableHeader>
-              <TableBody className="[&>tr:nth-child(even)]:bg-muted">
+              <TableBody>
                 {events.map((event) => (
                   <AuditEventRow
                     key={`${event.timestamp}-${event.agent_id}-${event.event_type}`}

--- a/frontend/src/pages/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/pages/dashboard/RecentActivityCard.tsx
@@ -126,22 +126,14 @@ export function RecentActivityCard() {
             <div className="overflow-hidden rounded-lg">
               <Table>
                 <TableHeader>
-                  <TableRow className="border-none bg-primary hover:bg-primary">
-                    <TableHead className="font-semibold text-primary-foreground">
-                      When
-                    </TableHead>
-                    <TableHead className="font-semibold text-primary-foreground">
-                      Agent
-                    </TableHead>
-                    <TableHead className="font-semibold text-primary-foreground">
-                      Action
-                    </TableHead>
-                    <TableHead className="font-semibold text-primary-foreground">
-                      Outcome
-                    </TableHead>
+                  <TableRow className="border-none bg-muted/50 hover:bg-muted/50">
+                    <TableHead>When</TableHead>
+                    <TableHead>Agent</TableHead>
+                    <TableHead>Action</TableHead>
+                    <TableHead>Outcome</TableHead>
                   </TableRow>
                 </TableHeader>
-                <TableBody className="[&>tr:nth-child(even)]:bg-muted">
+                <TableBody>
                   {events.map((event) => (
                     <AuditEventRow
                       key={`${event.timestamp}-${event.agent_id}-${event.event_type}`}

--- a/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
+++ b/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
@@ -281,25 +281,17 @@ function AgentsTable({ agents }: { agents: Agent[] }) {
     <div className="overflow-hidden rounded-lg">
       <Table>
         <TableHeader>
-          <TableRow className="border-none bg-primary hover:bg-primary">
-            <TableHead className="font-semibold text-primary-foreground">
-              Agent
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
-              Status
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
-              Last Active
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
-              Requests
-            </TableHead>
-            <TableHead className="font-semibold text-primary-foreground">
+          <TableRow className="border-none bg-muted/50 hover:bg-muted/50">
+            <TableHead>Agent</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Last Active</TableHead>
+            <TableHead>Requests</TableHead>
+            <TableHead>
               <span className="sr-only">Actions</span>
             </TableHead>
           </TableRow>
         </TableHeader>
-        <TableBody className="[&>tr:nth-child(even)]:bg-muted">
+        <TableBody>
           {agents.map((agent) => (
             <AgentRow key={agent.agent_id} agent={agent} />
           ))}

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -282,28 +282,18 @@ function StandingApprovalsTable({
       <div className="min-w-[600px] overflow-hidden rounded-lg sm:min-w-0">
         <Table>
           <TableHeader>
-            <TableRow className="border-none bg-primary hover:bg-primary">
-              <TableHead className="font-semibold text-primary-foreground">
-                Action
-              </TableHead>
-              <TableHead className="font-semibold text-primary-foreground">
-                Agent
-              </TableHead>
-              <TableHead className="font-semibold text-primary-foreground">
-                Constraints
-              </TableHead>
-              <TableHead className="font-semibold text-primary-foreground">
-                Executions
-              </TableHead>
-              <TableHead className="font-semibold text-primary-foreground">
-                Expires
-              </TableHead>
-              <TableHead className="font-semibold text-primary-foreground">
+            <TableRow className="border-none bg-muted/50 hover:bg-muted/50">
+              <TableHead>Action</TableHead>
+              <TableHead>Agent</TableHead>
+              <TableHead>Constraints</TableHead>
+              <TableHead>Executions</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead>
                 <span className="sr-only">Actions</span>
               </TableHead>
             </TableRow>
           </TableHeader>
-          <TableBody className="[&>tr:nth-child(even)]:bg-muted">
+          <TableBody>
             {approvals.map((sa) => (
               <StandingApprovalRow
                 key={sa.standing_approval_id}


### PR DESCRIPTION
## Summary

- Replaces heavy `bg-primary` table header rows with `bg-muted/50` across 4 files (ActivityPage, RecentActivityCard, RegisteredAgentsCard, StandingApprovalsCard)
- Removes `font-semibold text-primary-foreground` overrides from all TableHead cells (they now inherit the improved styling from Phase 1C)
- Removes zebra striping (`[&>tr:nth-child(even)]:bg-muted`) from all table bodies for a cleaner, less admin-template look

Part of #610

## Test plan

### Claude Code
- [x] `make test-frontend` passes (905 tests)
- [x] `npm run build` (TypeScript compilation) passes

### Manual Testing
- [ ] Visual QA: Dashboard tables (Registered Agents, Standing Approvals, Recent Activity) — confirm headers look subtle/muted, not heavy purple
- [ ] Visual QA: Activity Log page — same header check
- [ ] Verify in both light and dark mode

https://claude.ai/code/session_01WU5FHkB2ne8Gz6yxttupNK