### PR TITLE
fix: map server-side Graph error codes to ExternalError for Sentry visibility

### DIFF
--- a/connectors/microsoft/response.go
+++ b/connectors/microsoft/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -25,17 +26,19 @@ type graphError struct {
 // than silently treated as client ValidationErrors.
 //
 // Reference: https://learn.microsoft.com/en-us/graph/errors
+// All keys are lowercase; the lookup normalises the incoming code with
+// strings.ToLower so that variant capitalisations (e.g. "FileCorruptTryRepair"
+// observed in the wild) are handled without maintaining paired entries.
 var serverSideGraphErrorCodes = map[string]bool{
 	// File is not yet ready for editing (e.g. newly created workbook).
-	"fileCorruptTryRepair":   true,
-	"FileCorruptTryRepair":   true,
+	"filecorrupttryrepair": true,
 	// Transient service unavailability / internal errors.
-	"serviceNotAvailable":    true,
-	"generalException":       true,
-	"notSupported":           true,
-	"resourceModified":       true,
-	"lockMismatch":           true,
-	"editModeRequired":       true,
+	"servicenotavailable": true,
+	"generalexception":    true,
+	"notsupported":        true,
+	"resourcemodified":    true,
+	"lockmismatch":        true,
+	"editmoderequired":    true,
 }
 
 // mapGraphError converts a Microsoft Graph API error response to the
@@ -75,7 +78,7 @@ func mapGraphError(statusCode int, body []byte) error {
 		// Some Graph error codes indicate server-side / transient issues even on
 		// HTTP 400. Map those to ExternalError so they are captured in Sentry
 		// rather than silently treated as client validation errors.
-		if serverSideGraphErrorCodes[code] {
+		if serverSideGraphErrorCodes[strings.ToLower(code)] {
 			return &connectors.ExternalError{
 				StatusCode: statusCode,
 				Message:    fmt.Sprintf("Microsoft Graph service error (%s): %s", code, ge.Error.Message),

--- a/connectors/microsoft/response.go
+++ b/connectors/microsoft/response.go
@@ -17,6 +17,27 @@ type graphError struct {
 	} `json:"error"`
 }
 
+// serverSideGraphErrorCodes is the set of Microsoft Graph error codes that
+// indicate a server-side or infrastructure issue rather than a bad client
+// request. Even when Graph returns HTTP 400 for these, they represent
+// unexpected service conditions (file not yet ready, internal service errors,
+// transient locks) and should be reported to Sentry as ExternalErrors rather
+// than silently treated as client ValidationErrors.
+//
+// Reference: https://learn.microsoft.com/en-us/graph/errors
+var serverSideGraphErrorCodes = map[string]bool{
+	// File is not yet ready for editing (e.g. newly created workbook).
+	"fileCorruptTryRepair":   true,
+	"FileCorruptTryRepair":   true,
+	// Transient service unavailability / internal errors.
+	"serviceNotAvailable":    true,
+	"generalException":       true,
+	"notSupported":           true,
+	"resourceModified":       true,
+	"lockMismatch":           true,
+	"editModeRequired":       true,
+}
+
 // mapGraphError converts a Microsoft Graph API error response to the
 // appropriate connector error type with actionable messages.
 //
@@ -24,6 +45,7 @@ type graphError struct {
 //
 //	401 → AuthError (token expired/invalid — suggest reconnecting)
 //	403 → AuthError (insufficient scopes — suggest re-authorizing)
+//	400 + server-side error code → ExternalError (Graph service issue, not client error)
 //	400 → ValidationError (bad request — surface the Graph error message)
 //	404 → ExternalError (resource not found)
 //	other → ExternalError (generic Graph API failure)
@@ -50,6 +72,15 @@ func mapGraphError(statusCode int, body []byte) error {
 			Message:    fmt.Sprintf("Microsoft Graph resource not found (%s): %s", code, ge.Error.Message),
 		}
 	case http.StatusBadRequest:
+		// Some Graph error codes indicate server-side / transient issues even on
+		// HTTP 400. Map those to ExternalError so they are captured in Sentry
+		// rather than silently treated as client validation errors.
+		if serverSideGraphErrorCodes[code] {
+			return &connectors.ExternalError{
+				StatusCode: statusCode,
+				Message:    fmt.Sprintf("Microsoft Graph service error (%s): %s", code, ge.Error.Message),
+			}
+		}
 		return &connectors.ValidationError{
 			Message: fmt.Sprintf("Microsoft Graph rejected the request (%s): %s", code, ge.Error.Message),
 		}

--- a/connectors/microsoft/response_test.go
+++ b/connectors/microsoft/response_test.go
@@ -1,0 +1,167 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func graphErrorBody(code, message string) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
+		},
+	})
+	return b
+}
+
+func TestMapGraphError_401_ReturnsAuthError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusUnauthorized, graphErrorBody("InvalidAuthenticationToken", "token expired"))
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got %T: %v", err, err)
+	}
+}
+
+func TestMapGraphError_403_ReturnsAuthError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusForbidden, graphErrorBody("accessDenied", "insufficient scopes"))
+	if !connectors.IsAuthError(err) {
+		t.Errorf("expected AuthError, got %T: %v", err, err)
+	}
+}
+
+func TestMapGraphError_404_ReturnsExternalError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusNotFound, graphErrorBody("itemNotFound", "resource not found"))
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got %T: %v", err, err)
+	}
+}
+
+func TestMapGraphError_400_ClientError_ReturnsValidationError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusBadRequest, graphErrorBody("invalidRequest", "bad field"))
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+// TestMapGraphError_400_FileCorruptTryRepair ensures that Graph errors indicating
+// server-side or transient infrastructure issues are NOT silently treated as
+// client validation errors. They must be mapped to ExternalError so they are
+// captured in Sentry and visible to operators.
+func TestMapGraphError_400_FileCorruptTryRepair_ReturnsExternalError(t *testing.T) {
+	t.Parallel()
+	// Both capitalizations observed in the wild.
+	for _, code := range []string{"fileCorruptTryRepair", "FileCorruptTryRepair"} {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+			err := mapGraphError(http.StatusBadRequest, graphErrorBody(code, "The file is corrupt. Please try to repair the file."))
+			if !connectors.IsExternalError(err) {
+				t.Errorf("expected ExternalError for %q, got %T: %v", code, err, err)
+			}
+			if connectors.IsValidationError(err) {
+				t.Errorf("must NOT be ValidationError for %q (would be swallowed by Sentry)", code)
+			}
+		})
+	}
+}
+
+func TestMapGraphError_400_ServiceNotAvailable_ReturnsExternalError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusBadRequest, graphErrorBody("serviceNotAvailable", "service is unavailable"))
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got %T: %v", err, err)
+	}
+}
+
+func TestMapGraphError_400_GeneralException_ReturnsExternalError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusBadRequest, graphErrorBody("generalException", "unexpected error"))
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got %T: %v", err, err)
+	}
+}
+
+func TestMapGraphError_500_ReturnsExternalError(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusInternalServerError, graphErrorBody("generalException", "internal error"))
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got %T: %v", err, err)
+	}
+}
+
+func TestMapGraphError_ErrorMessageContainsCode(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusBadRequest, graphErrorBody("fileCorruptTryRepair", "the workbook is locked"))
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	msg := err.Error()
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+	// The error message should surface the Graph error code so operators
+	// can identify the root cause without digging into raw logs.
+	expected := "fileCorruptTryRepair"
+	if !containsString(msg, expected) {
+		t.Errorf("expected error message to contain %q, got: %q", expected, msg)
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && func() bool {
+		for i := 0; i+len(substr) <= len(s); i++ {
+			if s[i:i+len(substr)] == substr {
+				return true
+			}
+		}
+		return false
+	}())
+}
+
+func TestMapGraphError_MalformedBody_FallsBackToRawBody(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusInternalServerError, []byte("not valid json"))
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("expected ExternalError, got %T: %v", err, err)
+	}
+}
+
+// TestServerSideGraphErrorCodesCompleteness ensures the serverSideGraphErrorCodes
+// map is not accidentally empty (regression guard for future refactors).
+func TestServerSideGraphErrorCodesCompleteness(t *testing.T) {
+	t.Parallel()
+	required := []string{
+		"fileCorruptTryRepair",
+		"FileCorruptTryRepair",
+		"serviceNotAvailable",
+		"generalException",
+	}
+	for _, code := range required {
+		if !serverSideGraphErrorCodes[code] {
+			t.Errorf("serverSideGraphErrorCodes is missing required entry %q", code)
+		}
+	}
+}
+
+// Ensure the error message includes the Graph error code for debuggability.
+func TestMapGraphError_400_FileCorruptTryRepair_MessageIncludesCode(t *testing.T) {
+	t.Parallel()
+	err := mapGraphError(http.StatusBadRequest, graphErrorBody("fileCorruptTryRepair", "workbook locked"))
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	msg := fmt.Sprintf("%v", err)
+	if !containsString(msg, "fileCorruptTryRepair") {
+		t.Errorf("error message should contain the Graph error code, got: %q", msg)
+	}
+}

--- a/connectors/microsoft/response_test.go
+++ b/connectors/microsoft/response_test.go
@@ -2,8 +2,8 @@ package microsoft
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -51,17 +51,30 @@ func TestMapGraphError_400_ClientError_ReturnsValidationError(t *testing.T) {
 	}
 }
 
-// TestMapGraphError_400_FileCorruptTryRepair ensures that Graph errors indicating
-// server-side or transient infrastructure issues are NOT silently treated as
-// client validation errors. They must be mapped to ExternalError so they are
-// captured in Sentry and visible to operators.
-func TestMapGraphError_400_FileCorruptTryRepair_ReturnsExternalError(t *testing.T) {
+// TestMapGraphError_400_ServerSideCodes ensures that all Graph error codes
+// indicating server-side or transient infrastructure issues are mapped to
+// ExternalError (not ValidationError) even when the HTTP status is 400.
+// Covers all codes in serverSideGraphErrorCodes, including variant
+// capitalisations observed in the wild.
+func TestMapGraphError_400_ServerSideCodes_ReturnExternalError(t *testing.T) {
 	t.Parallel()
-	// Both capitalizations observed in the wild.
-	for _, code := range []string{"fileCorruptTryRepair", "FileCorruptTryRepair"} {
+	codes := []string{
+		// Both capitalisations observed in the wild.
+		"fileCorruptTryRepair",
+		"FileCorruptTryRepair",
+		// Standard codes.
+		"serviceNotAvailable",
+		"generalException",
+		"notSupported",
+		"resourceModified",
+		"lockMismatch",
+		"editModeRequired",
+	}
+	for _, code := range codes {
+		code := code
 		t.Run(code, func(t *testing.T) {
 			t.Parallel()
-			err := mapGraphError(http.StatusBadRequest, graphErrorBody(code, "The file is corrupt. Please try to repair the file."))
+			err := mapGraphError(http.StatusBadRequest, graphErrorBody(code, "server-side error"))
 			if !connectors.IsExternalError(err) {
 				t.Errorf("expected ExternalError for %q, got %T: %v", code, err, err)
 			}
@@ -69,22 +82,6 @@ func TestMapGraphError_400_FileCorruptTryRepair_ReturnsExternalError(t *testing.
 				t.Errorf("must NOT be ValidationError for %q (would be swallowed by Sentry)", code)
 			}
 		})
-	}
-}
-
-func TestMapGraphError_400_ServiceNotAvailable_ReturnsExternalError(t *testing.T) {
-	t.Parallel()
-	err := mapGraphError(http.StatusBadRequest, graphErrorBody("serviceNotAvailable", "service is unavailable"))
-	if !connectors.IsExternalError(err) {
-		t.Errorf("expected ExternalError, got %T: %v", err, err)
-	}
-}
-
-func TestMapGraphError_400_GeneralException_ReturnsExternalError(t *testing.T) {
-	t.Parallel()
-	err := mapGraphError(http.StatusBadRequest, graphErrorBody("generalException", "unexpected error"))
-	if !connectors.IsExternalError(err) {
-		t.Errorf("expected ExternalError, got %T: %v", err, err)
 	}
 }
 
@@ -108,21 +105,9 @@ func TestMapGraphError_ErrorMessageContainsCode(t *testing.T) {
 	}
 	// The error message should surface the Graph error code so operators
 	// can identify the root cause without digging into raw logs.
-	expected := "fileCorruptTryRepair"
-	if !containsString(msg, expected) {
-		t.Errorf("expected error message to contain %q, got: %q", expected, msg)
+	if !strings.Contains(msg, "fileCorruptTryRepair") {
+		t.Errorf("expected error message to contain %q, got: %q", "fileCorruptTryRepair", msg)
 	}
-}
-
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && func() bool {
-		for i := 0; i+len(substr) <= len(s); i++ {
-			if s[i:i+len(substr)] == substr {
-				return true
-			}
-		}
-		return false
-	}())
 }
 
 func TestMapGraphError_MalformedBody_FallsBackToRawBody(t *testing.T) {
@@ -137,31 +122,22 @@ func TestMapGraphError_MalformedBody_FallsBackToRawBody(t *testing.T) {
 }
 
 // TestServerSideGraphErrorCodesCompleteness ensures the serverSideGraphErrorCodes
-// map is not accidentally empty (regression guard for future refactors).
+// map contains all expected entries (regression guard for future refactors).
+// Keys are stored lowercase; the lookup normalises via strings.ToLower.
 func TestServerSideGraphErrorCodesCompleteness(t *testing.T) {
 	t.Parallel()
 	required := []string{
-		"fileCorruptTryRepair",
-		"FileCorruptTryRepair",
-		"serviceNotAvailable",
-		"generalException",
+		"filecorrupttryrepair",
+		"servicenotavailable",
+		"generalexception",
+		"notsupported",
+		"resourcemodified",
+		"lockmismatch",
+		"editmoderequired",
 	}
 	for _, code := range required {
 		if !serverSideGraphErrorCodes[code] {
 			t.Errorf("serverSideGraphErrorCodes is missing required entry %q", code)
 		}
-	}
-}
-
-// Ensure the error message includes the Graph error code for debuggability.
-func TestMapGraphError_400_FileCorruptTryRepair_MessageIncludesCode(t *testing.T) {
-	t.Parallel()
-	err := mapGraphError(http.StatusBadRequest, graphErrorBody("fileCorruptTryRepair", "workbook locked"))
-	if err == nil {
-		t.Fatal("expected non-nil error")
-	}
-	msg := fmt.Sprintf("%v", err)
-	if !containsString(msg, "fileCorruptTryRepair") {
-		t.Errorf("error message should contain the Graph error code, got: %q", msg)
 	}
 }


### PR DESCRIPTION
## Problem

Microsoft Graph sometimes returns server-side / transient error codes (e.g. `fileCorruptTryRepair`, `serviceNotAvailable`, `generalException`) with **HTTP 400**. The previous `mapGraphError` implementation mapped all 400s to `ValidationError`, which is intentionally **not** reported to Sentry (it's treated as a client error).

This meant Graph infrastructure errors were silently swallowed — no Sentry visibility.

## Root Cause

In `connectors/microsoft/response.go`, `mapGraphError` treated every HTTP 400 as a client validation error:

```go
case http.StatusBadRequest:
    return &connectors.ValidationError{...}
```

And in `api/connector_errors.go`, `ValidationError` has no `CaptureConnectorError` call (intentionally — bad params aren't a bug). So any transient Graph service error that happened to use HTTP 400 was dropped.

## Fix

Introduce `serverSideGraphErrorCodes` — a set of known Graph error codes indicating service-side conditions. When a 400 response carries one of these codes, `mapGraphError` returns `ExternalError` instead of `ValidationError`. `ExternalError` flows through `CaptureConnectorError` → Sentry with full context (`action_type`, `connector_id`, `agent_id`, `trace_id`).

Standard client 400 errors (bad parameters, invalid field values) still map to `ValidationError` — no change there.

## Affected error codes

| Code | Description |
|------|-------------|
| `fileCorruptTryRepair` / `FileCorruptTryRepair` | File not ready yet (e.g. newly created workbook) |
| `serviceNotAvailable` | Transient Graph service unavailability |
| `generalException` | Unexpected internal Graph error |
| `notSupported` | Operation not supported by service |
| `resourceModified` | Resource modified conflict |
| `lockMismatch` | Lock conflict |
| `editModeRequired` | Edit session required |

## Testing

Added `connectors/microsoft/response_test.go` covering all status mappings and the new server-side code behavior.