### PR TITLE
Promote QuickBooks and X to built-in OAuth providers, disable BYOA on hosted

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -10,6 +10,7 @@ type configResponse struct {
 	GoogleOAuthConfigured    bool `json:"google_oauth_configured"`
 	MicrosoftOAuthConfigured bool `json:"microsoft_oauth_configured"`
 	SMSEnabled               bool `json:"sms_enabled"`
+	BYOAEnabled              bool `json:"byoa_enabled"`
 }
 
 func init() {
@@ -40,6 +41,7 @@ func handleGetConfig(deps *Deps) http.HandlerFunc {
 			GoogleOAuthConfigured:    googleConfigured,
 			MicrosoftOAuthConfigured: microsoftConfigured,
 			SMSEnabled:               deps.SMSEnabled,
+			BYOAEnabled:              !deps.BillingEnabled,
 		})
 	}
 }

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -33,6 +33,9 @@ func TestGetConfig_BillingDisabled(t *testing.T) {
 	if resp.BillingEnabled {
 		t.Error("expected billing_enabled=false when BillingEnabled is false")
 	}
+	if !resp.BYOAEnabled {
+		t.Error("expected byoa_enabled=true when BillingEnabled is false (self-hosted)")
+	}
 }
 
 func TestGetConfig_BillingEnabled(t *testing.T) {
@@ -58,6 +61,9 @@ func TestGetConfig_BillingEnabled(t *testing.T) {
 	}
 	if !resp.BillingEnabled {
 		t.Error("expected billing_enabled=true when BillingEnabled is true")
+	}
+	if resp.BYOAEnabled {
+		t.Error("expected byoa_enabled=false when BillingEnabled is true (hosted)")
 	}
 }
 

--- a/api/oauth_byoa.go
+++ b/api/oauth_byoa.go
@@ -1,14 +1,16 @@
 // BYOA (Bring Your Own OAuth App) endpoints.
 //
-// These endpoints let users register their own OAuth client credentials for
-// any provider declared in a connector manifest. This is needed when a
-// connector's OAuth provider has no platform-level credentials — i.e. the
-// manifest declares endpoints and scopes but no client ID/secret (e.g.
-// Salesforce, X/Twitter). Users create an OAuth app in the provider's
-// developer console, then enter the client ID and secret here.
+// These endpoints let self-hosted users register their own OAuth client
+// credentials for any provider declared in a connector manifest or built-in
+// config. This is useful when a provider has no platform-level credentials —
+// the manifest declares endpoints and scopes but no client ID/secret (e.g.
+// Salesforce). Users create an OAuth app in the provider's developer console,
+// then enter the client ID and secret here.
 //
-// Self-hosted deployments do NOT need BYOA — they should set provider
-// credentials via environment variables (GOOGLE_CLIENT_ID, etc.) instead.
+// BYOA is DISABLED on the hosted platform (app.permissionslip.dev) where
+// BillingEnabled is true. All providers ship with platform-level credentials
+// on the hosted platform. On self-hosted deployments, users can either set
+// provider credentials via environment variables or use BYOA.
 //
 // Provider resolution order: platform-level built-in → user-level BYOA config.
 // BYOA credentials are merged into the existing provider config (preserving
@@ -76,7 +78,23 @@ func init() {
 }
 
 // RegisterOAuthBYOARoutes adds BYOA provider management endpoints to the mux.
+// BYOA is only available on self-hosted deployments (BillingEnabled == false).
+// On the hosted platform (app.permissionslip.dev), all providers ship with
+// platform-level credentials so BYOA is unnecessary.
 func RegisterOAuthBYOARoutes(mux *http.ServeMux, deps *Deps) {
+	if deps.BillingEnabled {
+		// Hosted deployment — BYOA is disabled. Register handlers that
+		// return 404 so the endpoints don't leak into the hosted API.
+		byoaDisabled := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConfigurationDisabled, "BYOA is not available on hosted deployments"))
+		})
+		mux.Handle("POST /oauth/provider-configs", byoaDisabled)
+		mux.Handle("GET /oauth/provider-configs", byoaDisabled)
+		mux.Handle("PUT /oauth/provider-configs/{provider}", byoaDisabled)
+		mux.Handle("DELETE /oauth/provider-configs/{provider}", byoaDisabled)
+		return
+	}
+
 	requireProfile := RequireProfile(deps)
 
 	mux.Handle("POST /oauth/provider-configs", requireProfile(handleCreateOAuthProviderConfig(deps)))

--- a/api/oauth_byoa.go
+++ b/api/oauth_byoa.go
@@ -85,9 +85,12 @@ func RegisterOAuthBYOARoutes(mux *http.ServeMux, deps *Deps) {
 	if deps.BillingEnabled {
 		// Hosted deployment — BYOA is disabled. Register handlers that
 		// return 404 so the endpoints don't leak into the hosted API.
-		byoaDisabled := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wrap in requireProfile so unauthenticated callers get 401 (same
+		// as self-hosted), preventing deployment-type fingerprinting.
+		requireProfile := RequireProfile(deps)
+		byoaDisabled := requireProfile(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			RespondError(w, r, http.StatusNotFound, NotFound(ErrConfigurationDisabled, "BYOA is not available on hosted deployments"))
-		})
+		}))
 		mux.Handle("POST /oauth/provider-configs", byoaDisabled)
 		mux.Handle("GET /oauth/provider-configs", byoaDisabled)
 		mux.Handle("PUT /oauth/provider-configs/{provider}", byoaDisabled)

--- a/connectors/providers/quickbooks.go
+++ b/connectors/providers/quickbooks.go
@@ -1,0 +1,7 @@
+package providers
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+func init() {
+	connectors.RegisterBuiltInOAuthProvider("quickbooks")
+}

--- a/connectors/providers/x.go
+++ b/connectors/providers/x.go
@@ -1,0 +1,7 @@
+package providers
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+func init() {
+	connectors.RegisterBuiltInOAuthProvider("x")
+}

--- a/connectors/quickbooks/manifest.go
+++ b/connectors/quickbooks/manifest.go
@@ -449,14 +449,6 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 				InstructionsURL: "https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization",
 			},
 		},
-		OAuthProviders: []connectors.ManifestOAuthProvider{
-			{
-				ID:           "quickbooks",
-				AuthorizeURL: "https://appcenter.intuit.com/connect/oauth2",
-				TokenURL:     "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
-				Scopes:       []string{"com.intuit.quickbooks.accounting"},
-			},
-		},
 		Templates: quickbooksTemplates(),
 	}
 }

--- a/connectors/quickbooks/quickbooks_test.go
+++ b/connectors/quickbooks/quickbooks_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/supersuit-tech/permission-slip-web/connectors/providers"
+
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
@@ -369,8 +371,8 @@ func TestManifest_Valid(t *testing.T) {
 	if len(m.Templates) != 8 {
 		t.Errorf("Manifest().Templates has %d entries, want 8", len(m.Templates))
 	}
-	if len(m.OAuthProviders) != 1 {
-		t.Errorf("Manifest().OAuthProviders has %d entries, want 1", len(m.OAuthProviders))
+	if len(m.OAuthProviders) != 0 {
+		t.Errorf("Manifest().OAuthProviders has %d entries, want 0 (quickbooks is now a built-in provider)", len(m.OAuthProviders))
 	}
 }
 

--- a/connectors/x/manifest.go
+++ b/connectors/x/manifest.go
@@ -366,14 +366,6 @@ func (c *XConnector) Manifest() *connectors.ConnectorManifest {
 				OAuthScopes:   []string{"tweet.read", "tweet.write", "users.read", "dm.read", "dm.write", "offline.access", "like.read", "like.write", "follows.read", "follows.write"},
 			},
 		},
-		OAuthProviders: []connectors.ManifestOAuthProvider{
-			{
-				ID:           "x",
-				AuthorizeURL: "https://x.com/i/oauth2/authorize",
-				TokenURL:     "https://api.x.com/2/oauth2/token",
-				Scopes:       []string{"tweet.read", "tweet.write", "users.read", "dm.read", "dm.write", "offline.access", "like.read", "like.write", "follows.read", "follows.write"},
-			},
-		},
 		Templates: []connectors.ManifestTemplate{
 			{
 				ID:          "tpl_x_post_tweet",

--- a/connectors/x/x_test.go
+++ b/connectors/x/x_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
+	_ "github.com/supersuit-tech/permission-slip-web/connectors/providers"
 )
 
 func TestXConnector_ID(t *testing.T) {
@@ -103,10 +104,8 @@ func TestXConnector_Manifest(t *testing.T) {
 	if len(m.Templates) != 16 {
 		t.Errorf("Manifest().Templates has %d templates, want 16", len(m.Templates))
 	}
-	if len(m.OAuthProviders) != 1 {
-		t.Errorf("Manifest().OAuthProviders has %d providers, want 1", len(m.OAuthProviders))
-	} else if m.OAuthProviders[0].ID != "x" {
-		t.Errorf("OAuthProviders[0].ID = %q, want %q", m.OAuthProviders[0].ID, "x")
+	if len(m.OAuthProviders) != 0 {
+		t.Errorf("Manifest().OAuthProviders has %d providers, want 0 (x is now a built-in provider)", len(m.OAuthProviders))
 	}
 	if len(m.RequiredCredentials) != 1 {
 		t.Errorf("Manifest().RequiredCredentials has %d credentials, want 1", len(m.RequiredCredentials))

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -33,6 +33,7 @@ import {
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
 import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
+import { useConfig } from "@/hooks/useConfig";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
@@ -212,6 +213,8 @@ function OAuthCredentialRow({
   providers: { id: string; has_credentials: boolean }[];
 }) {
   const { session } = useAuth();
+  const { config } = useConfig();
+  const byoaEnabled = config?.byoa_enabled ?? false;
   const [shopDialogState, setShopDialogState] = useState<{
     replaceId?: string;
   } | null>(null);
@@ -378,7 +381,7 @@ function OAuthCredentialRow({
           </div>
         )}
 
-        {!hasAnyConnection && provider != null && !provider.has_credentials && (
+        {byoaEnabled && !hasAnyConnection && provider != null && !provider.has_credentials && (
           <BYOASetupBanner providerId={providerId} />
         )}
       </div>

--- a/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/BYOASetupBanner.test.tsx
@@ -33,6 +33,15 @@ function setupMockGet(overrides: Record<string, unknown> = {}) {
         ],
       },
     },
+    "/v1/config": {
+      data: {
+        billing_enabled: false,
+        google_oauth_configured: false,
+        microsoft_oauth_configured: false,
+        sms_enabled: false,
+        byoa_enabled: true,
+      },
+    },
     ...overrides,
   };
   mockGet.mockImplementation((path: string, ..._args: unknown[]) => {
@@ -228,6 +237,15 @@ describe("BYOASetupBanner", () => {
       "/v1/credentials": { data: { credentials: [] } },
       "/v1/oauth/connections": { data: { connections: [] } },
       "/v1/oauth/provider-configs": { data: { configs: [] } },
+      "/v1/config": {
+        data: {
+          billing_enabled: false,
+          google_oauth_configured: false,
+          microsoft_oauth_configured: false,
+          sms_enabled: false,
+          byoa_enabled: true,
+        },
+      },
     };
     mockGet.mockImplementation((path: string, ..._args: unknown[]) => {
       if (

--- a/frontend/src/pages/settings/OAuthProviderSection.tsx
+++ b/frontend/src/pages/settings/OAuthProviderSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { KeyRound, Loader2, Settings2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { useConfig } from "@/hooks/useConfig";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
 import { useOAuthProviderConfigs } from "@/hooks/useOAuthProviderConfigs";
 import { useDeleteOAuthProviderConfig } from "@/hooks/useDeleteOAuthProviderConfig";
@@ -18,6 +19,7 @@ import { providerLabel } from "@/lib/labels";
 import { BYOAConfigDialog } from "./BYOAConfigDialog";
 
 export function OAuthProviderSection() {
+  const { config } = useConfig();
   const { providers, isLoading: providersLoading } = useOAuthProviders();
   const { configs, isLoading: configsLoading } = useOAuthProviderConfigs();
   const { deleteConfig, isLoading: isDeleting } =
@@ -44,6 +46,11 @@ export function OAuthProviderSection() {
         err instanceof Error ? err.message : "Failed to remove credentials.";
       toast.error(message);
     }
+  }
+
+  // BYOA is only available on self-hosted deployments
+  if (config?.byoa_enabled === false) {
+    return null;
   }
 
   // Don't render this section if there are no BYOA configs and no unconfigured providers

--- a/frontend/src/pages/settings/OAuthProviderSection.tsx
+++ b/frontend/src/pages/settings/OAuthProviderSection.tsx
@@ -48,8 +48,10 @@ export function OAuthProviderSection() {
     }
   }
 
-  // BYOA is only available on self-hosted deployments
-  if (config?.byoa_enabled === false) {
+  // BYOA is only available on self-hosted deployments.
+  // Also suppress rendering while config is still loading to prevent a brief
+  // flash of the BYOA section on hosted deployments.
+  if (!config || config.byoa_enabled === false) {
     return null;
   }
 

--- a/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
@@ -50,6 +50,44 @@ describe("OAuthProviderSection", () => {
     wrapper = createAuthWrapper(["/settings"]);
   });
 
+  it("renders nothing when byoa_enabled is false", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/oauth/providers") {
+        return Promise.resolve({
+          data: {
+            providers: [
+              { id: "salesforce", scopes: ["api"], source: "manifest", has_credentials: false },
+            ],
+          },
+        });
+      }
+      if (url === "/v1/config") {
+        return Promise.resolve({
+          data: {
+            billing_enabled: true,
+            byoa_enabled: false,
+            google_oauth_configured: false,
+            microsoft_oauth_configured: false,
+            sms_enabled: false,
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    const { container } = render(<OAuthProviderSection />, { wrapper });
+
+    await waitFor(() =>
+      expect(mockGet).toHaveBeenCalledWith("/v1/config", expect.anything()),
+    );
+    await waitFor(() => {
+      expect(
+        container.querySelector("[data-slot='card']"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("does not render when no BYOA configs or unconfigured providers", async () => {
     // All providers have credentials, no BYOA configs
     mockApiFetch(

--- a/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/OAuthProviderSection.test.tsx
@@ -26,6 +26,17 @@ function mockApiFetch(
     if (url === "/v1/oauth/provider-configs") {
       return Promise.resolve({ data: { configs } });
     }
+    if (url === "/v1/config") {
+      return Promise.resolve({
+        data: {
+          billing_enabled: false,
+          google_oauth_configured: false,
+          microsoft_oauth_configured: false,
+          sms_enabled: false,
+          byoa_enabled: true,
+        },
+      });
+    }
     return Promise.resolve({ data: null });
   });
 }

--- a/oauth/providers/quickbooks.go
+++ b/oauth/providers/quickbooks.go
@@ -1,0 +1,23 @@
+package providers
+
+import (
+	"os"
+
+	"github.com/supersuit-tech/permission-slip-web/oauth"
+)
+
+func init() {
+	oauth.RegisterBuiltIn(func() oauth.Provider {
+		return oauth.Provider{
+			ID:           "quickbooks",
+			AuthorizeURL: "https://appcenter.intuit.com/connect/oauth2",
+			TokenURL:     "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+			Scopes: []string{
+				"com.intuit.quickbooks.accounting",
+			},
+			ClientID:     os.Getenv("QUICKBOOKS_CLIENT_ID"),
+			ClientSecret: os.Getenv("QUICKBOOKS_CLIENT_SECRET"),
+			Source:       oauth.SourceBuiltIn,
+		}
+	})
+}

--- a/oauth/providers/x.go
+++ b/oauth/providers/x.go
@@ -1,0 +1,32 @@
+package providers
+
+import (
+	"os"
+
+	"github.com/supersuit-tech/permission-slip-web/oauth"
+)
+
+func init() {
+	oauth.RegisterBuiltIn(func() oauth.Provider {
+		return oauth.Provider{
+			ID:           "x",
+			AuthorizeURL: "https://x.com/i/oauth2/authorize",
+			TokenURL:     "https://api.x.com/2/oauth2/token",
+			Scopes: []string{
+				"tweet.read",
+				"tweet.write",
+				"users.read",
+				"dm.read",
+				"dm.write",
+				"offline.access",
+				"like.read",
+				"like.write",
+				"follows.read",
+				"follows.write",
+			},
+			ClientID:     os.Getenv("X_CLIENT_ID"),
+			ClientSecret: os.Getenv("X_CLIENT_SECRET"),
+			Source:       oauth.SourceBuiltIn,
+		}
+	})
+}

--- a/spec/openapi/components/schemas/config.yaml
+++ b/spec/openapi/components/schemas/config.yaml
@@ -8,6 +8,7 @@ ConfigResponse:
     - google_oauth_configured
     - microsoft_oauth_configured
     - sms_enabled
+    - byoa_enabled
   properties:
     billing_enabled:
       type: boolean
@@ -44,3 +45,12 @@ ConfigResponse:
         this set automatically; the hosted platform (app.permissionslip.dev)
         sets `SMS_NOTIFICATIONS_HIDDEN=true` to hide SMS from users.
       example: false
+    byoa_enabled:
+      type: boolean
+      description: |
+        Whether BYOA (Bring Your Own App) OAuth credential management is
+        available. BYOA is enabled on self-hosted deployments (where users
+        may need to supply their own OAuth client credentials) and disabled
+        on the hosted platform (app.permissionslip.dev) where all providers
+        ship with platform-level credentials.
+      example: true

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -11044,6 +11044,7 @@ components:
         - google_oauth_configured
         - microsoft_oauth_configured
         - sms_enabled
+        - byoa_enabled
       properties:
         billing_enabled:
           type: boolean
@@ -11080,6 +11081,15 @@ components:
             this set automatically; the hosted platform (app.permissionslip.dev)
             sets `SMS_NOTIFICATIONS_HIDDEN=true` to hide SMS from users.
           example: false
+        byoa_enabled:
+          type: boolean
+          description: |
+            Whether BYOA (Bring Your Own App) OAuth credential management is
+            available. BYOA is enabled on self-hosted deployments (where users
+            may need to supply their own OAuth client credentials) and disabled
+            on the hosted platform (app.permissionslip.dev) where all providers
+            ship with platform-level credentials.
+          example: true
     Action:
       type: object
       required:


### PR DESCRIPTION
## Summary

- Promotes QuickBooks and X/Twitter from manifest-declared OAuth providers to built-in providers, making them work like Google, GitHub, and other built-in connectors
- Disables BYOA (Bring Your Own App) on the hosted platform (app.permissionslip.dev) since all providers now ship with platform-level credentials
- Adds `byoa_enabled` config flag so the frontend can conditionally hide BYOA UI

## Changes

**Backend:**
- New `oauth/providers/quickbooks.go` and `oauth/providers/x.go` — built-in provider registrations with `QUICKBOOKS_CLIENT_ID`/`QUICKBOOKS_CLIENT_SECRET` and `X_CLIENT_ID`/`X_CLIENT_SECRET` env vars
- New `connectors/providers/quickbooks.go` and `connectors/providers/x.go` — registry consistency entries
- Removed `OAuthProviders` sections from QuickBooks and X connector manifests
- Gated all BYOA endpoints (`/oauth/provider-configs`) behind `BillingEnabled` — returns 404 on hosted deployments
- Added `byoa_enabled` to `/v1/config` response (true when `BillingEnabled` is false, i.e. self-hosted)

**Frontend:**
- `OAuthProviderSection` now returns null when `byoa_enabled` is false
- `BYOASetupBanner` in `ManageCredentialsDialog` only renders when `byoa_enabled` is true
- Updated test mocks to include config endpoint with `byoa_enabled`

**Spec:**
- Added `byoa_enabled` field to `ConfigResponse` schema in OpenAPI spec

## Test plan

### Claude Code
- [x] All backend tests pass (except pre-existing mysql/sqldb module cache issue)
- [x] All 958 frontend tests pass
- [x] TypeScript compiles cleanly
- [x] Go build succeeds

### Manual Testing
- [ ] Verify QuickBooks OAuth flow works with `QUICKBOOKS_CLIENT_ID`/`QUICKBOOKS_CLIENT_SECRET` env vars set
- [ ] Verify X OAuth flow works with `X_CLIENT_ID`/`X_CLIENT_SECRET` env vars set
- [ ] Verify BYOA endpoints return 404 on app.permissionslip.dev
- [ ] Verify BYOA UI is hidden on app.permissionslip.dev
- [ ] Verify BYOA still works on self-hosted deployments

Closes #353

https://claude.ai/code/session_01CpKygj9FJemzkZS6Ftr6KD