### PR TITLE
Fix GitHub repo creation returning opaque 404 error

### DIFF
--- a/connectors/github/create_repo.go
+++ b/connectors/github/create_repo.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -72,6 +73,14 @@ func (a *createRepoAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, path, ghBody, &ghResp); err != nil {
+		if params.Org != "" {
+			var ve *connectors.ValidationError
+			if errors.As(err, &ve) {
+				return nil, &connectors.ValidationError{
+					Message: fmt.Sprintf("could not create repo in org %q: %s", params.Org, ve.Message),
+				}
+			}
+		}
 		return nil, err
 	}
 

--- a/connectors/github/create_repo_test.go
+++ b/connectors/github/create_repo_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -316,6 +317,67 @@ func TestCreateRepo_MissingParams(t *testing.T) {
 				t.Errorf("expected ValidationError, got %T: %v", err, err)
 			}
 		})
+	}
+}
+
+func TestCreateRepo_OrgNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Not Found",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"test-repo","org":"nonexistent-org"}`),
+		Credentials: validCreds(),
+	})
+
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+	// Should mention the org name in the error for debugging.
+	if got := err.Error(); !strings.Contains(got, "nonexistent-org") {
+		t.Errorf("error should mention org name, got: %s", got)
+	}
+}
+
+func TestCreateRepo_PersonalNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Not Found",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["github.create_repo"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "github.create_repo",
+		Parameters:  json.RawMessage(`{"name":"test-repo"}`),
+		Credentials: validCreds(),
+	})
+
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	// Personal repo 404 should still be a ValidationError (from checkResponse).
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
 	}
 }
 

--- a/connectors/github/response.go
+++ b/connectors/github/response.go
@@ -38,6 +38,8 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 			Message:    fmt.Sprintf("GitHub API rate limit exceeded (403): %s", msg),
 			RetryAfter: retryAfter,
 		}
+	case statusCode == http.StatusNotFound:
+		return &connectors.ValidationError{Message: fmt.Sprintf("GitHub API resource not found: %s — check that the resource exists and your token has access", msg)}
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
 		return &connectors.AuthError{Message: fmt.Sprintf("GitHub API auth error (%d): %s", statusCode, msg)}
 	case statusCode == http.StatusUnprocessableEntity:


### PR DESCRIPTION
## Summary
- GitHub returns 404 when an org doesn't exist or the token lacks access (privacy behavior), but this was falling through to a generic `ExternalError` → HTTP 502 "External service returned an error" with no context
- Added 404 → `ValidationError` mapping in `checkResponse` with a helpful message about checking resource existence and token permissions
- Added org-name context wrapping in `createRepoAction.Execute` so errors like `could not create repo in org "acme": ...` make it clear what went wrong

## Test plan
### Claude Code
- [x] Added `TestCreateRepo_OrgNotFound` — verifies 404 on org repo returns `ValidationError` mentioning the org name
- [x] Added `TestCreateRepo_PersonalNotFound` — verifies 404 on personal repo returns `ValidationError`
- [x] All existing `TestCreateRepo_*` tests pass (no regressions)
- [x] Full `connectors/github` test suite passes

### Manual Testing
- [ ] Trigger a repo creation approval for a non-existent org and verify the error message is actionable
- [ ] Verify existing repo creation flows (personal + org) still work end-to-end

https://claude.ai/code/session_012xfdUHBRxWfhA6GoNp1dVc