### PR TITLE
Surface connector API error messages to agents

### DIFF
--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"log"
 	"net/http"
 
@@ -11,8 +12,10 @@ import (
 // Returns true if the error was handled, false if the caller should handle it
 // as an untyped (500) error.
 //
-// Error details are logged server-side but not exposed to the caller to avoid
-// leaking internal information (upstream URLs, service internals, etc.).
+// Connector error messages are surfaced to the caller so agents can see
+// exactly what went wrong (e.g., "Slack channel not found", "GitHub API
+// validation error: ..."). Connectors are responsible for crafting
+// user-friendly, safe-to-expose messages.
 func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) bool {
 	traceID := TraceID(r.Context())
 
@@ -55,9 +58,11 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		return true
 
 	case connectors.IsExternalError(err):
+		var ee *connectors.ExternalError
+		errors.As(err, &ee)
 		log.Printf("[%s] connector external error: %v", traceID, err)
 		CaptureError(r.Context(), err)
-		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, "External service returned an error", true))
+		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, ee.Message, true))
 		return true
 
 	case connectors.IsOAuthRefreshError(err):
@@ -76,15 +81,19 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		return true
 
 	case connectors.IsAuthError(err):
+		var ae *connectors.AuthError
+		errors.As(err, &ae)
 		log.Printf("[%s] connector auth error: %v", traceID, err)
 		CaptureError(r.Context(), err)
-		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, "External service rejected credentials", true))
+		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, ae.Message, true))
 		return true
 
 	case connectors.IsTimeoutError(err):
+		var te *connectors.TimeoutError
+		errors.As(err, &te)
 		log.Printf("[%s] connector timeout: %v", traceID, err)
 		CaptureError(r.Context(), err)
-		RespondError(w, r, http.StatusGatewayTimeout, newErrorResponse(ErrUpstreamError, "External service did not respond in time", true))
+		RespondError(w, r, http.StatusGatewayTimeout, newErrorResponse(ErrUpstreamError, te.Message, true))
 		return true
 
 	default:

--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -58,11 +58,14 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		return true
 
 	case connectors.IsExternalError(err):
+		msg := "External service returned an error"
 		var ee *connectors.ExternalError
-		errors.As(err, &ee)
+		if errors.As(err, &ee) && ee.Message != "" {
+			msg = ee.Message
+		}
 		log.Printf("[%s] connector external error: %v", traceID, err)
 		CaptureError(r.Context(), err)
-		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, ee.Message, true))
+		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, msg, true))
 		return true
 
 	case connectors.IsOAuthRefreshError(err):
@@ -81,19 +84,25 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		return true
 
 	case connectors.IsAuthError(err):
+		msg := "External service rejected credentials"
 		var ae *connectors.AuthError
-		errors.As(err, &ae)
+		if errors.As(err, &ae) && ae.Message != "" {
+			msg = ae.Message
+		}
 		log.Printf("[%s] connector auth error: %v", traceID, err)
 		CaptureError(r.Context(), err)
-		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, ae.Message, true))
+		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, msg, true))
 		return true
 
 	case connectors.IsTimeoutError(err):
+		msg := "External service did not respond in time"
 		var te *connectors.TimeoutError
-		errors.As(err, &te)
+		if errors.As(err, &te) && te.Message != "" {
+			msg = te.Message
+		}
 		log.Printf("[%s] connector timeout: %v", traceID, err)
 		CaptureError(r.Context(), err)
-		RespondError(w, r, http.StatusGatewayTimeout, newErrorResponse(ErrUpstreamError, te.Message, true))
+		RespondError(w, r, http.StatusGatewayTimeout, newErrorResponse(ErrUpstreamError, msg, true))
 		return true
 
 	default:

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -970,6 +970,77 @@ func TestHandleConnectorError_NonOAuthError_NotHandled(t *testing.T) {
 	}
 }
 
+// ── handleConnectorError: ExternalError/AuthError/TimeoutError message surfacing ──
+
+func TestHandleConnectorError_ExternalError_SurfacesMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_ext"))
+
+	extErr := &connectors.ExternalError{StatusCode: 200, Message: "Slack channel not found — verify the channel ID exists and the bot has access"}
+	handled := handleConnectorError(w, r, extErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle ExternalError")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status 502, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != extErr.Message {
+		t.Errorf("expected message %q, got %q", extErr.Message, resp.Error.Message)
+	}
+}
+
+func TestHandleConnectorError_AuthError_SurfacesMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_auth"))
+
+	authErr := &connectors.AuthError{Message: "GitHub API auth error (403): Resource not accessible by integration"}
+	handled := handleConnectorError(w, r, authErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle AuthError")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status 502, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != authErr.Message {
+		t.Errorf("expected message %q, got %q", authErr.Message, resp.Error.Message)
+	}
+}
+
+func TestHandleConnectorError_TimeoutError_SurfacesMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_timeout"))
+
+	timeoutErr := &connectors.TimeoutError{Message: "Slack API request timed out: context deadline exceeded"}
+	handled := handleConnectorError(w, r, timeoutErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle TimeoutError")
+	}
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("expected status 504, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != timeoutErr.Message {
+		t.Errorf("expected message %q, got %q", timeoutErr.Message, resp.Error.Message)
+	}
+}
+
 // ── executeConnectorAction: payment method integration ──────────────────────
 
 // paymentExecFixture holds common setup for payment method execution tests.

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -978,7 +978,7 @@ func TestHandleConnectorError_ExternalError_SurfacesMessage(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
 	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_ext"))
 
-	extErr := &connectors.ExternalError{StatusCode: 200, Message: "Slack channel not found — verify the channel ID exists and the bot has access"}
+	extErr := &connectors.ExternalError{StatusCode: 404, Message: "Slack channel not found — verify the channel ID exists and the bot has access"}
 	handled := handleConnectorError(w, r, extErr)
 	if !handled {
 		t.Fatal("expected handleConnectorError to handle ExternalError")


### PR DESCRIPTION
## Summary

- Surfaces the actual connector error messages (e.g., "Slack channel not found", "GitHub API auth error (403): Resource not accessible by integration") in API responses instead of generic strings like "External service returned an error"
- Connectors already craft safe, user-friendly messages — the previous sanitization layer was hiding actionable details that agents need to diagnose failures and guide users
- Adds 3 tests verifying ExternalError, AuthError, and TimeoutError messages are surfaced

## Test plan

### Claude Code
- [x] All `handleConnectorError` tests pass (10/10 including 3 new)
- [x] `go vet ./api/` passes cleanly
- [x] No changes to HTTP status codes or error structure — only the message content

### Manual Testing
- [ ] Trigger a connector execution failure (e.g., send a Slack message to an invalid channel) and verify the agent sees the specific error in the API response
- [ ] Verify no sensitive internal data leaks in error messages across GitHub, Slack, and Google connectors

https://claude.ai/code/session_01YWV4Rr2mLbRqhqXNo3JVYw