### PR TITLE
Show connector and action name in standing approval dialog

### DIFF
--- a/frontend/src/components/SchemaParameterDetails.tsx
+++ b/frontend/src/components/SchemaParameterDetails.tsx
@@ -86,7 +86,6 @@ function ParameterRow({
   name,
   label,
   value,
-  type,
   enumValues,
   defaultValue,
   isRequired,

--- a/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
@@ -16,7 +16,6 @@ import {
   Bot,
   ChevronDown,
   ChevronRight,
-  Code2,
   Eye,
   EyeOff,
 } from "lucide-react";

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useState, useMemo } from "react";
 import { Loader2, ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { ConnectorLogo } from "@/components/ConnectorLogo";
 import {
   Dialog,
   DialogContent,
@@ -149,8 +150,13 @@ export function CreateStandingApprovalDialog({
     ? selectedConfig.action_type
     : customActionType;
 
-  const { schema: fetchedSchema, isLoading: schemaLoading } =
-    useActionSchema(effectiveActionType);
+  const {
+    schema: fetchedSchema,
+    isLoading: schemaLoading,
+    connectorName,
+    actionName,
+    connectorLogoSvg,
+  } = useActionSchema(effectiveActionType);
 
   const configSchema = fetchedSchema;
 
@@ -378,12 +384,39 @@ export function CreateStandingApprovalDialog({
     >
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Create Standing Approval</DialogTitle>
-          <DialogDescription>
-            {hasInitialContext
-              ? `Step ${step - 2} of 2: ${STEP_LABELS[step]}`
-              : `Step ${step} of 4: ${STEP_LABELS[step]}`}
-          </DialogDescription>
+          {effectiveActionType ? (
+            <>
+              <div className="flex items-center gap-3">
+                <ConnectorLogo
+                  name={connectorName ?? effectiveActionType}
+                  logoSvg={connectorLogoSvg}
+                  size="lg"
+                />
+                <div className="min-w-0">
+                  <DialogTitle className="truncate text-base">
+                    {actionName ?? effectiveActionType}
+                  </DialogTitle>
+                  {connectorName && (
+                    <p className="text-muted-foreground text-sm">
+                      {connectorName}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <DialogDescription>
+                {hasInitialContext
+                  ? `Step ${step - 2} of 2: ${STEP_LABELS[step]}`
+                  : `Step ${step} of 4: ${STEP_LABELS[step]}`}
+              </DialogDescription>
+            </>
+          ) : (
+            <>
+              <DialogTitle>Create Standing Approval</DialogTitle>
+              <DialogDescription>
+                {`Step ${step} of 4: ${STEP_LABELS[step]}`}
+              </DialogDescription>
+            </>
+          )}
         </DialogHeader>
 
         <div className="flex items-center gap-1 px-1">

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -413,7 +413,9 @@ export function CreateStandingApprovalDialog({
             <>
               <DialogTitle>Create Standing Approval</DialogTitle>
               <DialogDescription>
-                {`Step ${step} of 4: ${STEP_LABELS[step]}`}
+                {hasInitialContext
+                  ? `Step ${step - 2} of 2: ${STEP_LABELS[step]}`
+                  : `Step ${step} of 4: ${STEP_LABELS[step]}`}
               </DialogDescription>
             </>
           )}

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -177,7 +177,7 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
 
     // The CreateStandingApprovalDialog should open (skipping to constraints step)
     await waitFor(() => {
-      expect(screen.getByText("Create Standing Approval")).toBeInTheDocument();
+      expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
     });
 
     // Should show step 1 of 2 (constraints), not step 1 of 4

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -221,6 +221,6 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       expect(screen.getByText("Execution Failed")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Create Standing Approval")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Step 1 of 2/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- The "Create Standing Approval" dialog now shows the connector logo, action name, and connector name in the header, so users always know what they're configuring
- Uses the same layout pattern as `ReviewApprovalDialog` (logo + title + subtitle)
- Falls back to the raw action type string when human-readable names aren't available; preserves the generic title on step 1 before an action is selected

## Test plan

### Claude Code
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] All frontend tests pass (`make test-frontend` — only pre-existing SchemaParameterDetails failures remain)
- [x] Updated `ReviewApprovalDialog.test.tsx` to reflect the new header content

### Manual Testing
- [ ] Open standing approval from "Always Allow" on a pending approval — verify connector logo, action name, and connector subtitle appear
- [ ] Open standing approval from the Standing Approvals card — verify step 1 shows generic title, steps 2+ show connector/action context
- [ ] Verify layout looks good on mobile (dialog is `sm:max-w-lg`)

https://claude.ai/code/session_01KLteuBL4iYn8vR7pou69VK