### PR TITLE
Surface connector error messages for all error types

### DIFF
--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -42,19 +42,26 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		return true
 
 	case connectors.IsValidationError(err):
-		// ValidationError messages are safe to surface — they describe
-		// parameter/credential issues the caller can fix.
-		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
+		msg := "Validation failed"
+		var ve *connectors.ValidationError
+		if errors.As(err, &ve) && ve.Message != "" {
+			msg = ve.Message
+		}
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, msg))
 		return true
 
 	case connectors.IsRateLimitError(err):
+		msg := "External service rate limited"
 		var rl *connectors.RateLimitError
 		retrySeconds := 0
 		if connectors.AsRateLimitError(err, &rl) {
 			retrySeconds = int(rl.RetryAfter.Seconds())
+			if rl.Message != "" {
+				msg = rl.Message
+			}
 		}
 		log.Printf("[%s] connector rate limited: %v", traceID, err)
-		RespondError(w, r, http.StatusTooManyRequests, TooManyRequests("External service rate limited", retrySeconds))
+		RespondError(w, r, http.StatusTooManyRequests, TooManyRequests(msg, retrySeconds))
 		return true
 
 	case connectors.IsExternalError(err):
@@ -77,6 +84,9 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error) boo
 		}
 		if connectors.AsOAuthRefreshError(err, &oauthErr) {
 			details["provider"] = oauthErr.Provider
+			if oauthErr.Message != "" {
+				msg = oauthErr.Message
+			}
 		}
 		resp := newErrorResponse(ErrOAuthRefreshFailed, msg, false)
 		resp.Error.Details = details

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -1112,6 +1112,78 @@ func TestHandleConnectorError_OAuthRefreshError_SurfacesMessage(t *testing.T) {
 	}
 }
 
+// ── handleConnectorError: fallback messages when Message is empty ──
+
+func TestHandleConnectorError_RateLimitError_FallbackMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_rl_fallback"))
+
+	rlErr := &connectors.RateLimitError{RetryAfter: 30 * time.Second} // no Message
+	handled := handleConnectorError(w, r, rlErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle RateLimitError")
+	}
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected status 429, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != "External service rate limited" {
+		t.Errorf("expected fallback message, got %q", resp.Error.Message)
+	}
+}
+
+func TestHandleConnectorError_ValidationError_FallbackMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_val_fallback"))
+
+	valErr := &connectors.ValidationError{} // no Message
+	handled := handleConnectorError(w, r, valErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle ValidationError")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != "Validation failed" {
+		t.Errorf("expected fallback message, got %q", resp.Error.Message)
+	}
+}
+
+func TestHandleConnectorError_OAuthRefreshError_FallbackMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_oauth_fallback"))
+
+	oauthErr := &connectors.OAuthRefreshError{Provider: "google"} // no Message
+	handled := handleConnectorError(w, r, oauthErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle OAuthRefreshError")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	expected := "OAuth authorization required — user must re-connect the provider in Settings"
+	if resp.Error.Message != expected {
+		t.Errorf("expected fallback message %q, got %q", expected, resp.Error.Message)
+	}
+}
+
 // ── executeConnectorAction: payment method integration ──────────────────────
 
 // paymentExecFixture holds common setup for payment method execution tests.

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -1041,6 +1041,77 @@ func TestHandleConnectorError_TimeoutError_SurfacesMessage(t *testing.T) {
 	}
 }
 
+// ── handleConnectorError: RateLimitError/ValidationError/OAuthRefreshError message surfacing ──
+
+func TestHandleConnectorError_RateLimitError_SurfacesMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_rl"))
+
+	rlErr := &connectors.RateLimitError{Message: "GitHub API rate limit exceeded — resets in 42 minutes", RetryAfter: 42 * time.Minute}
+	handled := handleConnectorError(w, r, rlErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle RateLimitError")
+	}
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected status 429, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != rlErr.Message {
+		t.Errorf("expected message %q, got %q", rlErr.Message, resp.Error.Message)
+	}
+}
+
+func TestHandleConnectorError_ValidationError_SurfacesMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_val"))
+
+	valErr := &connectors.ValidationError{Message: "channel_id is required"}
+	handled := handleConnectorError(w, r, valErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle ValidationError")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != valErr.Message {
+		t.Errorf("expected message %q, got %q", valErr.Message, resp.Error.Message)
+	}
+}
+
+func TestHandleConnectorError_OAuthRefreshError_SurfacesMessage(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/actions/execute", nil)
+	r = r.WithContext(context.WithValue(r.Context(), traceIDKey{}, "trace_oauth"))
+
+	oauthErr := &connectors.OAuthRefreshError{Provider: "google", Message: "Google OAuth token expired — user must re-authorize in Settings"}
+	handled := handleConnectorError(w, r, oauthErr)
+	if !handled {
+		t.Fatal("expected handleConnectorError to handle OAuthRefreshError")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error.Message != oauthErr.Message {
+		t.Errorf("expected message %q, got %q", oauthErr.Message, resp.Error.Message)
+	}
+}
+
 // ── executeConnectorAction: payment method integration ──────────────────────
 
 // paymentExecFixture holds common setup for payment method execution tests.


### PR DESCRIPTION
## Summary

- Extends the pattern from PR #670 to the 3 remaining error types that were still using generic messages:
  - **RateLimitError**: now surfaces the connector's message (e.g., "GitHub API rate limit exceeded — resets in 42 minutes") instead of generic "External service rate limited"
  - **ValidationError**: extracts `.Message` directly instead of using `err.Error()` which prepended "validation error: "
  - **OAuthRefreshError**: surfaces the connector's message (e.g., "Google OAuth token expired — user must re-authorize in Settings") instead of always using a generic fallback
- All error types retain safe fallback messages when the connector doesn't provide one
- Adds 3 tests verifying message surfacing for RateLimitError, ValidationError, and OAuthRefreshError

## Test plan

### Claude Code
- [x] All `handleConnectorError` tests pass (13/13 including 3 new)
- [x] `go build ./api/...` passes cleanly
- [x] No changes to HTTP status codes or error structure — only message content

### Manual Testing
- [ ] Trigger a rate-limited connector request and verify the agent sees the specific rate limit message
- [ ] Trigger an OAuth refresh failure and verify the specific provider message is surfaced
- [ ] Verify no sensitive internal data leaks in error messages

https://claude.ai/code/session_01Fig63WTRuk8X9K6MXx2ByT