### PR TITLE
Add policy: never open draft PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 - Always ask for permission before writing any code.
 - Do not git push without confirming first
 - After making the first commit on a branch, automatically create a pull request using `gh pr create`. Use a concise title and include a descriptive body with a summary and test plan. For subsequent commits, push to the existing PR branch.
+- **Never open draft PRs.** Always open PRs as ready for review.
 - When suggesting a PR body that includes a checklist, **split the checklist into two sections** based on who should handle each item:
   - `### Claude Code` — items that Claude Code can address autonomously (e.g., add tests, fix lint, update docs, add error handling, run checks). The `/watch` command will pick these up and check them off.
   - `### Manual Testing` — items that require manual verification, design review, or hands-on testing that Claude Code can't perform.


### PR DESCRIPTION
## Summary
- Adds a rule to CLAUDE.md instructing Claude Code to never open draft PRs and always open PRs as ready for review.

## Test plan
- [ ] Verify the new rule appears in CLAUDE.md under the Interaction Rules section
- [ ] Confirm future PRs are opened as ready for review (not draft)

https://claude.ai/code/session_01GK23e3LSdTKpnTdhuvqiQt