### PR TITLE
Fix SegmentedControl overflow on mobile

### DIFF
--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -55,7 +55,7 @@ export function SegmentedControl<T extends string>({
   return (
     <div
       ref={groupRef}
-      className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
+      className="flex gap-0.5 overflow-x-auto rounded-lg bg-muted p-1"
       role="radiogroup"
       aria-label={ariaLabel}
     >
@@ -70,8 +70,8 @@ export function SegmentedControl<T extends string>({
           onKeyDown={handleKeyDown}
           className={
             value === opt.value
-              ? "rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
-              : "rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
+              ? "shrink-0 rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
+              : "shrink-0 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
           }
         >
           {opt.label}

--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback, type KeyboardEvent } from "react";
+import { cn } from "@/lib/utils";
 
 interface Option<T extends string> {
   label: string;
@@ -11,6 +12,9 @@ interface SegmentedControlProps<T extends string> {
   onChange: (v: T) => void;
   ariaLabel: string;
 }
+
+const baseButtonClass =
+  "shrink-0 rounded-md px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none";
 
 export function SegmentedControl<T extends string>({
   options,
@@ -43,7 +47,9 @@ export function SegmentedControl<T extends string>({
           const buttons = groupRef.current?.querySelectorAll<HTMLButtonElement>(
             '[role="radio"]',
           );
-          buttons?.[next]?.focus();
+          const btn = buttons?.[next];
+          btn?.focus();
+          btn?.scrollIntoView({ block: "nearest", inline: "nearest" });
         }
       } else if (next >= 0) {
         e.preventDefault();
@@ -68,11 +74,12 @@ export function SegmentedControl<T extends string>({
           tabIndex={value === opt.value ? 0 : -1}
           onClick={() => onChange(opt.value)}
           onKeyDown={handleKeyDown}
-          className={
+          className={cn(
+            baseButtonClass,
             value === opt.value
-              ? "shrink-0 rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
-              : "shrink-0 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
-          }
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
         >
           {opt.label}
         </button>


### PR DESCRIPTION
## Summary
- Fixed the "Auto-executed" filter tab overflowing off the right edge of the screen on mobile in the Recent Activity card
- Changed the `SegmentedControl` container from `inline-flex` to `flex` with `overflow-x-auto` so tabs scroll horizontally when they don't fit
- Added `shrink-0` to tab buttons to prevent them from being compressed — this protects against similar overflow issues anywhere `SegmentedControl` is used

## Test plan

### Claude Code
- [x] Verify frontend TypeScript compilation passes
- [x] Verify frontend tests pass (no regressions)

### Manual Testing
- [ ] On a narrow mobile viewport (~375px), confirm all 5 filter tabs are accessible via horizontal scroll
- [ ] Confirm the segmented control still looks correct on desktop widths

https://claude.ai/code/session_01AhYpeCMYqgAj6L6tL5B1Cv