### PR TITLE
Raise free monthly API requests to 1000 (free + paid included allowance)

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -471,7 +471,7 @@ func handleGetUsage(deps *Deps) http.HandlerFunc {
 		}
 
 		// Determine included request allowance.
-		// Paid plans get the same free allowance as the free tier (250 requests).
+		// Paid plans get the same free allowance as the free tier (1000 requests).
 		included := int(pstripe.FreeRequestAllowance())
 		if sub.Plan.MaxRequestsPerMonth != nil {
 			included = *sub.Plan.MaxRequestsPerMonth

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -187,8 +187,8 @@ func TestGetBillingPlan_PaidPlan(t *testing.T) {
 	if resp.Pricing == nil {
 		t.Fatal("expected pricing to be present for paid plan")
 	}
-	if resp.Pricing.FreeRequestAllowance != 250 {
-		t.Errorf("expected free_request_allowance=250, got %d", resp.Pricing.FreeRequestAllowance)
+	if resp.Pricing.FreeRequestAllowance != 1000 {
+		t.Errorf("expected free_request_allowance=1000, got %d", resp.Pricing.FreeRequestAllowance)
 	}
 	if resp.Pricing.PricePerRequestDisplay != "$0.005" {
 		t.Errorf("expected price_per_request_display=$0.005, got %s", resp.Pricing.PricePerRequestDisplay)
@@ -222,8 +222,8 @@ func TestGetBillingPlan_FreePlan_IncludesPricing(t *testing.T) {
 	if resp.Pricing == nil {
 		t.Fatal("expected pricing to be present for free plan (for upgrade flow)")
 	}
-	if resp.Pricing.FreeRequestAllowance != 250 {
-		t.Errorf("expected free_request_allowance=250, got %d", resp.Pricing.FreeRequestAllowance)
+	if resp.Pricing.FreeRequestAllowance != 1000 {
+		t.Errorf("expected free_request_allowance=1000, got %d", resp.Pricing.FreeRequestAllowance)
 	}
 }
 
@@ -404,7 +404,7 @@ func TestGetSubscription_WithUsage(t *testing.T) {
 		t.Errorf("expected request_count=5, got %d", resp.Usage.RequestCount)
 	}
 	if resp.Usage.OverLimit {
-		t.Error("expected over_limit=false for 5 requests on free plan (250 limit)")
+		t.Error("expected over_limit=false for 5 requests on free plan (1000 limit)")
 	}
 }
 
@@ -538,8 +538,8 @@ func TestGetUsage_ReturnsUsage(t *testing.T) {
 	if resp.Requests.Total != 5 {
 		t.Errorf("expected requests.total=5, got %d", resp.Requests.Total)
 	}
-	if resp.Requests.Included != 250 {
-		t.Errorf("expected requests.included=250, got %d", resp.Requests.Included)
+	if resp.Requests.Included != 1000 {
+		t.Errorf("expected requests.included=1000, got %d", resp.Requests.Included)
 	}
 	if resp.Requests.Overage != 0 {
 		t.Errorf("expected requests.overage=0, got %d", resp.Requests.Overage)
@@ -600,8 +600,8 @@ func TestGetUsage_ZeroUsage(t *testing.T) {
 	if resp.Requests.Total != 0 {
 		t.Errorf("expected requests.total=0, got %d", resp.Requests.Total)
 	}
-	if resp.Requests.Included != 250 {
-		t.Errorf("expected requests.included=250 (free plan), got %d", resp.Requests.Included)
+	if resp.Requests.Included != 1000 {
+		t.Errorf("expected requests.included=1000 (free plan), got %d", resp.Requests.Included)
 	}
 }
 
@@ -613,11 +613,11 @@ func TestGetUsage_WithOverage(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	// Insert usage that exceeds the free limit (250) directly.
+	// Insert usage that exceeds the free limit (1000) directly.
 	periodStart, periodEnd := db.BillingPeriodBounds(time.Now())
 	testhelper.MustExec(t, tx,
 		`INSERT INTO usage_periods (user_id, period_start, period_end, request_count)
-		 VALUES ($1, $2, $3, 300)`,
+		 VALUES ($1, $2, $3, 1050)`,
 		uid, periodStart, periodEnd)
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
@@ -635,8 +635,8 @@ func TestGetUsage_WithOverage(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	if resp.Requests.Total != 300 {
-		t.Errorf("expected requests.total=300, got %d", resp.Requests.Total)
+	if resp.Requests.Total != 1050 {
+		t.Errorf("expected requests.total=1050, got %d", resp.Requests.Total)
 	}
 	if resp.Requests.Overage != 50 {
 		t.Errorf("expected requests.overage=50, got %d", resp.Requests.Overage)

--- a/api/quota_test.go
+++ b/api/quota_test.go
@@ -28,8 +28,8 @@ func TestCheckRequestQuota_FreePlan_UnderLimit_Allows(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	// 249 requests used (under limit of 250).
-	testhelper.SetUsageCount(t, tx, uid, 249)
+	// 999 requests used (under limit of 1000).
+	testhelper.SetUsageCount(t, tx, uid, 999)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/test", nil)
@@ -45,8 +45,8 @@ func TestCheckRequestQuota_FreePlan_UnderLimit_Allows(t *testing.T) {
 	}
 
 	// Verify informational quota headers are set on allowed requests.
-	if w.Header().Get("X-Quota-Limit") != "250" {
-		t.Errorf("expected X-Quota-Limit=250, got %q", w.Header().Get("X-Quota-Limit"))
+	if w.Header().Get("X-Quota-Limit") != "1000" {
+		t.Errorf("expected X-Quota-Limit=1000, got %q", w.Header().Get("X-Quota-Limit"))
 	}
 	if w.Header().Get("X-Quota-Remaining") != "0" {
 		t.Errorf("expected X-Quota-Remaining=0 (249 used, +1 for this request), got %q", w.Header().Get("X-Quota-Remaining"))
@@ -63,8 +63,8 @@ func TestCheckRequestQuota_FreePlan_AtLimit_Returns429(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	// Exactly at the limit (250).
-	testhelper.SetUsageCount(t, tx, uid, 250)
+	// Exactly at the limit (1000).
+	testhelper.SetUsageCount(t, tx, uid, 1000)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/test", nil)
@@ -93,11 +93,11 @@ func TestCheckRequestQuota_FreePlan_AtLimit_Returns429(t *testing.T) {
 	if resp.Error.Details == nil {
 		t.Fatal("expected details in error response")
 	}
-	if usage, ok := resp.Error.Details["current_usage"].(float64); !ok || int(usage) != 250 {
-		t.Errorf("expected current_usage=250, got %v", resp.Error.Details["current_usage"])
+	if usage, ok := resp.Error.Details["current_usage"].(float64); !ok || int(usage) != 1000 {
+		t.Errorf("expected current_usage=1000, got %v", resp.Error.Details["current_usage"])
 	}
-	if limit, ok := resp.Error.Details["limit"].(float64); !ok || int(limit) != 250 {
-		t.Errorf("expected limit=250, got %v", resp.Error.Details["limit"])
+	if limit, ok := resp.Error.Details["limit"].(float64); !ok || int(limit) != 1000 {
+		t.Errorf("expected limit=1000, got %v", resp.Error.Details["limit"])
 	}
 	if planID, ok := resp.Error.Details["plan_id"].(string); !ok || planID != db.PlanFree {
 		t.Errorf("expected plan_id=%q, got %v", db.PlanFree, resp.Error.Details["plan_id"])
@@ -191,7 +191,7 @@ func TestCheckRequestQuota_RetryAfterHeader(t *testing.T) {
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
-	testhelper.SetUsageCount(t, tx, uid, 250)
+	testhelper.SetUsageCount(t, tx, uid, 1000)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/test", nil)
@@ -234,7 +234,7 @@ func TestQuota_ApprovalRequest_FreePlan_AtLimit_Returns429(t *testing.T) {
 	t.Parallel()
 	m := setupMeteringTest(t)
 	testhelper.InsertSubscription(t, m.DB, m.UserID, db.PlanFree)
-	testhelper.SetUsageCount(t, m.DB, m.UserID, 250)
+	testhelper.SetUsageCount(t, m.DB, m.UserID, 1000)
 
 	reqBody := `{"request_id":"quota_blocked_001","action":{"type":"email.send","parameters":{}},"context":{"description":"test"}}`
 	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, m.PrivKey, m.AgentID)
@@ -254,14 +254,14 @@ func TestQuota_ApprovalRequest_FreePlan_AtLimit_Returns429(t *testing.T) {
 	}
 
 	// Usage count should not have increased (request was rejected).
-	testhelper.RequireUsageCount(t, m.DB, m.UserID, 250)
+	testhelper.RequireUsageCount(t, m.DB, m.UserID, 1000)
 }
 
 func TestQuota_ApprovalRequest_FreePlan_UnderLimit_Succeeds(t *testing.T) {
 	t.Parallel()
 	m := setupMeteringTest(t)
 	testhelper.InsertSubscription(t, m.DB, m.UserID, db.PlanFree)
-	testhelper.SetUsageCount(t, m.DB, m.UserID, 249)
+	testhelper.SetUsageCount(t, m.DB, m.UserID, 999)
 
 	reqBody := `{"request_id":"quota_ok_001","action":{"type":"email.send","parameters":{}},"context":{"description":"test"}}`
 	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, m.PrivKey, m.AgentID)
@@ -272,8 +272,8 @@ func TestQuota_ApprovalRequest_FreePlan_UnderLimit_Succeeds(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Usage should have incremented to 250.
-	testhelper.RequireUsageCount(t, m.DB, m.UserID, 250)
+	// Usage should have incremented to 1000.
+	testhelper.RequireUsageCount(t, m.DB, m.UserID, 1000)
 }
 
 func TestQuota_ApprovalRequest_PaidPlan_NoLimit(t *testing.T) {
@@ -298,7 +298,7 @@ func TestQuota_AgentStandingExecution_FreePlan_AtLimit_Returns429(t *testing.T) 
 	t.Parallel()
 	tx, _, router, agentID, privKey, _, uid := setupStandingExecuteTest(t, "email.read")
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
-	testhelper.SetUsageCount(t, tx, uid, 250)
+	testhelper.SetUsageCount(t, tx, uid, 1000)
 
 	reqBody := `{"request_id":"quota_sa_001","action":{"type":"email.read","version":"1","parameters":{}},"context":{"description":"test"}}`
 	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
@@ -310,14 +310,14 @@ func TestQuota_AgentStandingExecution_FreePlan_AtLimit_Returns429(t *testing.T) 
 	}
 
 	// Usage should not have increased.
-	testhelper.RequireUsageCount(t, tx, uid, 250)
+	testhelper.RequireUsageCount(t, tx, uid, 1000)
 }
 
 func TestQuota_AgentStandingExecution_FreePlan_UnderLimit_Succeeds(t *testing.T) {
 	t.Parallel()
 	tx, _, router, agentID, privKey, _, uid := setupStandingExecuteTest(t, "email.read")
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
-	testhelper.SetUsageCount(t, tx, uid, 249)
+	testhelper.SetUsageCount(t, tx, uid, 999)
 
 	reqBody := `{"request_id":"quota_sa_ok_001","action":{"type":"email.read","version":"1","parameters":{}},"context":{"description":"test"}}`
 	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
@@ -329,7 +329,7 @@ func TestQuota_AgentStandingExecution_FreePlan_UnderLimit_Succeeds(t *testing.T)
 	}
 
 	// Usage should have incremented.
-	testhelper.RequireUsageCount(t, tx, uid, 250)
+	testhelper.RequireUsageCount(t, tx, uid, 1000)
 }
 
 // ── Integration: standing approval execution (dashboard path) blocked by quota ──
@@ -342,7 +342,7 @@ func TestQuota_DashboardStandingExecution_FreePlan_AtLimit_Returns429(t *testing
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertStandingApprovalWithActionType(t, tx, saID, agentID, uid, "email.send")
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
-	testhelper.SetUsageCount(t, tx, uid, 250)
+	testhelper.SetUsageCount(t, tx, uid, 1000)
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -356,7 +356,7 @@ func TestQuota_DashboardStandingExecution_FreePlan_AtLimit_Returns429(t *testing
 	}
 
 	// Usage should not have increased.
-	testhelper.RequireUsageCount(t, tx, uid, 250)
+	testhelper.RequireUsageCount(t, tx, uid, 1000)
 }
 
 func TestQuota_DashboardStandingExecution_FreePlan_UnderLimit_Succeeds(t *testing.T) {
@@ -367,7 +367,7 @@ func TestQuota_DashboardStandingExecution_FreePlan_UnderLimit_Succeeds(t *testin
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertStandingApprovalWithActionType(t, tx, saID, agentID, uid, "email.send")
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
-	testhelper.SetUsageCount(t, tx, uid, 249)
+	testhelper.SetUsageCount(t, tx, uid, 999)
 
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -381,6 +381,6 @@ func TestQuota_DashboardStandingExecution_FreePlan_UnderLimit_Succeeds(t *testin
 	}
 
 	// Usage should have incremented.
-	testhelper.RequireUsageCount(t, tx, uid, 250)
+	testhelper.RequireUsageCount(t, tx, uid, 1000)
 }
 

--- a/config/plans.json
+++ b/config/plans.json
@@ -1,7 +1,7 @@
 {
   "free": {
     "name": "Free",
-    "max_requests_per_month": 250,
+    "max_requests_per_month": 1000,
     "max_agents": 3,
     "max_standing_approvals": 5,
     "max_credentials": 5,

--- a/config/plans_test.go
+++ b/config/plans_test.go
@@ -15,8 +15,8 @@ func TestGetPlan_Free(t *testing.T) {
 	if p.Name != "Free" {
 		t.Errorf("expected Name 'Free', got %q", p.Name)
 	}
-	if p.MaxRequestsPerMonth == nil || *p.MaxRequestsPerMonth != 250 {
-		t.Errorf("expected MaxRequestsPerMonth=250, got %v", p.MaxRequestsPerMonth)
+	if p.MaxRequestsPerMonth == nil || *p.MaxRequestsPerMonth != 1000 {
+		t.Errorf("expected MaxRequestsPerMonth=1000, got %v", p.MaxRequestsPerMonth)
 	}
 	if p.MaxAgents == nil || *p.MaxAgents != 3 {
 		t.Errorf("expected MaxAgents=3, got %v", p.MaxAgents)

--- a/db/migrations/20260228200000_plans_subscriptions.sql
+++ b/db/migrations/20260228200000_plans_subscriptions.sql
@@ -14,9 +14,8 @@ CREATE TABLE plans (
 );
 
 -- Seed the two plan tiers.
--- NOTE: The free plan limit below (1000) is stale — the authoritative value
--- is now in config/plans.json (currently 250). This migration is historical;
--- the plans table was dropped in 20260314131844_drop_plans_table.sql.
+-- NOTE: Free plan max_requests_per_month matches config/plans.json (1000 at time of writing).
+-- This migration is historical; the plans table was dropped in 20260314131844_drop_plans_table.sql.
 INSERT INTO plans (id, name, max_requests_per_month, max_agents, max_standing_approvals, max_credentials, audit_retention_days, price_per_request_millicents)
 VALUES
     ('free',          'Free',          1000, 3,    5,    5,    7,  0),

--- a/db/migrations/20260314131844_drop_plans_table.sql
+++ b/db/migrations/20260314131844_drop_plans_table.sql
@@ -81,9 +81,8 @@ CREATE TABLE IF NOT EXISTS plans (
     created_at                  timestamptz NOT NULL DEFAULT now()
 );
 
--- NOTE: The free plan limit below (1000) is stale — the authoritative value
--- is now in config/plans.json (currently 250). This rollback only matters if
--- rolling back past this migration.
+-- NOTE: Free plan max_requests_per_month matches config/plans.json (1000 at time of writing).
+-- This rollback only matters if rolling back past this migration.
 INSERT INTO plans (id, name, max_requests_per_month, max_agents, max_standing_approvals, max_credentials, audit_retention_days, price_per_request_millicents)
 VALUES
     ('free',          'Free',          1000, 3,    5,    5,    7,  0),

--- a/db/plans_test.go
+++ b/db/plans_test.go
@@ -15,8 +15,8 @@ func TestGetPlan_Free(t *testing.T) {
 	if plan.Name != "Free" {
 		t.Errorf("expected name %q, got %q", "Free", plan.Name)
 	}
-	if plan.MaxRequestsPerMonth == nil || *plan.MaxRequestsPerMonth != 250 {
-		t.Errorf("expected max_requests_per_month=250, got %v", plan.MaxRequestsPerMonth)
+	if plan.MaxRequestsPerMonth == nil || *plan.MaxRequestsPerMonth != 1000 {
+		t.Errorf("expected max_requests_per_month=1000, got %v", plan.MaxRequestsPerMonth)
 	}
 	if plan.MaxAgents == nil || *plan.MaxAgents != 3 {
 		t.Errorf("expected max_agents=3, got %v", plan.MaxAgents)

--- a/docs/adr/010-calendar-month-billing-cycles.md
+++ b/docs/adr/010-calendar-month-billing-cycles.md
@@ -19,11 +19,11 @@ We use **calendar-month cycles with the full allowance** for all free-tier users
 
 ## Rationale
 
-**Per-user anchors create confusing UX on the free tier.** Showing users "your 250 requests reset on the 23rd" feels arbitrary and is harder to reason about. Clean calendar boundaries ("resets on the 1st") are simple to communicate and understand.
+**Per-user anchors create confusing UX on the free tier.** Showing users "your 1000 requests reset on the 23rd" feels arbitrary and is harder to reason about. Clean calendar boundaries ("resets on the 1st") are simple to communicate and understand.
 
 **Proration punishes new users.** If someone signs up on March 25 and gets prorated to ~40 requests for the rest of the month, their first impression is hitting a paywall almost immediately. Generous first experiences convert better — the whole point of a free tier is to let people evaluate the product without friction.
 
-**The "exploit" isn't worth optimizing against.** The worst case is someone signing up on March 31, using 250 requests, then getting another 250 on April 1. That's 500 free requests — a negligible cost that doesn't justify the added complexity of proration or per-user anchors.
+**The "exploit" isn't worth optimizing against.** The worst case is someone signing up on March 31, using 1000 requests, then getting another 1000 on April 1. That's 2000 free requests — a negligible cost that doesn't justify the added complexity of proration or per-user anchors.
 
 **Simplicity reduces bugs.** Calendar-month alignment means one function (`BillingPeriodBounds`) handles all period calculations. No per-user state to track, no edge cases around anchor dates falling on the 29th/30th/31st, no timezone confusion.
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -338,7 +338,7 @@ Defines pricing tiers and resource limits. Seeded with two built-in plans.
 | `price_per_request_millicents` | integer | NOT NULL, DEFAULT 0 |
 | `created_at` | timestamptz | NOT NULL, DEFAULT now() |
 
-**Seed data:** `free` (250 req/mo, 7-day audit, $0/req), `pay_as_you_go` (unlimited, 90-day audit, $0.005/req). Source of truth for current limits: `config/plans.json`.
+**Seed data:** `free` (1000 req/mo, 7-day audit, $0/req), `pay_as_you_go` (unlimited, 90-day audit, $0.005/req). Source of truth for current limits: `config/plans.json`.
 
 ### `subscriptions`
 

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -19,7 +19,7 @@ Billing is gated behind `BILLING_ENABLED` (defaults to `false`). When disabled, 
 
 ### 2. Create a metered Price for per-request billing
 
-This creates a usage-based price so users are charged based on API request volume (250 free per month, then $0.005/request). See `config/plans.json` for the current free-tier limit.
+This creates a usage-based price so users are charged based on API request volume (1000 free per month, then $0.005/request). See `config/plans.json` for the current free-tier limit.
 
 1. Go to [Stripe Dashboard → Products](https://dashboard.stripe.com/products)
 2. Click **+ Add product**
@@ -227,8 +227,8 @@ After setup (local or production), verify the end-to-end flow:
 
 | Plan | Included requests | Overage cost | Audit retention |
 |---|---|---|---|
-| `free` | 250/month | N/A (blocked) | 7 days |
-| `pay_as_you_go` | Unlimited | $0.005/request | 90 days |
+| `free` | 1000/month | N/A (blocked) | 7 days |
+| `pay_as_you_go` | 1000/mo free, then metered | $0.005/request | 90 days |
 
 > **Source of truth:** Plan limits are defined in `config/plans.json`. The values above reflect that config at time of writing.
 

--- a/frontend/src/api/bundled.yaml
+++ b/frontend/src/api/bundled.yaml
@@ -5011,7 +5011,7 @@ paths:
                 has_payment_method: false
                 can_upgrade: true
                 plan_limits:
-                  max_requests_per_month: 250
+                  max_requests_per_month: 1000
                   max_agents: 5
                   max_standing_approvals: 10
                   max_credentials: 5
@@ -5019,7 +5019,7 @@ paths:
                 usage:
                   request_count: 42
                   sms_count: 0
-                  request_limit: 250
+                  request_limit: 1000
                   over_limit: false
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -5066,9 +5066,9 @@ paths:
                 period_end: '2026-04-01T00:00:00Z'
                 requests:
                   total: 1542
-                  included: 250
-                  overage: 1292
-                  cost_cents: 646
+                  included: 1000
+                  overage: 542
+                  cost_cents: 271
                 sms:
                   total: 5
                   cost_cents: 5
@@ -5396,7 +5396,7 @@ paths:
                 plan:
                   id: free
                   name: Free
-                  max_requests_per_month: 250
+                  max_requests_per_month: 1000
                   max_agents: 3
                   max_standing_approvals: 5
                   max_credentials: 5
@@ -9805,7 +9805,7 @@ components:
           type: integer
           nullable: true
           description: Monthly request limit for the current plan (null = unlimited)
-          example: 250
+          example: 1000
         over_limit:
           type: boolean
           description: Whether current usage exceeds the plan's request limit
@@ -9845,7 +9845,7 @@ components:
         included:
           type: integer
           description: Number of requests included in the plan for free (0 = unlimited on paid plans)
-          example: 250
+          example: 1000
         overage:
           type: integer
           description: Number of requests exceeding the included allowance
@@ -10107,7 +10107,7 @@ components:
           description: |
             Number of requests included in the plan at no extra cost.
             0 when the plan has no request limit (e.g. pay-as-you-go).
-          example: 250
+          example: 1000
         overage:
           type: integer
           description: |
@@ -10248,12 +10248,12 @@ components:
       example:
         error:
           code: monthly_quota_exceeded
-          message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+          message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
           retryable: true
           retry_after: 2419200
           details:
-            limit: 250
-            current_usage: 250
+            limit: 1000
+            current_usage: 1000
             plan_id: free
             reset_at: '2026-04-01T00:00:00Z'
     QuotaExceededDetails:
@@ -10263,7 +10263,7 @@ components:
         limit:
           type: integer
           description: The plan's request limit
-          example: 250
+          example: 1000
         current_count:
           type: integer
           description: Current usage count
@@ -11325,7 +11325,7 @@ components:
           type: integer
           nullable: true
           description: Monthly request limit (null = unlimited)
-          example: 250
+          example: 1000
         max_agents:
           type: integer
           nullable: true
@@ -11786,12 +11786,12 @@ components:
               value:
                 error:
                   code: monthly_quota_exceeded
-                  message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+                  message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
                   retryable: true
                   retry_after: 86400
                   details:
-                    current_usage: 250
-                    limit: 250
+                    current_usage: 1000
+                    limit: 1000
                     plan_id: free
                     reset_at: '2026-04-01T00:00:00Z'
                   trace_id: trace_xyz789

--- a/frontend/src/hooks/__tests__/useResourceLimit.test.tsx
+++ b/frontend/src/hooks/__tests__/useResourceLimit.test.tsx
@@ -12,7 +12,7 @@ const freePlan = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 250,
+    max_requests_per_month: 1000,
     max_agents: 3,
     max_standing_approvals: 5,
     max_credentials: 5,

--- a/frontend/src/pages/billing/RequestUsageBar.tsx
+++ b/frontend/src/pages/billing/RequestUsageBar.tsx
@@ -3,7 +3,7 @@ import { PRICE_PER_REQUEST } from "./constants";
 interface RequestUsageBarProps {
   total: number;
   limit: number | null;
-  /** Free request allowance for paid plans (e.g. 250). */
+  /** Free request allowance for paid plans (e.g. 1000). */
   included?: number;
   /** Per-request price display string from API (e.g. "$0.005"). Falls back to config constant. */
   priceDisplay?: string;
@@ -17,7 +17,7 @@ function PaidRequestBar({ total, included, priceDisplay }: { total: number; incl
   const overage = Math.max(0, total - included);
   const hasOverage = overage > 0;
 
-  // Bar is measured against included allowance (e.g. 250).
+  // Bar is measured against included allowance (e.g. 1000).
   // When under: green bar grows toward 100%.
   // When over: green fills 100%, amber extends proportionally.
   const freePercent = Math.min((total / included) * 100, 100);

--- a/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -292,7 +292,7 @@ describe("BillingPage", () => {
       await waitFor(() => {
         expect(screen.getByText("Usage")).toBeInTheDocument();
       });
-      // Paid plan shows requests against the 250 free allowance with billed count
+      // Paid plan shows requests against the 1000 free allowance with billed count
       expect(screen.getByText(/billed/)).toBeInTheDocument();
       expect(screen.getByText(/\$0.005\/request/)).toBeInTheDocument();
     });
@@ -528,8 +528,8 @@ describe("BillingPage", () => {
       await waitFor(() => {
         expect(screen.getByText("Estimated cost")).toBeInTheDocument();
       });
-      // $6.46 requests + $0.05 SMS = $6.51 (shown in both UsageDashboard and PlanDetailsCard)
-      expect(screen.getAllByText("$6.51").length).toBeGreaterThanOrEqual(1);
+      // $2.71 requests + $0.05 SMS = $2.76 (shown in both UsageDashboard and PlanDetailsCard)
+      expect(screen.getAllByText("$2.76").length).toBeGreaterThanOrEqual(1);
     });
 
     it("shows free requests remaining when under allowance", async () => {

--- a/frontend/src/pages/billing/__tests__/fixtures.ts
+++ b/frontend/src/pages/billing/__tests__/fixtures.ts
@@ -9,7 +9,7 @@ export const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 250,
+    max_requests_per_month: 1000,
     max_agents: 3,
     max_standing_approvals: 5,
     max_credentials: 5,
@@ -74,7 +74,7 @@ export const overLimitPaidPlanResponse = {
 export const atLimitPaidPlanResponse = {
   ...paidPlanResponse,
   usage: {
-    requests: 250,
+    requests: 1000,
     agents: 3,
     standing_approvals: 5,
     credentials: 5,
@@ -84,7 +84,7 @@ export const atLimitPaidPlanResponse = {
 export const usageDetailResponse = {
   period_start: "2026-03-01T00:00:00Z",
   period_end: "2026-04-01T00:00:00Z",
-  requests: { total: 1542, included: 250, overage: 1292, cost_cents: 646 },
+  requests: { total: 1542, included: 1000, overage: 542, cost_cents: 271 },
   sms: { total: 5, cost_cents: 5 },
   breakdown: {
     by_agent: { "1": 500, "2": 1042 },
@@ -97,7 +97,7 @@ export const usageDetailResponse = {
 export const paidUnderAllowanceUsageResponse = {
   period_start: "2026-03-01T00:00:00Z",
   period_end: "2026-04-01T00:00:00Z",
-  requests: { total: 80, included: 250, overage: 0, cost_cents: 0 },
+  requests: { total: 80, included: 1000, overage: 0, cost_cents: 0 },
   sms: { total: 0, cost_cents: 0 },
   breakdown: {
     by_agent: { "1": 80 },
@@ -109,7 +109,7 @@ export const paidUnderAllowanceUsageResponse = {
 export const freeUsageDetailResponse = {
   period_start: "2026-03-01T00:00:00Z",
   period_end: "2026-04-01T00:00:00Z",
-  requests: { total: 150, included: 250, overage: 0, cost_cents: 0 },
+  requests: { total: 150, included: 1000, overage: 0, cost_cents: 0 },
   sms: { total: 0, cost_cents: 0 },
   breakdown: {
     by_agent: { "1": 80, "2": 70 },

--- a/frontend/src/pages/billing/constants.ts
+++ b/frontend/src/pages/billing/constants.ts
@@ -1,7 +1,7 @@
 import { freePlan, paidPlan, formatLimit, PRICE_PER_REQUEST } from "@/config/plans";
 
 /** Number of free requests included per month for all plans. */
-export const FREE_REQUEST_ALLOWANCE: number = freePlan.max_requests_per_month ?? 250;
+export const FREE_REQUEST_ALLOWANCE: number = freePlan.max_requests_per_month ?? 1000;
 
 // Re-export for backward compatibility — canonical definition is in @/config/plans.
 export { PRICE_PER_REQUEST };

--- a/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
@@ -35,7 +35,7 @@ const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 250 as number | null,
+    max_requests_per_month: 1000 as number | null,
     max_agents: 3 as number | null,
     max_standing_approvals: 5 as number | null,
     max_credentials: 5 as number | null,

--- a/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
@@ -48,7 +48,7 @@ const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 250 as number | null,
+    max_requests_per_month: 1000 as number | null,
     max_agents: 3 as number | null,
     max_standing_approvals: 5 as number | null,
     max_credentials: 5 as number | null,

--- a/frontend/src/pages/settings/__tests__/CredentialSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/CredentialSection.test.tsx
@@ -17,7 +17,7 @@ const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 250,
+    max_requests_per_month: 1000,
     max_agents: 3,
     max_standing_approvals: 5,
     max_credentials: 5,

--- a/spec/openapi/bundled.yaml
+++ b/spec/openapi/bundled.yaml
@@ -5011,7 +5011,7 @@ paths:
                 has_payment_method: false
                 can_upgrade: true
                 plan_limits:
-                  max_requests_per_month: 250
+                  max_requests_per_month: 1000
                   max_agents: 5
                   max_standing_approvals: 10
                   max_credentials: 5
@@ -5019,7 +5019,7 @@ paths:
                 usage:
                   request_count: 42
                   sms_count: 0
-                  request_limit: 250
+                  request_limit: 1000
                   over_limit: false
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -5066,9 +5066,9 @@ paths:
                 period_end: '2026-04-01T00:00:00Z'
                 requests:
                   total: 1542
-                  included: 250
-                  overage: 1292
-                  cost_cents: 646
+                  included: 1000
+                  overage: 542
+                  cost_cents: 271
                 sms:
                   total: 5
                   cost_cents: 5
@@ -5396,7 +5396,7 @@ paths:
                 plan:
                   id: free
                   name: Free
-                  max_requests_per_month: 250
+                  max_requests_per_month: 1000
                   max_agents: 3
                   max_standing_approvals: 5
                   max_credentials: 5
@@ -9820,7 +9820,7 @@ components:
           type: integer
           nullable: true
           description: Monthly request limit for the current plan (null = unlimited)
-          example: 250
+          example: 1000
         over_limit:
           type: boolean
           description: Whether current usage exceeds the plan's request limit
@@ -9860,7 +9860,7 @@ components:
         included:
           type: integer
           description: Number of requests included in the plan for free (0 = unlimited on paid plans)
-          example: 250
+          example: 1000
         overage:
           type: integer
           description: Number of requests exceeding the included allowance
@@ -10122,7 +10122,7 @@ components:
           description: |
             Number of requests included in the plan at no extra cost.
             0 when the plan has no request limit (e.g. pay-as-you-go).
-          example: 250
+          example: 1000
         overage:
           type: integer
           description: |
@@ -10263,12 +10263,12 @@ components:
       example:
         error:
           code: monthly_quota_exceeded
-          message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+          message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
           retryable: true
           retry_after: 2419200
           details:
-            limit: 250
-            current_usage: 250
+            limit: 1000
+            current_usage: 1000
             plan_id: free
             reset_at: '2026-04-01T00:00:00Z'
     QuotaExceededDetails:
@@ -10278,7 +10278,7 @@ components:
         limit:
           type: integer
           description: The plan's request limit
-          example: 250
+          example: 1000
         current_count:
           type: integer
           description: Current usage count
@@ -11340,7 +11340,7 @@ components:
           type: integer
           nullable: true
           description: Monthly request limit (null = unlimited)
-          example: 250
+          example: 1000
         max_agents:
           type: integer
           nullable: true
@@ -11801,12 +11801,12 @@ components:
               value:
                 error:
                   code: monthly_quota_exceeded
-                  message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+                  message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
                   retryable: true
                   retry_after: 86400
                   details:
-                    current_usage: 250
-                    limit: 250
+                    current_usage: 1000
+                    limit: 1000
                     plan_id: free
                     reset_at: '2026-04-01T00:00:00Z'
                   trace_id: trace_xyz789

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -273,8 +273,8 @@ usage:
               requests:
                 total: 1542
                 included: 1000
-                overage: 1292
-                cost_cents: 646
+                overage: 542
+                cost_cents: 271
               sms:
                 total: 5
                 cost_cents: 5

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -31,7 +31,7 @@ subscription:
               has_payment_method: false
               can_upgrade: true
               plan_limits:
-                max_requests_per_month: 250
+                max_requests_per_month: 1000
                 max_agents: 5
                 max_standing_approvals: 10
                 max_credentials: 5
@@ -39,7 +39,7 @@ subscription:
               usage:
                 request_count: 42
                 sms_count: 0
-                request_limit: 250
+                request_limit: 1000
                 over_limit: false
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
@@ -202,7 +202,7 @@ plan:
               plan:
                 id: free
                 name: Free
-                max_requests_per_month: 250
+                max_requests_per_month: 1000
                 max_agents: 3
                 max_standing_approvals: 5
                 max_credentials: 5
@@ -272,7 +272,7 @@ usage:
               period_end: '2026-04-01T00:00:00Z'
               requests:
                 total: 1542
-                included: 250
+                included: 1000
                 overage: 1292
                 cost_cents: 646
               sms:

--- a/spec/openapi/components/responses/errors.yaml
+++ b/spec/openapi/components/responses/errors.yaml
@@ -289,12 +289,12 @@ TooManyRequests:
           value:
             error:
               code: "monthly_quota_exceeded"
-              message: "Free tier limit of 250 requests/month reached. Upgrade to continue."
+              message: "Free tier limit of 1000 requests/month reached. Upgrade to continue."
               retryable: true
               retry_after: 86400
               details:
-                current_usage: 250
-                limit: 250
+                current_usage: 1000
+                limit: 1000
                 plan_id: "free"
                 reset_at: "2026-04-01T00:00:00Z"
               trace_id: "trace_xyz789"

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -57,7 +57,7 @@ PlanLimits:
       type: integer
       nullable: true
       description: Monthly request limit (null = unlimited)
-      example: 250
+      example: 1000
     max_agents:
       type: integer
       nullable: true
@@ -97,7 +97,7 @@ UsageInfo:
       type: integer
       nullable: true
       description: Monthly request limit for the current plan (null = unlimited)
-      example: 250
+      example: 1000
     over_limit:
       type: boolean
       description: Whether current usage exceeds the plan's request limit
@@ -139,7 +139,7 @@ RequestsUsage:
     included:
       type: integer
       description: Number of requests included in the plan for free (0 = unlimited on paid plans)
-      example: 250
+      example: 1000
     overage:
       type: integer
       description: Number of requests exceeding the included allowance
@@ -379,7 +379,7 @@ BillingPricing:
     free_request_allowance:
       type: integer
       description: Number of requests included free each billing period before per-request charges apply.
-      example: 250
+      example: 1000
     price_per_request_display:
       type: string
       description: Human-readable per-request price string (e.g. "$0.005"), sourced from the Stripe price object.
@@ -442,7 +442,7 @@ RequestUsageDetail:
       description: |
         Number of requests included in the plan at no extra cost.
         0 when the plan has no request limit (e.g. pay-as-you-go).
-      example: 250
+      example: 1000
     overage:
       type: integer
       description: |
@@ -657,12 +657,12 @@ QuotaExceededError:
   example:
     error:
       code: monthly_quota_exceeded
-      message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+      message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
       retryable: true
       retry_after: 2419200
       details:
-        limit: 250
-        current_usage: 250
+        limit: 1000
+        current_usage: 1000
         plan_id: free
         reset_at: '2026-04-01T00:00:00Z'
 
@@ -673,7 +673,7 @@ QuotaExceededDetails:
     limit:
       type: integer
       description: The plan's request limit
-      example: 250
+      example: 1000
     current_count:
       type: integer
       description: Current usage count

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4922,8 +4922,8 @@ paths:
                 requests:
                   total: 1542
                   included: 1000
-                  overage: 1292
-                  cost_cents: 646
+                  overage: 542
+                  cost_cents: 271
                 sms:
                   total: 5
                   cost_cents: 5

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4866,7 +4866,7 @@ paths:
                 has_payment_method: false
                 can_upgrade: true
                 plan_limits:
-                  max_requests_per_month: 250
+                  max_requests_per_month: 1000
                   max_agents: 5
                   max_standing_approvals: 10
                   max_credentials: 5
@@ -4874,7 +4874,7 @@ paths:
                 usage:
                   request_count: 42
                   sms_count: 0
-                  request_limit: 250
+                  request_limit: 1000
                   over_limit: false
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -4921,7 +4921,7 @@ paths:
                 period_end: '2026-04-01T00:00:00Z'
                 requests:
                   total: 1542
-                  included: 250
+                  included: 1000
                   overage: 1292
                   cost_cents: 646
                 sms:
@@ -5251,7 +5251,7 @@ paths:
                 plan:
                   id: free
                   name: Free
-                  max_requests_per_month: 250
+                  max_requests_per_month: 1000
                   max_agents: 3
                   max_standing_approvals: 5
                   max_credentials: 5
@@ -9947,7 +9947,7 @@ components:
           type: integer
           nullable: true
           description: Monthly request limit for the current plan (null = unlimited)
-          example: 250
+          example: 1000
         over_limit:
           type: boolean
           description: Whether current usage exceeds the plan's request limit
@@ -9987,7 +9987,7 @@ components:
         included:
           type: integer
           description: Number of requests included in the plan for free (0 = unlimited on paid plans)
-          example: 250
+          example: 1000
         overage:
           type: integer
           description: Number of requests exceeding the included allowance
@@ -10252,7 +10252,7 @@ components:
           description: |
             Number of requests included in the plan at no extra cost.
             0 when the plan has no request limit (e.g. pay-as-you-go).
-          example: 250
+          example: 1000
         overage:
           type: integer
           description: |
@@ -10393,12 +10393,12 @@ components:
       example:
         error:
           code: monthly_quota_exceeded
-          message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+          message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
           retryable: true
           retry_after: 2419200
           details:
-            limit: 250
-            current_usage: 250
+            limit: 1000
+            current_usage: 1000
             plan_id: free
             reset_at: '2026-04-01T00:00:00Z'
     QuotaExceededDetails:
@@ -10408,7 +10408,7 @@ components:
         limit:
           type: integer
           description: The plan's request limit
-          example: 250
+          example: 1000
         current_count:
           type: integer
           description: Current usage count
@@ -11525,7 +11525,7 @@ components:
           type: integer
           nullable: true
           description: Monthly request limit (null = unlimited)
-          example: 250
+          example: 1000
         max_agents:
           type: integer
           nullable: true
@@ -11604,7 +11604,7 @@ components:
         free_request_allowance:
           type: integer
           description: Number of requests included free each billing period before per-request charges apply.
-          example: 250
+          example: 1000
         price_per_request_display:
           type: string
           description: Human-readable per-request price string (e.g. "$0.005"), sourced from the Stripe price object.
@@ -12016,12 +12016,12 @@ components:
               value:
                 error:
                   code: monthly_quota_exceeded
-                  message: Free tier limit of 250 requests/month reached. Upgrade to continue.
+                  message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
                   retryable: true
                   retry_after: 86400
                   details:
-                    current_usage: 250
-                    limit: 250
+                    current_usage: 1000
+                    limit: 1000
                     plan_id: free
                     reset_at: '2026-04-01T00:00:00Z'
                   trace_id: trace_xyz789

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -205,7 +205,7 @@ var freeRequestAllowance = func() int64 {
 	if p != nil && p.MaxRequestsPerMonth != nil {
 		return int64(*p.MaxRequestsPerMonth)
 	}
-	return 250 // fallback
+	return 1000 // fallback
 }()
 
 // FreeRequestAllowance returns the number of free requests per billing period.

--- a/stripe/client_test.go
+++ b/stripe/client_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestFreeRequestAllowance(t *testing.T) {
-	if FreeRequestAllowance() != 250 {
-		t.Errorf("expected FreeRequestAllowance()=250 (from config/plans.json free plan), got %d", FreeRequestAllowance())
+	if FreeRequestAllowance() != 1000 {
+		t.Errorf("expected FreeRequestAllowance()=1000 (from config/plans.json free plan), got %d", FreeRequestAllowance())
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the monthly free request allowance from **250 → 1000** everywhere it is defined or documented. The **source of truth** remains `config/plans.json` (`free.max_requests_per_month`). Pay-as-you-go continues to have unlimited `max_requests_per_month` in config; the **included free bucket** before metered charges is the same allowance (read from the free plan / Stripe helper).

## Changes
- `config/plans.json`: free plan `max_requests_per_month` → 1000
- Stripe `FreeRequestAllowance()` fallback, Go/API tests, OpenAPI modular specs + `openapi.bundle.yaml`, duplicate `bundled.yaml` copies, frontend billing fixtures/tests, docs (Stripe setup, schema, ADR 010), migration comments (historical INSERT values already matched 1000)

## Test plan
### Automated (ran locally)
- `go test ./config/`
- `npx vitest run src/pages/billing` (and related hook/dashboard/settings tests)

### CI / follow-up
- `make test-backend` / `make build` (Go toolchain in CI should match `go.mod`)

## Manual
- [ ] Confirm Stripe metered billing / product copy in dashboard (if any) matches 1000 in production Stripe settings if configured outside this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e906413b-36c7-467b-a4f9-82afb2cf0750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e906413b-36c7-467b-a4f9-82afb2cf0750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

