### PR TITLE
Show OAuth username in credential display

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -973,15 +973,19 @@ func instanceFromExtraData(extraData json.RawMessage) string {
 	return ""
 }
 
-// emailFromExtraData extracts the email field from an OAuth connection's
-// extra_data JSON. Returns "" if no email is present.
-func emailFromExtraData(extraData json.RawMessage) string {
+// displayNameFromExtraData extracts a human-readable display name from an
+// OAuth connection's extra_data JSON. Prefers "username" (e.g. GitHub login),
+// falls back to "email". Returns "" if neither is present.
+func displayNameFromExtraData(extraData json.RawMessage) string {
 	if len(extraData) == 0 {
 		return ""
 	}
 	var extra map[string]string
 	if err := json.Unmarshal(extraData, &extra); err != nil {
 		return ""
+	}
+	if username := extra["username"]; username != "" {
+		return username
 	}
 	return extra["email"]
 }
@@ -1011,7 +1015,7 @@ func handleListOAuthConnections(deps *Deps) http.HandlerFunc {
 				Status:      c.Status,
 				ConnectedAt: c.CreatedAt,
 				Instance:    instanceFromExtraData(c.ExtraData),
-				DisplayName: emailFromExtraData(c.ExtraData),
+				DisplayName: displayNameFromExtraData(c.ExtraData),
 			}
 		}
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -974,8 +974,9 @@ func instanceFromExtraData(extraData json.RawMessage) string {
 }
 
 // displayNameFromExtraData extracts a human-readable display name from an
-// OAuth connection's extra_data JSON. Prefers "username" (e.g. GitHub login),
-// falls back to "email". Returns "" if neither is present.
+// OAuth connection's extra_data JSON. Prefers "display_name" (e.g. GitHub
+// login or Microsoft displayName), falls back to "email". Returns "" if
+// neither is present.
 func displayNameFromExtraData(extraData json.RawMessage) string {
 	if len(extraData) == 0 {
 		return ""
@@ -984,8 +985,8 @@ func displayNameFromExtraData(extraData json.RawMessage) string {
 	if err := json.Unmarshal(extraData, &extra); err != nil {
 		return ""
 	}
-	if username := extra["username"]; username != "" {
-		return username
+	if dn := extra["display_name"]; dn != "" {
+		return dn
 	}
 	return extra["email"]
 }

--- a/api/oauth_email_enrichers.go
+++ b/api/oauth_email_enrichers.go
@@ -30,39 +30,84 @@ var softOAuthEnrichers = map[string]postOAuthEnricher{
 // emailHTTPClient is a shared HTTP client for email enrichers.
 var emailHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
-// fetchGoogleEmail fetches the user's email from Google's userinfo endpoint.
+// fetchGoogleEmail fetches the user's email and name from Google's userinfo endpoint.
 func fetchGoogleEmail(ctx context.Context, accessToken string) (map[string]string, error) {
-	return fetchEmailFromJSON(ctx, accessToken, "https://www.googleapis.com/oauth2/v3/userinfo", "email")
+	return fetchProfileFromJSON(ctx, accessToken, "https://www.googleapis.com/oauth2/v3/userinfo", "email", "name")
 }
 
-// fetchGitHubEmail fetches the user's email from GitHub's user endpoint.
-// Falls back to the /user/emails endpoint for users with private emails.
+// fetchGitHubEmail fetches the user's email and username from GitHub's user
+// endpoint. Falls back to the /user/emails endpoint for users with private
+// emails. The "username" key in the returned map contains the GitHub login.
 func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]string, error) {
-	extra, err := fetchEmailFromJSON(ctx, accessToken, "https://api.github.com/user", "email")
-	if err == nil && extra["email"] != "" {
-		return extra, nil
-	}
-
-	// GitHub users can have a private email; fall back to /user/emails.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user/emails", nil)
+	// First, fetch the /user endpoint which has both login and email.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
 	if err != nil {
-		return nil, fmt.Errorf("create github emails request: %w", err)
+		return nil, fmt.Errorf("create github user request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Accept", "application/vnd.github+json")
 
 	resp, err := emailHTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("github emails request failed: %w", err)
+		return nil, fmt.Errorf("github user request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("github emails returned HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("github user returned HTTP %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
+		return nil, fmt.Errorf("read github user response: %w", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("parse github user: %w", err)
+	}
+
+	extra := make(map[string]string)
+	if login, _ := data["login"].(string); login != "" {
+		extra["username"] = login
+	}
+	if email, _ := data["email"].(string); email != "" {
+		extra["email"] = email
+		return extra, nil
+	}
+
+	// GitHub users can have a private email; fall back to /user/emails.
+	emailReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user/emails", nil)
+	if err != nil {
+		if len(extra) > 0 {
+			return extra, nil
+		}
+		return nil, fmt.Errorf("create github emails request: %w", err)
+	}
+	emailReq.Header.Set("Authorization", "Bearer "+accessToken)
+	emailReq.Header.Set("Accept", "application/vnd.github+json")
+
+	emailResp, err := emailHTTPClient.Do(emailReq)
+	if err != nil {
+		if len(extra) > 0 {
+			return extra, nil
+		}
+		return nil, fmt.Errorf("github emails request failed: %w", err)
+	}
+	defer emailResp.Body.Close()
+
+	if emailResp.StatusCode != http.StatusOK {
+		if len(extra) > 0 {
+			return extra, nil
+		}
+		return nil, fmt.Errorf("github emails returned HTTP %d", emailResp.StatusCode)
+	}
+
+	emailBody, err := io.ReadAll(io.LimitReader(emailResp.Body, 64*1024))
+	if err != nil {
+		if len(extra) > 0 {
+			return extra, nil
+		}
 		return nil, fmt.Errorf("read github emails response: %w", err)
 	}
 
@@ -70,19 +115,27 @@ func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]strin
 		Email   string `json:"email"`
 		Primary bool   `json:"primary"`
 	}
-	if err := json.Unmarshal(body, &emails); err != nil {
+	if err := json.Unmarshal(emailBody, &emails); err != nil {
+		if len(extra) > 0 {
+			return extra, nil
+		}
 		return nil, fmt.Errorf("parse github emails: %w", err)
 	}
 
 	for _, e := range emails {
 		if e.Primary && e.Email != "" {
-			return map[string]string{"email": e.Email}, nil
+			extra["email"] = e.Email
+			return extra, nil
 		}
 	}
 	if len(emails) > 0 && emails[0].Email != "" {
-		return map[string]string{"email": emails[0].Email}, nil
+		extra["email"] = emails[0].Email
+		return extra, nil
 	}
 
+	if len(extra) > 0 {
+		return extra, nil
+	}
 	return nil, fmt.Errorf("no email found in GitHub response")
 }
 
@@ -115,23 +168,32 @@ func fetchMicrosoftEmail(ctx context.Context, accessToken string) (map[string]st
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 
+	extra := make(map[string]string)
+	if name, _ := data["displayName"].(string); name != "" {
+		extra["username"] = name
+	}
 	if mail, _ := data["mail"].(string); mail != "" {
-		return map[string]string{"email": mail}, nil
+		extra["email"] = mail
+		return extra, nil
 	}
 	if upn, _ := data["userPrincipalName"].(string); upn != "" {
-		return map[string]string{"email": upn}, nil
+		extra["email"] = upn
+		return extra, nil
+	}
+	if len(extra) > 0 {
+		return extra, nil
 	}
 	return nil, fmt.Errorf("no email found in Microsoft profile")
 }
 
-// fetchSlackEmail fetches the user's email from Slack's OIDC userinfo endpoint.
+// fetchSlackEmail fetches the user's email and name from Slack's OIDC userinfo endpoint.
 func fetchSlackEmail(ctx context.Context, accessToken string) (map[string]string, error) {
-	return fetchEmailFromJSON(ctx, accessToken, "https://slack.com/api/openid.connect.userInfo", "email")
+	return fetchProfileFromJSON(ctx, accessToken, "https://slack.com/api/openid.connect.userInfo", "email", "name")
 }
 
-// fetchEmailFromJSON is a generic helper that calls a JSON endpoint with the
-// access token and extracts a string field into {"email": value}.
-func fetchEmailFromJSON(ctx context.Context, accessToken, url, field string) (map[string]string, error) {
+// fetchProfileFromJSON is a generic helper that calls a JSON endpoint with the
+// access token and extracts an email and optional username/name field.
+func fetchProfileFromJSON(ctx context.Context, accessToken, url, emailField, nameField string) (map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
@@ -158,12 +220,18 @@ func fetchEmailFromJSON(ctx context.Context, accessToken, url, field string) (ma
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 
-	email, _ := data[field].(string)
-	if email == "" {
-		return nil, fmt.Errorf("field %q not found or empty", field)
+	extra := make(map[string]string)
+	if name, _ := data[nameField].(string); name != "" {
+		extra["username"] = name
+	}
+	if email, _ := data[emailField].(string); email != "" {
+		extra["email"] = email
 	}
 
-	return map[string]string{"email": email}, nil
+	if len(extra) == 0 {
+		return nil, fmt.Errorf("fields %q and %q not found or empty", emailField, nameField)
+	}
+	return extra, nil
 }
 
 // runSoftEnrichers runs the best-effort email enrichers for a provider.

--- a/api/oauth_email_enrichers.go
+++ b/api/oauth_email_enrichers.go
@@ -37,7 +37,7 @@ func fetchGoogleEmail(ctx context.Context, accessToken string) (map[string]strin
 
 // fetchGitHubEmail fetches the user's email and username from GitHub's user
 // endpoint. Falls back to the /user/emails endpoint for users with private
-// emails. The "username" key in the returned map contains the GitHub login.
+// emails. The "display_name" key in the returned map contains the GitHub login.
 func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]string, error) {
 	// First, fetch the /user endpoint which has both login and email.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
@@ -69,7 +69,7 @@ func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]strin
 
 	extra := make(map[string]string)
 	if login, _ := data["login"].(string); login != "" {
-		extra["username"] = login
+		extra["display_name"] = login
 	}
 	if email, _ := data["email"].(string); email != "" {
 		extra["email"] = email
@@ -77,11 +77,26 @@ func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]strin
 	}
 
 	// GitHub users can have a private email; fall back to /user/emails.
-	emailReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user/emails", nil)
-	if err != nil {
+	fallbackExtra, fallbackErr := fetchGitHubEmailFallback(ctx, accessToken)
+	if fallbackErr != nil {
 		if len(extra) > 0 {
+			log.Printf("oauth: github email fallback failed (non-fatal, have login): %v", fallbackErr)
 			return extra, nil
 		}
+		return nil, fallbackErr
+	}
+
+	for k, v := range fallbackExtra {
+		extra[k] = v
+	}
+	return extra, nil
+}
+
+// fetchGitHubEmailFallback fetches the primary email from GitHub's /user/emails
+// endpoint. Used when the /user endpoint doesn't include an email.
+func fetchGitHubEmailFallback(ctx context.Context, accessToken string) (map[string]string, error) {
+	emailReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user/emails", nil)
+	if err != nil {
 		return nil, fmt.Errorf("create github emails request: %w", err)
 	}
 	emailReq.Header.Set("Authorization", "Bearer "+accessToken)
@@ -89,25 +104,16 @@ func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]strin
 
 	emailResp, err := emailHTTPClient.Do(emailReq)
 	if err != nil {
-		if len(extra) > 0 {
-			return extra, nil
-		}
 		return nil, fmt.Errorf("github emails request failed: %w", err)
 	}
 	defer emailResp.Body.Close()
 
 	if emailResp.StatusCode != http.StatusOK {
-		if len(extra) > 0 {
-			return extra, nil
-		}
 		return nil, fmt.Errorf("github emails returned HTTP %d", emailResp.StatusCode)
 	}
 
 	emailBody, err := io.ReadAll(io.LimitReader(emailResp.Body, 64*1024))
 	if err != nil {
-		if len(extra) > 0 {
-			return extra, nil
-		}
 		return nil, fmt.Errorf("read github emails response: %w", err)
 	}
 
@@ -116,31 +122,24 @@ func fetchGitHubEmail(ctx context.Context, accessToken string) (map[string]strin
 		Primary bool   `json:"primary"`
 	}
 	if err := json.Unmarshal(emailBody, &emails); err != nil {
-		if len(extra) > 0 {
-			return extra, nil
-		}
 		return nil, fmt.Errorf("parse github emails: %w", err)
 	}
 
 	for _, e := range emails {
 		if e.Primary && e.Email != "" {
-			extra["email"] = e.Email
-			return extra, nil
+			return map[string]string{"email": e.Email}, nil
 		}
 	}
 	if len(emails) > 0 && emails[0].Email != "" {
-		extra["email"] = emails[0].Email
-		return extra, nil
+		return map[string]string{"email": emails[0].Email}, nil
 	}
 
-	if len(extra) > 0 {
-		return extra, nil
-	}
-	return nil, fmt.Errorf("no email found in GitHub response")
+	return nil, fmt.Errorf("no email found in GitHub /user/emails response")
 }
 
-// fetchMicrosoftEmail fetches the user's email from Microsoft Graph.
-// Tries the "mail" field first, falling back to "userPrincipalName".
+// fetchMicrosoftEmail fetches the user's email and display name from Microsoft
+// Graph. Stores displayName as "display_name", tries "mail" first for email,
+// falling back to "userPrincipalName".
 func fetchMicrosoftEmail(ctx context.Context, accessToken string) (map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://graph.microsoft.com/v1.0/me", nil)
 	if err != nil {
@@ -170,7 +169,7 @@ func fetchMicrosoftEmail(ctx context.Context, accessToken string) (map[string]st
 
 	extra := make(map[string]string)
 	if name, _ := data["displayName"].(string); name != "" {
-		extra["username"] = name
+		extra["display_name"] = name
 	}
 	if mail, _ := data["mail"].(string); mail != "" {
 		extra["email"] = mail
@@ -192,7 +191,8 @@ func fetchSlackEmail(ctx context.Context, accessToken string) (map[string]string
 }
 
 // fetchProfileFromJSON is a generic helper that calls a JSON endpoint with the
-// access token and extracts an email and optional username/name field.
+// access token and extracts an email and optional display name field. The name
+// is stored under the "display_name" key in the returned map.
 func fetchProfileFromJSON(ctx context.Context, accessToken, url, emailField, nameField string) (map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -222,14 +222,14 @@ func fetchProfileFromJSON(ctx context.Context, accessToken, url, emailField, nam
 
 	extra := make(map[string]string)
 	if name, _ := data[nameField].(string); name != "" {
-		extra["username"] = name
+		extra["display_name"] = name
 	}
 	if email, _ := data[emailField].(string); email != "" {
 		extra["email"] = email
 	}
 
 	if len(extra) == 0 {
-		return nil, fmt.Errorf("fields %q and %q not found or empty", emailField, nameField)
+		return nil, fmt.Errorf("neither field %q nor %q found in response", emailField, nameField)
 	}
 	return extra, nil
 }

--- a/api/oauth_email_enrichers.go
+++ b/api/oauth_email_enrichers.go
@@ -180,6 +180,7 @@ func fetchMicrosoftEmail(ctx context.Context, accessToken string) (map[string]st
 		return extra, nil
 	}
 	if len(extra) > 0 {
+		log.Printf("oauth: microsoft enricher got display name but no email (non-fatal)")
 		return extra, nil
 	}
 	return nil, fmt.Errorf("no email found in Microsoft profile")
@@ -230,6 +231,9 @@ func fetchProfileFromJSON(ctx context.Context, accessToken, url, emailField, nam
 
 	if len(extra) == 0 {
 		return nil, fmt.Errorf("neither field %q nor %q found in response", emailField, nameField)
+	}
+	if _, hasEmail := extra["email"]; !hasEmail {
+		log.Printf("oauth: enricher got %q but no %q (non-fatal)", nameField, emailField)
 	}
 	return extra, nil
 }

--- a/spec/openapi/components/schemas/oauth.yaml
+++ b/spec/openapi/components/schemas/oauth.yaml
@@ -85,10 +85,11 @@ OAuthConnection:
     display_name:
       type: string
       description: >
-        A human-readable identifier for this connection, typically the
+        A human-readable identifier for this connection — the provider
+        username (e.g. GitHub login) when available, otherwise the
         authenticated user's email address. Omitted when no identifying
         information is available.
-      example: "user@example.com"
+      example: "octocat"
 
 OAuthConnectionListResponse:
   type: object


### PR DESCRIPTION
## Summary
- OAuth enrichers now fetch the provider username/name alongside email (GitHub login, Microsoft displayName, Google/Slack name)
- `display_name` in the API response prefers username over email, so the credential dropdown and connected accounts show the account identity (e.g. `octocat` for GitHub) rather than just an email
- Existing connections will continue showing email until re-authorized (enricher runs at connection time)

## Test plan

### Claude Code
- [x] Verify Go build passes
- [x] Verify frontend TypeScript compilation passes

### Manual Testing
- [ ] Connect a GitHub OAuth account and verify the username (login) appears in the credential dropdown
- [ ] Connect a Google OAuth account and verify the name appears in the credential dropdown
- [ ] Reconnect an existing OAuth connection and verify the username now shows
- [ ] Verify the Connected Accounts settings page shows the username correctly

https://claude.ai/code/session_011Toqe4Qy16orUTyGcAP9tp