### PR TITLE
feat(ui): polish raw parameter value styling

### DIFF
--- a/frontend/src/components/SchemaParameterDetails.stories.tsx
+++ b/frontend/src/components/SchemaParameterDetails.stories.tsx
@@ -132,6 +132,25 @@ export const NoSchema: Story = {
   },
 };
 
+export const WithMultilineBody: Story = {
+  args: {
+    parameters: {
+      to: "alice@example.com",
+      subject: "Weekly standup notes — March 16",
+      body: "Hi Alice,\n\nHere are this week's standup notes.\n\nThe team made great progress on the API migration. All endpoints are now versioned and the legacy routes have been deprecated with a 90-day sunset window.\n\nThe new dashboard is ready for QA — please review it before Thursday's release window. Key things to check: permissions, empty states, and the mobile breakpoints.\n\nFinally, a reminder that next Monday is a company holiday, so the standup will be moved to Tuesday at 10am EST.\n\nBest,\nChiedobot",
+    },
+    schema: {
+      type: "object",
+      required: ["to", "subject", "body"],
+      properties: {
+        to: { type: "string", description: "Recipient email address" },
+        subject: { type: "string", description: "Email subject line" },
+        body: { type: "string", description: "Email body (plain text)" },
+      },
+    },
+  },
+};
+
 export const ManyParameters: Story = {
   args: {
     parameters: {

--- a/frontend/src/components/SchemaParameterDetails.tsx
+++ b/frontend/src/components/SchemaParameterDetails.tsx
@@ -104,18 +104,17 @@ function ParameterRow({
   const displayValue = formatParameterValue(value);
   const isDefault =
     defaultValue !== undefined && String(value) === String(defaultValue);
+  const isMultiline = typeof value === "string" && value.includes("\n");
 
   return (
-    <div className="space-y-0.5 py-2 first:pt-0 last:pb-0">
+    <div className="space-y-1.5 py-3 first:pt-0 last:pb-0">
+      {/* Label row */}
       <div className="flex items-center gap-1.5">
-        <span className="text-muted-foreground text-xs font-medium">
+        <span className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">
           {label !== name ? label : humanizeKey(name)}
         </span>
         {label !== name && (
-          <code className="text-muted-foreground/60 text-[10px]">{name}</code>
-        )}
-        {type && (
-          <span className="text-muted-foreground/50 text-[10px]">{type}</span>
+          <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 text-[10px] font-mono">{name}</code>
         )}
         {isRequired && !isProvided && (
           <Badge
@@ -125,22 +124,34 @@ function ParameterRow({
             missing
           </Badge>
         )}
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="text-sm break-all">
-          {isProvided ? displayValue : <span className="text-muted-foreground italic">not provided</span>}
-        </span>
         {isDefault && (
-          <Badge variant="secondary" className="text-[9px] leading-tight">
+          <Badge variant="secondary" className="text-[9px] leading-tight ml-auto">
             default
           </Badge>
         )}
-        {enumValues && enumValues.length > 0 && isProvided && (
-          <span className="text-muted-foreground text-[10px]">
-            ({enumValues.join(" | ")})
-          </span>
-        )}
       </div>
+
+      {/* Value */}
+      {isProvided ? (
+        isMultiline ? (
+          <pre className="bg-muted/60 border-border rounded-md border px-3 py-2 text-xs leading-relaxed whitespace-pre-wrap break-words font-sans text-foreground">
+            {displayValue}
+          </pre>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="bg-muted/60 border-border text-foreground inline-block rounded-md border px-2.5 py-1 text-sm font-medium break-all">
+              {displayValue}
+            </span>
+            {enumValues && enumValues.length > 0 && (
+              <span className="text-muted-foreground text-[10px]">
+                one of: {enumValues.join(", ")}
+              </span>
+            )}
+          </div>
+        )
+      ) : (
+        <span className="text-muted-foreground text-sm italic">not provided</span>
+      )}
     </div>
   );
 }
@@ -152,14 +163,28 @@ function FallbackDetails({
 }) {
   return (
     <dl className="divide-border divide-y">
-      {Object.entries(parameters).map(([key, value]) => (
-        <div key={key} className="flex gap-3 py-2 first:pt-0 last:pb-0">
-          <dt className="text-muted-foreground text-xs font-medium shrink-0">
-            {humanizeKey(key)}
-          </dt>
-          <dd className="text-sm truncate">{formatParameterValue(value)}</dd>
-        </div>
-      ))}
+      {Object.entries(parameters).map(([key, value]) => {
+        const displayValue = formatParameterValue(value);
+        const isMultiline = typeof value === "string" && value.includes("\n");
+        return (
+          <div key={key} className="space-y-1.5 py-3 first:pt-0 last:pb-0">
+            <dt className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">
+              {humanizeKey(key)}
+            </dt>
+            <dd>
+              {isMultiline ? (
+                <pre className="bg-muted/60 border-border rounded-md border px-3 py-2 text-xs leading-relaxed whitespace-pre-wrap break-words font-sans text-foreground">
+                  {displayValue}
+                </pre>
+              ) : (
+                <span className="bg-muted/60 border-border text-foreground inline-block rounded-md border px-2.5 py-1 text-sm font-medium break-all">
+                  {displayValue}
+                </span>
+              )}
+            </dd>
+          </div>
+        );
+      })}
     </dl>
   );
 }

--- a/frontend/src/components/SchemaParameterDetailsVariants.stories.tsx
+++ b/frontend/src/components/SchemaParameterDetailsVariants.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta = {
+  title: "Components/SchemaParameterDetails/Value Style Variants",
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+const singleLineValue = "alice@example.com";
+const multilineValue = `Hi Alice,
+
+Here are this week's standup notes.
+
+The team made great progress on the API migration. All endpoints are now versioned and the legacy routes have been deprecated with a 90-day sunset window.
+
+The new dashboard is ready for QA — please review it before Thursday's release window.
+
+Best,
+Chiedobot`;
+
+type VariantStyle = { bg: string; border: string; color: string };
+
+function VariantBlock({ label, style }: { label: string; style: VariantStyle }) {
+  const blockStyle = { background: style.bg, border: `1px solid ${style.border}`, color: style.color };
+  return (
+    <div className="space-y-4">
+      <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground border-b pb-1">{label}</p>
+      {/* Single line */}
+      <div className="space-y-1.5">
+        <p className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">Recipient Email Address</p>
+        <span
+          className="inline-block rounded-md px-2.5 py-1 text-sm font-medium break-all"
+          style={blockStyle}
+        >
+          {singleLineValue}
+        </span>
+      </div>
+      {/* Multiline */}
+      <div className="space-y-1.5">
+        <p className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">Email Body</p>
+        <pre
+          className="rounded-md px-3 py-2 text-xs leading-relaxed whitespace-pre-wrap break-words font-sans"
+          style={blockStyle}
+        >
+          {multilineValue}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function AllVariants() {
+  return (
+    <div className="w-[500px] space-y-8">
+      <VariantBlock
+        label="A — Slate-100 bg, slate-700 text, slate-200 border"
+        style={{ bg: "#f1f5f9", border: "#e2e8f0", color: "#334155" }}
+      />
+      <VariantBlock
+        label="B — Slate-100 bg, slate-900 text, slate-300 border"
+        style={{ bg: "#f1f5f9", border: "#cbd5e1", color: "#0f172a" }}
+      />
+      <VariantBlock
+        label="C — Slate-50 bg, slate-600 text, slate-200 border"
+        style={{ bg: "#f8fafc", border: "#e2e8f0", color: "#475569" }}
+      />
+      <VariantBlock
+        label="D — Zinc-100 bg, zinc-700 text, zinc-200 border"
+        style={{ bg: "#f4f4f5", border: "#e4e4e7", color: "#3f3f46" }}
+      />
+      <VariantBlock
+        label="E — Zinc-100 bg, zinc-900 text, zinc-300 border"
+        style={{ bg: "#f4f4f5", border: "#d4d4d8", color: "#18181b" }}
+      />
+    </div>
+  );
+}
+
+export const Variants: StoryObj = {
+  render: () => <AllVariants />,
+  decorators: [
+    (Story) => (
+      <div className="bg-background p-6 rounded-lg border">
+        <Story />
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
Improves the visual treatment of parameter values in `SchemaParameterDetails`:

- **Single-line values** get a bordered chip/pill (bg-muted/60 with border + rounded-md)
- **Multiline values** get a pre block with whitespace-pre-wrap and proper line height
- **Labels** are uppercase, semibold with wider tracking for clear hierarchy
- **Raw key** shown as a subtle monospace code badge next to the label
- Same improvements applied to the FallbackDetails (no-schema) path