### PR TITLE
Fix modal scrolling on mobile Safari

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -52,20 +52,22 @@ function DialogContent({
   return (
     <DialogPortal>
       <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
-        )}
-        {...props}
-      >
-        {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      </DialogPrimitive.Content>
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          className={cn(
+            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid w-full gap-4 overflow-hidden overscroll-contain rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+      </div>
     </DialogPortal>
   );
 }

--- a/frontend/src/pages/agents/ManagePaymentMethodsDialog.tsx
+++ b/frontend/src/pages/agents/ManagePaymentMethodsDialog.tsx
@@ -164,7 +164,7 @@ export function ManagePaymentMethodsDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
           <DialogHeader>
             <div className="flex items-center gap-2">
               <CreditCard className="text-muted-foreground size-5" />

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -169,7 +169,7 @@ export function AddActionConfigDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Add Action Configuration</DialogTitle>

--- a/frontend/src/pages/agents/connectors/ConnectorActionsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorActionsDialog.tsx
@@ -28,7 +28,7 @@ export function ConnectorActionsDialog({
 }: ConnectorActionsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Available Actions</DialogTitle>
           <DialogDescription>

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -120,7 +120,7 @@ export function EditActionConfigDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Edit Action Configuration</DialogTitle>

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -82,7 +82,7 @@ export function ManageCredentialsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             Manage {connectorLabel ?? "Credentials"}

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -376,7 +376,7 @@ export function CreateStandingApprovalDialog({
         onOpenChange(v);
       }}
     >
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Create Standing Approval</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- Replace CSS translate-based centering with a flexbox wrapper in `DialogContent`, fixing unreliable touch scrolling on iOS Safari
- Switch all dialog `max-height` values from `vh` to `dvh` (dynamic viewport height) so modals respect the mobile address bar

## Why
On iOS Safari, `overflow-y: auto` on a `fixed` element with CSS transforms (`translate-x/y`) creates a new stacking context that breaks touch scroll events. The fix uses a flex-centering wrapper (`fixed inset-0 flex items-center justify-center`) so the dialog content is `relative` instead of `fixed+transformed`.

## Test plan

### Claude Code
- [x] Run `make test-frontend` — passes (pre-existing failures only)
- [x] Run TypeScript type check — no new errors

### Manual Testing
- [ ] Open "Create Standing Approval" modal on iOS Safari and verify smooth scrolling through all constraint fields
- [ ] Verify other dialogs (Add Action Config, Edit Action Config, Manage Credentials, Payment Methods) scroll correctly on mobile
- [ ] Verify click-outside-to-dismiss still works on desktop
- [ ] Verify dialog open/close animations look correct
- [ ] Verify close (X) button still works

https://claude.ai/code/session_01Ya1pEiuoiwcUysuPeLu561