### PR TITLE
Add Slack workspace & username to OAuth credential display

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -605,13 +605,21 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Slack-specific: extract the user access token from the OAuth v2
-		// response. Slack returns both a bot token (access_token) and a user
-		// token (authed_user.access_token). The user token is needed for
-		// endpoints like search.messages that don't support bot tokens.
+		// Slack-specific: extract the user access token and team name from
+		// the OAuth v2 response. Slack returns both a bot token (access_token)
+		// and a user token (authed_user.access_token). The user token is needed
+		// for endpoints like search.messages that don't support bot tokens.
+		// The team name is stored so the credential display shows which
+		// workspace was connected.
 		var userAccessToken string
 		if providerID == "slack" {
 			userAccessToken = extractSlackUserToken(token)
+			if teamName := extractSlackTeamName(token); teamName != "" {
+				if stateExtraData == nil {
+					stateExtraData = make(map[string]string)
+				}
+				stateExtraData["team_name"] = teamName
+			}
 		}
 
 		// Store tokens in vault within a transaction. Use scopes from the
@@ -663,7 +671,13 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 
 		// Run best-effort email enrichers (fetches user email from provider
 		// userinfo endpoints). Failures are logged but don't block the flow.
-		if softExtra := runSoftEnrichers(ctx, providerID, token.AccessToken); softExtra != nil {
+		// For Slack, the OIDC userinfo endpoint requires the user token (not
+		// the bot token returned as the primary access_token).
+		enricherToken := token.AccessToken
+		if providerID == "slack" && userAccessToken != "" {
+			enricherToken = userAccessToken
+		}
+		if softExtra := runSoftEnrichers(ctx, providerID, enricherToken); softExtra != nil {
 			if stateExtraData == nil {
 				stateExtraData = make(map[string]string)
 			}
@@ -1028,8 +1042,9 @@ func instanceFromExtraData(extraData json.RawMessage) string {
 
 // displayNameFromExtraData extracts a human-readable display name from an
 // OAuth connection's extra_data JSON. Prefers "display_name" (e.g. GitHub
-// login or Microsoft displayName), falls back to "email". Returns "" if
-// neither is present.
+// login or Microsoft displayName), falls back to "email". When "team_name"
+// is present (Slack), appends " @ <workspace>" to help distinguish
+// connections to different workspaces. Returns "" if no identifier is found.
 func displayNameFromExtraData(extraData json.RawMessage) string {
 	if len(extraData) == 0 {
 		return ""
@@ -1038,10 +1053,19 @@ func displayNameFromExtraData(extraData json.RawMessage) string {
 	if err := json.Unmarshal(extraData, &extra); err != nil {
 		return ""
 	}
-	if dn := extra["display_name"]; dn != "" {
-		return dn
+
+	identifier := extra["display_name"]
+	if identifier == "" {
+		identifier = extra["email"]
 	}
-	return extra["email"]
+	if identifier == "" {
+		return ""
+	}
+
+	if teamName := extra["team_name"]; teamName != "" {
+		return identifier + " @ " + teamName
+	}
+	return identifier
 }
 
 // handleListOAuthConnections returns all OAuth connections for the authenticated user.
@@ -1229,6 +1253,17 @@ func extractSlackUserToken(token *oauth2.Token) string {
 	}
 	userToken, _ := authedUser["access_token"].(string)
 	return userToken
+}
+
+// extractSlackTeamName extracts the workspace name from a Slack OAuth v2
+// token response. The team object is always present in a successful response.
+func extractSlackTeamName(token *oauth2.Token) string {
+	team, ok := token.Extra("team").(map[string]any)
+	if !ok {
+		return ""
+	}
+	name, _ := team["name"].(string)
+	return name
 }
 
 // userTokenVaultIDFromExtraData extracts the user access token vault ID from

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -605,21 +605,13 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Slack-specific: extract the user access token and team name from
-		// the OAuth v2 response. Slack returns both a bot token (access_token)
-		// and a user token (authed_user.access_token). The user token is needed
-		// for endpoints like search.messages that don't support bot tokens.
-		// The team name is stored so the credential display shows which
-		// workspace was connected.
+		// Slack-specific: extract the user access token from the OAuth v2
+		// response. Slack returns both a bot token (access_token) and a user
+		// token (authed_user.access_token). The user token is needed for
+		// endpoints like search.messages that don't support bot tokens.
 		var userAccessToken string
 		if providerID == "slack" {
 			userAccessToken = extractSlackUserToken(token)
-			if teamName := extractSlackTeamName(token); teamName != "" {
-				if stateExtraData == nil {
-					stateExtraData = make(map[string]string)
-				}
-				stateExtraData["team_name"] = teamName
-			}
 		}
 
 		// Store tokens in vault within a transaction. Use scopes from the
@@ -645,6 +637,17 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 				stateExtraData = map[string]string{"shop_domain": state.Shop + ".myshopify.com"}
 			}
 			// Other per-instance providers: no extra_data needed beyond the token.
+		}
+
+		// Slack-specific: extract the workspace name from the token response
+		// so the credential display shows which workspace was connected.
+		if providerID == "slack" {
+			if teamName := extractSlackTeamName(token); teamName != "" {
+				if stateExtraData == nil {
+					stateExtraData = make(map[string]string)
+				}
+				stateExtraData["team_name"] = teamName
+			}
 		}
 
 		// Run the provider's post-exchange enricher (if any). Enrichers fetch
@@ -682,7 +685,9 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 				stateExtraData = make(map[string]string)
 			}
 			for k, v := range softExtra {
-				stateExtraData[k] = v
+				if _, exists := stateExtraData[k]; !exists {
+					stateExtraData[k] = v
+				}
 			}
 		}
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -685,6 +685,9 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 				stateExtraData = make(map[string]string)
 			}
 			for k, v := range softExtra {
+				// Soft enrichers provide supplemental display info; they must not
+				// overwrite hard-enricher fields (e.g. team_name, account_id, base_url)
+				// that are authoritative for connection routing and display.
 				if _, exists := stateExtraData[k]; !exists {
 					stateExtraData[k] = v
 				}
@@ -1064,6 +1067,11 @@ func displayNameFromExtraData(extraData json.RawMessage) string {
 		identifier = extra["email"]
 	}
 	if identifier == "" {
+		// Fall back to workspace name alone when no personal identifier is available
+		// (e.g. Slack OIDC enricher failed but team_name was captured from the token).
+		if teamName := extra["team_name"]; teamName != "" {
+			return teamName
+		}
 		return ""
 	}
 


### PR DESCRIPTION
## Summary
- Extracts workspace name from Slack OAuth v2 token response and stores it in `extra_data["team_name"]`
- Fixes the OIDC userinfo enricher to use the Slack **user** token instead of the bot token (the bot token doesn't work with `openid.connect.userInfo`, which is why Slack connections were missing display_name/email)
- Updates `displayNameFromExtraData` to append `" @ <workspace>"` when `team_name` is present, producing displays like **"John @ Acme Corp"** instead of just "connected 3/19/2026"

No frontend changes — the richer `display_name` flows through the existing API response.

## Test plan

### Claude Code
- [x] Verify backend compiles cleanly
- [x] Verify no regressions in existing provider display names (Google shows email, GitHub shows login)

### Manual Testing
- [ ] Connect a new Slack workspace and verify the credential selector shows `"<name> @ <workspace>"` 
- [ ] Re-authorize an existing Slack connection and confirm it picks up the new identifiers
- [ ] Connect a second Slack workspace and confirm both are distinguishable

https://claude.ai/code/session_01HzPAZJ3PURdtoLXGa9yLmC