### PR TITLE
Make content optional for microsoft.upload_drive_file

### DIFF
--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -235,7 +235,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["file_path", "content"],
+					"required": ["file_path"],
 					"properties": {
 						"file_path": {
 							"type": "string",
@@ -243,7 +243,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"content": {
 							"type": "string",
-							"description": "File content to upload (max 4 MB)"
+							"description": "File content to upload (max 4 MB). Omit to create an empty file."
 						},
 						"conflict_behavior": {
 							"type": "string",

--- a/connectors/microsoft/upload_drive_file.go
+++ b/connectors/microsoft/upload_drive_file.go
@@ -33,10 +33,7 @@ func (p *uploadDriveFileParams) validate() error {
 	if p.FilePath == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: file_path"}
 	}
-	if p.Content == "" {
-		return &connectors.ValidationError{Message: "missing required parameter: content"}
-	}
-	if len(p.Content) > maxUploadContentSize {
+	if p.Content != "" && len(p.Content) > maxUploadContentSize {
 		return &connectors.ValidationError{
 			Message: "content exceeds maximum upload size of 4 MB",
 		}

--- a/connectors/microsoft/upload_drive_file_test.go
+++ b/connectors/microsoft/upload_drive_file_test.go
@@ -134,24 +134,44 @@ func TestUploadDriveFile_MissingFilePath(t *testing.T) {
 	}
 }
 
-func TestUploadDriveFile_MissingContent(t *testing.T) {
+func TestUploadDriveFile_EmptyContent(t *testing.T) {
 	t.Parallel()
 
-	conn := New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if len(body) != 0 {
+			t.Errorf("expected empty body, got %d bytes", len(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "new-workbook-1",
+			"name": "report.xlsx",
+			"size": 0,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
 	action := &uploadDriveFileAction{conn: conn}
 
-	params, _ := json.Marshal(map[string]string{"file_path": "test.txt"})
+	params, _ := json.Marshal(map[string]string{"file_path": "Documents/report.xlsx"})
 
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "microsoft.upload_drive_file",
 		Parameters:  params,
 		Credentials: validCreds(),
 	})
-	if err == nil {
-		t.Fatal("expected error for missing content")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !connectors.IsValidationError(err) {
-		t.Errorf("expected ValidationError, got: %T", err)
+
+	var res uploadDriveFileResult
+	if err := json.Unmarshal(result.Data, &res); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if res.ID != "new-workbook-1" {
+		t.Errorf("expected id 'new-workbook-1', got %q", res.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Makes the `content` parameter optional for `microsoft.upload_drive_file` so agents can create empty files (e.g. Excel workbooks) without providing text content
- Previously, creating a spreadsheet via the Microsoft connector would fail with "missing required parameter: content" because Excel files are binary and there's no meaningful text content to provide
- Removes `content` from the `required` array in the parameter schema and the empty-string validation check

## Test plan

### Claude Code
- [x] All existing `TestUploadDriveFile_*` tests pass
- [x] New `TestUploadDriveFile_EmptyContent` test verifies empty file creation works
- [x] `go vet` passes on the microsoft connector package
- [x] Build succeeds

### Manual Testing
- [ ] Create an Excel spreadsheet via the Microsoft connector and verify it succeeds
- [ ] Verify existing file uploads with content still work as expected
- [ ] Verify the approval flow correctly validates parameters (content no longer required)

https://claude.ai/code/session_01HK1HMdeLxgPKJDqvid4vvV