### PR TITLE
Remove permissions requested section from connector dialogs

### DIFF
--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -196,7 +196,6 @@ export function SetupConnectorCredentialsDialog({
               providerName={providerLabel(
                 effectiveOAuthProvider ?? connectorId,
               )}
-              scopes={oauthCredential?.oauth_scopes ?? []}
               needsShopDomain={needsShopDomain}
               shopSubdomain={shopSubdomain}
               onShopSubdomainChange={setShopSubdomain}
@@ -339,14 +338,12 @@ function NeedsReauthContent({
 
 function OAuthSetupContent({
   providerName,
-  scopes,
   needsShopDomain,
   shopSubdomain,
   onShopSubdomainChange,
   onConnect,
 }: {
   providerName: string;
-  scopes: string[];
   needsShopDomain: boolean;
   shopSubdomain: string;
   onShopSubdomainChange: (value: string) => void;
@@ -382,11 +379,6 @@ function OAuthSetupContent({
         Connect with {providerName}
       </Button>
 
-      {scopes.length > 0 && (
-        <p className="text-muted-foreground text-sm">
-          Permissions requested: {scopes.join(", ")}
-        </p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removed the "Permissions requested: ..." text from the connector setup dialog
- These scopes are already displayed on the OAuth provider's consent screen, making them redundant in our UI
- Cleaned up the unused `scopes` prop from `OAuthSetupContent`

## Test plan

### Claude Code
- [x] TypeScript compilation passes
- [x] All 953 frontend tests pass

### Manual Testing
- [ ] Open a connector setup dialog (e.g. Slack) and verify the permissions list is no longer shown
- [ ] Verify the OAuth flow still works correctly (scopes are still passed to the OAuth URL)

https://claude.ai/code/session_01E5NwQCWkmGUx7EN1VG72SH