### PR TITLE
Update OpenAPI bundle

### DIFF
--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -10807,8 +10807,8 @@ components:
         display_name:
           type: string
           description: |
-            A human-readable identifier for this connection, typically the authenticated user's email address. Omitted when no identifying information is available.
-          example: user@example.com
+            A human-readable identifier for this connection — the provider username (e.g. GitHub login) when available, otherwise the authenticated user's email address. Omitted when no identifying information is available.
+          example: octocat
     OAuthConnectionListResponse:
       type: object
       required:


### PR DESCRIPTION
## Summary
- Regenerated `spec/openapi/openapi.bundle.yaml` via `make bundle` to sync with upstream spec changes
- The bundle was out of date — the `display_name` field on `OAuthConnectionResponse` was updated to prefer provider username over email

## Test plan
- [ ] Verify bundle matches source spec (`make bundle` produces no diff)

https://claude.ai/code/session_01Hqbkh9zi6Ze1q1AJtXLcjQ