### PR TITLE
Add webhook notification on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,4 +126,5 @@ jobs:
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh workflow run trigger-webhook.yml \
-            -f message="CI failed on main — investigate: ${RUN_URL}"
+          gh workflow run trigger-webhook.yml \
+            -f message="CI failed on ${{ github.ref_name }} — investigate: ${RUN_URL}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,11 @@ jobs:
             --data-urlencode "To=${TWILIO_PHONE_TO}" \
             --data-urlencode "From=${TWILIO_PHONE_FROM}" \
             --data-urlencode "Body=${MESSAGE}"
+
+      - name: Send webhook notification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh workflow run trigger-webhook.yml \
+            -f message="CI failed on main — investigate: ${RUN_URL}"

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -2,6 +2,10 @@ name: Trigger Webhook
 on:
   workflow_dispatch:
     inputs:
+      message:
+        description: "Custom message (overrides pr_url/pr_title construction when provided)"
+        required: false
+        default: ""
       pr_url:
         description: "PR URL (optional — omitted for non-PR notifications)"
         required: false
@@ -17,6 +21,7 @@ jobs:
     steps:
       - name: Send Webhook
         env:
+          MESSAGE_OVERRIDE: ${{ inputs.message }}
           PR_URL: ${{ inputs.pr_url }}
           PR_TITLE: ${{ inputs.pr_title }}
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
@@ -27,7 +32,9 @@ jobs:
             exit 1
           fi
 
-          if [ -n "$PR_URL" ] && [ -n "$PR_TITLE" ]; then
+          if [ -n "$MESSAGE_OVERRIDE" ]; then
+            MESSAGE="permission-slip: ${MESSAGE_OVERRIDE}"
+          elif [ -n "$PR_URL" ] && [ -n "$PR_TITLE" ]; then
             MESSAGE="permission-slip: ${PR_TITLE} — ${PR_URL}"
           elif [ -n "$PR_URL" ]; then
             MESSAGE="permission-slip: PR needs attention — ${PR_URL}"


### PR DESCRIPTION
## Summary

- Adds a webhook notification step to the `notify-failure` job in CI, so when CI fails on a push to main, you get a ping through the Claude Code webhook channel (in addition to the existing Twilio SMS)
- Adds a `message` input to `trigger-webhook.yml` so callers can pass a custom message directly, without needing to use the `pr_url`/`pr_title` inputs
- The webhook message includes a direct link to the failed CI run

## Test plan

### Claude Code
- [ ] Verify YAML syntax is valid
- [ ] Confirm existing `trigger-webhook.yml` behavior is unchanged when `message` input is not provided

### Manual Testing
- [ ] Trigger a CI failure on main and verify the webhook notification is received
- [ ] Verify the run URL in the notification links to the correct Actions run

https://claude.ai/code/session_01G1DmykW33V9Ekmm9ED9G2V