### PR TITLE
Make modal inputs user-friendly for non-technical users

### DIFF
--- a/frontend/src/components/SchemaParameterDetails.tsx
+++ b/frontend/src/components/SchemaParameterDetails.tsx
@@ -106,6 +106,7 @@ function ParameterRow({
   const isDefault =
     defaultValue !== undefined && String(value) === String(defaultValue);
   const isMultiline = typeof value === "string" && value.includes("\n");
+  const typeLabel = friendlyTypeLabel(type);
 
   return (
     <div className="space-y-1.5 py-3 first:pt-0 last:pb-0">
@@ -117,8 +118,8 @@ function ParameterRow({
         {label !== name && (
           <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 text-[10px] font-mono">{name}</code>
         )}
-        {friendlyTypeLabel(type) && (
-          <span className="text-muted-foreground text-[10px] font-mono">{friendlyTypeLabel(type)}</span>
+        {typeLabel && (
+          <span className="text-muted-foreground text-[10px] font-mono">{typeLabel}</span>
         )}
         {isRequired && !isProvided && (
           <Badge

--- a/frontend/src/components/SchemaParameterDetails.tsx
+++ b/frontend/src/components/SchemaParameterDetails.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import type { ParametersSchema } from "@/lib/parameterSchema";
+import { friendlyTypeLabel } from "@/lib/parameterSchema";
 import { formatParameterValue, humanizeKey } from "@/lib/formatValues";
 
 export type { ParametersSchema } from "@/lib/parameterSchema";
@@ -86,6 +87,7 @@ function ParameterRow({
   name,
   label,
   value,
+  type,
   enumValues,
   defaultValue,
   isRequired,
@@ -115,8 +117,8 @@ function ParameterRow({
         {label !== name && (
           <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 text-[10px] font-mono">{name}</code>
         )}
-        {type && (
-          <span className="text-muted-foreground text-[10px] font-mono">{type}</span>
+        {friendlyTypeLabel(type) && (
+          <span className="text-muted-foreground text-[10px] font-mono">{friendlyTypeLabel(type)}</span>
         )}
         {isRequired && !isProvided && (
           <Badge

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -93,10 +93,9 @@ export function parseParametersSchema(
       const propType = typeof prop.type === "string" ? prop.type : undefined;
       const format = typeof prop.format === "string" ? prop.format : undefined;
       const parsedUI = parsePropertyUI(prop["x-ui"]);
-      // Auto-map types to widgets when no explicit widget is set
-      const ui = autoMapWidget(propType, format, prop, parsedUI);
-      // Preserve items schema for array types
       const items = parseItems(prop.items);
+      // Auto-map types to widgets when no explicit widget is set
+      const ui = autoMapWidget(propType, format, items, parsedUI);
       properties[key] = {
         type: propType,
         format,
@@ -206,13 +205,11 @@ export function inferWidgetFromProperty(property: SchemaProperty): WidgetType {
 function autoMapWidget(
   type: string | undefined,
   format: string | undefined,
-  prop: Record<string, unknown>,
+  items: { type?: string } | undefined,
   parsedUI: SchemaPropertyUI | undefined,
 ): SchemaPropertyUI | undefined {
   if (parsedUI?.widget) return parsedUI;
 
-  // Build a temporary SchemaProperty for inferWidgetFromProperty
-  const items = parseItems(prop.items);
   const inferred = inferWidgetFromProperty({ type, format, items });
   if (inferred !== "text") {
     return { ...parsedUI, widget: inferred };

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -187,8 +187,21 @@ export function friendlyTypeLabel(type: string | undefined): string | undefined 
 }
 
 /**
+ * Infer the appropriate widget for a schema property based on its type/format.
+ * Returns "text" as default when no better match is found.
+ */
+export function inferWidgetFromProperty(property: SchemaProperty): WidgetType {
+  if (property.format === "date-time") return "datetime";
+  if (property.type === "boolean") return "toggle";
+  if (property.type === "integer" || property.type === "number") return "number";
+  if (property.type === "array" && property.items?.type === "string") return "list";
+  return "text";
+}
+
+/**
  * Auto-map JSON Schema type/format to a widget when no explicit widget is set.
- * Explicit x-ui.widget always takes precedence.
+ * Explicit x-ui.widget always takes precedence. Uses inferWidgetFromProperty
+ * for the actual mapping logic.
  */
 function autoMapWidget(
   type: string | undefined,
@@ -198,24 +211,11 @@ function autoMapWidget(
 ): SchemaPropertyUI | undefined {
   if (parsedUI?.widget) return parsedUI;
 
-  // Existing: format date-time → datetime widget
-  if (format === "date-time") {
-    return { ...parsedUI, widget: "datetime" as const };
-  }
-  // boolean → toggle
-  if (type === "boolean") {
-    return { ...parsedUI, widget: "toggle" as const };
-  }
-  // integer/number → number
-  if (type === "integer" || type === "number") {
-    return { ...parsedUI, widget: "number" as const };
-  }
-  // array with string items → list
-  if (type === "array") {
-    const items = prop.items;
-    if (items && typeof items === "object" && (items as Record<string, unknown>).type === "string") {
-      return { ...parsedUI, widget: "list" as const };
-    }
+  // Build a temporary SchemaProperty for inferWidgetFromProperty
+  const items = parseItems(prop.items);
+  const inferred = inferWidgetFromProperty({ type, format, items });
+  if (inferred !== "text") {
+    return { ...parsedUI, widget: inferred };
   }
   return parsedUI;
 }

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -15,7 +15,7 @@ export interface VisibleWhen {
 
 /** Property-level `x-ui` rendering hints for a single parameter. */
 export interface SchemaPropertyUI {
-  widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date" | "datetime";
+  widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date" | "datetime" | "list";
   label?: string;
   placeholder?: string;
   group?: string;
@@ -45,6 +45,7 @@ export interface SchemaProperty {
   description?: string;
   enum?: string[];
   default?: unknown;
+  items?: { type?: string };
   "x-ui"?: SchemaPropertyUI;
 }
 
@@ -89,15 +90,15 @@ export function parseParametersSchema(
   )) {
     if (typeof val === "object" && val !== null) {
       const prop = val as Record<string, unknown>;
+      const propType = typeof prop.type === "string" ? prop.type : undefined;
       const format = typeof prop.format === "string" ? prop.format : undefined;
       const parsedUI = parsePropertyUI(prop["x-ui"]);
-      // Auto-map format: "date-time" → widget: "datetime" when no explicit widget is set
-      const ui =
-        format === "date-time" && !parsedUI?.widget
-          ? { ...parsedUI, widget: "datetime" as const }
-          : parsedUI;
+      // Auto-map types to widgets when no explicit widget is set
+      const ui = autoMapWidget(propType, format, prop, parsedUI);
+      // Preserve items schema for array types
+      const items = parseItems(prop.items);
       properties[key] = {
-        type: typeof prop.type === "string" ? prop.type : undefined,
+        type: propType,
         format,
         description:
           typeof prop.description === "string" ? prop.description : undefined,
@@ -105,6 +106,7 @@ export function parseParametersSchema(
           ? prop.enum.filter((e): e is string => typeof e === "string")
           : undefined,
         default: prop.default,
+        items,
         "x-ui": ui,
       };
     }
@@ -114,7 +116,7 @@ export function parseParametersSchema(
 }
 
 /** All valid widget type values. */
-export const VALID_WIDGETS = ["text", "select", "textarea", "toggle", "number", "date", "datetime"] as const;
+export const VALID_WIDGETS = ["text", "select", "textarea", "toggle", "number", "date", "datetime", "list"] as const;
 
 /** Widget type as a union — useful for exhaustive switch checks. */
 export type WidgetType = (typeof VALID_WIDGETS)[number];
@@ -165,6 +167,65 @@ export function isFieldVisible(
     return Number(fieldValue) === rule.equals;
   }
   return fieldValue === rule.equals;
+}
+
+const FRIENDLY_TYPE_LABELS: Record<string, string> = {
+  string: "text",
+  boolean: "yes / no",
+  integer: "number",
+  number: "number",
+  array: "list",
+};
+
+/**
+ * Return a user-friendly label for a JSON Schema type.
+ * Returns undefined for types that should not be displayed (object, unknown).
+ */
+export function friendlyTypeLabel(type: string | undefined): string | undefined {
+  if (!type) return undefined;
+  return FRIENDLY_TYPE_LABELS[type];
+}
+
+/**
+ * Auto-map JSON Schema type/format to a widget when no explicit widget is set.
+ * Explicit x-ui.widget always takes precedence.
+ */
+function autoMapWidget(
+  type: string | undefined,
+  format: string | undefined,
+  prop: Record<string, unknown>,
+  parsedUI: SchemaPropertyUI | undefined,
+): SchemaPropertyUI | undefined {
+  if (parsedUI?.widget) return parsedUI;
+
+  // Existing: format date-time → datetime widget
+  if (format === "date-time") {
+    return { ...parsedUI, widget: "datetime" as const };
+  }
+  // boolean → toggle
+  if (type === "boolean") {
+    return { ...parsedUI, widget: "toggle" as const };
+  }
+  // integer/number → number
+  if (type === "integer" || type === "number") {
+    return { ...parsedUI, widget: "number" as const };
+  }
+  // array with string items → list
+  if (type === "array") {
+    const items = prop.items;
+    if (items && typeof items === "object" && (items as Record<string, unknown>).type === "string") {
+      return { ...parsedUI, widget: "list" as const };
+    }
+  }
+  return parsedUI;
+}
+
+/** Parse an items schema from a JSON Schema array property. */
+function parseItems(raw: unknown): { type?: string } | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.type === "string") return { type: obj.type };
+  return undefined;
 }
 
 /** Parse a property-level `x-ui` object, returning undefined if invalid. */

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -188,6 +188,13 @@ export function buildParametersFromForm(
     } else if (type === "boolean") {
       if (value === "true") { parameters[key] = true; continue; }
       if (value === "false") { parameters[key] = false; continue; }
+    } else if (type === "array") {
+      if (value.startsWith("[")) {
+        try {
+          const parsed: unknown = JSON.parse(value);
+          if (Array.isArray(parsed)) { parameters[key] = parsed; continue; }
+        } catch { /* fall through to string */ }
+      }
     }
 
     parameters[key] = value;

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -192,7 +192,10 @@ export function buildParametersFromForm(
       if (value.startsWith("[")) {
         try {
           const parsed: unknown = JSON.parse(value);
-          if (Array.isArray(parsed)) { parameters[key] = parsed; continue; }
+          if (Array.isArray(parsed)) {
+            parameters[key] = (parsed as unknown[]).filter((item) => item !== "");
+            continue;
+          }
         } catch { /* fall through to string */ }
       }
     }

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -178,7 +178,10 @@ export function buildParametersFromForm(
       try {
         const parsed: unknown = JSON.parse(value);
         if (Array.isArray(parsed)) {
-          parameters[key] = (parsed as unknown[]).filter((item) => item !== "");
+          const filtered = (parsed as unknown[]).filter((item) => item !== "");
+          if (filtered.length > 0) {
+            parameters[key] = filtered;
+          }
           continue;
         }
       } catch { /* fall through */ }

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -170,6 +170,20 @@ export function buildParametersFromForm(
       continue;
     }
 
+    const type = schemaProperties?.[key]?.type;
+
+    // Array type: parse JSON before pattern detection, since array values
+    // may contain items with "*" that should not be treated as glob patterns.
+    if (type === "array" && value.startsWith("[")) {
+      try {
+        const parsed: unknown = JSON.parse(value);
+        if (Array.isArray(parsed)) {
+          parameters[key] = (parsed as unknown[]).filter((item) => item !== "");
+          continue;
+        }
+      } catch { /* fall through */ }
+    }
+
     // Auto-detect pattern: any value containing "*" is a glob pattern.
     // Also preserves legacy "pattern" mode for backward compatibility
     // (e.g. existing $pattern values without * created by the old UI).
@@ -177,8 +191,6 @@ export function buildParametersFromForm(
       parameters[key] = { $pattern: value };
       continue;
     }
-
-    const type = schemaProperties?.[key]?.type;
     if (type === "integer") {
       const parsed = Number.parseInt(value, 10);
       if (!Number.isNaN(parsed)) { parameters[key] = parsed; continue; }
@@ -188,16 +200,6 @@ export function buildParametersFromForm(
     } else if (type === "boolean") {
       if (value === "true") { parameters[key] = true; continue; }
       if (value === "false") { parameters[key] = false; continue; }
-    } else if (type === "array") {
-      if (value.startsWith("[")) {
-        try {
-          const parsed: unknown = JSON.parse(value);
-          if (Array.isArray(parsed)) {
-            parameters[key] = (parsed as unknown[]).filter((item) => item !== "");
-            continue;
-          }
-        } catch { /* fall through to string */ }
-      }
     }
 
     parameters[key] = value;

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -168,6 +168,7 @@ function ParameterField({
   const widgetDisabled = disabled || isWildcard;
   const widgetClassName = isWildcard ? "bg-muted" : "";
   const widgetPlaceholder = isWildcard ? "Agent can use any value" : undefined;
+  const typeLabel = friendlyTypeLabel(property.type);
 
   return (
     <div className="space-y-1.5">
@@ -180,9 +181,9 @@ function ParameterField({
             required
           </Badge>
         )}
-        {friendlyTypeLabel(property.type) && (
+        {typeLabel && (
           <span className="text-muted-foreground text-xs">
-            ({friendlyTypeLabel(property.type)})
+            ({typeLabel})
           </span>
         )}
       </div>

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -10,6 +10,7 @@ import {
   getOrderedFieldKeys,
   getFieldLabel,
   isFieldVisible,
+  friendlyTypeLabel,
 } from "@/lib/parameterSchema";
 
 interface ActionConfigParameterFieldsProps {
@@ -177,9 +178,9 @@ function ParameterField({
             required
           </Badge>
         )}
-        {property.type && (
+        {friendlyTypeLabel(property.type) && (
           <span className="text-muted-foreground text-xs">
-            ({property.type})
+            ({friendlyTypeLabel(property.type)})
           </span>
         )}
       </div>

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -11,6 +11,7 @@ import {
   getFieldLabel,
   isFieldVisible,
   friendlyTypeLabel,
+  inferWidgetFromProperty,
 } from "@/lib/parameterSchema";
 
 interface ActionConfigParameterFieldsProps {
@@ -169,6 +170,30 @@ function ParameterField({
   const widgetClassName = isWildcard ? "bg-muted" : "";
   const widgetPlaceholder = isWildcard ? "Agent can use any value" : undefined;
   const typeLabel = friendlyTypeLabel(property.type);
+  const effectiveWidget = property["x-ui"]?.widget ?? inferWidgetFromProperty(property);
+  const isMultiRow = effectiveWidget === "list";
+
+  const anyValueCheckbox = (
+    <label
+      className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs whitespace-nowrap"
+    >
+      <Checkbox
+        checked={isWildcard}
+        disabled={disabled}
+        onCheckedChange={(checked) => {
+          if (checked === true) {
+            onModeChange(paramKey, "wildcard");
+            onValueChange(paramKey, "*");
+          } else if (checked === false) {
+            onModeChange(paramKey, "fixed");
+            onValueChange(paramKey, "");
+          }
+        }}
+      />
+      <Asterisk className="size-3" />
+      Any value
+    </label>
+  );
 
   return (
     <div className="space-y-1.5">
@@ -186,42 +211,39 @@ function ParameterField({
             ({typeLabel})
           </span>
         )}
+        {isMultiRow && anyValueCheckbox}
       </div>
       {property.description && (
         <p className="text-muted-foreground text-sm">
           {property.description}
         </p>
       )}
-      <div className="flex items-center gap-2">
-        <ParameterFieldWidget
-          paramKey={paramKey}
-          property={property}
-          value={widgetValue}
-          onChange={(v) => onValueChange(paramKey, v)}
-          disabled={widgetDisabled}
-          className={widgetClassName}
-          placeholder={widgetPlaceholder}
-        />
-        <label
-          className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs whitespace-nowrap"
-        >
-          <Checkbox
-            checked={isWildcard}
-            disabled={disabled}
-            onCheckedChange={(checked) => {
-              if (checked === true) {
-                onModeChange(paramKey, "wildcard");
-                onValueChange(paramKey, "*");
-              } else if (checked === false) {
-                onModeChange(paramKey, "fixed");
-                onValueChange(paramKey, "");
-              }
-            }}
+      {isMultiRow ? (
+        !isWildcard && (
+          <ParameterFieldWidget
+            paramKey={paramKey}
+            property={property}
+            value={widgetValue}
+            onChange={(v) => onValueChange(paramKey, v)}
+            disabled={widgetDisabled}
+            className={widgetClassName}
+            placeholder={widgetPlaceholder}
           />
-          <Asterisk className="size-3" />
-          Any value
-        </label>
-      </div>
+        )
+      ) : (
+        <div className="flex items-center gap-2">
+          <ParameterFieldWidget
+            paramKey={paramKey}
+            property={property}
+            value={widgetValue}
+            onChange={(v) => onValueChange(paramKey, v)}
+            disabled={widgetDisabled}
+            className={widgetClassName}
+            placeholder={widgetPlaceholder}
+          />
+          {anyValueCheckbox}
+        </div>
+      )}
       {!isWildcard && value.includes("*") && (
         <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
           <p className="text-muted-foreground text-xs leading-relaxed">

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -1,8 +1,10 @@
+import { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
+import { inferWidgetFromProperty } from "@/lib/parameterSchema";
 
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
@@ -35,7 +37,7 @@ export function ParameterFieldWidget({
   placeholder: placeholderOverride,
 }: ParameterFieldWidgetProps) {
   const ui = property["x-ui"];
-  const widget: WidgetType = ui?.widget ?? inferWidget(property);
+  const widget: WidgetType = ui?.widget ?? inferWidgetFromProperty(property);
   const placeholder = placeholderOverride ?? ui?.placeholder;
   const inputId = `param-${paramKey}`;
 
@@ -53,14 +55,6 @@ export function ParameterFieldWidget({
       <FieldHints ui={ui} />
     </div>
   );
-}
-
-/** Infer widget from schema type when no explicit x-ui.widget is set. */
-function inferWidget(property: SchemaProperty): WidgetType {
-  if (property.type === "boolean") return "toggle";
-  if (property.type === "integer" || property.type === "number") return "number";
-  if (property.type === "array" && property.items?.type === "string") return "list";
-  return "text";
 }
 
 interface WidgetRenderProps {
@@ -229,13 +223,22 @@ function parseListValue(value: string): string[] {
 
 /** Serialize a string array into a JSON array string for form state. */
 function serializeListValue(items: string[]): string {
-  const filtered = items.filter((item) => item !== "");
-  if (filtered.length === 0) return "";
-  return JSON.stringify(filtered);
+  if (items.length === 0) return "";
+  return JSON.stringify(items);
 }
 
 function ListWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
   const items = parseListValue(value);
+  const nextId = useRef(0);
+  const rowIds = useRef<number[]>([]);
+
+  // Keep rowIds in sync with items length, assigning stable IDs to new rows.
+  while (rowIds.current.length < items.length) {
+    rowIds.current.push(nextId.current++);
+  }
+  if (rowIds.current.length > items.length) {
+    rowIds.current = rowIds.current.slice(0, items.length);
+  }
 
   function updateItem(index: number, newValue: string) {
     const next = [...items];
@@ -245,17 +248,19 @@ function ListWidget({ inputId, value, onChange, disabled, placeholder, className
 
   function removeItem(index: number) {
     const next = items.filter((_, i) => i !== index);
+    rowIds.current = rowIds.current.filter((_, i) => i !== index);
     onChange(serializeListValue(next));
   }
 
   function addItem() {
+    rowIds.current.push(nextId.current++);
     onChange(serializeListValue([...items, ""]));
   }
 
   return (
     <div className="w-full space-y-2" data-testid={`list-${inputId}`}>
       {items.map((item, index) => (
-        <div key={index} className="flex items-center gap-2">
+        <div key={rowIds.current[index]} className="flex items-center gap-2">
           <Input
             id={index === 0 ? inputId : undefined}
             type="text"

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -1,6 +1,7 @@
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
 
 export interface ParameterFieldWidgetProps {
@@ -34,7 +35,7 @@ export function ParameterFieldWidget({
   placeholder: placeholderOverride,
 }: ParameterFieldWidgetProps) {
   const ui = property["x-ui"];
-  const widget: WidgetType = ui?.widget ?? "text";
+  const widget: WidgetType = ui?.widget ?? inferWidget(property);
   const placeholder = placeholderOverride ?? ui?.placeholder;
   const inputId = `param-${paramKey}`;
 
@@ -52,6 +53,14 @@ export function ParameterFieldWidget({
       <FieldHints ui={ui} />
     </div>
   );
+}
+
+/** Infer widget from schema type when no explicit x-ui.widget is set. */
+function inferWidget(property: SchemaProperty): WidgetType {
+  if (property.type === "boolean") return "toggle";
+  if (property.type === "integer" || property.type === "number") return "number";
+  if (property.type === "array" && property.items?.type === "string") return "list";
+  return "text";
 }
 
 interface WidgetRenderProps {
@@ -78,6 +87,8 @@ function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
       return <DateWidget {...props} />;
     case "datetime":
       return <DateTimeWidget {...props} />;
+    case "list":
+      return <ListWidget {...props} />;
     case "text":
     default:
       return <TextWidget {...props} />;
@@ -199,6 +210,86 @@ function DateTimeWidget({ inputId, value, onChange, disabled, placeholder, class
       placeholder={placeholder}
       className={className}
     />
+  );
+}
+
+/** Parse a JSON array string into a string array, with fallback for non-JSON values. */
+function parseListValue(value: string): string[] {
+  if (!value) return [];
+  if (value.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.map(String);
+    } catch {
+      // fall through
+    }
+  }
+  return [value];
+}
+
+/** Serialize a string array into a JSON array string for form state. */
+function serializeListValue(items: string[]): string {
+  const filtered = items.filter((item) => item !== "");
+  if (filtered.length === 0) return "";
+  return JSON.stringify(filtered);
+}
+
+function ListWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
+  const items = parseListValue(value);
+
+  function updateItem(index: number, newValue: string) {
+    const next = [...items];
+    next[index] = newValue;
+    onChange(serializeListValue(next));
+  }
+
+  function removeItem(index: number) {
+    const next = items.filter((_, i) => i !== index);
+    onChange(serializeListValue(next));
+  }
+
+  function addItem() {
+    onChange(serializeListValue([...items, ""]));
+  }
+
+  return (
+    <div className="w-full space-y-2" data-testid={`list-${inputId}`}>
+      {items.map((item, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Input
+            id={index === 0 ? inputId : undefined}
+            type="text"
+            value={item}
+            onChange={(e) => updateItem(index, e.target.value)}
+            disabled={disabled}
+            placeholder={placeholder ?? `Item ${index + 1}`}
+            className={className}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0"
+            onClick={() => removeItem(index)}
+            disabled={disabled}
+            aria-label={`Remove item ${index + 1}`}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="gap-1"
+        onClick={addItem}
+        disabled={disabled}
+      >
+        <Plus className="size-4" />
+        Add item
+      </Button>
+    </div>
   );
 }
 

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
@@ -65,4 +65,16 @@ describe("buildParametersFromForm", () => {
     expect(result.field).toBe("*");
     expect(result.field).not.toEqual({ $pattern: "*" });
   });
+
+  it("coerces array types from JSON string to array", () => {
+    const schema = { tags: { type: "array" } };
+    const result = buildParametersFromForm({ tags: '["a","b"]' }, schema);
+    expect(result).toEqual({ tags: ["a", "b"] });
+  });
+
+  it("falls through to string when array JSON is invalid", () => {
+    const schema = { tags: { type: "array" } };
+    const result = buildParametersFromForm({ tags: "not-json" }, schema);
+    expect(result).toEqual({ tags: "not-json" });
+  });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
@@ -78,6 +78,12 @@ describe("buildParametersFromForm", () => {
     expect(result).toEqual({ tags: ["a", "b"] });
   });
 
+  it("preserves array with wildcard item instead of treating it as a pattern", () => {
+    const schema = { tags: { type: "array" } };
+    const result = buildParametersFromForm({ tags: '["tag*","billing"]' }, schema);
+    expect(result).toEqual({ tags: ["tag*", "billing"] });
+  });
+
   it("falls through to string when array JSON is invalid", () => {
     const schema = { tags: { type: "array" } };
     const result = buildParametersFromForm({ tags: "not-json" }, schema);

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
@@ -84,6 +84,12 @@ describe("buildParametersFromForm", () => {
     expect(result).toEqual({ tags: ["tag*", "billing"] });
   });
 
+  it("omits array key when all items are empty strings", () => {
+    const schema = { tags: { type: "array" } };
+    const result = buildParametersFromForm({ tags: '["",""]' }, schema);
+    expect(result).toEqual({});
+  });
+
   it("falls through to string when array JSON is invalid", () => {
     const schema = { tags: { type: "array" } };
     const result = buildParametersFromForm({ tags: "not-json" }, schema);

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigFormFields.test.ts
@@ -72,6 +72,12 @@ describe("buildParametersFromForm", () => {
     expect(result).toEqual({ tags: ["a", "b"] });
   });
 
+  it("filters empty strings from array values at submission", () => {
+    const schema = { tags: { type: "array" } };
+    const result = buildParametersFromForm({ tags: '["a","","b",""]' }, schema);
+    expect(result).toEqual({ tags: ["a", "b"] });
+  });
+
   it("falls through to string when array JSON is invalid", () => {
     const schema = { tags: { type: "array" } };
     const result = buildParametersFromForm({ tags: "not-json" }, schema);

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
@@ -76,11 +76,11 @@ describe("ActionConfigParameterFields", () => {
       expect(screen.getByText("required")).toBeInTheDocument();
     });
 
-    it("shows type annotation", () => {
+    it("shows friendly type annotation", () => {
       renderFields(basicSchema);
 
-      // Both fields are type: "string", so there should be two type annotations
-      expect(screen.getAllByText("(string)")).toHaveLength(2);
+      // Both fields are type: "string", displayed as "(text)"
+      expect(screen.getAllByText("(text)")).toHaveLength(2);
     });
 
     it("shows description text", () => {
@@ -542,6 +542,49 @@ describe("ActionConfigParameterFields", () => {
       });
 
       expect(screen.queryByText("matches any text")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("auto-mapping", () => {
+    it("auto-maps boolean type to toggle widget without explicit x-ui.widget", () => {
+      const schema: ParametersSchema = {
+        type: "object",
+        properties: {
+          enabled: { type: "boolean", description: "Enable feature" },
+        },
+      };
+
+      renderFields(schema, { values: { enabled: "false" } });
+
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+      expect(screen.getByText("(yes / no)")).toBeInTheDocument();
+    });
+
+    it("auto-maps array type with string items to list widget", () => {
+      const schema: ParametersSchema = {
+        type: "object",
+        properties: {
+          tags: { type: "array", items: { type: "string" }, description: "Tags" },
+        },
+      };
+
+      renderFields(schema);
+
+      expect(screen.getByTestId("list-param-tags")).toBeInTheDocument();
+      expect(screen.getByText("(list)")).toBeInTheDocument();
+    });
+
+    it("does not show type annotation for object type", () => {
+      const schema: ParametersSchema = {
+        type: "object",
+        properties: {
+          metadata: { type: "object", description: "Extra data" },
+        },
+      };
+
+      renderFields(schema);
+
+      expect(screen.queryByText("(object)")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -368,8 +368,8 @@ describe("ParameterFieldWidget", () => {
 
       await user.click(screen.getByRole("button", { name: /add item/i }));
 
-      // Adding an empty item then filtering empties gives empty string
-      expect(onChange).toHaveBeenCalled();
+      // Should serialize with the empty item so a row appears for the user to type into
+      expect(onChange).toHaveBeenCalledWith('[""]');
     });
 
     it("removes an item when the remove button is clicked", async () => {

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -340,6 +340,69 @@ describe("ParameterFieldWidget", () => {
     });
   });
 
+  describe("list widget", () => {
+    const listProp: SchemaProperty = {
+      type: "array",
+      items: { type: "string" },
+      "x-ui": { widget: "list" },
+    };
+
+    it("renders an add item button when value is empty", () => {
+      renderWidget(listProp, "");
+
+      expect(screen.getByRole("button", { name: /add item/i })).toBeInTheDocument();
+    });
+
+    it("renders items from a JSON array value", () => {
+      renderWidget(listProp, '["tag1","tag2"]');
+
+      const inputs = screen.getAllByRole("textbox");
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0]).toHaveValue("tag1");
+      expect(inputs[1]).toHaveValue("tag2");
+    });
+
+    it("adds a new empty item when Add item is clicked", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(listProp, "");
+
+      await user.click(screen.getByRole("button", { name: /add item/i }));
+
+      // Adding an empty item then filtering empties gives empty string
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it("removes an item when the remove button is clicked", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(listProp, '["a","b"]');
+
+      const removeButtons = screen.getAllByRole("button", { name: /remove item/i });
+      await user.click(removeButtons[0]!);
+
+      expect(onChange).toHaveBeenCalledWith('["b"]');
+    });
+
+    it("fires onChange with updated JSON when an item is edited", async () => {
+      const user = userEvent.setup();
+      const { onChange } = renderWidget(listProp, '["a"]');
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "b");
+
+      // Last call should serialize the appended value
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1]?.[0];
+      expect(lastCall).toBe('["ab"]');
+    });
+
+    it("disables inputs and buttons when disabled", () => {
+      renderWidget(listProp, '["a"]', vi.fn(), true);
+
+      expect(screen.getByRole("textbox")).toBeDisabled();
+      expect(screen.getByRole("button", { name: /remove item/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /add item/i })).toBeDisabled();
+    });
+  });
+
   describe("disabled state", () => {
     it("disables the text input when disabled", () => {
       renderWidget({ type: "string" }, "", vi.fn(), true);


### PR DESCRIPTION
## Summary
- Replace technical JSON Schema type labels with friendly names visible to users: `string`→`text`, `boolean`→`yes / no`, `array`→`list`, `integer`/`number`→`number`. Types like `object` are hidden entirely.
- Auto-map schema types to appropriate widgets even without explicit `x-ui.widget` hints: `boolean`→toggle switch, `array` (with string items)→list widget, `integer`/`number`→number input.
- Add a new **list widget** for array-type parameters with add/remove item buttons and a clean multi-value UI, replacing the previous plain text input where users had to guess the format.

## Test plan

### Claude Code
- [x] All 943 frontend tests pass
- [x] TypeScript compilation passes with no errors
- [x] Verify no regressions in existing action config and standing approval flows

### Manual Testing
- [ ] Open action config modal for a connector with boolean params (e.g., Stripe `auto_advance`) — should show toggle switch instead of text input
- [ ] Open action config modal for a connector with array params (e.g., Asana `tags`) — should show list widget with Add item button
- [ ] Verify type labels show "text", "yes / no", "number", "list" instead of "string", "boolean", "integer", "array"
- [ ] Verify the standing approval constraint form also uses the new friendly inputs
- [ ] Test adding/removing items in the list widget, then saving the config

https://claude.ai/code/session_018uJE63wn5GKYhZHTe6b1Ry