### PR TITLE
Fix markdown textarea and datetime picker rendering in constraint forms

### DIFF
--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -47,7 +47,8 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Issue body (Markdown supported)"
+							"description": "Issue body (Markdown supported)",
+							"x-ui": {"widget": "textarea"}
 						}
 					}
 				}`)),
@@ -105,7 +106,8 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Pull request body (Markdown supported)"
+							"description": "Pull request body (Markdown supported)",
+							"x-ui": {"widget": "textarea"}
 						},
 						"head": {
 							"type": "string",
@@ -179,7 +181,8 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Release notes (Markdown supported)"
+							"description": "Release notes (Markdown supported)",
+							"x-ui": {"widget": "textarea"}
 						},
 						"draft": {
 							"type": "boolean",
@@ -280,7 +283,8 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Comment body (Markdown supported)"
+							"description": "Comment body (Markdown supported)",
+							"x-ui": {"widget": "textarea"}
 						}
 					}
 				}`)),

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -95,10 +95,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "Start time in RFC 3339 format (e.g. '2024-01-15T09:00:00-05:00')"
 						},
 						"end_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "End time in RFC 3339 format (e.g. '2024-01-15T10:00:00-05:00')"
 						},
 						"attendees": {
@@ -137,10 +139,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"time_min": {
 							"type": "string",
+							"format": "date-time",
 							"description": "Lower bound (inclusive) for event start time in RFC 3339 format. Defaults to now."
 						},
 						"time_max": {
 							"type": "string",
+							"format": "date-time",
 							"description": "Upper bound (exclusive) for event start time in RFC 3339 format"
 						}
 					}
@@ -458,10 +462,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "Start time in RFC 3339 format (e.g. '2024-01-15T09:00:00-05:00')"
 						},
 						"end_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "End time in RFC 3339 format (e.g. '2024-01-15T10:00:00-05:00')"
 						},
 						"attendees": {
@@ -607,10 +613,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "New start time in RFC 3339 format. Must be provided together with end_time."
 						},
 						"end_time": {
 							"type": "string",
+							"format": "date-time",
 							"description": "New end time in RFC 3339 format. Must be provided together with start_time."
 						},
 						"attendees": {

--- a/connectors/linear/manifest.go
+++ b/connectors/linear/manifest.go
@@ -39,7 +39,8 @@ func (c *LinearConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"description": {
 							"type": "string",
-							"description": "Issue description (markdown)"
+							"description": "Issue description (markdown)",
+							"x-ui": {"widget": "textarea"}
 						},
 						"assignee_id": {
 							"type": "string",
@@ -86,7 +87,8 @@ func (c *LinearConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"description": {
 							"type": "string",
-							"description": "New issue description (markdown)"
+							"description": "New issue description (markdown)",
+							"x-ui": {"widget": "textarea"}
 						},
 						"assignee_id": {
 							"type": "string",
@@ -125,7 +127,8 @@ func (c *LinearConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Comment body (markdown)"
+							"description": "Comment body (markdown)",
+							"x-ui": {"widget": "textarea"}
 						}
 					}
 				}`)),

--- a/connectors/trello/manifest_actions.go
+++ b/connectors/trello/manifest_actions.go
@@ -30,7 +30,8 @@ func trelloActions() []connectors.ManifestAction {
 					},
 					"desc": {
 						"type": "string",
-						"description": "Card description (supports Markdown)"
+						"description": "Card description (supports Markdown)",
+						"x-ui": {"widget": "textarea"}
 					},
 					"pos": {
 						"type": "string",
@@ -70,10 +71,12 @@ func trelloActions() []connectors.ManifestAction {
 					},
 					"desc": {
 						"type": "string",
-						"description": "New card description (supports Markdown)"
+						"description": "New card description (supports Markdown)",
+						"x-ui": {"widget": "textarea"}
 					},
 					"due": {
 						"type": "string",
+						"format": "date-time",
 						"description": "Due date in ISO 8601 format"
 					},
 					"dueComplete": {

--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -4,6 +4,7 @@ import {
   getFieldLabel,
   getOrderedFieldKeys,
   isFieldVisible,
+  inferWidgetFromProperty,
   type SchemaPropertyUI,
   type SchemaUI,
 } from "../parameterSchema";
@@ -606,6 +607,80 @@ describe("parseParametersSchema", () => {
       });
 
       expect(result?.properties?.name?.format).toBeUndefined();
+    });
+  });
+
+  describe("inferWidgetFromProperty heuristics", () => {
+    it("infers datetime for RFC 3339 description", () => {
+      expect(inferWidgetFromProperty({
+        type: "string",
+        description: "Start time in RFC 3339 format",
+      })).toBe("datetime");
+    });
+
+    it("infers datetime for ISO 8601 description", () => {
+      expect(inferWidgetFromProperty({
+        type: "string",
+        description: "Due date in ISO 8601 format",
+      })).toBe("datetime");
+    });
+
+    it("does not infer datetime when description mentions epoch", () => {
+      expect(inferWidgetFromProperty({
+        type: "string",
+        description: "Start date/time (ISO 8601 or epoch milliseconds)",
+      })).toBe("text");
+    });
+
+    it("infers textarea for markdown description", () => {
+      expect(inferWidgetFromProperty({
+        type: "string",
+        description: "Issue body (Markdown supported)",
+      })).toBe("textarea");
+    });
+
+    it("infers textarea for lowercase markdown description", () => {
+      expect(inferWidgetFromProperty({
+        type: "string",
+        description: "Comment body (markdown)",
+      })).toBe("textarea");
+    });
+
+    it("does not apply heuristics for non-string types", () => {
+      expect(inferWidgetFromProperty({
+        type: "integer",
+        description: "Some RFC 3339 thing",
+      })).toBe("number");
+    });
+  });
+
+  describe("auto-mapping heuristics in parseParametersSchema", () => {
+    it("auto-maps RFC 3339 string fields to datetime widget", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          start_time: {
+            type: "string",
+            description: "Start time in RFC 3339 format (e.g. '2024-01-15T09:00:00-05:00')",
+          },
+        },
+      });
+
+      expect(result?.properties?.start_time?.["x-ui"]?.widget).toBe("datetime");
+    });
+
+    it("auto-maps markdown body fields to textarea widget", () => {
+      const result = parseParametersSchema({
+        type: "object",
+        properties: {
+          body: {
+            type: "string",
+            description: "Issue body (Markdown supported)",
+          },
+        },
+      });
+
+      expect(result?.properties?.body?.["x-ui"]?.widget).toBe("textarea");
     });
   });
 

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -92,15 +92,15 @@ export function parseParametersSchema(
       const prop = val as Record<string, unknown>;
       const propType = typeof prop.type === "string" ? prop.type : undefined;
       const format = typeof prop.format === "string" ? prop.format : undefined;
+      const description = typeof prop.description === "string" ? prop.description : undefined;
       const parsedUI = parsePropertyUI(prop["x-ui"]);
       const items = parseItems(prop.items);
       // Auto-map types to widgets when no explicit widget is set
-      const ui = autoMapWidget(propType, format, items, parsedUI);
+      const ui = autoMapWidget(propType, format, items, description, parsedUI);
       properties[key] = {
         type: propType,
         format,
-        description:
-          typeof prop.description === "string" ? prop.description : undefined,
+        description,
         enum: Array.isArray(prop.enum)
           ? prop.enum.filter((e): e is string => typeof e === "string")
           : undefined,
@@ -194,6 +194,19 @@ export function inferWidgetFromProperty(property: SchemaProperty): WidgetType {
   if (property.type === "boolean") return "toggle";
   if (property.type === "integer" || property.type === "number") return "number";
   if (property.type === "array" && property.items?.type === "string") return "list";
+
+  // Heuristic: detect datetime fields by description mentioning RFC 3339 or ISO 8601
+  if (property.type === "string" && property.description) {
+    const desc = property.description.toLowerCase();
+    if ((desc.includes("rfc 3339") || desc.includes("rfc3339") || desc.includes("iso 8601")) && !desc.includes("epoch")) {
+      return "datetime";
+    }
+    // Heuristic: detect textarea fields for markdown body content
+    if (desc.includes("markdown")) {
+      return "textarea";
+    }
+  }
+
   return "text";
 }
 
@@ -206,11 +219,12 @@ function autoMapWidget(
   type: string | undefined,
   format: string | undefined,
   items: { type?: string } | undefined,
+  description: string | undefined,
   parsedUI: SchemaPropertyUI | undefined,
 ): SchemaPropertyUI | undefined {
   if (parsedUI?.widget) return parsedUI;
 
-  const inferred = inferWidgetFromProperty({ type, format, items });
+  const inferred = inferWidgetFromProperty({ type, format, items, description });
   if (inferred !== "text") {
     return { ...parsedUI, widget: inferred };
   }


### PR DESCRIPTION
## Summary

- **Markdown body fields** (GitHub issues/PRs/comments, Linear issues/comments, Trello card descriptions) were rendering as single-line `<input>` instead of `<textarea>`. Added explicit `x-ui: {"widget": "textarea"}` to all affected connector schemas.
- **Date/time fields** (Google Calendar start/end times, list event filters, Trello due dates) were rendering as plain text inputs expecting raw RFC 3339 strings. Added `"format": "date-time"` so they auto-map to `datetime-local` pickers.
- **Heuristic safety net**: Added fallback detection in `inferWidgetFromProperty` — descriptions mentioning "RFC 3339" or "ISO 8601" infer datetime widget, descriptions mentioning "markdown" infer textarea widget. Excludes fields that also mention "epoch" (e.g. HubSpot dual-format fields).

## Test plan

### Claude Code
- [x] All 954 frontend tests pass
- [x] New unit tests added for heuristic detection (6 tests)
- [ ] Verify Go build compiles cleanly

### Manual Testing
- [ ] Create a standing approval for GitHub "Create Issue" — verify body field renders as textarea
- [ ] Create a standing approval for Google Calendar "Create Event" — verify start/end times render as datetime pickers
- [ ] Create a standing approval for Linear "Create Issue" — verify description renders as textarea
- [ ] Create a standing approval for Trello "Create Card" — verify description renders as textarea and due date renders as datetime picker

https://claude.ai/code/session_01BvyFsi1N4cy4MVegpuKBoR