### PR TITLE
Add Slack DM/MPIM channel listing and scope support

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -98,7 +98,7 @@ Lists Slack channels visible to the bot. When listing private channel types (`pr
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `types` | string | No | `public_channel,private_channel,mpim,im` | Comma-separated channel types: `public_channel`, `private_channel`, `mpim`, `im`. Defaults to all types. |
+| `types` | string | No | `public_channel,private_channel,mpim,im` | Comma-separated channel types: `public_channel`, `private_channel`, `mpim`, `im`. Defaults to all types when user email is available; falls back to `public_channel` only when no email is set. |
 | `limit` | integer | No | `100` | Max channels to return (1–1000) |
 | `cursor` | string | No | — | Pagination cursor from a previous response |
 | `exclude_archived` | boolean | No | `true` | Exclude archived channels from results |

--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -369,7 +369,7 @@ Adds an emoji reaction to a Slack message.
 
 ### `slack.send_dm`
 
-Sends a direct message to a Slack user. Opens (or reuses) a DM channel with the user, then posts the message.
+Sends a direct message to a Slack user. Opens (or reuses) a DM channel with the user, then posts the message. Self-DMs are supported — passing your own user ID opens a "note to self" channel.
 
 **Risk level:** low
 

--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -98,7 +98,7 @@ Lists Slack channels visible to the bot. When listing private channel types (`pr
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `types` | string | No | `public_channel` | Comma-separated channel types: `public_channel`, `private_channel`, `mpim`, `im` |
+| `types` | string | No | `public_channel,private_channel,mpim,im` | Comma-separated channel types: `public_channel`, `private_channel`, `mpim`, `im`. Defaults to all types. |
 | `limit` | integer | No | `100` | Max channels to return (1–1000) |
 | `cursor` | string | No | — | Pagination cursor from a previous response |
 | `exclude_archived` | boolean | No | `true` | Exclude archived channels from results |
@@ -115,15 +115,23 @@ Lists Slack channels visible to the bot. When listing private channel types (`pr
       "topic": "General discussion",
       "purpose": "Company-wide announcements",
       "num_members": 42
+    },
+    {
+      "id": "D09876543",
+      "user": "U001",
+      "is_private": true,
+      "num_members": 0
     }
   ],
   "next_cursor": "dGVhbTpDMDI="
 }
 ```
 
+> **Note:** IM channels (DMs) don't have a `name` field. Instead, they include a `user` field with the other participant's Slack user ID.
+
 **Slack API:** `POST /conversations.list` ([docs](https://api.slack.com/methods/conversations.list))
 
-**Required bot token scopes:** `channels:read` (public), `groups:read` (private)
+**Required bot token scopes:** `channels:read` (public), `groups:read` (private), `im:read` (DMs), `mpim:read` (group DMs)
 
 ---
 
@@ -383,7 +391,7 @@ Sends a direct message to a Slack user. Opens (or reuses) a DM channel with the 
 
 **Slack API:** `POST /conversations.open` + `POST /chat.postMessage` ([docs](https://api.slack.com/methods/conversations.open))
 
-**Required bot token scopes:** `im:write`, `chat:write`
+**Required bot token scopes:** `im:write`, `mpim:write`, `chat:write`
 
 ---
 
@@ -673,6 +681,42 @@ connectors/slack/
 ├── *_test.go                       # Per-action test files (one per action)
 └── README.md                       # This file
 ```
+
+## Required OAuth Scopes (Complete Reference)
+
+When connecting via OAuth, scopes are requested automatically. If you're creating a Slack app manually (bot token flow), add all the scopes below to your app's **Bot Token Scopes** in the [Slack App Dashboard](https://api.slack.com/apps).
+
+**Bot token scopes (`xoxb-`):**
+
+| Scope | Purpose |
+|-------|---------|
+| `channels:history` | Read messages in public channels |
+| `channels:join` | Join public channels |
+| `channels:manage` | Create/archive/rename public channels |
+| `channels:read` | List public channels |
+| `chat:write` | Send messages, update/delete bot messages |
+| `files:write` | Upload files |
+| `groups:history` | Read messages in private channels |
+| `groups:read` | List private channels |
+| `im:history` | Read DM messages |
+| `im:read` | List DM channels |
+| `im:write` | Open DM conversations |
+| `mpim:history` | Read group DM messages |
+| `mpim:read` | List group DM channels |
+| `mpim:write` | Open group DM conversations |
+| `reactions:write` | Add emoji reactions |
+| `users:read` | List workspace users |
+| `users:read.email` | Access user email addresses (needed for identity verification) |
+
+**User token scopes (`xoxp-`)** — only needed for `search_messages`:
+
+| Scope | Purpose |
+|-------|---------|
+| `search:read.public` | Search public channel messages |
+| `search:read.private` | Search private channel messages |
+| `search:read.im` | Search DM messages |
+| `search:read.mpim` | Search group DM messages |
+| `search:read.files` | Search shared files |
 
 ## Testing
 

--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -299,3 +299,17 @@ func channelTypesIncludePrivate(types string) bool {
 	}
 	return false
 }
+
+// filterPrivateTypes strips public_channel from a comma-separated types string,
+// returning only private types. Used to avoid fetching unnecessary public channel
+// memberships from users.conversations.
+func filterPrivateTypes(types string) string {
+	var private []string
+	for _, t := range strings.Split(types, ",") {
+		t = strings.TrimSpace(t)
+		if t != "" && t != "public_channel" {
+			private = append(private, t)
+		}
+	}
+	return strings.Join(private, ",")
+}

--- a/connectors/slack/channel_membership_test.go
+++ b/connectors/slack/channel_membership_test.go
@@ -439,25 +439,24 @@ func TestSearchMessages_FiltersPrivateResults(t *testing.T) {
 	}
 }
 
-func TestListChannels_PrivateTypesRequireEmail(t *testing.T) {
+func TestFilterPrivateTypes(t *testing.T) {
 	t.Parallel()
 
-	conn := New()
-	action := &listChannelsAction{conn: conn}
-
-	params, _ := json.Marshal(listChannelsParams{
-		Types: "im",
-	})
-
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
-		ActionType:  "slack.list_channels",
-		Parameters:  params,
-		Credentials: validCreds(),
-	})
-	if err == nil {
-		t.Fatal("expected error for listing DMs without email")
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"public_channel,private_channel,mpim,im", "private_channel,mpim,im"},
+		{"public_channel", ""},
+		{"im", "im"},
+		{"private_channel,mpim", "private_channel,mpim"},
+		{"public_channel, im", "im"},
+		{"", ""},
 	}
-	if !connectors.IsValidationError(err) {
-		t.Errorf("expected ValidationError, got: %T", err)
+	for _, tt := range tests {
+		got := filterPrivateTypes(tt.input)
+		if got != tt.want {
+			t.Errorf("filterPrivateTypes(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -47,6 +47,9 @@ type listChannelsResponse struct {
 	Meta     *paginationMeta    `json:"response_metadata,omitempty"`
 }
 
+// listChannelEntry maps the Slack API response for a single channel from
+// conversations.list. IM channels (DMs) omit Name and instead populate User
+// with the other participant's Slack user ID.
 type listChannelEntry struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
@@ -68,6 +71,9 @@ type listChannelsResult struct {
 	NextCursor string               `json:"next_cursor,omitempty"`
 }
 
+// listChannelSummary is the user-facing output for a single channel. For IM
+// channels, Name is empty and User contains the other participant's Slack user
+// ID. Both fields use omitempty so the JSON output only includes relevant fields.
 type listChannelSummary struct {
 	ID         string `json:"id"`
 	Name       string `json:"name,omitempty"`

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -17,7 +17,9 @@ type listChannelsAction struct {
 // listChannelsParams defines the user-facing parameter schema.
 type listChannelsParams struct {
 	// Types filters by channel type. Comma-separated list of:
-	// public_channel, private_channel, mpim, im. Defaults to public_channel.
+	// public_channel, private_channel, mpim, im.
+	// Defaults to all types: public_channel,private_channel,mpim,im.
+	// Falls back to public_channel if UserEmail is not set (required for private types).
 	Types string `json:"types,omitempty"`
 	// Limit is the max number of channels to return (1-1000, default 100).
 	Limit int `json:"limit,omitempty"`
@@ -89,6 +91,7 @@ func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionR
 	}
 
 	types := params.Types
+	explicitTypes := types != ""
 	if types == "" {
 		types = "public_channel,private_channel,mpim,im"
 	}
@@ -97,25 +100,39 @@ func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionR
 	// Slack identity and pre-fetch their channel memberships so we can filter
 	// results efficiently. Uses users.conversations (one paginated call) instead
 	// of per-channel isUserInChannel to avoid N+1 API calls.
+	//
+	// If the caller didn't explicitly request private types (using the default)
+	// and has no email set, gracefully fall back to public_channel only instead
+	// of returning an error. This preserves backward compatibility for callers
+	// that previously relied on the old public_channel-only default.
 	var userChannelIDs map[string]bool
 	if channelTypesIncludePrivate(types) {
 		if req.UserEmail == "" {
-			return nil, &connectors.ValidationError{
-				Message: "listing private channels, group DMs, or DMs requires your Permission Slip profile to have an email address matching your Slack account",
+			if explicitTypes {
+				return nil, &connectors.ValidationError{
+					Message: "listing private channels, group DMs, or DMs requires your Permission Slip profile to have an email address matching your Slack account",
+				}
 			}
-		}
-		slackUserID, err := a.conn.lookupSlackUserByEmail(ctx, req.Credentials, req.UserEmail)
-		if err != nil {
-			return nil, fmt.Errorf("unable to verify Slack identity: %w", err)
-		}
-		if slackUserID == "" {
-			return nil, &connectors.ValidationError{
-				Message: fmt.Sprintf("no Slack user found matching email %q — ensure your Permission Slip email matches your Slack account", req.UserEmail),
+			// Graceful fallback: caller used the default, so fall back to
+			// public channels only rather than breaking existing integrations.
+			types = "public_channel"
+		} else {
+			slackUserID, err := a.conn.lookupSlackUserByEmail(ctx, req.Credentials, req.UserEmail)
+			if err != nil {
+				return nil, fmt.Errorf("unable to verify Slack identity: %w", err)
 			}
-		}
-		userChannelIDs, err = a.conn.getUserChannelIDs(ctx, req.Credentials, slackUserID, types)
-		if err != nil {
-			return nil, fmt.Errorf("fetching user channel memberships: %w", err)
+			if slackUserID == "" {
+				return nil, &connectors.ValidationError{
+					Message: fmt.Sprintf("no Slack user found matching email %q — ensure your Permission Slip email matches your Slack account", req.UserEmail),
+				}
+			}
+			// Only fetch memberships for private channel types — public channels
+			// are never filtered, so including them wastes API quota.
+			privateTypes := filterPrivateTypes(types)
+			userChannelIDs, err = a.conn.getUserChannelIDs(ctx, req.Credentials, slackUserID, privateTypes)
+			if err != nil {
+				return nil, fmt.Errorf("fetching user channel memberships: %w", err)
+			}
 		}
 	}
 

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -48,6 +48,7 @@ type listChannelsResponse struct {
 type listChannelEntry struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
+	User       string `json:"user,omitempty"`
 	IsPrivate  bool   `json:"is_private"`
 	IsArchived bool   `json:"is_archived"`
 	NumMembers int    `json:"num_members"`
@@ -67,7 +68,8 @@ type listChannelsResult struct {
 
 type listChannelSummary struct {
 	ID         string `json:"id"`
-	Name       string `json:"name"`
+	Name       string `json:"name,omitempty"`
+	User       string `json:"user,omitempty"`
 	IsPrivate  bool   `json:"is_private"`
 	Topic      string `json:"topic,omitempty"`
 	Purpose    string `json:"purpose,omitempty"`
@@ -88,7 +90,7 @@ func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionR
 
 	types := params.Types
 	if types == "" {
-		types = "public_channel"
+		types = "public_channel,private_channel,mpim,im"
 	}
 
 	// When listing private channels, group DMs, or DMs, resolve the user's
@@ -150,6 +152,7 @@ func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionR
 		result.Channels = append(result.Channels, listChannelSummary{
 			ID:         ch.ID,
 			Name:       ch.Name,
+			User:       ch.User,
 			IsPrivate:  ch.IsPrivate,
 			Topic:      ch.Topic.Value,
 			Purpose:    ch.Purpose.Value,

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -117,6 +117,14 @@ func TestListChannels_DefaultTypes(t *testing.T) {
 				"user": map[string]string{"id": "U_CALLER"},
 			})
 		case "/users.conversations":
+			var body usersConversationsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode users.conversations body: %v", err)
+			}
+			// public_channel should be stripped — only private types are needed.
+			if body.Types != "private_channel,mpim,im" {
+				t.Errorf("expected types 'private_channel,mpim,im' for users.conversations, got %q", body.Types)
+			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,
 				"channels": []map[string]any{

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -456,5 +457,28 @@ func TestListChannels_DefaultFallbackWithoutEmail(t *testing.T) {
 	}
 	if data.Channels[0].ID != "C001" {
 		t.Errorf("expected channel C001, got %q", data.Channels[0].ID)
+	}
+}
+
+func TestListChannels_ExplicitPrivateTypesWithoutEmail(t *testing.T) {
+	t.Parallel()
+
+	// When the caller explicitly requests private types (e.g. types=im) but
+	// has no UserEmail set, list_channels must return a ValidationError —
+	// not silently fall back to public_channel.
+	conn := newForTest(http.DefaultClient, "http://unused")
+	action := &listChannelsAction{conn: conn}
+
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		// UserEmail intentionally omitted
+	})
+	var valErr *connectors.ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected ValidationError for explicit private types without email, got: %v", err)
 	}
 }

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -67,7 +67,9 @@ func TestListChannels_Success(t *testing.T) {
 	conn := newForTest(srv.Client(), srv.URL)
 	action := &listChannelsAction{conn: conn}
 
-	params, _ := json.Marshal(listChannelsParams{})
+	// Pass types explicitly — the new default includes private types which
+	// require UserEmail and access-control mocks.
+	params, _ := json.Marshal(listChannelsParams{Types: "public_channel"})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "slack.list_channels",
@@ -102,6 +104,175 @@ func TestListChannels_Success(t *testing.T) {
 	}
 }
 
+func TestListChannels_DefaultTypes(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "C001"},
+					{"id": "D001"},
+				},
+			})
+		case "/conversations.list":
+			var body listChannelsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode: %v", err)
+			}
+			if body.Types != "public_channel,private_channel,mpim,im" {
+				t.Errorf("expected default types 'public_channel,private_channel,mpim,im', got %q", body.Types)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "C001", "name": "general", "is_private": false, "num_members": 10},
+					{"id": "D001", "user": "U_OTHER", "is_private": true, "num_members": 0},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+
+	// No types param — should use the new default (all types).
+	params, _ := json.Marshal(listChannelsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Channels) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(data.Channels))
+	}
+	if data.Channels[0].ID != "C001" {
+		t.Errorf("expected first channel C001, got %q", data.Channels[0].ID)
+	}
+	if data.Channels[1].ID != "D001" {
+		t.Errorf("expected second channel D001, got %q", data.Channels[1].ID)
+	}
+}
+
+func TestListChannels_IMChannels(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			// Return the IM channel as one the caller belongs to.
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "D001"},
+					{"id": "D002"},
+				},
+			})
+		case "/conversations.list":
+			var body listChannelsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode: %v", err)
+			}
+			if body.Types != "im" {
+				t.Errorf("expected types 'im', got %q", body.Types)
+			}
+			// IM channels have no name — they have a user field instead.
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{
+						"id":         "D001",
+						"user":       "U_OTHER",
+						"is_private": true,
+						"num_members": 0,
+					},
+					{
+						"id":         "D002",
+						"user":       "U_ANOTHER",
+						"is_private": true,
+						"num_members": 0,
+					},
+					{
+						// DM the caller is NOT a member of — should be filtered out.
+						"id":         "D999",
+						"user":       "U_STRANGER",
+						"is_private": true,
+						"num_members": 0,
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	// D999 should be filtered out (not in caller's membership set).
+	if len(data.Channels) != 2 {
+		t.Fatalf("expected 2 IM channels, got %d", len(data.Channels))
+	}
+	if data.Channels[0].ID != "D001" {
+		t.Errorf("expected first channel D001, got %q", data.Channels[0].ID)
+	}
+	if data.Channels[0].User != "U_OTHER" {
+		t.Errorf("expected user field 'U_OTHER', got %q", data.Channels[0].User)
+	}
+	if data.Channels[0].Name != "" {
+		t.Errorf("expected empty name for IM channel, got %q", data.Channels[0].Name)
+	}
+	if data.Channels[1].ID != "D002" {
+		t.Errorf("expected second channel D002, got %q", data.Channels[1].ID)
+	}
+}
+
 func TestListChannels_WithPagination(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +303,7 @@ func TestListChannels_WithPagination(t *testing.T) {
 	action := &listChannelsAction{conn: conn}
 
 	params, _ := json.Marshal(listChannelsParams{
+		Types:  "public_channel",
 		Limit:  10,
 		Cursor: "dGVhbTpDMDI=",
 	})
@@ -169,7 +341,7 @@ func TestListChannels_SlackAPIError(t *testing.T) {
 	conn := newForTest(srv.Client(), srv.URL)
 	action := &listChannelsAction{conn: conn}
 
-	params, _ := json.Marshal(listChannelsParams{})
+	params, _ := json.Marshal(listChannelsParams{Types: "public_channel"})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "slack.list_channels",

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -395,3 +395,58 @@ func TestListChannels_InvalidJSON(t *testing.T) {
 		t.Errorf("expected ValidationError, got: %T", err)
 	}
 }
+
+func TestListChannels_DefaultFallbackWithoutEmail(t *testing.T) {
+	t.Parallel()
+
+	// When no types are specified (using the default) and no UserEmail is set,
+	// list_channels should gracefully fall back to public_channel only instead
+	// of returning a ValidationError. This preserves backward compatibility.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/conversations.list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var body listChannelsRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode: %v", err)
+		}
+		if body.Types != "public_channel" {
+			t.Errorf("expected fallback types 'public_channel', got %q", body.Types)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"channels": []map[string]any{
+				{"id": "C001", "name": "general", "is_private": false, "num_members": 5},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+
+	// No types param, no UserEmail — should fall back to public_channel.
+	params, _ := json.Marshal(listChannelsParams{})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("expected graceful fallback, got error: %v", err)
+	}
+
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(data.Channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(data.Channels))
+	}
+	if data.Channels[0].ID != "C001" {
+		t.Errorf("expected channel C001, got %q", data.Channels[0].ID)
+	}
+}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -69,15 +69,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.list_channels",
 				Name:        "List Channels",
-				Description: "List Slack channels visible to the bot",
+				Description: "List Slack channels visible to the bot. Returns all channel types (public, private, group DMs, DMs) by default.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
 						"types": {
 							"type": "string",
-							"default": "public_channel",
-							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im"
+							"default": "public_channel,private_channel,mpim,im",
+							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types."
 						},
 						"limit": {
 							"type": "integer",

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -77,7 +77,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"types": {
 							"type": "string",
 							"default": "public_channel,private_channel,mpim,im",
-							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types."
+							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types when a user email is available; falls back to public_channel only when no email is set."
 						},
 						"limit": {
 							"type": "integer",

--- a/connectors/slack/send_dm.go
+++ b/connectors/slack/send_dm.go
@@ -8,7 +8,8 @@ import (
 
 // sendDMAction implements connectors.Action for slack.send_dm.
 // It opens (or reuses) a DM channel with a user and sends a message
-// via conversations.open + chat.postMessage.
+// via conversations.open + chat.postMessage. Self-DMs (passing your own
+// user ID) are supported — Slack opens a "note to self" channel.
 type sendDMAction struct {
 	conn *SlackConnector
 }

--- a/connectors/slack/send_dm_test.go
+++ b/connectors/slack/send_dm_test.go
@@ -92,6 +92,86 @@ func TestSendDM_Success(t *testing.T) {
 	}
 }
 
+func TestSendDM_SelfDM(t *testing.T) {
+	t.Parallel()
+
+	// Slack supports DM-ing yourself by passing your own user ID to
+	// conversations.open. The code path is identical — no special-casing needed.
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/conversations.open":
+			callCount++
+			var body conversationsOpenRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode conversations.open body: %v", err)
+			}
+			// The user ID is the caller's own — Slack returns a self-DM channel.
+			if body.Users != "U_MYSELF" {
+				t.Errorf("expected users 'U_MYSELF', got %q", body.Users)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"channel": map[string]string{"id": "D_SELF"},
+			})
+
+		case "/chat.postMessage":
+			callCount++
+			var body sendMessageRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode chat.postMessage body: %v", err)
+			}
+			if body.Channel != "D_SELF" {
+				t.Errorf("expected channel 'D_SELF', got %q", body.Channel)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"ts":      "1700000000.000001",
+				"channel": "D_SELF",
+			})
+
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendDMAction{conn: conn}
+
+	params, _ := json.Marshal(sendDMParams{
+		UserID:  "U_MYSELF",
+		Message: "Note to self",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_dm",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["channel"] != "D_SELF" {
+		t.Errorf("expected channel 'D_SELF', got %q", data["channel"])
+	}
+}
+
 func TestSendDM_MissingUserID(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -56,6 +56,7 @@ var OAuthScopes = []string{
 	"im:write",
 	"mpim:history",
 	"mpim:read",
+	"mpim:write",
 	"reactions:write",
 	"users:read",
 	"users:read.email",


### PR DESCRIPTION
## Summary

- Adds `mpim:write` OAuth scope for opening group DM conversations
- Changes `list_channels` default `types` from `public_channel` to `public_channel,private_channel,mpim,im` so all channel types (including DMs and group DMs) are returned by default
- Adds `user` field to channel listing response for IM channels (which don't have a `name` field)
- Updates manifest schema and README documentation with new defaults and complete OAuth scopes reference

## Test plan

### Claude Code
- [x] All existing Slack connector tests pass with updated defaults
- [x] New `TestListChannels_DefaultTypes` verifies all-types default with access control
- [x] New `TestListChannels_IMChannels` verifies IM channel listing, `user` field population, and membership filtering
- [x] New `TestSendDM_SelfDM` verifies self-DM path works via conversations.open
- [x] `go vet ./connectors/slack/...` passes clean

### Manual Testing
- [ ] Verify OAuth flow requests the new `mpim:write` scope from Slack
- [ ] Test `list_channels` with no params returns DMs/MPIMs in a real workspace
- [ ] Test `list_channels` with `types=im` returns only DM channels
- [ ] Verify IM channels show `user` field instead of `name` in API response
- [ ] Test self-DM via `send_dm` with your own user ID

https://claude.ai/code/session_01JQGco1VNwE3YEjBpZQPQ8q