### PR TITLE
Replace constraint mode dropdown with wildcard auto-detect

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -171,7 +171,9 @@ export function buildParametersFromForm(
     }
 
     // Auto-detect pattern: any value containing "*" is a glob pattern.
-    if (value.includes("*")) {
+    // Also preserves legacy "pattern" mode for backward compatibility
+    // (e.g. existing $pattern values without * created by the old UI).
+    if (value.includes("*") || paramModes?.[key] === "pattern") {
       parameters[key] = { $pattern: value };
       continue;
     }

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -151,8 +151,9 @@ export type ParamMode = "fixed" | "pattern" | "wildcard";
  * When schema properties are provided, coerces values back to their declared
  * types (integer, number, boolean) so the backend receives correct JSON types.
  *
- * When paramModes is provided, parameters in "pattern" mode are wrapped as
- * {"$pattern": "<glob>"} objects for explicit pattern matching on the backend.
+ * Wildcard parameters (mode === "wildcard") are stored as "*".
+ * Values containing "*" are auto-detected as patterns and wrapped as
+ * {"$pattern": "<glob>"} for backend pattern matching.
  */
 export function buildParametersFromForm(
   paramValues: Record<string, string>,
@@ -163,8 +164,14 @@ export function buildParametersFromForm(
   for (const [key, value] of Object.entries(paramValues)) {
     if (value === "") continue;
 
-    // Pattern mode: wrap in $pattern object for explicit backend handling.
-    if (paramModes?.[key] === "pattern") {
+    // Wildcard mode: agent can use any value.
+    if (paramModes?.[key] === "wildcard") {
+      parameters[key] = "*";
+      continue;
+    }
+
+    // Auto-detect pattern: any value containing "*" is a glob pattern.
+    if (value.includes("*")) {
       parameters[key] = { $pattern: value };
       continue;
     }

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -1,15 +1,8 @@
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Button } from "@/components/ui/button";
-import { Asterisk, ChevronDown, ChevronRight, Lock, Regex } from "lucide-react";
+import { Asterisk, ChevronDown, ChevronRight } from "lucide-react";
 import type { ParamMode } from "./ActionConfigFormFields";
 import { ParameterFieldWidget } from "./ParameterFieldWidget";
 import type { ParametersSchema, SchemaProperty, FieldGroup } from "@/lib/parameterSchema";
@@ -29,9 +22,10 @@ interface ActionConfigParameterFieldsProps {
 }
 
 /**
- * Renders parameter fields for action configuration, with a constraint mode
- * dropdown (Fixed/Pattern/Wildcard) per parameter. Used in both the Add and
- * Edit action configuration dialogs.
+ * Renders parameter fields for action configuration, with an "Any value"
+ * checkbox per parameter. Wildcards in values (e.g. `*@company.com`) are
+ * auto-detected and serialized as patterns. Used in both the Add and Edit
+ * action configuration dialogs.
  *
  * Supports x-ui rendering hints: field ordering, labels, placeholders,
  * grouped collapsible sections, conditional visibility, and widget types.
@@ -89,15 +83,13 @@ export function ActionConfigParameterFields({
 
   const introText = (
     <p className="text-muted-foreground text-xs">
-      For each parameter, choose a constraint mode: <strong>Fixed</strong>{" "}
-      locks in an exact value,{" "}
-      <strong>Pattern</strong> uses{" "}
+      Use{" "}
       <Badge variant="outline" className="border-dashed font-mono text-xs">
         *
       </Badge>{" "}
-      as a glob wildcard (e.g.{" "}
-      <code className="text-xs">*@mycompany.com</code>), or{" "}
-      <strong>Wildcard</strong> lets the agent choose freely.
+      as a wildcard in any value (e.g.{" "}
+      <code className="text-xs">*@mycompany.com</code>). Check{" "}
+      <strong>Any value</strong> to let the agent choose freely.
     </p>
   );
 
@@ -148,7 +140,7 @@ export function ActionConfigParameterFields({
   );
 }
 
-/** Renders a single parameter field with label, widget, and constraint mode dropdown. */
+/** Renders a single parameter field with label, widget, and "Any value" checkbox. */
 function ParameterField({
   paramKey,
   property,
@@ -170,17 +162,11 @@ function ParameterField({
   onValueChange: (key: string, value: string) => void;
   onModeChange: (key: string, mode: ParamMode) => void;
 }) {
-  // Mode-aware placeholder: wildcard/pattern override x-ui.placeholder
-  const modePlaceholder =
-    mode === "wildcard"
-      ? "Agent can use any value"
-      : mode === "pattern"
-        ? "e.g. *@mycompany.com, supersuit-tech/*"
-        : undefined; // let ParameterFieldWidget use x-ui.placeholder or its default
-
-  const widgetValue = mode === "wildcard" ? "" : value;
-  const widgetDisabled = disabled || mode === "wildcard";
-  const widgetClassName = mode === "wildcard" ? "bg-muted" : "";
+  const isWildcard = mode === "wildcard";
+  const widgetValue = isWildcard ? "" : value;
+  const widgetDisabled = disabled || isWildcard;
+  const widgetClassName = isWildcard ? "bg-muted" : "";
+  const widgetPlaceholder = isWildcard ? "Agent can use any value" : undefined;
 
   return (
     <div className="space-y-1.5">
@@ -212,26 +198,33 @@ function ParameterField({
           onChange={(v) => onValueChange(paramKey, v)}
           disabled={widgetDisabled}
           className={widgetClassName}
-          placeholder={modePlaceholder}
+          placeholder={widgetPlaceholder}
         />
-        <ConstraintModeDropdown
-          mode={mode}
-          disabled={disabled}
-          onChange={(nextMode) => {
-            const prevMode = mode;
-            onModeChange(paramKey, nextMode);
-            if (nextMode === "wildcard") {
-              onValueChange(paramKey, "*");
-            } else if (prevMode === "wildcard") {
-              onValueChange(paramKey, "");
-            }
-          }}
-        />
+        <label
+          htmlFor={`any-value-${paramKey}`}
+          className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs whitespace-nowrap"
+        >
+          <Checkbox
+            id={`any-value-${paramKey}`}
+            checked={isWildcard}
+            disabled={disabled}
+            onCheckedChange={(checked) => {
+              if (checked) {
+                onModeChange(paramKey, "wildcard");
+                onValueChange(paramKey, "*");
+              } else {
+                onModeChange(paramKey, "fixed");
+                onValueChange(paramKey, "");
+              }
+            }}
+          />
+          <Asterisk className="size-3" />
+          Any value
+        </label>
       </div>
-      {mode === "pattern" && value !== "" && !value.includes("*") && (
+      {!isWildcard && value.includes("*") && (
         <p className="text-muted-foreground text-xs">
-          Tip: Include <code className="font-mono">*</code> in the value
-          for glob matching (e.g. <code>*@mycompany.com</code>).
+          <code className="font-mono">*</code> matches any text
         </p>
       )}
     </div>
@@ -281,87 +274,8 @@ function CollapsibleFieldGroup({
  */
 function inferModeFromValue(value: string): ParamMode {
   if (value === "*") return "wildcard";
+  if (value.includes("*")) return "pattern";
   return "fixed";
-}
-
-const modeConfig: Record<
-  ParamMode,
-  { icon: React.ReactNode; label: string; description: string }
-> = {
-  fixed: {
-    icon: <Lock className="size-3" />,
-    label: "Fixed",
-    description: "Exact value",
-  },
-  pattern: {
-    icon: <Regex className="size-3" />,
-    label: "Pattern",
-    description: "Glob matching with *",
-  },
-  wildcard: {
-    icon: <Asterisk className="size-3" />,
-    label: "Wildcard",
-    description: "Agent chooses freely",
-  },
-};
-
-const allModes: ParamMode[] = ["fixed", "pattern", "wildcard"];
-
-function isParamMode(value: string): value is ParamMode {
-  return allModes.includes(value as ParamMode);
-}
-
-/** Dropdown selector for constraint mode (Fixed/Pattern/Wildcard) with radio semantics. */
-function ConstraintModeDropdown({
-  mode,
-  disabled,
-  onChange,
-}: {
-  mode: ParamMode;
-  disabled?: boolean;
-  onChange: (next: ParamMode) => void;
-}) {
-  const current = modeConfig[mode];
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled}
-          title={current.description}
-          className="shrink-0 gap-1.5"
-        >
-          {current.icon}
-          {current.label}
-          <ChevronDown className="size-3 opacity-50" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuRadioGroup
-          value={mode}
-          onValueChange={(v) => {
-            if (v !== mode && isParamMode(v)) onChange(v);
-          }}
-        >
-          {allModes.map((m) => {
-            const cfg = modeConfig[m];
-            return (
-              <DropdownMenuRadioItem key={m} value={m}>
-                {cfg.icon}
-                <span className="font-medium">{cfg.label}</span>
-                <span className="text-muted-foreground text-xs">
-                  {cfg.description}
-                </span>
-              </DropdownMenuRadioItem>
-            );
-          })}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
 }
 
 // Re-export the shared parseParametersSchema so callers don't break.

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -201,18 +201,16 @@ function ParameterField({
           placeholder={widgetPlaceholder}
         />
         <label
-          htmlFor={`any-value-${paramKey}`}
           className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs whitespace-nowrap"
         >
           <Checkbox
-            id={`any-value-${paramKey}`}
             checked={isWildcard}
             disabled={disabled}
             onCheckedChange={(checked) => {
-              if (checked) {
+              if (checked === true) {
                 onModeChange(paramKey, "wildcard");
                 onValueChange(paramKey, "*");
-              } else {
+              } else if (checked === false) {
                 onModeChange(paramKey, "fixed");
                 onValueChange(paramKey, "");
               }

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
@@ -46,6 +46,12 @@ describe("buildParametersFromForm", () => {
     expect(result).toEqual({ count: 42 });
   });
 
+  it("coerces number types", () => {
+    const schema = { price: { type: "number" } };
+    const result = buildParametersFromForm({ price: "3.14" }, schema);
+    expect(result).toEqual({ price: 3.14 });
+  });
+
   it("coerces boolean types", () => {
     const schema = { enabled: { type: "boolean" } };
     const result = buildParametersFromForm({ enabled: "true" }, schema);

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { buildParametersFromForm, type ParamMode } from "../ActionConfigFormFields";
+
+describe("buildParametersFromForm", () => {
+  it("auto-wraps value containing * as $pattern", () => {
+    const result = buildParametersFromForm({ email: "*@company.com" });
+    expect(result).toEqual({ email: { $pattern: "*@company.com" } });
+  });
+
+  it("auto-wraps prefix wildcard as $pattern", () => {
+    const result = buildParametersFromForm({ repo: "supersuit-tech/*" });
+    expect(result).toEqual({ repo: { $pattern: "supersuit-tech/*" } });
+  });
+
+  it("auto-wraps value with * even when mode is fixed", () => {
+    const modes: Record<string, ParamMode> = { title: "fixed" };
+    const result = buildParametersFromForm({ title: "Prefix: *" }, undefined, modes);
+    expect(result).toEqual({ title: { $pattern: "Prefix: *" } });
+  });
+
+  it("stores plain string when value has no *", () => {
+    const result = buildParametersFromForm({ name: "hello" });
+    expect(result).toEqual({ name: "hello" });
+  });
+
+  it("stores wildcard mode as plain * string", () => {
+    const modes: Record<string, ParamMode> = { title: "wildcard" };
+    const result = buildParametersFromForm({ title: "*" }, undefined, modes);
+    expect(result).toEqual({ title: "*" });
+  });
+
+  it("preserves legacy pattern mode for values without *", () => {
+    const modes: Record<string, ParamMode> = { query: "pattern" };
+    const result = buildParametersFromForm({ query: "exact-match" }, undefined, modes);
+    expect(result).toEqual({ query: { $pattern: "exact-match" } });
+  });
+
+  it("skips empty values", () => {
+    const result = buildParametersFromForm({ name: "", email: "test@example.com" });
+    expect(result).toEqual({ email: "test@example.com" });
+  });
+
+  it("coerces integer types", () => {
+    const schema = { count: { type: "integer" } };
+    const result = buildParametersFromForm({ count: "42" }, schema);
+    expect(result).toEqual({ count: 42 });
+  });
+
+  it("coerces boolean types", () => {
+    const schema = { enabled: { type: "boolean" } };
+    const result = buildParametersFromForm({ enabled: "true" }, schema);
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it("wildcard mode takes precedence over * auto-detect", () => {
+    // Wildcard stores plain "*", not { $pattern: "*" }
+    const modes: Record<string, ParamMode> = { field: "wildcard" };
+    const result = buildParametersFromForm({ field: "*" }, undefined, modes);
+    expect(result.field).toBe("*");
+    expect(result.field).not.toEqual({ $pattern: "*" });
+  });
+});

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
@@ -190,7 +190,7 @@ describe("ActionConfigParameterFields", () => {
       expect(screen.queryByPlaceholderText("cus_ABC123")).not.toBeInTheDocument();
     });
 
-    it("overrides x-ui.placeholder in pattern mode", () => {
+    it("uses x-ui.placeholder in pattern mode (no override)", () => {
       const schema: ParametersSchema = {
         type: "object",
         properties: {
@@ -205,9 +205,8 @@ describe("ActionConfigParameterFields", () => {
         modes: { customer_id: "pattern" },
       });
 
-      expect(
-        screen.getByPlaceholderText("e.g. *@mycompany.com, supersuit-tech/*"),
-      ).toBeInTheDocument();
+      // Pattern mode no longer overrides the placeholder — the field uses x-ui.placeholder
+      expect(screen.getByPlaceholderText("cus_ABC123")).toBeInTheDocument();
     });
   });
 
@@ -473,6 +472,63 @@ describe("ActionConfigParameterFields", () => {
       await user.type(screen.getByLabelText("name"), "a");
 
       expect(onValueChange).toHaveBeenCalledWith("name", "a");
+    });
+
+    it("checking 'Any value' sets wildcard mode and value", async () => {
+      const user = userEvent.setup();
+      const onModeChange = vi.fn<(key: string, mode: ParamMode) => void>();
+      const onValueChange = vi.fn<(key: string, value: string) => void>();
+      renderFields(basicSchema, { onModeChange, onValueChange });
+
+      const checkbox = screen.getAllByRole("checkbox")[0]!;
+      await user.click(checkbox);
+
+      expect(onModeChange).toHaveBeenCalledWith("name", "wildcard");
+      expect(onValueChange).toHaveBeenCalledWith("name", "*");
+    });
+
+    it("unchecking 'Any value' sets fixed mode and clears value", async () => {
+      const user = userEvent.setup();
+      const onModeChange = vi.fn<(key: string, mode: ParamMode) => void>();
+      const onValueChange = vi.fn<(key: string, value: string) => void>();
+      renderFields(basicSchema, {
+        onModeChange,
+        onValueChange,
+        values: { name: "*" },
+        modes: { name: "wildcard" },
+      });
+
+      const checkbox = screen.getAllByRole("checkbox")[0]!;
+      await user.click(checkbox);
+
+      expect(onModeChange).toHaveBeenCalledWith("name", "fixed");
+      expect(onValueChange).toHaveBeenCalledWith("name", "");
+    });
+
+    it("disables input when mode is wildcard", () => {
+      renderFields(basicSchema, {
+        values: { name: "*" },
+        modes: { name: "wildcard" },
+      });
+
+      expect(screen.getByLabelText("name")).toBeDisabled();
+    });
+
+    it("shows wildcard hint when value contains *", () => {
+      renderFields(basicSchema, {
+        values: { name: "*@company.com" },
+      });
+
+      expect(screen.getByText("matches any text")).toBeInTheDocument();
+    });
+
+    it("does not show wildcard hint when mode is wildcard", () => {
+      renderFields(basicSchema, {
+        values: { name: "*" },
+        modes: { name: "wildcard" },
+      });
+
+      expect(screen.queryByText("matches any text")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -194,13 +194,10 @@ describe("ActionConfigurationsSection", () => {
       "my-repo",
     );
 
-    // Set title to wildcard via dropdown.
-    // Target the dropdown trigger within the "title" parameter group.
+    // Set title to wildcard via "Any value" checkbox.
     const titleInput = screen.getByLabelText("title");
     const titleGroup = titleInput.closest(".space-y-1\\.5")!;
-    await user.click(within(titleGroup as HTMLElement).getByRole("button", { name: /Fixed/ }));
-    // Select "Wildcard" from the dropdown menu.
-    await user.click(screen.getByRole("menuitemradio", { name: /Wildcard/ }));
+    await user.click(within(titleGroup as HTMLElement).getByRole("checkbox"));
 
     await user.click(screen.getByText("Create Configuration"));
 


### PR DESCRIPTION
## Summary
- Removes the Fixed/Pattern/Wildcard dropdown from parameter constraint fields
- Users now just type values — any value containing `*` is automatically treated as a glob pattern (e.g. `*@mycompany.com`, `Prefix: *`)
- A simple "Any value" checkbox replaces the Wildcard option for letting the agent choose freely
- `buildParametersFromForm` auto-detects patterns from value content instead of relying on explicit mode selection

## Test plan

### Claude Code
- [x] Frontend tests pass (55 connector tests, 100 dashboard tests)
- [x] TypeScript compilation passes (no new errors)
- [x] Run full test suite (`make test-frontend`)

### Manual Testing
- [ ] Open action config editor, type `*@company.com` in a field — should show "* matches any text" hint
- [ ] Check "Any value" checkbox — input should disable, show "Agent can use any value" placeholder
- [ ] Uncheck "Any value" — input should re-enable and clear
- [ ] Edit existing config with pattern values — should display correctly
- [ ] Create standing approval with pattern constraints — should serialize as `{"$pattern": "..."}`
- [ ] Verify mobile layout looks good (checkbox doesn't overflow)

https://claude.ai/code/session_01GsBv2HVswzWoUw3wNFPPbU