### PR TITLE
Migrate CI SMS notification from Twilio to SNS (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
           SNS_PHONE_TO: ${{ secrets.SNS_PHONE_TO }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BRANCH: ${{ github.ref_name }}
+          TITLE: ${{ github.workflow }}
         run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BRANCH="${{ github.ref_name }}"
-          TITLE="${{ github.workflow }}"
+          if [ -z "$SNS_PHONE_TO" ]; then
+            echo "::warning::SNS_PHONE_TO secret is not set, skipping SMS"
+            exit 0
+          fi
           MESSAGE="permission-slip CI failed: ${TITLE} on ${BRANCH} — ${RUN_URL}"
 
           aws sns publish \
@@ -122,13 +126,14 @@ jobs:
         env:
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
           NOTIFY_WEBHOOK_SECRET: ${{ secrets.NOTIFY_WEBHOOK_SECRET }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           if [ -z "$NOTIFY_WEBHOOK_URL" ]; then
             echo "::warning::NOTIFY_WEBHOOK_URL secret is not set, skipping webhook"
             exit 0
           fi
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="permission-slip: CI failed on ${{ github.ref_name }} — investigate: ${RUN_URL}"
+          MESSAGE="permission-slip: CI failed on ${BRANCH} — investigate: ${RUN_URL}"
           PAYLOAD=$(jq -n --arg msg "$MESSAGE" --arg secret "$NOTIFY_WEBHOOK_SECRET" \
             '{message: $msg, secret: $secret}')
           curl -s -f -X POST "$NOTIFY_WEBHOOK_URL" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,24 +101,22 @@ jobs:
     needs: [backend, frontend, build]
     if: ${{ failure() && github.event_name == 'push' }}
     steps:
-      - name: Send Twilio SMS
+      - name: Send SNS SMS
         env:
-          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
-          TWILIO_PHONE_FROM: ${{ secrets.TWILIO_PHONE_FROM }}
-          TWILIO_PHONE_TO: ${{ secrets.TWILIO_PHONE_TO }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          SNS_PHONE_TO: ${{ secrets.SNS_PHONE_TO }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
           TITLE="${{ github.workflow }}"
           MESSAGE="permission-slip CI failed: ${TITLE} on ${BRANCH} — ${RUN_URL}"
 
-          curl -s -f -X POST \
-            "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json" \
-            -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
-            --data-urlencode "To=${TWILIO_PHONE_TO}" \
-            --data-urlencode "From=${TWILIO_PHONE_FROM}" \
-            --data-urlencode "Body=${MESSAGE}"
+          aws sns publish \
+            --phone-number "${SNS_PHONE_TO}" \
+            --message "${MESSAGE}" \
+            --message-attributes '{"AWS.SNS.SMS.SMSType":{"DataType":"String","StringValue":"Transactional"}}'
 
       - name: Send webhook notification
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           TITLE: ${{ github.workflow }}
         run: |
+          if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_DEFAULT_REGION" ]; then
+            echo "::warning::AWS credentials/region not configured, skipping SNS SMS"
+            exit 0
+          fi
           if [ -z "$SNS_PHONE_TO" ]; then
             echo "::warning::SNS_PHONE_TO secret is not set, skipping SMS"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
             --message-attributes '{"AWS.SNS.SMS.SMSType":{"DataType":"String","StringValue":"Transactional"}}'
 
       - name: Send webhook notification
+        if: always()
         env:
           NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
           NOTIFY_WEBHOOK_SECRET: ${{ secrets.NOTIFY_WEBHOOK_SECRET }}

--- a/notify/dispatcher_test.go
+++ b/notify/dispatcher_test.go
@@ -103,7 +103,7 @@ func TestDispatcher_MultipleSenders(t *testing.T) {
 func TestDispatcher_PartialFailure(t *testing.T) {
 	t.Parallel()
 	s1 := &stubSender{name: "email"}
-	s2 := &stubSender{name: "sms", err: errors.New("twilio timeout")}
+	s2 := &stubSender{name: "sms", err: errors.New("SNS throttling")}
 	s3 := &stubSender{name: "web-push"}
 	d := NewDispatcher([]Sender{s1, s2, s3}, nil)
 

--- a/notify/sms_gate_test.go
+++ b/notify/sms_gate_test.go
@@ -89,7 +89,7 @@ func TestPlanGatedSender_PlanCheckError_SkipsSMS(t *testing.T) {
 
 func TestPlanGatedSender_InnerSendError_DoesNotTrackUsage(t *testing.T) {
 	t.Parallel()
-	inner := &stubSender{name: "sms", err: errors.New("twilio error")}
+	inner := &stubSender{name: "sms", err: errors.New("SNS publish error")}
 	gate := &stubGate{allowed: true}
 	s := NewPlanGatedSender(inner, gate)
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -263,6 +263,8 @@ inactivity_timeout = "8h"
 # uri = "pg-functions://<database>/<schema>/<hook_name>"
 
 # Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+# NOTE: This is for Supabase Auth OTP delivery only. App-level notification SMS uses Amazon SNS
+# (see notify/sms.go). The Twilio provider below is disabled and unused.
 [auth.sms.twilio]
 enabled = false
 account_sid = ""


### PR DESCRIPTION
## Summary

- Replace "Send Twilio SMS" step in CI `notify-failure` job with AWS SNS `aws sns publish` command
- Update `supabase/config.toml` with clarifying comment that auth SMS provider is separate from app notification SMS (now using SNS)
- Update test stub error messages from "twilio" to "SNS" in `dispatcher_test.go` and `sms_gate_test.go`
- `sms_test.go` was already rewritten in Phase 1 to mock SNS — verified all tests pass

Part of #690

## Test plan

### Claude Code
- [x] Verify all notify package tests pass (excluding DB-dependent tests that require PostgreSQL)
- [x] Confirm no remaining Twilio references in `notify/sms*.go` files

### Manual Testing
- [ ] Verify AWS secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `SNS_PHONE_TO`) are configured in GitHub Actions secrets
- [ ] Trigger a CI failure to confirm SNS SMS notification is sent correctly

https://claude.ai/code/session_01GZvhsDVSwHp2PvoCiP2zmk