### PR TITLE
Segmented control filters (Phase 3B)

### DIFF
--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -19,15 +19,15 @@ export function SegmentedControl<T extends string>({
   return (
     <div
       className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
-      role="tablist"
+      role="radiogroup"
       aria-label={ariaLabel}
     >
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
-          role="tab"
-          aria-selected={value === opt.value}
+          role="radio"
+          aria-checked={value === opt.value}
           onClick={() => onChange(opt.value)}
           className={
             value === opt.value

--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -29,6 +29,10 @@ export function SegmentedControl<T extends string>({
         next = (idx + 1) % options.length;
       } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
         next = (idx - 1 + options.length) % options.length;
+      } else if (e.key === "Home") {
+        next = 0;
+      } else if (e.key === "End") {
+        next = options.length - 1;
       }
 
       if (next >= 0) {

--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -1,3 +1,5 @@
+import { useRef, useCallback, type KeyboardEvent } from "react";
+
 interface Option<T extends string> {
   label: string;
   value: T;
@@ -16,8 +18,37 @@ export function SegmentedControl<T extends string>({
   onChange,
   ariaLabel,
 }: SegmentedControlProps<T>) {
+  const groupRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      const idx = options.findIndex((o) => o.value === value);
+      let next = -1;
+
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        next = (idx + 1) % options.length;
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        next = (idx - 1 + options.length) % options.length;
+      }
+
+      if (next >= 0) {
+        e.preventDefault();
+        const opt = options[next];
+        if (opt) {
+          onChange(opt.value);
+          const buttons = groupRef.current?.querySelectorAll<HTMLButtonElement>(
+            '[role="radio"]',
+          );
+          buttons?.[next]?.focus();
+        }
+      }
+    },
+    [options, value, onChange],
+  );
+
   return (
     <div
+      ref={groupRef}
       className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
       role="radiogroup"
       aria-label={ariaLabel}
@@ -28,7 +59,9 @@ export function SegmentedControl<T extends string>({
           type="button"
           role="radio"
           aria-checked={value === opt.value}
+          tabIndex={value === opt.value ? 0 : -1}
           onClick={() => onChange(opt.value)}
+          onKeyDown={handleKeyDown}
           className={
             value === opt.value
               ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"

--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -1,0 +1,43 @@
+interface Option<T extends string> {
+  label: string;
+  value: T;
+}
+
+interface SegmentedControlProps<T extends string> {
+  options: Option<T>[];
+  value: T;
+  onChange: (v: T) => void;
+  ariaLabel: string;
+}
+
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: SegmentedControlProps<T>) {
+  return (
+    <div
+      className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
+      role="tablist"
+      aria-label={ariaLabel}
+    >
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          role="tab"
+          aria-selected={value === opt.value}
+          onClick={() => onChange(opt.value)}
+          className={
+            value === opt.value
+              ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
+              : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
+          }
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -35,7 +35,7 @@ export function SegmentedControl<T extends string>({
         next = options.length - 1;
       }
 
-      if (next >= 0) {
+      if (next >= 0 && next !== idx) {
         e.preventDefault();
         const opt = options[next];
         if (opt) {
@@ -45,6 +45,8 @@ export function SegmentedControl<T extends string>({
           );
           buttons?.[next]?.focus();
         }
+      } else if (next >= 0) {
+        e.preventDefault();
       }
     },
     [options, value, onChange],

--- a/frontend/src/pages/activity/ActivityFilters.tsx
+++ b/frontend/src/pages/activity/ActivityFilters.tsx
@@ -1,3 +1,4 @@
+import { SegmentedControl } from "@/components/ui/segmented-control";
 import { type OutcomeFilter, ALL_OUTCOME_FILTERS } from "@/lib/auditEvents";
 import { getAgentDisplayName } from "@/lib/agents";
 import type { Agent } from "@/hooks/useAgents";
@@ -84,27 +85,12 @@ export function ActivityFilters({
       </div>
 
       {/* Outcome filter tabs */}
-      <div
-        className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
-        role="tablist"
-        aria-label="Filter activity by outcome"
-      >
-        {ALL_OUTCOME_FILTERS.map((f) => (
-          <button
-            key={f.value}
-            role="tab"
-            aria-selected={outcomeFilter === f.value}
-            onClick={() => onOutcomeChange(f.value)}
-            className={
-              outcomeFilter === f.value
-                ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
-                : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
-            }
-          >
-            {f.label}
-          </button>
-        ))}
-      </div>
+      <SegmentedControl
+        options={ALL_OUTCOME_FILTERS}
+        value={outcomeFilter}
+        onChange={onOutcomeChange}
+        ariaLabel="Filter activity by outcome"
+      />
     </div>
   );
 }

--- a/frontend/src/pages/activity/ActivityFilters.tsx
+++ b/frontend/src/pages/activity/ActivityFilters.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/ui/button";
 import { type OutcomeFilter, ALL_OUTCOME_FILTERS } from "@/lib/auditEvents";
 import { getAgentDisplayName } from "@/lib/agents";
 import type { Agent } from "@/hooks/useAgents";
@@ -86,21 +85,24 @@ export function ActivityFilters({
 
       {/* Outcome filter tabs */}
       <div
-        className="flex flex-wrap gap-1"
+        className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
         role="tablist"
         aria-label="Filter activity by outcome"
       >
         {ALL_OUTCOME_FILTERS.map((f) => (
-          <Button
+          <button
             key={f.value}
-            variant={outcomeFilter === f.value ? "default" : "ghost"}
-            size="sm"
             role="tab"
             aria-selected={outcomeFilter === f.value}
             onClick={() => onOutcomeChange(f.value)}
+            className={
+              outcomeFilter === f.value
+                ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
+                : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+            }
           >
             {f.label}
-          </Button>
+          </button>
         ))}
       </div>
     </div>

--- a/frontend/src/pages/activity/__tests__/ActivityPage.test.tsx
+++ b/frontend/src/pages/activity/__tests__/ActivityPage.test.tsx
@@ -194,14 +194,14 @@ describe("ActivityPage", () => {
     render(<ActivityPage />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "All" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "All" })).toBeInTheDocument();
     });
-    expect(screen.getByRole("tab", { name: "Approved" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Denied" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Auto-executed" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Cancelled" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Registered" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Deactivated" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Approved" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Denied" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Auto-executed" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Cancelled" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Registered" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Deactivated" })).toBeInTheDocument();
   });
 
   it("calls API with outcome filter when tab is clicked", async () => {
@@ -214,7 +214,7 @@ describe("ActivityPage", () => {
       expect(screen.getAllByText("My Bot").length).toBeGreaterThanOrEqual(2);
     });
 
-    await user.click(screen.getByRole("tab", { name: "Denied" }));
+    await user.click(screen.getByRole("radio", { name: "Denied" }));
 
     await waitFor(() => {
       expect(getLastAuditQuery(mockGet)?.outcome).toBe("denied");

--- a/frontend/src/pages/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/pages/dashboard/RecentActivityCard.tsx
@@ -39,21 +39,24 @@ function OutcomeFilterTabs({
 }) {
   return (
     <div
-      className="flex flex-wrap gap-1"
+      className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
       role="tablist"
       aria-label="Filter activity by outcome"
     >
       {OUTCOME_FILTERS.map((f) => (
-        <Button
+        <button
           key={f.value}
-          variant={value === f.value ? "default" : "ghost"}
-          size="sm"
           role="tab"
           aria-selected={value === f.value}
           onClick={() => onChange(f.value)}
+          className={
+            value === f.value
+              ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
+              : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+          }
         >
           {f.label}
-        </Button>
+        </button>
       ))}
     </div>
   );

--- a/frontend/src/pages/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/pages/dashboard/RecentActivityCard.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { Loader2, Activity } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
 import {
   Card,
   CardHeader,
@@ -38,27 +39,12 @@ function OutcomeFilterTabs({
   onChange: (v: OutcomeFilter) => void;
 }) {
   return (
-    <div
-      className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
-      role="tablist"
-      aria-label="Filter activity by outcome"
-    >
-      {OUTCOME_FILTERS.map((f) => (
-        <button
-          key={f.value}
-          role="tab"
-          aria-selected={value === f.value}
-          onClick={() => onChange(f.value)}
-          className={
-            value === f.value
-              ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
-              : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
-          }
-        >
-          {f.label}
-        </button>
-      ))}
-    </div>
+    <SegmentedControl
+      options={OUTCOME_FILTERS}
+      value={value}
+      onChange={onChange}
+      ariaLabel="Filter activity by outcome"
+    />
   );
 }
 

--- a/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
+++ b/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
@@ -159,18 +159,25 @@ function StatusFilterTabs({
   ];
 
   return (
-    <div className="flex gap-1" role="tablist" aria-label="Filter agents by status">
+    <div
+      className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
+      role="tablist"
+      aria-label="Filter agents by status"
+    >
       {filters.map((f) => (
-        <Button
+        <button
           key={f.value}
-          variant={value === f.value ? "default" : "ghost"}
-          size="sm"
           role="tab"
           aria-selected={value === f.value}
           onClick={() => onChange(f.value)}
+          className={
+            value === f.value
+              ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
+              : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+          }
         >
           {f.label}
-        </Button>
+        </button>
       ))}
     </div>
   );

--- a/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
+++ b/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Loader2, Bot, Settings, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
 import { CopyableCode } from "@/components/CopyableCode";
 import { LimitBadge } from "@/components/LimitBadge";
 import { UpgradePrompt } from "@/components/UpgradePrompt";
@@ -144,6 +145,13 @@ function AgentRow({ agent }: { agent: Agent }) {
   );
 }
 
+const STATUS_FILTER_OPTIONS: { label: string; value: StatusFilter }[] = [
+  { label: "Active", value: "active" },
+  { label: "Pending", value: "pending" },
+  { label: "Deactivated", value: "deactivated" },
+  { label: "All", value: "all" },
+];
+
 function StatusFilterTabs({
   value,
   onChange,
@@ -151,35 +159,13 @@ function StatusFilterTabs({
   value: StatusFilter;
   onChange: (v: StatusFilter) => void;
 }) {
-  const filters: { label: string; value: StatusFilter }[] = [
-    { label: "Active", value: "active" },
-    { label: "Pending", value: "pending" },
-    { label: "Deactivated", value: "deactivated" },
-    { label: "All", value: "all" },
-  ];
-
   return (
-    <div
-      className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
-      role="tablist"
-      aria-label="Filter agents by status"
-    >
-      {filters.map((f) => (
-        <button
-          key={f.value}
-          role="tab"
-          aria-selected={value === f.value}
-          onClick={() => onChange(f.value)}
-          className={
-            value === f.value
-              ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
-              : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
-          }
-        >
-          {f.label}
-        </button>
-      ))}
-    </div>
+    <SegmentedControl
+      options={STATUS_FILTER_OPTIONS}
+      value={value}
+      onChange={onChange}
+      ariaLabel="Filter agents by status"
+    />
   );
 }
 

--- a/frontend/src/pages/dashboard/__tests__/RecentActivityCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/RecentActivityCard.test.tsx
@@ -155,14 +155,14 @@ describe("RecentActivityCard", () => {
     render(<RecentActivityCard />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "All" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "All" })).toBeInTheDocument();
     });
     expect(
-      screen.getByRole("tab", { name: "Approved" }),
+      screen.getByRole("radio", { name: "Approved" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Denied" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Denied" })).toBeInTheDocument();
     expect(
-      screen.getByRole("tab", { name: "Auto-executed" }),
+      screen.getByRole("radio", { name: "Auto-executed" }),
     ).toBeInTheDocument();
   });
 
@@ -176,7 +176,7 @@ describe("RecentActivityCard", () => {
       expect(screen.getAllByText("My Bot")).toHaveLength(2);
     });
 
-    await user.click(screen.getByRole("tab", { name: "Denied" }));
+    await user.click(screen.getByRole("radio", { name: "Denied" }));
 
     await waitFor(() => {
       // The mock should have been called with the outcome filter

--- a/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
@@ -211,11 +211,11 @@ describe("RegisteredAgentsCard", () => {
     render(<RegisteredAgentsCard />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Active" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Active" })).toBeInTheDocument();
     });
-    expect(screen.getByRole("tab", { name: "Pending" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Deactivated" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Pending" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Deactivated" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "All" })).toBeInTheDocument();
   });
 
   it("filters agents by status when clicking filter tabs", async () => {
@@ -248,7 +248,7 @@ describe("RegisteredAgentsCard", () => {
     expect(screen.queryByText("Agent 2")).not.toBeInTheDocument();
 
     // Click "All" to show everything
-    await user.click(screen.getByRole("tab", { name: "All" }));
+    await user.click(screen.getByRole("radio", { name: "All" }));
     await waitFor(() => {
       expect(screen.getByText("Agent 2")).toBeInTheDocument();
     });
@@ -297,9 +297,9 @@ describe("RegisteredAgentsCard", () => {
 
     // Switch to "Pending" tab to see the pending agent.
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Pending" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Pending" })).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("tab", { name: "Pending" }));
+    await user.click(screen.getByRole("radio", { name: "Pending" }));
 
     await waitFor(() => {
       expect(screen.getByText("XK7-M9P")).toBeInTheDocument();
@@ -329,9 +329,9 @@ describe("RegisteredAgentsCard", () => {
     render(<RegisteredAgentsCard />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Pending" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Pending" })).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("tab", { name: "Pending" }));
+    await user.click(screen.getByRole("radio", { name: "Pending" }));
 
     await waitFor(() => {
       expect(screen.getByText(/Expires/)).toBeInTheDocument();
@@ -358,9 +358,9 @@ describe("RegisteredAgentsCard", () => {
     render(<RegisteredAgentsCard />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Pending" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Pending" })).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("tab", { name: "Pending" }));
+    await user.click(screen.getByRole("radio", { name: "Pending" }));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Review/ })).toBeInTheDocument();
@@ -438,9 +438,9 @@ describe("RegisteredAgentsCard", () => {
     render(<RegisteredAgentsCard />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Pending" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Pending" })).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("tab", { name: "Pending" }));
+    await user.click(screen.getByRole("radio", { name: "Pending" }));
 
     await waitFor(() => {
       expect(screen.getByText("Awaiting verification")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Replaces ghost-button filter tabs with a segmented control pattern across 3 components: `ActivityFilters`, `OutcomeFilterTabs` (RecentActivityCard), and `StatusFilterTabs` (RegisteredAgentsCard)
- Container: `rounded-lg bg-muted p-1 inline-flex gap-0.5` with active/inactive button styles matching the issue spec
- Active state uses `bg-background shadow-sm`, inactive uses `text-muted-foreground hover:text-foreground`

Part of #610

## Test plan

### Claude Code
- [x] All 905 frontend tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

### Manual Testing
- [ ] Visual QA: Dashboard page — RecentActivityCard outcome filter tabs render as segmented control
- [ ] Visual QA: Dashboard page — RegisteredAgentsCard status filter tabs render as segmented control
- [ ] Visual QA: Activity page — outcome filter tabs render as segmented control
- [ ] Verify filter interaction still works (clicking tabs changes filtered results)
- [ ] Check both light and dark mode

https://claude.ai/code/session_01GDvzPQZ3pwCKBGTW5Z8xNV