### PR TITLE
Fix UpdateStandingApproval SQL parameter type error

### DIFF
--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -427,7 +427,7 @@ func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprov
 		 SET constraints = $3, max_executions = $4, expires_at = $5
 		 WHERE standing_approval_id = $1 AND user_id = $2
 		   AND status = 'active'
-		   AND ($4 IS NULL OR $4 >= execution_count)
+		   AND ($4::int IS NULL OR $4::int >= execution_count)
 		 RETURNING `+standingApprovalColumns,
 		p.StandingApprovalID, p.UserID, p.Constraints, p.MaxExecutions, p.ExpiresAt,
 	)


### PR DESCRIPTION
## Summary

- Add explicit `::int` cast to `$4` (max_executions) in the `UpdateStandingApproval` SQL query
- PostgreSQL cannot infer the type of a NULL parameter used in `$4 IS NULL OR $4 >= execution_count`, causing `SQLSTATE 42P08: could not determine data type of parameter $4`
- The cast resolves the ambiguity so updates work regardless of whether max_executions is NULL or an integer

## Test plan

### Claude Code
- [x] `go vet ./db/...` passes
- [x] All standing approval db tests pass

### Manual Testing
- [ ] Update a standing approval with unlimited executions (max_executions = NULL) and verify it saves
- [ ] Update a standing approval with a specific max_executions value and verify it saves

https://claude.ai/code/session_01WxWf9Dn6M5rBNQzoxVS2XL