### PR TITLE
Remove standing approval expiry limit, allow permanent approvals

### DIFF
--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -50,7 +50,7 @@ type standingApprovalCapability struct {
 	Constraints         json.RawMessage `json:"constraints"`
 	MaxExecutions       *int            `json:"max_executions"`
 	ExecutionsRemaining *int            `json:"executions_remaining"`
-	ExpiresAt           time.Time       `json:"expires_at"`
+	ExpiresAt           *time.Time      `json:"expires_at"`
 }
 
 // ── Route registration ──────────────────────────────────────────────────────

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -28,7 +28,7 @@ type standingApprovalResponse struct {
 	MaxExecutions               *int       `json:"max_executions"`
 	ExecutionCount              int        `json:"execution_count"`
 	StartsAt                    time.Time  `json:"starts_at"`
-	ExpiresAt                   time.Time  `json:"expires_at"`
+	ExpiresAt                   *time.Time `json:"expires_at"`
 	CreatedAt                   time.Time  `json:"created_at"`
 	RevokedAt                   *time.Time `json:"revoked_at,omitempty"`
 }
@@ -53,7 +53,7 @@ type createStandingApprovalRequest struct {
 	SourceActionConfigurationID *string     `json:"source_action_configuration_id"`
 	MaxExecutions          *int            `json:"max_executions" validate:"omitempty,gte=1"`
 	StartsAt               *time.Time      `json:"starts_at"`
-	ExpiresAt              time.Time       `json:"expires_at" validate:"required"`
+	ExpiresAt              *time.Time      `json:"expires_at"`
 }
 
 type executeStandingApprovalRequest struct {
@@ -189,13 +189,8 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			startsAt = *req.StartsAt
 		}
 
-		if req.ExpiresAt.Before(startsAt) {
+		if req.ExpiresAt != nil && req.ExpiresAt.Before(startsAt) {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "expires_at must be after starts_at"))
-			return
-		}
-
-		if req.ExpiresAt.Sub(startsAt) > shared.StandingApprovalMaxDuration {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "duration exceeds maximum"))
 			return
 		}
 

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -54,7 +54,7 @@ type CapabilityStandingApproval struct {
 	Constraints         json.RawMessage // raw JSONB
 	MaxExecutions       *int
 	ExecutionsRemaining *int
-	ExpiresAt           time.Time
+	ExpiresAt           *time.Time
 }
 
 // GetAgentCapabilities retrieves all data needed for the capabilities endpoint:
@@ -157,9 +157,9 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 		WHERE sa.agent_id = $1
 		  AND sa.user_id = $2
 		  AND sa.status = 'active'
-		  AND sa.expires_at > now()
+		  AND (sa.expires_at IS NULL OR sa.expires_at > now())
 		  AND sa.starts_at <= now()
-		ORDER BY sa.action_type, sa.expires_at`,
+		ORDER BY sa.action_type, sa.expires_at NULLS LAST`,
 		agentID, approverID,
 	)
 	if err != nil {

--- a/db/migrations/20260317124702_remove_standing_approval_expiry_limit.sql
+++ b/db/migrations/20260317124702_remove_standing_approval_expiry_limit.sql
@@ -1,0 +1,55 @@
+-- +goose Up
+
+-- Make expires_at nullable (NULL = no expiry, lasts until revoked).
+ALTER TABLE standing_approvals ALTER COLUMN expires_at DROP NOT NULL;
+
+-- Drop the 90-day maximum duration constraint.
+-- The constraint name is auto-generated; find it by definition.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    SELECT conname INTO constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'standing_approvals'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%expires_at - starts_at%90 days%';
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE standing_approvals DROP CONSTRAINT %I', constraint_name);
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- Drop the expires_at >= starts_at constraint since expires_at can now be NULL.
+-- Re-add it as a conditional: only enforce when expires_at IS NOT NULL.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    SELECT conname INTO constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'standing_approvals'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%expires_at >= starts_at%';
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE standing_approvals DROP CONSTRAINT %I', constraint_name);
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+ALTER TABLE standing_approvals ADD CONSTRAINT standing_approvals_expires_at_after_starts_at
+    CHECK (expires_at IS NULL OR expires_at >= starts_at);
+
+-- +goose Down
+
+-- Restore NOT NULL.
+-- First set any NULL expires_at to starts_at + 90 days so the column can be made NOT NULL.
+UPDATE standing_approvals SET expires_at = starts_at + interval '90 days' WHERE expires_at IS NULL;
+ALTER TABLE standing_approvals ALTER COLUMN expires_at SET NOT NULL;
+
+-- Drop the conditional constraint and restore the original pair.
+ALTER TABLE standing_approvals DROP CONSTRAINT IF EXISTS standing_approvals_expires_at_after_starts_at;
+ALTER TABLE standing_approvals ADD CHECK (expires_at >= starts_at);
+ALTER TABLE standing_approvals ADD CHECK (expires_at - starts_at <= interval '90 days');

--- a/db/migrations/20260317124702_remove_standing_approval_expiry_limit.sql
+++ b/db/migrations/20260317124702_remove_standing_approval_expiry_limit.sql
@@ -17,6 +17,8 @@ BEGIN
       AND pg_get_constraintdef(oid) LIKE '%expires_at - starts_at%90 days%';
     IF constraint_name IS NOT NULL THEN
         EXECUTE format('ALTER TABLE standing_approvals DROP CONSTRAINT %I', constraint_name);
+    ELSE
+        RAISE EXCEPTION 'Could not find 90-day duration CHECK constraint on standing_approvals – migration cannot proceed safely';
     END IF;
 END $$;
 -- +goose StatementEnd
@@ -35,6 +37,8 @@ BEGIN
       AND pg_get_constraintdef(oid) LIKE '%expires_at >= starts_at%';
     IF constraint_name IS NOT NULL THEN
         EXECUTE format('ALTER TABLE standing_approvals DROP CONSTRAINT %I', constraint_name);
+    ELSE
+        RAISE EXCEPTION 'Could not find expires_at >= starts_at CHECK constraint on standing_approvals – migration cannot proceed safely';
     END IF;
 END $$;
 -- +goose StatementEnd

--- a/db/migrations/20260317124702_remove_standing_approval_expiry_limit.sql
+++ b/db/migrations/20260317124702_remove_standing_approval_expiry_limit.sql
@@ -49,8 +49,15 @@ ALTER TABLE standing_approvals ADD CONSTRAINT standing_approvals_expires_at_afte
 -- +goose Down
 
 -- Restore NOT NULL.
--- First set any NULL expires_at to starts_at + 90 days so the column can be made NOT NULL.
-UPDATE standing_approvals SET expires_at = starts_at + interval '90 days' WHERE expires_at IS NULL;
+-- Refuse to roll back if permanent approvals exist — fabricating expiry dates would silently corrupt data.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM standing_approvals WHERE expires_at IS NULL) THEN
+        RAISE EXCEPTION 'Cannot roll back: standing approvals with no expiry (expires_at IS NULL) exist. Revoke or delete them first to avoid data corruption.';
+    END IF;
+END $$;
+-- +goose StatementEnd
 ALTER TABLE standing_approvals ALTER COLUMN expires_at SET NOT NULL;
 
 -- Drop the conditional constraint and restore the original pair.

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -23,7 +23,7 @@ type StandingApproval struct {
 	MaxExecutions               *int
 	ExecutionCount              int
 	StartsAt                    time.Time
-	ExpiresAt                   time.Time
+	ExpiresAt                   *time.Time // nil means no expiry (until revoked)
 	CreatedAt                   time.Time
 	RevokedAt                   *time.Time
 	ExpiredAt                   *time.Time
@@ -85,7 +85,7 @@ func CountActiveStandingApprovalsByUser(ctx context.Context, db DBTX, userID str
 	var count int
 	err := db.QueryRow(ctx,
 		`SELECT COUNT(*) FROM standing_approvals
-		 WHERE user_id = $1 AND status = 'active' AND expires_at > now()`,
+		 WHERE user_id = $1 AND status = 'active' AND (expires_at IS NULL OR expires_at > now())`,
 		userID,
 	).Scan(&count)
 	return count, err
@@ -118,7 +118,7 @@ type CreateStandingApprovalParams struct {
 	SourceActionConfigurationID *string
 	MaxExecutions               *int
 	StartsAt                    time.Time
-	ExpiresAt                   time.Time
+	ExpiresAt                   *time.Time // nil means no expiry (until revoked)
 }
 
 // CreateStandingApproval inserts a new standing approval with status 'active'.
@@ -415,7 +415,7 @@ func FindActiveStandingApprovalForAgent(ctx context.Context, db DBTX, agentID in
 		   AND action_type = $2
 		   AND status = 'active'
 		   AND starts_at <= now()
-		   AND expires_at > now()
+		   AND (expires_at IS NULL OR expires_at > now())
 		   AND (max_executions IS NULL OR execution_count < max_executions)
 		 ORDER BY created_at DESC
 		 LIMIT 1`,
@@ -450,7 +450,7 @@ func RecordStandingApprovalExecutionByAgent(ctx context.Context, db DBTX, standi
 			  AND agent_id = $2
 			  AND status = 'active'
 			  AND starts_at <= now()
-			  AND expires_at > now()
+			  AND (expires_at IS NULL OR expires_at > now())
 			  AND (max_executions IS NULL OR execution_count < max_executions)
 			RETURNING standing_approval_id, agent_id, user_id, action_type, max_executions, execution_count
 		),

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -72,7 +72,8 @@ func scanStandingApproval(row pgx.Row) (*StandingApproval, error) {
 
 // CountActiveStandingApprovalsByUser returns the number of standing approvals
 // that are currently active for the given user. An approval counts as active
-// if its status is 'active' and it hasn't expired (expires_at > now()).
+// if its status is 'active' and either has no expiry (expires_at IS NULL) or
+// has not yet expired (expires_at > now()).
 // This excludes approvals that have technically expired but whose status
 // hasn't yet been updated by the cleanup job, so users aren't penalized
 // by stale data.
@@ -364,6 +365,7 @@ func RecordStandingApprovalExecution(ctx context.Context, db DBTX, standingAppro
 			UPDATE standing_approvals
 			SET execution_count = execution_count + 1
 			WHERE standing_approval_id = $1 AND user_id = $2 AND status = 'active'
+			  AND (expires_at IS NULL OR expires_at > now())
 			RETURNING standing_approval_id, agent_id, user_id, action_type
 		),
 		ins AS (

--- a/db/standing_approvals_test.go
+++ b/db/standing_approvals_test.go
@@ -74,7 +74,7 @@ func TestStandingApprovalsStatusCheckConstraint(t *testing.T) {
 		})
 }
 
-func TestStandingApprovals90DayMaxConstraint(t *testing.T) {
+func TestStandingApprovalsExpiryConstraints(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	ctx := context.Background()
@@ -84,37 +84,25 @@ func TestStandingApprovals90DayMaxConstraint(t *testing.T) {
 
 	base := testhelper.GenerateID(t, "sa_")
 
-	// Exactly 90 days should succeed
+	// NULL expires_at (no expiry) should succeed
 	_, err := tx.Exec(ctx,
 		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at)
-		 VALUES ($1, $2, $3, 'test.action', 'active', '2026-01-01 00:00:00+00', '2026-04-01 00:00:00+00')`,
-		base+"_90d_ok", agentID, uid)
+		 VALUES ($1, $2, $3, 'test.action', 'active', '2026-01-01 00:00:00+00', NULL)`,
+		base+"_null_ok", agentID, uid)
 	if err != nil {
-		t.Errorf("exactly 90 days was rejected: %v", err)
+		t.Errorf("NULL expires_at was rejected: %v", err)
 	}
 
-	// 91 days should fail
-	err = testhelper.WithSavepoint(t, tx, func() error {
-		_, err := tx.Exec(ctx,
-			`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at)
-			 VALUES ($1, $2, $3, 'test.action', 'active', '2026-01-01 00:00:00+00', '2026-04-02 00:00:00+00')`,
-			base+"_91d_fail", agentID, uid)
-		return err
-	})
-	if err == nil {
-		t.Error("expected CHECK constraint violation for expires_at beyond 90 days, but insert succeeded")
-	}
-
-	// 30 days should succeed
+	// 365 days should succeed (no max duration limit)
 	_, err = tx.Exec(ctx,
 		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at)
-		 VALUES ($1, $2, $3, 'test.action', 'active', '2026-01-01 00:00:00+00', '2026-01-31 00:00:00+00')`,
-		base+"_30d_ok", agentID, uid)
+		 VALUES ($1, $2, $3, 'test.action', 'active', '2026-01-01 00:00:00+00', '2027-01-01 00:00:00+00')`,
+		base+"_365d_ok", agentID, uid)
 	if err != nil {
-		t.Errorf("30 days was rejected: %v", err)
+		t.Errorf("365 days was rejected: %v", err)
 	}
 
-	// expires_at before starts_at should fail
+	// expires_at before starts_at should still fail
 	err = testhelper.WithSavepoint(t, tx, func() error {
 		_, err := tx.Exec(ctx,
 			`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, starts_at, expires_at)

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
@@ -401,6 +401,7 @@ function CreateStandingApprovalWizard({
   const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
   const [manualConstraintsJson, setManualConstraintsJson] = useState("");
   const [maxExecutions, setMaxExecutions] = useState("");
+  const [noExpiry, setNoExpiry] = useState(true);
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
   const isCustomAction = selectedConfigId === CUSTOM_ACTION_SENTINEL;
@@ -512,6 +513,8 @@ function CreateStandingApprovalWizard({
               }}
               expiresAt={expiresAt}
               onExpiresAtChange={setExpiresAt}
+              noExpiry={noExpiry}
+              onNoExpiryChange={setNoExpiry}
             />
           )}
 

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -123,6 +123,7 @@ export function CreateStandingApprovalDialog({
       : "",
   );
   const [maxExecutions, setMaxExecutions] = useState("");
+  const [noExpiry, setNoExpiry] = useState(true);
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
   const activeAgents = agents.filter((a) => a.status !== "deactivated");
@@ -195,6 +196,7 @@ export function CreateStandingApprovalDialog({
         : "",
     );
     setMaxExecutions("");
+    setNoExpiry(true);
     setExpiresAt(defaultExpiresAt());
   }
 
@@ -308,7 +310,7 @@ export function CreateStandingApprovalDialog({
     e.preventDefault();
     if (step !== 4) return;
 
-    if (!agentId || !effectiveActionType || !expiresAt) {
+    if (!agentId || !effectiveActionType || (!noExpiry && !expiresAt)) {
       toast.error("Please fill in all required fields");
       return;
     }
@@ -357,7 +359,7 @@ export function CreateStandingApprovalDialog({
         constraints,
         source_action_configuration_id: selectedConfig?.id,
         max_executions: maxExecutions ? Number(maxExecutions) : null,
-        expires_at: new Date(expiresAt).toISOString(),
+        ...(noExpiry ? {} : { expires_at: new Date(expiresAt).toISOString() }),
       });
       toast.success("Standing approval created");
       resetForm();
@@ -372,7 +374,7 @@ export function CreateStandingApprovalDialog({
     }
   }
 
-  const canCreate = !isPending && !!agentId && !!effectiveActionType && !!expiresAt;
+  const canCreate = !isPending && !!agentId && !!effectiveActionType && (noExpiry || !!expiresAt);
 
   return (
     <Dialog
@@ -491,6 +493,8 @@ export function CreateStandingApprovalDialog({
               }}
               expiresAt={expiresAt}
               onExpiresAtChange={setExpiresAt}
+              noExpiry={noExpiry}
+              onNoExpiryChange={setNoExpiry}
             />
           )}
 

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -1,4 +1,5 @@
 import { Loader2, Info } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
@@ -241,15 +242,16 @@ export function StepLimits({
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <Label htmlFor="sa-expires-at">Expires At</Label>
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="sa-no-expiry"
               checked={noExpiry}
-              onChange={(e) => onNoExpiryChange(e.target.checked)}
-              className="accent-primary size-4 rounded"
+              onCheckedChange={(checked) => onNoExpiryChange(checked === true)}
             />
-            Until revoked
-          </label>
+            <Label htmlFor="sa-no-expiry" className="text-sm font-normal">
+              Until revoked
+            </Label>
+          </div>
         </div>
         {!noExpiry && (
           <Input

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -210,11 +210,15 @@ export function StepLimits({
   onMaxExecutionsChange,
   expiresAt,
   onExpiresAtChange,
+  noExpiry,
+  onNoExpiryChange,
 }: {
   maxExecutions: string;
   onMaxExecutionsChange: (value: string) => void;
   expiresAt: string;
   onExpiresAtChange: (value: string) => void;
+  noExpiry: boolean;
+  onNoExpiryChange: (value: boolean) => void;
 }) {
   return (
     <div className="space-y-4">
@@ -235,16 +239,31 @@ export function StepLimits({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="sa-expires-at">Expires At</Label>
-        <Input
-          id="sa-expires-at"
-          type="datetime-local"
-          value={expiresAt}
-          onChange={(e) => onExpiresAtChange(e.target.value)}
-          required
-        />
+        <div className="flex items-center justify-between">
+          <Label htmlFor="sa-expires-at">Expires At</Label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={noExpiry}
+              onChange={(e) => onNoExpiryChange(e.target.checked)}
+              className="accent-primary size-4 rounded"
+            />
+            Until revoked
+          </label>
+        </div>
+        {!noExpiry && (
+          <Input
+            id="sa-expires-at"
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => onExpiresAtChange(e.target.value)}
+            required
+          />
+        )}
         <p className="text-muted-foreground text-sm">
-          Maximum 90 days from now.
+          {noExpiry
+            ? "This standing approval will remain active until you revoke it."
+            : "Set a specific expiration date, or check \"Until revoked\" for no expiry."}
         </p>
       </div>
     </div>

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -33,7 +33,8 @@ import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import { ConstraintsSummary } from "./ConstraintsSummary";
 
 function formatExpiresIn(expiresAt: string | null | undefined): string {
-  if (!expiresAt) return "Never";
+  if (expiresAt === null) return "Never";
+  if (!expiresAt) return "\u2014";
 
   const exp = new Date(expiresAt);
   if (Number.isNaN(exp.getTime())) return "\u2014";

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -33,7 +33,7 @@ import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import { ConstraintsSummary } from "./ConstraintsSummary";
 
 function formatExpiresIn(expiresAt: string | null | undefined): string {
-  if (!expiresAt) return "\u2014";
+  if (!expiresAt) return "Never";
 
   const exp = new Date(expiresAt);
   if (Number.isNaN(exp.getTime())) return "\u2014";

--- a/shared/validation.go
+++ b/shared/validation.go
@@ -7,7 +7,6 @@ package shared
 import (
 	_ "embed"
 	"encoding/json"
-	"time"
 )
 
 //go:embed validation.json
@@ -33,7 +32,6 @@ type validationConfig struct {
 	ConfirmationCode         fieldLimits `json:"confirmationCode"`
 	ConstraintsBytes         fieldLimits `json:"constraintsBytes"`
 	ParametersBytes          fieldLimits `json:"parametersBytes"`
-	StandingApprovalMaxDays  fieldLimits `json:"standingApprovalMaxDays"`
 }
 
 // --- Exported constants ---
@@ -52,7 +50,6 @@ var (
 	ConfirmationCodeLength      int
 	MaxConstraintsBytes         int
 	MaxParametersBytes          int
-	StandingApprovalMaxDuration time.Duration
 )
 
 // mustInt dereferences a *int parsed from validation.json, panicking with a
@@ -83,5 +80,4 @@ func init() {
 	ConfirmationCodeLength = mustInt("confirmationCode.length", cfg.ConfirmationCode.Length)
 	MaxConstraintsBytes = mustInt("constraintsBytes.max", cfg.ConstraintsBytes.Max)
 	MaxParametersBytes = mustInt("parametersBytes.max", cfg.ParametersBytes.Max)
-	StandingApprovalMaxDuration = time.Duration(mustInt("standingApprovalMaxDays.max", cfg.StandingApprovalMaxDays.Max)) * 24 * time.Hour
 }

--- a/shared/validation.json
+++ b/shared/validation.json
@@ -9,6 +9,5 @@
   "actionVersion": { "maxLength": 10 },
   "confirmationCode": { "length": 6 },
   "constraintsBytes": { "max": 16384 },
-  "parametersBytes": { "max": 16384 },
-  "standingApprovalMaxDays": { "max": 90 }
+  "parametersBytes": { "max": 16384 }
 }

--- a/shared/validation_test.go
+++ b/shared/validation_test.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"testing"
-	"time"
 )
 
 func TestValidationConfigLoads(t *testing.T) {
@@ -29,10 +28,5 @@ func TestValidationConfigLoads(t *testing.T) {
 		if tt.got != tt.want {
 			t.Errorf("%s = %d, want %d", tt.name, tt.got, tt.want)
 		}
-	}
-
-	wantDuration := 90 * 24 * time.Hour
-	if StandingApprovalMaxDuration != wantDuration {
-		t.Errorf("StandingApprovalMaxDuration = %v, want %v", StandingApprovalMaxDuration, wantDuration)
 	}
 }

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -60,7 +60,6 @@ StandingApproval:
     - status
     - execution_count
     - starts_at
-    - expires_at
     - created_at
     - source_action_configuration_id
   properties:
@@ -165,11 +164,12 @@ StandingApproval:
     expires_at:
       type: string
       format: date-time
+      nullable: true
       description: |
         ISO 8601 timestamp (RFC 3339 format, UTC) when this standing approval expires.
-        Required when creating a standing approval. Maximum duration is 90 days from
-        `starts_at`.
-      example: "2026-02-21T00:00:00Z"
+        `null` means the standing approval never expires and remains active until
+        explicitly revoked.
+      example: null
 
     created_at:
       type: string
@@ -268,7 +268,6 @@ CreateStandingApprovalRequest:
     - agent_id
     - action_type
     - constraints
-    - expires_at
   properties:
     agent_id:
       type: integer
@@ -332,8 +331,11 @@ CreateStandingApprovalRequest:
     expires_at:
       type: string
       format: date-time
-      description: When this standing approval expires. Required. Maximum 90 days from starts_at.
-      example: "2026-03-14T00:00:00Z"
+      nullable: true
+      description: |
+        When this standing approval expires. Omit or set to null for no expiry
+        (the approval remains active until revoked).
+      example: null
 
   example:
     agent_id: 42
@@ -343,8 +345,6 @@ CreateStandingApprovalRequest:
       recipient_pattern: "*@mycompany.com"
     source_action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
     max_executions: 100
-    expires_at: "2026-03-14T00:00:00Z"
-
 RevokeStandingApprovalResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -8046,7 +8046,6 @@ components:
         - status
         - execution_count
         - starts_at
-        - expires_at
         - created_at
         - source_action_configuration_id
       properties:
@@ -8141,11 +8140,12 @@ components:
         expires_at:
           type: string
           format: date-time
+          nullable: true
           description: |
             ISO 8601 timestamp (RFC 3339 format, UTC) when this standing approval expires.
-            Required when creating a standing approval. Maximum duration is 90 days from
-            `starts_at`.
-          example: '2026-02-21T00:00:00Z'
+            `null` means the standing approval never expires and remains active until
+            explicitly revoked.
+          example: null
         created_at:
           type: string
           format: date-time
@@ -8386,7 +8386,6 @@ components:
         - agent_id
         - action_type
         - constraints
-        - expires_at
       properties:
         agent_id:
           type: integer
@@ -8443,8 +8442,11 @@ components:
         expires_at:
           type: string
           format: date-time
-          description: When this standing approval expires. Required. Maximum 90 days from starts_at.
-          example: '2026-03-14T00:00:00Z'
+          nullable: true
+          description: |
+            When this standing approval expires. Omit or set to null for no expiry
+            (the approval remains active until revoked).
+          example: null
       example:
         agent_id: 42
         action_type: email.send
@@ -8453,7 +8455,6 @@ components:
           recipient_pattern: '*@mycompany.com'
         source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         max_executions: 100
-        expires_at: '2026-03-14T00:00:00Z'
     RevokeStandingApprovalResponse:
       type: object
       required:


### PR DESCRIPTION
## Summary

- Standing approvals can now last forever (until revoked) by omitting `expires_at` or setting it to null
- Removes the 90-day maximum duration constraint from the database, backend validation, and frontend
- Frontend defaults to "Until revoked" with an optional expiry date toggle

Closes the standing approval expiry annoyance — permanent approvals until explicitly revoked.

## Test plan

### Claude Code
- [x] Backend tests pass (shared, db packages)
- [x] Frontend tests pass (953 tests)
- [x] TypeScript type check passes
- [x] Migration applies cleanly
- [x] New DB test verifies NULL expires_at and long durations are accepted

### Manual Testing
- [ ] Create a standing approval with "Until revoked" checked — verify no expiry date is sent
- [ ] Create a standing approval with a specific expiry date — verify it still works
- [ ] Verify the standing approvals list shows "Never" for approvals without expiry
- [ ] Verify existing standing approvals with expiry dates still work correctly

https://claude.ai/code/session_01BM6SuBc1eqpsLLMjr8PHWa