### PR TITLE
docs: Slack OAuth setup and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,12 @@ SUPABASE_URL=http://127.0.0.1:54321
 # SHOPIFY_CLIENT_ID=
 # SHOPIFY_CLIENT_SECRET=
 #
+# Slack — create at https://api.slack.com/apps → OAuth & Permissions
+# Set redirect URL: https://<domain>/api/v1/oauth/slack/callback
+# Add bot and user scopes per docs/oauth-setup.md (Slack OAuth Setup)
+# SLACK_CLIENT_ID=
+# SLACK_CLIENT_SECRET=
+#
 # Zendesk — create an OAuth client at https://<subdomain>.zendesk.com/admin/apps-integrations/apis/apis/oauth_clients
 # Configure OAuth scopes: read, write
 # Set callback URL: https://<domain>/api/v1/oauth/zendesk/callback

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -1,6 +1,6 @@
 # OAuth Setup Guide
 
-Permission Slip uses OAuth 2.0 to connect with Atlassian (Jira), Datadog, Dropbox, Figma, GitHub, Google, HubSpot, Linear, Meta (Facebook/Instagram), Microsoft, Notion, PagerDuty, Square, Stripe, and X (Twitter) services. This guide covers how to configure OAuth for both hosted and self-hosted deployments.
+Permission Slip uses OAuth 2.0 to connect with Atlassian (Jira), Datadog, Dropbox, Figma, GitHub, Google, HubSpot, Linear, Meta (Facebook/Instagram), Microsoft, Notion, PagerDuty, Slack, Square, Stripe, and X (Twitter) services. This guide covers how to configure OAuth for both hosted and self-hosted deployments.
 
 ## Overview
 
@@ -87,6 +87,13 @@ Permission Slip supports two modes for OAuth provider credentials:
 |---|---|
 | `SQUARE_CLIENT_ID` | Production Application ID from Square Developer Dashboard |
 | `SQUARE_CLIENT_SECRET` | Production Application Secret from Square Developer Dashboard |
+
+### Slack OAuth
+
+| Variable | Description |
+|---|---|
+| `SLACK_CLIENT_ID` | Client ID from [Your Apps](https://api.slack.com/apps) (App Credentials) |
+| `SLACK_CLIENT_SECRET` | Client Secret from the same Slack app |
 
 ### Stripe OAuth
 
@@ -543,6 +550,56 @@ SQUARE_CLIENT_SECRET=your-production-application-secret
 
 > **Note:** The Square connector supports both OAuth and API key authentication. OAuth is recommended for production use. API keys can be generated from the Square Developer Dashboard under **Credentials > Production Access Token**.
 
+## Slack OAuth Setup
+
+Slack uses [OAuth 2.0 with the V2 flow](https://api.slack.com/authentication/oauth-v2): bot scopes produce a bot user token (`xoxb-`), and user scopes produce a user token (`xoxp-`) used for APIs that only accept user tokens (for example `search.messages`).
+
+### 1. Create a Slack app
+
+1. Go to [Your Apps](https://api.slack.com/apps)
+2. Click **Create New App** and choose **From scratch**
+3. Name the app (e.g., "Permission Slip") and pick a development workspace
+
+### 2. Configure redirect URL
+
+1. Open **OAuth & Permissions**
+2. Under **Redirect URLs**, add:
+   ```
+   https://your-domain.com/api/v1/oauth/slack/callback
+   ```
+
+### 3. Configure scopes
+
+Under **Scopes**, add **Bot Token Scopes** and **User Token Scopes** to match what the connector requests:
+
+**Bot Token Scopes**
+
+- `channels:history`, `channels:join`, `channels:manage`, `channels:read`
+- `chat:write`
+- `files:write`
+- `groups:history`, `groups:read`
+- `im:history`, `im:read`, `im:write`
+- `mpim:history`, `mpim:read`
+- `reactions:write`
+- `users:read`, `users:read.email`
+
+**User Token Scopes** (required for search actions that only work with user tokens)
+
+- `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`
+
+### 4. Configure environment
+
+```bash
+SLACK_CLIENT_ID=your-slack-client-id
+SLACK_CLIENT_SECRET=your-slack-client-secret
+```
+
+Find **Client ID** and **Client Secret** under **Basic Information > App Credentials**.
+
+### 5. Install to workspace
+
+When a user connects Slack from Permission Slip, they complete Slack’s OAuth consent and install the app to their workspace. No manual “reinstall” is required beyond that flow unless you change scopes—in that case, users may need to **Re-authorize** from the connector settings.
+
 ## Stripe OAuth Setup
 
 Stripe uses [Stripe Connect](https://docs.stripe.com/connect) OAuth to authorize access to Stripe accounts. This lets users connect their Stripe account without manually creating and pasting API keys.
@@ -771,6 +828,7 @@ Ensure the redirect URI in your OAuth app matches exactly:
 - Microsoft: `https://your-domain.com/api/v1/oauth/microsoft/callback`
 - Notion: `https://your-domain.com/api/v1/oauth/notion/callback`
 - PagerDuty: `https://your-domain.com/api/v1/oauth/pagerduty/callback`
+- Slack: `https://your-domain.com/api/v1/oauth/slack/callback`
 - Square: `https://your-domain.com/api/v1/oauth/square/callback`
 - Stripe: `https://your-domain.com/api/v1/oauth/stripe/callback`
 - X: `https://your-domain.com/api/v1/oauth/x/callback`

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -81,19 +81,19 @@ Permission Slip supports two modes for OAuth provider credentials:
 | `NOTION_CLIENT_ID` | OAuth Client ID from [Notion Integrations](https://www.notion.so/my-integrations) |
 | `NOTION_CLIENT_SECRET` | OAuth Client Secret from Notion Integrations |
 
-### Square OAuth
-
-| Variable | Description |
-|---|---|
-| `SQUARE_CLIENT_ID` | Production Application ID from Square Developer Dashboard |
-| `SQUARE_CLIENT_SECRET` | Production Application Secret from Square Developer Dashboard |
-
 ### Slack OAuth
 
 | Variable | Description |
 |---|---|
 | `SLACK_CLIENT_ID` | Client ID from [Your Apps](https://api.slack.com/apps) (App Credentials) |
 | `SLACK_CLIENT_SECRET` | Client Secret from the same Slack app |
+
+### Square OAuth
+
+| Variable | Description |
+|---|---|
+| `SQUARE_CLIENT_ID` | Production Application ID from Square Developer Dashboard |
+| `SQUARE_CLIENT_SECRET` | Production Application Secret from Square Developer Dashboard |
 
 ### Stripe OAuth
 
@@ -512,44 +512,6 @@ If you don't need OAuth, you can use an internal integration token instead:
 
 The Notion connector accepts either auth method. When both are configured, OAuth is preferred.
 
-## Square OAuth Setup
-
-### 1. Create a Square Developer Application
-
-1. Go to [Square Developer Dashboard](https://developer.squareup.com/apps)
-2. Click **+** to create a new application
-3. Fill in the application name (e.g., "Permission Slip")
-
-### 2. Configure OAuth Settings
-
-1. Navigate to **OAuth** in the left sidebar
-2. Add the redirect URI:
-   ```
-   https://your-domain.com/api/v1/oauth/square/callback
-   ```
-3. Select the required OAuth permissions (scopes):
-   - `ORDERS_READ`, `ORDERS_WRITE`
-   - `PAYMENTS_READ`, `PAYMENTS_WRITE`
-   - `ITEMS_READ`, `ITEMS_WRITE`
-   - `CUSTOMERS_READ`, `CUSTOMERS_WRITE`
-   - `APPOINTMENTS_READ`, `APPOINTMENTS_WRITE`
-   - `INVOICES_READ`, `INVOICES_WRITE`
-   - `INVENTORY_READ`, `INVENTORY_WRITE`
-
-### 3. Get Credentials
-
-1. Navigate to **Credentials** in the left sidebar
-2. Copy the **Production Application ID** and **Production Application Secret**
-
-### 4. Configure Environment
-
-```bash
-SQUARE_CLIENT_ID=your-production-application-id
-SQUARE_CLIENT_SECRET=your-production-application-secret
-```
-
-> **Note:** The Square connector supports both OAuth and API key authentication. OAuth is recommended for production use. API keys can be generated from the Square Developer Dashboard under **Credentials > Production Access Token**.
-
 ## Slack OAuth Setup
 
 Slack uses [OAuth 2.0 with the V2 flow](https://api.slack.com/authentication/oauth-v2): bot scopes produce a bot user token (`xoxb-`), and user scopes produce a user token (`xoxp-`) used for APIs that only accept user tokens (for example `search.messages`).
@@ -599,6 +561,44 @@ Find **Client ID** and **Client Secret** under **Basic Information > App Credent
 ### 5. Install to workspace
 
 When a user connects Slack from Permission Slip, they complete Slack’s OAuth consent and install the app to their workspace. No manual “reinstall” is required beyond that flow unless you change scopes—in that case, users may need to **Re-authorize** from the connector settings.
+
+## Square OAuth Setup
+
+### 1. Create a Square Developer Application
+
+1. Go to [Square Developer Dashboard](https://developer.squareup.com/apps)
+2. Click **+** to create a new application
+3. Fill in the application name (e.g., "Permission Slip")
+
+### 2. Configure OAuth Settings
+
+1. Navigate to **OAuth** in the left sidebar
+2. Add the redirect URI:
+   ```
+   https://your-domain.com/api/v1/oauth/square/callback
+   ```
+3. Select the required OAuth permissions (scopes):
+   - `ORDERS_READ`, `ORDERS_WRITE`
+   - `PAYMENTS_READ`, `PAYMENTS_WRITE`
+   - `ITEMS_READ`, `ITEMS_WRITE`
+   - `CUSTOMERS_READ`, `CUSTOMERS_WRITE`
+   - `APPOINTMENTS_READ`, `APPOINTMENTS_WRITE`
+   - `INVOICES_READ`, `INVOICES_WRITE`
+   - `INVENTORY_READ`, `INVENTORY_WRITE`
+
+### 3. Get Credentials
+
+1. Navigate to **Credentials** in the left sidebar
+2. Copy the **Production Application ID** and **Production Application Secret**
+
+### 4. Configure Environment
+
+```bash
+SQUARE_CLIENT_ID=your-production-application-id
+SQUARE_CLIENT_SECRET=your-production-application-secret
+```
+
+> **Note:** The Square connector supports both OAuth and API key authentication. OAuth is recommended for production use. API keys can be generated from the Square Developer Dashboard under **Credentials > Production Access Token**.
 
 ## Stripe OAuth Setup
 
@@ -834,6 +834,12 @@ Ensure the redirect URI in your OAuth app matches exactly:
 - X: `https://your-domain.com/api/v1/oauth/x/callback`
 
 If using `OAUTH_REDIRECT_BASE_URL`, the callback URL is `{OAUTH_REDIRECT_BASE_URL}/v1/oauth/{provider}/callback`.
+
+### Slack API errors (`missing_scope`, `invalid_auth`, search without user token)
+
+- **`missing_scope`** — The Slack app is missing bot or user scopes listed in [Slack OAuth Setup](#slack-oauth-setup). Add them under **OAuth & Permissions**, then have the user **Re-authorize** so Slack issues new tokens.
+- **`invalid_auth` / `token_revoked`** — The workspace uninstalled the app or tokens were rotated. **Re-authorize** from the connector settings.
+- **Search actions fail but messaging works** — Search uses a user token (`xoxp-`). Ensure **User Token Scopes** (especially `search:read.*`) are configured in the Slack app and the user completed consent for user scopes.
 
 ### "Failed to initiate OAuth flow" error
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -541,7 +541,7 @@ Under **Scopes**, add **Bot Token Scopes** and **User Token Scopes** to match wh
 - `files:write`
 - `groups:history`, `groups:read`
 - `im:history`, `im:read`, `im:write`
-- `mpim:history`, `mpim:read`
+- `mpim:history`, `mpim:read`, `mpim:write`
 - `reactions:write`
 - `users:read`, `users:read.email`
 


### PR DESCRIPTION
## Summary
- Add Slack OAuth section to `docs/oauth-setup.md` (env vars table, setup steps, redirect URL, bot/user scopes, troubleshooting entry, overview line).
- Add `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` to `.env.example` with pointers to the doc and Slack app settings.

## Test plan
- [ ] N/A — documentation and `.env.example` comments only

### Claude Code
- [x] Align scope lists with `connectors/slack/slack.go` (`OAuthScopes`, `OAuthUserScopes`)

### Manual Testing
- [ ] Skim `docs/oauth-setup.md` Slack section for typos and Slack UI path accuracy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates plus `.env.example` comment placeholders; no runtime code changes or data/security logic modified.
> 
> **Overview**
> Adds **Slack OAuth** documentation, including required `SLACK_CLIENT_ID`/`SLACK_CLIENT_SECRET`, redirect URL, and the bot vs user scope sets aligned with the Slack connector’s needs.
> 
> Updates `.env.example` to include commented Slack OAuth credentials and pointers to the new setup guide, and adds Slack to the OAuth provider list and callback URL troubleshooting section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 093b7819be1673abe2ce9930f888fdb50f186323. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->