### PR TITLE
fix: auto-assign credential to agent after OAuth or API key creation

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -515,18 +515,18 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		// triggering frontend redirects with arbitrary error text.
 		stateStr := r.URL.Query().Get("state")
 		if stateStr == "" {
-			redirectToFrontend(w, r, deps, providerID, "error", "Missing state parameter", "")
+			redirectToFrontend(w, r, deps, providerID, "error", "Missing state parameter", "", "")
 			return
 		}
 		state, err := verifyOAuthState(deps, stateStr)
 		if err != nil {
 			log.Printf("[%s] OAuthCallback: invalid state: %v", TraceID(r.Context()), err)
-			redirectToFrontend(w, r, deps, providerID, "error", "Invalid or expired state token", "")
+			redirectToFrontend(w, r, deps, providerID, "error", "Invalid or expired state token", "", "")
 			return
 		}
 		if state.Provider != providerID {
 			log.Printf("[%s] OAuthCallback: provider mismatch: state=%s path=%s", TraceID(r.Context()), state.Provider, providerID)
-			redirectToFrontend(w, r, deps, providerID, "error", "Provider mismatch", state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", "Provider mismatch", state.ReturnTo, "")
 			return
 		}
 
@@ -538,7 +538,7 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			if errDesc == "" {
 				errDesc = errCode
 			}
-			redirectToFrontend(w, r, deps, providerID, "error", errDesc, state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", errDesc, state.ReturnTo, "")
 			return
 		}
 
@@ -552,19 +552,19 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		profile, err := db.GetProfileByUserID(r.Context(), deps.DB, userID)
 		if err != nil || profile == nil {
 			log.Printf("[%s] OAuthCallback: profile lookup failed: %v", TraceID(r.Context()), err)
-			redirectToFrontend(w, r, deps, providerID, "error", "Profile not found", state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", "Profile not found", state.ReturnTo, "")
 			return
 		}
 
 		code := r.URL.Query().Get("code")
 		if code == "" {
-			redirectToFrontend(w, r, deps, providerID, "error", "Missing authorization code", state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", "Missing authorization code", state.ReturnTo, "")
 			return
 		}
 
 		provider, ok := deps.OAuthProviders.Get(providerID)
 		if !ok {
-			redirectToFrontend(w, r, deps, providerID, "error", "Provider not found", state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", "Provider not found", state.ReturnTo, "")
 			return
 		}
 
@@ -590,7 +590,7 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		token, err := cfg.Exchange(ctx, code)
 		if err != nil {
 			log.Printf("[%s] OAuthCallback: token exchange failed: %v", TraceID(r.Context()), err)
-			redirectToFrontend(w, r, deps, providerID, "error", "Token exchange failed", state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", "Token exchange failed", state.ReturnTo, "")
 			return
 		}
 
@@ -629,7 +629,7 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			extra, err := enricher(ctx, token.AccessToken)
 			if err != nil {
 				log.Printf("[%s] OAuthCallback: post-OAuth enrichment for %q failed: %v", TraceID(r.Context()), providerID, err)
-				redirectToFrontend(w, r, deps, providerID, "error", "Could not retrieve account information — please try again", state.ReturnTo)
+				redirectToFrontend(w, r, deps, providerID, "error", "Could not retrieve account information — please try again", state.ReturnTo, "")
 				return
 			}
 			if stateExtraData == nil {
@@ -651,13 +651,14 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		if err := storeOAuthTokens(r.Context(), deps, profile.ID, providerID, storedScopes, token, stateExtraData, state.ReplaceID); err != nil {
+		connID, err := storeOAuthTokens(r.Context(), deps, profile.ID, providerID, storedScopes, token, stateExtraData, state.ReplaceID)
+		if err != nil {
 			log.Printf("[%s] OAuthCallback: store tokens: %v", TraceID(r.Context()), err)
-			redirectToFrontend(w, r, deps, providerID, "error", "Failed to store connection", state.ReturnTo)
+			redirectToFrontend(w, r, deps, providerID, "error", "Failed to store connection", state.ReturnTo, "")
 			return
 		}
 
-		redirectToFrontend(w, r, deps, providerID, "success", "", state.ReturnTo)
+		redirectToFrontend(w, r, deps, providerID, "success", "", state.ReturnTo, connID)
 	}
 }
 
@@ -673,10 +674,10 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 // replaceID, if non-empty, is the ID of an existing connection to replace.
 // When set, only that specific connection is deleted. When empty, a new
 // connection is created alongside any existing ones for the same provider.
-func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string, scopes []string, token *oauth2.Token, stateExtra map[string]string, replaceID string) error {
+func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string, scopes []string, token *oauth2.Token, stateExtra map[string]string, replaceID string) (string, error) {
 	tx, owned, err := db.BeginOrContinue(ctx, deps.DB)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return "", fmt.Errorf("begin tx: %w", err)
 	}
 	if owned {
 		defer db.RollbackTx(ctx, tx) //nolint:errcheck // best-effort cleanup
@@ -692,14 +693,14 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 		// connection while authorizing Google).
 		oldConn, lookupErr := db.GetOAuthConnectionByID(ctx, tx, replaceID)
 		if lookupErr != nil {
-			return fmt.Errorf("lookup connection to replace: %w", lookupErr)
+			return "", fmt.Errorf("lookup connection to replace: %w", lookupErr)
 		}
 		if oldConn != nil && oldConn.UserID == userID && oldConn.Provider == providerID {
 			existing, err = db.DeleteOAuthConnectionByID(ctx, tx, userID, replaceID)
 			if err != nil {
 				var connErr *db.OAuthConnectionError
 				if !errors.As(err, &connErr) || connErr.Code != db.OAuthConnectionErrNotFound {
-					return fmt.Errorf("delete existing connection: %w", err)
+					return "", fmt.Errorf("delete existing connection: %w", err)
 				}
 			}
 		} else if oldConn != nil && oldConn.Provider != providerID {
@@ -718,14 +719,14 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 
 		// Always clean up the old access token secret.
 		if err := deps.Vault.DeleteSecret(ctx, tx, existing.AccessTokenVaultID); err != nil {
-			return fmt.Errorf("delete orphaned access token secret: %w", err)
+			return "", fmt.Errorf("delete orphaned access token secret: %w", err)
 		}
 
 		// Only delete the old refresh token secret if the new token includes
 		// a replacement. Otherwise we reuse the existing vault entry.
 		if existing.RefreshTokenVaultID != nil && token.RefreshToken != "" {
 			if err := deps.Vault.DeleteSecret(ctx, tx, *existing.RefreshTokenVaultID); err != nil {
-				return fmt.Errorf("delete orphaned refresh token secret: %w", err)
+				return "", fmt.Errorf("delete orphaned refresh token secret: %w", err)
 			}
 			oldRefreshVaultID = nil // cleared — will create fresh below
 		}
@@ -733,19 +734,19 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 
 	connID, err := generatePrefixedID("oconn_", 16)
 	if err != nil {
-		return fmt.Errorf("generate connection ID: %w", err)
+		return "", fmt.Errorf("generate connection ID: %w", err)
 	}
 
 	accessVaultID, err := deps.Vault.CreateSecret(ctx, tx, connID+"_access", []byte(token.AccessToken))
 	if err != nil {
-		return fmt.Errorf("vault create access token: %w", err)
+		return "", fmt.Errorf("vault create access token: %w", err)
 	}
 
 	var refreshVaultID *string
 	if token.RefreshToken != "" {
 		id, err := deps.Vault.CreateSecret(ctx, tx, connID+"_refresh", []byte(token.RefreshToken))
 		if err != nil {
-			return fmt.Errorf("vault create refresh token: %w", err)
+			return "", fmt.Errorf("vault create refresh token: %w", err)
 		}
 		refreshVaultID = &id
 	} else if oldRefreshVaultID != nil {
@@ -778,15 +779,15 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 		ExtraData:           extraData,
 	})
 	if err != nil {
-		return fmt.Errorf("create connection: %w", err)
+		return "", fmt.Errorf("create connection: %w", err)
 	}
 
 	if owned {
 		if err := db.CommitTx(ctx, tx); err != nil {
-			return fmt.Errorf("commit: %w", err)
+			return "", fmt.Errorf("commit: %w", err)
 		}
 	}
-	return nil
+	return connID, nil
 }
 
 // tokenExtraKeys lists the extra fields from OAuth token responses that should
@@ -1119,7 +1120,7 @@ func oauthCallbackURL(deps *Deps, providerID string) string {
 // started the OAuth flow from (returnTo), or to "/" if no return path was
 // provided. Status and error info are passed as query parameters so the
 // frontend can display an appropriate toast.
-func redirectToFrontend(w http.ResponseWriter, r *http.Request, deps *Deps, provider, status, errMsg, returnTo string) {
+func redirectToFrontend(w http.ResponseWriter, r *http.Request, deps *Deps, provider, status, errMsg, returnTo, connectionID string) {
 	path := "/"
 	if returnTo != "" && isRelativePath(returnTo) {
 		path = returnTo
@@ -1133,6 +1134,9 @@ func redirectToFrontend(w http.ResponseWriter, r *http.Request, deps *Deps, prov
 	q.Set("oauth_status", status)
 	if errMsg != "" {
 		q.Set("oauth_error", errMsg)
+	}
+	if connectionID != "" {
+		q.Set("oauth_connection_id", connectionID)
 	}
 	parsedURL.RawQuery = q.Encode()
 	http.Redirect(w, r, parsedURL.String(), http.StatusTemporaryRedirect)

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -804,7 +804,7 @@ func TestStoreOAuthTokens_CreateNew(t *testing.T) {
 		TokenType:    "Bearer",
 	}
 
-	err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token, nil, "")
+	_, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token, nil, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}
@@ -843,7 +843,7 @@ func TestStoreOAuthTokens_ReplacesExisting(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -860,7 +860,7 @@ func TestStoreOAuthTokens_ReplacesExisting(t *testing.T) {
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -892,7 +892,7 @@ func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -914,7 +914,7 @@ func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -965,7 +965,7 @@ func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -982,7 +982,7 @@ func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil, conn1.ID); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -1307,7 +1307,7 @@ func TestStoreOAuthTokens_WithStateExtra(t *testing.T) {
 	}
 
 	stateExtra := map[string]string{"shop_domain": "mystore.myshopify.com"}
-	err := storeOAuthTokens(t.Context(), deps, uid, "shopify", []string{"write_orders"}, token, stateExtra, "")
+	_, err := storeOAuthTokens(t.Context(), deps, uid, "shopify", []string{"write_orders"}, token, stateExtra, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}
@@ -1818,7 +1818,7 @@ func TestStoreOAuthTokens_WithZendeskSubdomain(t *testing.T) {
 	}
 
 	stateExtra := map[string]string{"subdomain": "mycompany"}
-	err := storeOAuthTokens(t.Context(), deps, uid, "zendesk", []string{"read", "write"}, token, stateExtra, "")
+	_, err := storeOAuthTokens(t.Context(), deps, uid, "zendesk", []string{"read", "write"}, token, stateExtra, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}

--- a/frontend/src/hooks/useAutoAssignOAuthCredential.ts
+++ b/frontend/src/hooks/useAutoAssignOAuthCredential.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import {
+  useAgentConnectorCredential,
+  useAssignAgentConnectorCredential,
+} from "./useAgentConnectorCredential";
+
+/**
+ * After an OAuth flow completes, the backend redirects back with
+ * `oauth_connection_id` as a query parameter. This hook reads that
+ * parameter and auto-assigns the new OAuth connection to the current
+ * agent+connector — unless a credential is already assigned.
+ *
+ * Mount this on the agent connector page (ConnectorCredentialsSection).
+ */
+export function useAutoAssignOAuthCredential(
+  agentId: number,
+  connectorId: string,
+) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { binding, isLoading: bindingLoading } =
+    useAgentConnectorCredential(agentId, connectorId);
+  const { assign } = useAssignAgentConnectorCredential();
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    if (bindingLoading) return;
+
+    const connectionId = searchParams.get("oauth_connection_id");
+    if (!connectionId) return;
+
+    firedRef.current = true;
+
+    // Clean up the param from the URL
+    searchParams.delete("oauth_connection_id");
+    setSearchParams(searchParams, { replace: true });
+
+    // Skip if agent already has a credential assigned
+    if (binding?.credential_id || binding?.oauth_connection_id) return;
+
+    assign({ agentId, connectorId, oauthConnectionId: connectionId })
+      .then(() => {
+        toast.success("OAuth connection assigned to this agent.");
+      })
+      .catch(() => {
+        // Assignment failed — user can still assign manually via dropdown
+      });
+  }, [bindingLoading]); // eslint-disable-line react-hooks/exhaustive-deps -- run once when binding loads
+}

--- a/frontend/src/hooks/useAutoAssignOAuthCredential.ts
+++ b/frontend/src/hooks/useAutoAssignOAuthCredential.ts
@@ -30,9 +30,11 @@ export function useAutoAssignOAuthCredential(
 
     firedRef.current = true;
 
-    // Clean up the param from the URL
-    params.delete("oauth_connection_id");
-    setSearchParams(params, { replace: true });
+    // Clean up the param from the URL (work on a copy to avoid mutating
+    // the live URLSearchParams instance before React Router re-renders).
+    const cleaned = new URLSearchParams(params);
+    cleaned.delete("oauth_connection_id");
+    setSearchParams(cleaned, { replace: true });
 
     // connectionId comes from the URL (set by our backend's OAuth redirect).
     // The assign endpoint validates ownership and provider match server-side.

--- a/frontend/src/hooks/useAutoAssignOAuthCredential.ts
+++ b/frontend/src/hooks/useAutoAssignOAuthCredential.ts
@@ -44,8 +44,12 @@ export function useAutoAssignOAuthCredential(
       .then(() => {
         toast.success("OAuth connection assigned to this agent.");
       })
-      .catch(() => {
-        // Assignment failed — user can still assign manually via dropdown
+      .catch((err) => {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : "Could not auto-assign credential — please select it manually.",
+        );
       });
   }, [bindingLoading]); // eslint-disable-line react-hooks/exhaustive-deps -- run once when binding loads
 }

--- a/frontend/src/hooks/useAutoAssignOAuthCredential.ts
+++ b/frontend/src/hooks/useAutoAssignOAuthCredential.ts
@@ -34,6 +34,8 @@ export function useAutoAssignOAuthCredential(
     params.delete("oauth_connection_id");
     setSearchParams(params, { replace: true });
 
+    // connectionId comes from the URL (set by our backend's OAuth redirect).
+    // The assign endpoint validates ownership and provider match server-side.
     tryAssign({ oauthConnectionId: connectionId });
   }, [bindingLoading]); // eslint-disable-line react-hooks/exhaustive-deps -- run once when binding loads
 }

--- a/frontend/src/hooks/useAutoAssignOAuthCredential.ts
+++ b/frontend/src/hooks/useAutoAssignOAuthCredential.ts
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
-import { toast } from "sonner";
-import {
-  useAgentConnectorCredential,
-  useAssignAgentConnectorCredential,
-} from "./useAgentConnectorCredential";
+import { useTryAutoAssign } from "./useTryAutoAssign";
 
 /**
  * After an OAuth flow completes, the backend redirects back with
@@ -19,37 +15,25 @@ export function useAutoAssignOAuthCredential(
   connectorId: string,
 ) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { binding, isLoading: bindingLoading } =
-    useAgentConnectorCredential(agentId, connectorId);
-  const { assign } = useAssignAgentConnectorCredential();
+  const { tryAssign, bindingLoading } = useTryAutoAssign(agentId, connectorId);
   const firedRef = useRef(false);
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
 
   useEffect(() => {
     if (firedRef.current) return;
     if (bindingLoading) return;
 
-    const connectionId = searchParams.get("oauth_connection_id");
+    const params = searchParamsRef.current;
+    const connectionId = params.get("oauth_connection_id");
     if (!connectionId) return;
 
     firedRef.current = true;
 
     // Clean up the param from the URL
-    searchParams.delete("oauth_connection_id");
-    setSearchParams(searchParams, { replace: true });
+    params.delete("oauth_connection_id");
+    setSearchParams(params, { replace: true });
 
-    // Skip if agent already has a credential assigned
-    if (binding?.credential_id || binding?.oauth_connection_id) return;
-
-    assign({ agentId, connectorId, oauthConnectionId: connectionId })
-      .then(() => {
-        toast.success("OAuth connection assigned to this agent.");
-      })
-      .catch((err) => {
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : "Could not auto-assign credential — please select it manually.",
-        );
-      });
+    tryAssign({ oauthConnectionId: connectionId });
   }, [bindingLoading]); // eslint-disable-line react-hooks/exhaustive-deps -- run once when binding loads
 }

--- a/frontend/src/hooks/useOAuthCallbackToast.ts
+++ b/frontend/src/hooks/useOAuthCallbackToast.ts
@@ -43,8 +43,10 @@ export function useOAuthCallbackToast() {
     }
 
     // Remove OAuth params without a full navigation.
-    // Note: oauth_connection_id is cleaned up separately by
-    // useAutoAssignOAuthCredential so it can read the value first.
+    // Note: oauth_connection_id is left for useAutoAssignOAuthCredential
+    // which reads it on the agent connector page. On non-agent pages the
+    // param is harmless but we don't strip it here to avoid a race where
+    // the auto-assign hook hasn't read it yet.
     searchParams.delete("oauth_status");
     searchParams.delete("oauth_provider");
     searchParams.delete("oauth_error");

--- a/frontend/src/hooks/useOAuthCallbackToast.ts
+++ b/frontend/src/hooks/useOAuthCallbackToast.ts
@@ -42,7 +42,9 @@ export function useOAuthCallbackToast() {
       toast.error(detail);
     }
 
-    // Remove OAuth params without a full navigation
+    // Remove OAuth params without a full navigation.
+    // Note: oauth_connection_id is cleaned up separately by
+    // useAutoAssignOAuthCredential so it can read the value first.
     searchParams.delete("oauth_status");
     searchParams.delete("oauth_provider");
     searchParams.delete("oauth_error");

--- a/frontend/src/hooks/useTryAutoAssign.ts
+++ b/frontend/src/hooks/useTryAutoAssign.ts
@@ -1,0 +1,55 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import {
+  useAgentConnectorCredential,
+  useAssignAgentConnectorCredential,
+} from "./useAgentConnectorCredential";
+
+/**
+ * Returns a function that attempts to auto-assign a credential (static or
+ * OAuth) to the given agent+connector — but only if no credential is already
+ * bound. Shows a toast on success or failure.
+ *
+ * Pass `agentId: 0` or `undefined` to disable (the returned function becomes
+ * a no-op).
+ */
+export function useTryAutoAssign(
+  agentId: number | undefined,
+  connectorId: string,
+) {
+  const effectiveId = agentId ?? 0;
+  const { binding, isLoading: bindingLoading } =
+    useAgentConnectorCredential(effectiveId, connectorId);
+  const { assign } = useAssignAgentConnectorCredential();
+
+  const tryAssign = useCallback(
+    (params: { credentialId?: string; oauthConnectionId?: string }) => {
+      if (!effectiveId || effectiveId <= 0) return;
+      if (binding?.credential_id || binding?.oauth_connection_id) return;
+
+      assign({
+        agentId: effectiveId,
+        connectorId,
+        credentialId: params.credentialId,
+        oauthConnectionId: params.oauthConnectionId,
+      })
+        .then(() => {
+          toast.success(
+            params.oauthConnectionId
+              ? "OAuth connection assigned to this agent."
+              : "Credential assigned to this agent.",
+          );
+        })
+        .catch((err) => {
+          toast.error(
+            err instanceof Error
+              ? err.message
+              : "Could not auto-assign credential — please select it manually.",
+          );
+        });
+    },
+    [effectiveId, connectorId, binding, assign],
+  );
+
+  return { tryAssign, bindingLoading };
+}

--- a/frontend/src/hooks/useTryAutoAssign.ts
+++ b/frontend/src/hooks/useTryAutoAssign.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { toast } from "sonner";
 import {
   useAgentConnectorCredential,
@@ -21,11 +21,13 @@ export function useTryAutoAssign(
   const { binding, isLoading: bindingLoading } =
     useAgentConnectorCredential(effectiveId, connectorId);
   const { assign } = useAssignAgentConnectorCredential();
+  const bindingRef = useRef(binding);
+  bindingRef.current = binding;
 
   const tryAssign = useCallback(
     (params: { credentialId?: string; oauthConnectionId?: string }) => {
       if (!effectiveId || effectiveId <= 0) return;
-      if (binding?.credential_id || binding?.oauth_connection_id) return;
+      if (bindingRef.current?.credential_id || bindingRef.current?.oauth_connection_id) return;
 
       assign({
         agentId: effectiveId,
@@ -48,7 +50,7 @@ export function useTryAutoAssign(
           );
         });
     },
-    [effectiveId, connectorId, binding, assign],
+    [effectiveId, connectorId, assign],
   );
 
   return { tryAssign, bindingLoading };

--- a/frontend/src/pages/agents/AddConnectorDialog.tsx
+++ b/frontend/src/pages/agents/AddConnectorDialog.tsx
@@ -147,6 +147,7 @@ export function AddConnectorDialog({
             onOpenChange(false);
           }
         }}
+        agentId={agentId}
         connectorId={setupConnector.id}
         connectorName={setupConnector.name}
         connectorLogoSvg={setupConnector.logo_svg}

--- a/frontend/src/pages/agents/AgentConnectorsSection.tsx
+++ b/frontend/src/pages/agents/AgentConnectorsSection.tsx
@@ -166,6 +166,7 @@ export function AgentConnectorsSection({
             navigate(`/agents/${agentId}/connectors/${connectorId}`);
           }
         }}
+        agentId={agentId}
         connectorId={setupConnector.id}
         connectorName={setupConnector.name}
         connectorLogoSvg={setupConnector.logo_svg}

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -28,8 +28,8 @@ interface AddCredentialDialogProps {
   fieldPlaceholder?: string;
   /** Override the dialog title (default: "Add Credential"). */
   title?: string;
-  /** Called after credentials are successfully stored. */
-  onSuccess?: () => void;
+  /** Called after credentials are successfully stored, with the new credential ID. */
+  onSuccess?: (credentialId: string) => void;
 }
 
 export function AddCredentialDialog({
@@ -67,7 +67,7 @@ export function AddCredentialDialog({
     if (!credentials) return;
 
     try {
-      await storeCredential({
+      const result = await storeCredential({
         service: credential.service,
         credentials,
         label: label.trim() || undefined,
@@ -75,7 +75,9 @@ export function AddCredentialDialog({
       toast.success(`Credentials stored for ${credential.service}`);
       resetForm();
       onOpenChange(false);
-      onSuccess?.();
+      if (result?.id) {
+        onSuccess?.(result.id);
+      }
     } catch (err) {
       toast.error(
         err instanceof Error

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -75,9 +75,7 @@ export function AddCredentialDialog({
       toast.success(`Credentials stored for ${credential.service}`);
       resetForm();
       onOpenChange(false);
-      if (result?.id) {
-        onSuccess?.(result.id);
-      }
+      onSuccess?.(result?.id ?? "");
     } catch (err) {
       toast.error(
         err instanceof Error

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -75,7 +75,8 @@ export function AddCredentialDialog({
       toast.success(`Credentials stored for ${credential.service}`);
       resetForm();
       onOpenChange(false);
-      onSuccess?.(result?.id ?? "");
+      if (!result?.id) throw new Error("Unexpected response: missing credential id");
+      onSuccess?.(result.id);
     } catch (err) {
       toast.error(
         err instanceof Error

--- a/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorCredentialsSection.tsx
@@ -21,6 +21,7 @@ import {
   useAgentConnectorCredential,
   useAssignAgentConnectorCredential,
 } from "@/hooks/useAgentConnectorCredential";
+import { useAutoAssignOAuthCredential } from "@/hooks/useAutoAssignOAuthCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import type { OAuthConnection } from "@/hooks/useOAuthConnections";
 import { ManageCredentialsDialog } from "./ManageCredentialsDialog";
@@ -43,6 +44,9 @@ export function ConnectorCredentialsSection({
     [connectorId, requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
+
+  // Auto-assign OAuth credential when returning from OAuth flow
+  useAutoAssignOAuthCredential(agentId, connectorId);
 
   const hasRequiredCredentials = requiredCredentials.length > 0;
   const hasExplicitOAuth = requiredCredentials.some(
@@ -121,6 +125,7 @@ export function ConnectorCredentialsSection({
       <ManageCredentialsDialog
         open={manageDialogOpen}
         onOpenChange={setManageDialogOpen}
+        agentId={agentId}
         connectorId={connectorId}
         connectorLabel={serviceLabel(connectorId)}
         hasRequiredCredentials={hasRequiredCredentials}

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -32,6 +32,10 @@ import {
 } from "@/lib/oauth";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
+import {
+  useAgentConnectorCredential,
+  useAssignAgentConnectorCredential,
+} from "@/hooks/useAgentConnectorCredential";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
@@ -40,6 +44,7 @@ import { BYOASetupBanner } from "./BYOASetupBanner";
 export interface ManageCredentialsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  agentId?: number;
   connectorId: string;
   connectorLabel?: string;
   hasRequiredCredentials: boolean;
@@ -58,6 +63,7 @@ export interface ManageCredentialsDialogProps {
 export function ManageCredentialsDialog({
   open,
   onOpenChange,
+  agentId,
   connectorId,
   connectorLabel,
   hasRequiredCredentials,
@@ -185,6 +191,8 @@ export function ManageCredentialsDialog({
                       requiredCredential={cred}
                       storedCredentials={storedCredentials}
                       isAlternative={hasOAuth}
+                      agentId={agentId}
+                      connectorId={connectorId}
                     />
                   )}
                 </div>
@@ -488,13 +496,19 @@ function StaticCredentialRow({
   requiredCredential,
   storedCredentials,
   isAlternative,
+  agentId,
+  connectorId,
 }: {
   requiredCredential: RequiredCredential;
   storedCredentials: CredentialSummary[];
   isAlternative: boolean;
+  agentId?: number;
+  connectorId: string;
 }) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(null);
+  const { binding } = useAgentConnectorCredential(agentId ?? 0, connectorId);
+  const { assign } = useAssignAgentConnectorCredential();
 
   const isConnected = storedCredentials.length > 0;
 
@@ -590,6 +604,16 @@ function StaticCredentialRow({
         open={addDialogOpen}
         onOpenChange={setAddDialogOpen}
         credential={requiredCredential}
+        onSuccess={(credentialId) => {
+          if (
+            agentId != null &&
+            agentId > 0 &&
+            !binding?.credential_id &&
+            !binding?.oauth_connection_id
+          ) {
+            assign({ agentId, connectorId, credentialId }).catch(() => {});
+          }
+        }}
       />
 
       {removeTarget && (

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -616,7 +616,13 @@ function StaticCredentialRow({
               .then(() => {
                 toast.success("Credential assigned to this agent.");
               })
-              .catch(() => {});
+              .catch((err) => {
+                toast.error(
+                  err instanceof Error
+                    ? err.message
+                    : "Could not auto-assign credential — please select it manually.",
+                );
+              });
           }
         }}
       />

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -611,7 +612,11 @@ function StaticCredentialRow({
             !binding?.credential_id &&
             !binding?.oauth_connection_id
           ) {
-            assign({ agentId, connectorId, credentialId }).catch(() => {});
+            assign({ agentId, connectorId, credentialId })
+              .then(() => {
+                toast.success("Credential assigned to this agent.");
+              })
+              .catch(() => {});
           }
         }}
       />

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { toast } from "sonner";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -33,10 +32,7 @@ import {
 } from "@/lib/oauth";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
-import {
-  useAgentConnectorCredential,
-  useAssignAgentConnectorCredential,
-} from "@/hooks/useAgentConnectorCredential";
+import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
@@ -508,8 +504,7 @@ function StaticCredentialRow({
 }) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(null);
-  const { binding } = useAgentConnectorCredential(agentId ?? 0, connectorId);
-  const { assign } = useAssignAgentConnectorCredential();
+  const { tryAssign } = useTryAutoAssign(agentId, connectorId);
 
   const isConnected = storedCredentials.length > 0;
 
@@ -606,24 +601,7 @@ function StaticCredentialRow({
         onOpenChange={setAddDialogOpen}
         credential={requiredCredential}
         onSuccess={(credentialId) => {
-          if (
-            agentId != null &&
-            agentId > 0 &&
-            !binding?.credential_id &&
-            !binding?.oauth_connection_id
-          ) {
-            assign({ agentId, connectorId, credentialId })
-              .then(() => {
-                toast.success("Credential assigned to this agent.");
-              })
-              .catch((err) => {
-                toast.error(
-                  err instanceof Error
-                    ? err.message
-                    : "Could not auto-assign credential — please select it manually.",
-                );
-              });
-          }
+          tryAssign({ credentialId });
         }}
       />
 

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -277,7 +277,13 @@ export function SetupConnectorCredentialsDialog({
                 .then(() => {
                   toast.success("Credential assigned to this agent.");
                 })
-                .catch(() => {});
+                .catch((err) => {
+                  toast.error(
+                    err instanceof Error
+                      ? err.message
+                      : "Could not auto-assign credential — please select it manually.",
+                  );
+                });
             }
             onOpenChange(false);
           }}

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -272,7 +273,11 @@ export function SetupConnectorCredentialsDialog({
               !binding?.credential_id &&
               !binding?.oauth_connection_id
             ) {
-              assign({ agentId, connectorId, credentialId }).catch(() => {});
+              assign({ agentId, connectorId, credentialId })
+                .then(() => {
+                  toast.success("Credential assigned to this agent.");
+                })
+                .catch(() => {});
             }
             onOpenChange(false);
           }}

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -27,11 +27,16 @@ import {
   SHOP_REQUIRED_PROVIDERS,
 } from "@/lib/oauth";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import {
+  useAgentConnectorCredential,
+  useAssignAgentConnectorCredential,
+} from "@/hooks/useAgentConnectorCredential";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 
 interface SetupConnectorCredentialsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  agentId?: number;
   connectorId: string;
   connectorName: string;
   connectorLogoSvg?: string;
@@ -55,6 +60,7 @@ interface SetupConnectorCredentialsDialogProps {
 export function SetupConnectorCredentialsDialog({
   open,
   onOpenChange,
+  agentId,
   connectorId,
   connectorName,
   connectorLogoSvg,
@@ -70,6 +76,8 @@ export function SetupConnectorCredentialsDialog({
     useState(false);
   const [addCredentialTarget, setAddCredentialTarget] =
     useState<RequiredCredential | null>(null);
+  const { binding } = useAgentConnectorCredential(agentId ?? 0, connectorId);
+  const { assign } = useAssignAgentConnectorCredential();
 
   const isLoading = detailLoading || providersLoading || connectionsLoading;
   const requiredCredentials = connector?.required_credentials ?? [];
@@ -257,7 +265,17 @@ export function SetupConnectorCredentialsDialog({
             }
           }}
           credential={addCredentialTarget}
-          onSuccess={() => onOpenChange(false)}
+          onSuccess={(credentialId) => {
+            if (
+              agentId != null &&
+              agentId > 0 &&
+              !binding?.credential_id &&
+              !binding?.oauth_connection_id
+            ) {
+              assign({ agentId, connectorId, credentialId }).catch(() => {});
+            }
+            onOpenChange(false);
+          }}
         />
       )}
     </>

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { toast } from "sonner";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -28,10 +27,7 @@ import {
   SHOP_REQUIRED_PROVIDERS,
 } from "@/lib/oauth";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
-import {
-  useAgentConnectorCredential,
-  useAssignAgentConnectorCredential,
-} from "@/hooks/useAgentConnectorCredential";
+import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 
 interface SetupConnectorCredentialsDialogProps {
@@ -77,8 +73,7 @@ export function SetupConnectorCredentialsDialog({
     useState(false);
   const [addCredentialTarget, setAddCredentialTarget] =
     useState<RequiredCredential | null>(null);
-  const { binding } = useAgentConnectorCredential(agentId ?? 0, connectorId);
-  const { assign } = useAssignAgentConnectorCredential();
+  const { tryAssign } = useTryAutoAssign(agentId, connectorId);
 
   const isLoading = detailLoading || providersLoading || connectionsLoading;
   const requiredCredentials = connector?.required_credentials ?? [];
@@ -267,24 +262,7 @@ export function SetupConnectorCredentialsDialog({
           }}
           credential={addCredentialTarget}
           onSuccess={(credentialId) => {
-            if (
-              agentId != null &&
-              agentId > 0 &&
-              !binding?.credential_id &&
-              !binding?.oauth_connection_id
-            ) {
-              assign({ agentId, connectorId, credentialId })
-                .then(() => {
-                  toast.success("Credential assigned to this agent.");
-                })
-                .catch((err) => {
-                  toast.error(
-                    err instanceof Error
-                      ? err.message
-                      : "Could not auto-assign credential — please select it manually.",
-                  );
-                });
-            }
+            tryAssign({ credentialId });
             onOpenChange(false);
           }}
         />


### PR DESCRIPTION
## Summary
- When creating a credential (OAuth or API key) from an agent's connector page, the credential is now automatically assigned to that agent — no manual dropdown selection needed
- Backend: `storeOAuthTokens` returns the new connection ID, passed through the redirect URL as `oauth_connection_id`
- Frontend: New `useAutoAssignOAuthCredential` hook reads the connection ID from URL params and assigns it; for static credentials, `agentId` is threaded through dialog chain to call assign on success
- Skips auto-assignment if the agent already has a credential bound

## Test plan

### Claude Code
- [x] TypeScript compilation passes (2 pre-existing errors only)
- [x] Go `vet` passes
- [x] `ConnectorCredentialsSection` tests pass (14/14)
- [x] `AgentConnectorsSection` tests pass (8/8)
- [x] Frontend test suite passes (905/907 — 2 pre-existing failures in SchemaParameterDetails)

### Manual Testing
- [ ] Enable a connector on agent page → complete OAuth → verify credential auto-assigned
- [ ] Enable a connector on agent page → add API key → verify credential auto-assigned
- [ ] From "Manage credentials" dialog → add new OAuth connection → verify auto-assigned
- [ ] From "Manage credentials" dialog → add new API key → verify auto-assigned
- [ ] Agent already has credential → add new one → verify existing NOT replaced

https://claude.ai/code/session_01R2fjJLxwgGd73mG3mPjsum