### PR TITLE
Fix 501/FileCorruptTryRepair when writing to empty .xlsx files

### DIFF
--- a/connectors/microsoft/upload_drive_file.go
+++ b/connectors/microsoft/upload_drive_file.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -75,7 +76,16 @@ func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 	path := fmt.Sprintf("/me/drive/root:/%s:/content?@microsoft.graph.conflictBehavior=%s",
 		params.FilePath, params.ConflictBehavior)
 
-	content, err := a.conn.doPutRaw(ctx, path, req.Credentials, []byte(params.Content))
+	// When creating an .xlsx file with no content, use the minimal XLSX template
+	// so the file is a valid workbook. An empty file (0 bytes) with an .xlsx
+	// extension is not valid Office Open XML, and the Graph API will return
+	// 501/FileCorruptTryRepair when any Excel operation is attempted on it.
+	uploadContent := []byte(params.Content)
+	if params.Content == "" && strings.HasSuffix(strings.ToLower(params.FilePath), ".xlsx") {
+		uploadContent = minimalXLSX
+	}
+
+	content, err := a.conn.doPutRaw(ctx, path, req.Credentials, uploadContent)
 	if err != nil {
 		return nil, err
 	}

--- a/connectors/microsoft/upload_drive_file.go
+++ b/connectors/microsoft/upload_drive_file.go
@@ -1,6 +1,7 @@
 package microsoft
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -82,7 +83,7 @@ func (a *uploadDriveFileAction) Execute(ctx context.Context, req connectors.Acti
 	// 501/FileCorruptTryRepair when any Excel operation is attempted on it.
 	uploadContent := []byte(params.Content)
 	if params.Content == "" && strings.HasSuffix(strings.ToLower(params.FilePath), ".xlsx") {
-		uploadContent = minimalXLSX
+		uploadContent = bytes.Clone(minimalXLSX)
 	}
 
 	content, err := a.conn.doPutRaw(ctx, path, req.Credentials, uploadContent)

--- a/connectors/microsoft/upload_drive_file_test.go
+++ b/connectors/microsoft/upload_drive_file_test.go
@@ -134,20 +134,25 @@ func TestUploadDriveFile_MissingFilePath(t *testing.T) {
 	}
 }
 
-func TestUploadDriveFile_EmptyContent(t *testing.T) {
+func TestUploadDriveFile_EmptyContentXlsx(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		if len(body) != 0 {
-			t.Errorf("expected empty body, got %d bytes", len(body))
+		// Empty .xlsx uploads should use the minimal XLSX template,
+		// not 0 bytes, so the file is a valid workbook.
+		if len(body) == 0 {
+			t.Errorf("expected XLSX template body for empty .xlsx upload, got 0 bytes")
+		}
+		if len(body) != len(minimalXLSX) {
+			t.Errorf("expected body length %d (XLSX template), got %d", len(minimalXLSX), len(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]any{
 			"id":   "new-workbook-1",
 			"name": "report.xlsx",
-			"size": 0,
+			"size": len(minimalXLSX),
 		})
 	}))
 	defer srv.Close()
@@ -172,6 +177,73 @@ func TestUploadDriveFile_EmptyContent(t *testing.T) {
 	}
 	if res.ID != "new-workbook-1" {
 		t.Errorf("expected id 'new-workbook-1', got %q", res.ID)
+	}
+}
+
+func TestUploadDriveFile_EmptyContentXlsxUpperCase(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if len(body) != len(minimalXLSX) {
+			t.Errorf("expected XLSX template for .XLSX extension, got %d bytes", len(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "new-workbook-2",
+			"name": "Report.XLSX",
+			"size": len(minimalXLSX),
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"file_path": "Documents/Report.XLSX"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUploadDriveFile_EmptyContentNonXlsx(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		// Non-.xlsx files with empty content should still upload 0 bytes.
+		if len(body) != 0 {
+			t.Errorf("expected empty body for non-xlsx file, got %d bytes", len(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "new-file-1",
+			"name": "notes.txt",
+			"size": 0,
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"file_path": "Documents/notes.txt"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/connectors/microsoft/upload_drive_file_test.go
+++ b/connectors/microsoft/upload_drive_file_test.go
@@ -1,6 +1,7 @@
 package microsoft
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -141,11 +142,8 @@ func TestUploadDriveFile_EmptyContentXlsx(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		// Empty .xlsx uploads should use the minimal XLSX template,
 		// not 0 bytes, so the file is a valid workbook.
-		if len(body) == 0 {
-			t.Errorf("expected XLSX template body for empty .xlsx upload, got 0 bytes")
-		}
-		if len(body) != len(minimalXLSX) {
-			t.Errorf("expected body length %d (XLSX template), got %d", len(minimalXLSX), len(body))
+		if !bytes.Equal(body, minimalXLSX) {
+			t.Errorf("expected XLSX template body, got different bytes (len=%d)", len(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -185,8 +183,8 @@ func TestUploadDriveFile_EmptyContentXlsxUpperCase(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		if len(body) != len(minimalXLSX) {
-			t.Errorf("expected XLSX template for .XLSX extension, got %d bytes", len(body))
+		if !bytes.Equal(body, minimalXLSX) {
+			t.Errorf("expected XLSX template body, got different bytes (len=%d)", len(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -236,6 +234,43 @@ func TestUploadDriveFile_EmptyContentNonXlsx(t *testing.T) {
 	action := &uploadDriveFileAction{conn: conn}
 
 	params, _ := json.Marshal(map[string]string{"file_path": "Documents/notes.txt"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.upload_drive_file",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUploadDriveFile_NonEmptyContentXlsx(t *testing.T) {
+	t.Parallel()
+
+	wantBody := "PK\x03\x04real xlsx bytes"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != wantBody {
+			t.Errorf("expected caller content, got %d bytes", len(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "existing-workbook-1",
+			"name": "data.xlsx",
+			"size": len(wantBody),
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &uploadDriveFileAction{conn: conn}
+
+	params, _ := json.Marshal(uploadDriveFileParams{
+		FilePath: "Documents/data.xlsx",
+		Content:  wantBody,
+	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "microsoft.upload_drive_file",

--- a/connectors/microsoft/upload_drive_file_test.go
+++ b/connectors/microsoft/upload_drive_file_test.go
@@ -252,7 +252,7 @@ func TestUploadDriveFile_NonEmptyContentXlsx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		if string(body) != wantBody {
-			t.Errorf("expected caller content, got %d bytes", len(body))
+			t.Errorf("expected caller content %q, got %q", wantBody, string(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- When `upload_drive_file` creates an `.xlsx` file with empty content, the resulting 0-byte file is not valid Office Open XML
- Any subsequent `excel_write_range` call on it fails with Graph API `501/FileCorruptTryRepair: We're sorry, but something went wrong with this file`
- Fix: use the existing minimal XLSX template (from `xlsx_template.go`) when the file path ends in `.xlsx` and content is empty, so the file is always a valid workbook

Fixes [PERMISSION-SLIP-GO-7](https://supersuit-technologies.sentry.io/issues/7346100537/)

## Test plan

### Claude Code
- [x] Updated existing `TestUploadDriveFile_EmptyContent` → `TestUploadDriveFile_EmptyContentXlsx` to verify XLSX template is sent
- [x] Added `TestUploadDriveFile_EmptyContentXlsxUpperCase` for case-insensitive extension matching
- [x] Added `TestUploadDriveFile_EmptyContentNonXlsx` to verify non-xlsx files still upload 0 bytes
- [x] All existing tests pass (no regressions)
- [x] `make build` passes

### Manual Testing
- [ ] Create a spreadsheet via `upload_drive_file` with empty content and verify it opens in Excel Online
- [ ] Write to the created spreadsheet via `excel_write_range` and verify no 501 error

https://claude.ai/code/session_01MAN1pmP5p2u2rddyG3p7Rh