### PR TITLE
fix(dashboard): keep standing approval wizard open after Always Allow

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -417,8 +417,8 @@ export function CreateStandingApprovalDialog({
         });
         toast.success("Standing approval updated");
         resetForm();
-        onOpenChange(false);
         onUpdated?.();
+        onOpenChange(false);
       } else {
         await createStandingApproval({
           agent_id: agentId,
@@ -431,8 +431,8 @@ export function CreateStandingApprovalDialog({
         });
         toast.success("Standing approval created");
         resetForm();
-        onOpenChange(false);
         onCreated?.();
+        onOpenChange(false);
       }
     } catch (err) {
       toast.error(

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -196,7 +196,10 @@ export function ReviewApprovalDialog({
 
   function handleStandingDialogChange(nextOpen: boolean) {
     setStandingDialogOpen(nextOpen);
-    if (!nextOpen && !standingApprovalCreated) {
+    // Unblock parent auto-close whenever the nested wizard closes (cancel or success).
+    // Do not gate on standingApprovalCreated — that state updates after this handler runs,
+    // so a closure check would always see the pre-create value.
+    if (!nextOpen) {
       setAutoCloseBlocked(false);
     }
   }

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -144,12 +144,14 @@ export function ReviewApprovalDialog({
   );
   const showAlwaysAllow = hasParams && !standingApprovalsLoading && !hasExistingStandingApproval;
 
-  // Auto-close dialog after successful approval
+  // Auto-close dialog after successful approval (never while the nested standing-approval
+  // wizard is open — a render with isApproved true before autoCloseBlocked flips true
+  // would otherwise start the timer and unmount the child dialog).
   useEffect(() => {
-    if (!isApproved || autoCloseBlocked) return;
+    if (!isApproved || autoCloseBlocked || standingDialogOpen) return;
     const timer = setTimeout(() => onOpenChange(false), SUCCESS_AUTO_CLOSE_MS);
     return () => clearTimeout(timer);
-  }, [isApproved, autoCloseBlocked, onOpenChange]);
+  }, [isApproved, autoCloseBlocked, standingDialogOpen, onOpenChange]);
 
   const handleApprove = useCallback(async () => {
     setPendingAction("approve");
@@ -175,14 +177,17 @@ export function ReviewApprovalDialog({
 
   const handleAlwaysAllow = useCallback(async () => {
     setPendingAction("alwaysAllow");
+    setAutoCloseBlocked(true);
     try {
       const result = await approveApproval(approval.approval_id);
       setApproveResult(result);
-      setAutoCloseBlocked(true);
-      if (result.execution_status !== "error") {
+      if (result.execution_status === "error") {
+        setAutoCloseBlocked(false);
+      } else {
         setStandingDialogOpen(true);
       }
     } catch {
+      setAutoCloseBlocked(false);
       toast.error("Failed to approve request. Please try again.");
     } finally {
       setPendingAction(null);

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -184,6 +184,56 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
   });
 
+  it(
+    "does NOT call onOpenChange(false) while the standing-approval wizard is open",
+    async () => {
+      setupMocks();
+      const approval = makeApproval();
+      const onOpenChange = vi.fn();
+
+      mockPost.mockResolvedValueOnce({
+        data: {
+          approval_id: approval.approval_id,
+          status: "approved",
+          approved_at: new Date().toISOString(),
+          confirmation_code: "ABC-123",
+          execution_status: "success",
+          execution_result: null,
+        },
+      });
+
+      const user = userEvent.setup();
+
+      render(
+        <ReviewApprovalDialog
+          approval={approval}
+          agentDisplayName="Test Bot"
+          open={true}
+          onOpenChange={onOpenChange}
+        />,
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Always allow this action")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("Always allow this action"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
+      });
+
+      // Parent auto-close is SUCCESS_AUTO_CLOSE_MS (3000); if a regression schedules it
+      // while the wizard is open, this would fire too early. Real timers avoid RTL waitFor
+      // hanging under vi.useFakeTimers().
+      await new Promise((r) => setTimeout(r, 3_100));
+
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    },
+    10_000,
+  );
+
   it("does NOT open standing approval wizard when execution fails after 'Always Allow'", async () => {
     setupMocks();
     const approval = makeApproval();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The nested **Create Standing Approval** flow (e.g. Send Email → Step 2 *Set Limits*) lives inside `ReviewApprovalDialog`. The parent dialog auto-closes after a successful approval via a timeout when `isApproved` is true and `autoCloseBlocked` is false.

There was a race: `setApproveResult` could commit before `setAutoCloseBlocked(true)`, so the auto-close timer could start and call `onOpenChange(false)` on the parent, unmounting the child wizard almost immediately.

## Changes
- `setAutoCloseBlocked(true)` is set synchronously before the `approveApproval` async call in `handleAlwaysAllow`, ensuring `autoCloseBlocked` is already `true` when any subsequent `setApproveResult` triggers a re-render.
- `autoCloseBlocked` is cleared on execution error or network failure so the normal post-approval auto-close still applies in those paths.
- `standingDialogOpen` is added as a second guard in the auto-close `useEffect`.
- `handleStandingDialogChange` always clears `autoCloseBlocked` when the nested wizard closes (the previous `!standingApprovalCreated` check was ineffective because that state updated after the close handler ran).
- `CreateStandingApprovalDialog` calls `onCreated` / `onUpdated` before `onOpenChange(false)` after a successful save.
- Regression test: parent `onOpenChange(false)` is not invoked while the wizard is visible, after waiting past `SUCCESS_AUTO_CLOSE_MS`.

## Test plan
### Claude Code
- [x] `npx vitest run src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx`
- [x] `npx vitest run src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx`

### Manual Testing
- [ ] From a pending approval with parameters, choose **Always allow this action**; confirm the standing-approval wizard stays open through Step 1 (constraints) and Step 2 (limits) without the parent dialog disappearing.
- [ ] After saving limits, confirm success flow still behaves as expected (nested closes, parent shows approved state / Done).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ef04fe6-cf56-433a-8894-89d664f95492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ef04fe6-cf56-433a-8894-89d664f95492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

