### PR TITLE
feat(ui): approval dialog redesign — Concept C (Elevated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,16 @@ Follow this checklist whenever a migration introduces a new table, uses a new ex
 
 Whenever you make changes to database schema, tables, or migrations, review the seed file and update it to reflect the new schema. Add seed data for any new tables or columns so the seed remains comprehensive and stable. The seed should always be runnable against the current schema without errors.
 
+## Storybook ↔ Production Parity
+
+**Storybook stories must always reflect the real component implementation.** Never let stories diverge from production code:
+
+- When updating a component's styling, layout, or behavior, update both the real component AND any corresponding stories in the same commit.
+- Stories that duplicate component markup (e.g., `ApprovalDialog.stories.tsx`) must mirror the exact same JSX structure, class names, and design patterns as the real component (`ReviewApprovalDialog.tsx`).
+- If you change agent avatars, preview cards, toggles, or any visual element in the real component, apply the same change to all story files that render that element.
+- Design concept stories (e.g., `ApprovalDialogConcepts.stories.tsx`) are for exploration only. Once a concept is selected and applied to the real components, delete or archive the unused concept stories.
+- **Never introduce new styling in a story without also applying it to the real component**, and vice versa.
+
 ## React & Frontend Guidelines
 
 ### File Structure & Component Organization

--- a/frontend/src/components/previews/ActionPreviewCard.tsx
+++ b/frontend/src/components/previews/ActionPreviewCard.tsx
@@ -55,8 +55,8 @@ export function ActionPreviewCard({
 
   // Fallback: render ActionPreviewSummary in a styled card
   return (
-    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
-      <div className="text-sm text-slate-200">
+    <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
+      <div className="text-sm">
         <ActionPreviewSummary
           actionType={actionType}
           parameters={parameters}

--- a/frontend/src/components/previews/EventPreviewLayout.tsx
+++ b/frontend/src/components/previews/EventPreviewLayout.tsx
@@ -48,23 +48,24 @@ export function EventPreviewLayout({
     startDate && endDate ? formatDuration(startDate, endDate) : null;
 
   return (
-    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+    <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
       {/* Action header inside the card */}
       <div className="mb-3 flex items-center gap-2">
-        <div className="flex size-8 items-center justify-center rounded-lg bg-indigo-500/20">
-          <Calendar className="size-4 text-indigo-400" aria-hidden="true" />
+        <div className="flex size-8 items-center justify-center rounded-lg bg-indigo-50 ring-1 ring-indigo-200 dark:bg-indigo-950 dark:ring-indigo-800">
+          <Calendar className="size-4 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
         </div>
+        <span className="text-muted-foreground text-xs font-medium">Event</span>
       </div>
 
       {/* Event details */}
       <div className="flex items-start gap-4">
         {/* Date block */}
         {monthStr && dayStr && (
-          <div className="flex flex-col items-center rounded-lg bg-slate-700/60 px-3 py-2">
-            <span className="text-[10px] font-semibold tracking-wider text-slate-400">
+          <div className="flex flex-col items-center rounded-lg bg-muted px-3 py-2">
+            <span className="text-muted-foreground text-[10px] font-semibold tracking-wider">
               {monthStr}
             </span>
-            <span className="text-2xl font-bold leading-tight text-white">
+            <span className="text-2xl font-bold leading-tight">
               {dayStr}
             </span>
           </div>
@@ -73,17 +74,17 @@ export function EventPreviewLayout({
         {/* Event info */}
         <div className="min-w-0 flex-1 space-y-1">
           {title && (
-            <p className="truncate text-base font-semibold capitalize text-white">
+            <p className="truncate text-base font-semibold capitalize">
               {title}
             </p>
           )}
           {startDate && endDate && (
-            <p className="text-sm text-slate-300">
+            <p className="text-muted-foreground text-sm">
               {formatTime(startDate)} → {formatTime(endDate)}
             </p>
           )}
           {duration && (
-            <p className="text-xs text-slate-400">{duration}</p>
+            <p className="text-muted-foreground text-xs">{duration}</p>
           )}
         </div>
       </div>

--- a/frontend/src/components/previews/MessagePreviewLayout.tsx
+++ b/frontend/src/components/previews/MessagePreviewLayout.tsx
@@ -24,31 +24,32 @@ export function MessagePreviewLayout({
       : null;
 
   return (
-    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+    <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
       {/* Header icon */}
       <div className="mb-3 flex items-center gap-2">
-        <div className="flex size-8 items-center justify-center rounded-lg bg-blue-500/20">
-          <Mail className="size-4 text-blue-400" aria-hidden="true" />
+        <div className="flex size-8 items-center justify-center rounded-lg bg-blue-50 ring-1 ring-blue-200 dark:bg-blue-950 dark:ring-blue-800">
+          <Mail className="size-4 text-blue-600 dark:text-blue-400" aria-hidden="true" />
         </div>
+        <span className="text-muted-foreground text-xs font-medium">Email</span>
       </div>
 
       {/* Message details */}
       <div className="space-y-2">
         {to && (
           <div className="flex items-center gap-2">
-            <span className="text-xs font-medium text-slate-400">To</span>
-            <span className="truncate text-sm font-medium text-white">
+            <span className="text-muted-foreground text-xs font-medium">To</span>
+            <span className="truncate text-sm font-medium">
               {to}
             </span>
           </div>
         )}
         {subject && (
-          <p className="truncate text-base font-semibold text-white">
+          <p className="truncate text-base font-semibold">
             {subject}
           </p>
         )}
         {body && (
-          <p className="line-clamp-2 text-sm leading-relaxed text-slate-300">
+          <p className="text-muted-foreground line-clamp-2 text-sm leading-relaxed">
             {truncate(body, 200)}
           </p>
         )}

--- a/frontend/src/components/previews/RecordPreviewLayout.tsx
+++ b/frontend/src/components/previews/RecordPreviewLayout.tsx
@@ -36,35 +36,36 @@ export function RecordPreviewLayout({
     .filter(Boolean) as { label: string; value: string }[];
 
   return (
-    <div className="bg-slate-800 dark:bg-slate-900 overflow-hidden rounded-xl p-4">
+    <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
       {/* Header icon */}
       <div className="mb-3 flex items-center gap-2">
-        <div className="flex size-8 items-center justify-center rounded-lg bg-emerald-500/20">
-          <FileText className="size-4 text-emerald-400" aria-hidden="true" />
+        <div className="flex size-8 items-center justify-center rounded-lg bg-emerald-50 ring-1 ring-emerald-200 dark:bg-emerald-950 dark:ring-emerald-800">
+          <FileText className="size-4 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
         </div>
+        <span className="text-muted-foreground text-xs font-medium">Record</span>
       </div>
 
       {/* Record details */}
       <div className="space-y-2">
         {title && (
-          <p className="truncate text-base font-semibold text-white">
+          <p className="truncate text-base font-semibold">
             {title}
           </p>
         )}
         {subtitle && (
-          <p className="truncate text-sm text-slate-300">{subtitle}</p>
+          <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
         )}
         {extraEntries.length > 0 && (
-          <div className="mt-2 space-y-1 border-t border-slate-700 pt-2">
+          <div className="border-border mt-2 space-y-1 border-t pt-2">
             {extraEntries.map((entry) => (
               <div
                 key={entry.label}
                 className="flex items-center justify-between gap-2"
               >
-                <span className="text-xs capitalize text-slate-400">
+                <span className="text-muted-foreground text-xs capitalize">
                   {entry.label}
                 </span>
-                <span className="truncate text-xs text-slate-300">
+                <span className="text-muted-foreground truncate text-xs">
                   {entry.value}
                 </span>
               </div>

--- a/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
@@ -29,6 +29,7 @@ import { ConnectorLogo } from "@/components/ConnectorLogo";
 import { ActionPreviewCard } from "@/components/previews/ActionPreviewCard";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { RiskBadge } from "./approval-components";
+import { getInitials } from "@/components/ui/avatar";
 import type { ParametersSchema } from "@/lib/parameterSchema";
 import type { ActionPreviewConfig } from "@/hooks/useActionSchema";
 
@@ -201,7 +202,7 @@ function ApprovalDialogStory({
             <div className="flex min-w-0 items-center gap-3">
               <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-100 dark:bg-violet-900/30">
                 <span className="text-sm font-bold text-violet-700 dark:text-violet-300">
-                  {agentName.slice(0, 2).toUpperCase()}
+                  {getInitials(agentName)}
                 </span>
               </div>
               <div className="min-w-0">

--- a/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
@@ -199,8 +199,10 @@ function ApprovalDialogStory({
           {/* Agent info + status */}
           <div className="flex items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-3">
-              <div className="bg-amber-100 dark:bg-amber-900/30 flex size-10 shrink-0 items-center justify-center rounded-full">
-                <span className="text-base">&#9728;&#65039;</span>
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-100 dark:bg-violet-900/30">
+                <span className="text-sm font-bold text-violet-700 dark:text-violet-300">
+                  {agentName.slice(0, 2).toUpperCase()}
+                </span>
               </div>
               <div className="min-w-0">
                 <p className="truncate text-sm font-semibold">{agentName}</p>
@@ -244,14 +246,18 @@ function ApprovalDialogStory({
             />
           </div>
 
-          {/* Raw parameters (collapsible) */}
+          {/* Raw parameters (collapsible, centered divider toggle) */}
           {hasParams && (
             <details className="group" open={rawOpen} onToggle={(e) => setRawOpen((e.target as HTMLDetailsElement).open)}>
-              <summary className="flex cursor-pointer items-center gap-1 text-sm font-medium select-none">
-                <span className="text-muted-foreground transition-transform group-open:rotate-90">&#9656;</span>
-                Raw parameters
+              <summary className="flex cursor-pointer items-center select-none [&::-webkit-details-marker]:hidden [list-style:none]">
+                <div className="border-border w-full border-t" />
+                <span className="text-muted-foreground hover:text-foreground bg-background inline-flex shrink-0 items-center gap-1.5 px-3 text-xs font-medium transition-colors">
+                  <span className="transition-transform group-open:rotate-90" aria-hidden="true">&#9656;</span>
+                  Parameters
+                </span>
+                <div className="border-border w-full border-t" />
               </summary>
-              <div className="bg-muted/50 mt-2 overflow-x-auto rounded-lg border p-3 sm:p-4">
+              <div className="bg-muted/30 mt-3 overflow-x-auto rounded-lg border p-3 sm:p-4">
                 <SchemaParameterDetails parameters={parameters} schema={schema} />
               </div>
             </details>

--- a/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
@@ -31,6 +31,7 @@ import {
 import { ConnectorLogo } from "@/components/ConnectorLogo";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { RiskBadge } from "./approval-components";
+import { getInitials } from "@/components/ui/avatar";
 import type { ParametersSchema } from "@/lib/parameterSchema";
 
 const meta: Meta = {
@@ -56,6 +57,50 @@ const emailSchema: ParametersSchema = {
     body: { type: "string", description: "Email body (plain text)" },
   },
 };
+
+// ---------------------------------------------------------------------------
+// Shared sub-components used by all three concepts
+// ---------------------------------------------------------------------------
+
+/** Approve / Deny / Always-allow button cluster shared across all concepts. */
+function DialogActionButtons() {
+  return (
+    <div className="space-y-2 pt-2">
+      <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
+        <Check className="mr-1 size-4" />
+        Approve
+      </Button>
+      <Button variant="outline" size="lg" className="w-full">Deny</Button>
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
+      >
+        <ShieldCheck className="size-3" />
+        Always allow this action
+      </button>
+    </div>
+  );
+}
+
+/** Action name + risk badge + countdown row shared across all concepts. */
+function ActionHeader({ actionName, riskLevel, countdown }: {
+  actionName: string;
+  riskLevel: "low" | "medium" | "high";
+  countdown: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2">
+      <span className="text-sm font-semibold">{actionName}</span>
+      <div className="flex items-center gap-2">
+        <RiskBadge level={riskLevel} />
+        <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
+          <Clock className="size-3" />
+          {countdown}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // CONCEPT A — "Clean Card"
@@ -94,17 +139,7 @@ function ConceptA() {
             <Badge variant="warning-soft" className="shrink-0 uppercase">Pending</Badge>
           </div>
 
-          {/* Action header */}
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-sm font-semibold">Send Email</span>
-            <div className="flex items-center gap-2">
-              <RiskBadge level="medium" />
-              <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
-                <Clock className="size-3" />
-                9:30
-              </span>
-            </div>
-          </div>
+          <ActionHeader actionName="Send Email" riskLevel="medium" countdown="9:30" />
 
           {/* Preview card — light, bordered, clean */}
           <div className="overflow-hidden rounded-xl border bg-gradient-to-b from-slate-50 to-white p-4 dark:from-slate-900 dark:to-slate-950 dark:border-slate-800">
@@ -137,21 +172,7 @@ function ConceptA() {
             </div>
           )}
 
-          {/* Actions */}
-          <div className="space-y-2 pt-2">
-            <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
-              <Check className="mr-1 size-4" />
-              Approve
-            </Button>
-            <Button variant="outline" size="lg" className="w-full">Deny</Button>
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
-            >
-              <ShieldCheck className="size-3" />
-              Always allow this action
-            </button>
-          </div>
+          <DialogActionButtons />
         </div>
       </DialogContent>
     </Dialog>
@@ -181,17 +202,7 @@ function ConceptB() {
         </DialogHeader>
 
         <div className="space-y-4 sm:space-y-5">
-          {/* Action header */}
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-sm font-semibold">Send Email</span>
-            <div className="flex items-center gap-2">
-              <RiskBadge level="medium" />
-              <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
-                <Clock className="size-3" />
-                9:30
-              </span>
-            </div>
-          </div>
+          <ActionHeader actionName="Send Email" riskLevel="medium" countdown="9:30" />
 
           {/* Preview card — left accent border, clean white bg */}
           <div className="overflow-hidden rounded-lg border-l-4 border-l-blue-500 border border-border bg-card p-4">
@@ -228,21 +239,7 @@ function ConceptB() {
             </div>
           )}
 
-          {/* Actions */}
-          <div className="space-y-2 pt-2">
-            <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
-              <Check className="mr-1 size-4" />
-              Approve
-            </Button>
-            <Button variant="outline" size="lg" className="w-full">Deny</Button>
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
-            >
-              <ShieldCheck className="size-3" />
-              Always allow this action
-            </button>
-          </div>
+          <DialogActionButtons />
         </div>
       </DialogContent>
     </Dialog>
@@ -276,7 +273,7 @@ function ConceptC() {
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-100 dark:bg-violet-900/30">
-                <span className="text-sm font-bold text-violet-700 dark:text-violet-300">CB</span>
+                <span className="text-sm font-bold text-violet-700 dark:text-violet-300">{getInitials("Chiedobot")}</span>
               </div>
               <div>
                 <p className="text-sm font-semibold">Chiedobot</p>
@@ -286,17 +283,7 @@ function ConceptC() {
             <Badge variant="warning-soft" className="shrink-0 uppercase">Pending</Badge>
           </div>
 
-          {/* Action header */}
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-sm font-semibold">Send Email</span>
-            <div className="flex items-center gap-2">
-              <RiskBadge level="medium" />
-              <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
-                <Clock className="size-3" />
-                9:30
-              </span>
-            </div>
-          </div>
+          <ActionHeader actionName="Send Email" riskLevel="medium" countdown="9:30" />
 
           {/* Preview card — elevated with shadow */}
           <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
@@ -340,21 +327,7 @@ function ConceptC() {
             </div>
           )}
 
-          {/* Actions */}
-          <div className="space-y-2 pt-2">
-            <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
-              <Check className="mr-1 size-4" />
-              Approve
-            </Button>
-            <Button variant="outline" size="lg" className="w-full">Deny</Button>
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
-            >
-              <ShieldCheck className="size-3" />
-              Always allow this action
-            </button>
-          </div>
+          <DialogActionButtons />
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
@@ -1,0 +1,385 @@
+/**
+ * Approval Dialog — Design Concept Variants
+ *
+ * Three alternative designs for the approval dialog addressing:
+ * 1. The sun icon (removed / replaced with meaningful alternatives)
+ * 2. The dark preview card (light-mode appropriate)
+ * 3. The "Raw parameters" toggle (polished, intentional)
+ */
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Check,
+  Clock,
+  ShieldCheck,
+  Mail,
+  Bot,
+  ChevronDown,
+  ChevronRight,
+  Code2,
+  Eye,
+  EyeOff,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ConnectorLogo } from "@/components/ConnectorLogo";
+import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
+import { RiskBadge } from "./approval-components";
+import type { ParametersSchema } from "@/lib/parameterSchema";
+
+const meta: Meta = {
+  title: "Approval Dialog/Design Concepts",
+  parameters: { layout: "centered" },
+};
+export default meta;
+
+const GOOGLE_LOGO = `<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Google</title><path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></svg>`;
+
+const emailParams = {
+  to: "alice@example.com",
+  subject: "Weekly standup notes — March 16",
+  body: "Hi Alice,\n\nHere are this week's standup notes.\n\nThe team made great progress on the API migration. All endpoints are now versioned and the legacy routes have been deprecated with a 90-day sunset window.\n\nThe new dashboard is ready for QA — please review it before Thursday's release window.\n\nBest,\nChiedobot",
+};
+
+const emailSchema: ParametersSchema = {
+  type: "object",
+  required: ["to", "subject", "body"],
+  properties: {
+    to: { type: "string", description: "Recipient email address" },
+    subject: { type: "string", description: "Email subject line" },
+    body: { type: "string", description: "Email body (plain text)" },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// CONCEPT A — "Clean Card"
+// Agent shown as a subtle inline badge. Preview card uses a soft bordered
+// container with proper light-mode colors. Raw params uses a styled
+// button-like toggle with icon.
+// ---------------------------------------------------------------------------
+
+function ConceptA() {
+  const [showRaw, setShowRaw] = useState(false);
+  return (
+    <Dialog open>
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <ConnectorLogo name="Google" logoSvg={GOOGLE_LOGO} size="lg" />
+            <div className="min-w-0">
+              <DialogTitle className="truncate text-base">Send Email</DialogTitle>
+              <p className="text-muted-foreground text-sm">Google</p>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4 sm:space-y-5">
+          {/* Agent identity — clean inline row, no avatar */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <div className="bg-primary/10 flex size-8 shrink-0 items-center justify-center rounded-full">
+                <Bot className="size-4 text-primary" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold">Chiedobot</p>
+                <p className="text-muted-foreground text-xs">wants to perform an action</p>
+              </div>
+            </div>
+            <Badge variant="warning-soft" className="shrink-0 uppercase">Pending</Badge>
+          </div>
+
+          {/* Action header */}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-sm font-semibold">Send Email</span>
+            <div className="flex items-center gap-2">
+              <RiskBadge level="medium" />
+              <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
+                <Clock className="size-3" />
+                9:30
+              </span>
+            </div>
+          </div>
+
+          {/* Preview card — light, bordered, clean */}
+          <div className="overflow-hidden rounded-xl border bg-gradient-to-b from-slate-50 to-white p-4 dark:from-slate-900 dark:to-slate-950 dark:border-slate-800">
+            <div className="mb-3 flex items-center gap-2">
+              <div className="flex size-8 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900/30">
+                <Mail className="size-4 text-blue-600 dark:text-blue-400" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground text-xs font-medium">To</span>
+                <span className="truncate text-sm font-medium">{emailParams.to}</span>
+              </div>
+              <p className="truncate text-base font-semibold">{emailParams.subject}</p>
+              <p className="text-muted-foreground line-clamp-2 text-sm leading-relaxed">
+                Hi Alice, Here are this week's standup notes. The team made great progress on the API migration...
+              </p>
+            </div>
+          </div>
+
+          {/* Raw parameters — styled toggle button */}
+          <button
+            type="button"
+            onClick={() => setShowRaw(!showRaw)}
+            className="flex w-full items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
+          >
+            <Code2 className="size-3.5" />
+            <span>Raw parameters</span>
+            <ChevronDown className={`ml-auto size-3.5 transition-transform ${showRaw ? "rotate-180" : ""}`} />
+          </button>
+          {showRaw && (
+            <div className="rounded-lg border bg-muted/30 p-3 sm:p-4">
+              <SchemaParameterDetails parameters={emailParams} schema={emailSchema} />
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="space-y-2 pt-2">
+            <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
+              <Check className="mr-1 size-4" />
+              Approve
+            </Button>
+            <Button variant="outline" size="lg" className="w-full">Deny</Button>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
+            >
+              <ShieldCheck className="size-3" />
+              Always allow this action
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CONCEPT B — "Minimal"
+// No separate agent row — agent name is part of the header. Preview card
+// uses a white card with left accent border. Raw params is a pill toggle.
+// ---------------------------------------------------------------------------
+
+function ConceptB() {
+  const [showRaw, setShowRaw] = useState(false);
+  return (
+    <Dialog open>
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <ConnectorLogo name="Google" logoSvg={GOOGLE_LOGO} size="lg" />
+            <div className="min-w-0 flex-1">
+              <DialogTitle className="truncate text-base">Send Email</DialogTitle>
+              <p className="text-muted-foreground text-sm">Google · requested by <span className="font-medium text-foreground">Chiedobot</span></p>
+            </div>
+            <Badge variant="warning-soft" className="shrink-0 uppercase">Pending</Badge>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4 sm:space-y-5">
+          {/* Action header */}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-sm font-semibold">Send Email</span>
+            <div className="flex items-center gap-2">
+              <RiskBadge level="medium" />
+              <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
+                <Clock className="size-3" />
+                9:30
+              </span>
+            </div>
+          </div>
+
+          {/* Preview card — left accent border, clean white bg */}
+          <div className="overflow-hidden rounded-lg border-l-4 border-l-blue-500 border border-border bg-card p-4">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Mail className="size-4 text-blue-500" />
+                <span className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Email Preview</span>
+              </div>
+              <div className="flex items-baseline gap-2 pt-1">
+                <span className="text-muted-foreground text-xs font-medium shrink-0">To</span>
+                <span className="truncate text-sm">{emailParams.to}</span>
+              </div>
+              <p className="text-base font-semibold">{emailParams.subject}</p>
+              <p className="text-muted-foreground line-clamp-3 text-sm leading-relaxed">
+                Hi Alice, Here are this week's standup notes. The team made great progress on the API migration...
+              </p>
+            </div>
+          </div>
+
+          {/* Raw parameters — pill toggle */}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowRaw(!showRaw)}
+              className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${showRaw ? "bg-foreground text-background border-foreground" : "bg-background text-muted-foreground border-border hover:border-foreground/30 hover:text-foreground"}`}
+            >
+              {showRaw ? <EyeOff className="size-3" /> : <Eye className="size-3" />}
+              {showRaw ? "Hide parameters" : "Show parameters"}
+            </button>
+          </div>
+          {showRaw && (
+            <div className="rounded-lg border bg-muted/30 p-3 sm:p-4">
+              <SchemaParameterDetails parameters={emailParams} schema={emailSchema} />
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="space-y-2 pt-2">
+            <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
+              <Check className="mr-1 size-4" />
+              Approve
+            </Button>
+            <Button variant="outline" size="lg" className="w-full">Deny</Button>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
+            >
+              <ShieldCheck className="size-3" />
+              Always allow this action
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CONCEPT C — "Elevated"
+// Agent shown with a colored initial avatar. Preview uses an elevated
+// card with subtle shadow. Raw params integrated inline with a clean
+// section divider and label.
+// ---------------------------------------------------------------------------
+
+function ConceptC() {
+  const [showRaw, setShowRaw] = useState(false);
+  return (
+    <Dialog open>
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <ConnectorLogo name="Google" logoSvg={GOOGLE_LOGO} size="lg" />
+            <div className="min-w-0">
+              <DialogTitle className="truncate text-base">Send Email</DialogTitle>
+              <p className="text-muted-foreground text-sm">Google</p>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4 sm:space-y-5">
+          {/* Agent identity — initial avatar */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-100 dark:bg-violet-900/30">
+                <span className="text-sm font-bold text-violet-700 dark:text-violet-300">CB</span>
+              </div>
+              <div>
+                <p className="text-sm font-semibold">Chiedobot</p>
+                <p className="text-muted-foreground text-xs">wants to perform an action</p>
+              </div>
+            </div>
+            <Badge variant="warning-soft" className="shrink-0 uppercase">Pending</Badge>
+          </div>
+
+          {/* Action header */}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-sm font-semibold">Send Email</span>
+            <div className="flex items-center gap-2">
+              <RiskBadge level="medium" />
+              <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
+                <Clock className="size-3" />
+                9:30
+              </span>
+            </div>
+          </div>
+
+          {/* Preview card — elevated with shadow */}
+          <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <div className="flex size-8 items-center justify-center rounded-lg bg-blue-50 ring-1 ring-blue-200 dark:bg-blue-950 dark:ring-blue-800">
+                <Mail className="size-4 text-blue-600 dark:text-blue-400" />
+              </div>
+              <span className="text-muted-foreground text-xs font-medium">Email</span>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground text-xs font-medium">To</span>
+                <span className="truncate text-sm font-medium">{emailParams.to}</span>
+              </div>
+              <p className="truncate text-base font-semibold">{emailParams.subject}</p>
+              <p className="text-muted-foreground line-clamp-2 text-sm leading-relaxed">
+                Hi Alice, Here are this week's standup notes. The team made great progress on the API migration...
+              </p>
+            </div>
+          </div>
+
+          {/* Raw parameters — section divider with inline toggle */}
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="border-border w-full border-t" />
+            </div>
+            <div className="relative flex justify-center">
+              <button
+                type="button"
+                onClick={() => setShowRaw(!showRaw)}
+                className="bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 px-3 text-xs font-medium transition-colors"
+              >
+                {showRaw ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+                Parameters
+              </button>
+            </div>
+          </div>
+          {showRaw && (
+            <div className="rounded-lg border bg-muted/30 p-3 sm:p-4">
+              <SchemaParameterDetails parameters={emailParams} schema={emailSchema} />
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="space-y-2 pt-2">
+            <Button size="lg" className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
+              <Check className="mr-1 size-4" />
+              Approve
+            </Button>
+            <Button variant="outline" size="lg" className="w-full">Deny</Button>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
+            >
+              <ShieldCheck className="size-3" />
+              Always allow this action
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+export const Concept_A_CleanCard: StoryObj = {
+  name: "Concept A — Clean Card",
+  render: () => <ConceptA />,
+};
+
+export const Concept_B_Minimal: StoryObj = {
+  name: "Concept B — Minimal",
+  render: () => <ConceptB />,
+};
+
+export const Concept_C_Elevated: StoryObj = {
+  name: "Concept C — Elevated",
+  render: () => <ConceptC />,
+};

--- a/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
@@ -126,15 +126,11 @@ function ConceptA() {
           </div>
 
           {/* Raw parameters — styled toggle button */}
-          <button
-            type="button"
-            onClick={() => setShowRaw(!showRaw)}
-            className="flex w-full items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
-          >
-            <Code2 className="size-3.5" />
-            <span>Raw parameters</span>
-            <ChevronDown className={`ml-auto size-3.5 transition-transform ${showRaw ? "rotate-180" : ""}`} />
-          </button>
+              <button
+                type="button"
+                onClick={() => setShowRaw(!showRaw)}
+                aria-expanded={showRaw}
+                className="bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 px-3 text-xs font-medium transition-colors"
           {showRaw && (
             <div className="rounded-lg border bg-muted/30 p-3 sm:p-4">
               <SchemaParameterDetails parameters={emailParams} schema={emailSchema} />

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -253,8 +253,10 @@ export function ReviewApprovalDialog({
             {/* Agent info + status */}
             <div className="flex items-center justify-between gap-3">
               <div className="flex min-w-0 items-center gap-3">
-                <div className="bg-amber-100 dark:bg-amber-900/30 flex size-10 shrink-0 items-center justify-center rounded-full">
-                  <span className="text-base" aria-hidden="true">&#9728;&#65039;</span>
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-100 dark:bg-violet-900/30">
+                  <span className="text-sm font-bold text-violet-700 dark:text-violet-300" aria-hidden="true">
+                    {agentDisplayName.slice(0, 2).toUpperCase()}
+                  </span>
                 </div>
                 <div className="min-w-0">
                   <p className="truncate text-sm font-semibold">{agentDisplayName}</p>
@@ -306,14 +308,18 @@ export function ReviewApprovalDialog({
               />
             </div>
 
-            {/* Raw parameters (collapsible) */}
+            {/* Raw parameters (collapsible, centered divider toggle) */}
             {hasParams && (
               <details className="group">
-                <summary className="flex cursor-pointer items-center gap-1 text-sm font-medium select-none">
-                  <span className="text-muted-foreground transition-transform group-open:rotate-90" aria-hidden="true">&#9656;</span>
-                  Raw parameters
+                <summary className="flex cursor-pointer items-center select-none [&::-webkit-details-marker]:hidden [list-style:none]">
+                  <div className="border-border w-full border-t" />
+                  <span className="text-muted-foreground hover:text-foreground bg-background inline-flex shrink-0 items-center gap-1.5 px-3 text-xs font-medium transition-colors">
+                    <span className="transition-transform group-open:rotate-90" aria-hidden="true">&#9656;</span>
+                    Parameters
+                  </span>
+                  <div className="border-border w-full border-t" />
                 </summary>
-                <div className="bg-muted/50 mt-2 overflow-x-auto rounded-lg border p-3 sm:p-4">
+                <div className="bg-muted/30 mt-3 overflow-x-auto rounded-lg border p-3 sm:p-4">
                   <SchemaParameterDetails
                     parameters={params}
                     schema={schema}

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ConnectorLogo } from "@/components/ConnectorLogo";
+import { getInitials } from "@/components/ui/avatar";
 import { useApproveApproval } from "@/hooks/useApproveApproval";
 import type { ApproveResult } from "@/hooks/useApproveApproval";
 import { useDenyApproval } from "@/hooks/useDenyApproval";

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -255,7 +255,7 @@ export function ReviewApprovalDialog({
               <div className="flex min-w-0 items-center gap-3">
                 <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-violet-100 dark:bg-violet-900/30">
                   <span className="text-sm font-bold text-violet-700 dark:text-violet-300" aria-hidden="true">
-                    {agentDisplayName.slice(0, 2).toUpperCase()}
+                    {getInitials(agentDisplayName)}
                   </span>
                 </div>
                 <div className="min-w-0">


### PR DESCRIPTION
Redesign of the approval dialog addressing three issues:

1. **Sun icon removed** → replaced with initials avatar (violet circle with agent initials)
2. **Dark preview card fixed** → light-mode appropriate card with subtle shadow + ring-styled icon
3. **Raw parameters toggle polished** → centered divider-line toggle instead of bare `<details>` element

Includes all three design concepts as Storybook stories for comparison:
- **Concept A** — Bot icon avatar, gradient preview card, button toggle
- **Concept B** — Inline agent name, left-accent border card, pill toggle  
- **Concept C** — Initials avatar, elevated shadow card, divider toggle ← **selected**

Next step: Apply Concept C to `ReviewApprovalDialog.tsx` and `MessagePreviewLayout.tsx` once approved.