### PR TITLE
Fix approval dialog flash on load

### DIFF
--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -67,7 +67,7 @@ function val(t: string): SummaryPart {
 /** Inline highlight for parameter values within the summary. */
 function ValSpan({ children }: { children: ReactNode }) {
   return (
-    <span className="bg-muted text-foreground rounded px-1 py-0.5 font-medium">
+    <span className="bg-muted text-foreground inline rounded px-1 py-0.5 font-medium box-decoration-clone">
       {children}
     </span>
   );
@@ -114,7 +114,7 @@ export function ActionPreviewSummary({
   const parts = buildParts(actionType, parameters, schema, actionName, displayTemplate, resourceDetails);
 
   return (
-    <p className="text-sm leading-relaxed" data-testid="action-preview-summary">
+    <p className="text-sm leading-loose" data-testid="action-preview-summary">
       {renderRich(parts)}
     </p>
   );

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { Loader2, Clock, AlertTriangle, CheckCircle, XCircle, ShieldCheck, Check } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -121,7 +122,7 @@ export function ReviewApprovalDialog({
   const isApproved = approveResult !== null;
   const { approveApproval } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
-  const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg } =
+  const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg, isLoading: schemaLoading } =
     useActionSchema(approval.action.type);
   const remaining = useCountdown(approval.expires_at);
   const isExpired = remaining <= 0;
@@ -211,21 +212,34 @@ export function ReviewApprovalDialog({
         {/* Connector header with logo, action name, and connector name */}
         <DialogHeader>
           <div className="flex items-center gap-3">
-            <ConnectorLogo
-              name={connectorName ?? approval.action.type}
-              logoSvg={connectorLogoSvg}
-              size="lg"
-            />
-            <div className="min-w-0">
-              <DialogTitle className="truncate text-base">
-                {actionName ?? approval.action.type}
-              </DialogTitle>
-              {connectorName && (
-                <p className="text-muted-foreground text-sm">
-                  {connectorName}
-                </p>
-              )}
-            </div>
+            {schemaLoading ? (
+              <>
+                <Skeleton className="size-10 rounded-lg shrink-0" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <DialogTitle className="sr-only">Loading action details…</DialogTitle>
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+              </>
+            ) : (
+              <>
+                <ConnectorLogo
+                  name={connectorName ?? approval.action.type}
+                  logoSvg={connectorLogoSvg}
+                  size="lg"
+                />
+                <div className="min-w-0">
+                  <DialogTitle className="truncate text-base">
+                    {actionName ?? approval.action.type}
+                  </DialogTitle>
+                  {connectorName && (
+                    <p className="text-muted-foreground text-sm">
+                      {connectorName}
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
           </div>
         </DialogHeader>
 
@@ -298,16 +312,29 @@ export function ReviewApprovalDialog({
                 </p>
               )}
 
-              {/* Preview card — connector-driven or fallback */}
-              <ActionPreviewCard
-                preview={preview}
-                parameters={params}
-                actionType={approval.action.type}
-                schema={schema}
-                actionName={actionName}
-                displayTemplate={displayTemplate}
-                resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
-              />
+              {/* Preview card — show skeleton while connector metadata loads */}
+              {schemaLoading ? (
+                <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm space-y-3">
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="size-10 rounded-lg shrink-0" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-3/4" />
+                      <Skeleton className="h-3 w-1/2" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              ) : (
+                <ActionPreviewCard
+                  preview={preview}
+                  parameters={params}
+                  actionType={approval.action.type}
+                  schema={schema}
+                  actionName={actionName}
+                  displayTemplate={displayTemplate}
+                  resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
+                />
+              )}
             </div>
 
             {/* Raw parameters (collapsible pill toggle) */}


### PR DESCRIPTION
## Summary
- Show a loading skeleton in the approval dialog header and preview card area while connector metadata loads, preventing the raw action data flash
- Increase line-height on `ActionPreviewSummary` from `leading-relaxed` to `leading-loose` and add `box-decoration-clone` on `ValSpan` so inline highlighted values with background padding don't visually overlap when wrapping across lines

## Test plan

### Claude Code
- [x] Verify `ReviewApprovalDialog` tests pass (5/5)
- [x] Verify `ActionPreviewSummary` tests pass (33/33)
- [x] TypeScript compilation clean for changed files

### Manual Testing
- [ ] Open an approval dialog and verify the skeleton loads briefly before the rich preview card appears (no raw data flash)
- [ ] Check a fallback summary with long parameter values that wrap across multiple lines — highlighted values should have clear spacing between lines

https://claude.ai/code/session_01QZto2JhwP73kYZT8YxW4df