### PR TITLE
Fix Slack modal widgets and add schema quality lint

### DIFF
--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -21,29 +21,106 @@ import (
 // lint.
 var knownMissingAnnotations = map[string]bool{
 	// textarea — sendgrid HTML content fields
-	"sendgrid.sendgrid.send_campaign:html_content":              true,
-	"sendgrid.sendgrid.schedule_campaign:html_content":          true,
-	"sendgrid.sendgrid.send_transactional_email:html_content":   true,
+	"sendgrid.sendgrid.send_campaign:html_content":            true,
+	"sendgrid.sendgrid.schedule_campaign:html_content":        true,
+	"sendgrid.sendgrid.send_transactional_email:html_content": true,
 
 	// datetime — various connectors with ISO 8601 fields missing format
-	"asana.asana.create_task:due_at":                            true,
-	"asana.asana.update_task:due_at":                            true,
-	"calendly.calendly.list_scheduled_events:min_start_time":    true,
-	"calendly.calendly.list_scheduled_events:max_start_time":    true,
-	"calendly.calendly.list_available_times:start_time":         true,
-	"calendly.calendly.list_available_times:end_time":           true,
-	"dropbox.dropbox.share_file:expires":                        true,
-	"hubspot.hubspot.create_deal:closedate":                     true,
-	"hubspot.hubspot.update_deal_stage:close_date":              true,
-	"jira.jira.create_sprint:start_date":                        true,
-	"jira.jira.create_sprint:end_date":                          true,
-	"microsoft.microsoft.create_calendar_event:start":           true,
-	"microsoft.microsoft.create_calendar_event:end":             true,
-	"pagerduty.pagerduty.list_on_call:since":                    true,
-	"pagerduty.pagerduty.list_on_call:until":                    true,
-	"trello.trello.create_card:due":                             true,
-	"zoom.zoom.create_meeting:start_time":                       true,
-	"zoom.zoom.update_meeting:start_time":                       true,
+	"asana.asana.create_task:due_at":                         true,
+	"asana.asana.update_task:due_at":                         true,
+	"calendly.calendly.list_scheduled_events:min_start_time": true,
+	"calendly.calendly.list_scheduled_events:max_start_time": true,
+	"calendly.calendly.list_available_times:start_time":      true,
+	"calendly.calendly.list_available_times:end_time":        true,
+	"dropbox.dropbox.share_file:expires":                     true,
+	"hubspot.hubspot.create_deal:closedate":                  true,
+	"hubspot.hubspot.update_deal_stage:close_date":           true,
+	"jira.jira.create_sprint:start_date":                     true,
+	"jira.jira.create_sprint:end_date":                       true,
+	"microsoft.microsoft.create_calendar_event:start":        true,
+	"microsoft.microsoft.create_calendar_event:end":          true,
+	"pagerduty.pagerduty.list_on_call:since":                 true,
+	"pagerduty.pagerduty.list_on_call:until":                 true,
+	"trello.trello.create_card:due":                          true,
+	"zoom.zoom.create_meeting:start_time":                    true,
+	"zoom.zoom.update_meeting:start_time":                    true,
+}
+
+// annotationIssue describes a single missing annotation found by the lint.
+type annotationIssue struct {
+	fieldKey   string // "connector.action_type:field_name"
+	actionType string
+	fieldName  string
+	rule       string // "textarea" or "datetime"
+	desc       string // original description
+	widget     string // current widget (empty = default text)
+}
+
+// collectMissingAnnotations scans all built-in connector manifests and returns
+// every field that is missing a widget annotation. Both test functions use this
+// to avoid duplicating the detection logic.
+func collectMissingAnnotations(t *testing.T) []annotationIssue {
+	t.Helper()
+
+	var issues []annotationIssue
+
+	for _, c := range connectors.BuiltInConnectors() {
+		mp, ok := c.(connectors.ManifestProvider)
+		if !ok {
+			continue
+		}
+		m := mp.Manifest()
+
+		for _, action := range m.Actions {
+			schema := parseSchema(t, m.ID, action.ActionType, action.ParametersSchema)
+			if schema == nil {
+				continue
+			}
+
+			props, ok := schema["properties"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			for key, rawProp := range props {
+				prop, ok := rawProp.(map[string]any)
+				if !ok {
+					continue
+				}
+				propType, _ := prop["type"].(string)
+				desc, _ := prop["description"].(string)
+				descLower := strings.ToLower(desc)
+				widget := extractWidget(prop)
+				fieldKey := fmt.Sprintf("%s.%s:%s", m.ID, action.ActionType, key)
+
+				// Rule 1: rich text fields should be textarea
+				if propType == "string" && widget != "textarea" {
+					if containsAny(descLower, "markdown", "mrkdwn", "html body", "html content") {
+						issues = append(issues, annotationIssue{
+							fieldKey: fieldKey, actionType: action.ActionType,
+							fieldName: key, rule: "textarea", desc: desc, widget: widget,
+						})
+					}
+				}
+
+				// Rule 2: datetime fields should have format: "date-time"
+				if propType == "string" && widget != "datetime" {
+					format, _ := prop["format"].(string)
+					if format == "date-time" {
+						continue
+					}
+					if (strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) && !strings.Contains(descLower, "epoch") {
+						issues = append(issues, annotationIssue{
+							fieldKey: fieldKey, actionType: action.ActionType,
+							fieldName: key, rule: "datetime", desc: desc, widget: widget,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return issues
 }
 
 // TestSchemaWidgetAnnotations is a quality lint that ensures all connector
@@ -57,65 +134,17 @@ var knownMissingAnnotations = map[string]bool{
 func TestSchemaWidgetAnnotations(t *testing.T) {
 	t.Parallel()
 
-	for _, c := range connectors.BuiltInConnectors() {
-		mp, ok := c.(connectors.ManifestProvider)
-		if !ok {
+	for _, issue := range collectMissingAnnotations(t) {
+		if knownMissingAnnotations[issue.fieldKey] {
 			continue
 		}
-		m := mp.Manifest()
-
-		for _, action := range m.Actions {
-			schema := parseSchema(t, m.ID, action.ActionType, action.ParametersSchema)
-			if schema == nil {
-				continue
-			}
-
-			props, ok := schema["properties"].(map[string]any)
-			if !ok {
-				continue
-			}
-
-			for key, rawProp := range props {
-				prop, ok := rawProp.(map[string]any)
-				if !ok {
-					continue
-				}
-				propType, _ := prop["type"].(string)
-				desc, _ := prop["description"].(string)
-				descLower := strings.ToLower(desc)
-				widget := extractWidget(prop)
-				fieldKey := fmt.Sprintf("%s.%s:%s", m.ID, action.ActionType, key)
-
-				// Rule 1: String fields whose description mentions "markdown",
-				// "mrkdwn", "html body", or "html content" should render as
-				// textarea — either via explicit widget or format-based auto-map.
-				if propType == "string" && widget != "textarea" {
-					if containsAny(descLower, "markdown", "mrkdwn", "html body", "html content") {
-						if knownMissingAnnotations[fieldKey] {
-							continue
-						}
-						t.Errorf("%s field %q: description mentions rich text (%q) but widget is %q — add `\"x-ui\": {\"widget\": \"textarea\"}`",
-							action.ActionType, key, desc, widgetOrDefault(widget))
-					}
-				}
-
-				// Rule 2: String fields with format "date-time" or descriptions
-				// mentioning RFC 3339 / ISO 8601 (without "epoch") should
-				// auto-map to datetime via format. Verify format is present.
-				if propType == "string" && widget != "datetime" {
-					format, _ := prop["format"].(string)
-					if format == "date-time" {
-						continue
-					}
-					if (strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) && !strings.Contains(descLower, "epoch") {
-						if knownMissingAnnotations[fieldKey] {
-							continue
-						}
-						t.Errorf("%s field %q: description mentions datetime format (%q) but missing `\"format\": \"date-time\"` — add it so the frontend renders a date picker",
-							action.ActionType, key, desc)
-					}
-				}
-			}
+		switch issue.rule {
+		case "textarea":
+			t.Errorf("%s field %q: description mentions rich text (%q) but widget is %q — add `\"x-ui\": {\"widget\": \"textarea\"}`",
+				issue.actionType, issue.fieldName, issue.desc, widgetOrDefault(issue.widget))
+		case "datetime":
+			t.Errorf("%s field %q: description mentions datetime format (%q) but missing `\"format\": \"date-time\"` — add it so the frontend renders a date picker",
+				issue.actionType, issue.fieldName, issue.desc)
 		}
 	}
 }
@@ -126,47 +155,9 @@ func TestSchemaWidgetAnnotations(t *testing.T) {
 func TestKnownMissingAnnotationsAreStillMissing(t *testing.T) {
 	t.Parallel()
 
-	// Build a set of all fields that are actually missing annotations.
 	actuallyMissing := make(map[string]bool)
-
-	for _, c := range connectors.BuiltInConnectors() {
-		mp, ok := c.(connectors.ManifestProvider)
-		if !ok {
-			continue
-		}
-		m := mp.Manifest()
-
-		for _, action := range m.Actions {
-			schema := parseSchema(t, m.ID, action.ActionType, action.ParametersSchema)
-			if schema == nil {
-				continue
-			}
-			props, ok := schema["properties"].(map[string]any)
-			if !ok {
-				continue
-			}
-			for key, rawProp := range props {
-				prop, ok := rawProp.(map[string]any)
-				if !ok {
-					continue
-				}
-				propType, _ := prop["type"].(string)
-				desc, _ := prop["description"].(string)
-				descLower := strings.ToLower(desc)
-				widget := extractWidget(prop)
-				fieldKey := fmt.Sprintf("%s.%s:%s", m.ID, action.ActionType, key)
-
-				if propType == "string" && widget != "textarea" && containsAny(descLower, "markdown", "mrkdwn", "html body", "html content") {
-					actuallyMissing[fieldKey] = true
-				}
-				if propType == "string" && widget != "datetime" {
-					format, _ := prop["format"].(string)
-					if format != "date-time" && (strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) && !strings.Contains(descLower, "epoch") {
-						actuallyMissing[fieldKey] = true
-					}
-				}
-			}
-		}
+	for _, issue := range collectMissingAnnotations(t) {
+		actuallyMissing[issue.fieldKey] = true
 	}
 
 	for fieldKey := range knownMissingAnnotations {

--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -1,0 +1,220 @@
+package all
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// knownMissingAnnotations lists connector fields that are known to be missing
+// widget annotations. Each entry is "connector.action_type:field_name".
+//
+// When you fix one of these, remove it from the list — the test will fail if
+// an allowlisted field is actually annotated correctly (i.e., the fix landed
+// but the allowlist wasn't updated).
+//
+// When adding a NEW connector, do NOT add entries here. Fix the annotation
+// instead. This list exists only for pre-existing connectors that predate the
+// lint.
+var knownMissingAnnotations = map[string]bool{
+	// textarea — sendgrid HTML content fields
+	"sendgrid.sendgrid.send_campaign:html_content":              true,
+	"sendgrid.sendgrid.schedule_campaign:html_content":          true,
+	"sendgrid.sendgrid.send_transactional_email:html_content":   true,
+
+	// datetime — various connectors with ISO 8601 fields missing format
+	"asana.asana.create_task:due_at":                            true,
+	"asana.asana.update_task:due_at":                            true,
+	"calendly.calendly.list_scheduled_events:min_start_time":    true,
+	"calendly.calendly.list_scheduled_events:max_start_time":    true,
+	"calendly.calendly.list_available_times:start_time":         true,
+	"calendly.calendly.list_available_times:end_time":           true,
+	"dropbox.dropbox.share_file:expires":                        true,
+	"hubspot.hubspot.create_deal:closedate":                     true,
+	"hubspot.hubspot.update_deal_stage:close_date":              true,
+	"jira.jira.create_sprint:start_date":                        true,
+	"jira.jira.create_sprint:end_date":                          true,
+	"microsoft.microsoft.create_calendar_event:start":           true,
+	"microsoft.microsoft.create_calendar_event:end":             true,
+	"pagerduty.pagerduty.list_on_call:since":                    true,
+	"pagerduty.pagerduty.list_on_call:until":                    true,
+	"trello.trello.create_card:due":                             true,
+	"zoom.zoom.create_meeting:start_time":                       true,
+	"zoom.zoom.update_meeting:start_time":                       true,
+}
+
+// TestSchemaWidgetAnnotations is a quality lint that ensures all connector
+// schemas have appropriate x-ui widget annotations. Without these, the
+// frontend renders default <input type="text"> for fields that should be
+// textareas, date pickers, toggles, etc.
+//
+// This test catches the class of bug fixed in PRs #658 and #659 — where
+// markdown body fields rendered as single-line inputs and datetime fields
+// rendered as plain text boxes.
+func TestSchemaWidgetAnnotations(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range connectors.BuiltInConnectors() {
+		mp, ok := c.(connectors.ManifestProvider)
+		if !ok {
+			continue
+		}
+		m := mp.Manifest()
+
+		for _, action := range m.Actions {
+			schema := parseSchema(t, m.ID, action.ActionType, action.ParametersSchema)
+			if schema == nil {
+				continue
+			}
+
+			props, ok := schema["properties"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			for key, rawProp := range props {
+				prop, ok := rawProp.(map[string]any)
+				if !ok {
+					continue
+				}
+				propType, _ := prop["type"].(string)
+				desc, _ := prop["description"].(string)
+				descLower := strings.ToLower(desc)
+				widget := extractWidget(prop)
+				fieldKey := fmt.Sprintf("%s.%s:%s", m.ID, action.ActionType, key)
+
+				// Rule 1: String fields whose description mentions "markdown",
+				// "mrkdwn", "html body", or "html content" should render as
+				// textarea — either via explicit widget or format-based auto-map.
+				if propType == "string" && widget != "textarea" {
+					if containsAny(descLower, "markdown", "mrkdwn", "html body", "html content") {
+						if knownMissingAnnotations[fieldKey] {
+							continue
+						}
+						t.Errorf("%s field %q: description mentions rich text (%q) but widget is %q — add `\"x-ui\": {\"widget\": \"textarea\"}`",
+							action.ActionType, key, desc, widgetOrDefault(widget))
+					}
+				}
+
+				// Rule 2: String fields with format "date-time" or descriptions
+				// mentioning RFC 3339 / ISO 8601 (without "epoch") should
+				// auto-map to datetime via format. Verify format is present.
+				if propType == "string" && widget != "datetime" {
+					format, _ := prop["format"].(string)
+					if format == "date-time" {
+						continue
+					}
+					if (strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) && !strings.Contains(descLower, "epoch") {
+						if knownMissingAnnotations[fieldKey] {
+							continue
+						}
+						t.Errorf("%s field %q: description mentions datetime format (%q) but missing `\"format\": \"date-time\"` — add it so the frontend renders a date picker",
+							action.ActionType, key, desc)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestKnownMissingAnnotationsAreStillMissing ensures the allowlist stays
+// current. If a field is fixed but still in the allowlist, this test fails —
+// forcing the developer to remove the stale entry.
+func TestKnownMissingAnnotationsAreStillMissing(t *testing.T) {
+	t.Parallel()
+
+	// Build a set of all fields that are actually missing annotations.
+	actuallyMissing := make(map[string]bool)
+
+	for _, c := range connectors.BuiltInConnectors() {
+		mp, ok := c.(connectors.ManifestProvider)
+		if !ok {
+			continue
+		}
+		m := mp.Manifest()
+
+		for _, action := range m.Actions {
+			schema := parseSchema(t, m.ID, action.ActionType, action.ParametersSchema)
+			if schema == nil {
+				continue
+			}
+			props, ok := schema["properties"].(map[string]any)
+			if !ok {
+				continue
+			}
+			for key, rawProp := range props {
+				prop, ok := rawProp.(map[string]any)
+				if !ok {
+					continue
+				}
+				propType, _ := prop["type"].(string)
+				desc, _ := prop["description"].(string)
+				descLower := strings.ToLower(desc)
+				widget := extractWidget(prop)
+				fieldKey := fmt.Sprintf("%s.%s:%s", m.ID, action.ActionType, key)
+
+				if propType == "string" && widget != "textarea" && containsAny(descLower, "markdown", "mrkdwn", "html body", "html content") {
+					actuallyMissing[fieldKey] = true
+				}
+				if propType == "string" && widget != "datetime" {
+					format, _ := prop["format"].(string)
+					if format != "date-time" && (strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) && !strings.Contains(descLower, "epoch") {
+						actuallyMissing[fieldKey] = true
+					}
+				}
+			}
+		}
+	}
+
+	for fieldKey := range knownMissingAnnotations {
+		if !actuallyMissing[fieldKey] {
+			t.Errorf("knownMissingAnnotations contains %q but that field is now properly annotated — remove it from the allowlist", fieldKey)
+		}
+	}
+}
+
+// parseSchema unmarshals a JSON Schema from a RawMessage, returning nil on
+// empty or invalid input.
+func parseSchema(t *testing.T, connID, actionType string, raw json.RawMessage) map[string]any {
+	t.Helper()
+	if len(raw) == 0 {
+		return nil
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Errorf("%s.%s: invalid parameters_schema JSON: %v", connID, actionType, err)
+		return nil
+	}
+	return schema
+}
+
+// extractWidget returns the x-ui.widget value from a property, or "".
+func extractWidget(prop map[string]any) string {
+	xui, ok := prop["x-ui"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	w, _ := xui["widget"].(string)
+	return w
+}
+
+// widgetOrDefault returns the widget name or "text" (the default) if empty.
+func widgetOrDefault(w string) string {
+	if w == "" {
+		return "text (default)"
+	}
+	return w
+}
+
+// containsAny returns true if s contains any of the substrings.
+func containsAny(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -106,10 +106,9 @@ func collectMissingAnnotations(t *testing.T) []annotationIssue {
 				// Rule 2: datetime fields should have format: "date-time"
 				if propType == "string" && widget != "datetime" {
 					format, _ := prop["format"].(string)
-					if format == "date-time" {
-						continue
-					}
-					if (strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) && !strings.Contains(descLower, "epoch") {
+					if format != "date-time" &&
+						(strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) &&
+						!strings.Contains(descLower, "epoch") {
 						issues = append(issues, annotationIssue{
 							fieldKey: fieldKey, actionType: action.ActionType,
 							fieldName: key, rule: "datetime", desc: desc, widget: widget,

--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -107,7 +107,7 @@ func collectMissingAnnotations(t *testing.T) []annotationIssue {
 				if propType == "string" && widget != "datetime" {
 					format, _ := prop["format"].(string)
 					if format != "date-time" &&
-						(strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "iso 8601")) &&
+						(strings.Contains(descLower, "rfc 3339") || strings.Contains(descLower, "rfc3339") || strings.Contains(descLower, "iso 8601")) &&
 						!strings.Contains(descLower, "epoch") {
 						issues = append(issues, annotationIssue{
 							fieldKey: fieldKey, actionType: action.ActionType,

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -113,6 +113,8 @@ var validWidgets = map[string]bool{
 	"toggle":   true,
 	"number":   true,
 	"date":     true,
+	"datetime": true,
+	"list":     true,
 }
 
 // validAuthTypes are the allowed values for credential auth types.

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -760,7 +760,7 @@ func TestParseManifest_XUIVisibleWhenEqualsNull(t *testing.T) {
 
 func TestParseManifest_XUIAllWidgetTypes(t *testing.T) {
 	// All valid widget types should be accepted.
-	for _, widget := range []string{"text", "select", "textarea", "toggle", "number", "date"} {
+	for _, widget := range []string{"text", "select", "textarea", "toggle", "number", "date", "datetime", "list"} {
 		t.Run(widget, func(t *testing.T) {
 			// "select" requires an enum array on the property.
 			propExtra := ""

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -178,7 +178,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"post_at": {
 							"type": "string",
 							"format": "date-time",
-							"description": "When the message should be sent (e.g. 2026-03-20T09:00)"
+							"description": "When the message should be sent in RFC 3339 format (e.g. 2026-03-20T09:00:00Z)"
 						}
 					}
 				}`)),

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -38,7 +38,8 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"message": {
 							"type": "string",
-							"description": "Message text (supports Slack mrkdwn formatting)"
+							"description": "Message text (supports Slack mrkdwn formatting)",
+							"x-ui": {"widget": "textarea"}
 						}
 					}
 				}`)),
@@ -171,11 +172,13 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"message": {
 							"type": "string",
-							"description": "Message text (supports Slack mrkdwn formatting)"
+							"description": "Message text (supports Slack mrkdwn formatting)",
+							"x-ui": {"widget": "textarea"}
 						},
 						"post_at": {
-							"type": "integer",
-							"description": "Unix timestamp for when the message should be sent (must be in the future)"
+							"type": "string",
+							"format": "date-time",
+							"description": "When the message should be sent (e.g. 2026-03-20T09:00)"
 						}
 					}
 				}`)),
@@ -239,7 +242,8 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"content": {
 							"type": "string",
-							"description": "File content as text"
+							"description": "File content as text",
+							"x-ui": {"widget": "textarea"}
 						},
 						"title": {
 							"type": "string",
@@ -287,7 +291,8 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"message": {
 							"type": "string",
-							"description": "Message text (supports Slack mrkdwn formatting)"
+							"description": "Message text (supports Slack mrkdwn formatting)",
+							"x-ui": {"widget": "textarea"}
 						}
 					}
 				}`)),
@@ -311,7 +316,8 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"message": {
 							"type": "string",
-							"description": "New message text (supports Slack mrkdwn formatting)"
+							"description": "New message text (supports Slack mrkdwn formatting)",
+							"x-ui": {"widget": "textarea"}
 						}
 					}
 				}`)),

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -40,15 +40,22 @@ func (p *scheduleMessageParams) validate() error {
 func (p *scheduleMessageParams) postAtUnix() (int64, error) {
 	// Try RFC 3339 first; also accept "datetime-local" format (no seconds, no TZ)
 	// emitted by HTML <input type="datetime-local">, treating it as UTC.
-	t, err := time.Parse(time.RFC3339, p.PostAt)
+	t, err := time.Parse(time.RFC3339Nano, p.PostAt)
 	if err != nil {
-		t2, err2 := time.Parse("2006-01-02T15:04", p.PostAt)
-		if err2 != nil {
+		// Also accept "datetime-local" formats (no TZ) emitted by HTML
+		// <input type="datetime-local">, treating them as UTC.
+		for _, layout := range []string{"2006-01-02T15:04:05", "2006-01-02T15:04"} {
+			if t2, err2 := time.Parse(layout, p.PostAt); err2 == nil {
+				t = t2.UTC()
+				err = nil
+				break
+			}
+		}
+		if err != nil {
 			return 0, &connectors.ValidationError{
 				Message: fmt.Sprintf("post_at must be a valid RFC 3339 datetime (e.g. 2026-03-20T09:00:00Z), got %q", p.PostAt),
 			}
 		}
-		t = t2.UTC()
 	}
 	unix := t.Unix()
 	if unix <= time.Now().Unix() {

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -18,7 +18,7 @@ type scheduleMessageAction struct {
 type scheduleMessageParams struct {
 	Channel string `json:"channel"`
 	Message string `json:"message"`
-	PostAt  int64  `json:"post_at"`
+	PostAt  string `json:"post_at"`
 }
 
 func (p *scheduleMessageParams) validate() error {
@@ -28,15 +28,29 @@ func (p *scheduleMessageParams) validate() error {
 	if p.Message == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: message"}
 	}
-	if p.PostAt <= 0 {
-		return &connectors.ValidationError{Message: "missing or invalid parameter: post_at (must be a positive Unix timestamp)"}
-	}
-	if p.PostAt <= time.Now().Unix() {
-		return &connectors.ValidationError{
-			Message: fmt.Sprintf("post_at must be in the future (got %d, current time is %d)", p.PostAt, time.Now().Unix()),
-		}
+	if p.PostAt == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: post_at"}
 	}
 	return nil
+}
+
+// postAtUnix parses the post_at field as RFC 3339 and returns the Unix
+// timestamp. Returns a ValidationError if the value is unparseable or in the
+// past.
+func (p *scheduleMessageParams) postAtUnix() (int64, error) {
+	t, err := time.Parse(time.RFC3339, p.PostAt)
+	if err != nil {
+		return 0, &connectors.ValidationError{
+			Message: fmt.Sprintf("post_at must be a valid RFC 3339 datetime (e.g. 2026-03-20T09:00:00Z), got %q", p.PostAt),
+		}
+	}
+	unix := t.Unix()
+	if unix <= time.Now().Unix() {
+		return 0, &connectors.ValidationError{
+			Message: fmt.Sprintf("post_at must be in the future (got %s)", p.PostAt),
+		}
+	}
+	return unix, nil
 }
 
 // scheduleMessageRequest is the Slack API request body for chat.scheduleMessage.
@@ -60,10 +74,15 @@ func (a *scheduleMessageAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
+	postAtUnix, err := params.postAtUnix()
+	if err != nil {
+		return nil, err
+	}
+
 	body := scheduleMessageRequest{
 		Channel: params.Channel,
 		Text:    params.Message,
-		PostAt:  params.PostAt,
+		PostAt:  postAtUnix,
 	}
 
 	var resp scheduleMessageResponse

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -30,25 +30,32 @@ type scheduleMessageParams struct {
 type flexDateTime string
 
 func (f *flexDateTime) UnmarshalJSON(data []byte) error {
-	// Try string first (new format)
+	// Handle null — leave the field empty for validate() to catch.
+	if string(data) == "null" {
+		*f = ""
+		return nil
+	}
+	// Try string first (new format: RFC 3339, datetime-local, or numeric string)
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
 		*f = flexDateTime(s)
 		return nil
 	}
-	// Try integer (legacy Unix timestamp)
+	// Try integer (legacy stored approvals with Unix timestamp)
 	var n int64
 	if err := json.Unmarshal(data, &n); err == nil {
 		*f = flexDateTime(time.Unix(n, 0).UTC().Format(time.RFC3339))
 		return nil
 	}
-	// Try float (JSON numbers can be floats)
+	// Try float (JSON numbers can be decoded as floats)
 	var fl float64
 	if err := json.Unmarshal(data, &fl); err == nil {
 		*f = flexDateTime(time.Unix(int64(fl), 0).UTC().Format(time.RFC3339))
 		return nil
 	}
-	return fmt.Errorf("post_at must be a datetime string or Unix timestamp, got %s", string(data))
+	return &connectors.ValidationError{
+		Message: fmt.Sprintf("post_at must be a datetime string or Unix timestamp, got %s", string(data)),
+	}
 }
 
 func (p *scheduleMessageParams) validate() error {

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -38,11 +38,17 @@ func (p *scheduleMessageParams) validate() error {
 // timestamp. Returns a ValidationError if the value is unparseable or in the
 // past.
 func (p *scheduleMessageParams) postAtUnix() (int64, error) {
+	// Try RFC 3339 first; also accept "datetime-local" format (no seconds, no TZ)
+	// emitted by HTML <input type="datetime-local">, treating it as UTC.
 	t, err := time.Parse(time.RFC3339, p.PostAt)
 	if err != nil {
-		return 0, &connectors.ValidationError{
-			Message: fmt.Sprintf("post_at must be a valid RFC 3339 datetime (e.g. 2026-03-20T09:00:00Z), got %q", p.PostAt),
+		t2, err2 := time.Parse("2006-01-02T15:04", p.PostAt)
+		if err2 != nil {
+			return 0, &connectors.ValidationError{
+				Message: fmt.Sprintf("post_at must be a valid RFC 3339 datetime (e.g. 2026-03-20T09:00:00Z), got %q", p.PostAt),
+			}
 		}
+		t = t2.UTC()
 	}
 	unix := t.Unix()
 	if unix <= time.Now().Unix() {

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -2,7 +2,9 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -16,9 +18,37 @@ type scheduleMessageAction struct {
 
 // scheduleMessageParams is the user-facing parameter schema.
 type scheduleMessageParams struct {
-	Channel string `json:"channel"`
-	Message string `json:"message"`
-	PostAt  string `json:"post_at"`
+	Channel string       `json:"channel"`
+	Message string       `json:"message"`
+	PostAt  flexDateTime `json:"post_at"`
+}
+
+// flexDateTime accepts both a string (RFC 3339, datetime-local) and a legacy
+// integer (Unix timestamp) from JSON, converting either to a string. This
+// ensures backward compatibility with existing stored approvals that have
+// integer post_at values.
+type flexDateTime string
+
+func (f *flexDateTime) UnmarshalJSON(data []byte) error {
+	// Try string first (new format)
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*f = flexDateTime(s)
+		return nil
+	}
+	// Try integer (legacy Unix timestamp)
+	var n int64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = flexDateTime(time.Unix(n, 0).UTC().Format(time.RFC3339))
+		return nil
+	}
+	// Try float (JSON numbers can be floats)
+	var fl float64
+	if err := json.Unmarshal(data, &fl); err == nil {
+		*f = flexDateTime(time.Unix(int64(fl), 0).UTC().Format(time.RFC3339))
+		return nil
+	}
+	return fmt.Errorf("post_at must be a datetime string or Unix timestamp, got %s", string(data))
 }
 
 func (p *scheduleMessageParams) validate() error {
@@ -34,18 +64,30 @@ func (p *scheduleMessageParams) validate() error {
 	return nil
 }
 
-// postAtUnix parses the post_at field as RFC 3339 and returns the Unix
-// timestamp. Returns a ValidationError if the value is unparseable or in the
-// past.
+// postAtUnix parses the post_at field and returns the Unix timestamp.
+// Accepts RFC 3339 (with optional fractional seconds) and datetime-local
+// formats (with or without seconds, no timezone — treated as UTC).
+// Returns a ValidationError if the value is unparseable or in the past.
 func (p *scheduleMessageParams) postAtUnix() (int64, error) {
-	// Try RFC 3339 first; also accept "datetime-local" format (no seconds, no TZ)
-	// emitted by HTML <input type="datetime-local">, treating it as UTC.
-	t, err := time.Parse(time.RFC3339Nano, p.PostAt)
+	postAt := string(p.PostAt)
+
+	// If the value is purely numeric, it's already a Unix timestamp (legacy path).
+	if n, err := strconv.ParseInt(postAt, 10, 64); err == nil {
+		if n <= time.Now().Unix() {
+			return 0, &connectors.ValidationError{
+				Message: fmt.Sprintf("post_at must be in the future (got %s)", postAt),
+			}
+		}
+		return n, nil
+	}
+
+	// Try RFC 3339 / RFC 3339 Nano (e.g. "2026-03-20T09:00:00Z" or "…000Z").
+	t, err := time.Parse(time.RFC3339Nano, postAt)
 	if err != nil {
-		// Also accept "datetime-local" formats (no TZ) emitted by HTML
+		// Fall back to datetime-local formats (no TZ) emitted by HTML
 		// <input type="datetime-local">, treating them as UTC.
 		for _, layout := range []string{"2006-01-02T15:04:05", "2006-01-02T15:04"} {
-			if t2, err2 := time.Parse(layout, p.PostAt); err2 == nil {
+			if t2, err2 := time.Parse(layout, postAt); err2 == nil {
 				t = t2.UTC()
 				err = nil
 				break
@@ -53,14 +95,14 @@ func (p *scheduleMessageParams) postAtUnix() (int64, error) {
 		}
 		if err != nil {
 			return 0, &connectors.ValidationError{
-				Message: fmt.Sprintf("post_at must be a valid RFC 3339 datetime (e.g. 2026-03-20T09:00:00Z), got %q", p.PostAt),
+				Message: fmt.Sprintf("post_at must be a valid RFC 3339 datetime (e.g. 2026-03-20T09:00:00Z), got %q", postAt),
 			}
 		}
 	}
 	unix := t.Unix()
 	if unix <= time.Now().Unix() {
 		return 0, &connectors.ValidationError{
-			Message: fmt.Sprintf("post_at must be in the future (got %s)", p.PostAt),
+			Message: fmt.Sprintf("post_at must be in the future (got %s)", postAt),
 		}
 	}
 	return unix, nil

--- a/connectors/slack/schedule_message_test.go
+++ b/connectors/slack/schedule_message_test.go
@@ -27,15 +27,15 @@ func TestScheduleMessage_Success(t *testing.T) {
 		if body.Text != "Hello later!" {
 			t.Errorf("expected text 'Hello later!', got %q", body.Text)
 		}
-		if body.PostAt != 1893456000 {
-			t.Errorf("expected post_at 1893456000, got %d", body.PostAt)
+		if body.PostAt != 1893369600 {
+			t.Errorf("expected post_at 1893369600, got %d", body.PostAt)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"ok":                   true,
 			"scheduled_message_id": "Q1234ABCD",
-			"post_at":              1893456000,
+			"post_at":              1893369600,
 			"channel":              "C01234567",
 		})
 	}))
@@ -44,10 +44,11 @@ func TestScheduleMessage_Success(t *testing.T) {
 	conn := newForTest(srv.Client(), srv.URL)
 	action := &scheduleMessageAction{conn: conn}
 
+	// 1893369600 = 2029-12-31T00:00:00Z
 	params, _ := json.Marshal(scheduleMessageParams{
 		Channel: "#general",
 		Message: "Hello later!",
-		PostAt:  1893456000,
+		PostAt:  "2029-12-31T00:00:00Z",
 	})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -79,7 +80,7 @@ func TestScheduleMessage_MissingChannel(t *testing.T) {
 
 	params, _ := json.Marshal(map[string]any{
 		"message": "Hello",
-		"post_at": 1893456000,
+		"post_at": "2029-12-31T00:00:00Z",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -128,7 +129,7 @@ func TestScheduleMessage_PostAtInPast(t *testing.T) {
 	params, _ := json.Marshal(scheduleMessageParams{
 		Channel: "#general",
 		Message: "Hello",
-		PostAt:  1000000000, // 2001-09-08, well in the past
+		PostAt:  "2001-09-08T00:00:00Z", // well in the past
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -138,6 +139,31 @@ func TestScheduleMessage_PostAtInPast(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for post_at in the past")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestScheduleMessage_InvalidPostAtFormat(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &scheduleMessageAction{conn: conn}
+
+	params, _ := json.Marshal(scheduleMessageParams{
+		Channel: "#general",
+		Message: "Hello",
+		PostAt:  "not-a-date",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid post_at format")
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)
@@ -162,7 +188,7 @@ func TestScheduleMessage_SlackAPIError(t *testing.T) {
 	params, _ := json.Marshal(scheduleMessageParams{
 		Channel: "#general",
 		Message: "Hello",
-		PostAt:  1893456000,
+		PostAt:  "2029-12-31T00:00:00Z",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/slack/schedule_message_test.go
+++ b/connectors/slack/schedule_message_test.go
@@ -145,6 +145,49 @@ func TestScheduleMessage_PostAtInPast(t *testing.T) {
 	}
 }
 
+func TestScheduleMessage_DatetimeLocalFormat(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body scheduleMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		// 2029-12-31T00:00 interpreted as UTC = 1893369600
+		if body.PostAt != 1893369600 {
+			t.Errorf("expected post_at 1893369600, got %d", body.PostAt)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":                   true,
+			"scheduled_message_id": "Q1234ABCD",
+			"post_at":              1893369600,
+			"channel":              "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &scheduleMessageAction{conn: conn}
+
+	// HTML datetime-local format: no seconds, no timezone
+	params, _ := json.Marshal(scheduleMessageParams{
+		Channel: "#general",
+		Message: "Hello later!",
+		PostAt:  "2029-12-31T00:00",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestScheduleMessage_InvalidPostAtFormat(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/schedule_message_test.go
+++ b/connectors/slack/schedule_message_test.go
@@ -72,6 +72,43 @@ func TestScheduleMessage_Success(t *testing.T) {
 	}
 }
 
+func TestScheduleMessage_LegacyIntegerPostAt(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body scheduleMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.PostAt != 1893369600 {
+			t.Errorf("expected post_at 1893369600, got %d", body.PostAt)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":                   true,
+			"scheduled_message_id": "Q1234ABCD",
+			"post_at":              1893369600,
+			"channel":              "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &scheduleMessageAction{conn: conn}
+
+	// Simulate legacy stored approval with integer post_at
+	params := []byte(`{"channel":"#general","message":"Hello later!","post_at":1893369600}`)
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestScheduleMessage_MissingChannel(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/schedule_message_test.go
+++ b/connectors/slack/schedule_message_test.go
@@ -188,6 +188,48 @@ func TestScheduleMessage_DatetimeLocalFormat(t *testing.T) {
 	}
 }
 
+func TestScheduleMessage_DatetimeLocalWithSeconds(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body scheduleMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		// 2029-12-31T00:00:05 interpreted as UTC = 1893369605
+		if body.PostAt != 1893369605 {
+			t.Errorf("expected post_at 1893369605, got %d", body.PostAt)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":                   true,
+			"scheduled_message_id": "Q1234ABCD",
+			"post_at":              1893369605,
+			"channel":              "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &scheduleMessageAction{conn: conn}
+
+	// datetime-local with seconds but no timezone
+	params, _ := json.Marshal(scheduleMessageParams{
+		Channel: "#general",
+		Message: "Hello later!",
+		PostAt:  "2029-12-31T00:00:05",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestScheduleMessage_FractionalSeconds(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/schedule_message_test.go
+++ b/connectors/slack/schedule_message_test.go
@@ -333,6 +333,70 @@ func TestScheduleMessage_InvalidPostAtFormat(t *testing.T) {
 	}
 }
 
+func TestScheduleMessage_NullPostAt(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &scheduleMessageAction{conn: conn}
+
+	// Simulate JSON with null post_at — should be caught by validate() as missing.
+	params := []byte(`{"channel":"#general","message":"Hello","post_at":null}`)
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for null post_at")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestScheduleMessage_NumericStringPostAt(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body scheduleMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.PostAt != 1893369600 {
+			t.Errorf("expected post_at 1893369600, got %d", body.PostAt)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":                   true,
+			"scheduled_message_id": "Q1234ABCD",
+			"post_at":              1893369600,
+			"channel":              "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &scheduleMessageAction{conn: conn}
+
+	// Numeric string (e.g. from flexDateTime converting int → RFC 3339 string,
+	// or from a user passing a Unix timestamp as a string).
+	params, _ := json.Marshal(scheduleMessageParams{
+		Channel: "#general",
+		Message: "Hello later!",
+		PostAt:  "1893369600",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestScheduleMessage_SlackAPIError(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/schedule_message_test.go
+++ b/connectors/slack/schedule_message_test.go
@@ -188,6 +188,47 @@ func TestScheduleMessage_DatetimeLocalFormat(t *testing.T) {
 	}
 }
 
+func TestScheduleMessage_FractionalSeconds(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body scheduleMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.PostAt != 1893369600 {
+			t.Errorf("expected post_at 1893369600, got %d", body.PostAt)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":                   true,
+			"scheduled_message_id": "Q1234ABCD",
+			"post_at":              1893369600,
+			"channel":              "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &scheduleMessageAction{conn: conn}
+
+	// JavaScript Date.toISOString() format with fractional seconds
+	params, _ := json.Marshal(scheduleMessageParams{
+		Channel: "#general",
+		Message: "Hello later!",
+		PostAt:  "2029-12-31T00:00:00.000Z",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.schedule_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestScheduleMessage_InvalidPostAtFormat(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/lib/__tests__/parameterSchema.test.ts
+++ b/frontend/src/lib/__tests__/parameterSchema.test.ts
@@ -491,12 +491,12 @@ describe("parseParametersSchema", () => {
       expect(getFieldLabel("customer_id", { type: "string", "x-ui": { label: "Customer" } })).toBe("Customer");
     });
 
-    it("falls back to property key when no x-ui label", () => {
-      expect(getFieldLabel("customer_id", { type: "string" })).toBe("customer_id");
+    it("converts snake_case key to Title Case when no x-ui label", () => {
+      expect(getFieldLabel("customer_id", { type: "string" })).toBe("Customer ID");
     });
 
-    it("falls back to property key when x-ui exists but no label", () => {
-      expect(getFieldLabel("amount", { type: "number", "x-ui": { widget: "number" } })).toBe("amount");
+    it("converts key to Title Case when x-ui exists but no label", () => {
+      expect(getFieldLabel("amount", { type: "number", "x-ui": { widget: "number" } })).toBe("Amount");
     });
   });
 


### PR DESCRIPTION
## Summary

- **Slack modal fixes**: Added `x-ui: textarea` to all message/content fields (send_message, schedule_message, send_dm, update_message, upload_file) so they render as multi-line textareas instead of single-line inputs. Changed `post_at` on schedule_message from integer (Unix timestamp) to `string` with `format: "date-time"` so the UI renders a datetime picker — the Go backend now parses RFC 3339 and converts to Unix timestamp for Slack's API.
- **Schema quality lint test**: Added `TestSchemaWidgetAnnotations` that validates all connector schemas have proper widget annotations (textarea for rich text, date-time format for datetime fields). Uses an allowlist for 21 pre-existing gaps across other connectors so it doesn't block CI, but will catch regressions in new/updated connectors. A companion test (`TestKnownMissingAnnotationsAreStillMissing`) ensures the allowlist stays current.
- **Go validWidgets sync**: Added `datetime` and `list` to the Go `validWidgets` map to match the frontend's supported widget types.
- **Test fix**: Updated `getFieldLabel` test expectations that were stale after PR #659's snake_case→Title Case change.

> **Task:** Fix Slack modal widget annotations (textarea for messages, datetime for post_at) and add schema quality lint to prevent regression in future connectors.

## Test plan

### Claude Code
- [x] All Slack backend tests pass (including new `TestScheduleMessage_InvalidPostAtFormat`)
- [x] Schema quality lint tests pass (`TestSchemaWidgetAnnotations`, `TestKnownMissingAnnotationsAreStillMissing`)
- [x] All 54 parameterSchema frontend tests pass
- [x] Go build compiles cleanly
- [x] TypeScript type check passes

### Manual Testing
- [ ] Create a standing approval for Slack "Send Message" — verify message field renders as textarea
- [ ] Create a standing approval for Slack "Schedule Message" — verify post_at renders as datetime picker and message as textarea
- [ ] Verify schedule_message still works end-to-end (RFC 3339 → Unix timestamp conversion)

https://claude.ai/code/session_01EpGWUq8wEzBvsFBPG2YzwW