### PR TITLE
Fix text overflow in approval dialog on mobile

### DIFF
--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -67,7 +67,7 @@ function val(t: string): SummaryPart {
 /** Inline highlight for parameter values within the summary. */
 function ValSpan({ children }: { children: ReactNode }) {
   return (
-    <span className="bg-muted text-foreground inline rounded px-1 py-0.5 font-medium box-decoration-clone">
+    <span className="bg-muted text-foreground inline rounded px-1 py-0.5 font-medium box-decoration-clone break-all">
       {children}
     </span>
   );
@@ -114,7 +114,7 @@ export function ActionPreviewSummary({
   const parts = buildParts(actionType, parameters, schema, actionName, displayTemplate, resourceDetails);
 
   return (
-    <p className="text-sm leading-loose" data-testid="action-preview-summary">
+    <p className="text-sm leading-loose break-words" data-testid="action-preview-summary">
       {renderRich(parts)}
     </p>
   );

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -56,7 +56,7 @@ function DialogContent({
         <DialogPrimitive.Content
           data-slot="dialog-content"
           className={cn(
-            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid w-full gap-4 overflow-hidden overscroll-contain rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid w-full min-w-0 gap-4 overflow-hidden overscroll-contain rounded-lg border p-6 shadow-lg duration-200 [&>*]:min-w-0 sm:max-w-lg",
             className
           )}
           {...props}


### PR DESCRIPTION
## Summary
- Long unbroken strings (like OneDrive item IDs) were overflowing horizontally in the action preview card on mobile
- Added `min-w-0` to the dialog grid container and its children to prevent content from blowing out the CSS grid
- Added `break-words` to the ActionPreviewSummary paragraph and `break-all` to the ValSpan component so long parameter values wrap instead of overflow

## Test plan

### Claude Code
- [x] Frontend tests pass (953/953)
- [x] TypeScript compilation clean

### Manual Testing
- [ ] Open an approval with long parameter values on a mobile device (or narrow browser)
- [ ] Verify text wraps within the preview card instead of overflowing
- [ ] Verify other dialogs using DialogContent still render correctly

https://claude.ai/code/session_01W9wefecF5i3m1VSkgC1LvL