### PR TITLE
Improve GitHub API error messages to include error details array

### DIFF
--- a/connectors/github/response.go
+++ b/connectors/github/response.go
@@ -16,13 +16,32 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 		return nil
 	}
 
-	// Try to extract GitHub's error message.
+	// Try to extract GitHub's error message and error details.
 	var ghErr struct {
 		Message string `json:"message"`
+		Errors  []struct {
+			Message string `json:"message"`
+			Field   string `json:"field"`
+			Code    string `json:"code"`
+		} `json:"errors"`
 	}
 	msg := string(body)
-	if json.Unmarshal(body, &ghErr) == nil && ghErr.Message != "" {
-		msg = ghErr.Message
+	if json.Unmarshal(body, &ghErr) == nil {
+		if ghErr.Message != "" {
+			msg = ghErr.Message
+		}
+		// Append error details if available
+		if len(ghErr.Errors) > 0 {
+			for i, err := range ghErr.Errors {
+				if err.Message != "" {
+					if i == 0 {
+						msg += ". Details: " + err.Message
+					} else {
+						msg += "; " + err.Message
+					}
+				}
+			}
+		}
 	}
 
 	switch {


### PR DESCRIPTION
The checkResponse function now extracts and includes the `errors` array from GitHub API responses, providing much more actionable error messages.

## Example
A 422 response like:
```json
{
  "message": "Repository creation failed.",
  "errors": [{"field": "name", "message": "name already exists on this account"}]
}
```

**Before:** "GitHub API validation error: Repository creation failed."

**After:** "GitHub API validation error: Repository creation failed. Details: name already exists on this account"

## Testing
- [x] All existing GitHub connector tests pass
- [x] Error formatting handles single and multiple error entries
- [x] Backward compatible — errors array is optional

Fixes debugging issues like the recent repo creation failures that returned generic "Repository creation failed" with no actual reason.