### PR TITLE
fix(audit): allow standing_approval.updated in DB constraints (Sentry PERMISSION-SLIP-GO-B)

### DIFF
--- a/api/audit_events.go
+++ b/api/audit_events.go
@@ -64,7 +64,7 @@ type auditEventListResponse struct {
 }
 
 var validOutcomeValues = []string{
-	"approved", "auto_executed", "cancelled", "charged", "deactivated", "denied", "expired", "pending", "registered",
+	"approved", "auto_executed", "cancelled", "charged", "deactivated", "denied", "expired", "pending", "registered", "updated",
 }
 
 var validOutcomeFilters = func() map[string]bool {

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -541,7 +541,7 @@ func emitStandingApprovalUpdateAuditEvent(ctx context.Context, d db.DBTX, userID
 		UserID:      userID,
 		AgentID:     agentID,
 		EventType:   db.AuditEventStandingUpdated,
-		Outcome:     "updated",
+		Outcome:     db.OutcomeUpdated,
 		SourceID:    saID,
 		SourceType:  "standing_approval",
 		Action:      actionJSON,

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -99,8 +99,12 @@ const (
 // Payment audit event constants.
 const (
 	OutcomeCharged            = "charged"
-	OutcomeUpdated            = "updated"
 	SourceTypePaymentMethodTx = "payment_method_transaction"
+)
+
+// Standing approval audit event constants.
+const (
+	OutcomeUpdated = "updated"
 )
 
 // InsertAuditEventParams holds the parameters for inserting an audit event.

--- a/db/audit_events.go
+++ b/db/audit_events.go
@@ -52,7 +52,7 @@ type AuditEvent struct {
 	AgentID         int64
 	AgentMeta       []byte  // raw JSONB (agent metadata snapshot at event time)
 	Action          []byte  // raw JSONB (approval action details, nullable)
-	Outcome         string  // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
+	Outcome         string  // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired", "charged", "updated"
 	SourceID        string  // unique ID per event source (e.g. approval_id)
 	SourceType      string  // "approval", "standing_approval", "agent", "payment_method_transaction"
 	ConnectorID     *string // which connector handled the action (nullable for lifecycle events)
@@ -78,7 +78,7 @@ type AuditEventCursor struct {
 type AuditEventFilter struct {
 	AgentID     *int64
 	EventTypes  []AuditEventType // if non-empty, include only these types
-	Outcome     string           // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired"
+	Outcome     string           // "approved", "denied", "cancelled", "auto_executed", "registered", "deactivated", "pending", "expired", "charged", "updated"
 	ConnectorID *string          // if non-nil, include only events for this connector
 }
 
@@ -99,6 +99,7 @@ const (
 // Payment audit event constants.
 const (
 	OutcomeCharged            = "charged"
+	OutcomeUpdated            = "updated"
 	SourceTypePaymentMethodTx = "payment_method_transaction"
 )
 

--- a/db/audit_events_test.go
+++ b/db/audit_events_test.go
@@ -1034,6 +1034,49 @@ func TestInsertAuditEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("StandingApprovalUpdated", func(t *testing.T) {
+		t.Parallel()
+		tx := testhelper.SetupTestDB(t)
+		uid := testhelper.GenerateUID(t)
+		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+		testhelper.InsertConnector(t, tx, "github")
+		saID := testhelper.GenerateID(t, "sa_")
+		connectorID := "github"
+		actionJSON := []byte(`{"type":"github.create_issue"}`)
+
+		err := db.InsertAuditEvent(ctx, tx, db.InsertAuditEventParams{
+			UserID:      uid,
+			AgentID:     agentID,
+			EventType:   db.AuditEventStandingUpdated,
+			Outcome:     db.OutcomeUpdated,
+			SourceID:    saID,
+			SourceType:  "standing_approval",
+			Action:      actionJSON,
+			ConnectorID: &connectorID,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		page, err := db.ListAuditEvents(ctx, tx, uid, 20, nil, nil, 0)
+		if err != nil {
+			t.Fatalf("list error: %v", err)
+		}
+		if len(page.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(page.Events))
+		}
+		e := page.Events[0]
+		if e.EventType != db.AuditEventStandingUpdated {
+			t.Errorf("expected standing_approval.updated, got %s", e.EventType)
+		}
+		if e.Outcome != db.OutcomeUpdated {
+			t.Errorf("expected outcome updated, got %q", e.Outcome)
+		}
+		if e.SourceID != saID {
+			t.Errorf("expected source_id %q, got %q", saID, e.SourceID)
+		}
+	})
+
 	t.Run("NilAction", func(t *testing.T) {
 		t.Parallel()
 		tx := testhelper.SetupTestDB(t)

--- a/db/migrations/20260320131321_audit_standing_approval_updated_event_type.sql
+++ b/db/migrations/20260320131321_audit_standing_approval_updated_event_type.sql
@@ -1,6 +1,9 @@
 -- +goose Up
 -- Add standing_approval.updated and outcome 'updated' for PATCH/POST standing approval updates.
 -- Go code (emitStandingApprovalUpdateAuditEvent) already emits these; production failed on DB CHECK.
+--
+-- Use NOT VALID + VALIDATE CONSTRAINT to shorten ACCESS EXCLUSIVE time vs a single ADD that
+-- validates immediately (existing rows already satisfy the widened checks).
 
 ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_event_type_check;
 ALTER TABLE audit_events ADD CONSTRAINT audit_events_event_type_check CHECK (
@@ -16,15 +19,19 @@ ALTER TABLE audit_events ADD CONSTRAINT audit_events_event_type_check CHECK (
         'agent.deactivated',
         'payment_method.charged'
     )
-);
+) NOT VALID;
+ALTER TABLE audit_events VALIDATE CONSTRAINT audit_events_event_type_check;
 
 ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_outcome_check;
 ALTER TABLE audit_events ADD CONSTRAINT audit_events_outcome_check
     CHECK (outcome IN (
         'approved', 'denied', 'cancelled', 'auto_executed', 'registered', 'deactivated', 'pending', 'expired', 'charged', 'updated'
-    ));
+    )) NOT VALID;
+ALTER TABLE audit_events VALIDATE CONSTRAINT audit_events_outcome_check;
 
 -- +goose Down
+-- NOT VALID so rollback does not fail when rows already contain standing_approval.updated / updated.
+-- New inserts/updates are still checked against the restored (narrower) rules.
 ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_event_type_check;
 ALTER TABLE audit_events ADD CONSTRAINT audit_events_event_type_check CHECK (
     event_type IN (
@@ -38,10 +45,10 @@ ALTER TABLE audit_events ADD CONSTRAINT audit_events_event_type_check CHECK (
         'agent.deactivated',
         'payment_method.charged'
     )
-);
+) NOT VALID;
 
 ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_outcome_check;
 ALTER TABLE audit_events ADD CONSTRAINT audit_events_outcome_check
     CHECK (outcome IN (
         'approved', 'denied', 'cancelled', 'auto_executed', 'registered', 'deactivated', 'pending', 'expired', 'charged'
-    ));
+    )) NOT VALID;

--- a/db/migrations/20260320131321_audit_standing_approval_updated_event_type.sql
+++ b/db/migrations/20260320131321_audit_standing_approval_updated_event_type.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- Add standing_approval.updated and outcome 'updated' for PATCH/POST standing approval updates.
+-- Go code (emitStandingApprovalUpdateAuditEvent) already emits these; production failed on DB CHECK.
+
+ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_event_type_check;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_event_type_check CHECK (
+    event_type IN (
+        'approval.requested',
+        'approval.approved',
+        'approval.denied',
+        'approval.cancelled',
+        'action.executed',
+        'standing_approval.executed',
+        'standing_approval.updated',
+        'agent.registered',
+        'agent.deactivated',
+        'payment_method.charged'
+    )
+);
+
+ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_outcome_check;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_outcome_check
+    CHECK (outcome IN (
+        'approved', 'denied', 'cancelled', 'auto_executed', 'registered', 'deactivated', 'pending', 'expired', 'charged', 'updated'
+    ));
+
+-- +goose Down
+ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_event_type_check;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_event_type_check CHECK (
+    event_type IN (
+        'approval.requested',
+        'approval.approved',
+        'approval.denied',
+        'approval.cancelled',
+        'action.executed',
+        'standing_approval.executed',
+        'agent.registered',
+        'agent.deactivated',
+        'payment_method.charged'
+    )
+);
+
+ALTER TABLE audit_events DROP CONSTRAINT IF EXISTS audit_events_outcome_check;
+ALTER TABLE audit_events ADD CONSTRAINT audit_events_outcome_check
+    CHECK (outcome IN (
+        'approved', 'denied', 'cancelled', 'auto_executed', 'registered', 'deactivated', 'pending', 'expired', 'charged'
+    ));

--- a/frontend/src/lib/auditEvents.tsx
+++ b/frontend/src/lib/auditEvents.tsx
@@ -9,6 +9,7 @@ import {
   TimerOff,
   CreditCard,
   HelpCircle,
+  PencilLine,
 } from "lucide-react";
 import { Badge, type badgeVariants } from "@/components/ui/badge";
 import type { VariantProps } from "class-variance-authority";
@@ -38,7 +39,7 @@ export const OUTCOME_FILTERS: { label: string; value: OutcomeFilter }[] = [
  * when no explicit event_type filter is set.
  */
 export const ACTION_EVENT_TYPES =
-  "approval.requested,approval.approved,approval.denied,approval.cancelled,action.executed,standing_approval.executed,payment_method.charged";
+  "approval.requested,approval.approved,approval.denied,approval.cancelled,action.executed,standing_approval.executed,standing_approval.updated,payment_method.charged";
 
 interface OutcomeStyle {
   label: string;
@@ -56,6 +57,7 @@ export const OUTCOME_CONFIG: Record<string, OutcomeStyle> = {
   pending: { label: "Pending", variant: "warning", Icon: Clock },
   expired: { label: "Expired", variant: "outline", Icon: TimerOff },
   charged: { label: "Charged", variant: "info", Icon: CreditCard },
+  updated: { label: "Updated", variant: "secondary", Icon: PencilLine },
 };
 
 /** All outcome values (derived from OUTCOME_CONFIG) plus "all", for the full activity page. */

--- a/spec/openapi/components/paths/audit_events.yaml
+++ b/spec/openapi/components/paths/audit_events.yaml
@@ -246,6 +246,7 @@ listAuditEvents:
             - pending
             - expired
             - charged
+            - updated
         example: "approved"
       - name: connector_id
         in: query

--- a/spec/openapi/components/paths/standing_approvals.yaml
+++ b/spec/openapi/components/paths/standing_approvals.yaml
@@ -401,6 +401,8 @@ updateStandingApproval:
       `execution_count`. The update is rejected atomically at the database level to prevent
       a race condition where concurrent executions could otherwise create a zombie approval.
 
+      Emits a `standing_approval.updated` audit event on success.
+
     tags:
       - Standing Approvals
 

--- a/spec/openapi/components/schemas/audit_events.yaml
+++ b/spec/openapi/components/schemas/audit_events.yaml
@@ -16,6 +16,7 @@ AuditEvent:
         - approval.cancelled
         - action.executed
         - standing_approval.executed
+        - standing_approval.updated
         - agent.registered
         - agent.deactivated
         - payment_method.charged
@@ -45,7 +46,8 @@ AuditEvent:
         approvals, contains `type`, `version`, and `parameters`. For standing
         approval executions, contains `type`, `version`, `parameters` (the
         actual parameters used in the execution), and `constraints` (the
-        boundary rules from the standing approval). For payment_method.charged
+        boundary rules from the standing approval). For standing_approval.updated,
+        contains `type` (action type) only. For payment_method.charged
         events, contains `type`, `payment_method_id`, `brand`, `last4`,
         `amount_cents`, `currency`, and optionally `description` (a human-readable
         summary of the charge). Never includes raw card details.
@@ -62,6 +64,7 @@ AuditEvent:
         - pending
         - expired
         - charged
+        - updated
       description: The outcome of the event.
       example: "approved"
     source_id:
@@ -131,6 +134,7 @@ AuditLogEvent:
         - approval.cancelled
         - action.executed
         - standing_approval.executed
+        - standing_approval.updated
         - agent.registered
         - agent.deactivated
         - payment_method.charged
@@ -171,6 +175,7 @@ AuditLogEvent:
         - pending
         - expired
         - charged
+        - updated
       description: The outcome of the event.
       example: "approved"
     source_id:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4104,6 +4104,8 @@ paths:
         **Execution count**: `max_executions` cannot be set below the approval's current
         `execution_count`. The update is rejected atomically at the database level to prevent
         a race condition where concurrent executions could otherwise create a zombie approval.
+
+        Emits a `standing_approval.updated` audit event on success.
       tags:
         - Standing Approvals
       security:
@@ -8437,6 +8439,7 @@ components:
             - approval.cancelled
             - action.executed
             - standing_approval.executed
+            - standing_approval.updated
             - agent.registered
             - agent.deactivated
             - payment_method.charged
@@ -8466,7 +8469,8 @@ components:
             approvals, contains `type`, `version`, and `parameters`. For standing
             approval executions, contains `type`, `version`, `parameters` (the
             actual parameters used in the execution), and `constraints` (the
-            boundary rules from the standing approval). For payment_method.charged
+            boundary rules from the standing approval). For standing_approval.updated,
+            contains `type` (action type) only. For payment_method.charged
             events, contains `type`, `payment_method_id`, `brand`, `last4`,
             `amount_cents`, `currency`, and optionally `description` (a human-readable
             summary of the charge). Never includes raw card details.
@@ -8483,6 +8487,7 @@ components:
             - pending
             - expired
             - charged
+            - updated
           description: The outcome of the event.
           example: approved
         source_id:
@@ -8575,6 +8580,7 @@ components:
             - approval.cancelled
             - action.executed
             - standing_approval.executed
+            - standing_approval.updated
             - agent.registered
             - agent.deactivated
             - payment_method.charged
@@ -8615,6 +8621,7 @@ components:
             - pending
             - expired
             - charged
+            - updated
           description: The outcome of the event.
           example: approved
         source_id:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1951,6 +1951,7 @@ paths:
               - pending
               - expired
               - charged
+              - updated
           example: approved
         - name: connector_id
           in: query


### PR DESCRIPTION
## Summary
Production Sentry issue **PERMISSION-SLIP-GO-B** (`7350933060`): updating a standing approval returned 500 because `emitStandingApprovalUpdateAuditEvent` inserts `event_type = standing_approval.updated` and `outcome = updated`, which violated `audit_events_event_type_check` (and would have violated `audit_events_outcome_check` next).

## Changes
- New migration extends `audit_events` CHECK constraints for `standing_approval.updated` and outcome `updated`.
- API: `validOutcomeValues` includes `updated` for `GET /audit-events` filtering.
- OpenAPI + bundled spec; standing approval update operation documents the audit event.
- Frontend: `ACTION_EVENT_TYPES` and outcome badge config for activity UI.
- `db.OutcomeUpdated` constant; `TestInsertAuditEvent/StandingApprovalUpdated` regression test.

## Test plan
- [ ] `make test-backend` (includes `db` tests and migration integrity)
- [ ] `make build`
- [ ] Apply migration to staging/production before/at deploy

### Claude Code
- [x] Migration created via `make migrate-create`
- [x] OpenAPI bundle regenerated (`make bundle`)
- [x] Run full backend tests in CI (local Go version mismatch in agent env)

### Manual Testing
- [ ] After deploy: PATCH/POST standing approval update succeeds and audit row appears
- [ ] Activity feed shows update events with "Updated" outcome badge
