### PR TITLE
Upgrade CI Node.js from 20 to 22 to fix mobile CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -85,7 +85,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: mobile/package-lock.json
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: npm
           cache-dependency-path: cli/package-lock.json

--- a/.github/workflows/regenerate-api-types.yml
+++ b/.github/workflows/regenerate-api-types.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- Mobile CI has been failing since PR #673 because `mobile/package-lock.json` was regenerated with npm bundled with Node 22, causing `npm ci` to fail on the Node 20 CI runners
- Upgrades Node.js from 20 to 22 across all CI workflows (CI, Mobile CI, Regenerate API Types, Publish CLI, Audit)
- Node 20 is also deprecated on GitHub Actions (forced to Node 24 by June 2026)

Note: The backend test failure on commit a450f8e (`shared.StandingApprovalMaxDuration` undefined) was already fixed by PR #679.

## Test plan

### Claude Code
- [x] Mobile CI passes with Node 22
- [x] Frontend CI passes with Node 22
- [x] Backend CI continues to pass

### Manual Testing
- [ ] Verify no regressions in other CI workflows (publish-cli, audit, regenerate-api-types)

https://claude.ai/code/session_01HnGLQAXbgJ97TYDvPR8xCx