### PR TITLE
Add Slack Events API subscription infrastructure (Phase 2)

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -39,6 +39,8 @@ type Deps struct {
 	AllowedOrigins        []string             // allowed CORS origins; empty means cross-origin requests are blocked
 	Logger                *slog.Logger         // structured logger for request logging; if nil, request logging is skipped
 	ApprovalEvents        *ApprovalEventBroker // SSE broker for real-time approval notifications; nil disables SSE
+	SlackSigningSecret    string               // Slack signing secret for verifying Events API webhook signatures; empty disables Slack events
+	EventBroker           *connectors.EventBroker // connector event dispatch; nil means inbound events are accepted but not processed
 }
 
 // NewRouter returns an http.Handler that serves all /api/v1/ routes.

--- a/api/slack_events.go
+++ b/api/slack_events.go
@@ -35,10 +35,20 @@ func handleSlackEvent(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		body, err := io.ReadAll(io.LimitReader(r.Body, maxSlackEventBodyBytes))
+		// Read body with a limit slightly above maxSlackEventBodyBytes to
+		// detect oversized payloads. If the body exceeds the limit, return
+		// 413 instead of letting a truncated body fail signature verification
+		// with a confusing 401.
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxSlackEventBodyBytes+1))
 		if err != nil {
 			logError(deps.Logger, r, "SlackEvents: error reading body", "error", err)
 			http.Error(w, "error reading body", http.StatusBadRequest)
+			return
+		}
+		if len(body) > maxSlackEventBodyBytes {
+			logWarn(deps.Logger, r, "SlackEvents: request body too large",
+				"size", len(body), "max", maxSlackEventBodyBytes)
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
 
@@ -71,7 +81,9 @@ func handleSlackEvent(deps *Deps) http.HandlerFunc {
 		// Handle URL verification challenge.
 		if envelope.Challenge != "" {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{"challenge": envelope.Challenge})
+			if err := json.NewEncoder(w).Encode(map[string]string{"challenge": envelope.Challenge}); err != nil {
+				logError(deps.Logger, r, "SlackEvents: failed to write challenge response", "error", err)
+			}
 			return
 		}
 

--- a/api/slack_events.go
+++ b/api/slack_events.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -30,14 +30,14 @@ func handleSlackEvent(deps *Deps) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if deps.SlackSigningSecret == "" {
-			log.Printf("[%s] SlackEvents: signing secret not configured", TraceID(r.Context()))
+			logWarn(deps.Logger, r, "SlackEvents: signing secret not configured")
 			http.Error(w, "slack events not configured", http.StatusServiceUnavailable)
 			return
 		}
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, maxSlackEventBodyBytes))
 		if err != nil {
-			log.Printf("[%s] SlackEvents: error reading body: %v", TraceID(r.Context()), err)
+			logError(deps.Logger, r, "SlackEvents: error reading body", "error", err)
 			http.Error(w, "error reading body", http.StatusBadRequest)
 			return
 		}
@@ -49,21 +49,21 @@ func handleSlackEvent(deps *Deps) http.HandlerFunc {
 		}
 		conn, ok := deps.Connectors.Get("slack")
 		if !ok {
-			log.Printf("[%s] SlackEvents: slack connector not registered", TraceID(r.Context()))
+			logWarn(deps.Logger, r, "SlackEvents: slack connector not registered")
 			http.Error(w, "slack connector not available", http.StatusServiceUnavailable)
 			return
 		}
 
 		eventSource, ok := conn.(connectors.EventSource)
 		if !ok {
-			log.Printf("[%s] SlackEvents: slack connector does not implement EventSource", TraceID(r.Context()))
+			logWarn(deps.Logger, r, "SlackEvents: slack connector does not implement EventSource")
 			http.Error(w, "slack connector does not support events", http.StatusServiceUnavailable)
 			return
 		}
 
 		envelope, err := eventSource.VerifyAndParseEvent(body, r.Header, deps.SlackSigningSecret)
 		if err != nil {
-			log.Printf("[%s] SlackEvents: verification failed: %v", TraceID(r.Context()), err)
+			logWarn(deps.Logger, r, "SlackEvents: verification failed", "error", err)
 			http.Error(w, "verification failed", http.StatusUnauthorized)
 			return
 		}
@@ -81,12 +81,13 @@ func handleSlackEvent(deps *Deps) http.HandlerFunc {
 		}
 
 		event := envelope.Event
-		log.Printf("[%s] SlackEvents: received event %s type=%s team=%s",
-			TraceID(r.Context()), event.EventID, event.EventType, event.TeamID)
+		logInfo(deps.Logger, r, "SlackEvents: received event",
+			"event_id", event.EventID, "event_type", event.EventType, "team_id", event.TeamID)
 
-		// Deduplication: skip events we've already processed.
-		if dedup.isDuplicate(event.EventID) {
-			log.Printf("[%s] SlackEvents: event %s already processed, skipping", TraceID(r.Context()), event.EventID)
+		// Deduplication: skip events we've already successfully processed.
+		if dedup.isSeen(event.EventID) {
+			logInfo(deps.Logger, r, "SlackEvents: event already processed, skipping",
+				"event_id", event.EventID)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -94,19 +95,50 @@ func handleSlackEvent(deps *Deps) http.HandlerFunc {
 		// Dispatch to registered event handlers.
 		if deps.EventBroker != nil {
 			if err := deps.EventBroker.Dispatch(r.Context(), event); err != nil {
-				log.Printf("[%s] SlackEvents: handler error for event %s: %v", TraceID(r.Context()), event.EventID, err)
+				logError(deps.Logger, r, "SlackEvents: handler error",
+					"event_id", event.EventID, "error", err)
 				CaptureError(r.Context(), err)
+				// Do NOT mark as seen — return 500 so Slack retries.
 				http.Error(w, "processing failed", http.StatusInternalServerError)
 				return
 			}
 		}
 
+		// Only mark as seen after successful dispatch, so Slack retries
+		// are processed if the handler failed on the first attempt.
+		dedup.markSeen(event.EventID)
 		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// logInfo logs at info level using deps.Logger if available.
+func logInfo(logger *slog.Logger, r *http.Request, msg string, args ...any) {
+	if logger != nil {
+		logger.InfoContext(r.Context(), msg, append([]any{"trace_id", TraceID(r.Context())}, args...)...)
+	}
+}
+
+// logWarn logs at warn level using deps.Logger if available.
+func logWarn(logger *slog.Logger, r *http.Request, msg string, args ...any) {
+	if logger != nil {
+		logger.WarnContext(r.Context(), msg, append([]any{"trace_id", TraceID(r.Context())}, args...)...)
+	}
+}
+
+// logError logs at error level using deps.Logger if available.
+func logError(logger *slog.Logger, r *http.Request, msg string, args ...any) {
+	if logger != nil {
+		logger.ErrorContext(r.Context(), msg, append([]any{"trace_id", TraceID(r.Context())}, args...)...)
 	}
 }
 
 // eventDeduplicator tracks recently processed event IDs to prevent
 // duplicate processing when Slack retries delivery.
+//
+// TODO: This is a per-process in-memory store. For multi-instance deployments,
+// replace with a shared store (Redis SET NX EX or DB INSERT ON CONFLICT) to
+// prevent duplicate processing across pods. For single-instance Phase 2
+// deployments, the in-memory approach is sufficient.
 type eventDeduplicator struct {
 	mu   sync.Mutex
 	seen map[string]time.Time
@@ -120,9 +152,9 @@ func newEventDeduplicator(ttl time.Duration) *eventDeduplicator {
 	}
 }
 
-// isDuplicate returns true if the event ID has been seen within the TTL window.
-// If not a duplicate, it records the event ID.
-func (d *eventDeduplicator) isDuplicate(eventID string) bool {
+// isSeen returns true if the event ID has been seen within the TTL window.
+// It does NOT record the event — call markSeen after successful processing.
+func (d *eventDeduplicator) isSeen(eventID string) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -135,9 +167,14 @@ func (d *eventDeduplicator) isDuplicate(eventID string) bool {
 		}
 	}
 
-	if _, ok := d.seen[eventID]; ok {
-		return true
-	}
-	d.seen[eventID] = now
-	return false
+	_, ok := d.seen[eventID]
+	return ok
+}
+
+// markSeen records an event ID as successfully processed. Call this only
+// after dispatch succeeds, so failed events can be retried by Slack.
+func (d *eventDeduplicator) markSeen(eventID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.seen[eventID] = time.Now()
 }

--- a/api/slack_events.go
+++ b/api/slack_events.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// maxSlackEventBodyBytes limits the event request body to 64 KB.
+const maxSlackEventBodyBytes = 65536
+
+// eventDeduplicationTTL is how long event IDs are remembered for dedup.
+// Slack retries events for up to 60 minutes, so 1 hour provides full coverage.
+const eventDeduplicationTTL = 1 * time.Hour
+
+// RegisterSlackEventRoutes adds the Slack Events API webhook endpoint to the mux.
+// Like the Stripe webhook, this lives outside /api/v1/ to bypass auth middleware.
+// Slack authenticates requests via HMAC-SHA256 signature verification.
+func RegisterSlackEventRoutes(mux *http.ServeMux, deps *Deps) {
+	mux.Handle("POST /api/webhooks/slack/events", handleSlackEvent(deps))
+}
+
+func handleSlackEvent(deps *Deps) http.HandlerFunc {
+	dedup := newEventDeduplicator(eventDeduplicationTTL)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if deps.SlackSigningSecret == "" {
+			log.Printf("[%s] SlackEvents: signing secret not configured", TraceID(r.Context()))
+			http.Error(w, "slack events not configured", http.StatusServiceUnavailable)
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxSlackEventBodyBytes))
+		if err != nil {
+			log.Printf("[%s] SlackEvents: error reading body: %v", TraceID(r.Context()), err)
+			http.Error(w, "error reading body", http.StatusBadRequest)
+			return
+		}
+
+		// Look up the Slack connector as an EventSource.
+		if deps.Connectors == nil {
+			http.Error(w, "connectors not available", http.StatusServiceUnavailable)
+			return
+		}
+		conn, ok := deps.Connectors.Get("slack")
+		if !ok {
+			log.Printf("[%s] SlackEvents: slack connector not registered", TraceID(r.Context()))
+			http.Error(w, "slack connector not available", http.StatusServiceUnavailable)
+			return
+		}
+
+		eventSource, ok := conn.(connectors.EventSource)
+		if !ok {
+			log.Printf("[%s] SlackEvents: slack connector does not implement EventSource", TraceID(r.Context()))
+			http.Error(w, "slack connector does not support events", http.StatusServiceUnavailable)
+			return
+		}
+
+		envelope, err := eventSource.VerifyAndParseEvent(body, r.Header, deps.SlackSigningSecret)
+		if err != nil {
+			log.Printf("[%s] SlackEvents: verification failed: %v", TraceID(r.Context()), err)
+			http.Error(w, "verification failed", http.StatusUnauthorized)
+			return
+		}
+
+		// Handle URL verification challenge.
+		if envelope.Challenge != "" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"challenge": envelope.Challenge})
+			return
+		}
+
+		if envelope.Event == nil {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		event := envelope.Event
+		log.Printf("[%s] SlackEvents: received event %s type=%s team=%s",
+			TraceID(r.Context()), event.EventID, event.EventType, event.TeamID)
+
+		// Deduplication: skip events we've already processed.
+		if dedup.isDuplicate(event.EventID) {
+			log.Printf("[%s] SlackEvents: event %s already processed, skipping", TraceID(r.Context()), event.EventID)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Dispatch to registered event handlers.
+		if deps.EventBroker != nil {
+			if err := deps.EventBroker.Dispatch(r.Context(), event); err != nil {
+				log.Printf("[%s] SlackEvents: handler error for event %s: %v", TraceID(r.Context()), event.EventID, err)
+				CaptureError(r.Context(), err)
+				http.Error(w, "processing failed", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// eventDeduplicator tracks recently processed event IDs to prevent
+// duplicate processing when Slack retries delivery.
+type eventDeduplicator struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+	ttl  time.Duration
+}
+
+func newEventDeduplicator(ttl time.Duration) *eventDeduplicator {
+	return &eventDeduplicator{
+		seen: make(map[string]time.Time),
+		ttl:  ttl,
+	}
+}
+
+// isDuplicate returns true if the event ID has been seen within the TTL window.
+// If not a duplicate, it records the event ID.
+func (d *eventDeduplicator) isDuplicate(eventID string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+
+	// Lazy cleanup: remove expired entries.
+	for id, ts := range d.seen {
+		if now.Sub(ts) > d.ttl {
+			delete(d.seen, id)
+		}
+	}
+
+	if _, ok := d.seen[eventID]; ok {
+		return true
+	}
+	d.seen[eventID] = now
+	return false
+}

--- a/api/slack_events_test.go
+++ b/api/slack_events_test.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	_ "github.com/supersuit-tech/permission-slip-web/connectors/all"
+)
+
+const testSlackSecret = "test-signing-secret-abc123"
+
+// slackSign creates valid Slack signature headers for a test payload.
+func slackSign(t *testing.T, payload string, secret string) (string, string) {
+	t.Helper()
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	sigBase := fmt.Sprintf("v0:%s:%s", ts, payload)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(sigBase))
+	sig := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return ts, sig
+}
+
+func newSlackEventDeps() *Deps {
+	registry := connectors.NewRegistry()
+	for _, c := range connectors.BuiltInConnectors() {
+		registry.Register(c)
+	}
+	return &Deps{
+		SlackSigningSecret: testSlackSecret,
+		Connectors:         registry,
+		EventBroker:        connectors.NewEventBroker(),
+	}
+}
+
+func TestSlackEvents_URLVerification(t *testing.T) {
+	deps := newSlackEventDeps()
+	handler := handleSlackEvent(deps)
+
+	payload := `{"type":"url_verification","challenge":"test-challenge-xyz","token":"deprecated"}`
+	ts, sig := slackSign(t, payload, testSlackSecret)
+
+	req := httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader(payload))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["challenge"] != "test-challenge-xyz" {
+		t.Errorf("expected challenge %q, got %q", "test-challenge-xyz", resp["challenge"])
+	}
+}
+
+func TestSlackEvents_ValidEvent(t *testing.T) {
+	deps := newSlackEventDeps()
+
+	var dispatched *connectors.Event
+	deps.EventBroker.Subscribe("message.im", connectors.EventHandlerFunc(func(_ context.Context, event *connectors.Event) error {
+		dispatched = event
+		return nil
+	}))
+
+	handler := handleSlackEvent(deps)
+
+	payload := `{
+		"type": "event_callback",
+		"team_id": "T01234",
+		"event": {
+			"type": "message",
+			"channel_type": "im",
+			"channel": "D01234",
+			"user": "U01234",
+			"text": "hello",
+			"ts": "1710000000.123456"
+		},
+		"event_id": "Ev01234",
+		"event_time": 1710000000
+	}`
+	ts, sig := slackSign(t, payload, testSlackSecret)
+
+	req := httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader(payload))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if dispatched == nil {
+		t.Fatal("expected event to be dispatched")
+	}
+	if dispatched.EventType != "message.im" {
+		t.Errorf("expected event type %q, got %q", "message.im", dispatched.EventType)
+	}
+}
+
+func TestSlackEvents_InvalidSignature(t *testing.T) {
+	deps := newSlackEventDeps()
+	handler := handleSlackEvent(deps)
+
+	payload := `{"type":"event_callback","event":{}}`
+	req := httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader(payload))
+	req.Header.Set("X-Slack-Request-Timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	req.Header.Set("X-Slack-Signature", "v0=invalid")
+
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSlackEvents_MissingSigningSecret(t *testing.T) {
+	deps := newSlackEventDeps()
+	deps.SlackSigningSecret = ""
+	handler := handleSlackEvent(deps)
+
+	req := httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader("{}"))
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSlackEvents_Deduplication(t *testing.T) {
+	deps := newSlackEventDeps()
+	dispatchCount := 0
+	deps.EventBroker.Subscribe("message.im", connectors.EventHandlerFunc(func(_ context.Context, _ *connectors.Event) error {
+		dispatchCount++
+		return nil
+	}))
+
+	handler := handleSlackEvent(deps)
+
+	payload := `{
+		"type": "event_callback",
+		"team_id": "T01234",
+		"event": {
+			"type": "message",
+			"channel_type": "im",
+			"channel": "D01234",
+			"user": "U01234",
+			"text": "hello",
+			"ts": "1710000000.123456"
+		},
+		"event_id": "Ev_dedup_test",
+		"event_time": 1710000000
+	}`
+
+	// Send the same event twice.
+	for i := 0; i < 2; i++ {
+		ts, sig := slackSign(t, payload, testSlackSecret)
+		req := httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader(payload))
+		req.Header.Set("X-Slack-Request-Timestamp", ts)
+		req.Header.Set("X-Slack-Signature", sig)
+
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i, rr.Code)
+		}
+	}
+
+	if dispatchCount != 1 {
+		t.Errorf("expected event to be dispatched once, got %d", dispatchCount)
+	}
+}
+
+func TestEventDeduplicator_TTLExpiry(t *testing.T) {
+	dedup := newEventDeduplicator(10 * time.Millisecond)
+
+	if dedup.isDuplicate("ev1") {
+		t.Fatal("first occurrence should not be duplicate")
+	}
+	if !dedup.isDuplicate("ev1") {
+		t.Fatal("second occurrence should be duplicate")
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	if dedup.isDuplicate("ev1") {
+		t.Fatal("after TTL expiry, should not be duplicate")
+	}
+}

--- a/api/slack_events_test.go
+++ b/api/slack_events_test.go
@@ -6,9 +6,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -40,6 +43,7 @@ func newSlackEventDeps() *Deps {
 		SlackSigningSecret: testSlackSecret,
 		Connectors:         registry,
 		EventBroker:        connectors.NewEventBroker(),
+		Logger:             slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 }
 
@@ -192,20 +196,82 @@ func TestSlackEvents_Deduplication(t *testing.T) {
 	}
 }
 
+func TestSlackEvents_RetryAfterHandlerFailure(t *testing.T) {
+	deps := newSlackEventDeps()
+	callCount := 0
+	deps.EventBroker.Subscribe("message.im", connectors.EventHandlerFunc(func(_ context.Context, _ *connectors.Event) error {
+		callCount++
+		if callCount == 1 {
+			return errors.New("transient failure")
+		}
+		return nil
+	}))
+
+	handler := handleSlackEvent(deps)
+
+	payload := `{
+		"type": "event_callback",
+		"team_id": "T01234",
+		"event": {
+			"type": "message",
+			"channel_type": "im",
+			"channel": "D01234",
+			"user": "U01234",
+			"text": "hello",
+			"ts": "1710000000.123456"
+		},
+		"event_id": "Ev_retry_test",
+		"event_time": 1710000000
+	}`
+
+	// First attempt: handler fails, should return 500.
+	ts, sig := slackSign(t, payload, testSlackSecret)
+	req := httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader(payload))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("first attempt: expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Second attempt (Slack retry): handler succeeds, should return 200.
+	ts, sig = slackSign(t, payload, testSlackSecret)
+	req = httptest.NewRequest("POST", "/api/webhooks/slack/events", strings.NewReader(payload))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+
+	rr = httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("retry attempt: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected handler to be called twice (fail + retry), got %d", callCount)
+	}
+}
+
 func TestEventDeduplicator_TTLExpiry(t *testing.T) {
 	dedup := newEventDeduplicator(10 * time.Millisecond)
 
-	if dedup.isDuplicate("ev1") {
-		t.Fatal("first occurrence should not be duplicate")
+	if dedup.isSeen("ev1") {
+		t.Fatal("unseen event should not be seen")
 	}
-	if !dedup.isDuplicate("ev1") {
-		t.Fatal("second occurrence should be duplicate")
+
+	dedup.markSeen("ev1")
+
+	if !dedup.isSeen("ev1") {
+		t.Fatal("marked event should be seen")
 	}
 
 	// Wait for TTL to expire.
 	time.Sleep(20 * time.Millisecond)
 
-	if dedup.isDuplicate("ev1") {
-		t.Fatal("after TTL expiry, should not be duplicate")
+	if dedup.isSeen("ev1") {
+		t.Fatal("after TTL expiry, should not be seen")
 	}
 }

--- a/connectors/events.go
+++ b/connectors/events.go
@@ -1,0 +1,91 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Event represents an inbound event from an external service.
+type Event struct {
+	ConnectorID string          `json:"connector_id"` // e.g., "slack"
+	EventType   string          `json:"event_type"`   // e.g., "message.im"
+	EventID     string          `json:"event_id"`     // service-specific ID for deduplication
+	TeamID      string          `json:"team_id"`      // workspace/org identifier
+	Timestamp   time.Time       `json:"timestamp"`
+	Payload     json.RawMessage `json:"payload"` // event-type-specific data
+}
+
+// EventEnvelope wraps either a verification challenge response or a parsed event.
+// Some services (e.g., Slack) require responding to a challenge during initial
+// webhook URL registration. When Challenge is non-empty, the HTTP handler should
+// respond with it directly instead of processing an event.
+type EventEnvelope struct {
+	Challenge string // non-empty for url_verification challenges
+	Event     *Event // non-nil for normal events
+}
+
+// EventSource is optionally implemented by connectors that can receive
+// inbound events from external services (e.g., Slack Events API, GitHub
+// webhooks). The API layer checks for this interface when routing incoming
+// webhook requests to the appropriate connector.
+type EventSource interface {
+	// VerifyAndParseEvent validates the authenticity of an incoming webhook
+	// payload (e.g., HMAC signature verification) and parses it into an Event.
+	//
+	// The signingSecret is the connector-specific secret used for verification
+	// (e.g., Slack signing secret, GitHub webhook secret).
+	//
+	// If the payload is a verification challenge, the returned EventEnvelope
+	// has a non-empty Challenge field and nil Event.
+	VerifyAndParseEvent(payload []byte, headers http.Header, signingSecret string) (*EventEnvelope, error)
+}
+
+// EventHandler processes inbound events from external services.
+type EventHandler interface {
+	HandleEvent(ctx context.Context, event *Event) error
+}
+
+// EventHandlerFunc adapts a plain function to the EventHandler interface.
+type EventHandlerFunc func(ctx context.Context, event *Event) error
+
+func (f EventHandlerFunc) HandleEvent(ctx context.Context, event *Event) error {
+	return f(ctx, event)
+}
+
+// EventBroker manages event handler registration and dispatch.
+// Handlers are registered by event type and called sequentially when
+// an event of that type is dispatched.
+type EventBroker struct {
+	mu       sync.RWMutex
+	handlers map[string][]EventHandler
+}
+
+// NewEventBroker creates an empty event broker.
+func NewEventBroker() *EventBroker {
+	return &EventBroker{handlers: make(map[string][]EventHandler)}
+}
+
+// Subscribe registers a handler for the given event type.
+func (b *EventBroker) Subscribe(eventType string, handler EventHandler) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers[eventType] = append(b.handlers[eventType], handler)
+}
+
+// Dispatch sends an event to all handlers registered for its event type.
+// Handlers are called sequentially. Returns the first error encountered.
+func (b *EventBroker) Dispatch(ctx context.Context, event *Event) error {
+	b.mu.RLock()
+	handlers := b.handlers[event.EventType]
+	b.mu.RUnlock()
+
+	for _, h := range handlers {
+		if err := h.HandleEvent(ctx, event); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/connectors/events_test.go
+++ b/connectors/events_test.go
@@ -1,0 +1,91 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEventBroker_Dispatch(t *testing.T) {
+	broker := NewEventBroker()
+
+	var received *Event
+	broker.Subscribe("message.im", EventHandlerFunc(func(_ context.Context, event *Event) error {
+		received = event
+		return nil
+	}))
+
+	event := &Event{
+		ConnectorID: "slack",
+		EventType:   "message.im",
+		EventID:     "Ev01234",
+		TeamID:      "T01234",
+		Timestamp:   time.Now(),
+		Payload:     json.RawMessage(`{"user":"U01234"}`),
+	}
+
+	if err := broker.Dispatch(context.Background(), event); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if received == nil {
+		t.Fatal("expected handler to be called")
+	}
+	if received.EventID != "Ev01234" {
+		t.Errorf("expected event_id %q, got %q", "Ev01234", received.EventID)
+	}
+}
+
+func TestEventBroker_NoHandlers(t *testing.T) {
+	broker := NewEventBroker()
+
+	event := &Event{
+		EventType: "unregistered.type",
+	}
+
+	// Should not error when no handlers are registered.
+	if err := broker.Dispatch(context.Background(), event); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEventBroker_HandlerError(t *testing.T) {
+	broker := NewEventBroker()
+
+	handlerErr := errors.New("handler failed")
+	broker.Subscribe("test.event", EventHandlerFunc(func(_ context.Context, _ *Event) error {
+		return handlerErr
+	}))
+
+	event := &Event{EventType: "test.event"}
+
+	err := broker.Dispatch(context.Background(), event)
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("expected handler error, got: %v", err)
+	}
+}
+
+func TestEventBroker_MultipleHandlers(t *testing.T) {
+	broker := NewEventBroker()
+
+	var order []int
+	broker.Subscribe("test.event", EventHandlerFunc(func(_ context.Context, _ *Event) error {
+		order = append(order, 1)
+		return nil
+	}))
+	broker.Subscribe("test.event", EventHandlerFunc(func(_ context.Context, _ *Event) error {
+		order = append(order, 2)
+		return nil
+	}))
+
+	event := &Event{EventType: "test.event"}
+	if err := broker.Dispatch(context.Background(), event); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Errorf("expected handlers called in order [1,2], got %v", order)
+	}
+}

--- a/connectors/slack/events.go
+++ b/connectors/slack/events.go
@@ -1,0 +1,162 @@
+package slack
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// Slack Events API envelope types.
+const (
+	slackEventTypeURLVerification = "url_verification"
+	slackEventTypeEventCallback   = "event_callback"
+)
+
+// maxTimestampAge is the maximum age of a Slack event timestamp before it's
+// rejected. Slack recommends rejecting requests older than 5 minutes to
+// prevent replay attacks.
+const maxTimestampAge = 5 * time.Minute
+
+// slackEventEnvelope is the outer JSON structure of a Slack Events API payload.
+type slackEventEnvelope struct {
+	Type      string          `json:"type"`
+	Challenge string          `json:"challenge"` // only for url_verification
+	TeamID    string          `json:"team_id"`
+	APIAppID  string          `json:"api_app_id"`
+	Event     json.RawMessage `json:"event"`
+	EventID   string          `json:"event_id"`
+	EventTime int64           `json:"event_time"`
+}
+
+// slackInnerEvent is the inner event structure within an event_callback.
+type slackInnerEvent struct {
+	Type        string `json:"type"`
+	ChannelType string `json:"channel_type"` // "im", "mpim", "channel", "group"
+	Channel     string `json:"channel"`
+	User        string `json:"user"`
+	Text        string `json:"text"`
+	TS          string `json:"ts"`
+	BotID       string `json:"bot_id,omitempty"`
+}
+
+// IMMessagePayload is the typed payload for message.im events.
+// It contains the fields specified for DM event routing.
+type IMMessagePayload struct {
+	User      string `json:"user"`    // sender user ID (e.g., "U01234567")
+	Channel   string `json:"channel"` // DM channel ID (e.g., "D01234567")
+	Text      string `json:"text"`    // message text
+	Timestamp string `json:"ts"`      // Slack message timestamp (e.g., "1234567890.123456")
+}
+
+// VerifyAndParseEvent implements connectors.EventSource for Slack.
+// It verifies the request signature using HMAC-SHA256, handles URL verification
+// challenges, and parses event_callback payloads into connector Events.
+func (c *SlackConnector) VerifyAndParseEvent(payload []byte, headers http.Header, signingSecret string) (*connectors.EventEnvelope, error) {
+	if err := verifySlackSignature(payload, headers, signingSecret); err != nil {
+		return nil, err
+	}
+
+	var envelope slackEventEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, fmt.Errorf("invalid event payload: %w", err)
+	}
+
+	// Handle URL verification challenge.
+	if envelope.Type == slackEventTypeURLVerification {
+		return &connectors.EventEnvelope{Challenge: envelope.Challenge}, nil
+	}
+
+	if envelope.Type != slackEventTypeEventCallback {
+		return nil, fmt.Errorf("unsupported envelope type: %s", envelope.Type)
+	}
+
+	// Parse the inner event to determine the connector event type.
+	var inner slackInnerEvent
+	if err := json.Unmarshal(envelope.Event, &inner); err != nil {
+		return nil, fmt.Errorf("invalid inner event: %w", err)
+	}
+
+	eventType := mapSlackEventType(inner)
+
+	// Build typed payload for known event types; pass through raw for others.
+	var eventPayload json.RawMessage
+	if eventType == "message.im" {
+		p := IMMessagePayload{
+			User:      inner.User,
+			Channel:   inner.Channel,
+			Text:      inner.Text,
+			Timestamp: inner.TS,
+		}
+		eventPayload, _ = json.Marshal(p)
+	} else {
+		eventPayload = envelope.Event
+	}
+
+	return &connectors.EventEnvelope{
+		Event: &connectors.Event{
+			ConnectorID: "slack",
+			EventType:   eventType,
+			EventID:     envelope.EventID,
+			TeamID:      envelope.TeamID,
+			Timestamp:   time.Unix(envelope.EventTime, 0),
+			Payload:     eventPayload,
+		},
+	}, nil
+}
+
+// mapSlackEventType maps a Slack inner event to a connector event type string.
+// message events with channel_type "im" are mapped to "message.im" to match
+// Slack's event subscription naming.
+func mapSlackEventType(inner slackInnerEvent) string {
+	if inner.Type == "message" && inner.ChannelType == "im" {
+		return "message.im"
+	}
+	return inner.Type
+}
+
+// verifySlackSignature verifies the HMAC-SHA256 signature of a Slack Events API
+// request. Slack computes the signature as:
+//
+//	v0=HMAC-SHA256(signing_secret, "v0:{timestamp}:{body}")
+//
+// The signature is sent in the X-Slack-Signature header and the timestamp in
+// X-Slack-Request-Timestamp. Requests older than 5 minutes are rejected to
+// prevent replay attacks.
+func verifySlackSignature(payload []byte, headers http.Header, signingSecret string) error {
+	timestamp := headers.Get("X-Slack-Request-Timestamp")
+	signature := headers.Get("X-Slack-Signature")
+
+	if timestamp == "" || signature == "" {
+		return fmt.Errorf("missing required headers: X-Slack-Request-Timestamp and X-Slack-Signature")
+	}
+
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid timestamp: %w", err)
+	}
+
+	age := time.Duration(math.Abs(float64(time.Now().Unix()-ts))) * time.Second
+	if age > maxTimestampAge {
+		return fmt.Errorf("request timestamp too old (%v > %v)", age, maxTimestampAge)
+	}
+
+	// Compute expected signature: v0=HMAC-SHA256(secret, "v0:{ts}:{body}")
+	sigBase := fmt.Sprintf("v0:%s:%s", timestamp, string(payload))
+	mac := hmac.New(sha256.New, []byte(signingSecret))
+	mac.Write([]byte(sigBase))
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(expected), []byte(signature)) {
+		return fmt.Errorf("invalid signature")
+	}
+
+	return nil
+}

--- a/connectors/slack/events.go
+++ b/connectors/slack/events.go
@@ -95,7 +95,11 @@ func (c *SlackConnector) VerifyAndParseEvent(payload []byte, headers http.Header
 			Text:      inner.Text,
 			Timestamp: inner.TS,
 		}
-		eventPayload, _ = json.Marshal(p)
+		var marshalErr error
+		eventPayload, marshalErr = json.Marshal(p)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("marshalling message.im payload: %w", marshalErr)
+		}
 	} else {
 		eventPayload = envelope.Event
 	}

--- a/connectors/slack/events_test.go
+++ b/connectors/slack/events_test.go
@@ -1,0 +1,227 @@
+package slack
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+const testSigningSecret = "test-signing-secret-abc123"
+
+// signPayload creates valid Slack signature headers for a test payload.
+func signPayload(t *testing.T, payload []byte, signingSecret string) http.Header {
+	t.Helper()
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	sigBase := fmt.Sprintf("v0:%s:%s", ts, string(payload))
+	mac := hmac.New(sha256.New, []byte(signingSecret))
+	mac.Write([]byte(sigBase))
+	sig := "v0=" + hex.EncodeToString(mac.Sum(nil))
+
+	headers := http.Header{}
+	headers.Set("X-Slack-Request-Timestamp", ts)
+	headers.Set("X-Slack-Signature", sig)
+	return headers
+}
+
+func TestVerifyAndParseEvent_URLVerification(t *testing.T) {
+	conn := New()
+	payload := []byte(`{"type":"url_verification","challenge":"test-challenge-123","token":"deprecated"}`)
+	headers := signPayload(t, payload, testSigningSecret)
+
+	envelope, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envelope.Challenge != "test-challenge-123" {
+		t.Errorf("expected challenge %q, got %q", "test-challenge-123", envelope.Challenge)
+	}
+	if envelope.Event != nil {
+		t.Error("expected nil event for url_verification")
+	}
+}
+
+func TestVerifyAndParseEvent_MessageIM(t *testing.T) {
+	conn := New()
+	payload := []byte(`{
+		"type": "event_callback",
+		"team_id": "T01234",
+		"api_app_id": "A01234",
+		"event": {
+			"type": "message",
+			"channel_type": "im",
+			"channel": "D01234",
+			"user": "U01234",
+			"text": "hello from DM",
+			"ts": "1710000000.123456"
+		},
+		"event_id": "Ev01234",
+		"event_time": 1710000000
+	}`)
+	headers := signPayload(t, payload, testSigningSecret)
+
+	envelope, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envelope.Challenge != "" {
+		t.Error("expected empty challenge for event_callback")
+	}
+	if envelope.Event == nil {
+		t.Fatal("expected non-nil event")
+	}
+
+	event := envelope.Event
+	if event.ConnectorID != "slack" {
+		t.Errorf("expected connector_id %q, got %q", "slack", event.ConnectorID)
+	}
+	if event.EventType != "message.im" {
+		t.Errorf("expected event_type %q, got %q", "message.im", event.EventType)
+	}
+	if event.EventID != "Ev01234" {
+		t.Errorf("expected event_id %q, got %q", "Ev01234", event.EventID)
+	}
+	if event.TeamID != "T01234" {
+		t.Errorf("expected team_id %q, got %q", "T01234", event.TeamID)
+	}
+
+	// Verify typed payload.
+	var msg IMMessagePayload
+	if err := json.Unmarshal(event.Payload, &msg); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if msg.User != "U01234" {
+		t.Errorf("expected user %q, got %q", "U01234", msg.User)
+	}
+	if msg.Channel != "D01234" {
+		t.Errorf("expected channel %q, got %q", "D01234", msg.Channel)
+	}
+	if msg.Text != "hello from DM" {
+		t.Errorf("expected text %q, got %q", "hello from DM", msg.Text)
+	}
+	if msg.Timestamp != "1710000000.123456" {
+		t.Errorf("expected ts %q, got %q", "1710000000.123456", msg.Timestamp)
+	}
+}
+
+func TestVerifyAndParseEvent_NonIMMessage(t *testing.T) {
+	conn := New()
+	payload := []byte(`{
+		"type": "event_callback",
+		"team_id": "T01234",
+		"event": {
+			"type": "message",
+			"channel_type": "channel",
+			"channel": "C01234",
+			"user": "U01234",
+			"text": "hello from channel",
+			"ts": "1710000000.123456"
+		},
+		"event_id": "Ev01234",
+		"event_time": 1710000000
+	}`)
+	headers := signPayload(t, payload, testSigningSecret)
+
+	envelope, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Non-IM messages get the raw event type, not "message.im".
+	if envelope.Event.EventType != "message" {
+		t.Errorf("expected event_type %q, got %q", "message", envelope.Event.EventType)
+	}
+}
+
+func TestVerifyAndParseEvent_InvalidSignature(t *testing.T) {
+	conn := New()
+	payload := []byte(`{"type":"url_verification","challenge":"test"}`)
+	headers := signPayload(t, payload, testSigningSecret)
+	// Tamper with the signature.
+	headers.Set("X-Slack-Signature", "v0=invalid")
+
+	_, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err == nil {
+		t.Fatal("expected error for invalid signature")
+	}
+}
+
+func TestVerifyAndParseEvent_MissingHeaders(t *testing.T) {
+	conn := New()
+	payload := []byte(`{"type":"url_verification","challenge":"test"}`)
+
+	_, err := conn.VerifyAndParseEvent(payload, http.Header{}, testSigningSecret)
+	if err == nil {
+		t.Fatal("expected error for missing headers")
+	}
+}
+
+func TestVerifyAndParseEvent_ExpiredTimestamp(t *testing.T) {
+	conn := New()
+	payload := []byte(`{"type":"url_verification","challenge":"test"}`)
+
+	// Use a timestamp from 10 minutes ago.
+	oldTS := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+	sigBase := fmt.Sprintf("v0:%s:%s", oldTS, string(payload))
+	mac := hmac.New(sha256.New, []byte(testSigningSecret))
+	mac.Write([]byte(sigBase))
+	sig := "v0=" + hex.EncodeToString(mac.Sum(nil))
+
+	headers := http.Header{}
+	headers.Set("X-Slack-Request-Timestamp", oldTS)
+	headers.Set("X-Slack-Signature", sig)
+
+	_, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err == nil {
+		t.Fatal("expected error for expired timestamp")
+	}
+}
+
+func TestVerifyAndParseEvent_UnsupportedEnvelopeType(t *testing.T) {
+	conn := New()
+	payload := []byte(`{"type":"unknown_type"}`)
+	headers := signPayload(t, payload, testSigningSecret)
+
+	_, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err == nil {
+		t.Fatal("expected error for unsupported envelope type")
+	}
+}
+
+func TestMapSlackEventType(t *testing.T) {
+	tests := []struct {
+		name     string
+		inner    slackInnerEvent
+		expected string
+	}{
+		{
+			name:     "message in IM",
+			inner:    slackInnerEvent{Type: "message", ChannelType: "im"},
+			expected: "message.im",
+		},
+		{
+			name:     "message in channel",
+			inner:    slackInnerEvent{Type: "message", ChannelType: "channel"},
+			expected: "message",
+		},
+		{
+			name:     "reaction_added",
+			inner:    slackInnerEvent{Type: "reaction_added"},
+			expected: "reaction_added",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSlackEventType(tt.inner)
+			if got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/event_handlers.go
+++ b/event_handlers.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -11,7 +11,7 @@ import (
 // handleIMMessage processes message.im events from Slack DMs.
 // It parses the typed payload and logs structured event data.
 // This handler is the integration point for future DM automation workflows.
-func handleIMMessage(_ context.Context, event *connectors.Event) error {
+func handleIMMessage(ctx context.Context, logger *slog.Logger, event *connectors.Event) error {
 	var msg struct {
 		User      string `json:"user"`
 		Channel   string `json:"channel"`
@@ -19,12 +19,20 @@ func handleIMMessage(_ context.Context, event *connectors.Event) error {
 		Timestamp string `json:"ts"`
 	}
 	if err := json.Unmarshal(event.Payload, &msg); err != nil {
-		log.Printf("SlackEvents: failed to parse message.im payload: %v", err)
+		if logger != nil {
+			logger.WarnContext(ctx, "SlackEvents: failed to parse message.im payload", "error", err)
+		}
 		return nil // don't retry on parse errors
 	}
 
-	log.Printf("SlackEvents: DM received: team=%s channel=%s user=%s ts=%s text_length=%d",
-		event.TeamID, msg.Channel, msg.User, msg.Timestamp, len(msg.Text))
+	if logger != nil {
+		logger.InfoContext(ctx, "SlackEvents: DM received",
+			"team_id", event.TeamID,
+			"channel", msg.Channel,
+			"user", msg.User,
+			"ts", msg.Timestamp,
+			"text_length", len(msg.Text))
+	}
 
 	return nil
 }

--- a/event_handlers.go
+++ b/event_handlers.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// handleIMMessage processes message.im events from Slack DMs.
+// It parses the typed payload and logs structured event data.
+// This handler is the integration point for future DM automation workflows.
+func handleIMMessage(_ context.Context, event *connectors.Event) error {
+	var msg struct {
+		User      string `json:"user"`
+		Channel   string `json:"channel"`
+		Text      string `json:"text"`
+		Timestamp string `json:"ts"`
+	}
+	if err := json.Unmarshal(event.Payload, &msg); err != nil {
+		log.Printf("SlackEvents: failed to parse message.im payload: %v", err)
+		return nil // don't retry on parse errors
+	}
+
+	log.Printf("SlackEvents: DM received: team=%s channel=%s user=%s ts=%s text_length=%d",
+		event.TeamID, msg.Channel, msg.User, msg.Timestamp, len(msg.Text))
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -296,7 +296,11 @@ func main() {
 	deps.EventBroker = connectors.NewEventBroker()
 	// Register the message.im event handler. Currently logs structured event
 	// data; extend to trigger workflows when DM automation is implemented.
-	deps.EventBroker.Subscribe("message.im", connectors.EventHandlerFunc(handleIMMessage))
+	deps.EventBroker.Subscribe("message.im", connectors.EventHandlerFunc(
+		func(ctx context.Context, event *connectors.Event) error {
+			return handleIMMessage(ctx, logger, event)
+		},
+	))
 	if deps.SlackSigningSecret != "" {
 		log.Println("Slack events: signing secret configured, Events API webhook enabled")
 	} else {

--- a/main.go
+++ b/main.go
@@ -289,6 +289,20 @@ func main() {
 
 	deps.Connectors = registry
 
+	// Initialize Slack event infrastructure.
+	// SLACK_SIGNING_SECRET is the signing secret from the Slack app's Basic
+	// Information page — used for HMAC-SHA256 verification of Events API webhooks.
+	deps.SlackSigningSecret = os.Getenv("SLACK_SIGNING_SECRET")
+	deps.EventBroker = connectors.NewEventBroker()
+	// Register the message.im event handler. Currently logs structured event
+	// data; extend to trigger workflows when DM automation is implemented.
+	deps.EventBroker.Subscribe("message.im", connectors.EventHandlerFunc(handleIMMessage))
+	if deps.SlackSigningSecret != "" {
+		log.Println("Slack events: signing secret configured, Events API webhook enabled")
+	} else {
+		log.Println("Slack events: SLACK_SIGNING_SECRET not set, Events API webhook will reject requests")
+	}
+
 	// Initialize OAuth provider registry with built-in providers (Google, Microsoft)
 	// and merge in any providers declared by connector manifests.
 	oauthRegistry := poauth.NewRegistryWithBuiltIns()
@@ -355,6 +369,11 @@ func main() {
 	// and rate-limiting middleware. Stripe verifies requests via signature
 	// (Stripe-Signature header), not Bearer tokens.
 	api.RegisterBillingWebhookRoutes(mux, &deps)
+
+	// Slack Events API webhook endpoint lives outside /api/v1/ — it must
+	// bypass auth middleware. Slack authenticates via HMAC-SHA256 signature
+	// (X-Slack-Signature header).
+	api.RegisterSlackEventRoutes(mux, &deps)
 
 	// Invite endpoint lives outside /api/v1/ — it's a user-facing onboarding
 	// URL (e.g., https://app.permissionslip.dev/invite/PS-XXXX-XXXX), not a


### PR DESCRIPTION
## Summary

- Adds generic `EventSource` interface and `EventBroker` to the connectors package for inbound event handling
- Implements Slack Events API webhook endpoint (`POST /api/webhooks/slack/events`) with HMAC-SHA256 signature verification, URL verification challenge handling, and event deduplication
- Wires `message.im` event handler that parses incoming DMs with structured payload (user, channel, text, timestamp)

Part of #703

## Architecture Decision

Chose **Events API (HTTP webhooks)** over Socket Mode because:
- Follows existing Stripe webhook pattern in the codebase
- Stateless, scales horizontally
- No persistent WebSocket connections to manage
- No new OAuth scopes needed (existing bot scopes cover it)

## Configuration

Requires `SLACK_SIGNING_SECRET` environment variable (from Slack app's Basic Information page). Without it, the endpoint returns 503.

## Test plan

### Claude Code
- [x] Slack signature verification tests (valid, invalid, expired, missing headers)
- [x] URL verification challenge handling
- [x] Event parsing for message.im and non-IM messages
- [x] HTTP handler tests (auth, dedup, dispatch)
- [x] EventBroker dispatch tests (single handler, multiple, errors, no handlers)
- [x] Deduplication TTL expiry test
- [x] Go build succeeds
- [x] Frontend tests pass (957/957)

### Manual Testing
- [ ] Configure Slack app with Events API subscription URL
- [ ] Verify URL verification challenge works with real Slack
- [ ] Send DM to bot and verify event is received and logged
- [ ] Verify signature rejection with tampered payload

https://claude.ai/code/session_01JPMk8SjZF8rKTtoexQrPza