### PR TITLE
Validate action parameters at approval request time

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -154,6 +154,21 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 						}
 					}
 				}
+				// Validate parameters early so the agent gets an immediate error
+				// instead of the approval failing at execution time.
+				if rv, ok := action.(connectors.RequestValidator); ok {
+					if rawParams, hasParams := actionObj["parameters"]; hasParams {
+						if err := rv.ValidateRequest(json.RawMessage(rawParams)); err != nil {
+							var ve *connectors.ValidationError
+							if errors.As(err, &ve) {
+								RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, ve.Message))
+							} else {
+								RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "invalid action parameters"))
+							}
+							return
+						}
+					}
+				}
 			}
 		}
 

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -156,6 +156,8 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 				}
 				// Validate parameters early so the agent gets an immediate error
 				// instead of the approval failing at execution time.
+				// If "parameters" is absent entirely, skip — schema validation
+				// (validateActionParameters below) catches missing required fields.
 				if rv, ok := action.(connectors.RequestValidator); ok {
 					if rawParams, hasParams := actionObj["parameters"]; hasParams {
 						if err := rv.ValidateRequest(json.RawMessage(rawParams)); err != nil {

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/connectors/slack"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
 )
@@ -860,5 +862,83 @@ func TestAgentApprovalStatus_OtherAgentAccess(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for other agent's approval, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ── RequestValidator early rejection ──────────────────────────────────────
+
+func TestAgentRequestApproval_RequestValidatorRejectsInvalidChannel(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Register the Slack connector so RequestValidator is exercised.
+	registry := connectors.NewRegistry()
+	registry.Register(slack.New())
+	deps := &Deps{
+		DB:                tx,
+		SupabaseJWTSecret: testJWTSecret,
+		Connectors:        registry,
+	}
+	router := NewRouter(deps)
+
+	// Agent sends a user ID (U prefix) instead of a channel ID (C/G/D prefix).
+	reqBody := `{"request_id":"req_bad_channel","action":{"type":"slack.read_channel_messages","parameters":{"channel":"U0AM0RW432Q"}},"context":{"description":"Read messages"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid channel ID, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if errResp.Error.Code != ErrInvalidRequest {
+		t.Errorf("expected error code %q, got %q", ErrInvalidRequest, errResp.Error.Code)
+	}
+
+	// Verify the error message mentions the channel ID issue.
+	if errResp.Error.Message == "" {
+		t.Error("expected error message to be non-empty")
+	}
+}
+
+func TestAgentRequestApproval_RequestValidatorAllowsValidChannel(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	registry := connectors.NewRegistry()
+	registry.Register(slack.New())
+	deps := &Deps{
+		DB:                tx,
+		SupabaseJWTSecret: testJWTSecret,
+		Connectors:        registry,
+	}
+	router := NewRouter(deps)
+
+	// Valid channel ID (C prefix) should be accepted.
+	reqBody := `{"request_id":"req_good_channel","action":{"type":"slack.read_channel_messages","parameters":{"channel":"C01234567"}},"context":{"description":"Read messages"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for valid channel ID, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -40,6 +40,15 @@ type Normalizer interface {
 	Normalize(params json.RawMessage) json.RawMessage
 }
 
+// RequestValidator is an optional interface for actions that can validate
+// parameters at approval request time. Called after ParameterAliaser and
+// Normalizer but before the approval is stored. Return a ValidationError
+// to reject the request immediately — the agent receives HTTP 400 with the
+// error message and can fix the parameters before the user ever sees it.
+type RequestValidator interface {
+	ValidateRequest(params json.RawMessage) error
+}
+
 // Connector represents an integration with an external service.
 // It owns shared configuration (HTTP clients, base URLs, auth helpers)
 // and registers the actions it supports.

--- a/connectors/slack/request_validate.go
+++ b/connectors/slack/request_validate.go
@@ -38,7 +38,7 @@ type userIDParams struct {
 func validateChannelFromRaw(params json.RawMessage) error {
 	var p channelParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+		return &connectors.ValidationError{Message: "invalid parameters: could not parse JSON"}
 	}
 	if p.Channel == "" {
 		return nil // required-field check is handled by schema validation
@@ -50,7 +50,7 @@ func validateChannelFromRaw(params json.RawMessage) error {
 func validateChannelAndTSFromRaw(params json.RawMessage) error {
 	var p channelAndTSParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+		return &connectors.ValidationError{Message: "invalid parameters: could not parse JSON"}
 	}
 	if p.Channel != "" {
 		if err := validateChannelID(p.Channel); err != nil {
@@ -82,7 +82,7 @@ func (a *scheduleMessageAction) ValidateRequest(params json.RawMessage) error {
 func (a *inviteToChannelAction) ValidateRequest(params json.RawMessage) error {
 	var p inviteParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+		return &connectors.ValidationError{Message: "invalid parameters: could not parse JSON"}
 	}
 	if p.Channel != "" {
 		if err := validateChannelID(p.Channel); err != nil {
@@ -113,7 +113,7 @@ func (a *readThreadAction) ValidateRequest(params json.RawMessage) error {
 		ThreadTS string `json:"thread_ts"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+		return &connectors.ValidationError{Message: "invalid parameters: could not parse JSON"}
 	}
 	if p.Channel != "" {
 		if err := validateChannelID(p.Channel); err != nil {
@@ -135,7 +135,24 @@ func (a *uploadFileAction) ValidateRequest(params json.RawMessage) error {
 // --- Channel + timestamp actions ---
 
 func (a *addReactionAction) ValidateRequest(params json.RawMessage) error {
-	return validateChannelAndTSFromRaw(params)
+	var p struct {
+		Channel   string `json:"channel"`
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: "invalid parameters: could not parse JSON"}
+	}
+	if p.Channel != "" {
+		if err := validateChannelID(p.Channel); err != nil {
+			return err
+		}
+	}
+	if p.Timestamp != "" {
+		if err := validateMessageTS(p.Timestamp); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *updateMessageAction) ValidateRequest(params json.RawMessage) error {
@@ -151,7 +168,7 @@ func (a *deleteMessageAction) ValidateRequest(params json.RawMessage) error {
 func (a *sendDMAction) ValidateRequest(params json.RawMessage) error {
 	var p userIDParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+		return &connectors.ValidationError{Message: "invalid parameters: could not parse JSON"}
 	}
 	if p.UserID == "" {
 		return nil // required-field check is handled by schema validation

--- a/connectors/slack/request_validate.go
+++ b/connectors/slack/request_validate.go
@@ -1,0 +1,116 @@
+package slack
+
+import (
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// This file implements connectors.RequestValidator for Slack actions that have
+// parameter format checks (channel ID, user ID, message timestamp). These
+// validations run at approval request time so the agent gets an immediate error
+// instead of the approval failing after the user approves it.
+
+// channelParams is a minimal struct for extracting the channel field.
+type channelParams struct {
+	Channel string `json:"channel"`
+}
+
+// channelAndTSParams extracts channel + ts fields.
+type channelAndTSParams struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+}
+
+// userIDParams extracts the user_id field.
+type userIDParams struct {
+	UserID string `json:"user_id"`
+}
+
+// validateChannelFromRaw unmarshals params and validates the channel ID format.
+func validateChannelFromRaw(params json.RawMessage) error {
+	var p channelParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+	}
+	if p.Channel == "" {
+		return nil // required-field check is handled by schema validation
+	}
+	return validateChannelID(p.Channel)
+}
+
+// validateChannelAndTSFromRaw validates both channel ID and message timestamp.
+func validateChannelAndTSFromRaw(params json.RawMessage) error {
+	var p channelAndTSParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+	}
+	if p.Channel != "" {
+		if err := validateChannelID(p.Channel); err != nil {
+			return err
+		}
+	}
+	if p.TS != "" {
+		if err := validateMessageTS(p.TS); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- Channel-only actions ---
+
+func (a *readChannelMessagesAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+func (a *sendMessageAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+func (a *scheduleMessageAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+func (a *inviteToChannelAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+func (a *setTopicAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+func (a *readThreadAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+func (a *uploadFileAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelFromRaw(params)
+}
+
+// --- Channel + timestamp actions ---
+
+func (a *addReactionAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelAndTSFromRaw(params)
+}
+
+func (a *updateMessageAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelAndTSFromRaw(params)
+}
+
+func (a *deleteMessageAction) ValidateRequest(params json.RawMessage) error {
+	return validateChannelAndTSFromRaw(params)
+}
+
+// --- User ID actions ---
+
+func (a *sendDMAction) ValidateRequest(params json.RawMessage) error {
+	var p userIDParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+	}
+	if p.UserID == "" {
+		return nil // required-field check is handled by schema validation
+	}
+	return validateUserID(p.UserID)
+}

--- a/connectors/slack/request_validate.go
+++ b/connectors/slack/request_validate.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -20,6 +21,12 @@ type channelParams struct {
 type channelAndTSParams struct {
 	Channel string `json:"channel"`
 	TS      string `json:"ts"`
+}
+
+// inviteParams extracts channel + users fields for invite_to_channel.
+type inviteParams struct {
+	Channel string `json:"channel"`
+	Users   string `json:"users"`
 }
 
 // userIDParams extracts the user_id field.
@@ -73,7 +80,27 @@ func (a *scheduleMessageAction) ValidateRequest(params json.RawMessage) error {
 }
 
 func (a *inviteToChannelAction) ValidateRequest(params json.RawMessage) error {
-	return validateChannelFromRaw(params)
+	var p inviteParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+	}
+	if p.Channel != "" {
+		if err := validateChannelID(p.Channel); err != nil {
+			return err
+		}
+	}
+	if p.Users != "" {
+		for _, uid := range strings.Split(p.Users, ",") {
+			uid = strings.TrimSpace(uid)
+			if uid == "" {
+				continue
+			}
+			if err := validateUserID(uid); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (a *setTopicAction) ValidateRequest(params json.RawMessage) error {

--- a/connectors/slack/request_validate.go
+++ b/connectors/slack/request_validate.go
@@ -108,7 +108,24 @@ func (a *setTopicAction) ValidateRequest(params json.RawMessage) error {
 }
 
 func (a *readThreadAction) ValidateRequest(params json.RawMessage) error {
-	return validateChannelFromRaw(params)
+	var p struct {
+		Channel  string `json:"channel"`
+		ThreadTS string `json:"thread_ts"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: "invalid parameters: " + err.Error()}
+	}
+	if p.Channel != "" {
+		if err := validateChannelID(p.Channel); err != nil {
+			return err
+		}
+	}
+	if p.ThreadTS != "" {
+		if err := validateMessageTS(p.ThreadTS); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *uploadFileAction) ValidateRequest(params json.RawMessage) error {

--- a/connectors/slack/request_validate_test.go
+++ b/connectors/slack/request_validate_test.go
@@ -102,7 +102,11 @@ func TestRequestValidator_ChannelAndTSActions(t *testing.T) {
 
 	for _, actionType := range tsActions {
 		action := actions[actionType]
-		rv := action.(connectors.RequestValidator)
+		rv, ok := action.(connectors.RequestValidator)
+		if !ok {
+			t.Errorf("%s does not implement RequestValidator", actionType)
+			continue
+		}
 
 		for _, tt := range tests {
 			t.Run(actionType+"/"+tt.name, func(t *testing.T) {
@@ -111,6 +115,9 @@ func TestRequestValidator_ChannelAndTSActions(t *testing.T) {
 				err := rv.ValidateRequest(params)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+					t.Errorf("expected ValidationError, got %T", err)
 				}
 			})
 		}
@@ -144,6 +151,46 @@ func TestRequestValidator_SendDM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			params, _ := json.Marshal(map[string]string{"user_id": tt.userID})
+			err := rv.ValidateRequest(params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}
+
+// TestRequestValidator_InviteUsers verifies that invite_to_channel validates the
+// comma-separated users field in addition to channel.
+func TestRequestValidator_InviteUsers(t *testing.T) {
+	t.Parallel()
+	c := New()
+	action := c.Actions()["slack.invite_to_channel"]
+
+	rv, ok := action.(connectors.RequestValidator)
+	if !ok {
+		t.Fatal("slack.invite_to_channel does not implement RequestValidator")
+	}
+
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{name: "valid channel and users", params: map[string]string{"channel": "C01234567", "users": "U111,U222"}, wantErr: false},
+		{name: "valid W-prefix user", params: map[string]string{"channel": "C01234567", "users": "W01234567"}, wantErr: false},
+		{name: "username instead of ID", params: map[string]string{"channel": "C01234567", "users": "john.doe"}, wantErr: true},
+		{name: "mixed valid and invalid", params: map[string]string{"channel": "C01234567", "users": "U111,john.doe"}, wantErr: true},
+		{name: "email instead of ID", params: map[string]string{"channel": "C01234567", "users": "john@example.com"}, wantErr: true},
+		{name: "empty users is ok", params: map[string]string{"channel": "C01234567", "users": ""}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params, _ := json.Marshal(tt.params)
 			err := rv.ValidateRequest(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)

--- a/connectors/slack/request_validate_test.go
+++ b/connectors/slack/request_validate_test.go
@@ -70,7 +70,6 @@ func TestRequestValidator_ChannelAndTSActions(t *testing.T) {
 	actions := c.Actions()
 
 	tsActions := []string{
-		"slack.add_reaction",
 		"slack.update_message",
 		"slack.delete_message",
 	}
@@ -148,6 +147,44 @@ func TestRequestValidator_SendDM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			params, _ := json.Marshal(map[string]string{"user_id": tt.userID})
+			err := rv.ValidateRequest(params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}
+
+// TestRequestValidator_AddReaction verifies that add_reaction validates both channel
+// and the "timestamp" parameter (not "ts") at request time.
+func TestRequestValidator_AddReaction(t *testing.T) {
+	t.Parallel()
+	c := New()
+	action := c.Actions()["slack.add_reaction"]
+
+	rv, ok := action.(connectors.RequestValidator)
+	if !ok {
+		t.Fatal("slack.add_reaction does not implement RequestValidator")
+	}
+
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{name: "valid channel and timestamp", params: map[string]string{"channel": "C01234567", "timestamp": "1234567890.123456"}, wantErr: false},
+		{name: "invalid channel", params: map[string]string{"channel": "general", "timestamp": "1234567890.123456"}, wantErr: true},
+		{name: "invalid timestamp", params: map[string]string{"channel": "C01234567", "timestamp": "not-a-timestamp"}, wantErr: true},
+		{name: "empty timestamp is ok", params: map[string]string{"channel": "C01234567", "timestamp": ""}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params, _ := json.Marshal(tt.params)
 			err := rv.ValidateRequest(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)

--- a/connectors/slack/request_validate_test.go
+++ b/connectors/slack/request_validate_test.go
@@ -22,9 +22,6 @@ func TestRequestValidator_ChannelActions(t *testing.T) {
 		"slack.set_topic",
 		"slack.read_thread",
 		"slack.upload_file",
-		"slack.add_reaction",
-		"slack.update_message",
-		"slack.delete_message",
 	}
 
 	tests := []struct {
@@ -151,6 +148,44 @@ func TestRequestValidator_SendDM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			params, _ := json.Marshal(map[string]string{"user_id": tt.userID})
+			err := rv.ValidateRequest(params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}
+
+// TestRequestValidator_ReadThread verifies that read_thread validates both channel
+// and thread_ts parameters at request time.
+func TestRequestValidator_ReadThread(t *testing.T) {
+	t.Parallel()
+	c := New()
+	action := c.Actions()["slack.read_thread"]
+
+	rv, ok := action.(connectors.RequestValidator)
+	if !ok {
+		t.Fatal("slack.read_thread does not implement RequestValidator")
+	}
+
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{name: "valid channel and thread_ts", params: map[string]string{"channel": "C01234567", "thread_ts": "1234567890.123456"}, wantErr: false},
+		{name: "invalid channel", params: map[string]string{"channel": "general", "thread_ts": "1234567890.123456"}, wantErr: true},
+		{name: "invalid thread_ts", params: map[string]string{"channel": "C01234567", "thread_ts": "not-a-timestamp"}, wantErr: true},
+		{name: "empty thread_ts is ok", params: map[string]string{"channel": "C01234567", "thread_ts": ""}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params, _ := json.Marshal(tt.params)
 			err := rv.ValidateRequest(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)

--- a/connectors/slack/request_validate_test.go
+++ b/connectors/slack/request_validate_test.go
@@ -1,0 +1,178 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// TestRequestValidator_ChannelActions verifies that all channel-based actions
+// implement RequestValidator and reject invalid channel IDs at request time.
+func TestRequestValidator_ChannelActions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	channelActions := []string{
+		"slack.read_channel_messages",
+		"slack.send_message",
+		"slack.schedule_message",
+		"slack.invite_to_channel",
+		"slack.set_topic",
+		"slack.read_thread",
+		"slack.upload_file",
+		"slack.add_reaction",
+		"slack.update_message",
+		"slack.delete_message",
+	}
+
+	tests := []struct {
+		name    string
+		channel string
+		wantErr bool
+	}{
+		{name: "valid C prefix", channel: "C01234567", wantErr: false},
+		{name: "valid G prefix", channel: "G01234567", wantErr: false},
+		{name: "valid D prefix", channel: "D01234567", wantErr: false},
+		{name: "user ID instead", channel: "U0AM0RW432Q", wantErr: true},
+		{name: "channel name", channel: "general", wantErr: true},
+		{name: "hash channel name", channel: "#general", wantErr: true},
+		{name: "empty is ok (schema validates required)", channel: "", wantErr: false},
+	}
+
+	for _, actionType := range channelActions {
+		action := actions[actionType]
+		rv, ok := action.(connectors.RequestValidator)
+		if !ok {
+			t.Errorf("%s does not implement RequestValidator", actionType)
+			continue
+		}
+
+		for _, tt := range tests {
+			t.Run(actionType+"/"+tt.name, func(t *testing.T) {
+				t.Parallel()
+				params, _ := json.Marshal(map[string]string{"channel": tt.channel})
+				err := rv.ValidateRequest(params)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+					t.Errorf("expected ValidationError, got %T", err)
+				}
+			})
+		}
+	}
+}
+
+// TestRequestValidator_ChannelAndTSActions verifies that actions with both channel
+// and timestamp parameters validate both fields at request time.
+func TestRequestValidator_ChannelAndTSActions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	tsActions := []string{
+		"slack.add_reaction",
+		"slack.update_message",
+		"slack.delete_message",
+	}
+
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "valid channel and ts",
+			params:  map[string]string{"channel": "C01234567", "ts": "1234567890.123456"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid channel with valid ts",
+			params:  map[string]string{"channel": "U0AM0RW432Q", "ts": "1234567890.123456"},
+			wantErr: true,
+		},
+		{
+			name:    "valid channel with invalid ts",
+			params:  map[string]string{"channel": "C01234567", "ts": "not-a-timestamp"},
+			wantErr: true,
+		},
+	}
+
+	for _, actionType := range tsActions {
+		action := actions[actionType]
+		rv := action.(connectors.RequestValidator)
+
+		for _, tt := range tests {
+			t.Run(actionType+"/"+tt.name, func(t *testing.T) {
+				t.Parallel()
+				params, _ := json.Marshal(tt.params)
+				err := rv.ValidateRequest(params)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+// TestRequestValidator_SendDM verifies that send_dm validates user_id format.
+func TestRequestValidator_SendDM(t *testing.T) {
+	t.Parallel()
+	c := New()
+	action := c.Actions()["slack.send_dm"]
+
+	rv, ok := action.(connectors.RequestValidator)
+	if !ok {
+		t.Fatal("slack.send_dm does not implement RequestValidator")
+	}
+
+	tests := []struct {
+		name    string
+		userID  string
+		wantErr bool
+	}{
+		{name: "valid U prefix", userID: "U01234567", wantErr: false},
+		{name: "valid W prefix", userID: "W01234567", wantErr: false},
+		{name: "channel ID instead", userID: "C01234567", wantErr: true},
+		{name: "username", userID: "john.doe", wantErr: true},
+		{name: "empty is ok (schema validates required)", userID: "", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params, _ := json.Marshal(map[string]string{"user_id": tt.userID})
+			err := rv.ValidateRequest(params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !connectors.IsValidationError(err) {
+				t.Errorf("expected ValidationError, got %T", err)
+			}
+		})
+	}
+}
+
+// TestRequestValidator_NotImplemented verifies that actions without ID parameters
+// do not implement RequestValidator (no unnecessary interface).
+func TestRequestValidator_NotImplemented(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	noValidation := []string{
+		"slack.create_channel",
+		"slack.list_channels",
+		"slack.list_users",
+		"slack.search_messages",
+	}
+
+	for _, actionType := range noValidation {
+		action := actions[actionType]
+		if _, ok := action.(connectors.RequestValidator); ok {
+			t.Errorf("%s implements RequestValidator but shouldn't need to", actionType)
+		}
+	}
+}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- Adds a `RequestValidator` interface to the connectors package — actions that implement it get parameters validated at approval ingestion time (before storage), so the agent receives an immediate HTTP 400 instead of a deferred execution failure
- Implements `ValidateRequest` for 11 Slack actions covering channel ID format (C/G/D prefix), user ID format (U/W prefix), and message timestamp format checks
- Fixes [PERMISSION-SLIP-GO-8](https://supersuit-technologies.sentry.io/issues/7346703312/) where an agent passed a user ID as a channel parameter, which was accepted, shown to the user, approved, then failed at execution

## Test plan

### Claude Code
- [x] Unit tests for all `ValidateRequest` implementations (channel, timestamp, user ID — valid and invalid cases)
- [x] Integration tests: invalid channel ID returns 400; valid channel ID returns 200
- [x] All existing backend tests pass (`make test-backend`)
- [x] Build passes (`make build`)

### Manual Testing
- [ ] Deploy to staging and have an agent send an approval request with an invalid Slack channel ID — verify it gets 400 with descriptive error
- [ ] Verify the agent can use the error message to self-correct and retry with a valid channel ID
- [ ] Verify existing valid approval requests continue to work (no regression)

https://claude.ai/code/session_01BDH4xy2pFUCRMDbTcGK2HE