### PR TITLE
feat: add github.create_repo action to GitHub connector

### DIFF
--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -27,7 +27,14 @@ type createRepoParams struct {
 
 func (p *createRepoParams) validate() error {
 	p.Name = strings.TrimSpace(p.Name)
-	return validateRepoName(p.Name)
+	if err := validateRepoName(p.Name); err != nil {
+		return err
+	}
+	p.Org = strings.TrimSpace(p.Org)
+	if p.Org != "" && !orgNameRe.MatchString(p.Org) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid org name %q: must contain only alphanumeric characters and hyphens", p.Org)}
+	}
+	return nil
 }
 
 // Execute creates a GitHub repository and returns the created repo data.
@@ -46,14 +53,9 @@ func (a *createRepoAction) Execute(ctx context.Context, req connectors.ActionReq
 		ghBody["description"] = params.Description
 	}
 
-	org := strings.TrimSpace(params.Org)
-	if org != "" && !orgNameRe.MatchString(org) {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid org name %q: must contain only alphanumeric characters and hyphens", org)}
-	}
-
 	var path string
-	if org != "" {
-		path = fmt.Sprintf("/orgs/%s/repos", url.PathEscape(org))
+	if params.Org != "" {
+		path = fmt.Sprintf("/orgs/%s/repos", url.PathEscape(params.Org))
 	} else {
 		path = "/user/repos"
 	}

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -25,6 +26,7 @@ type createRepoParams struct {
 }
 
 func (p *createRepoParams) validate() error {
+	p.Name = strings.TrimSpace(p.Name)
 	if p.Name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}
 	}

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -34,6 +34,7 @@ func (p *createRepoParams) validate() error {
 	if p.Org != "" && !orgNameRe.MatchString(p.Org) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid org name %q: must contain only alphanumeric characters and hyphens", p.Org)}
 	}
+	p.Description = strings.TrimSpace(p.Description)
 	return nil
 }
 

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -25,6 +26,7 @@ type createRepoParams struct {
 }
 
 func (p *createRepoParams) validate() error {
+	p.Name = strings.TrimSpace(p.Name)
 	if err := validateRepoName(p.Name); err != nil {
 		return err
 	}
@@ -47,9 +49,10 @@ func (a *createRepoAction) Execute(ctx context.Context, req connectors.ActionReq
 		ghBody["description"] = params.Description
 	}
 
+	org := strings.TrimSpace(params.Org)
 	var path string
-	if params.Org != "" {
-		path = fmt.Sprintf("/orgs/%s/repos", url.PathEscape(params.Org))
+	if org != "" {
+		path = fmt.Sprintf("/orgs/%s/repos", url.PathEscape(org))
 	} else {
 		path = "/user/repos"
 	}

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -47,6 +47,10 @@ func (a *createRepoAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	org := strings.TrimSpace(params.Org)
+	if org != "" && !repoNameRe.MatchString(org) {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid org name %q: must contain only alphanumeric characters, hyphens, underscores, and dots", org)}
+	}
+
 	var path string
 	if org != "" {
 		path = fmt.Sprintf("/orgs/%s/repos", url.PathEscape(org))

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// createRepoAction implements connectors.Action for github.create_repo.
+// It creates a new repository via POST /user/repos (personal) or
+// POST /orgs/{org}/repos (organization).
+type createRepoAction struct {
+	conn *GitHubConnector
+}
+
+type createRepoParams struct {
+	Name        string `json:"name"`
+	Org         string `json:"org"`
+	Description string `json:"description"`
+	Private     bool   `json:"private"`
+	AutoInit    bool   `json:"auto_init"`
+}
+
+func (p *createRepoParams) validate() error {
+	if p.Name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	return nil
+}
+
+// Execute creates a GitHub repository and returns the created repo data.
+func (a *createRepoAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseAndValidate[createRepoParams](req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	ghBody := map[string]any{
+		"name":      params.Name,
+		"private":   params.Private,
+		"auto_init": params.AutoInit,
+	}
+	if params.Description != "" {
+		ghBody["description"] = params.Description
+	}
+
+	var path string
+	if params.Org != "" {
+		path = fmt.Sprintf("/orgs/%s/repos", url.PathEscape(params.Org))
+	} else {
+		path = "/user/repos"
+	}
+
+	var ghResp struct {
+		ID          int    `json:"id"`
+		Name        string `json:"name"`
+		FullName    string `json:"full_name"`
+		Private     bool   `json:"private"`
+		HTMLURL     string `json:"html_url"`
+		CloneURL    string `json:"clone_url"`
+		Description string `json:"description"`
+	}
+
+	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(ghResp)
+}

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -26,9 +25,8 @@ type createRepoParams struct {
 }
 
 func (p *createRepoParams) validate() error {
-	p.Name = strings.TrimSpace(p.Name)
-	if p.Name == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	if err := validateRepoName(p.Name); err != nil {
+		return err
 	}
 	return nil
 }

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -27,10 +27,7 @@ type createRepoParams struct {
 
 func (p *createRepoParams) validate() error {
 	p.Name = strings.TrimSpace(p.Name)
-	if err := validateRepoName(p.Name); err != nil {
-		return err
-	}
-	return nil
+	return validateRepoName(p.Name)
 }
 
 // Execute creates a GitHub repository and returns the created repo data.

--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -47,8 +47,8 @@ func (a *createRepoAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	org := strings.TrimSpace(params.Org)
-	if org != "" && !repoNameRe.MatchString(org) {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid org name %q: must contain only alphanumeric characters, hyphens, underscores, and dots", org)}
+	if org != "" && !orgNameRe.MatchString(org) {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid org name %q: must contain only alphanumeric characters and hyphens", org)}
 	}
 
 	var path string

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -182,6 +182,10 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 			params: `{"name":"   "}`,
 		},
 		{
+			name:   "invalid characters in name",
+			params: `{"name":"my repo/here"}`,
+		},
+		{
 			name:   "invalid JSON",
 			params: `{invalid}`,
 		},

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -265,6 +265,10 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 			params: `{"name":".."}`,
 		},
 		{
+			name:   "name ending in .git",
+			params: `{"name":"myrepo.git"}`,
+		},
+		{
 			name:   "invalid characters in name",
 			params: `{"name":"my repo/here"}`,
 		},
@@ -283,6 +287,14 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 		{
 			name:   "invalid org name with underscores",
 			params: `{"name":"valid-repo","org":"my_org"}`,
+		},
+		{
+			name:   "invalid org name leading hyphen",
+			params: `{"name":"valid-repo","org":"-leading"}`,
+		},
+		{
+			name:   "invalid org name trailing hyphen",
+			params: `{"name":"valid-repo","org":"trailing-"}`,
 		},
 		{
 			name:   "invalid JSON",

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -178,6 +178,10 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 			params: `{"name":""}`,
 		},
 		{
+			name:   "whitespace-only name",
+			params: `{"name":"   "}`,
+		},
+		{
 			name:   "invalid JSON",
 			params: `{invalid}`,
 		},

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -122,6 +122,44 @@ func TestCreateRepo_OrgSuccess(t *testing.T) {
 	}
 }
 
+func TestCreateRepo_NameTrimmed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		// Verify the trimmed name reaches the API, not the padded original.
+		if reqBody["name"] != "my-repo" {
+			t.Errorf("name = %q, want %q (should be trimmed)", reqBody["name"], "my-repo")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "my-repo",
+			"full_name": "octocat/my-repo",
+			"html_url":  "https://github.com/octocat/my-repo",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"  my-repo  "}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
 func TestCreateRepo_DescriptionOptional(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -224,6 +224,14 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 			params: `{"name":"my repo/here"}`,
 		},
 		{
+			name:   "name exceeds 100 characters",
+			params: `{"name":"aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeX"}`,
+		},
+		{
+			name:   "invalid org name",
+			params: `{"name":"valid-repo","org":"bad org/name"}`,
+		},
+		{
 			name:   "invalid JSON",
 			params: `{invalid}`,
 		},

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -228,8 +228,16 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 			params: `{"name":"aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeX"}`,
 		},
 		{
-			name:   "invalid org name",
+			name:   "invalid org name with spaces and slashes",
 			params: `{"name":"valid-repo","org":"bad org/name"}`,
+		},
+		{
+			name:   "invalid org name with dots",
+			params: `{"name":"valid-repo","org":"my.company"}`,
+		},
+		{
+			name:   "invalid org name with underscores",
+			params: `{"name":"valid-repo","org":"my_org"}`,
 		},
 		{
 			name:   "invalid JSON",

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -1,0 +1,285 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCreateRepo_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/user/repos" {
+			t.Errorf("path = %s, want /user/repos", r.URL.Path)
+		}
+
+		if got := r.Header.Get("Authorization"); got != "Bearer ghp_test123" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer ghp_test123")
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if reqBody["name"] != "my-new-repo" {
+			t.Errorf("name = %q, want %q", reqBody["name"], "my-new-repo")
+		}
+		if reqBody["private"] != true {
+			t.Errorf("private = %v, want true", reqBody["private"])
+		}
+		if reqBody["description"] != "A test repo" {
+			t.Errorf("description = %q, want %q", reqBody["description"], "A test repo")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":          12345,
+			"name":        "my-new-repo",
+			"full_name":   "octocat/my-new-repo",
+			"private":     true,
+			"html_url":    "https://github.com/octocat/my-new-repo",
+			"clone_url":   "https://github.com/octocat/my-new-repo.git",
+			"description": "A test repo",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"my-new-repo","private":true,"description":"A test repo"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["full_name"] != "octocat/my-new-repo" {
+		t.Errorf("full_name = %v, want octocat/my-new-repo", data["full_name"])
+	}
+	if data["html_url"] != "https://github.com/octocat/my-new-repo" {
+		t.Errorf("html_url = %v, want https://github.com/octocat/my-new-repo", data["html_url"])
+	}
+}
+
+func TestCreateRepo_OrgSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orgs/my-org/repos" {
+			t.Errorf("path = %s, want /orgs/my-org/repos", r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":        67890,
+			"name":      "org-repo",
+			"full_name": "my-org/org-repo",
+			"private":   false,
+			"html_url":  "https://github.com/my-org/org-repo",
+			"clone_url": "https://github.com/my-org/org-repo.git",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"org-repo","org":"my-org"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["full_name"] != "my-org/org-repo" {
+		t.Errorf("full_name = %v, want my-org/org-repo", data["full_name"])
+	}
+}
+
+func TestCreateRepo_DescriptionOptional(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if _, ok := reqBody["description"]; ok {
+			t.Error("description field should not be present when empty")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "bare-repo",
+			"full_name": "octocat/bare-repo",
+			"html_url":  "https://github.com/octocat/bare-repo",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"bare-repo"}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
+func TestCreateRepo_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := conn.Actions()["github.create_repo"]
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{
+			name:   "missing name",
+			params: `{"org":"my-org"}`,
+		},
+		{
+			name:   "empty name",
+			params: `{"name":""}`,
+		},
+		{
+			name:   "invalid JSON",
+			params: `{invalid}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := action.Execute(t.Context(), connectors.ActionRequest{
+				ActionType:  "github.create_repo",
+				Parameters:  json.RawMessage(tt.params),
+				Credentials: validCreds(),
+			})
+			if err == nil {
+				t.Fatal("Execute() expected error, got nil")
+			}
+			if !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestCreateRepo_GitHubAPIError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Internal Server Error",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"test-repo"}`),
+		Credentials: validCreds(),
+	})
+
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got %T: %v", err, err)
+	}
+}
+
+func TestCreateRepo_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Bad credentials",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"test-repo"}`),
+		Credentials: connectors.NewCredentials(map[string]string{"api_key": "bad_token"}),
+	})
+
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got %T: %v", err, err)
+	}
+}
+
+func TestCreateRepo_Timeout(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
+	defer cancel()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(ctx, connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"test-repo"}`),
+		Credentials: validCreds(),
+	})
+
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	if !connectors.IsTimeoutError(err) {
+		t.Errorf("expected TimeoutError, got %T: %v", err, err)
+	}
+}

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -197,6 +197,43 @@ func TestCreateRepo_DescriptionOptional(t *testing.T) {
 	}
 }
 
+func TestCreateRepo_WhitespaceDescription(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshaling request body: %v", err)
+		}
+		if _, ok := reqBody["description"]; ok {
+			t.Error("description field should not be present when whitespace-only")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "my-repo",
+			"full_name": "octocat/my-repo",
+			"html_url":  "https://github.com/octocat/my-repo",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"my-repo","description":"   "}`),
+		Credentials: validCreds(),
+	})
+
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+}
+
 func TestCreateRepo_MissingParams(t *testing.T) {
 	t.Parallel()
 
@@ -218,6 +255,14 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 		{
 			name:   "whitespace-only name",
 			params: `{"name":"   "}`,
+		},
+		{
+			name:   "dot-only name",
+			params: `{"name":"."}`,
+		},
+		{
+			name:   "double-dot name",
+			params: `{"name":".."}`,
 		},
 		{
 			name:   "invalid characters in name",

--- a/connectors/github/github.go
+++ b/connectors/github/github.go
@@ -70,6 +70,7 @@ func (c *GitHubConnector) Actions() map[string]connectors.Action {
 		"github.create_webhook":        &createWebhookAction{conn: c},
 		"github.search_code":           &searchCodeAction{conn: c},
 		"github.search_issues":         &searchIssuesAction{conn: c},
+		"github.create_repo":           &createRepoAction{conn: c},
 	}
 }
 

--- a/connectors/github/github_test.go
+++ b/connectors/github/github_test.go
@@ -39,6 +39,7 @@ func TestGitHubConnector_Actions(t *testing.T) {
 		"github.create_webhook",
 		"github.search_code",
 		"github.search_issues",
+		"github.create_repo",
 	}
 	for _, at := range want {
 		if _, ok := actions[at]; !ok {
@@ -125,8 +126,8 @@ func TestGitHubConnector_Manifest(t *testing.T) {
 	if m.Name != "GitHub" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "GitHub")
 	}
-	if len(m.Actions) != 19 {
-		t.Fatalf("Manifest().Actions has %d items, want 19", len(m.Actions))
+	if len(m.Actions) != 20 {
+		t.Fatalf("Manifest().Actions has %d items, want 20", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -140,6 +141,7 @@ func TestGitHubConnector_Manifest(t *testing.T) {
 		"github.list_repos", "github.get_repo", "github.list_pull_requests",
 		"github.trigger_workflow", "github.list_workflow_runs",
 		"github.create_webhook", "github.search_code", "github.search_issues",
+		"github.create_repo",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)

--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -690,6 +690,44 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:  "github.create_repo",
+				Name:        "Create Repository",
+				Description: "Create a new repository for the authenticated user or an organization",
+				RiskLevel:   "medium",
+				Preview: &connectors.ActionPreview{
+					Layout: "record",
+					Fields: map[string]string{"title": "name", "subtitle": "org"},
+				},
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["name"],
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "Repository name"
+						},
+						"org": {
+							"type": "string",
+							"description": "Organization to create the repository in (omit to create under the authenticated user)"
+						},
+						"description": {
+							"type": "string",
+							"description": "Repository description"
+						},
+						"private": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether the repository is private"
+						},
+						"auto_init": {
+							"type": "boolean",
+							"default": false,
+							"description": "Whether to initialize with a README"
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -873,6 +911,21 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Name:        "Search issues and PRs",
 				Description: "Agent can search issues and pull requests across all accessible repositories.",
 				Parameters:  json.RawMessage(`{"q":"*","sort":"*","order":"*","per_page":"*"}`),
+			},
+			// --- Repo creation templates ---
+			{
+				ID:          "tpl_github_create_repo",
+				ActionType:  "github.create_repo",
+				Name:        "Create repositories",
+				Description: "Agent can create repositories for the authenticated user or any organization.",
+				Parameters:  json.RawMessage(`{"name":"*","org":"*","description":"*","private":"*","auto_init":"*"}`),
+			},
+			{
+				ID:          "tpl_github_create_repo_private",
+				ActionType:  "github.create_repo",
+				Name:        "Create private repositories only",
+				Description: "Agent can create repositories but they must be private.",
+				Parameters:  json.RawMessage(`{"name":"*","org":"*","description":"*","private":true,"auto_init":"*"}`),
 			},
 		},
 	}

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -115,10 +115,9 @@ func setPagination(q url.Values, perPage, page int) {
 var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // validateRepoName checks that a repository name is valid per GitHub's naming rules.
-// Names must be non-empty after trimming whitespace and contain only alphanumeric
-// characters, hyphens, underscores, and dots.
+// Names must be non-empty and contain only alphanumeric characters, hyphens,
+// underscores, and dots. Callers should TrimSpace before calling.
 func validateRepoName(name string) error {
-	name = strings.TrimSpace(name)
 	if name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}
 	}

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -121,6 +121,9 @@ func validateRepoName(name string) error {
 	if name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}
 	}
+	if len(name) > 100 {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name: must not exceed 100 characters (got %d)", len(name))}
+	}
 	if !repoNameRe.MatchString(name) {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name %q: must contain only alphanumeric characters, hyphens, underscores, and dots", name)}
 	}

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -108,6 +109,23 @@ func setPagination(q url.Values, perPage, page int) {
 	if page > 1 {
 		q.Set("page", fmt.Sprintf("%d", page))
 	}
+}
+
+// repoNameRe matches valid GitHub repository names: alphanumeric, hyphen, underscore, dot.
+var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// validateRepoName checks that a repository name is valid per GitHub's naming rules.
+// Names must be non-empty after trimming whitespace and contain only alphanumeric
+// characters, hyphens, underscores, and dots.
+func validateRepoName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: name"}
+	}
+	if !repoNameRe.MatchString(name) {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name %q: must contain only alphanumeric characters, hyphens, underscores, and dots", name)}
+	}
+	return nil
 }
 
 // invalidRefChars contains characters forbidden in git ref names.

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -124,6 +124,9 @@ func validateRepoName(name string) error {
 	if name == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: name"}
 	}
+	if name == "." || name == ".." {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name %q: '.' and '..' are reserved", name)}
+	}
 	if len(name) > 100 {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name: must not exceed 100 characters (got %d)", len(name))}
 	}

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -114,6 +114,9 @@ func setPagination(q url.Values, perPage, page int) {
 // repoNameRe matches valid GitHub repository names: alphanumeric, hyphen, underscore, dot.
 var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
+// orgNameRe matches valid GitHub organization/user names: alphanumeric and hyphens only.
+var orgNameRe = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+
 // validateRepoName checks that a repository name is valid per GitHub's naming rules.
 // Names must be non-empty and contain only alphanumeric characters, hyphens,
 // underscores, and dots. Callers should TrimSpace before calling.

--- a/connectors/github/validation.go
+++ b/connectors/github/validation.go
@@ -114,8 +114,9 @@ func setPagination(q url.Values, perPage, page int) {
 // repoNameRe matches valid GitHub repository names: alphanumeric, hyphen, underscore, dot.
 var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
-// orgNameRe matches valid GitHub organization/user names: alphanumeric and hyphens only.
-var orgNameRe = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+// orgNameRe matches valid GitHub organization/user names: alphanumeric and hyphens,
+// must start and end with an alphanumeric character.
+var orgNameRe = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`)
 
 // validateRepoName checks that a repository name is valid per GitHub's naming rules.
 // Names must be non-empty and contain only alphanumeric characters, hyphens,
@@ -126,6 +127,9 @@ func validateRepoName(name string) error {
 	}
 	if name == "." || name == ".." {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name %q: '.' and '..' are reserved", name)}
+	}
+	if strings.HasSuffix(name, ".git") {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name %q: names ending with '.git' are reserved", name)}
 	}
 	if len(name) > 100 {
 		return &connectors.ValidationError{Message: fmt.Sprintf("invalid repository name: must not exceed 100 characters (got %d)", len(name))}


### PR DESCRIPTION
## Summary

- Adds the missing `github.create_repo` action to the GitHub connector, fixing the "no connector for approval" error when users try to create repos through the GitHub connector
- Supports both personal repos (`POST /user/repos`) and organization repos (`POST /orgs/{org}/repos`)
- Includes manifest entry with parameter schema, preview config, and two permission templates (general + private-only)

## Test plan

### Claude Code
- [x] Unit tests for success (user repo), org repo, optional description, missing params, API error, auth failure, and timeout
- [x] Updated `TestGitHubConnector_Actions` and `TestGitHubConnector_Manifest` assertions for the new action
- [x] All existing GitHub connector tests still pass

### Manual Testing
- [ ] Create a repo approval through the UI and verify the action executes successfully
- [ ] Test org repo creation path
- [ ] Verify the manifest shows up correctly in connector settings

https://claude.ai/code/session_01P5iWPSLrdmeeM3geHLKYX6