### PR TITLE
style: restyle warning-soft badge to warm stone

### DIFF
--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -26,7 +26,7 @@ const badgeVariants = cva(
         "success-soft":
           "border-success/20 bg-success/10 text-success [a&]:hover:bg-success/15",
         "warning-soft":
-          "border-warning/20 bg-warning/10 text-warning/80 [a&]:hover:bg-warning/15",
+          "border-transparent bg-[var(--warning-soft-bg)] text-[var(--warning-soft-text)] [a&]:hover:opacity-90",
         "info-soft":
           "border-info/20 bg-info/10 text-info [a&]:hover:bg-info/15",
         "destructive-soft":

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,6 +27,8 @@
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-warning-soft-bg: var(--warning-soft-bg);
+  --color-warning-soft-text: var(--warning-soft-text);
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
   --color-border: var(--border);
@@ -75,8 +77,10 @@
     --destructive-foreground: oklch(0.985 0 0);
     --success: oklch(0.518 0.160 145.071);
     --success-foreground: oklch(0.985 0 0);
-    --warning: oklch(0.681 0.162 75.834);
-    --warning-foreground: oklch(0.228 0.038 282.932);
+    --warning: oklch(0.40 0.05 70);
+    --warning-foreground: oklch(0.93 0.03 80);
+    --warning-soft-bg: oklch(0.93 0.025 75);
+    --warning-soft-text: oklch(0.38 0.05 65);
     --info: oklch(0.546 0.180 252.417);
     --info-foreground: oklch(0.985 0 0);
     --border: oklch(0.800 0.010 261);
@@ -117,8 +121,10 @@
     --destructive-foreground: oklch(0.637 0.237 25.331);
     --success: oklch(0.600 0.160 145.071);
     --success-foreground: oklch(0.178 0.024 283);
-    --warning: oklch(0.750 0.162 75.834);
-    --warning-foreground: oklch(0.178 0.024 283);
+    --warning: oklch(0.45 0.05 70);
+    --warning-foreground: oklch(0.95 0.02 80);
+    --warning-soft-bg: oklch(0.30 0.03 70);
+    --warning-soft-text: oklch(0.88 0.04 75);
     --info: oklch(0.600 0.180 252.417);
     --info-foreground: oklch(0.178 0.024 283);
     --border: oklch(0.350 0.025 283);


### PR DESCRIPTION
## Problem
The `warning-soft` badge variant used opacity tricks (`bg-warning/10`, `text-warning/80`) causing orange text on a yellow background — muddy and unreadable.

## Solution
Warm Stone (#5 from 5 concepts reviewed). Desaturated warm beige background with muted tan text — subtle, readable, no color bleed.

**Before:** orange text on yellow bg
**After:** warm tan text on light beige bg

## Changes
- Added `--warning-soft-bg` and `--warning-soft-text` CSS variables (light + dark mode) with explicit non-opacity values
- Updated `--warning` / `--warning-foreground` to match new palette
- Refactored `warning-soft` badge variant to use new CSS vars directly instead of opacity-based utilities

## Affects
All `variant="warning-soft"` badges sitewide — currently used for the **Pending** status badge on approval dialogs.