### PR TITLE
Show expired status for pending requests past expiration

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -349,7 +349,7 @@ func handleAgentApprovalStatus(deps *Deps) http.HandlerFunc {
 
 		resp := agentApprovalStatusResponse{
 			ApprovalID: appr.ApprovalID,
-			Status:     appr.Status,
+			Status:     resolvedApprovalStatus(*appr),
 			ExpiresAt:  appr.ExpiresAt,
 			CreatedAt:  appr.CreatedAt,
 		}

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -362,11 +362,20 @@ func parseApprovalCursor(raw string) (*db.ApprovalCursor, error) {
 	return &db.ApprovalCursor{CreatedAt: t, ApprovalID: approvalID}, nil
 }
 
+// resolvedApprovalStatus returns "expired" for pending approvals past their
+// expiration time, otherwise returns the stored status.
+func resolvedApprovalStatus(a db.Approval) string {
+	if a.Status == "pending" && !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(time.Now()) {
+		return "expired"
+	}
+	return a.Status
+}
+
 func toApprovalResponse(ctx context.Context, a db.Approval) approvalResponse {
 	resp := approvalResponse{
 		ApprovalID:  a.ApprovalID,
 		AgentID:     a.AgentID,
-		Status:      a.Status,
+		Status:      resolvedApprovalStatus(a),
 		ExpiresAt:   a.ExpiresAt,
 		ApprovedAt:  a.ApprovedAt,
 		DeniedAt:    a.DeniedAt,
@@ -409,7 +418,7 @@ func toApprovalDetailResponse(a db.Approval) approvalDetailResponse {
 	resp := approvalDetailResponse{
 		ApprovalID:      a.ApprovalID,
 		AgentID:         a.AgentID,
-		Status:          a.Status,
+		Status:          resolvedApprovalStatus(a),
 		ExecutionStatus: a.ExecutionStatus,
 		ExecutedAt:      a.ExecutedAt,
 		ExpiresAt:       a.ExpiresAt,

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -133,13 +133,21 @@ func InsertAuditEvent(ctx context.Context, db DBTX, p InsertAuditEventParams) er
 }
 
 // resolvedOutcomeExpr is a SQL CASE expression that resolves "pending" audit
-// event outcomes to "expired" when the associated agent's registration has
-// timed out. This avoids the need for a background cleanup job.
+// event outcomes to "expired" when the associated entity has timed out:
+//   - Agent registrations: checks agents.expires_at via the LEFT JOIN on agents.
+//   - Approval requests: checks approvals.expires_at via the LEFT JOIN on approvals.
+//
+// This avoids the need for a background cleanup job.
 const resolvedOutcomeExpr = `CASE
 		WHEN ae.outcome = 'pending'
 		 AND a.status = 'pending'
 		 AND a.expires_at IS NOT NULL
 		 AND a.expires_at <= now()
+		THEN 'expired'
+		WHEN ae.outcome = 'pending'
+		 AND ae.source_type = 'approval'
+		 AND appr.status = 'pending'
+		 AND appr.expires_at <= now()
 		THEN 'expired'
 		ELSE ae.outcome
 	END`
@@ -230,6 +238,7 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 		        %s AS outcome, ae.source_id, ae.source_type, ae.connector_id, ae.execution_status, ae.execution_error
 		 FROM audit_events ae
 		 LEFT JOIN agents a ON ae.agent_id = a.agent_id
+		 LEFT JOIN approvals appr ON ae.source_id = appr.approval_id AND ae.source_type = 'approval'
 		 WHERE %s
 		 ORDER BY ae.created_at DESC, ae.id DESC
 		 LIMIT %s`,
@@ -253,14 +262,22 @@ func ListAuditEvents(ctx context.Context, db DBTX, userID string, limit int, cur
 
 // outcomeFilter returns a WHERE clause fragment that correctly handles the
 // "expired" and "pending" virtual outcomes. "expired" matches rows stored as
-// "pending" whose agent registration has timed out; "pending" matches stored
-// "pending" rows whose registration is still active.
+// "pending" whose agent registration or approval request has timed out;
+// "pending" matches stored "pending" rows that are still active.
 func outcomeFilter(outcome string, b *queryBuilder) string {
 	switch outcome {
 	case "expired":
-		return `(ae.outcome = 'pending' AND a.status = 'pending' AND a.expires_at IS NOT NULL AND a.expires_at <= now())`
+		// Agent registration expired OR approval request expired.
+		return `(ae.outcome = 'pending' AND (
+			(a.status = 'pending' AND a.expires_at IS NOT NULL AND a.expires_at <= now())
+			OR (ae.source_type = 'approval' AND appr.status = 'pending' AND appr.expires_at <= now())
+		))`
 	case "pending":
-		return `(ae.outcome = 'pending' AND NOT (a.status = 'pending' AND a.expires_at IS NOT NULL AND a.expires_at <= now()))`
+		// Still active: neither agent registration nor approval has expired.
+		return `(ae.outcome = 'pending'
+			AND NOT (a.status = 'pending' AND a.expires_at IS NOT NULL AND a.expires_at <= now())
+			AND NOT (ae.source_type = 'approval' AND appr.status = 'pending' AND appr.expires_at <= now())
+		)`
 	default:
 		return "ae.outcome = " + b.addArg(outcome)
 	}
@@ -351,6 +368,7 @@ func ExportAuditLogs(ctx context.Context, db DBTX, userID string, since time.Tim
 		        %s AS outcome, ae.source_id, ae.source_type, ae.connector_id, ae.execution_status, ae.execution_error
 		 FROM audit_events ae
 		 LEFT JOIN agents a ON ae.agent_id = a.agent_id
+		 LEFT JOIN approvals appr ON ae.source_id = appr.approval_id AND ae.source_type = 'approval'
 		 WHERE %s
 		 ORDER BY ae.created_at ASC, ae.id ASC
 		 LIMIT %s`,

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -230,7 +230,8 @@ ApprovalSummary:
         - approved
         - denied
         - cancelled
-      description: Current approval status
+        - expired
+      description: Current approval status. Pending approvals past their expiration time are returned as "expired".
       example: "pending"
     expires_at:
       type: string
@@ -363,7 +364,8 @@ ApprovalStatusResponse:
         - approved
         - denied
         - cancelled
-      description: Current status of the approval request.
+        - expired
+      description: Current status of the approval request. Pending approvals past their expiration time are returned as "expired".
       example: "approved"
     approved_at:
       type: string

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7008,7 +7008,8 @@ components:
             - approved
             - denied
             - cancelled
-          description: Current approval status
+            - expired
+          description: Current approval status. Pending approvals past their expiration time are returned as "expired".
           example: pending
         expires_at:
           type: string
@@ -7160,7 +7161,8 @@ components:
             - approved
             - denied
             - cancelled
-          description: Current status of the approval request.
+            - expired
+          description: Current status of the approval request. Pending approvals past their expiration time are returned as "expired".
           example: approved
         approved_at:
           type: string


### PR DESCRIPTION
## Summary
- Pending approval requests that pass their `expires_at` deadline now display "Expired" instead of "Pending" in both the activity feed and approval API endpoints
- The fix resolves the status at query time (audit events via SQL CASE expression) and response time (approval API via `resolvedApprovalStatus` helper) without changing stored data
- Added LEFT JOIN on `approvals` table in audit event queries to check approval expiration alongside existing agent registration expiration

## Test plan

### Claude Code
- [ ] Verify backend tests pass (db and api packages)
- [ ] Verify frontend TypeScript compilation succeeds
- [ ] Verify frontend tests pass

### Manual Testing
- [ ] Create an approval request and let it expire — verify it shows "Expired" badge in the activity feed
- [ ] Filter activity by "Pending" — verify expired approvals are excluded
- [ ] Filter activity by "Expired" — verify expired approvals appear
- [ ] Check the approval detail panel for an expired approval shows "expired" status
- [ ] Verify agent polling endpoint returns "expired" for expired approvals

https://claude.ai/code/session_01SL63m4hBv7pzVev2aWirJh