### PR TITLE
Add edit standing approvals

### DIFF
--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -46,14 +46,20 @@ type revokeStandingApprovalResponse struct {
 }
 
 type createStandingApprovalRequest struct {
-	AgentID                int64           `json:"agent_id" validate:"gt=0"`
-	ActionType             string          `json:"action_type" validate:"required"`
-	ActionVersion          string          `json:"action_version"`
-	Constraints            json.RawMessage `json:"constraints"`
-	SourceActionConfigurationID *string     `json:"source_action_configuration_id"`
-	MaxExecutions          *int            `json:"max_executions" validate:"omitempty,gte=1"`
-	StartsAt               *time.Time      `json:"starts_at"`
-	ExpiresAt              time.Time       `json:"expires_at" validate:"required"`
+	AgentID                     int64           `json:"agent_id" validate:"gt=0"`
+	ActionType                  string          `json:"action_type" validate:"required"`
+	ActionVersion               string          `json:"action_version"`
+	Constraints                 json.RawMessage `json:"constraints"`
+	SourceActionConfigurationID *string         `json:"source_action_configuration_id"`
+	MaxExecutions               *int            `json:"max_executions" validate:"omitempty,gte=1"`
+	StartsAt                    *time.Time      `json:"starts_at"`
+	ExpiresAt                   time.Time       `json:"expires_at" validate:"required"`
+}
+
+type updateStandingApprovalRequest struct {
+	Constraints   json.RawMessage `json:"constraints"`
+	MaxExecutions *int            `json:"max_executions" validate:"omitempty,gte=1"`
+	ExpiresAt     time.Time       `json:"expires_at" validate:"required"`
 }
 
 type executeStandingApprovalRequest struct {
@@ -92,6 +98,7 @@ func RegisterStandingApprovalRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.Handle("POST /standing-approvals/create", requireProfile(handleCreateStandingApproval(deps)))
 	mux.Handle("POST /standing-approvals/{standing_approval_id}/revoke", requireProfile(handleRevokeStandingApproval(deps)))
 	mux.Handle("POST /standing-approvals/{standing_approval_id}/execute", requireProfile(handleExecuteStandingApproval(deps)))
+	mux.Handle("POST /standing-approvals/{standing_approval_id}/update", requireProfile(handleUpdateStandingApproval(deps)))
 }
 
 func handleListStandingApprovals(deps *Deps) http.HandlerFunc {
@@ -403,6 +410,70 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 			ExecutedAt:         exec.ExecutedAt,
 			ActionResult:       actionResultPtr,
 		})
+	}
+}
+
+func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		saID := r.PathValue("standing_approval_id")
+
+		if strings.TrimSpace(saID) == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "standing_approval_id is required"))
+			return
+		}
+
+		var req updateStandingApprovalRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		if !ValidateRequest(w, r, &req) {
+			return
+		}
+
+		if len(req.Constraints) > shared.MaxConstraintsBytes {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "constraints exceeds maximum size"))
+			return
+		}
+
+		if req.ExpiresAt.Before(time.Now().UTC()) {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "expires_at must be in the future"))
+			return
+		}
+
+		if time.Until(req.ExpiresAt) > shared.StandingApprovalMaxDuration {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "duration exceeds maximum"))
+			return
+		}
+
+		constraintsBytes, err := validateStandingApprovalConstraints(req.Constraints)
+		if err != nil {
+			resp := BadRequest(ErrInvalidConstraints, err.Error())
+			resp.Error.Details = map[string]any{
+				"hint": "Provide a JSON object with at least one non-wildcard constraint, e.g. {\"repo\": \"my-org/my-repo\", \"title\": \"*\"}",
+			}
+			RespondError(w, r, http.StatusBadRequest, resp)
+			return
+		}
+
+		sa, err := db.UpdateStandingApproval(r.Context(), deps.DB, db.UpdateStandingApprovalParams{
+			StandingApprovalID: saID,
+			UserID:             profile.ID,
+			Constraints:        constraintsBytes,
+			MaxExecutions:      req.MaxExecutions,
+			ExpiresAt:          req.ExpiresAt,
+		})
+		if err != nil {
+			if handleStandingApprovalError(w, r, err) {
+				return
+			}
+			log.Printf("[%s] UpdateStandingApproval: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update standing approval"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, toStandingApprovalResponse(*sa))
 	}
 }
 

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -334,6 +334,8 @@ func handleStandingApprovalError(w http.ResponseWriter, r *http.Request, err err
 			resp.Error.Details = map[string]any{"status": saErr.Status}
 		}
 		RespondError(w, r, http.StatusGone, resp)
+	case db.StandingApprovalErrMaxExecutionsTooLow:
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "max_executions cannot be less than the current execution count"))
 	default:
 		return false
 	}
@@ -455,15 +457,11 @@ func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 		if existing.Status != "active" {
+			errCode := db.StandingApprovalErrNotActive
 			if existing.Status == "revoked" {
-				resp := Conflict(ErrApprovalAlreadyResolved, "Standing approval already revoked")
-				resp.Error.Details = map[string]any{"status": existing.Status}
-				RespondError(w, r, http.StatusConflict, resp)
-			} else {
-				resp := Gone(ErrStandingExpired, "Standing approval is no longer active")
-				resp.Error.Details = map[string]any{"status": existing.Status}
-				RespondError(w, r, http.StatusGone, resp)
+				errCode = db.StandingApprovalErrAlreadyRevoked
 			}
+			handleStandingApprovalError(w, r, &db.StandingApprovalError{Code: errCode, Status: existing.Status})
 			return
 		}
 
@@ -506,8 +504,24 @@ func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		emitStandingApprovalUpdateAuditEvent(r.Context(), deps.DB, profile.ID, sa.AgentID, saID, sa.ActionType)
 		RespondJSON(w, http.StatusOK, toStandingApprovalResponse(*sa))
 	}
+}
+
+// emitStandingApprovalUpdateAuditEvent writes a standing_approval.updated audit event.
+func emitStandingApprovalUpdateAuditEvent(ctx context.Context, d db.DBTX, userID string, agentID int64, saID, actionType string) {
+	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
+	emitAuditEventWithUsage(ctx, d, db.InsertAuditEventParams{
+		UserID:      userID,
+		AgentID:     agentID,
+		EventType:   db.AuditEventStandingUpdated,
+		Outcome:     "updated",
+		SourceID:    saID,
+		SourceType:  "standing_approval",
+		Action:      actionJSON,
+		ConnectorID: connectorIDFromActionType(actionType),
+	}, false)
 }
 
 // emitStandingApprovalAuditEvent writes a standing_approval.executed audit event.

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -442,8 +442,41 @@ func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		if time.Until(req.ExpiresAt) > shared.StandingApprovalMaxDuration {
+		// Fetch the existing approval to anchor duration check to starts_at and
+		// validate max_executions against current execution_count.
+		existing, err := db.GetStandingApprovalByIDAndUser(r.Context(), deps.DB, saID, profile.ID)
+		if err != nil {
+			log.Printf("[%s] UpdateStandingApproval: fetch existing: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update standing approval"))
+			return
+		}
+		if existing == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Standing approval not found"))
+			return
+		}
+		if existing.Status != "active" {
+			if existing.Status == "revoked" {
+				resp := Conflict(ErrApprovalAlreadyResolved, "Standing approval already revoked")
+				resp.Error.Details = map[string]any{"status": existing.Status}
+				RespondError(w, r, http.StatusConflict, resp)
+			} else {
+				resp := Gone(ErrStandingExpired, "Standing approval is no longer active")
+				resp.Error.Details = map[string]any{"status": existing.Status}
+				RespondError(w, r, http.StatusGone, resp)
+			}
+			return
+		}
+
+		// Anchor max-duration check to the original starts_at, consistent with create.
+		if req.ExpiresAt.Sub(existing.StartsAt) > shared.StandingApprovalMaxDuration {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "duration exceeds maximum"))
+			return
+		}
+
+		// Prevent setting max_executions below the current execution count, which
+		// would leave the approval active in the dashboard but unreachable by agents.
+		if req.MaxExecutions != nil && *req.MaxExecutions < existing.ExecutionCount {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "max_executions cannot be less than the current execution count"))
 			return
 		}
 

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -13,28 +13,30 @@ import (
 type AuditEventType string
 
 const (
-	AuditEventApprovalRequested AuditEventType = "approval.requested"
-	AuditEventApprovalApproved  AuditEventType = "approval.approved"
-	AuditEventApprovalDenied    AuditEventType = "approval.denied"
-	AuditEventApprovalCancelled AuditEventType = "approval.cancelled"
-	AuditEventActionExecuted    AuditEventType = "action.executed"
-	AuditEventStandingExecution AuditEventType = "standing_approval.executed"
-	AuditEventAgentRegistered   AuditEventType = "agent.registered"
-	AuditEventAgentDeactivated      AuditEventType = "agent.deactivated"
-	AuditEventPaymentMethodCharged  AuditEventType = "payment_method.charged"
+	AuditEventApprovalRequested    AuditEventType = "approval.requested"
+	AuditEventApprovalApproved     AuditEventType = "approval.approved"
+	AuditEventApprovalDenied       AuditEventType = "approval.denied"
+	AuditEventApprovalCancelled    AuditEventType = "approval.cancelled"
+	AuditEventActionExecuted       AuditEventType = "action.executed"
+	AuditEventStandingExecution    AuditEventType = "standing_approval.executed"
+	AuditEventStandingUpdated      AuditEventType = "standing_approval.updated"
+	AuditEventAgentRegistered      AuditEventType = "agent.registered"
+	AuditEventAgentDeactivated     AuditEventType = "agent.deactivated"
+	AuditEventPaymentMethodCharged AuditEventType = "payment_method.charged"
 )
 
 // validAuditEventTypes is used for input validation.
 var validAuditEventTypes = map[AuditEventType]bool{
-	AuditEventApprovalRequested: true,
-	AuditEventApprovalApproved:  true,
-	AuditEventApprovalDenied:    true,
-	AuditEventApprovalCancelled: true,
-	AuditEventActionExecuted:    true,
-	AuditEventStandingExecution: true,
-	AuditEventAgentRegistered:   true,
-	AuditEventAgentDeactivated:      true,
-	AuditEventPaymentMethodCharged:  true,
+	AuditEventApprovalRequested:    true,
+	AuditEventApprovalApproved:     true,
+	AuditEventApprovalDenied:       true,
+	AuditEventApprovalCancelled:    true,
+	AuditEventActionExecuted:       true,
+	AuditEventStandingExecution:    true,
+	AuditEventStandingUpdated:      true,
+	AuditEventAgentRegistered:      true,
+	AuditEventAgentDeactivated:     true,
+	AuditEventPaymentMethodCharged: true,
 }
 
 // IsValidAuditEventType checks if the given event type is valid.
@@ -96,8 +98,8 @@ const (
 
 // Payment audit event constants.
 const (
-	OutcomeCharged                = "charged"
-	SourceTypePaymentMethodTx     = "payment_method_transaction"
+	OutcomeCharged            = "charged"
+	SourceTypePaymentMethodTx = "payment_method_transaction"
 )
 
 // InsertAuditEventParams holds the parameters for inserting an audit event.
@@ -314,8 +316,8 @@ func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Tim
 	}
 
 	b := &queryBuilder{}
-	b.addArg(userID)            // $1
-	sincePh := b.addArg(since)  // $2
+	b.addArg(userID)           // $1
+	sincePh := b.addArg(since) // $2
 
 	where := []string{"ae.user_id = $1", fmt.Sprintf("ae.created_at >= %s", sincePh)}
 

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -347,7 +347,7 @@ type StandingApprovalExecution struct {
 	ExecutedAt         time.Time
 	// MaxExecutions and ExecutionCount are populated by
 	// RecordStandingApprovalExecutionByAgent only.
-	MaxExecutions *int
+	MaxExecutions  *int
 	ExecutionCount int
 }
 
@@ -401,6 +401,36 @@ func diagnoseStandingApprovalFailure(ctx context.Context, db DBTX, saID, userID 
 		return &StandingApprovalError{Code: StandingApprovalErrAlreadyRevoked, Status: sa.Status}
 	}
 	return &StandingApprovalError{Code: StandingApprovalErrNotActive, Status: sa.Status}
+}
+
+// UpdateStandingApprovalParams holds the fields that can be updated on an active standing approval.
+type UpdateStandingApprovalParams struct {
+	StandingApprovalID string
+	UserID             string
+	Constraints        []byte // raw JSONB
+	MaxExecutions      *int
+	ExpiresAt          time.Time
+}
+
+// UpdateStandingApproval updates the constraints, max_executions, and expires_at of an active
+// standing approval belonging to the given user. Returns the updated approval, or a domain error.
+func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprovalParams) (*StandingApproval, error) {
+	row := db.QueryRow(ctx,
+		`UPDATE standing_approvals
+		 SET constraints = $3, max_executions = $4, expires_at = $5
+		 WHERE standing_approval_id = $1 AND user_id = $2
+		   AND status = 'active'
+		 RETURNING `+standingApprovalColumns,
+		p.StandingApprovalID, p.UserID, p.Constraints, p.MaxExecutions, p.ExpiresAt,
+	)
+	updated, err := scanStandingApproval(row)
+	if err == nil {
+		return updated, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+	return nil, diagnoseStandingApprovalFailure(ctx, db, p.StandingApprovalID, p.UserID)
 }
 
 // FindActiveStandingApprovalForAgent returns the best matching active standing

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -100,11 +100,12 @@ type StandingApprovalError struct {
 func (e *StandingApprovalError) Error() string { return e.Code }
 
 const (
-	StandingApprovalErrNotFound         = "not_found"
-	StandingApprovalErrAlreadyRevoked   = "already_revoked"
-	StandingApprovalErrNotActive        = "not_active"
-	StandingApprovalErrAgentNotFound    = "agent_not_found"
-	StandingApprovalErrDuplicateRequest = "duplicate_request"
+	StandingApprovalErrNotFound            = "not_found"
+	StandingApprovalErrAlreadyRevoked      = "already_revoked"
+	StandingApprovalErrNotActive           = "not_active"
+	StandingApprovalErrAgentNotFound       = "agent_not_found"
+	StandingApprovalErrDuplicateRequest    = "duplicate_request"
+	StandingApprovalErrMaxExecutionsTooLow = "max_executions_too_low"
 )
 
 // CreateStandingApprovalParams holds the parameters for creating a standing approval.
@@ -414,12 +415,17 @@ type UpdateStandingApprovalParams struct {
 
 // UpdateStandingApproval updates the constraints, max_executions, and expires_at of an active
 // standing approval belonging to the given user. Returns the updated approval, or a domain error.
+//
+// The UPDATE atomically guards against setting max_executions below the current
+// execution_count — even in the presence of concurrent executions between the
+// caller's pre-flight validation and this write.
 func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprovalParams) (*StandingApproval, error) {
 	row := db.QueryRow(ctx,
 		`UPDATE standing_approvals
 		 SET constraints = $3, max_executions = $4, expires_at = $5
 		 WHERE standing_approval_id = $1 AND user_id = $2
 		   AND status = 'active'
+		   AND ($4 IS NULL OR $4 >= execution_count)
 		 RETURNING `+standingApprovalColumns,
 		p.StandingApprovalID, p.UserID, p.Constraints, p.MaxExecutions, p.ExpiresAt,
 	)
@@ -430,7 +436,23 @@ func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprov
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return nil, err
 	}
-	return nil, diagnoseStandingApprovalFailure(ctx, db, p.StandingApprovalID, p.UserID)
+
+	// Diagnose why the UPDATE matched zero rows. Check for the max_executions
+	// race before falling back to generic status diagnosis.
+	sa, err := GetStandingApprovalByIDAndUser(ctx, db, p.StandingApprovalID, p.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if sa == nil {
+		return nil, &StandingApprovalError{Code: StandingApprovalErrNotFound}
+	}
+	if sa.Status == "active" && p.MaxExecutions != nil && *p.MaxExecutions < sa.ExecutionCount {
+		return nil, &StandingApprovalError{Code: StandingApprovalErrMaxExecutionsTooLow}
+	}
+	if sa.Status == "revoked" {
+		return nil, &StandingApprovalError{Code: StandingApprovalErrAlreadyRevoked, Status: sa.Status}
+	}
+	return nil, &StandingApprovalError{Code: StandingApprovalErrNotActive, Status: sa.Status}
 }
 
 // FindActiveStandingApprovalForAgent returns the best matching active standing

--- a/frontend/src/hooks/useUpdateStandingApproval.ts
+++ b/frontend/src/hooks/useUpdateStandingApproval.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+import type { components } from "@/api/schema";
+import { trackEvent, PostHogEvents } from "@/lib/posthog";
+
+type UpdateStandingApprovalRequest =
+  components["schemas"]["UpdateStandingApprovalRequest"];
+
+export function useUpdateStandingApproval() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      standingApprovalId,
+      req,
+    }: {
+      standingApprovalId: string;
+      req: UpdateStandingApprovalRequest;
+    }) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST(
+        "/v1/standing-approvals/{standing_approval_id}/update",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { standing_approval_id: standingApprovalId } },
+          body: req,
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to update standing approval"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      trackEvent(PostHogEvents.STANDING_APPROVAL_UPDATED);
+      queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
+    },
+  });
+
+  return {
+    updateStandingApproval: (
+      standingApprovalId: string,
+      req: UpdateStandingApprovalRequest,
+    ) => mutation.mutateAsync({ standingApprovalId, req }),
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/lib/posthog-events.ts
+++ b/frontend/src/lib/posthog-events.ts
@@ -18,6 +18,7 @@ export const PostHogEvents = {
   // Standing approvals
   STANDING_APPROVAL_CREATED: "standing_approval_created",
   STANDING_APPROVAL_REVOKED: "standing_approval_revoked",
+  STANDING_APPROVAL_UPDATED: "standing_approval_updated",
 
   // Agent management
   AGENT_UPDATED: "agent_updated",

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
@@ -628,3 +628,139 @@ export const Step4Limits: Story = {
   },
   name: "Step 4 – Limits",
 };
+
+// ---------------------------------------------------------------------------
+// Edit mode wizard — starts at step 3, pre-filled, shows "Save" button
+// and "already used N times" hint on step 4
+// ---------------------------------------------------------------------------
+
+function EditStandingApprovalWizard() {
+  type EditStep = 3 | 4;
+  const [step, setStep] = useState<EditStep>(3);
+  const [paramValues, setParamValues] = useState<Record<string, string>>({
+    summary: "Team Standup",
+    calendar_id: "primary",
+    attendees: "*",
+  });
+  const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({
+    summary: "fixed",
+    calendar_id: "fixed",
+    attendees: "wildcard",
+  });
+  const [maxExecutions, setMaxExecutions] = useState("20");
+  const [expiresAt, setExpiresAt] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 14);
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 16);
+  });
+
+  // Simulated execution count for the existing approval
+  const currentExecutionCount = 7;
+
+  return (
+    <Dialog open>
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <ConnectorLogo
+              name="Google Calendar"
+              logoSvg={GOOGLE_LOGO}
+              size="lg"
+            />
+            <div className="min-w-0">
+              <DialogTitle className="truncate text-base">
+                Create Event
+              </DialogTitle>
+              <p className="text-muted-foreground text-sm">Google Calendar</p>
+            </div>
+          </div>
+          <DialogDescription>
+            Step {step - 2} of 2: {STEP_LABELS[step as Step]}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-1 px-1">
+          {([3, 4] as EditStep[]).map((s) => (
+            <div
+              key={s}
+              className={`h-1.5 flex-1 rounded-full transition-colors ${
+                s <= step ? "bg-primary" : "bg-muted"
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="space-y-4">
+          {step === 3 && (
+            <StoryStepConstraints
+              schema={CALENDAR_SCHEMA}
+              paramValues={paramValues}
+              paramModes={paramModes}
+              onParamValueChange={(key, value) =>
+                setParamValues((prev) => ({ ...prev, [key]: value }))
+              }
+              onParamModeChange={(key, mode) =>
+                setParamModes((prev) => ({ ...prev, [key]: mode }))
+              }
+              manualConstraintsJson=""
+              onManualConstraintsJsonChange={() => {}}
+            />
+          )}
+
+          {step === 4 && (
+            <StepLimits
+              maxExecutions={maxExecutions}
+              onMaxExecutionsChange={(value) => {
+                if (value === "") {
+                  setMaxExecutions("");
+                  return;
+                }
+                const intValue = parseInt(value, 10);
+                if (Number.isNaN(intValue) || intValue < 1) return;
+                setMaxExecutions(String(intValue));
+              }}
+              expiresAt={expiresAt}
+              onExpiresAtChange={setExpiresAt}
+              currentExecutionCount={currentExecutionCount}
+            />
+          )}
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            {step === 4 && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setStep(3)}
+              >
+                <ChevronLeft className="size-4" />
+                Back
+              </Button>
+            )}
+            <div className="flex-1" />
+            <Button type="button" variant="secondary">
+              Cancel
+            </Button>
+            {step === 3 ? (
+              <Button type="button" onClick={() => setStep(4)}>
+                Next
+                <ChevronRight className="size-4" />
+              </Button>
+            ) : (
+              <Button type="button">
+                <Check className="size-4" />
+                Save
+              </Button>
+            )}
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Edit mode — pre-filled constraints and limits, "Save" button, execution count hint. */
+export const EditMode: StoryObj = {
+  render: () => <EditStandingApprovalWizard />,
+  name: "Edit Mode",
+};

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -552,6 +552,7 @@ export function CreateStandingApprovalDialog({
               }}
               expiresAt={expiresAt}
               onExpiresAtChange={setExpiresAt}
+              currentExecutionCount={isEditMode ? editTarget.execution_count : undefined}
             />
           )}
 

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -12,6 +12,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useCreateStandingApproval } from "@/hooks/useCreateStandingApproval";
+import { useUpdateStandingApproval } from "@/hooks/useUpdateStandingApproval";
+import type { StandingApproval } from "@/hooks/useStandingApprovals";
 import { useActionConfigs } from "@/hooks/useActionConfigs";
 import { useActionSchema } from "@/hooks/useActionSchema";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
@@ -36,8 +38,12 @@ export interface CreateStandingApprovalDialogProps {
   initialAgentId?: number;
   initialActionType?: string;
   initialConstraints?: Record<string, unknown>;
+  /** When provided, the dialog operates in edit mode for the given standing approval. */
+  editTarget?: StandingApproval;
   /** Called after a standing approval is successfully created. */
   onCreated?: () => void;
+  /** Called after a standing approval is successfully updated. */
+  onUpdated?: () => void;
 }
 
 type Step = 1 | 2 | 3 | 4;
@@ -81,25 +87,39 @@ export function CreateStandingApprovalDialog({
   initialAgentId,
   initialActionType,
   initialConstraints,
+  editTarget,
   onCreated,
+  onUpdated,
 }: CreateStandingApprovalDialogProps) {
-  const { createStandingApproval, isPending } = useCreateStandingApproval();
+  const { createStandingApproval, isPending: isCreatePending } = useCreateStandingApproval();
+  const { updateStandingApproval, isPending: isUpdatePending } = useUpdateStandingApproval();
+  const isPending = isCreatePending || isUpdatePending;
+  const isEditMode = !!editTarget;
+
+  // In edit mode, derive initial values from the target approval.
+  const ctxAgentId = isEditMode ? editTarget.agent_id : initialAgentId;
+  const ctxActionType = isEditMode ? editTarget.action_type : initialActionType;
+  const ctxConstraints = isEditMode
+    ? (editTarget.constraints as Record<string, unknown>)
+    : initialConstraints;
 
   // Skip straight to constraints when agent + action are pre-filled
-  const hasInitialContext = !!(initialAgentId && initialActionType);
+  const hasInitialContext = !!(ctxAgentId && ctxActionType);
   const [step, setStep] = useState<Step>(hasInitialContext ? 3 : 1);
-  const [agentId, setAgentId] = useState<number | "">(initialAgentId ?? "");
+  const [agentId, setAgentId] = useState<number | "">(ctxAgentId ?? "");
   const [selectedConfigId, setSelectedConfigId] = useState<string>(
-    initialActionType ? CUSTOM_ACTION_SENTINEL : "",
+    isEditMode
+      ? (editTarget.source_action_configuration_id ?? CUSTOM_ACTION_SENTINEL)
+      : (ctxActionType ? CUSTOM_ACTION_SENTINEL : ""),
   );
   const [customActionType, setCustomActionType] = useState(
-    initialActionType ?? "",
+    ctxActionType ?? "",
   );
   // Pre-populate constraint form values when initial constraints are provided
   const [paramValues, setParamValues] = useState<Record<string, string>>(() => {
-    if (!hasInitialContext || !initialConstraints) return {};
+    if (!hasInitialContext || !ctxConstraints) return {};
     const values: Record<string, string> = {};
-    for (const [key, value] of Object.entries(initialConstraints)) {
+    for (const [key, value] of Object.entries(ctxConstraints)) {
       if (value === "*") values[key] = "*";
       else if (isPatternWrapper(value)) values[key] = value.$pattern;
       else if (value === null || value === undefined) values[key] = "";
@@ -108,9 +128,9 @@ export function CreateStandingApprovalDialog({
     return values;
   });
   const [paramModes, setParamModes] = useState<Record<string, ParamMode>>(() => {
-    if (!hasInitialContext || !initialConstraints) return {};
+    if (!hasInitialContext || !ctxConstraints) return {};
     const modes: Record<string, ParamMode> = {};
-    for (const [key, value] of Object.entries(initialConstraints)) {
+    for (const [key, value] of Object.entries(ctxConstraints)) {
       if (value === "*") modes[key] = "wildcard";
       else if (isPatternWrapper(value)) modes[key] = "pattern";
       else modes[key] = "fixed";
@@ -118,12 +138,23 @@ export function CreateStandingApprovalDialog({
     return modes;
   });
   const [manualConstraintsJson, setManualConstraintsJson] = useState(
-    hasInitialContext && initialConstraints
-      ? JSON.stringify(initialConstraints, null, 2)
+    hasInitialContext && ctxConstraints
+      ? JSON.stringify(ctxConstraints, null, 2)
       : "",
   );
-  const [maxExecutions, setMaxExecutions] = useState("");
-  const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
+  const [maxExecutions, setMaxExecutions] = useState(
+    isEditMode && editTarget.max_executions != null
+      ? String(editTarget.max_executions)
+      : "",
+  );
+  const [expiresAt, setExpiresAt] = useState(() => {
+    if (isEditMode && editTarget.expires_at) {
+      const d = new Date(editTarget.expires_at);
+      const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+      return local.toISOString().slice(0, 16);
+    }
+    return defaultExpiresAt();
+  });
 
   const activeAgents = agents.filter((a) => a.status !== "deactivated");
 
@@ -172,13 +203,17 @@ export function CreateStandingApprovalDialog({
 
   function resetForm() {
     setStep(hasInitialContext ? 3 : 1);
-    setAgentId(initialAgentId ?? "");
-    setSelectedConfigId(initialActionType ? CUSTOM_ACTION_SENTINEL : "");
-    setCustomActionType(initialActionType ?? "");
-    if (hasInitialContext && initialConstraints) {
+    setAgentId(ctxAgentId ?? "");
+    setSelectedConfigId(
+      isEditMode
+        ? (editTarget.source_action_configuration_id ?? CUSTOM_ACTION_SENTINEL)
+        : (ctxActionType ? CUSTOM_ACTION_SENTINEL : ""),
+    );
+    setCustomActionType(ctxActionType ?? "");
+    if (hasInitialContext && ctxConstraints) {
       const values: Record<string, string> = {};
       const modes: Record<string, ParamMode> = {};
-      for (const [key, value] of Object.entries(initialConstraints)) {
+      for (const [key, value] of Object.entries(ctxConstraints)) {
         if (value === "*") { values[key] = "*"; modes[key] = "wildcard"; }
         else if (isPatternWrapper(value)) { values[key] = value.$pattern; modes[key] = "pattern"; }
         else { values[key] = value === null || value === undefined ? "" : String(value); modes[key] = "fixed"; }
@@ -190,12 +225,22 @@ export function CreateStandingApprovalDialog({
       setParamModes({});
     }
     setManualConstraintsJson(
-      hasInitialContext && initialConstraints
-        ? JSON.stringify(initialConstraints, null, 2)
+      hasInitialContext && ctxConstraints
+        ? JSON.stringify(ctxConstraints, null, 2)
         : "",
     );
-    setMaxExecutions("");
-    setExpiresAt(defaultExpiresAt());
+    if (isEditMode && editTarget.max_executions != null) {
+      setMaxExecutions(String(editTarget.max_executions));
+    } else {
+      setMaxExecutions("");
+    }
+    if (isEditMode && editTarget.expires_at) {
+      const d = new Date(editTarget.expires_at);
+      const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+      setExpiresAt(local.toISOString().slice(0, 16));
+    } else {
+      setExpiresAt(defaultExpiresAt());
+    }
   }
 
   function initConstraintsFromRecord(record: Record<string, unknown>) {
@@ -243,9 +288,9 @@ export function CreateStandingApprovalDialog({
       if (selectedConfig) {
         initConstraintsFromRecord(selectedConfig.parameters);
         setManualConstraintsJson("");
-      } else if (initialConstraints && isCustomAction) {
-        initConstraintsFromRecord(initialConstraints);
-        setManualConstraintsJson(JSON.stringify(initialConstraints, null, 2));
+      } else if (ctxConstraints && isCustomAction) {
+        initConstraintsFromRecord(ctxConstraints);
+        setManualConstraintsJson(JSON.stringify(ctxConstraints, null, 2));
       } else {
         setParamValues({});
         setParamModes({});
@@ -350,24 +395,38 @@ export function CreateStandingApprovalDialog({
     }
 
     try {
-      await createStandingApproval({
-        agent_id: agentId,
-        action_type: effectiveActionType,
-        action_version: "1",
-        constraints,
-        source_action_configuration_id: selectedConfig?.id,
-        max_executions: maxExecutions ? Number(maxExecutions) : null,
-        expires_at: new Date(expiresAt).toISOString(),
-      });
-      toast.success("Standing approval created");
-      resetForm();
-      onOpenChange(false);
-      onCreated?.();
+      if (isEditMode) {
+        await updateStandingApproval(editTarget.standing_approval_id, {
+          constraints,
+          max_executions: maxExecutions ? Number(maxExecutions) : null,
+          expires_at: new Date(expiresAt).toISOString(),
+        });
+        toast.success("Standing approval updated");
+        resetForm();
+        onOpenChange(false);
+        onUpdated?.();
+      } else {
+        await createStandingApproval({
+          agent_id: agentId,
+          action_type: effectiveActionType,
+          action_version: "1",
+          constraints,
+          source_action_configuration_id: selectedConfig?.id,
+          max_executions: maxExecutions ? Number(maxExecutions) : null,
+          expires_at: new Date(expiresAt).toISOString(),
+        });
+        toast.success("Standing approval created");
+        resetForm();
+        onOpenChange(false);
+        onCreated?.();
+      }
     } catch (err) {
       toast.error(
         err instanceof Error
           ? err.message
-          : "Failed to create standing approval",
+          : isEditMode
+            ? "Failed to update standing approval"
+            : "Failed to create standing approval",
       );
     }
   }
@@ -411,7 +470,9 @@ export function CreateStandingApprovalDialog({
             </>
           ) : (
             <>
-              <DialogTitle>Create Standing Approval</DialogTitle>
+              <DialogTitle>
+                {isEditMode ? "Edit Standing Approval" : "Create Standing Approval"}
+              </DialogTitle>
               <DialogDescription>
                 {hasInitialContext
                   ? `Step ${step - 2} of 2: ${STEP_LABELS[step]}`
@@ -439,7 +500,7 @@ export function CreateStandingApprovalDialog({
               onAgentChange={(id) => {
                 setAgentId(id);
                 setSelectedConfigId("");
-                setCustomActionType(initialActionType ?? "");
+                setCustomActionType(ctxActionType ?? "");
                 setParamValues({});
                 setParamModes({});
               }}
@@ -537,7 +598,7 @@ export function CreateStandingApprovalDialog({
                 ) : (
                   <Check className="size-4" />
                 )}
-                Create
+                {isEditMode ? "Save" : "Create"}
               </Button>
             )}
           </DialogFooter>

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -547,7 +547,10 @@ export function CreateStandingApprovalDialog({
                   return;
                 }
                 const intValue = parseInt(value, 10);
-                if (Number.isNaN(intValue) || intValue < 1) return;
+                // In edit mode enforce the minimum at execution_count so the
+                // client rejects the input before it ever reaches the server.
+                const minAllowed = isEditMode ? editTarget.execution_count : 1;
+                if (Number.isNaN(intValue) || intValue < minAllowed) return;
                 setMaxExecutions(String(intValue));
               }}
               expiresAt={expiresAt}

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -210,11 +210,14 @@ export function StepLimits({
   onMaxExecutionsChange,
   expiresAt,
   onExpiresAtChange,
+  currentExecutionCount,
 }: {
   maxExecutions: string;
   onMaxExecutionsChange: (value: string) => void;
   expiresAt: string;
   onExpiresAtChange: (value: string) => void;
+  /** When editing an existing approval, the number of times it has already been used. */
+  currentExecutionCount?: number;
 }) {
   return (
     <div className="space-y-4">
@@ -223,15 +226,21 @@ export function StepLimits({
         <Input
           id="sa-max-executions"
           type="number"
-          min="1"
+          min={currentExecutionCount != null ? String(currentExecutionCount) : "1"}
           step="1"
           placeholder="Unlimited"
           value={maxExecutions}
           onChange={(e) => onMaxExecutionsChange(e.target.value)}
         />
-        <p className="text-muted-foreground text-sm">
-          Leave empty for unlimited executions.
-        </p>
+        {currentExecutionCount != null && currentExecutionCount > 0 ? (
+          <p className="text-muted-foreground text-sm">
+            Already used {currentExecutionCount} time{currentExecutionCount !== 1 ? "s" : ""} — minimum is {currentExecutionCount}. Leave empty for unlimited.
+          </p>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            Leave empty for unlimited executions.
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -135,13 +135,15 @@ function StandingApprovalRow({
       </TableCell>
       <TableCell>{formatExpiresIn(sa.expires_at)}</TableCell>
       <TableCell className="text-right">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onEdit(sa)}
-        >
-          Edit
-        </Button>
+        {sa.status === "active" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onEdit(sa)}
+          >
+            Edit
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -92,11 +92,13 @@ function resolveActionConfigName(
 
 function StandingApprovalRow({
   sa,
+  onEdit,
   onRevoke,
   agentMap,
   configMap,
 }: {
   sa: StandingApproval;
+  onEdit: (sa: StandingApproval) => void;
   onRevoke: (sa: StandingApproval) => void;
   agentMap: Map<number, Agent>;
   configMap: Map<string, ActionConfiguration>;
@@ -133,6 +135,13 @@ function StandingApprovalRow({
       </TableCell>
       <TableCell>{formatExpiresIn(sa.expires_at)}</TableCell>
       <TableCell className="text-right">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onEdit(sa)}
+        >
+          Edit
+        </Button>
         <Button
           variant="ghost"
           size="sm"
@@ -189,6 +198,7 @@ export function StandingApprovalsCard() {
     hasData: hasBillingData,
   } = useResourceLimit("max_standing_approvals", standingApprovals.length);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<StandingApproval | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<StandingApproval | null>(
     null,
   );
@@ -224,6 +234,7 @@ export function StandingApprovalsCard() {
         ) : (
           <StandingApprovalsTable
             approvals={standingApprovals}
+            onEdit={(sa) => setEditTarget(sa)}
             onRevoke={(sa) => setRevokeTarget(sa)}
             agentMap={agentMap}
             configMap={configMap}
@@ -251,6 +262,18 @@ export function StandingApprovalsCard() {
         onOpenChange={setCreateDialogOpen}
       />
 
+      {editTarget && (
+        <CreateStandingApprovalDialog
+          agents={agents}
+          open={!!editTarget}
+          onOpenChange={(open) => {
+            if (!open) setEditTarget(null);
+          }}
+          editTarget={editTarget}
+          onUpdated={() => setEditTarget(null)}
+        />
+      )}
+
       {revokeTarget && (
         <RevokeStandingApprovalDialog
           standingApprovalId={revokeTarget.standing_approval_id}
@@ -268,11 +291,13 @@ export function StandingApprovalsCard() {
 
 function StandingApprovalsTable({
   approvals,
+  onEdit,
   onRevoke,
   agentMap,
   configMap,
 }: {
   approvals: StandingApproval[];
+  onEdit: (sa: StandingApproval) => void;
   onRevoke: (sa: StandingApproval) => void;
   agentMap: Map<number, Agent>;
   configMap: Map<string, ActionConfiguration>;
@@ -298,6 +323,7 @@ function StandingApprovalsTable({
               <StandingApprovalRow
                 key={sa.standing_approval_id}
                 sa={sa}
+                onEdit={onEdit}
                 onRevoke={onRevoke}
                 agentMap={agentMap}
                 configMap={configMap}

--- a/spec/openapi/components/paths/standing_approvals.yaml
+++ b/spec/openapi/components/paths/standing_approvals.yaml
@@ -393,6 +393,14 @@ updateStandingApproval:
       The standing approval must belong to the authenticated user and be in `active` status.
       Agent and action type cannot be changed — only constraints and limits.
 
+      **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
+      the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
+      not a rolling window from the time of the update call.
+
+      **Execution count**: `max_executions` cannot be set below the approval's current
+      `execution_count`. The update is rejected atomically at the database level to prevent
+      a race condition where concurrent executions could otherwise create a zombie approval.
+
     tags:
       - Standing Approvals
 

--- a/spec/openapi/components/paths/standing_approvals.yaml
+++ b/spec/openapi/components/paths/standing_approvals.yaml
@@ -384,6 +384,90 @@ createStandingApproval:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+updateStandingApproval:
+  post:
+    operationId: updateStandingApproval
+    summary: Update Standing Approval
+    description: |
+      Update the constraints, max_executions, and expires_at of an active standing approval.
+      The standing approval must belong to the authenticated user and be in `active` status.
+      Agent and action type cannot be changed — only constraints and limits.
+
+    tags:
+      - Standing Approvals
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/StandingApprovalId'
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/standing_approvals.yaml#/UpdateStandingApprovalRequest'
+          example:
+            constraints:
+              recipient_pattern: "*@mycompany.com"
+            max_executions: 200
+            expires_at: "2026-04-14T00:00:00Z"
+
+    responses:
+      '200':
+        description: Standing approval updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/standing_approvals.yaml#/StandingApproval'
+
+      '400':
+        description: Invalid request
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Standing approval not found or not owned by user
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            example:
+              error:
+                code: "approval_not_found"
+                message: "Standing approval not found"
+                retryable: false
+                trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+
+      '409':
+        description: Standing approval already revoked
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '410':
+        description: Standing approval no longer active (expired or exhausted)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
 revokeStandingApproval:
   post:
     operationId: revokeStandingApproval

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -369,7 +369,7 @@ UpdateStandingApprovalRequest:
     expires_at:
       type: string
       format: date-time
-      description: Updated expiration time. Must be in the future. Maximum 90 days from now.
+      description: Updated expiration time. Must be in the future. The total duration from the approval's original start date may not exceed the maximum allowed window (90 days). As the approval ages, the available headroom shrinks.
       example: "2026-04-14T00:00:00Z"
 
   example:

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -345,6 +345,39 @@ CreateStandingApprovalRequest:
     max_executions: 100
     expires_at: "2026-03-14T00:00:00Z"
 
+UpdateStandingApprovalRequest:
+  type: object
+  required:
+    - constraints
+    - expires_at
+  properties:
+    constraints:
+      type: object
+      additionalProperties: true
+      description: |
+        Updated constraint boundaries. Must be non-empty with at least one non-wildcard value.
+      example:
+        recipient_pattern: "*@mycompany.com"
+
+    max_executions:
+      type: integer
+      minimum: 1
+      nullable: true
+      description: Updated maximum number of executions. Null means unlimited.
+      example: 200
+
+    expires_at:
+      type: string
+      format: date-time
+      description: Updated expiration time. Must be in the future. Maximum 90 days from now.
+      example: "2026-04-14T00:00:00Z"
+
+  example:
+    constraints:
+      recipient_pattern: "*@mycompany.com"
+    max_executions: 200
+    expires_at: "2026-04-14T00:00:00Z"
+
 RevokeStandingApprovalResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4345,6 +4345,14 @@ paths:
         Update the constraints, max_executions, and expires_at of an active standing approval.
         The standing approval must belong to the authenticated user and be in `active` status.
         Agent and action type cannot be changed — only constraints and limits.
+
+        **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
+        the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
+        not a rolling window from the time of the update call.
+
+        **Execution count**: `max_executions` cannot be set below the approval's current
+        `execution_count`. The update is rejected atomically at the database level to prevent
+        a race condition where concurrent executions could otherwise create a zombie approval.
       tags:
         - Standing Approvals
       security:
@@ -8565,7 +8573,7 @@ components:
         expires_at:
           type: string
           format: date-time
-          description: Updated expiration time. Must be in the future. Maximum 90 days from now.
+          description: Updated expiration time. Must be in the future. The total duration from the approval's original start date may not exceed the maximum allowed window (90 days). As the approval ages, the available headroom shrinks.
           example: '2026-04-14T00:00:00Z'
       example:
         constraints:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4337,6 +4337,76 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/standing-approvals/{standing_approval_id}/update:
+    post:
+      operationId: updateStandingApproval
+      summary: Update Standing Approval
+      description: |
+        Update the constraints, max_executions, and expires_at of an active standing approval.
+        The standing approval must belong to the authenticated user and be in `active` status.
+        Agent and action type cannot be changed — only constraints and limits.
+      tags:
+        - Standing Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/StandingApprovalId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateStandingApprovalRequest'
+            example:
+              constraints:
+                recipient_pattern: '*@mycompany.com'
+              max_executions: 200
+              expires_at: '2026-04-14T00:00:00Z'
+      responses:
+        '200':
+          description: Standing approval updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandingApproval'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Standing approval not found or not owned by user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: approval_not_found
+                  message: Standing approval not found
+                  retryable: false
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '409':
+          description: Standing approval already revoked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '410':
+          description: Standing approval no longer active (expired or exhausted)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/standing-approvals/{standing_approval_id}/execute:
     post:
       operationId: executeStandingApproval
@@ -8473,6 +8543,35 @@ components:
           type: string
           format: date-time
           example: '2026-02-21T10:30:00Z'
+    UpdateStandingApprovalRequest:
+      type: object
+      required:
+        - constraints
+        - expires_at
+      properties:
+        constraints:
+          type: object
+          additionalProperties: true
+          description: |
+            Updated constraint boundaries. Must be non-empty with at least one non-wildcard value.
+          example:
+            recipient_pattern: '*@mycompany.com'
+        max_executions:
+          type: integer
+          minimum: 1
+          nullable: true
+          description: Updated maximum number of executions. Null means unlimited.
+          example: 200
+        expires_at:
+          type: string
+          format: date-time
+          description: Updated expiration time. Must be in the future. Maximum 90 days from now.
+          example: '2026-04-14T00:00:00Z'
+      example:
+        constraints:
+          recipient_pattern: '*@mycompany.com'
+        max_executions: 200
+        expires_at: '2026-04-14T00:00:00Z'
     UserExecuteStandingApprovalRequest:
       type: object
       properties:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -218,6 +218,9 @@ paths:
   /v1/standing-approvals/{standing_approval_id}/revoke:
     $ref: './components/paths/standing_approvals.yaml#/revokeStandingApproval'
 
+  /v1/standing-approvals/{standing_approval_id}/update:
+    $ref: './components/paths/standing_approvals.yaml#/updateStandingApproval'
+
   /v1/standing-approvals/{standing_approval_id}/execute:
     $ref: './components/paths/standing_approvals.yaml#/executeStandingApproval'
 
@@ -426,6 +429,8 @@ components:
       $ref: './components/schemas/standing_approvals.yaml#/CreateStandingApprovalRequest'
     RevokeStandingApprovalResponse:
       $ref: './components/schemas/standing_approvals.yaml#/RevokeStandingApprovalResponse'
+    UpdateStandingApprovalRequest:
+      $ref: './components/schemas/standing_approvals.yaml#/UpdateStandingApprovalRequest'
     UserExecuteStandingApprovalRequest:
       $ref: './components/schemas/standing_approvals.yaml#/UserExecuteStandingApprovalRequest'
     UserExecuteStandingApprovalResponse:


### PR DESCRIPTION
## Summary

- **Backend**: New `POST /v1/standing-approvals/{id}/update` endpoint + `UpdateStandingApproval` db function — updates constraints, max_executions, and expires_at of an active standing approval
- **OpenAPI**: Added `updateStandingApproval` path and `UpdateStandingApprovalRequest` schema; rebundled spec
- **Frontend**: `CreateStandingApprovalDialog` gains an `editTarget` prop that switches it into edit mode (pre-filled, "Save" button, calls update instead of create); `StandingApprovalsCard` gains an Edit button per row

The edit flow reuses the same 2-step modal (constraints → limits) that's already used when creating from an approval request. Agent and action type stay fixed — only constraints and limits are editable.

## Test plan

### Claude Code
- [x] Run `make test-frontend` — all frontend tests pass
- [x] Run TypeScript type-check — no errors
- [x] Run `make build` — frontend builds cleanly

### Manual Testing
- [ ] Click Edit on a standing approval — modal opens pre-filled with existing constraints, max executions, and expiry
- [ ] Modify constraints and save — card refreshes with updated values
- [ ] Modify expiry date and save — Expires column updates
- [ ] Try saving with invalid constraints (e.g. all wildcards) — shows validation error
- [ ] Try editing an already-revoked approval via API — returns 410 Gone

https://claude.ai/code/session_01G1NRnx6Z7SocEMAxnrDi6W