### PR TITLE
Redesign approval dialog with connector-driven preview cards

### DIFF
--- a/api/connectors.go
+++ b/api/connectors.go
@@ -32,6 +32,7 @@ type connectorActionResponse struct {
 	ParametersSchema      any     `json:"parameters_schema,omitempty"`
 	RequiresPaymentMethod bool    `json:"requires_payment_method"`
 	DisplayTemplate       *string `json:"display_template,omitempty"`
+	Preview               any     `json:"preview,omitempty"`
 }
 
 type requiredCredentialResponse struct {
@@ -131,6 +132,14 @@ func toConnectorDetailResponse(ctx context.Context, c db.ConnectorDetail) connec
 				log.Printf("[%s] warning: failed to unmarshal connector %s action %s parameters_schema: %v", TraceID(ctx), c.ID, a.ActionType, err)
 			} else {
 				resp.ParametersSchema = schema
+			}
+		}
+		if len(a.Preview) > 0 {
+			var preview any
+			if err := json.Unmarshal(a.Preview, &preview); err != nil {
+				log.Printf("[%s] warning: failed to unmarshal connector %s action %s preview: %v", TraceID(ctx), c.ID, a.ActionType, err)
+			} else {
+				resp.Preview = preview
 			}
 		}
 		actions[i] = resp

--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -25,6 +25,10 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Create Issue",
 				Description: "Create a new issue in a repository",
 				RiskLevel:   "low",
+				Preview: &connectors.ActionPreview{
+					Layout: "record",
+					Fields: map[string]string{"title": "title", "subtitle": "repo"},
+				},
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["owner", "repo", "title"],

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -25,6 +25,10 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Description:     "Send an email via Gmail",
 				RiskLevel:       "medium",
 				DisplayTemplate: "Send email to {{to}} — {{subject}}",
+				Preview: &connectors.ActionPreview{
+					Layout: "message",
+					Fields: map[string]string{"to": "to", "subject": "subject", "body": "body"},
+				},
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["to", "subject", "body"],
@@ -73,6 +77,10 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Description: "Create a new event on Google Calendar",
 				RiskLevel:   "medium",
 				DisplayTemplate: "Create event {{summary}} on {{start_time:datetime}} with {{attendees:count}} attendees",
+				Preview: &connectors.ActionPreview{
+					Layout: "event",
+					Fields: map[string]string{"title": "summary", "start": "start_time", "end": "end_time"},
+				},
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["summary", "start_time", "end_time"],

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -36,6 +36,20 @@ type ManifestAction struct {
 	ParametersSchema      json.RawMessage `json:"parameters_schema,omitempty"`
 	RequiresPaymentMethod bool            `json:"requires_payment_method,omitempty"`
 	DisplayTemplate       string          `json:"display_template,omitempty"`
+	Preview               *ActionPreview  `json:"preview,omitempty"`
+}
+
+// ActionPreview defines a structured layout for rich rendering of an action's
+// parameters in the approval UI. Each layout type expects specific field roles
+// that map to parameter names from the action's schema.
+//
+// Supported layouts:
+//   - "event":   fields "title", "start", "end"
+//   - "message": fields "to", "subject", "body"
+//   - "record":  fields "title", "subtitle" (plus any extras)
+type ActionPreview struct {
+	Layout string            `json:"layout"`
+	Fields map[string]string `json:"fields"`
 }
 
 // ManifestCredential describes a credential requirement for an external connector.
@@ -81,6 +95,13 @@ var validRiskLevels = map[string]bool{
 	"low":    true,
 	"medium": true,
 	"high":   true,
+}
+
+// validPreviewLayouts are the allowed values for ActionPreview.Layout.
+var validPreviewLayouts = map[string]bool{
+	"event":   true,
+	"message": true,
+	"record":  true,
 }
 
 // validWidgets are the allowed values for x-ui.widget on schema properties.
@@ -194,6 +215,17 @@ func (m *ConnectorManifest) Validate() error {
 		}
 		if a.RiskLevel != "" && !validRiskLevels[a.RiskLevel] {
 			return fmt.Errorf("manifest validation: actions[%d].risk_level %q must be low, medium, or high", i, a.RiskLevel)
+		}
+		if a.Preview != nil {
+			if a.Preview.Layout == "" {
+				return fmt.Errorf("manifest validation: actions[%d].preview.layout is required", i)
+			}
+			if !validPreviewLayouts[a.Preview.Layout] {
+				return fmt.Errorf("manifest validation: actions[%d].preview.layout %q must be event, message, or record", i, a.Preview.Layout)
+			}
+			if len(a.Preview.Fields) == 0 {
+				return fmt.Errorf("manifest validation: actions[%d].preview.fields is required", i)
+			}
 		}
 	}
 
@@ -540,6 +572,10 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 		LogoSVG:     m.LogoSVG,
 	}
 	for _, a := range m.Actions {
+		var previewJSON []byte
+		if a.Preview != nil {
+			previewJSON, _ = json.Marshal(a.Preview)
+		}
 		out.Actions = append(out.Actions, db.ExternalConnectorAction{
 			ActionType:            a.ActionType,
 			Name:                  a.Name,
@@ -548,6 +584,7 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 			ParametersSchema:      a.ParametersSchema,
 			RequiresPaymentMethod: a.RequiresPaymentMethod,
 			DisplayTemplate:       a.DisplayTemplate,
+			Preview:               previewJSON,
 		})
 	}
 	for _, c := range m.RequiredCredentials {

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"regexp"
@@ -225,6 +226,19 @@ func (m *ConnectorManifest) Validate() error {
 			}
 			if len(a.Preview.Fields) == 0 {
 				return fmt.Errorf("manifest validation: actions[%d].preview.fields is required", i)
+			}
+			// Validate that layout-specific required field roles are present.
+			requiredFieldsByLayout := map[string][]string{
+				"event":   {"title", "start", "end"},
+				"message": {"to"},
+				"record":  {"title"},
+			}
+			if required, ok := requiredFieldsByLayout[a.Preview.Layout]; ok {
+				for _, role := range required {
+					if _, exists := a.Preview.Fields[role]; !exists {
+						return fmt.Errorf("manifest validation: actions[%d].preview.fields missing required role %q for layout %q", i, role, a.Preview.Layout)
+					}
+				}
 			}
 		}
 	}
@@ -574,7 +588,11 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 	for _, a := range m.Actions {
 		var previewJSON []byte
 		if a.Preview != nil {
-			previewJSON, _ = json.Marshal(a.Preview)
+			var err error
+			previewJSON, err = json.Marshal(a.Preview)
+			if err != nil {
+				log.Printf("warning: failed to marshal preview for action %s: %v", a.ActionType, err)
+			}
 		}
 		out.Actions = append(out.Actions, db.ExternalConnectorAction{
 			ActionType:            a.ActionType,

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -24,6 +24,10 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Send Message",
 				Description: "Send a message to a Slack channel",
 				RiskLevel:   "low",
+				Preview: &connectors.ActionPreview{
+					Layout: "message",
+					Fields: map[string]string{"to": "channel", "subject": "channel", "body": "message"},
+				},
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["channel", "message"],

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -26,7 +26,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				RiskLevel:   "low",
 				Preview: &connectors.ActionPreview{
 					Layout: "message",
-					Fields: map[string]string{"to": "channel", "subject": "channel", "body": "message"},
+					Fields: map[string]string{"to": "channel", "body": "message"},
 				},
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -37,6 +37,7 @@ type ConnectorAction struct {
 	ParametersSchema      []byte // raw JSONB
 	RequiresPaymentMethod bool
 	DisplayTemplate       *string
+	Preview               []byte // raw JSONB — structured preview layout config
 }
 
 // RequiredCredential represents a row from the connector_required_credentials table.
@@ -93,7 +94,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	// Fetch actions.
 	actionRows, err := db.Query(ctx,
-		`SELECT action_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template
+		`SELECT action_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template, preview
 		 FROM connector_actions
 		 WHERE connector_id = $1
 		 ORDER BY action_type`,
@@ -106,7 +107,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	for actionRows.Next() {
 		var a ConnectorAction
-		if err := actionRows.Scan(&a.ActionType, &a.Name, &a.Description, &a.RiskLevel, &a.ParametersSchema, &a.RequiresPaymentMethod, &a.DisplayTemplate); err != nil {
+		if err := actionRows.Scan(&a.ActionType, &a.Name, &a.Description, &a.RiskLevel, &a.ParametersSchema, &a.RequiresPaymentMethod, &a.DisplayTemplate, &a.Preview); err != nil {
 			return nil, err
 		}
 		cd.Actions = append(cd.Actions, a)
@@ -251,6 +252,7 @@ type ExternalConnectorAction struct {
 	ParametersSchema      []byte // raw JSON
 	RequiresPaymentMethod bool
 	DisplayTemplate       string
+	Preview               []byte // raw JSON — structured preview layout config
 }
 
 // ExternalConnectorCredential describes a required credential from an external connector manifest.
@@ -300,16 +302,17 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 	for _, a := range m.Actions {
 		actionTypes = append(actionTypes, a.ActionType)
 		_, err := tx.Exec(ctx, `
-			INSERT INTO connector_actions (connector_id, action_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			INSERT INTO connector_actions (connector_id, action_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template, preview)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 			ON CONFLICT (connector_id, action_type) DO UPDATE SET
 				name = EXCLUDED.name,
 				description = EXCLUDED.description,
 				risk_level = EXCLUDED.risk_level,
 				parameters_schema = EXCLUDED.parameters_schema,
 				requires_payment_method = EXCLUDED.requires_payment_method,
-				display_template = EXCLUDED.display_template`,
-			m.ID, a.ActionType, a.Name, nilIfEmpty(a.Description), nilIfEmpty(a.RiskLevel), nilIfEmptyBytes(a.ParametersSchema), a.RequiresPaymentMethod, nilIfEmpty(a.DisplayTemplate))
+				display_template = EXCLUDED.display_template,
+				preview = EXCLUDED.preview`,
+			m.ID, a.ActionType, a.Name, nilIfEmpty(a.Description), nilIfEmpty(a.RiskLevel), nilIfEmptyBytes(a.ParametersSchema), a.RequiresPaymentMethod, nilIfEmpty(a.DisplayTemplate), nilIfEmptyBytes(a.Preview))
 		if err != nil {
 			return err
 		}

--- a/db/migrations/20260316031306_add_preview_to_connector_actions.sql
+++ b/db/migrations/20260316031306_add_preview_to_connector_actions.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE connector_actions ADD COLUMN preview jsonb;
+
+-- +goose Down
+ALTER TABLE connector_actions DROP COLUMN IF EXISTS preview;

--- a/frontend/src/components/previews/ActionPreviewCard.tsx
+++ b/frontend/src/components/previews/ActionPreviewCard.tsx
@@ -1,0 +1,71 @@
+import type { ActionPreviewConfig } from "@/hooks/useActionSchema";
+import type { ParametersSchema } from "@/lib/parameterSchema";
+import { ActionPreviewSummary } from "@/components/ActionPreviewSummary";
+import { EventPreviewLayout } from "./EventPreviewLayout";
+import { MessagePreviewLayout } from "./MessagePreviewLayout";
+import { RecordPreviewLayout } from "./RecordPreviewLayout";
+
+interface ActionPreviewCardProps {
+  preview: ActionPreviewConfig | null;
+  parameters: Record<string, unknown>;
+  /** Fallback props for GenericPreviewLayout when no preview config exists. */
+  actionType: string;
+  schema: ParametersSchema | null;
+  actionName: string | null;
+  displayTemplate?: string | null;
+  resourceDetails?: Record<string, unknown> | null;
+}
+
+/**
+ * Dispatches to the correct layout component based on the connector's
+ * preview config. Falls back to ActionPreviewSummary wrapped in a card
+ * when no preview config is defined.
+ */
+export function ActionPreviewCard({
+  preview,
+  parameters,
+  actionType,
+  schema,
+  actionName,
+  displayTemplate,
+  resourceDetails,
+}: ActionPreviewCardProps) {
+  if (preview) {
+    switch (preview.layout) {
+      case "event":
+        return (
+          <EventPreviewLayout parameters={parameters} fields={preview.fields} />
+        );
+      case "message":
+        return (
+          <MessagePreviewLayout
+            parameters={parameters}
+            fields={preview.fields}
+          />
+        );
+      case "record":
+        return (
+          <RecordPreviewLayout
+            parameters={parameters}
+            fields={preview.fields}
+          />
+        );
+    }
+  }
+
+  // Fallback: render ActionPreviewSummary in a styled card
+  return (
+    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+      <div className="text-sm text-slate-200">
+        <ActionPreviewSummary
+          actionType={actionType}
+          parameters={parameters}
+          schema={schema}
+          actionName={actionName}
+          displayTemplate={displayTemplate}
+          resourceDetails={resourceDetails}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/previews/EventPreviewLayout.tsx
+++ b/frontend/src/components/previews/EventPreviewLayout.tsx
@@ -1,0 +1,92 @@
+import { Calendar } from "lucide-react";
+
+interface EventPreviewLayoutProps {
+  parameters: Record<string, unknown>;
+  fields: Record<string, string>;
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatDuration(startDate: Date, endDate: Date): string {
+  const diffMs = endDate.getTime() - startDate.getTime();
+  if (diffMs <= 0) return "";
+  const totalMinutes = Math.round(diffMs / 60_000);
+  if (totalMinutes < 60) return `${totalMinutes} min`;
+  const hours = Math.floor(totalMinutes / 60);
+  const mins = totalMinutes % 60;
+  if (mins === 0) return `${hours} hour${hours > 1 ? "s" : ""}`;
+  return `${hours}h ${mins}m`;
+}
+
+export function EventPreviewLayout({
+  parameters,
+  fields,
+}: EventPreviewLayoutProps) {
+  const title =
+    typeof parameters[fields.title ?? ""] === "string"
+      ? (parameters[fields.title ?? ""] as string)
+      : null;
+  const startDate = parseDate(parameters[fields.start ?? ""]);
+  const endDate = parseDate(parameters[fields.end ?? ""]);
+
+  const monthStr = startDate
+    ? startDate.toLocaleDateString(undefined, { month: "short" }).toUpperCase()
+    : null;
+  const dayStr = startDate ? String(startDate.getDate()) : null;
+  const duration =
+    startDate && endDate ? formatDuration(startDate, endDate) : null;
+
+  return (
+    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+      {/* Action header inside the card */}
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex size-8 items-center justify-center rounded-lg bg-indigo-500/20">
+          <Calendar className="size-4 text-indigo-400" aria-hidden="true" />
+        </div>
+      </div>
+
+      {/* Event details */}
+      <div className="flex items-start gap-4">
+        {/* Date block */}
+        {monthStr && dayStr && (
+          <div className="flex flex-col items-center rounded-lg bg-slate-700/60 px-3 py-2">
+            <span className="text-[10px] font-semibold tracking-wider text-slate-400">
+              {monthStr}
+            </span>
+            <span className="text-2xl font-bold leading-tight text-white">
+              {dayStr}
+            </span>
+          </div>
+        )}
+
+        {/* Event info */}
+        <div className="min-w-0 flex-1 space-y-1">
+          {title && (
+            <p className="truncate text-base font-semibold capitalize text-white">
+              {title}
+            </p>
+          )}
+          {startDate && endDate && (
+            <p className="text-sm text-slate-300">
+              {formatTime(startDate)} → {formatTime(endDate)}
+            </p>
+          )}
+          {duration && (
+            <p className="text-xs text-slate-400">{duration}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/previews/MessagePreviewLayout.tsx
+++ b/frontend/src/components/previews/MessagePreviewLayout.tsx
@@ -1,0 +1,58 @@
+import { Mail } from "lucide-react";
+import { truncate } from "@/lib/formatValues";
+
+interface MessagePreviewLayoutProps {
+  parameters: Record<string, unknown>;
+  fields: Record<string, string>;
+}
+
+export function MessagePreviewLayout({
+  parameters,
+  fields,
+}: MessagePreviewLayoutProps) {
+  const to =
+    typeof parameters[fields.to ?? ""] === "string"
+      ? (parameters[fields.to ?? ""] as string)
+      : null;
+  const subject =
+    typeof parameters[fields.subject ?? ""] === "string"
+      ? (parameters[fields.subject ?? ""] as string)
+      : null;
+  const body =
+    typeof parameters[fields.body ?? ""] === "string"
+      ? (parameters[fields.body ?? ""] as string)
+      : null;
+
+  return (
+    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+      {/* Header icon */}
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex size-8 items-center justify-center rounded-lg bg-blue-500/20">
+          <Mail className="size-4 text-blue-400" aria-hidden="true" />
+        </div>
+      </div>
+
+      {/* Message details */}
+      <div className="space-y-2">
+        {to && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-slate-400">To</span>
+            <span className="truncate text-sm font-medium text-white">
+              {to}
+            </span>
+          </div>
+        )}
+        {subject && (
+          <p className="truncate text-base font-semibold text-white">
+            {subject}
+          </p>
+        )}
+        {body && (
+          <p className="line-clamp-2 text-sm leading-relaxed text-slate-300">
+            {truncate(body, 200)}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/previews/RecordPreviewLayout.tsx
+++ b/frontend/src/components/previews/RecordPreviewLayout.tsx
@@ -1,0 +1,77 @@
+import { FileText } from "lucide-react";
+import { truncate } from "@/lib/formatValues";
+
+interface RecordPreviewLayoutProps {
+  parameters: Record<string, unknown>;
+  fields: Record<string, string>;
+}
+
+export function RecordPreviewLayout({
+  parameters,
+  fields,
+}: RecordPreviewLayoutProps) {
+  const title =
+    typeof parameters[fields.title ?? ""] === "string"
+      ? (parameters[fields.title ?? ""] as string)
+      : null;
+  const subtitle =
+    typeof parameters[fields.subtitle ?? ""] === "string"
+      ? (parameters[fields.subtitle ?? ""] as string)
+      : null;
+
+  // Gather extra fields beyond title/subtitle
+  const extraEntries = Object.entries(fields)
+    .filter(([role]) => role !== "title" && role !== "subtitle")
+    .map(([role, paramName]) => {
+      const val = parameters[paramName];
+      if (val == null) return null;
+      const display =
+        typeof val === "string"
+          ? truncate(val, 80)
+          : Array.isArray(val)
+            ? val.map(String).join(", ")
+            : String(val);
+      return { label: role, value: display };
+    })
+    .filter(Boolean) as { label: string; value: string }[];
+
+  return (
+    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+      {/* Header icon */}
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex size-8 items-center justify-center rounded-lg bg-emerald-500/20">
+          <FileText className="size-4 text-emerald-400" aria-hidden="true" />
+        </div>
+      </div>
+
+      {/* Record details */}
+      <div className="space-y-2">
+        {title && (
+          <p className="truncate text-base font-semibold text-white">
+            {title}
+          </p>
+        )}
+        {subtitle && (
+          <p className="truncate text-sm text-slate-300">{subtitle}</p>
+        )}
+        {extraEntries.length > 0 && (
+          <div className="mt-2 space-y-1 border-t border-slate-700 pt-2">
+            {extraEntries.map((entry) => (
+              <div
+                key={entry.label}
+                className="flex items-center justify-between gap-2"
+              >
+                <span className="text-xs capitalize text-slate-400">
+                  {entry.label}
+                </span>
+                <span className="truncate text-xs text-slate-300">
+                  {entry.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useActionSchema.ts
+++ b/frontend/src/hooks/useActionSchema.ts
@@ -5,6 +5,12 @@ import {
   type ParametersSchema,
 } from "@/lib/parameterSchema";
 
+/** Structured preview layout config from the connector manifest. */
+export interface ActionPreviewConfig {
+  layout: "event" | "message" | "record";
+  fields: Record<string, string>;
+}
+
 /**
  * Extracts the connector ID from an action type string.
  * e.g., "github.create_issue" → "github"
@@ -22,6 +28,9 @@ export function useActionSchema(actionType: string): {
   schema: ParametersSchema | null;
   actionName: string | null;
   displayTemplate: string | null;
+  preview: ActionPreviewConfig | null;
+  connectorName: string | null;
+  connectorLogoSvg: string | null;
   isLoading: boolean;
 } {
   const connectorId = connectorIdFromActionType(actionType);
@@ -29,14 +38,28 @@ export function useActionSchema(actionType: string): {
 
   const result = useMemo(() => {
     if (!connector?.actions) {
-      return { schema: null, actionName: null, displayTemplate: null };
+      return {
+        schema: null,
+        actionName: null,
+        displayTemplate: null,
+        preview: null,
+        connectorName: null,
+        connectorLogoSvg: null,
+      };
     }
 
     const action = connector.actions.find(
       (a) => a.action_type === actionType,
     );
     if (!action) {
-      return { schema: null, actionName: null, displayTemplate: null };
+      return {
+        schema: null,
+        actionName: null,
+        displayTemplate: null,
+        preview: null,
+        connectorName: connector.name ?? null,
+        connectorLogoSvg: connector.logo_svg ?? null,
+      };
     }
 
     // Safe cast: the generated API type for parameters_schema is
@@ -45,10 +68,29 @@ export function useActionSchema(actionType: string): {
       action.parameters_schema as Record<string, unknown> | undefined,
     );
 
+    // Parse preview config if present.
+    const rawPreview = action.preview as
+      | { layout?: string; fields?: Record<string, string> }
+      | undefined;
+    let preview: ActionPreviewConfig | null = null;
+    if (
+      rawPreview?.layout &&
+      rawPreview?.fields &&
+      typeof rawPreview.layout === "string"
+    ) {
+      preview = {
+        layout: rawPreview.layout as ActionPreviewConfig["layout"],
+        fields: rawPreview.fields,
+      };
+    }
+
     return {
       schema,
       actionName: action.name ?? null,
       displayTemplate: action.display_template ?? null,
+      preview,
+      connectorName: connector.name ?? null,
+      connectorLogoSvg: connector.logo_svg ?? null,
     };
   }, [connector, actionType]);
 

--- a/frontend/src/hooks/useActionSchema.ts
+++ b/frontend/src/hooks/useActionSchema.ts
@@ -73,10 +73,12 @@ export function useActionSchema(actionType: string): {
       | { layout?: string; fields?: Record<string, string> }
       | undefined;
     let preview: ActionPreviewConfig | null = null;
+    const validLayouts: ReadonlySet<string> = new Set(["event", "message", "record"]);
     if (
       rawPreview?.layout &&
-      rawPreview?.fields &&
-      typeof rawPreview.layout === "string"
+      typeof rawPreview.layout === "string" &&
+      validLayouts.has(rawPreview.layout) &&
+      rawPreview?.fields
     ) {
       preview = {
         layout: rawPreview.layout as ActionPreviewConfig["layout"],

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -271,17 +271,9 @@ export function ReviewApprovalDialog({
               {/* Action header above the card */}
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex min-w-0 items-center gap-2">
-                  <ConnectorLogo
-                    name={connectorName ?? approval.action.type}
-                    logoSvg={connectorLogoSvg}
-                    size="sm"
-                  />
                   <span className="truncate text-sm font-semibold">
                     {actionName ?? approval.action.type}
                   </span>
-                  {connectorName && (
-                    <span className="text-muted-foreground text-xs">{connectorName}</span>
-                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   <RiskBadge level={approval.context.risk_level} />

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -1,14 +1,15 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { Loader2, Clock, Bot, AlertTriangle, CheckCircle, XCircle, ShieldCheck } from "lucide-react";
+import { Loader2, Clock, AlertTriangle, CheckCircle, XCircle, ShieldCheck, Check } from "lucide-react";
 import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ConnectorLogo } from "@/components/ConnectorLogo";
 import { useApproveApproval } from "@/hooks/useApproveApproval";
 import type { ApproveResult } from "@/hooks/useApproveApproval";
 import { useDenyApproval } from "@/hooks/useDenyApproval";
@@ -16,8 +17,8 @@ import { useActionSchema } from "@/hooks/useActionSchema";
 import type { ApprovalSummary } from "@/hooks/useApprovals";
 import { useAgents } from "@/hooks/useAgents";
 import { useStandingApprovals } from "@/hooks/useStandingApprovals";
-import { ActionPreviewSummary } from "@/components/ActionPreviewSummary";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
+import { ActionPreviewCard } from "@/components/previews/ActionPreviewCard";
 import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import {
   useCountdown,
@@ -99,8 +100,6 @@ function deriveConstraintsFromParams(
 ): Record<string, unknown> {
   const constraints: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(parameters)) {
-    // Keep the raw value — CreateStandingApprovalDialog's
-    // initConstraintsFromRecord handles type coercion.
     constraints[key] = value ?? "";
   }
   return constraints;
@@ -120,14 +119,14 @@ export function ReviewApprovalDialog({
   const isApproved = approveResult !== null;
   const { approveApproval } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
-  const { schema, actionName, displayTemplate } = useActionSchema(approval.action.type);
+  const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg } =
+    useActionSchema(approval.action.type);
   const remaining = useCountdown(approval.expires_at);
   const isExpired = remaining <= 0;
   const isBusy = pendingAction !== null || isDenying;
 
   // Data for "Always Allow This"
   const { agents } = useAgents();
-  // API defaults to status=active, so only active standing approvals are returned
   const { standingApprovals, isLoading: standingApprovalsLoading } = useStandingApprovals();
   const params = approval.action.parameters as Record<string, unknown>;
   const hasParams = Object.keys(params).length > 0;
@@ -142,7 +141,7 @@ export function ReviewApprovalDialog({
   );
   const showAlwaysAllow = hasParams && !standingApprovalsLoading && !hasExistingStandingApproval;
 
-  // Auto-close dialog after successful approval (unless user is creating standing approval)
+  // Auto-close dialog after successful approval
   useEffect(() => {
     if (!isApproved || autoCloseBlocked) return;
     const timer = setTimeout(() => onOpenChange(false), SUCCESS_AUTO_CLOSE_MS);
@@ -190,8 +189,6 @@ export function ReviewApprovalDialog({
   function handleStandingDialogChange(nextOpen: boolean) {
     setStandingDialogOpen(nextOpen);
     if (!nextOpen && !standingApprovalCreated) {
-      // SA wizard was dismissed without creating — unblock auto-close
-      // so the user can click Done or let the dialog close naturally.
       setAutoCloseBlocked(false);
     }
   }
@@ -209,8 +206,25 @@ export function ReviewApprovalDialog({
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        {/* Connector header with logo, action name, and connector name */}
         <DialogHeader>
-          <DialogTitle>Review Approval Request</DialogTitle>
+          <div className="flex items-center gap-3">
+            <ConnectorLogo
+              name={connectorName ?? approval.action.type}
+              logoSvg={connectorLogoSvg}
+              size="lg"
+            />
+            <div className="min-w-0">
+              <DialogTitle className="truncate text-base">
+                {actionName ?? approval.action.type}
+              </DialogTitle>
+              {connectorName && (
+                <p className="text-muted-foreground text-sm">
+                  {connectorName}
+                </p>
+              )}
+            </div>
+          </div>
         </DialogHeader>
 
         {isApproved ? (
@@ -224,78 +238,92 @@ export function ReviewApprovalDialog({
                 </p>
               </div>
             )}
+
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full"
+              onClick={() => handleClose(false)}
+            >
+              Done
+            </Button>
           </div>
         ) : (
-          <div className="space-y-4 sm:space-y-6">
-            {/* Agent */}
-            <div className="flex items-center gap-3">
-              <div className="bg-muted rounded-full p-2">
-                <Bot className="text-muted-foreground size-5" aria-hidden="true" />
+          <div className="space-y-4 sm:space-y-5">
+            {/* Agent info + status */}
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="bg-amber-100 dark:bg-amber-900/30 flex size-10 shrink-0 items-center justify-center rounded-full">
+                  <span className="text-base" aria-hidden="true">&#9728;&#65039;</span>
+                </div>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold">{agentDisplayName}</p>
+                  <p className="text-muted-foreground text-xs">wants to perform an action</p>
+                </div>
               </div>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{agentDisplayName}</p>
-                {agentDisplayName !== String(approval.agent_id) && (
-                  <p className="text-muted-foreground truncate font-mono text-xs">
-                    {approval.agent_id}
-                  </p>
-                )}
-              </div>
+              <Badge variant="warning-soft" className="shrink-0 uppercase">
+                Pending
+              </Badge>
             </div>
 
-            {/* Action & Risk */}
-            <div className="bg-muted/50 space-y-3 rounded-lg border p-3 sm:p-4">
+            {/* Rich action preview card */}
+            <div className="space-y-2">
+              {/* Action header above the card */}
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <div className="min-w-0">
-                    <span className="block truncate text-sm font-semibold">
-                      {actionName ?? approval.action.type}
-                    </span>
-                    {actionName && (
-                      <span className="text-muted-foreground block truncate font-mono text-xs">
-                        {approval.action.type}
-                      </span>
-                    )}
-                  </div>
-                  <RiskBadge level={approval.context.risk_level} />
+                <div className="flex min-w-0 items-center gap-2">
+                  <ConnectorLogo
+                    name={connectorName ?? approval.action.type}
+                    logoSvg={connectorLogoSvg}
+                    size="sm"
+                  />
+                  <span className="truncate text-sm font-semibold">
+                    {actionName ?? approval.action.type}
+                  </span>
+                  {connectorName && (
+                    <span className="text-muted-foreground text-xs">{connectorName}</span>
+                  )}
                 </div>
-                <span
-                  aria-label={isExpired ? "Request expired" : `Time remaining: ${formatCountdown(remaining)}`}
-                  className={`inline-flex shrink-0 items-center gap-1 text-xs font-medium ${urgencyColor(remaining)}`}
-                >
-                  <Clock className="size-3" aria-hidden="true" />
-                  {isExpired ? "Expired" : formatCountdown(remaining)}
-                </span>
+                <div className="flex items-center gap-2">
+                  <RiskBadge level={approval.context.risk_level} />
+                  <span
+                    aria-label={isExpired ? "Request expired" : `Time remaining: ${formatCountdown(remaining)}`}
+                    className={`inline-flex shrink-0 items-center gap-1 text-xs font-medium ${urgencyColor(remaining)}`}
+                  >
+                    <Clock className="size-3" aria-hidden="true" />
+                    {isExpired ? "Expired" : formatCountdown(remaining)}
+                  </span>
+                </div>
               </div>
 
+              {/* Context description */}
               {approval.context.description && (
                 <p className="text-muted-foreground text-sm">
                   {approval.context.description}
                 </p>
               )}
 
-              {/* Action preview summary */}
-              <div className="border-t pt-3">
-                <ActionPreviewSummary
-                  actionType={approval.action.type}
-                  parameters={approval.action.parameters as Record<string, unknown>}
-                  schema={schema}
-                  actionName={actionName}
-                  displayTemplate={displayTemplate}
-                  resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
-                />
-              </div>
+              {/* Preview card — connector-driven or fallback */}
+              <ActionPreviewCard
+                preview={preview}
+                parameters={params}
+                actionType={approval.action.type}
+                schema={schema}
+                actionName={actionName}
+                displayTemplate={displayTemplate}
+                resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
+              />
             </div>
 
-            {/* Parameters (collapsible — summary above covers the essentials) */}
-            {Object.keys(approval.action.parameters).length > 0 && (
+            {/* Raw parameters (collapsible) */}
+            {hasParams && (
               <details className="group">
                 <summary className="flex cursor-pointer items-center gap-1 text-sm font-medium select-none">
                   <span className="text-muted-foreground transition-transform group-open:rotate-90" aria-hidden="true">&#9656;</span>
-                  Parameters
+                  Raw parameters
                 </summary>
                 <div className="bg-muted/50 mt-2 overflow-x-auto rounded-lg border p-3 sm:p-4">
                   <SchemaParameterDetails
-                    parameters={approval.action.parameters as Record<string, unknown>}
+                    parameters={params}
                     schema={schema}
                   />
                 </div>
@@ -323,65 +351,61 @@ export function ReviewApprovalDialog({
                 </p>
               </div>
             )}
-          </div>
-        )}
 
-        {isApproved ? (
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button
-              variant="outline"
-              size="lg"
-              onClick={() => handleClose(false)}
-            >
-              Done
-            </Button>
-          </DialogFooter>
-        ) : (
-          <DialogFooter>
-            <Button
-              variant="outline"
-              size="lg"
-              disabled={isBusy || isExpired}
-              onClick={handleDeny}
-              aria-label={isDenying ? "Denying request…" : undefined}
-            >
-              {isDenying ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                "Deny"
-              )}
-            </Button>
-            {showAlwaysAllow && (
+            {/* Action buttons — stacked full-width matching mockup */}
+            <div className="space-y-2 pt-2">
               <Button
                 size="lg"
-                variant="secondary"
+                className="w-full bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700"
                 disabled={isBusy || isExpired}
-                onClick={handleAlwaysAllow}
-                aria-label={pendingAction === "alwaysAllow" ? "Approving and creating rule…" : undefined}
+                onClick={handleApprove}
+                aria-label={pendingAction === "approve" ? "Approving request…" : undefined}
               >
-                {pendingAction === "alwaysAllow" ? (
+                {pendingAction === "approve" ? (
                   <Loader2 className="size-4 animate-spin" />
                 ) : (
                   <>
-                    <ShieldCheck className="mr-1 size-4" />
-                    Always Allow
+                    <Check className="mr-1 size-4" />
+                    Approve
                   </>
                 )}
               </Button>
-            )}
-            <Button
-              size="lg"
-              disabled={isBusy || isExpired}
-              onClick={handleApprove}
-              aria-label={pendingAction === "approve" ? "Approving request…" : undefined}
-            >
-              {pendingAction === "approve" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                "Approve"
+
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full"
+                disabled={isBusy || isExpired}
+                onClick={handleDeny}
+                aria-label={isDenying ? "Denying request…" : undefined}
+              >
+                {isDenying ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  "Deny"
+                )}
+              </Button>
+
+              {showAlwaysAllow && (
+                <button
+                  className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors disabled:opacity-50"
+                  disabled={isBusy || isExpired}
+                  onClick={handleAlwaysAllow}
+                  aria-label={pendingAction === "alwaysAllow" ? "Approving and creating rule…" : undefined}
+                  type="button"
+                >
+                  {pendingAction === "alwaysAllow" ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <>
+                      <ShieldCheck className="size-3" />
+                      Always allow this action
+                    </>
+                  )}
+                </button>
               )}
-            </Button>
-          </DialogFooter>
+            </div>
+          </div>
         )}
       </DialogContent>
 

--- a/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
@@ -183,14 +183,13 @@ describe("PendingApprovalsBanner", () => {
     const bannerItems = screen.getAllByRole("button", { name: /Pending approval/ });
     await user.click(bannerItems[0]!);
 
+    // The dialog should open — check for the description and action buttons
     await waitFor(() => {
       expect(
-        screen.getByText("Review Approval Request"),
+        screen.getByText("Send welcome email to new user"),
       ).toBeInTheDocument();
     });
-    expect(
-      screen.getByText("Send welcome email to new user"),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
   });
 
   it("approves via review dialog and shows success message", async () => {

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -90,7 +90,7 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
 
     // "Always Allow" button should be visible alongside Approve/Deny
     await waitFor(() => {
-      expect(screen.getByText("Always Allow")).toBeInTheDocument();
+      expect(screen.getByText("Always allow this action")).toBeInTheDocument();
     });
     expect(screen.getByText("Approve")).toBeInTheDocument();
     expect(screen.getByText("Deny")).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    expect(screen.queryByText("Always Allow")).not.toBeInTheDocument();
+    expect(screen.queryByText("Always allow this action")).not.toBeInTheDocument();
   });
 
   it("does NOT show 'Always Allow' when a standing approval already exists for agent+action", async () => {
@@ -139,7 +139,7 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       expect(screen.getByText("Approve")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Always Allow")).not.toBeInTheDocument();
+    expect(screen.queryByText("Always allow this action")).not.toBeInTheDocument();
   });
 
   it("approves request and opens CreateStandingApprovalDialog when 'Always Allow' is clicked", async () => {
@@ -170,10 +170,10 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
 
     // Click "Always Allow" from the pre-approval screen
     await waitFor(() => {
-      expect(screen.getByText("Always Allow")).toBeInTheDocument();
+      expect(screen.getByText("Always allow this action")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Always Allow"));
+    await user.click(screen.getByText("Always allow this action"));
 
     // The CreateStandingApprovalDialog should open (skipping to constraints step)
     await waitFor(() => {
@@ -211,10 +211,10 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Always Allow")).toBeInTheDocument();
+      expect(screen.getByText("Always allow this action")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Always Allow"));
+    await user.click(screen.getByText("Always allow this action"));
 
     // Should show execution failure, NOT the standing approval wizard
     await waitFor(() => {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -291,6 +291,42 @@ ConnectorAction:
         and `{{param:count}}` for array length. Falls back to generic rendering when absent.
       example: "Send email to {{to}} — {{subject}}"
 
+    preview:
+      type: object
+      description: |
+        Structured preview layout config for rich rendering in the approval UI.
+        Defines a layout type and maps layout-specific field roles to action parameter names.
+        When present, the frontend renders a visually rich preview card instead of plain text.
+      properties:
+        layout:
+          type: string
+          enum:
+            - event
+            - message
+            - record
+          description: |
+            Layout template type. Determines which visual layout the frontend uses.
+            - "event": Calendar-style card with date block, title, time range, duration
+            - "message": Communication card with recipient, subject, body preview
+            - "record": Entity card with title, subtitle, and key metadata fields
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Maps layout-specific field roles to action parameter names. For example,
+            an "event" layout expects "title", "start", and "end" fields mapped to
+            the corresponding parameter names from the action's schema.
+      required:
+        - layout
+        - fields
+      example:
+        layout: "event"
+        fields:
+          title: "summary"
+          start: "start_time"
+          end: "end_time"
+
   example:
     action_type: "github.create_issue"
     name: "Create Issue"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7935,6 +7935,41 @@ components:
             Uses `{{param}}` for raw value insertion, `{{param:datetime}}` for date formatting,
             and `{{param:count}}` for array length. Falls back to generic rendering when absent.
           example: Send email to {{to}} — {{subject}}
+        preview:
+          type: object
+          description: |
+            Structured preview layout config for rich rendering in the approval UI.
+            Defines a layout type and maps layout-specific field roles to action parameter names.
+            When present, the frontend renders a visually rich preview card instead of plain text.
+          properties:
+            layout:
+              type: string
+              enum:
+                - event
+                - message
+                - record
+              description: |
+                Layout template type. Determines which visual layout the frontend uses.
+                - "event": Calendar-style card with date block, title, time range, duration
+                - "message": Communication card with recipient, subject, body preview
+                - "record": Entity card with title, subtitle, and key metadata fields
+            fields:
+              type: object
+              additionalProperties:
+                type: string
+              description: |
+                Maps layout-specific field roles to action parameter names. For example,
+                an "event" layout expects "title", "start", and "end" fields mapped to
+                the corresponding parameter names from the action's schema.
+          required:
+            - layout
+            - fields
+          example:
+            layout: event
+            fields:
+              title: summary
+              start: start_time
+              end: end_time
       example:
         action_type: github.create_issue
         name: Create Issue


### PR DESCRIPTION
## Summary

- Redesigned the approval request dialog to match the mockup with rich, visually designed preview cards
- Added connector-driven `preview` config to `ManifestAction` so each connector action defines its own rich rendering layout (event, message, record)
- The frontend dispatches to layout-specific components based on the backend config, with a generic fallback for actions without a preview

### Backend
- New `ActionPreview` struct with `layout` (event/message/record) and `fields` (role→param mappings)
- DB migration adds `preview` JSONB column to `connector_actions`
- Preview configs added to Google Calendar, Gmail, Slack, and GitHub connectors

### Frontend
- `useActionSchema` hook extended to return `preview`, `connectorName`, `connectorLogoSvg`
- New preview layout components: `EventPreviewLayout`, `MessagePreviewLayout`, `RecordPreviewLayout`
- `ActionPreviewCard` dispatcher picks the right layout based on connector config
- `ReviewApprovalDialog` redesigned: connector branding header, agent status badge, rich preview card, collapsible "Raw parameters", stacked Approve/Deny buttons

## Test plan

### Claude Code
- [x] All 907 frontend tests pass
- [x] TypeScript builds clean (no errors)
- [x] OpenAPI spec bundled and types regenerated

### Manual Testing
- [ ] Open approval request for a Google Calendar action — verify date block, title, time range, duration render correctly
- [ ] Open approval request for a Gmail action — verify recipient, subject, body preview render
- [ ] Open approval request for a GitHub issue action — verify record card with title and repo
- [ ] Open approval request for an action without preview config — verify generic fallback works
- [ ] Verify Approve/Deny buttons work correctly
- [ ] Verify "Always allow this action" link works
- [ ] Test on mobile viewport (responsive)

https://claude.ai/code/session_01VzWP1h1WX3wz4KwjxB15cV