### PR TITLE
Replace search:read with granular search:read.* scopes

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -484,7 +484,7 @@ Lists workspace users visible to the bot, with cursor-based pagination.
 
 ### `slack.search_messages`
 
-Searches messages across Slack channels. **Requires a user token** (`xoxp-`) with the `search:read` scope — bot tokens (`xoxb-`) do not support this endpoint.
+Searches messages across Slack channels. **Requires a user token** (`xoxp-`) with the granular `search:read.*` scopes (`search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`) — bot tokens (`xoxb-`) do not support this endpoint.
 
 **Risk level:** low
 
@@ -520,7 +520,7 @@ Searches messages across Slack channels. **Requires a user token** (`xoxp-`) wit
 
 **Slack API:** `POST /search.messages` ([docs](https://api.slack.com/methods/search.messages))
 
-**Required scopes:** `search:read` (user token only)
+**Required scopes:** `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files` (user token only)
 
 > **Note:** This action will return a `missing_scope` error when invoked with a bot token. To use it, the OAuth flow must persist the user's access token (the `authed_user.access_token` field from Slack's OAuth v2 response).
 

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -359,7 +359,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.search_messages",
 				Name:        "Search Messages",
-				Description: "Search messages across Slack channels (requires a user token with search:read scope; bot tokens are not supported by Slack for this endpoint)",
+				Description: "Search messages across Slack channels (requires a user token with search:read.* scopes; bot tokens are not supported by Slack for this endpoint)",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -10,7 +10,8 @@ import (
 // It searches messages across channels via POST /search.messages.
 //
 // IMPORTANT: This Slack endpoint requires a user token (xoxp-) with the
-// search:read scope. Bot tokens (xoxb-) do NOT support search.messages.
+// search:read.* scopes (search:read.public, search:read.private, etc.).
+// Bot tokens (xoxb-) do NOT support search.messages.
 // For this action to work, the OAuth flow must persist the authed_user
 // access_token (returned alongside the bot token in Slack's OAuth v2
 // response) into the connector's credentials. Until user-token credential

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -52,7 +52,11 @@ var OAuthScopes = []string{
 	"reactions:write",
 	"users:read",
 	"im:write",
-	"search:read",
+	"search:read.public",
+	"search:read.private",
+	"search:read.im",
+	"search:read.mpim",
+	"search:read.files",
 }
 
 // SlackConnector owns the shared HTTP client and base URL used by all


### PR DESCRIPTION
## Summary
- Slack no longer offers `search:read` as a selectable OAuth scope for new apps
- Replaced single `search:read` scope with all five granular scopes: `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`
- Updated all references in Go code, manifest, and README

## Test plan

### Claude Code
- [ ] Verify no stale `search:read` references remain (only `search:read.*` variants)
- [ ] Run `make test-backend` and `make build`

### Manual Testing
- [ ] In Slack app settings, confirm all five `search:read.*` scopes can be added
- [ ] Test `search_messages` action with user token after re-authorizing with new scopes

https://claude.ai/code/session_01DFvum6RK2KHwrCDfnLnW2z