### PR TITLE
fix: repair broken button JSX in ApprovalDialogConcepts Concept A story

### DIFF
--- a/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
@@ -161,11 +161,17 @@ function ConceptA() {
           </div>
 
           {/* Raw parameters — styled toggle button */}
-              <button
-                type="button"
-                onClick={() => setShowRaw(!showRaw)}
-                aria-expanded={showRaw}
-                className="bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 px-3 text-xs font-medium transition-colors"
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowRaw(!showRaw)}
+              aria-expanded={showRaw}
+              className="bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded border px-3 py-1.5 text-xs font-medium transition-colors"
+            >
+              {showRaw ? <EyeOff className="size-3" /> : <Eye className="size-3" />}
+              {showRaw ? "Hide parameters" : "Show parameters"}
+            </button>
+          </div>
           {showRaw && (
             <div className="rounded-lg border bg-muted/30 p-3 sm:p-4">
               <SchemaParameterDetails parameters={emailParams} schema={emailSchema} />


### PR DESCRIPTION
## Problem

Storybook was failing to load because `ApprovalDialogConcepts.stories.tsx` had a syntax error at line 169. The button element in `ConceptA` was missing:
- Its closing `>`
- Inner content (icon + label text)
- Closing `</button>` tag

This caused Storybook's Babel parser to error with:
```
SyntaxError: Unexpected token, expected "..." (169:11)
```

## Fix

Completed the broken button element to match the pattern used in ConceptB and ConceptC:
- Wrapped in a `flex` container div
- Added `Eye`/`EyeOff` icon toggle
- Added "Show parameters" / "Hide parameters" label text
- Proper closing tag and indentation

## Verification

- Storybook starts cleanly with no indexing errors
- All three Design Concepts stories render correctly in the browser
- Main app TypeScript check passes (only pre-existing unused variable warnings, no regressions)