### PR TITLE
Fix constraint mode UX and add datetime picker

### DIFF
--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -28,6 +28,7 @@ describe("parseParametersSchema", () => {
         owner: {
           type: "string",
           description: "Repository owner",
+          format: undefined,
           enum: undefined,
           default: undefined,
           "x-ui": undefined,
@@ -35,6 +36,7 @@ describe("parseParametersSchema", () => {
         repo: {
           type: "string",
           description: "Repository name",
+          format: undefined,
           enum: undefined,
           default: undefined,
           "x-ui": undefined,
@@ -42,6 +44,7 @@ describe("parseParametersSchema", () => {
         title: {
           type: "string",
           description: undefined,
+          format: undefined,
           enum: undefined,
           default: undefined,
           "x-ui": undefined,
@@ -65,6 +68,7 @@ describe("parseParametersSchema", () => {
 
     expect(result?.properties?.method).toEqual({
       type: "string",
+      format: undefined,
       description: "Merge strategy",
       enum: ["merge", "squash", "rebase"],
       default: "merge",
@@ -155,6 +159,7 @@ describe("parseParametersSchema", () => {
 
     expect(result?.properties?.weird).toEqual({
       type: undefined,
+      format: undefined,
       description: undefined,
       enum: undefined,
       default: undefined,
@@ -329,7 +334,7 @@ describe("parseParametersSchema", () => {
     });
 
     it("accepts all valid widget types", () => {
-      const widgets = ["text", "select", "textarea", "toggle", "number", "date"] as const;
+      const widgets = ["text", "select", "textarea", "toggle", "number", "date", "datetime"] as const;
       for (const widget of widgets) {
         const result = parseParametersSchema({
           type: "object",
@@ -554,6 +559,56 @@ describe("parseParametersSchema", () => {
     });
   });
 
+  describe("format field and datetime auto-mapping", () => {
+    it("extracts format field from property", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          start_time: { type: "string", format: "date-time" },
+        },
+      });
+
+      expect(result?.properties?.start_time?.format).toBe("date-time");
+    });
+
+    it("auto-maps format date-time to datetime widget when no explicit widget", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          start_time: { type: "string", format: "date-time" },
+        },
+      });
+
+      expect(result?.properties?.start_time?.["x-ui"]?.widget).toBe("datetime");
+    });
+
+    it("does not override explicit widget when format is date-time", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          start_time: {
+            type: "string",
+            format: "date-time",
+            "x-ui": { widget: "text" },
+          },
+        },
+      });
+
+      expect(result?.properties?.start_time?.["x-ui"]?.widget).toBe("text");
+    });
+
+    it("sets format to undefined when not present", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      });
+
+      expect(result?.properties?.name?.format).toBeUndefined();
+    });
+  });
+
   it("preserves backwards compatibility — schemas without x-ui parse identically", () => {
     const input = {
       type: "object",
@@ -573,6 +628,7 @@ describe("parseParametersSchema", () => {
         owner: {
           type: "string",
           description: "Repository owner",
+          format: undefined,
           enum: undefined,
           default: undefined,
           "x-ui": undefined,

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -15,7 +15,7 @@ export interface VisibleWhen {
 
 /** Property-level `x-ui` rendering hints for a single parameter. */
 export interface SchemaPropertyUI {
-  widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date";
+  widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date" | "datetime";
   label?: string;
   placeholder?: string;
   group?: string;
@@ -41,6 +41,7 @@ export interface SchemaUI {
 /** JSON Schema property definition for a single action parameter. */
 export interface SchemaProperty {
   type?: string;
+  format?: string;
   description?: string;
   enum?: string[];
   default?: unknown;
@@ -88,15 +89,23 @@ export function parseParametersSchema(
   )) {
     if (typeof val === "object" && val !== null) {
       const prop = val as Record<string, unknown>;
+      const format = typeof prop.format === "string" ? prop.format : undefined;
+      const parsedUI = parsePropertyUI(prop["x-ui"]);
+      // Auto-map format: "date-time" → widget: "datetime" when no explicit widget is set
+      const ui =
+        format === "date-time" && !parsedUI?.widget
+          ? { ...parsedUI, widget: "datetime" as const }
+          : parsedUI;
       properties[key] = {
         type: typeof prop.type === "string" ? prop.type : undefined,
+        format,
         description:
           typeof prop.description === "string" ? prop.description : undefined,
         enum: Array.isArray(prop.enum)
           ? prop.enum.filter((e): e is string => typeof e === "string")
           : undefined,
         default: prop.default,
-        "x-ui": parsePropertyUI(prop["x-ui"]),
+        "x-ui": ui,
       };
     }
   }
@@ -105,7 +114,7 @@ export function parseParametersSchema(
 }
 
 /** All valid widget type values. */
-export const VALID_WIDGETS = ["text", "select", "textarea", "toggle", "number", "date"] as const;
+export const VALID_WIDGETS = ["text", "select", "textarea", "toggle", "number", "date", "datetime"] as const;
 
 /** Widget type as a union — useful for exhaustive switch checks. */
 export type WidgetType = (typeof VALID_WIDGETS)[number];

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -58,7 +58,7 @@ export function ActionConfigParameterFields({
   const groups = parametersSchema["x-ui"]?.groups;
 
   function getMode(key: string): ParamMode {
-    return modes[key] ?? inferModeFromValue(values[key] ?? "");
+    return modes[key] ?? "fixed";
   }
 
   function renderField(key: string) {
@@ -273,15 +273,6 @@ function CollapsibleFieldGroup({
       )}
     </div>
   );
-}
-
-/**
- * Infer the mode from a plain string value. Used as a fallback when no
- * explicit mode override exists (e.g., first render before any user clicks).
- */
-function inferModeFromValue(value: string): ParamMode {
-  if (value === "*") return "wildcard";
-  return "fixed";
 }
 
 const modeConfig: Record<

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -76,6 +76,8 @@ function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
       return <NumberWidget {...props} />;
     case "date":
       return <DateWidget {...props} />;
+    case "datetime":
+      return <DateTimeWidget {...props} />;
     case "text":
     default:
       return <TextWidget {...props} />;
@@ -175,6 +177,55 @@ function DateWidget({ inputId, value, onChange, disabled, placeholder, className
       className={className}
     />
   );
+}
+
+function DateTimeWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
+  const localValue = toDatetimeLocalValue(value);
+
+  return (
+    <Input
+      id={inputId}
+      type="datetime-local"
+      value={localValue}
+      onChange={(e) => {
+        const dtLocal = e.target.value;
+        if (!dtLocal) {
+          onChange("");
+          return;
+        }
+        onChange(toRfc3339(dtLocal));
+      }}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
+/** Convert a datetime-local value ("YYYY-MM-DDTHH:mm") to an RFC 3339 string with local timezone offset. */
+function toRfc3339(dtLocal: string): string {
+  const d = new Date(dtLocal);
+  if (isNaN(d.getTime())) return dtLocal;
+  const offset = d.getTimezoneOffset();
+  const sign = offset <= 0 ? "+" : "-";
+  const absOffset = Math.abs(offset);
+  const hours = String(Math.floor(absOffset / 60)).padStart(2, "0");
+  const minutes = String(absOffset % 60).padStart(2, "0");
+  return `${dtLocal}:00${sign}${hours}:${minutes}`;
+}
+
+/** Convert an RFC 3339 string to a datetime-local value ("YYYY-MM-DDTHH:mm") for the input element. */
+function toDatetimeLocalValue(value: string): string {
+  if (!value) return "";
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return value;
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return value;
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hrs = String(d.getHours()).padStart(2, "0");
+  const mins = String(d.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hrs}:${mins}`;
 }
 
 /** Renders help_text and help_url hints below the input. */

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
@@ -465,6 +465,19 @@ describe("ActionConfigParameterFields", () => {
   });
 
   describe("constraint mode interaction", () => {
+    it("defaults to fixed mode when no explicit mode is set, even with * value", () => {
+      renderFields(basicSchema, {
+        values: { name: "*" },
+        modes: {},
+      });
+
+      // The input should NOT be disabled (fixed mode allows editing)
+      const input = screen.getByLabelText("name");
+      expect(input).not.toBeDisabled();
+      // The value should show * as-is
+      expect(input).toHaveValue("*");
+    });
+
     it("passes value changes through to onValueChange", async () => {
       const user = userEvent.setup();
       const onValueChange = vi.fn<(key: string, value: string) => void>();

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -239,6 +239,53 @@ describe("ParameterFieldWidget", () => {
     });
   });
 
+  describe("datetime widget", () => {
+    const datetimeProp: SchemaProperty = {
+      type: "string",
+      "x-ui": { widget: "datetime" },
+    };
+
+    it("renders a datetime-local input", () => {
+      renderWidget(datetimeProp);
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input).toBeInTheDocument();
+      expect(input.type).toBe("datetime-local");
+    });
+
+    it("converts RFC 3339 value to datetime-local format for display", () => {
+      renderWidget(datetimeProp, "2026-03-16T17:00:00Z");
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      // Should be formatted as YYYY-MM-DDTHH:mm in local time
+      expect(input.value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    });
+
+    it("handles empty value", () => {
+      renderWidget(datetimeProp, "");
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input.value).toBe("");
+    });
+
+    it("fires onChange with RFC 3339 format", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(datetimeProp);
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      await user.type(input, "2026-03-16T17:00");
+
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it("disables the datetime input when disabled", () => {
+      renderWidget(datetimeProp, "", vi.fn(), true);
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input).toBeDisabled();
+    });
+  });
+
   describe("help hints", () => {
     it("renders help_text below the input", () => {
       renderWidget({


### PR DESCRIPTION
## Summary
- **Fix constraint mode auto-inference bug**: Removed `inferModeFromValue()` which auto-switched fields to wildcard mode when users typed `*`, trapping them in a disabled input. Mode now only changes when the user explicitly clicks the dropdown.
- **Add native datetime picker**: Parameters with `format: "date-time"` now render as `datetime-local` inputs instead of raw text fields. Includes schema auto-mapping and RFC 3339 conversion helpers.

### Claude Code
- [x] Add tests for both changes
- [x] Verify TypeScript compilation passes

### Manual Testing
- [ ] Test constraint mode dropdown: type `*` in a field, verify it stays in Fixed mode and input remains editable
- [ ] Test switching between Fixed/Pattern/Wildcard via the dropdown
- [ ] Test datetime picker renders for date-time format fields (e.g. start_time, end_time)
- [ ] Test datetime picker on mobile (native picker UX)

https://claude.ai/code/session_015qxvUKHMx4DRJkfoGTNch1