### PR TITLE
Display channel names and user names in Slack approval UI

### DIFF
--- a/connectors/slack/resolve_resource_details.go
+++ b/connectors/slack/resolve_resource_details.go
@@ -1,0 +1,132 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// ResolveResourceDetails fetches human-readable metadata for resources
+// referenced by opaque IDs in Slack action parameters. For channel-based
+// actions it resolves channel IDs to names; for user-based actions it
+// resolves user IDs to display names. Errors are non-fatal — the caller
+// stores the approval without details on failure.
+func (c *SlackConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	// Channel-based actions
+	case "slack.send_message", "slack.read_channel_messages", "slack.read_thread",
+		"slack.schedule_message", "slack.set_topic", "slack.invite_to_channel",
+		"slack.upload_file", "slack.add_reaction", "slack.update_message",
+		"slack.delete_message":
+		return c.resolveChannel(ctx, creds, params)
+
+	// User-based actions
+	case "slack.send_dm":
+		return c.resolveUser(ctx, creds, params)
+
+	default:
+		return nil, nil
+	}
+}
+
+// resolveChannel calls conversations.info to fetch the channel name for a
+// channel ID parameter.
+func (c *SlackConnector) resolveChannel(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		Channel string `json:"channel"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.Channel == "" {
+		return nil, fmt.Errorf("missing channel")
+	}
+
+	// Only resolve IDs (starting with C, G, or D) — not already-resolved names.
+	if len(p.Channel) < 2 || (p.Channel[0] != 'C' && p.Channel[0] != 'G' && p.Channel[0] != 'D') {
+		return nil, nil
+	}
+
+	type channelInfo struct {
+		Name      string `json:"name"`
+		IsPrivate bool   `json:"is_private"`
+	}
+	var resp struct {
+		slackResponse
+		Channel channelInfo `json:"channel"`
+	}
+
+	body := map[string]string{"channel": p.Channel}
+	if err := c.doPost(ctx, "conversations.info", creds, body, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("conversations.info: %s", resp.Error)
+	}
+
+	name := resp.Channel.Name
+	if name == "" {
+		return nil, nil
+	}
+
+	// Prefix with # for public channels, leave private as-is.
+	if !resp.Channel.IsPrivate {
+		name = "#" + name
+	}
+
+	return map[string]any{"channel_name": name}, nil
+}
+
+// resolveUser calls users.info to fetch a display name for a user ID parameter.
+func (c *SlackConnector) resolveUser(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.UserID == "" {
+		return nil, fmt.Errorf("missing user_id")
+	}
+
+	// Only resolve IDs (starting with U or W).
+	if len(p.UserID) < 2 || (p.UserID[0] != 'U' && p.UserID[0] != 'W') {
+		return nil, nil
+	}
+
+	type userProfile struct {
+		DisplayName string `json:"display_name"`
+		RealName    string `json:"real_name"`
+	}
+	type userInfo struct {
+		RealName string      `json:"real_name"`
+		Name     string      `json:"name"`
+		Profile  userProfile `json:"profile"`
+	}
+	var resp struct {
+		slackResponse
+		User userInfo `json:"user"`
+	}
+
+	body := map[string]string{"user": p.UserID}
+	if err := c.doPost(ctx, "users.info", creds, body, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("users.info: %s", resp.Error)
+	}
+
+	// Prefer display_name > real_name (profile) > real_name (top-level) > username.
+	displayName := strings.TrimSpace(resp.User.Profile.DisplayName)
+	if displayName == "" {
+		displayName = strings.TrimSpace(resp.User.Profile.RealName)
+	}
+	if displayName == "" {
+		displayName = strings.TrimSpace(resp.User.RealName)
+	}
+	if displayName == "" {
+		displayName = resp.User.Name
+	}
+	if displayName == "" {
+		return nil, nil
+	}
+
+	return map[string]any{"user_name": displayName}, nil
+}

--- a/connectors/slack/resolve_resource_details_test.go
+++ b/connectors/slack/resolve_resource_details_test.go
@@ -1,0 +1,156 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testSlackResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *SlackConnector) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	conn := newForTest(srv.Client(), srv.URL)
+	return srv, conn
+}
+
+func TestResolveResourceDetails_Channel(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testSlackResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/conversations.info" {
+			t.Errorf("expected /conversations.info, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channel": map[string]any{
+				"name":       "general",
+				"is_private": false,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	channelActions := []string{
+		"slack.send_message", "slack.read_channel_messages", "slack.read_thread",
+		"slack.schedule_message", "slack.set_topic", "slack.invite_to_channel",
+		"slack.upload_file", "slack.add_reaction", "slack.update_message",
+		"slack.delete_message",
+	}
+
+	params, _ := json.Marshal(map[string]string{"channel": "C0AMRGKRTA4"})
+
+	for _, actionType := range channelActions {
+		details, err := conn.ResolveResourceDetails(context.Background(), actionType, params, validCreds())
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", actionType, err)
+		}
+		if details["channel_name"] != "#general" {
+			t.Errorf("%s: expected channel_name '#general', got %v", actionType, details["channel_name"])
+		}
+	}
+}
+
+func TestResolveResourceDetails_PrivateChannel(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testSlackResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channel": map[string]any{
+				"name":       "secret-plans",
+				"is_private": true,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"channel": "G0AMRGKRTA4"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_message", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Private channels should not get # prefix.
+	if details["channel_name"] != "secret-plans" {
+		t.Errorf("expected channel_name 'secret-plans', got %v", details["channel_name"])
+	}
+}
+
+func TestResolveResourceDetails_User(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testSlackResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users.info" {
+			t.Errorf("expected /users.info, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"user": map[string]any{
+				"name":      "jsmith",
+				"real_name": "John Smith",
+				"profile": map[string]any{
+					"display_name": "Johnny",
+					"real_name":    "John Smith",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"user_id": "U12345678"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_dm", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should prefer display_name.
+	if details["user_name"] != "Johnny" {
+		t.Errorf("expected user_name 'Johnny', got %v", details["user_name"])
+	}
+}
+
+func TestResolveResourceDetails_UserFallbackToRealName(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testSlackResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"user": map[string]any{
+				"name":      "jsmith",
+				"real_name": "John Smith",
+				"profile": map[string]any{
+					"display_name": "",
+					"real_name":    "John Smith",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"user_id": "U12345678"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_dm", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["user_name"] != "John Smith" {
+		t.Errorf("expected user_name 'John Smith', got %v", details["user_name"])
+	}
+}
+
+func TestResolveResourceDetails_UnknownAction(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	params, _ := json.Marshal(map[string]string{"foo": "bar"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.unknown_action", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != nil {
+		t.Errorf("expected nil details for unknown action, got %v", details)
+	}
+}

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -200,11 +200,20 @@ const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
     return parts;
   },
 
-  "slack.send_message": (params) => {
-    const channel = strVal(params.channel);
+  "slack.send_message": (params, rd) => {
+    const channel = strVal(rd?.channel_name) ?? strVal(params.channel);
     if (!channel) return null;
     const message = strVal(params.message);
     const parts: SummaryPart[] = [text("Send message to "), val(channel)];
+    if (message) parts.push(text(` \u2014 ${truncate(message, 80)}`));
+    return parts;
+  },
+
+  "slack.send_dm": (params, rd) => {
+    const user = strVal(rd?.user_name) ?? strVal(params.user_id);
+    if (!user) return null;
+    const message = strVal(params.message);
+    const parts: SummaryPart[] = [text("Send DM to "), val(user)];
     if (message) parts.push(text(` \u2014 ${truncate(message, 80)}`));
     return parts;
   },

--- a/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
+++ b/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
@@ -132,6 +132,56 @@ describe("buildSummary", () => {
     });
   });
 
+  describe("slack.send_message with resourceDetails", () => {
+    it("uses channel_name from resourceDetails", () => {
+      const result = buildSummary(
+        "slack.send_message",
+        { channel: "C0AMRGKRTA4", message: "Hello!" },
+        null,
+        "Send Message",
+        undefined,
+        { channel_name: "#general" },
+      );
+      expect(result).toContain(q("#general"));
+      expect(result).not.toContain("C0AMRGKRTA4");
+    });
+
+    it("falls back to raw channel when no resourceDetails", () => {
+      const result = buildSummary(
+        "slack.send_message",
+        { channel: "C0AMRGKRTA4", message: "Hello!" },
+        null,
+        "Send Message",
+      );
+      expect(result).toContain(q("C0AMRGKRTA4"));
+    });
+  });
+
+  describe("slack.send_dm", () => {
+    it("uses user_name from resourceDetails", () => {
+      const result = buildSummary(
+        "slack.send_dm",
+        { user_id: "U12345678", message: "Hey!" },
+        null,
+        "Send DM",
+        undefined,
+        { user_name: "Johnny" },
+      );
+      expect(result).toContain(q("Johnny"));
+      expect(result).not.toContain("U12345678");
+    });
+
+    it("falls back to raw user_id when no resourceDetails", () => {
+      const result = buildSummary(
+        "slack.send_dm",
+        { user_id: "U12345678", message: "Hey!" },
+        null,
+        "Send DM",
+      );
+      expect(result).toContain(q("U12345678"));
+    });
+  });
+
   describe("slack.create_channel", () => {
     it("renders public channel", () => {
       expect(

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -77,7 +77,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const expired = checkExpired(approval.status, approval.expires_at);
   const canAct = isPending && !expired;
 
-  const summary = buildActionSummary(approval.action.type, parameters);
+  const summary = buildActionSummary(approval.action.type, parameters, undefined, approval.resource_details as Record<string, unknown> | undefined);
   const actionName = humanizeActionType(approval.action.type);
 
   // Derive display status for the hero header

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -213,6 +213,8 @@ const ApprovalRow = memo(function ApprovalRow({
   const summary = buildActionSummary(
     approval.action.type,
     safeParams(approval.action.parameters),
+    undefined,
+    approval.resource_details as Record<string, unknown> | undefined,
   );
   const expired = checkExpired(approval.status, approval.expires_at);
 

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -89,6 +89,36 @@ describe("buildActionSummary", () => {
     expect(result).toContain("#general");
   });
 
+  it("uses channel_name from resourceDetails for slack.send_message", () => {
+    const result = buildActionSummary(
+      "slack.send_message",
+      { channel: "C0AMRGKRTA4", message: "Hello team" },
+      undefined,
+      { channel_name: "#general" },
+    );
+    expect(result).toContain("#general");
+    expect(result).not.toContain("C0AMRGKRTA4");
+  });
+
+  it("uses user_name from resourceDetails for slack.send_dm", () => {
+    const result = buildActionSummary(
+      "slack.send_dm",
+      { user_id: "U12345678", message: "Hey!" },
+      undefined,
+      { user_name: "Johnny" },
+    );
+    expect(result).toContain("Johnny");
+    expect(result).not.toContain("U12345678");
+  });
+
+  it("falls back to raw ID when resourceDetails missing", () => {
+    const result = buildActionSummary(
+      "slack.send_dm",
+      { user_id: "U12345678", message: "Hey!" },
+    );
+    expect(result).toContain("U12345678");
+  });
+
   it("falls back to generic summary for unknown types", () => {
     const result = buildActionSummary("custom.do_thing", {
       target: "prod",

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -71,6 +71,7 @@ export function buildActionSummary(
   actionType: string,
   parameters: Record<string, unknown>,
   displayTemplate?: string | null,
+  resourceDetails?: Record<string, unknown> | null,
 ): string {
   // 1. Try display template from manifest.
   if (displayTemplate) {
@@ -81,7 +82,7 @@ export function buildActionSummary(
   // 2. Try action-specific formatter.
   const formatter = ACTION_FORMATTERS[actionType];
   if (formatter) {
-    const result = formatter(parameters);
+    const result = formatter(parameters, resourceDetails ?? undefined);
     if (result) return result;
   }
 
@@ -89,7 +90,7 @@ export function buildActionSummary(
   return buildGenericSummary(actionType, parameters);
 }
 
-type ActionFormatter = (params: Record<string, unknown>) => string | null;
+type ActionFormatter = (params: Record<string, unknown>, resourceDetails?: Record<string, unknown>) => string | null;
 
 /** Pattern matching {{param}} and {{param:directive}} placeholders. */
 const TEMPLATE_RE = /\{\{(\w+)(?::(\w+))?\}\}/g;
@@ -205,11 +206,20 @@ const ACTION_FORMATTERS: Record<string, ActionFormatter> = {
     return result;
   },
 
-  "slack.send_message": (params) => {
-    const channel = strVal(params.channel);
+  "slack.send_message": (params, rd) => {
+    const channel = strVal(rd?.channel_name) ?? strVal(params.channel);
     if (!channel) return null;
     const message = strVal(params.message);
     let result = `Send message to ${channel}`;
+    if (message) result += ` \u2014 ${truncate(message, 60)}`;
+    return result;
+  },
+
+  "slack.send_dm": (params, rd) => {
+    const user = strVal(rd?.user_name) ?? strVal(params.user_id);
+    if (!user) return null;
+    const message = strVal(params.message);
+    let result = `Send DM to ${user}`;
     if (message) result += ` \u2014 ${truncate(message, 60)}`;
     return result;
   },


### PR DESCRIPTION
## Summary

- Add `ResolveResourceDetails` to the Slack connector to resolve channel IDs → names (via `conversations.info`) and user IDs → display names (via `users.info`) at approval creation time
- Update web and mobile Slack formatters (`send_message`, `send_dm`) to use resolved names from `resourceDetails`, falling back to raw IDs when resolution isn't available
- Add comprehensive tests for the backend resolver (channel, private channel, user, fallback) and frontend/mobile formatters

> **Task:** Display human-readable channel names (e.g. `#general`) and user names (e.g. `Johnny`) instead of raw Slack IDs (e.g. `C0AMRGKRTA4`, `U12345678`) in the approval UI, following the existing `ResourceDetailResolver` pattern used by the Google connector.

## Test plan

### Claude Code
- [x] Backend resolver tests pass (5 tests: channel, private channel, user, user fallback, unknown action)
- [x] Frontend ActionPreviewSummary tests pass (37 tests including 4 new)
- [x] Mobile approvalUtils tests pass (44 tests including 3 new)
- [x] Full backend test suite passes

### Manual Testing
- [ ] Create a Slack `send_message` approval with a channel ID and verify the channel name appears in the approval dialog
- [ ] Create a Slack `send_dm` approval with a user ID and verify the user's display name appears
- [ ] Verify fallback behavior when Slack API is unreachable (should show raw ID)

https://claude.ai/code/session_01GzfC5CXo6WTTK7ZcrSm4LM