### PR TITLE
docs(privacy): disclose transient retention of agent request/response data

### DIFF
--- a/frontend/src/pages/policy/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/policy/PrivacyPolicyPage.tsx
@@ -3,7 +3,7 @@ import { PolicyLayout } from "./PolicyLayout";
 
 export function PrivacyPolicyPage() {
   return (
-    <PolicyLayout title="Privacy Policy" lastUpdated="February 28, 2026">
+    <PolicyLayout title="Privacy Policy" lastUpdated="March 16, 2026">
       <p>
         Supersuit Technologies LLC
         (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;), operates Permission
@@ -196,6 +196,12 @@ export function PrivacyPolicyPage() {
           services on your behalf
         </li>
       </ul>
+      <p>
+        Agent request payloads and connector responses are held transiently in
+        memory solely to process and route each request. This data is{" "}
+        <strong>not written to long-term storage</strong> and is discarded
+        within 24 hours. See Section 5 for retention details.
+      </p>
 
       <h2>5. Data Retention</h2>
       <table>
@@ -221,6 +227,10 @@ export function PrivacyPolicyPage() {
           <tr>
             <td>Payment records</td>
             <td>As required by law (typically 7 years)</td>
+          </tr>
+          <tr>
+            <td>Agent request payloads and connector responses</td>
+            <td>Up to 24 hours (transient processing only, not permanently stored)</td>
           </tr>
           <tr>
             <td>Notification logs</td>


### PR DESCRIPTION
## Summary

- Adds a new row to the Section 5 (Data Retention) table for agent request payloads and connector responses, stating they are held transiently for up to 24 hours and not permanently stored
- Adds a clarifying note in Section 4.2 (Request Content — Never Shared) linking to Section 5 and explaining the transient processing model
- Updates the Privacy Policy \`lastUpdated\` date to March 16, 2026

## Test plan

### Claude Code
- [ ] Verify the privacy policy page renders correctly and the new table row and note display as expected

### Manual Testing
- [ ] Read the updated Section 4.2 and Section 5 and confirm the language accurately reflects the intended data handling behavior
- [ ] Confirm legal/compliance sign-off on the "up to 24 hours" ceiling language

https://claude.ai/code/session_01LWoGbcMCFLagpxpMwCbPwx