### PR TITLE
Fix webhook notification in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,17 @@ jobs:
 
       - name: Send webhook notification
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+          NOTIFY_WEBHOOK_SECRET: ${{ secrets.NOTIFY_WEBHOOK_SECRET }}
         run: |
+          if [ -z "$NOTIFY_WEBHOOK_URL" ]; then
+            echo "::warning::NOTIFY_WEBHOOK_URL secret is not set, skipping webhook"
+            exit 0
+          fi
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh workflow run trigger-webhook.yml \
-            -f message="CI failed on ${{ github.ref_name }} — investigate: ${RUN_URL}"
+          MESSAGE="permission-slip: CI failed on ${{ github.ref_name }} — investigate: ${RUN_URL}"
+          PAYLOAD=$(jq -n --arg msg "$MESSAGE" --arg secret "$NOTIFY_WEBHOOK_SECRET" \
+            '{message: $msg, secret: $secret}')
+          curl -s -f -X POST "$NOTIFY_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary
- CI's "Send webhook notification" step was failing because `GITHUB_TOKEN` lacks permission to trigger `workflow_dispatch` events via `gh workflow run`
- Replaced with a direct `curl` call to the webhook URL, matching the same payload format used by `trigger-webhook.yml`
- Added a guard to skip gracefully if `NOTIFY_WEBHOOK_URL` is not configured

## Test plan

### Claude Code
- [ ] Verify CI workflow YAML is valid
- [ ] Confirm the webhook payload format matches `trigger-webhook.yml`

### Manual Testing
- [ ] Trigger a CI failure on a test branch and verify the webhook fires successfully
- [ ] Verify SMS notification still works (unchanged)

https://claude.ai/code/session_017RtKgBVnSCH457m68BvAwa