### PR TITLE
Fix CI failure webhook notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,5 +126,4 @@ jobs:
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh workflow run trigger-webhook.yml \
-          gh workflow run trigger-webhook.yml \
             -f message="CI failed on ${{ github.ref_name }} — investigate: ${RUN_URL}"


### PR DESCRIPTION
## Summary
- The `notify-failure` job's webhook step had a duplicate `gh workflow run trigger-webhook.yml \` line (lines 128-129), causing the shell to produce a malformed command. The webhook notification silently failed on every CI failure.
- Removed the duplicate line so the webhook fires correctly.

Triggered by: https://github.com/supersuit-tech/permission-slip/actions/runs/23170021097

## Test plan

### Claude Code
- [ ] Verify CI passes on this branch

### Manual Testing
- [ ] Trigger a CI failure on a test branch and confirm the webhook notification is received

https://claude.ai/code/session_01KXA4NzPse3QK1QMpv7EEJ9