### PR TITLE
Migrate SMS notifications: remove Twilio references, update docs for SNS (Phase 3)

### DIFF
--- a/config.go
+++ b/config.go
@@ -208,25 +208,25 @@ func validateConfig() (errs []configError, warnings []configError) {
 		}
 	}
 
-	// Twilio SMS — if any Twilio var is set, all three are required.
-	hasTwilioSID := os.Getenv("TWILIO_ACCOUNT_SID") != ""
-	hasTwilioToken := os.Getenv("TWILIO_AUTH_TOKEN") != ""
-	hasTwilioFrom := os.Getenv("TWILIO_FROM_NUMBER") != ""
-	anyTwilio := hasTwilioSID || hasTwilioToken || hasTwilioFrom
-	if anyTwilio && (!hasTwilioSID || !hasTwilioToken || !hasTwilioFrom) {
-		missing := []string{}
-		if !hasTwilioSID {
-			missing = append(missing, "TWILIO_ACCOUNT_SID")
-		}
-		if !hasTwilioToken {
-			missing = append(missing, "TWILIO_AUTH_TOKEN")
-		}
-		if !hasTwilioFrom {
-			missing = append(missing, "TWILIO_FROM_NUMBER")
+	// SMS (Amazon SNS) — AWS_REGION is required; credentials are optional
+	// (the AWS SDK falls back to IAM roles, shared config, etc.).
+	hasAWSRegion := os.Getenv("AWS_REGION") != ""
+	hasAWSKeyID := os.Getenv("AWS_ACCESS_KEY_ID") != ""
+	hasAWSSecret := os.Getenv("AWS_SECRET_ACCESS_KEY") != ""
+	if !hasAWSRegion && (hasAWSKeyID || hasAWSSecret) {
+		warnings = append(warnings, configError{
+			envVar:  "AWS_REGION",
+			message: "not set; AWS credentials are configured but AWS_REGION is required for SMS (SNS)",
+		})
+	}
+	if hasAWSRegion && (hasAWSKeyID != hasAWSSecret) {
+		missing := "AWS_SECRET_ACCESS_KEY"
+		if !hasAWSKeyID {
+			missing = "AWS_ACCESS_KEY_ID"
 		}
 		warnings = append(warnings, configError{
-			envVar:  strings.Join(missing, " / "),
-			message: "not set; SMS notifications partially configured — all three Twilio vars are required",
+			envVar:  missing,
+			message: "not set; AWS credentials are partially configured — set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or neither (to use IAM roles)",
 		})
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -70,6 +70,9 @@ func TestValidateConfig_DevelopmentModeNoWarningsWhenConfigured(t *testing.T) {
 		"MICROSOFT_CLIENT_SECRET":    "test-msft-secret",
 		"SALESFORCE_CLIENT_ID":       "test-sf-id",
 		"SALESFORCE_CLIENT_SECRET":   "test-sf-secret",
+		"AWS_REGION":                 "",
+		"AWS_ACCESS_KEY_ID":          "",
+		"AWS_SECRET_ACCESS_KEY":      "",
 	})
 
 	errs, warnings := validateConfig()
@@ -221,6 +224,9 @@ func TestValidateConfig_AllValid(t *testing.T) {
 		"MICROSOFT_CLIENT_SECRET":    "test-msft-secret",
 		"SALESFORCE_CLIENT_ID":       "test-sf-id",
 		"SALESFORCE_CLIENT_SECRET":   "test-sf-secret",
+		"AWS_REGION":                 "",
+		"AWS_ACCESS_KEY_ID":          "",
+		"AWS_SECRET_ACCESS_KEY":      "",
 	})
 
 	errs, warnings := validateConfig()
@@ -433,6 +439,9 @@ func TestValidateConfig_BillingEnabled_NoErrorsWhenConfigured(t *testing.T) {
 		"MICROSOFT_CLIENT_SECRET":    "test-msft-secret",
 		"SALESFORCE_CLIENT_ID":       "test-sf-id",
 		"SALESFORCE_CLIENT_SECRET":   "test-sf-secret",
+		"AWS_REGION":                 "",
+		"AWS_ACCESS_KEY_ID":          "",
+		"AWS_SECRET_ACCESS_KEY":      "",
 	})
 
 	errs, warnings := validateConfig()

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -187,7 +187,8 @@ fly deploy \
 
 **SMS — Amazon SNS:**
 - Used for SMS approval notifications
-- Requires an AWS account with SNS access
+- Requires an AWS account with SNS access and `sns:Publish` IAM permission
+- **Important:** New AWS accounts are in the [SMS Sandbox](https://docs.aws.amazon.com/sns/latest/dg/sns-sms-sandbox.html) by default. Request production SMS access in the SNS console before deploying, or SMS will only reach verified destination numbers.
 
 **Web Push — VAPID:**
 - Browser push notifications via FCM / Mozilla Push Service
@@ -486,7 +487,7 @@ Or hardcode in `fly.toml` for simpler deploys:
 | `NOTIFICATION_EMAIL_PROVIDER` | Runtime secret | **Set** | `twilio-sendgrid` |
 | `SENDGRID_API_KEY` | Runtime secret | **Set** | SendGrid API key |
 | `NOTIFICATION_EMAIL_FROM` | Runtime secret | **Set** | Sender address |
-| `AWS_REGION` | Runtime secret | **Set if SMS** | AWS region for SNS (e.g. `us-east-1`) |
+| `AWS_REGION` | Runtime secret | **Set if SMS** | AWS region for SNS (e.g. `us-east-1`); IAM user/role needs `sns:Publish` |
 | `AWS_ACCESS_KEY_ID` | Runtime secret | **Optional** | AWS access key (omit to use IAM roles) |
 | `AWS_SECRET_ACCESS_KEY` | Runtime secret | **Optional** | AWS secret key (omit to use IAM roles) |
 | `SENTRY_DSN` | Runtime secret | **Set** | Backend error tracking DSN |

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -24,10 +24,10 @@
         ┌──────────────┬───────────┼───────────┐
         │              │           │           │
  ┌──────▼───┐  ┌──────▼────┐  ┌──▼────┐  ┌───▼─────┐
- │ Supabase  │  │  Sentry   │  │Twilio │  │ PostHog │
- │ - Auth    │  │  - Errors │  │-SGrid │  │-Analytics│
- │ - Postgres│  │  - Perf   │  │- SMS  │  │-Replays │
- │ - Vault   │  │  - CSP    │  │       │  │         │
+ │ Supabase  │  │  Sentry   │  │SGrid  │  │ PostHog │
+ │ - Auth    │  │  - Errors │  │-Email │  │-Analytics│
+ │ - Postgres│  │  - Perf   │  │AWS SNS│  │-Replays │
+ │ - Vault   │  │  - CSP    │  │- SMS  │  │         │
  └───────────┘  └───────────┘  └───────┘  └─────────┘
                                                 ┌───────────────┐
                                                 │  UptimeRobot  │
@@ -47,7 +47,7 @@ Quick reference of every service in the production stack. See detailed sections 
 | 3 | [**Cloudflare**](#cloudflare-dns--proxy--web-analytics) | DNS proxy, TLS termination, Web Analytics | Live |
 | 4 | [**Sentry**](#sentry-error-tracking) | Error tracking (backend + frontend) + CSP violation reports | Live |
 | 5 | [**Twilio SendGrid**](#notification-services) | Email delivery for approval notifications | Live |
-| 6 | [**Twilio**](#notification-services) | SMS delivery for approval notifications | Live |
+| 6 | [**Amazon SNS**](#notification-services) | SMS delivery for approval notifications | Live |
 | 7 | [**VAPID / Web Push**](#notification-services) | Browser push notifications (FCM / Mozilla Push) | Live |
 | 8 | [**Expo Push Service**](#notification-services) | Mobile push notifications (iOS + Android via Expo) | Live |
 | 9 | [**GitHub Actions**](#cicd-pipeline) | CI (tests, build, audit) + planned CD | Live |
@@ -185,9 +185,9 @@ fly deploy \
 - Used for approval request notifications
 - Requires a verified sender domain and API key
 
-**SMS — Twilio:**
+**SMS — Amazon SNS:**
 - Used for SMS approval notifications
-- Requires a Twilio account with a phone number
+- Requires an AWS account with SNS access
 
 **Web Push — VAPID:**
 - Browser push notifications via FCM / Mozilla Push Service
@@ -209,11 +209,12 @@ fly secrets set \
   SENDGRID_API_KEY="SG.xxxx" \
   NOTIFICATION_EMAIL_FROM="approvals@permissionslip.dev"
 
-# SMS (Twilio)
+# SMS (Amazon SNS)
 fly secrets set \
-  TWILIO_ACCOUNT_SID="ACxxxx" \
-  TWILIO_AUTH_TOKEN="xxxx" \
-  TWILIO_FROM_NUMBER="+15551234567"
+  AWS_REGION="us-east-1" \
+  AWS_ACCESS_KEY_ID="AKIAxxxx" \
+  AWS_SECRET_ACCESS_KEY="xxxx"
+# Optional: SNS_SMS_SENDER_ID="PermSlip" SNS_SMS_ORIGINATION_NUMBER="+15551234567"
 
 # Web Push (VAPID) — generate keys first: go run ./cmd/generate-vapid-keys --format=fly
 fly secrets set \
@@ -404,12 +405,14 @@ fly secrets set \
   SENDGRID_API_KEY="SG.xxxx" \
   NOTIFICATION_EMAIL_FROM="approvals@permissionslip.dev"
 
-# ── SMS (Twilio) ─────────────────────────────────────────────────────────
+# ── SMS (Amazon SNS) ──────────────────────────────────────────────────────
 
 fly secrets set \
-  TWILIO_ACCOUNT_SID="ACxxxx" \
-  TWILIO_AUTH_TOKEN="xxxx" \
-  TWILIO_FROM_NUMBER="+15551234567"
+  AWS_REGION="us-east-1" \
+  AWS_ACCESS_KEY_ID="AKIAxxxx" \
+  AWS_SECRET_ACCESS_KEY="xxxx"
+# Optional:
+# fly secrets set SNS_SMS_SENDER_ID="PermSlip" SNS_SMS_ORIGINATION_NUMBER="+15551234567"
 
 # ── Error Tracking (Sentry) ──────────────────────────────────────────────
 
@@ -483,9 +486,9 @@ Or hardcode in `fly.toml` for simpler deploys:
 | `NOTIFICATION_EMAIL_PROVIDER` | Runtime secret | **Set** | `twilio-sendgrid` |
 | `SENDGRID_API_KEY` | Runtime secret | **Set** | SendGrid API key |
 | `NOTIFICATION_EMAIL_FROM` | Runtime secret | **Set** | Sender address |
-| `TWILIO_ACCOUNT_SID` | Runtime secret | **Set if SMS** | Twilio SID |
-| `TWILIO_AUTH_TOKEN` | Runtime secret | **Set if SMS** | Twilio auth token |
-| `TWILIO_FROM_NUMBER` | Runtime secret | **Set if SMS** | Twilio phone number |
+| `AWS_REGION` | Runtime secret | **Set if SMS** | AWS region for SNS (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | Runtime secret | **Optional** | AWS access key (omit to use IAM roles) |
+| `AWS_SECRET_ACCESS_KEY` | Runtime secret | **Optional** | AWS secret key (omit to use IAM roles) |
 | `SENTRY_DSN` | Runtime secret | **Set** | Backend error tracking DSN |
 | `SENTRY_CSP_ENDPOINT` | Runtime secret | **Set** | CSP violation reporting |
 | `CLOUDFLARE_INSIGHTS` | Runtime env | **Set** | `true` — allows Cloudflare Web Analytics beacon in CSP |
@@ -700,7 +703,7 @@ Setting any secret via `fly secrets set` triggers an automatic redeploy.
 | `DATABASE_URL_APP` (password) | Every 90 days | None — rotate via Supabase SQL Editor (`ALTER ROLE app_backend PASSWORD '...'`), then update Fly secret |
 | `INVITE_HMAC_KEY` | Every 90 days | **Invalidates pending (unused) invite links.** Accepted invites are unaffected |
 | `SENDGRID_API_KEY` | Every 90 days | None — revoke the old key in SendGrid after deploying the new one |
-| `TWILIO_AUTH_TOKEN` | Every 90 days | None — regenerate in Twilio console, then update Fly |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Every 90 days | None — rotate in AWS IAM console, then update Fly |
 | `STRIPE_SECRET_KEY` | Every 90 days | None — roll the key in Stripe dashboard, update Fly, then revoke the old key |
 | `STRIPE_WEBHOOK_SECRET` | Every 90 days | None — create a new webhook endpoint in Stripe, update Fly, then delete the old endpoint |
 | `SENTRY_DSN` | Rarely (only if compromised) | None — DSNs are project-scoped and low-risk |
@@ -752,13 +755,14 @@ fly secrets set INVITE_HMAC_KEY="$(openssl rand -hex 32)"
    ```
 3. After verifying email still works, revoke the old key in SendGrid
 
-**Twilio auth token:**
+**AWS access keys (for SNS SMS):**
 
-1. In the [Twilio console](https://console.twilio.com), go to Account > API keys and tokens and regenerate the auth token
-2. Deploy the new token:
+1. In the [AWS IAM console](https://console.aws.amazon.com/iam/), create a new access key for the SNS user
+2. Deploy the new credentials:
    ```bash
-   fly secrets set TWILIO_AUTH_TOKEN="new-token"
+   fly secrets set AWS_ACCESS_KEY_ID="AKIAnew" AWS_SECRET_ACCESS_KEY="new-secret"
    ```
+3. Delete the old access key in IAM after verifying SMS still works
 
 **Stripe keys:**
 
@@ -845,7 +849,7 @@ Quick reference for what's live vs. planned.
 | **Supabase** | Auth + Postgres + Vault | Live | — |
 | **Sentry** | Error tracking (backend + frontend) | Live | [#329](https://github.com/supersuit-tech/permission-slip-web/issues/329), [#330](https://github.com/supersuit-tech/permission-slip-web/issues/330) |
 | **SendGrid** | Email notifications | Live | — |
-| **Twilio** | SMS notifications | Live | — |
+| **Amazon SNS** | SMS notifications | Live | — |
 | **VAPID / Web Push** | Browser push notifications | Live | — |
 | **Expo Push Service** | Mobile push notifications (iOS + Android) | Live | — |
 | **PostHog** | Product analytics + session replay | Planned | [#352](https://github.com/supersuit-tech/permission-slip-web/issues/352) |

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -169,15 +169,17 @@ Pick one provider:
 | `SMTP_PASSWORD` | SMTP password or app password |
 | `NOTIFICATION_EMAIL_FROM` | Sender address |
 
-### SMS Notifications (Twilio)
+### SMS Notifications (Amazon SNS)
 
 | Variable | Description |
 |---|---|
-| `TWILIO_ACCOUNT_SID` | Twilio Account SID (`ACxxxx`) |
-| `TWILIO_AUTH_TOKEN` | Twilio Auth Token |
-| `TWILIO_FROM_NUMBER` | Twilio phone number (`+15551234567`) |
+| `AWS_REGION` | AWS region for SNS (e.g. `us-east-1`) — **required** |
+| `AWS_ACCESS_KEY_ID` | AWS access key (optional — omit to use IAM roles) |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key (optional — omit to use IAM roles) |
+| `SNS_SMS_SENDER_ID` | Optional alphanumeric sender ID (not supported in all countries) |
+| `SNS_SMS_ORIGINATION_NUMBER` | Optional origination phone number in E.164 format |
 
-All three are required to enable SMS. If partially configured, SMS is disabled with a warning.
+`AWS_REGION` is required to enable SMS. Credentials are optional when running on AWS with an IAM role.
 
 ### Error Tracking (Sentry)
 
@@ -393,7 +395,8 @@ Rotate secrets on a regular cadence (every 90 days recommended for API keys and 
 
 - **`DATABASE_URL`** — change the password in your database provider, then update the env var. No downtime.
 - **`INVITE_HMAC_KEY`** — regenerate with `openssl rand -hex 32`. **Invalidates pending invite links** (accepted invites are unaffected).
-- **`SENDGRID_API_KEY` / `TWILIO_AUTH_TOKEN`** — create a new key in the provider console, deploy it, then revoke the old key.
+- **`SENDGRID_API_KEY`** — create a new key in the SendGrid console, deploy it, then revoke the old key.
+- **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`** — rotate in AWS IAM console, deploy new credentials, then delete the old access key.
 - **`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`** — only rotate if compromised. **Invalidates all push subscriptions** (users must re-subscribe).
 - **`STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`** — roll keys in Stripe dashboard (supports overlap periods), update env var, then revoke old key.
 
@@ -449,9 +452,9 @@ Migrations run automatically on startup. If they fail, check database connectivi
 | `SMTP_PORT` | For SMTP | Runtime | SMTP port (default: `587`) |
 | `SMTP_USERNAME` | For SMTP | Runtime | SMTP username |
 | `SMTP_PASSWORD` | For SMTP | Runtime | SMTP password |
-| `TWILIO_ACCOUNT_SID` | For SMS | Runtime | Twilio Account SID |
-| `TWILIO_AUTH_TOKEN` | For SMS | Runtime | Twilio Auth Token |
-| `TWILIO_FROM_NUMBER` | For SMS | Runtime | Twilio sender phone number |
+| `AWS_REGION` | For SMS | Runtime | AWS region for SNS (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | For SMS | Runtime | AWS access key (optional with IAM roles) |
+| `AWS_SECRET_ACCESS_KEY` | For SMS | Runtime | AWS secret key (optional with IAM roles) |
 | `SENTRY_DSN` | No | Runtime | Backend error tracking |
 | `SENTRY_CSP_ENDPOINT` | No | Runtime | CSP violation reporting |
 | `VITE_SENTRY_DSN` | No | Build | Frontend error tracking |

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -179,7 +179,9 @@ Pick one provider:
 | `SNS_SMS_SENDER_ID` | Optional alphanumeric sender ID (not supported in all countries) |
 | `SNS_SMS_ORIGINATION_NUMBER` | Optional origination phone number in E.164 format |
 
-`AWS_REGION` is required to enable SMS. Credentials are optional when running on AWS with an IAM role.
+`AWS_REGION` is required to enable SMS. Credentials are optional when running on AWS with an IAM role. The IAM user/role needs `sns:Publish` permission.
+
+> **Important:** New AWS accounts are in the [SMS Sandbox](https://docs.aws.amazon.com/sns/latest/dg/sns-sms-sandbox.html) by default. Request production SMS access in the SNS console before deploying, or SMS will only reach verified destination numbers.
 
 ### Error Tracking (Sentry)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -181,11 +181,11 @@ fly secrets set \
   SMTP_PASSWORD="app-password" \
   NOTIFICATION_EMAIL_FROM="you@gmail.com"
 
-# SMS via Twilio
+# SMS via Amazon SNS
 fly secrets set \
-  TWILIO_ACCOUNT_SID="ACxxxx" \
-  TWILIO_AUTH_TOKEN="xxxx" \
-  TWILIO_FROM_NUMBER="+15551234567"
+  AWS_REGION="us-east-1" \
+  AWS_ACCESS_KEY_ID="AKIAxxxx" \
+  AWS_SECRET_ACCESS_KEY="xxxx"
 ```
 
 ## DNS Configuration

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -18,9 +18,9 @@ You need **two** external accounts:
 | Service | Why | Cost |
 |---|---|---|
 | [Supabase](https://supabase.com) | User authentication (login, MFA, JWTs) | Free tier is sufficient |
-| [Twilio](https://www.twilio.com) | SMS notifications for approval requests | Pay-as-you-go (~$0.0079/SMS) |
+| [AWS](https://aws.amazon.com) | SMS notifications via Amazon SNS | Pay-as-you-go (~$0.0075/SMS in the US) |
 
-Twilio ensures approvers get notified on their phone immediately — even without the app installed, without a browser open, and regardless of iOS vs Android. PostgreSQL runs locally on the Pi — no managed database needed.
+Amazon SNS ensures approvers get notified on their phone immediately — even without the app installed, without a browser open, and regardless of iOS vs Android. PostgreSQL runs locally on the Pi — no managed database needed.
 
 ## Step 1: Set Up Your Raspberry Pi
 
@@ -96,21 +96,21 @@ SQL
 
 Permission Slip is an approval system — approvers need to know when something's waiting for them. Without notifications, they'd have to keep checking the web UI manually.
 
-### Twilio SMS (works on any phone)
+### Amazon SNS SMS (works on any phone)
 
 SMS is the most reliable way to reach approvers on the go. It works on every phone — no app to install, no browser to keep open.
 
-1. Sign up at [twilio.com](https://www.twilio.com) (pay-as-you-go, ~$0.0079/SMS in the US)
-2. From the Twilio console, get your **Account SID** and **Auth Token**
-3. Buy a phone number (or use the trial number to test)
+1. Sign up for an [AWS account](https://aws.amazon.com) if you don't have one
+2. Create an IAM user with `sns:Publish` permission and generate access keys
+3. In the SNS console, request to move out of the SMS sandbox for production use
 
 You'll add these values to your environment in the next step:
 
 | Variable | Value |
 |---|---|
-| `TWILIO_ACCOUNT_SID` | Your Account SID (`ACxxxx`) |
-| `TWILIO_AUTH_TOKEN` | Your Auth Token |
-| `TWILIO_FROM_NUMBER` | Your Twilio phone number (`+15551234567`) |
+| `AWS_REGION` | AWS region (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | Your IAM access key (`AKIAxxxx`) |
+| `AWS_SECRET_ACCESS_KEY` | Your IAM secret key |
 
 > For more notification options (web push, email, mobile app), see the [Self-Hosted Deployment Guide](deployment-self-hosted.md).
 
@@ -135,10 +135,10 @@ ALLOWED_ORIGINS=http://raspberrypi.local:8080
 # Generate with: openssl rand -hex 32
 INVITE_HMAC_KEY=generate-me
 
-# SMS (Twilio) — paste your values from Step 5
-TWILIO_ACCOUNT_SID=ACxxxx
-TWILIO_AUTH_TOKEN=your-auth-token
-TWILIO_FROM_NUMBER=+15551234567
+# SMS (Amazon SNS) — paste your values from Step 5
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=AKIAxxxx
+AWS_SECRET_ACCESS_KEY=your-secret-key
 EOF
 ```
 
@@ -221,9 +221,9 @@ export SUPABASE_URL="https://abcdefgh.supabase.co"
 export BASE_URL="http://raspberrypi.local:8080"
 export ALLOWED_ORIGINS="http://raspberrypi.local:8080"
 export INVITE_HMAC_KEY="$(openssl rand -hex 32)"
-export TWILIO_ACCOUNT_SID="ACxxxx"
-export TWILIO_AUTH_TOKEN="your-auth-token"
-export TWILIO_FROM_NUMBER="+15551234567"
+export AWS_REGION="us-east-1"
+export AWS_ACCESS_KEY_ID="AKIAxxxx"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
 ./bin/server
 ```
 

--- a/docs/spec/notifications.md
+++ b/docs/spec/notifications.md
@@ -106,9 +106,9 @@ Permission Slip supports four notification channels. Channels are active only wh
 
 ### SMS Notifications (Optional)
 
-**SMS notifications** deliver approval requests as text messages via Twilio. SMS delivery is gated behind paid subscription tiers when billing is enabled.
+**SMS notifications** deliver approval requests as text messages via Amazon SNS. SMS delivery is gated behind paid subscription tiers when billing is enabled.
 
-**Configuration:** Set `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER`. All three are required; partial configuration disables the channel.
+**Configuration:** Set `AWS_REGION` to enable SMS. Optionally set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for static credentials (the AWS SDK falls back to IAM roles when omitted). See `.env.example` for all variables.
 
 **Requirement Level:** Services MAY support SMS as an optional enhancement.
 

--- a/frontend/src/pages/policy/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/policy/PrivacyPolicyPage.tsx
@@ -137,7 +137,7 @@ export function PrivacyPolicyPage() {
             <td>Contact email, notification content</td>
           </tr>
           <tr>
-            <td>Twilio (optional)</td>
+            <td>Amazon SNS (optional)</td>
             <td>SMS notifications</td>
             <td>Phone number, notification content</td>
           </tr>


### PR DESCRIPTION
## Summary

- Replace dead Twilio SMS config validation in `config.go` with AWS SNS validation (region + credential checks)
- Update all deployment docs, quickstart guide, notification spec, and privacy policy to reference Amazon SNS instead of Twilio for SMS notifications
- SendGrid email references (`twilio-sendgrid`) are intentionally preserved — SendGrid is still the email provider

Part of #690

## Test plan

### Claude Code
- [x] Verify `go vet` passes on config.go
- [x] Verify frontend tests pass (PrivacyPolicyPage change)
- [x] Verify no remaining Twilio SMS references in notify/ or docs (SendGrid email refs are expected)

### Manual Testing
- [ ] Verify SMS delivery works with SNS credentials in a staging environment
- [ ] Review doc accuracy for AWS IAM setup instructions

https://claude.ai/code/session_01A52ePPn1iAR97NspkhQJbd