### PR TITLE
Style parameters intro text as subtle callout

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -221,9 +221,11 @@ function ParameterField({
         </label>
       </div>
       {!isWildcard && value.includes("*") && (
-        <p className="text-muted-foreground text-sm">
-          <code className="rounded bg-muted px-1 font-mono">*</code> matches any text
-        </p>
+        <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            <code className="rounded bg-muted px-1 font-mono text-foreground/70">*</code> matches any text
+          </p>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -82,13 +82,15 @@ export function ActionConfigParameterFields({
   }
 
   const introText = (
-    <p className="text-muted-foreground text-sm leading-relaxed">
-      Use{" "}
-      <code className="rounded bg-muted px-1 font-mono">*</code>{" "}
-      as a wildcard in any value (e.g.{" "}
-      <code className="rounded bg-muted px-1 font-mono">*@mycompany.com</code>
-      ). Check <strong>Any value</strong> to let the agent choose freely.
-    </p>
+    <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+      <p className="text-muted-foreground text-xs leading-relaxed">
+        Use{" "}
+        <code className="rounded bg-muted px-1 font-mono text-foreground/70">*</code>{" "}
+        as a wildcard in any value (e.g.{" "}
+        <code className="rounded bg-muted px-1 font-mono text-foreground/70">*@mycompany.com</code>
+        ). Check <strong className="text-foreground/70">Any value</strong> to let the agent choose freely.
+      </p>
+    </div>
   );
 
   // If groups are defined, render ungrouped fields then each group section

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -98,10 +98,12 @@ export function StepPickAction({
               Custom action type...
             </option>
           </select>
-          <p className="text-muted-foreground text-sm">
-            Select an action configuration to pre-populate constraints, or
-            choose &quot;Custom action type&quot; for manual entry.
-          </p>
+          <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              Select an action configuration to pre-populate constraints, or
+              choose &quot;Custom action type&quot; for manual entry.
+            </p>
+          </div>
         </>
       )}
 
@@ -177,10 +179,12 @@ export function StepConstraints({
       ) : (
         <div className="space-y-2">
           <Label htmlFor="sa-manual-constraints">Constraints (JSON)</Label>
-          <p className="text-muted-foreground text-sm">
-            No parameter schema found for this action. Enter constraints
-            manually as a JSON object.
-          </p>
+          <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              No parameter schema found for this action. Enter constraints
+              manually as a JSON object.
+            </p>
+          </div>
           <textarea
             id="sa-manual-constraints"
             className="border-input bg-background ring-offset-background focus-visible:ring-ring flex min-h-[100px] w-full rounded-md border px-3 py-2 font-mono text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
@@ -189,10 +193,12 @@ export function StepConstraints({
             onChange={(e) => onManualConstraintsJsonChange(e.target.value)}
             disabled={isPending}
           />
-          <p className="text-muted-foreground text-sm">
-            Use <code className="rounded bg-muted px-1 font-mono">&quot;*&quot;</code> for wildcard
-            parameters, but at least one must be non-wildcard.
-          </p>
+          <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              Use <code className="rounded bg-muted px-1 font-mono text-foreground/70">&quot;*&quot;</code> for wildcard
+              parameters, but at least one must be non-wildcard.
+            </p>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Wrapped the "Use * as a wildcard..." help text in a rounded, dashed-border container with muted background (`bg-muted/40`) so it reads as an intentional design element rather than unstyled paragraph text
- Reduced font size from `text-sm` to `text-xs` and added `text-foreground/70` tints to inline `<code>` and `<strong>` elements for better visual hierarchy
- Matches the polished feel of the "Create repositories" applied-config card above it

## Test plan
### Claude Code
- [x] ActionConfigParameterFields tests pass (36/36)
- [x] TypeScript compiles (no new errors)

### Manual Testing
- [ ] Open Add/Edit Action Config dialog on mobile viewport — verify the intro text callout looks polished and doesn't overflow
- [ ] Confirm dashed border + muted background renders correctly in both light and dark themes

https://claude.ai/code/session_01XQyvRVXJFY4nvRcPEMyK1k