### PR TITLE
docs: GitHub connector tested + early access

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Permission Slip solves this with a **secure proxy + human-in-the-loop approval**
 
 | Connector | Status |
 |-----------|--------|
-| GitHub | 🟢 Tested · 🟡 Early access |
+| GitHub | 🟢 Tested · 🟡 Early Preview |
 | Google | 🟡 Early Preview |
 | Microsoft | 🟡 Early Preview |
 | Slack | 🟡 Early Preview |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Permission Slip solves this with a **secure proxy + human-in-the-loop approval**
 
 | Connector | Status |
 |-----------|--------|
-| GitHub | 🟢 Tested |
+| GitHub | 🟢 Tested · 🟡 Early access |
 | Google | 🟡 Early Preview |
 | Microsoft | 🟡 Early Preview |
 | Slack | 🟡 Early Preview |

--- a/connectors/github/README.md
+++ b/connectors/github/README.md
@@ -1,5 +1,7 @@
 # GitHub Connector
 
+**Status:** 🟢 Tested · 🟡 Early access
+
 The GitHub connector integrates Permission Slip with the [GitHub REST API](https://docs.github.com/en/rest). It uses plain `net/http` — no third-party GitHub SDK.
 
 ## Connector ID

--- a/connectors/github/README.md
+++ b/connectors/github/README.md
@@ -1,6 +1,8 @@
 # GitHub Connector
 
-**Status:** 🟢 Tested · 🟡 Early access
+**Status:** 🟢 Tested · 🟡 Early Preview
+
+The manifest `status` is `early_preview` (same grouping as **Early Preview** in the app and `/v1/connectors`). **Tested** here means the connector is covered by automated tests; it is separate from the rollout label.
 
 The GitHub connector integrates Permission Slip with the [GitHub REST API](https://docs.github.com/en/rest). It uses plain `net/http` — no third-party GitHub SDK.
 

--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -18,7 +18,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 		ID:          "github",
 		Name:        "GitHub",
 		Description: "GitHub integration for repository management",
-		Status:      "tested",
+		Status:      "early_preview",
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{

--- a/frontend/src/pages/agents/__tests__/AgentConnectorsSection.test.tsx
+++ b/frontend/src/pages/agents/__tests__/AgentConnectorsSection.test.tsx
@@ -38,7 +38,7 @@ function mockAllConnectors(connectors = [
     id: "github",
     name: "GitHub",
     description: "GitHub integration",
-    status: "tested" as const,
+    status: "early_preview" as const,
     actions: ["github.create_issue"],
     required_credentials: ["github"],
   },
@@ -153,7 +153,7 @@ describe("AgentConnectorsSection", () => {
     // Need 4+ connectors to show search
     mockAllConnectors([
       { id: "gmail", name: "Gmail", description: "Email", status: "untested" as const, actions: ["a"], required_credentials: [] },
-      { id: "github", name: "GitHub", description: "Code", status: "tested" as const, actions: ["b"], required_credentials: [] },
+      { id: "github", name: "GitHub", description: "Code", status: "early_preview" as const, actions: ["b"], required_credentials: [] },
       { id: "slack", name: "Slack", description: "Chat", status: "early_preview" as const, actions: ["c"], required_credentials: [] },
       { id: "stripe", name: "Stripe", description: "Payments", status: "untested" as const, actions: ["d"], required_credentials: [] },
     ]);
@@ -182,7 +182,7 @@ describe("AgentConnectorsSection", () => {
     const user = userEvent.setup();
     mockAllConnectors([
       { id: "gmail", name: "Gmail", description: "Email", status: "untested" as const, actions: ["a"], required_credentials: [] },
-      { id: "github", name: "GitHub", description: "Code", status: "tested" as const, actions: ["b"], required_credentials: [] },
+      { id: "github", name: "GitHub", description: "Code", status: "early_preview" as const, actions: ["b"], required_credentials: [] },
       { id: "slack", name: "Slack", description: "Chat", status: "early_preview" as const, actions: ["c"], required_credentials: [] },
       { id: "stripe", name: "Stripe", description: "Payments", status: "untested" as const, actions: ["d"], required_credentials: [] },
     ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Root **Connector Health** table: GitHub shows both tested and early access.
- `connectors/github/README.md`: Status line under the title.
- **`connectors/github/manifest.go`**: `status` is now `early_preview` so `/v1/connectors` and the agent **Connectors** UI group GitHub under **Early Preview** (same as Google / Microsoft / Slack).
- Frontend tests: mock GitHub connector uses `early_preview`.

## Test plan
- [x] `npx vitest run src/pages/agents/__tests__/AgentConnectorsSection.test.tsx`
- [ ] `make test-backend` (Go env not fully verified in this sandbox)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-334a0934-114f-4556-9113-ea13a220799c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-334a0934-114f-4556-9113-ea13a220799c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

