### PR TITLE
Enable SMS for self-hosted deployments, remove plan gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -281,7 +281,11 @@ VAULT_SECRET_KEY=your-vault-secret-key-from-openssl-rand
 # EXPO_ACCESS_TOKEN=
 
 # ── SMS (Amazon SNS) ─────────────────────────────────────────────────────────
-# AWS_REGION is required to enable SMS notifications (defaults to us-east-1).
+# SMS is the primary notification channel for self-hosted deployments.
+# When AWS_REGION is set and the SMS sender initializes successfully,
+# SMS appears in the user's notification preferences automatically.
+#
+# AWS_REGION is required to enable SMS notifications.
 # Credentials are optional when running on EC2/ECS/Lambda with an IAM role.
 # AWS_REGION=us-east-1
 # AWS_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxx
@@ -293,6 +297,12 @@ VAULT_SECRET_KEY=your-vault-secret-key-from-openssl-rand
 # Optional: origination phone number in E.164 format. Required for US
 # destinations when a short/long code or toll-free number is registered.
 # SNS_SMS_ORIGINATION_NUMBER=+15551234567
+#
+# Set to "true" to hide SMS from the notification preferences UI even when
+# AWS SNS is configured. Used on the hosted platform (app.permissionslip.dev)
+# to prevent users from seeing SMS settings. Self-hosted deployments should
+# leave this unset or set to "false".
+# SMS_NOTIFICATIONS_HIDDEN=true
 
 # ── Error Tracking (Sentry) ──────────────────────────────────────────────────
 #

--- a/api/config.go
+++ b/api/config.go
@@ -6,9 +6,10 @@ import "net/http"
 // Add new fields here as more server config needs to be exposed
 // (e.g., feature flags for upcoming features).
 type configResponse struct {
-	BillingEnabled       bool `json:"billing_enabled"`
+	BillingEnabled           bool `json:"billing_enabled"`
 	GoogleOAuthConfigured    bool `json:"google_oauth_configured"`
 	MicrosoftOAuthConfigured bool `json:"microsoft_oauth_configured"`
+	SMSEnabled               bool `json:"sms_enabled"`
 }
 
 func init() {
@@ -38,6 +39,7 @@ func handleGetConfig(deps *Deps) http.HandlerFunc {
 			BillingEnabled:           deps.BillingEnabled,
 			GoogleOAuthConfigured:    googleConfigured,
 			MicrosoftOAuthConfigured: microsoftConfigured,
+			SMSEnabled:               deps.SMSEnabled,
 		})
 	}
 }

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -54,6 +54,7 @@ const (
 	ErrBillingNotEnabled        ErrorCode = "billing_not_enabled"
 	ErrSMSRequiresPaidPlan      ErrorCode = "sms_requires_paid_plan"
 	ErrChannelUnavailableBeta   ErrorCode = "channel_unavailable_beta"
+	ErrChannelNotConfigured     ErrorCode = "channel_not_configured"
 	// OAuth
 	ErrOAuthProviderNotFound     ErrorCode = "oauth_provider_not_found"
 	ErrOAuthProviderUnconfigured ErrorCode = "oauth_provider_unconfigured"

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,8 +14,8 @@ import (
 )
 
 // notificationPreferenceResponse is a single channel preference.
-// The Available field indicates whether the user's plan supports this channel;
-// when false, the frontend should show an upgrade prompt instead of a toggle.
+// The Available field indicates whether the channel can be used;
+// when false, the frontend should show a "coming soon" badge instead of a toggle.
 type notificationPreferenceResponse struct {
 	Channel   string `json:"channel"`
 	Enabled   bool   `json:"enabled"`
@@ -57,9 +56,6 @@ var allChannels = func() []string {
 	return channels
 }()
 
-// paidOnlyChannels lists channels that require a paid plan.
-var paidOnlyChannels = map[string]bool{}
-
 // betaDisabledChannels lists channels that are disabled during the beta period.
 // These channels are always unavailable regardless of plan.
 var betaDisabledChannels = map[string]bool{
@@ -78,10 +74,8 @@ func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		planID := userPlanID(r.Context(), deps.DB, profile.ID)
-
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs, planID, deps.SMSEnabled),
+			Preferences: buildPreferencesResponse(prefs, deps.SMSEnabled),
 		})
 	}
 }
@@ -128,13 +122,10 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 		// or the operator has explicitly hidden SMS (SMS_NOTIFICATIONS_HIDDEN=true).
 		for _, p := range req.Preferences {
 			if p.Enabled && p.Channel == "sms" && !deps.SMSEnabled {
-				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelUnavailableBeta, "SMS notifications are not configured on this server."))
+				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelNotConfigured, "SMS notifications are not configured on this server."))
 				return
 			}
 		}
-
-		// Look up plan for the response (SMS availability in response payload).
-		planID := userPlanID(r.Context(), deps.DB, profile.ID)
 
 		for _, p := range req.Preferences {
 			if err := db.UpsertNotificationPreference(r.Context(), deps.DB, profile.ID, p.Channel, p.Enabled); err != nil {
@@ -155,43 +146,20 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs, planID, deps.SMSEnabled),
+			Preferences: buildPreferencesResponse(prefs, deps.SMSEnabled),
 		})
 	}
 }
 
-// userPlanID returns the user's current plan ID, defaulting to "free" if the
-// subscription is missing or the lookup fails. Errors are logged but not
-// surfaced — this is a read-only helper for response enrichment.
-func userPlanID(ctx context.Context, d db.DBTX, userID string) string {
-	sub, err := db.GetSubscriptionByUserID(ctx, d, userID)
-	if err != nil {
-		log.Printf("userPlanID: get subscription for %s: %v", userID, err)
-		CaptureError(ctx, err)
-		return db.PlanFree
-	}
-	if sub == nil {
-		return db.PlanFree
-	}
-	return sub.PlanID
-}
-
-// isPaidPlan returns true if the plan ID represents a paid (non-free) plan.
-func isPaidPlan(planID string) bool {
-	return planID != db.PlanFree
-}
-
 // buildPreferencesResponse converts DB preferences into the API response,
-// defaulting missing channels to enabled. The planID controls whether
-// plan-gated channels are marked as available. SMS is excluded entirely
+// defaulting missing channels to enabled. SMS is excluded entirely
 // when smsEnabled is false (server has no SMS sender or operator hid it).
-func buildPreferencesResponse(prefs []db.NotificationPreference, planID string, smsEnabled bool) []notificationPreferenceResponse {
+func buildPreferencesResponse(prefs []db.NotificationPreference, smsEnabled bool) []notificationPreferenceResponse {
 	channelMap := make(map[string]bool)
 	for _, p := range prefs {
 		channelMap[p.Channel] = p.Enabled
 	}
 
-	paid := isPaidPlan(planID)
 	result := make([]notificationPreferenceResponse, 0, len(allChannels))
 	for _, ch := range allChannels {
 		// Skip SMS entirely when the server doesn't have it configured.
@@ -206,12 +174,7 @@ func buildPreferencesResponse(prefs []db.NotificationPreference, planID string, 
 				enabled = true // missing rows default to enabled
 			}
 		}
-		available := true
-		if betaDisabledChannels[ch] {
-			available = false // always unavailable during beta
-		} else if paidOnlyChannels[ch] {
-			available = paid
-		}
+		available := !betaDisabledChannels[ch]
 		result = append(result, notificationPreferenceResponse{
 			Channel:   ch,
 			Enabled:   enabled,

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -58,14 +58,11 @@ var allChannels = func() []string {
 }()
 
 // paidOnlyChannels lists channels that require a paid plan.
-var paidOnlyChannels = map[string]bool{
-	"sms": true,
-}
+var paidOnlyChannels = map[string]bool{}
 
 // betaDisabledChannels lists channels that are disabled during the beta period.
 // These channels are always unavailable regardless of plan.
 var betaDisabledChannels = map[string]bool{
-	"sms":      true,
 	"web-push": true,
 }
 
@@ -84,7 +81,7 @@ func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 		planID := userPlanID(r.Context(), deps.DB, profile.ID)
 
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs, planID),
+			Preferences: buildPreferencesResponse(prefs, planID, deps.SMSEnabled),
 		})
 	}
 }
@@ -127,6 +124,15 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		// Gate SMS: reject enabling SMS when the server has no SMS sender configured
+		// or the operator has explicitly hidden SMS (SMS_NOTIFICATIONS_HIDDEN=true).
+		for _, p := range req.Preferences {
+			if p.Enabled && p.Channel == "sms" && !deps.SMSEnabled {
+				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelUnavailableBeta, "SMS notifications are not configured on this server."))
+				return
+			}
+		}
+
 		// Look up plan for the response (SMS availability in response payload).
 		planID := userPlanID(r.Context(), deps.DB, profile.ID)
 
@@ -149,7 +155,7 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusOK, notificationPreferencesResponse{
-			Preferences: buildPreferencesResponse(prefs, planID),
+			Preferences: buildPreferencesResponse(prefs, planID, deps.SMSEnabled),
 		})
 	}
 }
@@ -177,8 +183,9 @@ func isPaidPlan(planID string) bool {
 
 // buildPreferencesResponse converts DB preferences into the API response,
 // defaulting missing channels to enabled. The planID controls whether
-// plan-gated channels (SMS) are marked as available.
-func buildPreferencesResponse(prefs []db.NotificationPreference, planID string) []notificationPreferenceResponse {
+// plan-gated channels are marked as available. SMS is excluded entirely
+// when smsEnabled is false (server has no SMS sender or operator hid it).
+func buildPreferencesResponse(prefs []db.NotificationPreference, planID string, smsEnabled bool) []notificationPreferenceResponse {
 	channelMap := make(map[string]bool)
 	for _, p := range prefs {
 		channelMap[p.Channel] = p.Enabled
@@ -187,6 +194,10 @@ func buildPreferencesResponse(prefs []db.NotificationPreference, planID string) 
 	paid := isPaidPlan(planID)
 	result := make([]notificationPreferenceResponse, 0, len(allChannels))
 	for _, ch := range allChannels {
+		// Skip SMS entirely when the server doesn't have it configured.
+		if ch == "sms" && !smsEnabled {
+			continue
+		}
 		enabled, exists := channelMap[ch]
 		if !exists {
 			if betaDisabledChannels[ch] {

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -15,7 +15,9 @@ import (
 
 // notificationPreferenceResponse is a single channel preference.
 // The Available field indicates whether the channel can be used;
-// when false, the frontend should show a "coming soon" badge instead of a toggle.
+// when false, the frontend shows a "coming soon" badge instead of a toggle.
+// Note: SMS is excluded from the response entirely (not just marked unavailable)
+// when the server has no SMS sender configured.
 type notificationPreferenceResponse struct {
 	Channel   string `json:"channel"`
 	Enabled   bool   `json:"enabled"`
@@ -118,10 +120,12 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		// Gate SMS: reject enabling SMS when the server has no SMS sender configured
+		// Gate SMS: reject any SMS preference change when the server has no SMS sender configured
 		// or the operator has explicitly hidden SMS (SMS_NOTIFICATIONS_HIDDEN=true).
+		// This prevents stale clients from writing sms=false rows that would override the
+		// "missing rows default to enabled" behaviour when SMS is later configured.
 		for _, p := range req.Preferences {
-			if p.Enabled && p.Channel == "sms" && !deps.SMSEnabled {
+			if p.Channel == "sms" && !deps.SMSEnabled {
 				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelNotConfigured, "SMS notifications are not configured on this server."))
 				return
 			}

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
 )
 
-func TestUpdateNotificationPreferences_EnableSMS_FreeTier_Rejected(t *testing.T) {
+func TestUpdateNotificationPreferences_EnableSMS_WhenNotConfigured_Rejected(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret} // SMSEnabled defaults to false
 	router := NewRouter(deps)
 
 	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
@@ -38,14 +38,14 @@ func TestUpdateNotificationPreferences_EnableSMS_FreeTier_Rejected(t *testing.T)
 	}
 }
 
-func TestUpdateNotificationPreferences_EnableSMS_PaidTier_RejectedDuringBeta(t *testing.T) {
+func TestUpdateNotificationPreferences_EnableSMS_WhenConfigured_Allowed(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, SMSEnabled: true}
 	router := NewRouter(deps)
 
 	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
@@ -53,9 +53,8 @@ func TestUpdateNotificationPreferences_EnableSMS_PaidTier_RejectedDuringBeta(t *
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	// SMS is disabled during beta regardless of plan.
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -80,14 +79,15 @@ func TestUpdateNotificationPreferences_DisableSMS_FreeTier_Allowed(t *testing.T)
 	}
 }
 
-func TestUpdateNotificationPreferences_EnableSMS_NoSubscription_Rejected(t *testing.T) {
+func TestUpdateNotificationPreferences_EnableSMS_NoSubscription_WhenConfigured_Allowed(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
-	// No subscription row — should be treated as not allowed.
+	// No subscription row — SMS is no longer plan-gated, so this should succeed
+	// when the server has SMS configured.
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, SMSEnabled: true}
 	router := NewRouter(deps)
 
 	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
@@ -95,8 +95,8 @@ func TestUpdateNotificationPreferences_EnableSMS_NoSubscription_Rejected(t *test
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -121,17 +121,17 @@ func TestUpdateNotificationPreferences_EnableEmail_FreeTier_Allowed(t *testing.T
 	}
 }
 
-func TestUpdateNotificationPreferences_MixedChannels_FreeTier_SMSBlocked(t *testing.T) {
+func TestUpdateNotificationPreferences_MixedChannels_SMSBlocked_WhenNotConfigured(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret} // SMSEnabled=false
 	router := NewRouter(deps)
 
-	// Enabling email (allowed) + SMS (blocked) in a single request should fail.
+	// Enabling email (allowed) + SMS (blocked when not configured) in a single request should fail.
 	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
 		`{"preferences":[{"channel":"email","enabled":true},{"channel":"sms","enabled":true}]}`)
 	w := httptest.NewRecorder()
@@ -142,14 +142,14 @@ func TestUpdateNotificationPreferences_MixedChannels_FreeTier_SMSBlocked(t *test
 	}
 }
 
-func TestGetNotificationPreferences_SMSUnavailable_PaidTier_DuringBeta(t *testing.T) {
+func TestGetNotificationPreferences_SMSExcluded_WhenNotConfigured(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret} // SMSEnabled=false
 	router := NewRouter(deps)
 
 	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-preferences", uid)
@@ -165,31 +165,28 @@ func TestGetNotificationPreferences_SMSUnavailable_PaidTier_DuringBeta(t *testin
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	// SMS and web-push are unavailable during beta regardless of plan.
+	// SMS should be excluded entirely when not configured on the server.
+	// web-push is still present but unavailable (beta-disabled).
 	for _, p := range resp.Preferences {
-		if p.Channel == "sms" || p.Channel == "web-push" {
+		if p.Channel == "sms" {
+			t.Error("expected SMS to be excluded from response when not configured")
+		}
+		if p.Channel == "web-push" {
 			if p.Available {
-				t.Errorf("expected %q unavailable during beta even on paid plan", p.Channel)
-			}
-			if p.Enabled {
-				t.Errorf("expected %q to default to disabled during beta", p.Channel)
-			}
-		} else {
-			if !p.Available {
-				t.Errorf("expected %q available on paid plan", p.Channel)
+				t.Error("expected web-push unavailable during beta")
 			}
 		}
 	}
 }
 
-func TestGetNotificationPreferences_SMSUnavailable_FreeTier(t *testing.T) {
+func TestGetNotificationPreferences_SMSAvailable_WhenConfigured(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, SMSEnabled: true}
 	router := NewRouter(deps)
 
 	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-preferences", uid)
@@ -205,16 +202,20 @@ func TestGetNotificationPreferences_SMSUnavailable_FreeTier(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
+	found := false
 	for _, p := range resp.Preferences {
-		if p.Channel == "sms" || p.Channel == "web-push" {
-			if p.Available {
-				t.Errorf("expected %q unavailable (beta-disabled or plan-gated)", p.Channel)
-			}
-		} else {
+		if p.Channel == "sms" {
+			found = true
 			if !p.Available {
-				t.Errorf("expected %q available on free tier", p.Channel)
+				t.Error("expected SMS to be available when configured")
+			}
+			if !p.Enabled {
+				t.Error("expected SMS to default to enabled when configured")
 			}
 		}
+	}
+	if !found {
+		t.Error("expected SMS channel in preferences response when configured")
 	}
 }
 

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -58,17 +58,39 @@ func TestUpdateNotificationPreferences_EnableSMS_WhenConfigured_Allowed(t *testi
 	}
 }
 
-func TestUpdateNotificationPreferences_DisableSMS_FreeTier_Allowed(t *testing.T) {
+func TestUpdateNotificationPreferences_DisableSMS_WhenNotConfigured_Rejected(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret} // SMSEnabled=false
 	router := NewRouter(deps)
 
-	// Disabling SMS should work even on free tier (no plan check needed).
+	// Any SMS preference change should be rejected when SMS is not configured,
+	// including disabling — to prevent stale rows that override defaults.
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
+		`{"preferences":[{"channel":"sms","enabled":false}]}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateNotificationPreferences_DisableSMS_WhenConfigured_Allowed(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, SMSEnabled: true}
+	router := NewRouter(deps)
+
+	// Disabling SMS should work when SMS is configured on the server.
 	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-preferences", uid,
 		`{"preferences":[{"channel":"sms","enabled":false}]}`)
 	w := httptest.NewRecorder()

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -33,8 +33,8 @@ func TestUpdateNotificationPreferences_EnableSMS_WhenNotConfigured_Rejected(t *t
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal error response: %v", err)
 	}
-	if resp.Error.Code != ErrChannelUnavailableBeta {
-		t.Errorf("expected error code %q, got %q", ErrChannelUnavailableBeta, resp.Error.Code)
+	if resp.Error.Code != ErrChannelNotConfigured {
+		t.Errorf("expected error code %q, got %q", ErrChannelNotConfigured, resp.Error.Code)
 	}
 }
 

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -309,7 +309,7 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret} // SMSEnabled=false
 	router := NewRouter(deps)
 
 	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-preferences", uid)
@@ -324,8 +324,9 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
-	if len(resp.Preferences) != len(allChannels) {
-		t.Fatalf("expected %d preferences, got %d", len(allChannels), len(resp.Preferences))
+	// SMS is excluded when SMSEnabled=false, so expect 3 channels (email, mobile-push, web-push).
+	if len(resp.Preferences) != 3 {
+		t.Fatalf("expected 3 preferences (SMS excluded), got %d", len(resp.Preferences))
 	}
 
 	// Index preferences by channel for explicit assertions.
@@ -334,16 +335,16 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 		prefsByChannel[p.Channel] = p
 	}
 
-	// All channels default to enabled when no preferences are set.
-	// SMS and web-push are unavailable during beta regardless of plan.
-	requiredChannels := []string{"email", "web-push", "sms", "mobile-push"}
+	// All non-beta channels default to enabled. web-push is unavailable during beta.
+	// SMS is excluded entirely when SMSEnabled=false.
+	requiredChannels := []string{"email", "web-push", "mobile-push"}
 	for _, ch := range requiredChannels {
 		p, ok := prefsByChannel[ch]
 		if !ok {
 			t.Errorf("expected preference for channel %q", ch)
 			continue
 		}
-		if ch == "sms" || ch == "web-push" {
+		if ch == "web-push" {
 			if p.Enabled {
 				t.Errorf("expected %q to default to disabled during beta", ch)
 			}
@@ -353,11 +354,14 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 		} else if !p.Enabled {
 			t.Errorf("expected channel %q to default to enabled", ch)
 		}
-		if ch != "sms" && ch != "web-push" {
+		if ch != "web-push" {
 			if !p.Available {
 				t.Errorf("expected channel %q to be available", ch)
 			}
 		}
+	}
+	if _, ok := prefsByChannel["sms"]; ok {
+		t.Error("expected SMS to be excluded when SMSEnabled=false")
 	}
 }
 

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -324,9 +324,10 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
-	// SMS is excluded when SMSEnabled=false, so expect 3 channels (email, mobile-push, web-push).
-	if len(resp.Preferences) != 3 {
-		t.Fatalf("expected 3 preferences (SMS excluded), got %d", len(resp.Preferences))
+	// SMS is excluded when SMSEnabled=false.
+	expectedChannels := len(allChannels) - 1
+	if len(resp.Preferences) != expectedChannels {
+		t.Fatalf("expected %d preferences (SMS excluded), got %d", expectedChannels, len(resp.Preferences))
 	}
 
 	// Index preferences by channel for explicit assertions.

--- a/api/router.go
+++ b/api/router.go
@@ -32,6 +32,7 @@ type Deps struct {
 	OAuthStateSecret      string               // HMAC-SHA256 secret for signing OAuth CSRF state tokens; if empty, falls back to SupabaseJWTSecret
 	Stripe                *pstripe.Client      // Stripe API client; nil when billing is disabled or Stripe keys not set
 	BillingEnabled        bool                 // true when BILLING_ENABLED=true; gates Stripe, metering, and billing endpoints
+	SMSEnabled            bool                 // true when SMS sender is configured AND SMS_NOTIFICATIONS_HIDDEN != "true"; gates SMS preference visibility
 	DevMode               bool                 // true when MODE=development; disables rate limiting
 	RateLimiter           *RateLimiter         // pre-auth rate limiter (per-IP + global); nil disables
 	AgentRateLimiter      *RateLimiter         // post-auth rate limiter (per verified agent); nil disables

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -169,7 +169,26 @@ Pick one provider:
 | `SMTP_PASSWORD` | SMTP password or app password |
 | `NOTIFICATION_EMAIL_FROM` | Sender address |
 
-### SMS Notifications (Amazon SNS)
+### SMS Notifications (Amazon SNS) — Recommended for Self-Hosted
+
+SMS is the primary notification channel for self-hosted deployments. When configured, it appears automatically in each user's notification preferences — no plan or subscription required.
+
+You'll need an AWS account with Amazon SNS access. Here's how to set it up:
+
+1. **Create an AWS account** (if you don't have one) at [aws.amazon.com](https://aws.amazon.com)
+2. **Create an IAM user** (or use an existing one) with the `sns:Publish` permission. The minimal IAM policy:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Action": "sns:Publish",
+       "Resource": "*"
+     }]
+   }
+   ```
+3. **Request production SMS access** — new AWS accounts are in the [SMS Sandbox](https://docs.aws.amazon.com/sns/latest/dg/sns-sms-sandbox.html) by default. Go to the SNS console → Text messaging (SMS) → Exit sandbox. Until approved, SMS only reaches verified destination numbers.
+4. **Set the environment variables:**
 
 | Variable | Description |
 |---|---|
@@ -179,9 +198,11 @@ Pick one provider:
 | `SNS_SMS_SENDER_ID` | Optional alphanumeric sender ID (not supported in all countries) |
 | `SNS_SMS_ORIGINATION_NUMBER` | Optional origination phone number in E.164 format |
 
-`AWS_REGION` is required to enable SMS. Credentials are optional when running on AWS with an IAM role. The IAM user/role needs `sns:Publish` permission.
+`AWS_REGION` is required to enable SMS. Credentials are optional when running on AWS with an IAM role (EC2, ECS, Lambda).
 
-> **Important:** New AWS accounts are in the [SMS Sandbox](https://docs.aws.amazon.com/sns/latest/dg/sns-sms-sandbox.html) by default. Request production SMS access in the SNS console before deploying, or SMS will only reach verified destination numbers.
+> **Tip:** For US destinations, you'll likely need a toll-free number or 10DLC registration. Set `SNS_SMS_ORIGINATION_NUMBER` to your registered number in E.164 format (e.g., `+15551234567`).
+
+To hide SMS from the UI (e.g., on a hosted platform), set `SMS_NOTIFICATIONS_HIDDEN=true`. Self-hosted deployments should leave this unset.
 
 ### Error Tracking (Sentry)
 
@@ -232,6 +253,7 @@ When `BILLING_ENABLED=false` (the default), all users get an unlimited plan, Str
 | `SHUTDOWN_TIMEOUT` | `30s` | Graceful shutdown timeout for in-flight requests |
 | `CONNECTORS_DIR` | `~/.permission_slip/connectors/` | Directory for external connector plugins |
 | `CUSTOM_CONNECTORS_JSON` | (empty) | Inline JSON connector config (alternative to file on disk) |
+| `SMS_NOTIFICATIONS_HIDDEN` | `false` | Set to `true` to hide SMS from notification preferences UI even when SNS is configured |
 | `SUPABASE_JWT_SECRET` | (empty) | Legacy HS256 JWT secret (only for Supabase CLI v1 — not needed with modern Supabase) |
 | `SUPABASE_JWKS_URL` | (auto-derived) | Override JWKS endpoint URL (auto-derived from `SUPABASE_URL` if not set) |
 
@@ -457,6 +479,9 @@ Migrations run automatically on startup. If they fail, check database connectivi
 | `AWS_REGION` | For SMS | Runtime | AWS region for SNS (e.g. `us-east-1`) |
 | `AWS_ACCESS_KEY_ID` | For SMS | Runtime | AWS access key (optional with IAM roles) |
 | `AWS_SECRET_ACCESS_KEY` | For SMS | Runtime | AWS secret key (optional with IAM roles) |
+| `SNS_SMS_SENDER_ID` | No | Runtime | Alphanumeric SMS sender ID (not supported in all countries) |
+| `SNS_SMS_ORIGINATION_NUMBER` | No | Runtime | Origination phone number in E.164 format |
+| `SMS_NOTIFICATIONS_HIDDEN` | No | Runtime | Hide SMS from notification preferences UI (`true`/`false`, default: `false`) |
 | `SENTRY_DSN` | No | Runtime | Backend error tracking |
 | `SENTRY_CSP_ENDPOINT` | No | Runtime | CSP violation reporting |
 | `VITE_SENTRY_DSN` | No | Build | Frontend error tracking |

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -28,7 +28,7 @@ const CHANNEL_LABELS: Record<string, { name: string; description: string }> = {
   },
   sms: {
     name: "SMS",
-    description: "Text message notifications for urgent approval requests. Available after the beta.",
+    description: "Text message notifications for urgent approval requests.",
   },
   "mobile-push": {
     name: "Mobile Push",

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -14,18 +14,19 @@ import { NotificationSection } from "../NotificationSection";
 vi.mock("../../../lib/supabaseClient");
 vi.mock("../../../api/client");
 
+// Default fixture: SMS not configured on server, so excluded from response.
 const allEnabled = [
   { channel: "email", enabled: true, available: true },
   { channel: "web-push", enabled: true, available: true },
-  { channel: "sms", enabled: false, available: false },
   { channel: "mobile-push", enabled: true, available: true },
 ];
 
-const smsGated = [
+// Fixture: SMS configured on server and included.
+const withSmsEnabled = [
   { channel: "email", enabled: true, available: true },
-  { channel: "web-push", enabled: true, available: true },
-  { channel: "sms", enabled: false, available: false },
   { channel: "mobile-push", enabled: true, available: true },
+  { channel: "sms", enabled: true, available: true },
+  { channel: "web-push", enabled: true, available: true },
 ];
 
 interface MockProfile {
@@ -88,7 +89,7 @@ describe("NotificationSection", () => {
     });
   });
 
-  it("renders all four channels", async () => {
+  it("renders channels returned by server (no SMS when not configured)", async () => {
     mockApiFetch();
 
     render(<NotificationSection />, { wrapper });
@@ -97,8 +98,19 @@ describe("NotificationSection", () => {
       expect(screen.getByText("Email")).toBeInTheDocument();
     });
     expect(screen.getByText("Web Push")).toBeInTheDocument();
-    expect(screen.getByText("SMS")).toBeInTheDocument();
     expect(screen.getByText("Mobile Push")).toBeInTheDocument();
+    expect(screen.queryByText("SMS")).not.toBeInTheDocument();
+  });
+
+  it("renders SMS channel when configured on server", async () => {
+    mockApiFetch(profileWithContact, withSmsEnabled);
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("SMS")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Email")).toBeInTheDocument();
   });
 
   it("shows loading state", () => {
@@ -118,7 +130,6 @@ describe("NotificationSection", () => {
     const prefs = [
       { channel: "email", enabled: true, available: true },
       { channel: "web-push", enabled: false, available: true },
-      { channel: "sms", enabled: false, available: false },
       { channel: "mobile-push", enabled: true, available: true },
     ];
     mockApiFetch(profileWithContact, prefs);
@@ -134,7 +145,6 @@ describe("NotificationSection", () => {
         (s) => s.getAttribute("data-state") === "unchecked",
       );
       // 2 channels enabled (email, mobile-push) + 2 unchecked (web-push, product updates)
-      // SMS has no switch (beta-disabled)
       expect(checked).toHaveLength(2);
       expect(unchecked).toHaveLength(2);
     });
@@ -154,18 +164,32 @@ describe("NotificationSection", () => {
     });
   });
 
-  it("does not show phone warning when SMS is beta-disabled", async () => {
+  it("does not show phone warning when SMS is not configured", async () => {
     mockApiFetch(profileNoContact, allEnabled);
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Email")).toBeInTheDocument();
+    });
+    // SMS is excluded from response when not configured, so no phone warning.
+    expect(screen.queryByText("SMS")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Add a phone number/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows phone warning when SMS is configured and phone is missing", async () => {
+    mockApiFetch(profileNoContact, withSmsEnabled);
 
     render(<NotificationSection />, { wrapper });
 
     await waitFor(() => {
       expect(screen.getByText("SMS")).toBeInTheDocument();
     });
-    // SMS is gated during beta, so no phone warning should appear.
     expect(
-      screen.queryByText(/Add a phone number/),
-    ).not.toBeInTheDocument();
+      screen.getByText(/Add a phone number/),
+    ).toBeInTheDocument();
   });
 
   it("does not show warnings when contact info is present", async () => {
@@ -188,7 +212,6 @@ describe("NotificationSection", () => {
     const prefs = [
       { channel: "email", enabled: false, available: true },
       { channel: "web-push", enabled: true, available: true },
-      { channel: "sms", enabled: false, available: false },
       { channel: "mobile-push", enabled: true, available: true },
     ];
     mockApiFetch(profileNoContact, prefs);
@@ -327,20 +350,8 @@ describe("NotificationSection", () => {
     });
   });
 
-  it("shows SMS as coming soon during beta", async () => {
-    mockApiFetch(profileWithContact, smsGated);
-
-    render(<NotificationSection />, { wrapper });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Coming soon"),
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("does not show toggle button for plan-gated SMS", async () => {
-    mockApiFetch(profileWithContact, smsGated);
+  it("shows toggle for SMS when configured", async () => {
+    mockApiFetch(profileWithContact, withSmsEnabled);
 
     render(<NotificationSection />, { wrapper });
 
@@ -348,22 +359,8 @@ describe("NotificationSection", () => {
       expect(screen.getByText("SMS")).toBeInTheDocument();
     });
 
-    // Should have 3 channel switches (email, web-push, mobile-push) + 1 product updates = 4
-    // SMS should not have a switch (beta-disabled)
-    const switches = screen.getAllByRole("switch");
-    expect(switches).toHaveLength(4);
-  });
-
-  it("does not show missing phone warning for plan-gated SMS", async () => {
-    mockApiFetch(profileNoContact, smsGated);
-
-    render(<NotificationSection />, { wrapper });
-
-    await waitFor(() => {
-      expect(screen.getByText("SMS")).toBeInTheDocument();
-    });
-    expect(
-      screen.queryByText(/Add a phone number/),
-    ).not.toBeInTheDocument();
+    // SMS should have a toggle (available=true), not "Coming soon"
+    expect(screen.getByRole("switch", { name: /sms notifications/i })).toBeInTheDocument();
+    expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
   });
 });

--- a/main.go
+++ b/main.go
@@ -264,6 +264,17 @@ func main() {
 	})
 
 	notify.LogChannelSummary(senders)
+
+	// SMS is available when a sender named "sms" was built and the server
+	// operator hasn't explicitly hidden it (e.g. on app.permissionslip.dev).
+	smsConfigured := false
+	for _, s := range senders {
+		if s.Name() == "sms" {
+			smsConfigured = true
+			break
+		}
+	}
+	deps.SMSEnabled = smsConfigured && os.Getenv("SMS_NOTIFICATIONS_HIDDEN") != "true"
 	if deps.DB != nil && len(senders) > 0 {
 		deps.Notifier = notify.NewDispatcher(senders, &notify.DBPreferenceChecker{DB: deps.DB})
 	} else if len(senders) > 0 {

--- a/main.go
+++ b/main.go
@@ -274,7 +274,7 @@ func main() {
 			break
 		}
 	}
-	deps.SMSEnabled = smsConfigured && os.Getenv("SMS_NOTIFICATIONS_HIDDEN") != "true"
+	deps.SMSEnabled = smsConfigured && !strings.EqualFold(os.Getenv("SMS_NOTIFICATIONS_HIDDEN"), "true")
 	if deps.DB != nil && len(senders) > 0 {
 		deps.Notifier = notify.NewDispatcher(senders, &notify.DBPreferenceChecker{DB: deps.DB})
 	} else if len(senders) > 0 {

--- a/spec/openapi/components/paths/config.yaml
+++ b/spec/openapi/components/paths/config.yaml
@@ -25,5 +25,6 @@ config:
               $ref: '../schemas/config.yaml#/ConfigResponse'
             example:
               billing_enabled: false
+              sms_enabled: false
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'

--- a/spec/openapi/components/schemas/config.yaml
+++ b/spec/openapi/components/schemas/config.yaml
@@ -7,6 +7,7 @@ ConfigResponse:
     - billing_enabled
     - google_oauth_configured
     - microsoft_oauth_configured
+    - sms_enabled
   properties:
     billing_enabled:
       type: boolean
@@ -32,3 +33,14 @@ ConfigResponse:
         without BYOA setup. When `false`, users must provide their own Microsoft
         OAuth app credentials via the BYOA configuration UI.
       example: true
+    sms_enabled:
+      type: boolean
+      description: |
+        Whether SMS notifications are configured and available on this server.
+        When `true`, users can enable SMS notifications in their preferences.
+        SMS is enabled when the server has a working AWS SNS sender configured
+        (`AWS_REGION` is set) and the `SMS_NOTIFICATIONS_HIDDEN` env var is not
+        set to `"true"`. Self-hosted deployments that configure SNS will have
+        this set automatically; the hosted platform (app.permissionslip.dev)
+        sets `SMS_NOTIFICATIONS_HIDDEN=true` to hide SMS from users.
+      example: false

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -6488,6 +6488,7 @@ paths:
                 $ref: '#/components/schemas/ConfigResponse'
               example:
                 billing_enabled: false
+                sms_enabled: false
         '401':
           $ref: '#/components/responses/Unauthorized'
   /v1/config/vapid-key:
@@ -11279,6 +11280,7 @@ components:
         - billing_enabled
         - google_oauth_configured
         - microsoft_oauth_configured
+        - sms_enabled
       properties:
         billing_enabled:
           type: boolean
@@ -11304,6 +11306,17 @@ components:
             without BYOA setup. When `false`, users must provide their own Microsoft
             OAuth app credentials via the BYOA configuration UI.
           example: true
+        sms_enabled:
+          type: boolean
+          description: |
+            Whether SMS notifications are configured and available on this server.
+            When `true`, users can enable SMS notifications in their preferences.
+            SMS is enabled when the server has a working AWS SNS sender configured
+            (`AWS_REGION` is set) and the `SMS_NOTIFICATIONS_HIDDEN` env var is not
+            set to `"true"`. Self-hosted deployments that configure SNS will have
+            this set automatically; the hosted platform (app.permissionslip.dev)
+            sets `SMS_NOTIFICATIONS_HIDDEN=true` to hide SMS from users.
+          example: false
     Action:
       type: object
       required:


### PR DESCRIPTION
## Summary

- SMS notifications are no longer gated behind paid plans or beta flags
- SMS visibility is now controlled by server configuration: available when AWS SNS is configured (`AWS_REGION` set) and `SMS_NOTIFICATIONS_HIDDEN` env var is not `"true"`
- Self-hosted deployments that set up their own AWS SNS account will see SMS as a toggleable notification channel automatically
- The hosted platform (app.permissionslip.dev) can set `SMS_NOTIFICATIONS_HIDDEN=true` to completely hide SMS from the UI
- Updated self-hosted deployment docs with detailed AWS SNS setup guide (IAM policy, sandbox exit, origination numbers)

## Key changes

- **Backend:** `SMSEnabled` field on `Deps` struct, derived from sender detection + env var. SMS excluded from preferences response entirely when not enabled (instead of showing as unavailable). New SMS gate check in update handler.
- **Config endpoint:** New `sms_enabled` boolean exposed via `GET /config` and OpenAPI spec
- **Frontend:** SMS description updated (removed "Available after the beta" text). No gating logic needed—backend simply excludes SMS from the channel list when not configured.
- **Docs:** Enhanced SMS section in self-hosted guide with step-by-step AWS SNS setup. Added `SMS_NOTIFICATIONS_HIDDEN` to env var reference tables.

## Test plan

### Claude Code
- [x] Backend tests pass (`go test ./api/...`) — all notification preference tests updated
- [x] Frontend tests pass (`npx vitest run`) — 957/957 tests, 100 test files
- [x] Go build passes (`go build ./...`)
- [x] TypeScript compilation passes (`npx tsc --noEmit`)

### Manual Testing
- [ ] Deploy with `AWS_REGION` set → verify SMS appears in notification preferences
- [ ] Deploy without `AWS_REGION` → verify SMS is hidden from preferences
- [ ] Deploy with `AWS_REGION` + `SMS_NOTIFICATIONS_HIDDEN=true` → verify SMS is hidden
- [ ] Verify `GET /config` returns correct `sms_enabled` value in each scenario
- [ ] Test enabling/disabling SMS toggle in preferences UI when configured

https://claude.ai/code/session_01UN17KjFdJPodgmm8s4YoMt