### PR TITLE
Fix standing approval dialog auto-closing on step transitions

### DIFF
--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -455,7 +455,10 @@ export function CreateStandingApprovalDialog({
         onOpenChange(v);
       }}
     >
-      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+      <DialogContent
+        className="max-h-[85dvh] overflow-y-auto sm:max-w-lg"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           {effectiveActionType ? (
             <>

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -216,10 +216,7 @@ export function ReviewApprovalDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent
-        className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl"
-        onInteractOutside={standingDialogOpen ? (e) => e.preventDefault() : undefined}
-      >
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
         {/* Connector header with logo, action name, and connector name */}
         <DialogHeader>
           <div className="flex items-center gap-3">

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -216,7 +216,10 @@ export function ReviewApprovalDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent
+        className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl"
+        onInteractOutside={standingDialogOpen ? (e) => e.preventDefault() : undefined}
+      >
         {/* Connector header with logo, action name, and connector name */}
         <DialogHeader>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

- The "Set Limits" step (step 2 of 2) in the standing approval dialog was auto-closing within half a second, preventing users from changing any values
- Root cause: Radix Dialog's `DismissableLayer` was detecting focus/pointer events "outside" the dialog content due to two interacting issues:
  1. **Focus loss during step transitions** — the "Next" button unmounts and "Save" button mounts, briefly orphaning focus to the document body, which Radix interprets as focus leaving the dialog
  2. **Nested portal interactions** — the `CreateStandingApprovalDialog` is portaled as a DOM sibling (not descendant) of the `ReviewApprovalDialog`, so interactions with the inner dialog register as "outside" the outer dialog
- Fix: added `onInteractOutside` with `preventDefault()` to both dialog contents to prevent unintended dismissals while still allowing Cancel, X, Escape, and Save to work normally

## Test plan

### Claude Code
- [x] Frontend tests pass (957/957)
- [x] TypeScript compiles cleanly
- [x] Frontend build succeeds

### Manual Testing
- [ ] Open a pending approval → click "Always allow this action" → fill in constraints → click Next → verify the "Set Limits" step stays open and doesn't auto-close
- [ ] On the "Set Limits" step, verify Cancel, X button, and Escape key all still close the dialog
- [ ] On the "Set Limits" step, fill in values and click Save → verify standing approval is created successfully
- [ ] Open the standalone "Create Standing Approval" dialog from the standing approvals card → go through all 4 steps → verify step 4 doesn't auto-close

https://claude.ai/code/session_01J9SpfUBNLFV5XYKJMMyhQu