### PR TITLE
Style storybook constraints help text as subtle callout

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
@@ -252,10 +252,12 @@ function StoryConstraintField({
         </label>
       </div>
       {!isWildcard && value.includes("*") && (
-        <p className="text-muted-foreground text-sm">
-          <code className="rounded bg-muted px-1 font-mono">*</code> matches
-          any text
-        </p>
+        <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            <code className="rounded bg-muted px-1 font-mono text-foreground/70">*</code> matches
+            any text
+          </p>
+        </div>
       )}
     </div>
   );
@@ -294,15 +296,17 @@ function StoryStepConstraints({
       {properties ? (
         <div className="space-y-3">
           <Label>Constraints</Label>
-          <p className="text-muted-foreground text-sm leading-relaxed">
-            Use{" "}
-            <code className="rounded bg-muted px-1 font-mono">*</code> as a
-            wildcard in any value (e.g.{" "}
-            <code className="rounded bg-muted px-1 font-mono">
-              *@mycompany.com
-            </code>
-            ). Check <strong>Any value</strong> to let the agent choose freely.
-          </p>
+          <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              Use{" "}
+              <code className="rounded bg-muted px-1 font-mono text-foreground/70">*</code> as a
+              wildcard in any value (e.g.{" "}
+              <code className="rounded bg-muted px-1 font-mono text-foreground/70">
+                *@mycompany.com
+              </code>
+              ). Check <strong className="text-foreground/70">Any value</strong> to let the agent choose freely.
+            </p>
+          </div>
           {Object.entries(properties).map(([key, prop]) => (
             <StoryConstraintField
               key={key}
@@ -319,10 +323,12 @@ function StoryStepConstraints({
       ) : (
         <div className="space-y-2">
           <Label htmlFor="sa-manual-constraints">Constraints (JSON)</Label>
-          <p className="text-muted-foreground text-sm">
-            No parameter schema found for this action. Enter constraints
-            manually as a JSON object.
-          </p>
+          <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              No parameter schema found for this action. Enter constraints
+              manually as a JSON object.
+            </p>
+          </div>
           <textarea
             id="sa-manual-constraints"
             className="border-input bg-background ring-offset-background focus-visible:ring-ring flex min-h-[100px] w-full rounded-md border px-3 py-2 font-mono text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
@@ -332,11 +338,13 @@ function StoryStepConstraints({
             value={manualConstraintsJson}
             onChange={(e) => onManualConstraintsJsonChange(e.target.value)}
           />
-          <p className="text-muted-foreground text-sm">
-            Use{" "}
-            <code className="rounded bg-muted px-1 font-mono">&quot;*&quot;</code>{" "}
-            for wildcard parameters, but at least one must be non-wildcard.
-          </p>
+          <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              Use{" "}
+              <code className="rounded bg-muted px-1 font-mono text-foreground/70">&quot;*&quot;</code>{" "}
+              for wildcard parameters, but at least one must be non-wildcard.
+            </p>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Applied the same dashed-border callout styling from PR #654 to the storybook `StoryStepConstraints` and `StoryConstraintField` components
- Wrapped 4 help text blocks in `rounded-lg border border-dashed bg-muted/40` containers with `text-xs` and `text-foreground/70` tints
- Maintains storybook ↔ production parity per project guidelines

## Test plan
### Claude Code
- [x] TypeScript compiles (no new errors)
- [x] Frontend tests pass (pre-existing failures in SchemaParameterDetails are unrelated)

### Manual Testing
- [ ] Open Step 3 – Constraints (Schema) story — verify dashed callout on wildcard intro text
- [ ] Open Step 3 – Constraints (Manual JSON) story — verify both help text blocks styled
- [ ] Check dark theme rendering

https://claude.ai/code/session_01V4xtFGcRHgz2wH72QpzkFV