### PR TITLE
Fix blue focus outline on Parameters toggle

### DIFF
--- a/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
@@ -253,7 +253,7 @@ function ApprovalDialogStory({
               <button
                 type="button"
                 onClick={() => setRawOpen((o) => !o)}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors"
+                className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                 aria-expanded={rawOpen}
               >
                 <span
@@ -1717,7 +1717,7 @@ function ConceptA() {
             <button
               type="button"
               onClick={() => setOpen(!open)}
-              className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors"
+              className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             >
               <span
                 className="transition-transform duration-150"
@@ -1833,7 +1833,7 @@ function ConceptB() {
             <button
               type="button"
               onClick={() => setOpen(!open)}
-              className="bg-muted/40 hover:bg-muted/70 flex w-full items-center justify-between px-4 py-2.5 text-left transition-colors"
+              className="bg-muted/40 hover:bg-muted/70 flex w-full items-center justify-between px-4 py-2.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             >
               <span className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
                 Parameters

--- a/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialogConcepts.stories.tsx
@@ -319,7 +319,7 @@ function ConceptC() {
               <button
                 type="button"
                 onClick={() => setShowRaw(!showRaw)}
-                className="bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 px-3 text-xs font-medium transition-colors"
+                className="bg-background text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 px-3 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
               >
                 {showRaw ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
                 Parameters

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -343,7 +343,7 @@ export function ReviewApprovalDialog({
                 <button
                   type="button"
                   onClick={() => setParamsOpen((o) => !o)}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors"
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
                   aria-expanded={paramsOpen}
                 >
                   <span


### PR DESCRIPTION
## Summary
- Removes the default browser blue focus outline that appears when tapping the "Parameters" pill button in the approval modal on mobile
- Adds `focus:outline-none` with `focus-visible:ring-2` so keyboard users still get a visible focus indicator
- Updated matching story files to stay in sync with production component

## Test plan

### Claude Code
- [x] Frontend tests pass (953/953)
- [x] TypeScript compilation clean

### Manual Testing
- [ ] Open approval modal on mobile Safari/Chrome and tap the Parameters toggle — confirm no blue outline appears
- [ ] Tab to the Parameters toggle with a keyboard — confirm the focus ring appears

https://claude.ai/code/session_01N4hX47K3m7wwcawEvtAsuu