### PR TITLE
Reject unknown action types at approval creation

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -138,7 +138,9 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 		if deps.Connectors != nil {
 			action, ok := deps.Connectors.GetAction(actionType)
 			if !ok {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrUnsupportedActionType, fmt.Sprintf("unknown action type %q", actionType)))
+				errResp := BadRequest(ErrUnsupportedActionType, fmt.Sprintf("unknown action type %q", actionType))
+				errResp.Error.Details = map[string]any{"action_type": actionType}
+				RespondError(w, r, http.StatusBadRequest, errResp)
 				return
 			}
 			if aliaser, ok := action.(connectors.ParameterAliaser); ok {

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -129,6 +129,17 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Reject action types that don't map to a registered connector action.
+		// Without this check, agents can create approvals with bogus action types
+		// (e.g. "gmail.list_messages" instead of "google.list_emails") that store
+		// successfully but fail at execution time when the user approves them.
+		if deps.Connectors != nil {
+			if _, ok := deps.Connectors.GetAction(actionType); !ok {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, fmt.Sprintf("unknown action type %q", actionType)))
+				return
+			}
+		}
+
 		// Normalize parameters before storage so canonical keys are stored.
 		// First rewrites flat aliases (ParameterAliaser), then applies nested
 		// normalization (Normalizer). Must run before ValidateConfigurationReference

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -129,57 +129,51 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Reject action types that don't map to a registered connector action.
-		// Without this check, agents can create approvals with bogus action types
-		// (e.g. "gmail.list_messages" instead of "google.list_emails") that store
-		// successfully but fail at execution time when the user approves them.
-		if deps.Connectors != nil {
-			if _, ok := deps.Connectors.GetAction(actionType); !ok {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, fmt.Sprintf("unknown action type %q", actionType)))
-				return
-			}
-		}
-
-		// Normalize parameters before storage so canonical keys are stored.
-		// First rewrites flat aliases (ParameterAliaser), then applies nested
+		// Validate action type and normalize parameters before storage.
+		// Rejects unregistered action types immediately so agents get a clear
+		// error instead of approvals that silently fail at execution time.
+		// Then rewrites flat aliases (ParameterAliaser) and applies nested
 		// normalization (Normalizer). Must run before ValidateConfigurationReference
 		// so constraints are evaluated against canonical keys.
 		if deps.Connectors != nil {
-			if action, ok := deps.Connectors.GetAction(actionType); ok {
-				if aliaser, ok := action.(connectors.ParameterAliaser); ok {
-					if aliases := aliaser.ParameterAliases(); len(aliases) > 0 {
-						if rawParams, hasParams := actionObj["parameters"]; hasParams {
-							normalized := connectors.NormalizeParameters(aliases, rawParams)
-							actionObj["parameters"] = normalized
-							if updated, err := json.Marshal(actionObj); err == nil {
-								req.Action = updated
-							}
-						}
-					}
-				}
-				if normalizer, ok := action.(connectors.Normalizer); ok {
+			action, ok := deps.Connectors.GetAction(actionType)
+			if !ok {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrUnsupportedActionType, fmt.Sprintf("unknown action type %q", actionType)))
+				return
+			}
+			if aliaser, ok := action.(connectors.ParameterAliaser); ok {
+				if aliases := aliaser.ParameterAliases(); len(aliases) > 0 {
 					if rawParams, hasParams := actionObj["parameters"]; hasParams {
-						actionObj["parameters"] = normalizer.Normalize(rawParams)
+						normalized := connectors.NormalizeParameters(aliases, rawParams)
+						actionObj["parameters"] = normalized
 						if updated, err := json.Marshal(actionObj); err == nil {
 							req.Action = updated
 						}
 					}
 				}
-				// Validate parameters early so the agent gets an immediate error
-				// instead of the approval failing at execution time.
-				// If "parameters" is absent entirely, skip — schema validation
-				// (validateActionParameters below) catches missing required fields.
-				if rv, ok := action.(connectors.RequestValidator); ok {
-					if rawParams, hasParams := actionObj["parameters"]; hasParams {
-						if err := rv.ValidateRequest(json.RawMessage(rawParams)); err != nil {
-							var ve *connectors.ValidationError
-							if errors.As(err, &ve) {
-								RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, ve.Message))
-							} else {
-								RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "invalid action parameters"))
-							}
-							return
+			}
+			if normalizer, ok := action.(connectors.Normalizer); ok {
+				if rawParams, hasParams := actionObj["parameters"]; hasParams {
+					actionObj["parameters"] = normalizer.Normalize(rawParams)
+					if updated, err := json.Marshal(actionObj); err == nil {
+						req.Action = updated
+					}
+				}
+			}
+			// Validate parameters early so the agent gets an immediate error
+			// instead of the approval failing at execution time.
+			// If "parameters" is absent entirely, skip — schema validation
+			// (validateActionParameters below) catches missing required fields.
+			if rv, ok := action.(connectors.RequestValidator); ok {
+				if rawParams, hasParams := actionObj["parameters"]; hasParams {
+					if err := rv.ValidateRequest(json.RawMessage(rawParams)); err != nil {
+						var ve *connectors.ValidationError
+						if errors.As(err, &ve) {
+							RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, ve.Message))
+						} else {
+							RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "invalid action parameters"))
 						}
+						return
 					}
 				}
 			}

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
 )
@@ -66,6 +67,45 @@ func TestAgentRequestApproval_Success(t *testing.T) {
 	}
 	if resp.CreatedAt.IsZero() {
 		t.Error("expected created_at to be set")
+	}
+}
+
+func TestAgentRequestApproval_UnknownActionType(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Set up a connector registry with only "google" connector registered.
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector("google", "google.list_emails"))
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	router := NewRouter(deps)
+
+	// Use "gmail.list_messages" — a plausible but unregistered action type.
+	reqBody := `{"request_id":"req_bad","action":{"type":"gmail.list_messages","parameters":{}},"context":{"description":"List emails"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown action type, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if resp.Error.Message == "" {
+		t.Error("expected error message in response")
 	}
 }
 

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -108,6 +108,50 @@ func TestAgentRequestApproval_UnknownActionType(t *testing.T) {
 	if resp.Error.Message == "" {
 		t.Error("expected error message in response")
 	}
+	if resp.Error.Code != ErrUnsupportedActionType {
+		t.Errorf("expected error code %q, got %q", ErrUnsupportedActionType, resp.Error.Code)
+	}
+}
+
+func TestAgentRequestApproval_KnownActionType(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	// Set up a connector registry with "google" connector registered.
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector("google", "google.list_emails"))
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_known","action":{"type":"google.list_emails","parameters":{}},"context":{"description":"List emails"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for known action type, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.ApprovalID == "" {
+		t.Error("expected non-empty approval_id")
+	}
+	if resp.Status != "pending" {
+		t.Errorf("expected status 'pending', got %q", resp.Status)
+	}
 }
 
 func TestAgentRequestApproval_CustomExpiresIn(t *testing.T) {


### PR DESCRIPTION
## Summary

- Validates action types against the connector registry when agents create approvals via `POST /approvals/request`
- Returns 400 immediately for unregistered action types (e.g. `gmail.list_messages`) instead of storing them and failing silently at execution time
- Fixes [PERMISSION-SLIP-GO-9](https://supersuit-technologies.sentry.io/issues/7348373607/) where an agent submitted `gmail.list_messages` (no such connector) instead of `google.list_emails`, and the error only surfaced when the user approved it

## Test plan

### Claude Code
- [x] Added `TestAgentRequestApproval_UnknownActionType` — verifies 400 for unregistered action types
- [x] All existing `api/` tests pass (no regressions)
- [x] `go build ./...` and `go vet ./api/` clean

### Manual Testing
- [ ] Verify existing agents with valid action types can still create approvals
- [ ] Confirm the 400 error message is clear enough for agent developers to self-diagnose

https://claude.ai/code/session_01XXFaJVjSi6aLkGtBW28A3Z