### PR TITLE
GitHub-style metadata pills in ActivityDetailSheet (Phase 3C)

### DIFF
--- a/frontend/src/components/MetadataLabel.tsx
+++ b/frontend/src/components/MetadataLabel.tsx
@@ -5,18 +5,20 @@ interface MetadataLabelProps {
   icon?: LucideIcon;
   children: React.ReactNode;
   className?: string;
+  title?: string;
 }
 
 /** GitHub-style metadata pill — rounded border, icon + text, compact sizing. */
-export function MetadataLabel({ icon: Icon, children, className }: MetadataLabelProps) {
+export function MetadataLabel({ icon: Icon, children, className, title }: MetadataLabelProps) {
   return (
     <span
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium text-muted-foreground",
         className,
       )}
+      title={title}
     >
-      {Icon && <Icon className="size-3 shrink-0" />}
+      {Icon && <Icon className="size-3 shrink-0" aria-hidden="true" />}
       {children}
     </span>
   );

--- a/frontend/src/components/MetadataLabel.tsx
+++ b/frontend/src/components/MetadataLabel.tsx
@@ -1,0 +1,23 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MetadataLabelProps {
+  icon?: LucideIcon;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/** GitHub-style metadata pill — rounded border, icon + text, compact sizing. */
+export function MetadataLabel({ icon: Icon, children, className }: MetadataLabelProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium text-muted-foreground",
+        className,
+      )}
+    >
+      {Icon && <Icon className="size-3 shrink-0" />}
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/MetadataLabel.tsx
+++ b/frontend/src/components/MetadataLabel.tsx
@@ -1,9 +1,10 @@
+import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface MetadataLabelProps {
   icon?: LucideIcon;
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
   title?: string;
 }

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -268,10 +268,8 @@ export function ActivityDetailSheet({
           <div className="space-y-3">
             <OutcomeBadge outcome={event.outcome} />
             <div className="flex flex-wrap items-center gap-2">
-              <MetadataLabel icon={Clock}>
-                <span title={formatRelativeTime(event.timestamp)}>
-                  {formatAbsoluteTime(event.timestamp)}
-                </span>
+              <MetadataLabel icon={Clock} title={formatRelativeTime(event.timestamp)}>
+                {formatAbsoluteTime(event.timestamp)}
               </MetadataLabel>
               <MetadataLabel icon={Bot}>{getAuditAgentName(event)}</MetadataLabel>
               {event.connector_id && (

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -5,6 +5,7 @@ import {
   XCircle,
   AlertTriangle,
   Clock,
+  Plug,
 } from "lucide-react";
 import {
   Sheet,
@@ -13,7 +14,6 @@ import {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet";
-import { Badge } from "@/components/ui/badge";
 import {
   type AuditEvent,
   OutcomeBadge,
@@ -26,6 +26,7 @@ import { useActionSchema } from "@/hooks/useActionSchema";
 import { ActionPreviewSummary } from "@/components/ActionPreviewSummary";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { RiskBadge } from "@/pages/dashboard/approval-components";
+import { MetadataLabel } from "@/components/MetadataLabel";
 
 /** Matches Radix Sheet exit animation duration so content stays rendered during close. */
 export const SHEET_CLOSE_DELAY_MS = 300;
@@ -263,43 +264,23 @@ export function ActivityDetailSheet({
 
         {event && (
           <div className="space-y-5 px-4 pb-6">
-          {/* Event header */}
-          <div className="flex items-center justify-between gap-3">
+          {/* Event header — outcome badge + metadata pills */}
+          <div className="space-y-3">
             <OutcomeBadge outcome={event.outcome} />
-            <span className="text-muted-foreground text-xs" title={formatRelativeTime(event.timestamp)}>
-              {formatAbsoluteTime(event.timestamp)}
-            </span>
-          </div>
-
-          {/* Agent */}
-          <div className="space-y-2">
-            <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
-              Agent
-            </h4>
-            <div className="flex items-center gap-3">
-              <div className="bg-muted rounded-full p-2">
-                <Bot className="text-muted-foreground size-4" />
-              </div>
-              <div>
-                <p className="text-sm font-medium">{getAuditAgentName(event)}</p>
-                <p className="text-muted-foreground font-mono text-xs">
-                  ID: {event.agent_id}
-                </p>
-              </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <MetadataLabel icon={Clock}>
+                <span title={formatRelativeTime(event.timestamp)}>
+                  {formatAbsoluteTime(event.timestamp)}
+                </span>
+              </MetadataLabel>
+              <MetadataLabel icon={Bot}>{getAuditAgentName(event)}</MetadataLabel>
+              {event.connector_id && (
+                <MetadataLabel icon={Plug} className="capitalize">
+                  {event.connector_id}
+                </MetadataLabel>
+              )}
             </div>
           </div>
-
-          {/* Connector */}
-          {event.connector_id && (
-            <div className="space-y-2">
-              <h4 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
-                Connector
-              </h4>
-              <Badge variant="outline" className="capitalize">
-                {event.connector_id}
-              </Badge>
-            </div>
-          )}
 
           {/* Action summary from audit event */}
           {actionType && !shouldFetchApproval && (

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -271,7 +271,7 @@ export function ActivityDetailSheet({
               <MetadataLabel icon={Clock} title={formatRelativeTime(event.timestamp)}>
                 {formatAbsoluteTime(event.timestamp)}
               </MetadataLabel>
-              <MetadataLabel icon={Bot}>{getAuditAgentName(event)}</MetadataLabel>
+              <MetadataLabel icon={Bot} title={`ID: ${event.agent_id}`}>{getAuditAgentName(event)}</MetadataLabel>
               {event.connector_id && (
                 <MetadataLabel icon={Plug} className="capitalize">
                   {event.connector_id}

--- a/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
+++ b/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
@@ -200,6 +200,29 @@ describe("ActivityDetailSheet", () => {
     });
   });
 
+  it("shows connector pill when connector_id is present", async () => {
+    const event = makeEvent({ connector_id: "github" });
+    render(
+      <ActivityDetailSheet event={event as never} open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByText("github")).toBeInTheDocument();
+    });
+  });
+
+  it("hides connector pill when connector_id is absent", async () => {
+    const event = makeEvent({ connector_id: undefined });
+    render(
+      <ActivityDetailSheet event={event as never} open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(screen.getByText("My Bot")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("github")).not.toBeInTheDocument();
+  });
+
   it("does not crash when event is present but open is false", () => {
     const { container } = render(
       <ActivityDetailSheet

--- a/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
+++ b/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
@@ -67,7 +67,7 @@ describe("ActivityDetailSheet", () => {
     });
   });
 
-  it("shows agent name and ID", async () => {
+  it("shows agent name in metadata pill", async () => {
     const event = makeEvent();
     render(
       <ActivityDetailSheet
@@ -81,7 +81,6 @@ describe("ActivityDetailSheet", () => {
     await waitFor(() => {
       expect(screen.getByText("My Bot")).toBeInTheDocument();
     });
-    expect(screen.getByText(/ID: 1/)).toBeInTheDocument();
   });
 
   it("shows outcome badge", async () => {

--- a/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
+++ b/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
@@ -213,14 +213,21 @@ describe("ActivityDetailSheet", () => {
   });
 
   it("hides connector pill when connector_id is absent", async () => {
-    const event = makeEvent({ connector_id: undefined });
-    render(
-      <ActivityDetailSheet event={event as never} open={true} onOpenChange={() => {}} />,
+    // Render WITH a connector_id first to confirm the pill renders
+    const eventWith = makeEvent({ connector_id: "github" });
+    const { rerender } = render(
+      <ActivityDetailSheet event={eventWith as never} open={true} onOpenChange={() => {}} />,
       { wrapper },
     );
     await waitFor(() => {
-      expect(screen.getByText("My Bot")).toBeInTheDocument();
+      expect(screen.getByText("github")).toBeInTheDocument();
     });
+
+    // Re-render WITHOUT connector_id and confirm the pill is gone
+    const eventWithout = makeEvent({ connector_id: undefined });
+    rerender(
+      <ActivityDetailSheet event={eventWithout as never} open={true} onOpenChange={() => {}} />,
+    );
     expect(screen.queryByText("github")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
+++ b/frontend/src/pages/activity/__tests__/ActivityDetailSheet.test.tsx
@@ -81,6 +81,7 @@ describe("ActivityDetailSheet", () => {
     await waitFor(() => {
       expect(screen.getByText("My Bot")).toBeInTheDocument();
     });
+    expect(screen.getByTitle("ID: 1")).toBeInTheDocument();
   });
 
   it("shows outcome badge", async () => {


### PR DESCRIPTION
## Summary

- Extract a reusable `MetadataLabel` component for GitHub-style rounded pill labels with icon + text
- Replace flat outcome+timestamp header and verbose agent/connector sections in `ActivityDetailSheet` with compact metadata pills (timestamp with Clock, agent with Bot, connector with Plug)
- Outcome badge remains prominent above the metadata pill row

Part of #610

## Test plan

### Claude Code
- [x] All 905 frontend tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Verify no regressions in other components using Badge/OutcomeBadge

### Manual Testing
- [ ] Open an activity detail sheet — verify outcome badge, timestamp pill, agent pill, and connector pill render correctly
- [ ] Check dark mode appearance
- [ ] Verify connector pill only appears for events with a connector_id

https://claude.ai/code/session_019whvijc8CGTuzLLVyMsvFp