### PR TITLE
Fix beta text colors for readability

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -42,7 +42,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             P
           </span>
           <span className="hidden sm:inline">Permission Slip</span>
-          <span className="rounded-full bg-secondary/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-secondary">
+          <span className="rounded-full bg-secondary/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground">
             Beta
           </span>
         </Link>

--- a/frontend/src/components/BetaBanner.tsx
+++ b/frontend/src/components/BetaBanner.tsx
@@ -11,7 +11,7 @@ export function BetaBanner() {
     <div
       role="banner"
       aria-label="Beta notice"
-      className="w-full border-b border-secondary/20 bg-secondary/10 px-4 py-2 text-center text-xs text-secondary"
+      className="w-full border-b border-secondary/20 bg-secondary/10 px-4 py-2 text-center text-xs text-foreground"
     >
       <span className="font-semibold">Beta</span>
       {" — "}


### PR DESCRIPTION
## Summary
- Changed beta banner text and beta badge from `text-secondary` (orange/yellow) to `text-foreground` (black) for proper contrast against the yellow background
- Affected files: `BetaBanner.tsx` and `AppLayout.tsx`

## Test plan

### Claude Code
- [x] BetaBanner tests pass
- [ ] Run full frontend test suite
- [ ] Run build

### Manual Testing
- [ ] Verify beta banner text is readable on mobile and desktop
- [ ] Verify beta badge in nav bar has good contrast

https://claude.ai/code/session_014RwNK3teKaxZA9X1egFjLC