### PR TITLE
Fix standing approval matching for pattern constraints

### DIFF
--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -156,6 +156,7 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 
 	var sa *db.StandingApproval
 	var firstConstraintErr *db.ConfigValidationError
+	var firstConstraintErrSAID string
 	for _, candidate := range approvals {
 		if len(candidate.Constraints) == 0 {
 			sa = candidate
@@ -163,10 +164,19 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		}
 		if err := db.ValidateParametersAgainstConfig(candidate.Constraints, params); err != nil {
 			var configErr *db.ConfigValidationError
-			if errors.As(err, &configErr) && firstConstraintErr == nil {
-				firstConstraintErr = configErr
+			if errors.As(err, &configErr) {
+				if firstConstraintErr == nil {
+					firstConstraintErr = configErr
+					firstConstraintErrSAID = candidate.StandingApprovalID
+				}
+				continue
 			}
-			continue
+			// Non-ConfigValidationError (e.g. corrupt constraint JSON) — fail fast.
+			log.Printf("[%s] ExecuteActionStanding: constraint validation for %s: %v",
+				TraceID(r.Context()), candidate.StandingApprovalID, err)
+			RespondError(w, r, http.StatusInternalServerError,
+				InternalError("Failed to validate parameters against constraints"))
+			return
 		}
 		sa = candidate
 		break
@@ -176,7 +186,7 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		if firstConstraintErr != nil {
 			resp := Forbidden(ErrConstraintViolation, "Request parameters violate standing approval constraints")
 			resp.Error.Details = map[string]any{
-				"standing_approval_id": approvals[0].StandingApprovalID,
+				"standing_approval_id": firstConstraintErrSAID,
 				"violated_constraint":  firstConstraintErr.Parameter,
 				"constraint_error":     firstConstraintErr.Reason,
 			}

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -128,13 +128,13 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 
 	// ── Find matching standing approval ──────────────────────────
 
-	sa, err := db.FindActiveStandingApprovalForAgent(r.Context(), deps.DB, agent.AgentID, req.Action.Type)
+	approvals, err := db.FindActiveStandingApprovalsForAgent(r.Context(), deps.DB, agent.AgentID, req.Action.Type)
 	if err != nil {
-		log.Printf("[%s] ExecuteActionStanding: find standing approval: %v", TraceID(r.Context()), err)
+		log.Printf("[%s] ExecuteActionStanding: find standing approvals: %v", TraceID(r.Context()), err)
 		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to find standing approval"))
 		return
 	}
-	if sa == nil {
+	if len(approvals) == 0 {
 		resp := NotFound(ErrNoMatchingStanding, "No active standing approval matches this agent, action type, and parameters")
 		resp.Error.Details = map[string]any{
 			"action_type": req.Action.Type,
@@ -152,25 +152,40 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 		}
 	}
 
-	// ── Validate parameters against standing approval constraints ─
+	// ── Find first standing approval whose constraints match ─────
 
-	if len(sa.Constraints) > 0 {
-		if err := db.ValidateParametersAgainstConfig(sa.Constraints, params); err != nil {
+	var sa *db.StandingApproval
+	var firstConstraintErr *db.ConfigValidationError
+	for _, candidate := range approvals {
+		if len(candidate.Constraints) == 0 {
+			sa = candidate
+			break
+		}
+		if err := db.ValidateParametersAgainstConfig(candidate.Constraints, params); err != nil {
 			var configErr *db.ConfigValidationError
-			if errors.As(err, &configErr) {
-				resp := Forbidden(ErrConstraintViolation, "Request parameters violate standing approval constraints")
-				resp.Error.Details = map[string]any{
-					"standing_approval_id": sa.StandingApprovalID,
-					"violated_constraint":  configErr.Parameter,
-					"constraint_error":     configErr.Reason,
-				}
-				RespondError(w, r, http.StatusForbidden, resp)
-				return
+			if errors.As(err, &configErr) && firstConstraintErr == nil {
+				firstConstraintErr = configErr
 			}
-			log.Printf("[%s] ExecuteActionStanding: constraint validation: %v", TraceID(r.Context()), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to validate parameters against constraints"))
+			continue
+		}
+		sa = candidate
+		break
+	}
+
+	if sa == nil {
+		if firstConstraintErr != nil {
+			resp := Forbidden(ErrConstraintViolation, "Request parameters violate standing approval constraints")
+			resp.Error.Details = map[string]any{
+				"standing_approval_id": approvals[0].StandingApprovalID,
+				"violated_constraint":  firstConstraintErr.Parameter,
+				"constraint_error":     firstConstraintErr.Reason,
+			}
+			RespondError(w, r, http.StatusForbidden, resp)
 			return
 		}
+		log.Printf("[%s] ExecuteActionStanding: all %d standing approvals failed constraint validation", TraceID(r.Context()), len(approvals))
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to validate parameters against constraints"))
+		return
 	}
 
 	// ── Record execution ─────────────────────────────────────────

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -193,7 +193,10 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 			RespondError(w, r, http.StatusForbidden, resp)
 			return
 		}
-		log.Printf("[%s] ExecuteActionStanding: all %d standing approvals failed constraint validation", TraceID(r.Context()), len(approvals))
+		// Invariant: sa can only be nil here when firstConstraintErr != nil.
+		// If this log fires, a code path was added that skips setting both sa
+		// and firstConstraintErr without returning early.
+		log.Printf("[%s] ExecuteActionStanding: BUG: sa nil but no constraint error recorded; %d approvals checked", TraceID(r.Context()), len(approvals))
 		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to validate parameters against constraints"))
 		return
 	}

--- a/api/action_execute.go
+++ b/api/action_execute.go
@@ -158,6 +158,9 @@ func handleStandingApprovalPath(w http.ResponseWriter, r *http.Request, deps *De
 	var firstConstraintErr *db.ConfigValidationError
 	var firstConstraintErrSAID string
 	for _, candidate := range approvals {
+		// No constraints means "match-all". Because results are ordered
+		// newest-first, a newer no-constraint approval shadows older
+		// specific ones at the same priority level (intended behavior).
 		if len(candidate.Constraints) == 0 {
 			sa = candidate
 			break

--- a/api/action_execute_test.go
+++ b/api/action_execute_test.go
@@ -324,3 +324,86 @@ func TestExecuteActionStanding_RevokedApproval(t *testing.T) {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestExecuteActionStanding_SecondApprovalMatchesWhenFirstDoesNot(t *testing.T) {
+	t.Parallel()
+	// Create two standing approvals for the same agent+action type with different constraints.
+	// The newer one doesn't match the execution parameters, but the older one does.
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Older approval: matches sender=*@github.com
+	sa1ID := testhelper.GenerateID(t, "sa_")
+	testhelper.InsertStandingApprovalFull(t, tx, sa1ID, agentID, uid, testhelper.StandingApprovalOpts{
+		ActionType:  "email.read",
+		Constraints: []byte(`{"sender":{"$pattern":"*@github.com"}}`),
+		StartsAt:    time.Now().Add(-2 * time.Hour),
+	})
+
+	// Newer approval: requires sender=*@competitor.com (won't match our request)
+	sa2ID := testhelper.GenerateID(t, "sa_")
+	testhelper.InsertStandingApprovalFull(t, tx, sa2ID, agentID, uid, testhelper.StandingApprovalOpts{
+		ActionType:  "email.read",
+		Constraints: []byte(`{"sender":{"$pattern":"*@competitor.com"}}`),
+		StartsAt:    time.Now().Add(-1 * time.Hour),
+	})
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	// Execute with sender=alice@github.com — should match the older approval (sa1).
+	reqBody := `{"request_id":"multi-sa-test-001","action":{"type":"email.read","version":"1","parameters":{"sender":"alice@github.com"}}}`
+	r := signedJSONRequest(t, http.MethodPost, "/actions/execute", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (second approval should match), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp executeActionStandingResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.StandingApprovalID != sa1ID {
+		t.Errorf("expected standing_approval_id %q (older approval), got %q", sa1ID, resp.StandingApprovalID)
+	}
+
+	// Verify execution was recorded on sa1 (older), not sa2.
+	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", sa1ID, "execution_count", "1")
+	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", sa2ID, "execution_count", "0")
+}
+
+func TestExecuteActionStanding_WildcardActionTypeMatches(t *testing.T) {
+	t.Parallel()
+	// Create a standing approval with action_type="*" (wildcard) — should match any action type.
+	_, _, router, agentID, privKey, saID, _ := setupStandingExecuteTest(t, "any.action", testhelper.StandingApprovalOpts{
+		ActionType: "*",
+	})
+
+	reqBody := `{"request_id":"wildcard-action-test-001","action":{"type":"any.action","version":"1","parameters":{}}}`
+	r := signedJSONRequest(t, http.MethodPost, "/actions/execute", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (wildcard action_type should match), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp executeActionStandingResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.StandingApprovalID != saID {
+		t.Errorf("expected standing_approval_id %q, got %q", saID, resp.StandingApprovalID)
+	}
+}

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -611,6 +611,8 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 			// Only plain strings are wrapped; objects (e.g. already-wrapped
 			// {"$pattern": "..."}) are left unchanged since json.Unmarshal
 			// into a string fails for non-string JSON values.
+			// Note: other glob metacharacters (?, [...]) are NOT auto-wrapped;
+			// users who need them must use {"$pattern": "..."} explicitly.
 			if strings.Contains(s, "*") {
 				wrapped, err := json.Marshal(map[string]string{db.PatternKey: s})
 				if err != nil {

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"regexp"
@@ -460,14 +461,15 @@ func toStandingApprovalResponse(sa db.StandingApproval) standingApprovalResponse
 }
 
 // validateStandingApprovalConstraints is the single validation point for standing
-// approval constraints. It checks type, presence, and content. Returns the raw
-// bytes to store, or an error describing why the constraints are invalid.
+// approval constraints. It checks type, presence, and content. Returns the
+// normalized bytes to store, or an error describing why the constraints are invalid.
 //
 // Rules:
 //   - non-object JSON (array, string, number) → rejected
 //   - null, empty, or {} → rejected (constraints are required)
 //   - all values are "*" → rejected (at least one must be Fixed or Pattern)
-//   - valid otherwise → returns the raw bytes
+//   - bare strings containing "*" (except the wildcard "*") → auto-wrapped as {"$pattern": "<value>"}
+//   - valid otherwise → returns the normalized bytes
 func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 	// Null or absent.
 	if len(raw) == 0 || string(raw) == "null" {
@@ -485,19 +487,42 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 
 	// Check that at least one constraint value is not a wildcard ("*").
 	// Null values are rejected outright — use "*" for a wildcard or omit the key.
+	// Bare strings containing "*" (except the wildcard "*") are auto-wrapped as patterns.
 	allWildcard := true
-	for _, v := range obj {
+	mutated := false
+	for key, v := range obj {
 		if string(v) == "null" {
 			return nil, errors.New("constraint values must not be null; use \"*\" for a wildcard or omit the key entirely")
 		}
 		var s string
-		if json.Unmarshal(v, &s) != nil || s != "*" {
+		if json.Unmarshal(v, &s) == nil {
+			if s == "*" {
+				continue // bare wildcard — stays as-is
+			}
 			allWildcard = false
-			// No break — must continue iterating to check remaining values for null.
+			// Auto-wrap bare strings containing "*" as $pattern.
+			if strings.Contains(s, "*") {
+				wrapped, err := json.Marshal(map[string]string{db.PatternKey: s})
+				if err != nil {
+					return nil, fmt.Errorf("failed to wrap pattern for %q: %w", key, err)
+				}
+				obj[key] = wrapped
+				mutated = true
+			}
+		} else {
+			allWildcard = false
 		}
 	}
 	if allWildcard {
 		return nil, errors.New("at least one constraint must be a non-wildcard value")
+	}
+
+	if mutated {
+		normalized, err := json.Marshal(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize constraints: %w", err)
+		}
+		return normalized, nil
 	}
 
 	return raw, nil

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -608,6 +608,9 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 			}
 			allWildcard = false
 			// Auto-wrap bare strings containing "*" as $pattern.
+			// Only plain strings are wrapped; objects (e.g. already-wrapped
+			// {"$pattern": "..."}) are left unchanged since json.Unmarshal
+			// into a string fails for non-string JSON values.
 			if strings.Contains(s, "*") {
 				wrapped, err := json.Marshal(map[string]string{db.PatternKey: s})
 				if err != nil {

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -1234,3 +1234,63 @@ func TestRevokeStandingApproval_ConcurrentRevokes(t *testing.T) {
 		t.Errorf("expected [200, 409], got %v", codes)
 	}
 }
+
+func TestCreateStandingApproval_BareStringPatternAutoWrapped(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	// Create a standing approval with bare string "[Tracking]*" (not wrapped in $pattern).
+	// The backend should auto-normalize this to {"$pattern": "[Tracking]*"}.
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "github.create_issue",
+		"action_version": "1",
+		"constraints": {"owner":"testuser","repo":"testrepo","title":"[Tracking]*","body":"*"},
+		"expires_at": "%s"
+	}`, agentID, expiresAt)
+
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp standingApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	// Verify the title constraint was auto-wrapped as a pattern.
+	constraintsMap, ok := resp.Constraints.(map[string]any)
+	if !ok {
+		t.Fatalf("expected constraints to be a map, got %T", resp.Constraints)
+	}
+	titleConstraint, ok := constraintsMap["title"]
+	if !ok {
+		t.Fatal("expected title constraint to be present")
+	}
+	// Should be {"$pattern": "[Tracking]*"}, not a bare string.
+	patternObj, ok := titleConstraint.(map[string]any)
+	if !ok {
+		t.Fatalf("expected title constraint to be a pattern object, got %T: %v", titleConstraint, titleConstraint)
+	}
+	patternValue, ok := patternObj["$pattern"].(string)
+	if !ok || patternValue != "[Tracking]*" {
+		t.Errorf("expected title pattern to be \"[Tracking]*\", got %v", patternObj["$pattern"])
+	}
+
+	// Verify the body constraint remains a bare wildcard "*".
+	bodyConstraint, ok := constraintsMap["body"].(string)
+	if !ok || bodyConstraint != "*" {
+		t.Errorf("expected body constraint to remain \"*\", got %v", constraintsMap["body"])
+	}
+}

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -405,19 +405,23 @@ func diagnoseStandingApprovalFailure(ctx context.Context, db DBTX, saID, userID 
 
 // FindActiveStandingApprovalsForAgent returns all active standing approvals for
 // the given agent and action type, ordered by most recently created first.
-// It also matches standing approvals with the wildcard action type ("*").
+// Exact action_type matches are returned before wildcard ("*") matches.
 // Returns an empty slice if no match is found.
 func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID int64, actionType string) ([]*StandingApproval, error) {
 	rows, err := db.Query(ctx,
 		`SELECT `+standingApprovalColumns+`
-		 FROM standing_approvals
-		 WHERE agent_id = $1
-		   AND (action_type = $2 OR action_type = '*')
-		   AND status = 'active'
-		   AND starts_at <= now()
-		   AND expires_at > now()
-		   AND (max_executions IS NULL OR execution_count < max_executions)
-		 ORDER BY created_at DESC
+		 FROM (
+		   SELECT `+standingApprovalColumns+`, 1 AS priority FROM standing_approvals
+		   WHERE agent_id = $1 AND action_type = $2 AND status = 'active'
+		     AND starts_at <= now() AND expires_at > now()
+		     AND (max_executions IS NULL OR execution_count < max_executions)
+		   UNION ALL
+		   SELECT `+standingApprovalColumns+`, 2 AS priority FROM standing_approvals
+		   WHERE agent_id = $1 AND action_type = '*' AND status = 'active'
+		     AND starts_at <= now() AND expires_at > now()
+		     AND (max_executions IS NULL OR execution_count < max_executions)
+		 ) combined
+		 ORDER BY priority, created_at DESC
 		 LIMIT 100`,
 		agentID, actionType,
 	)

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -471,7 +471,7 @@ func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID i
 		     AND (max_executions IS NULL OR execution_count < max_executions)
 		   UNION ALL
 		   SELECT `+standingApprovalColumns+`, 2 AS priority FROM standing_approvals
-		   WHERE agent_id = $1 AND action_type = '*' AND status = 'active'
+		   WHERE agent_id = $1 AND action_type = '*' AND action_type != $2 AND status = 'active'
 		     AND starts_at <= now() AND (expires_at IS NULL OR expires_at > now())
 		     AND (max_executions IS NULL OR execution_count < max_executions)
 		 ) combined

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -403,32 +403,40 @@ func diagnoseStandingApprovalFailure(ctx context.Context, db DBTX, saID, userID 
 	return &StandingApprovalError{Code: StandingApprovalErrNotActive, Status: sa.Status}
 }
 
-// FindActiveStandingApprovalForAgent returns the best matching active standing
-// approval for the given agent and action type. "Best" is the most recently
-// created approval that is active, within its time window, and not exhausted.
-// Returns nil if no match is found.
-func FindActiveStandingApprovalForAgent(ctx context.Context, db DBTX, agentID int64, actionType string) (*StandingApproval, error) {
-	row := db.QueryRow(ctx,
+// FindActiveStandingApprovalsForAgent returns all active standing approvals for
+// the given agent and action type, ordered by most recently created first.
+// It also matches standing approvals with the wildcard action type ("*").
+// Returns an empty slice if no match is found.
+func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID int64, actionType string) ([]*StandingApproval, error) {
+	rows, err := db.Query(ctx,
 		`SELECT `+standingApprovalColumns+`
 		 FROM standing_approvals
 		 WHERE agent_id = $1
-		   AND action_type = $2
+		   AND (action_type = $2 OR action_type = '*')
 		   AND status = 'active'
 		   AND starts_at <= now()
 		   AND expires_at > now()
 		   AND (max_executions IS NULL OR execution_count < max_executions)
-		 ORDER BY created_at DESC
-		 LIMIT 1`,
+		 ORDER BY created_at DESC`,
 		agentID, actionType,
 	)
-	sa, err := scanStandingApproval(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}
-	return sa, nil
+	defer rows.Close()
+
+	var approvals []*StandingApproval
+	for rows.Next() {
+		sa, err := scanStandingApproval(rows)
+		if err != nil {
+			return nil, err
+		}
+		approvals = append(approvals, sa)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return approvals, nil
 }
 
 // RecordStandingApprovalExecutionByAgent atomically increments the standing

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -417,7 +417,8 @@ func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID i
 		   AND starts_at <= now()
 		   AND expires_at > now()
 		   AND (max_executions IS NULL OR execution_count < max_executions)
-		 ORDER BY created_at DESC`,
+		 ORDER BY created_at DESC
+		 LIMIT 100`,
 		agentID, actionType,
 	)
 	if err != nil {

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -421,7 +421,7 @@ func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID i
 		     AND starts_at <= now() AND expires_at > now()
 		     AND (max_executions IS NULL OR execution_count < max_executions)
 		 ) combined
-		 ORDER BY priority, created_at DESC
+		 ORDER BY priority, created_at DESC, standing_approval_id DESC
 		 LIMIT 100`,
 		agentID, actionType,
 	)

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -336,6 +336,13 @@ export function CreateStandingApprovalDialog({
         toast.error("Constraints must be a JSON object");
         return;
       }
+      // Auto-wrap bare strings containing "*" (except the bare wildcard "*")
+      // as pattern objects so the backend treats them as glob patterns.
+      for (const [key, value] of Object.entries(constraints)) {
+        if (typeof value === "string" && value !== "*" && value.includes("*")) {
+          constraints[key] = { $pattern: value };
+        }
+      }
       const allWildcard = Object.values(constraints).every((v) => v === "*");
       if (Object.keys(constraints).length === 0 || allWildcard) {
         toast.error("At least one parameter constraint must be non-wildcard");


### PR DESCRIPTION
## Summary
- **Try all matching standing approvals**, not just the newest. Previously `FindActiveStandingApprovalForAgent` returned only the most recent (LIMIT 1), so if its constraints didn't match, older valid approvals were skipped.
- **Auto-wrap bare string patterns** (e.g. `"[Tracking]*"`) as `{"$pattern": "[Tracking]*"}` on standing approval creation. Without wrapping, `*` had no special meaning and was treated as a literal fixed value.
- **Match wildcard action type** (`action_type = '*'`) in the standing approval query so universal standing approvals work.
- **Frontend defense-in-depth**: the manual JSON constraint path now also auto-wraps bare patterns.

## Test plan

### Claude Code
- [x] All existing backend tests pass (`go test ./api/... ./db/...`)
- [x] All frontend tests pass (953 tests)
- [x] TypeScript compilation clean
- [x] New test: second standing approval matches when first doesn't
- [x] New test: wildcard action_type standing approval matches any action
- [x] New test: bare string `[Tracking]*` auto-wrapped to `$pattern` on creation

### Manual Testing
- [ ] Create a standing approval with title pattern `[Tracking]*` via the UI
- [ ] Execute `github.create_issue` with title `[Tracking] should auto approve` and verify it auto-approves
- [ ] Create two standing approvals with different constraints for the same agent+action and verify the correct one matches

https://claude.ai/code/session_01N54PkUkHtF5wXxEHGZLu3m