### PR TITLE
fix(cli): add --request-id for idempotent approval requests

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -249,11 +249,14 @@ export class ApiClient {
     actionId: string,
     params: unknown,
     context?: { description?: string; risk_level?: string },
-    payment?: { requestId?: string; paymentMethodId?: string; amountCents?: number },
+    payment?: { paymentMethodId?: string; amountCents?: number },
+    requestId?: string,
   ) {
-    const requestId = payment?.requestId ?? crypto.randomUUID();
+    const resolvedRequestId = (requestId && requestId.trim().length > 0)
+      ? requestId
+      : crypto.randomUUID();
     const body: Record<string, unknown> = {
-      request_id: requestId,
+      request_id: resolvedRequestId,
       action: { type: actionId, parameters: params },
       context: context ?? {},
     };

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -249,9 +249,9 @@ export class ApiClient {
     actionId: string,
     params: unknown,
     context?: { description?: string; risk_level?: string },
-    payment?: { paymentMethodId?: string; amountCents?: number },
+    payment?: { requestId?: string; paymentMethodId?: string; amountCents?: number },
   ) {
-    const requestId = crypto.randomUUID();
+    const requestId = payment?.requestId ?? crypto.randomUUID();
     const body: Record<string, unknown> = {
       request_id: requestId,
       action: { type: actionId, parameters: params },

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -70,8 +70,9 @@ export function requestCommand(program: Command): void {
         });
 
         if (result.status === "approved") {
-          // Auto-approved via standing approval — result is inline.
-          output(result, outputOpts);
+          // Auto-approved via standing approval — action already executed, result is inline.
+          // Include executed flag so external tools know no further action is needed.
+          output({ ...result, executed: true }, outputOpts);
         } else {
           // Pending — tell the user how to check the result.
           output(

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -27,6 +27,7 @@ export function requestCommand(program: Command): void {
       "https://app.permissionslip.dev",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
+    .option("--request-id <id>", "Idempotency key — reuse across retries to prevent duplicate execution")
     .option("--payment-method-id <id>", "Payment method ID for payment-required actions")
     .option("--amount-cents <cents>", "Transaction amount in cents (required with --payment-method-id)", parseInt)
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
@@ -37,6 +38,7 @@ export function requestCommand(program: Command): void {
       riskLevel?: string;
       server: string;
       agentId?: string;
+      requestId?: string;
       paymentMethodId?: string;
       amountCents?: number;
       pretty?: boolean;
@@ -62,6 +64,7 @@ export function requestCommand(program: Command): void {
             : undefined;
 
         const result = await client.requestApproval(opts.action, params, context, {
+          requestId: opts.requestId,
           paymentMethodId: opts.paymentMethodId,
           amountCents: opts.amountCents,
         });

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Command } from "commander";
-import { ApiClient } from "../api/client.js";
+import { ApiClient, PermissionSlipApiError } from "../api/client.js";
 import { resolveAgentId } from "./status.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
@@ -63,11 +63,13 @@ export function requestCommand(program: Command): void {
               }
             : undefined;
 
-        const result = await client.requestApproval(opts.action, params, context, {
-          requestId: opts.requestId,
-          paymentMethodId: opts.paymentMethodId,
-          amountCents: opts.amountCents,
-        });
+        const result = await client.requestApproval(
+          opts.action,
+          params,
+          context,
+          { paymentMethodId: opts.paymentMethodId, amountCents: opts.amountCents },
+          opts.requestId,
+        );
 
         if (result.status === "approved") {
           // Auto-approved via standing approval — action already executed, result is inline.
@@ -87,6 +89,17 @@ export function requestCommand(program: Command): void {
           );
         }
       } catch (err) {
+        // Treat 409 duplicate_request_id as an idempotency success — the action
+        // was already executed on a prior call with this request_id. Exit 0 so
+        // external tools (AI agents, MCP wrappers) don't retry.
+        if (
+          err instanceof PermissionSlipApiError &&
+          err.statusCode === 409 &&
+          err.apiError.code === "duplicate_request_id"
+        ) {
+          output({ status: "duplicate", executed: true, request_id: opts.requestId }, outputOpts);
+          return;
+        }
         output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
         process.exit(1);
       }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -513,6 +513,7 @@ When a standing approval matches, the response returns `status: "approved"` with
 - **`standing_approval_id`** — identifies which pre-approval authorized this execution (useful for audit tracking and logging).
 - **`executions_remaining`** — how many more times this standing approval can be used. `null` means unlimited. Track this value to avoid hitting the limit unexpectedly.
 - **Idempotency** — if you receive `status: "approved"`, the action has already executed. Do not retry with the same `request_id` — you'll get `409 Conflict`.
+- **CLI `executed` field** — when using the CLI (`permission-slip request`), auto-approved responses include `"executed": true` to signal that the action has already completed and no polling or further action is needed. A `409 duplicate_request_id` is also returned as `{ "status": "duplicate", "executed": true }` with exit code `0`.
 
 If no standing approval matches, the response returns `status: "pending"` and the standard one-off approval flow begins (user receives a notification for review).
 
@@ -565,7 +566,9 @@ During registration (`POST /invite/{code}`), you don't have an agent ID yet. Use
 
 All POST requests must include a non-empty `request_id` (for example, a UUID v4) in the JSON body.
 
-The current implementation validates only that `request_id` is present and non-empty; it does not yet enforce uniqueness, idempotency, or replay protection based on this field.
+The server enforces `request_id` uniqueness within the standing approval execution flow — resubmitting the same `request_id` returns `409 duplicate_request_id` instead of executing the action again. This makes `request_id` an **idempotency key**: callers can safely retry with the same ID and the action will only execute once.
+
+For one-off approvals (the pending → human-approve flow), `request_id` uniqueness is also enforced — duplicate submission returns `409 Conflict`.
 
 ---
 
@@ -622,7 +625,7 @@ All errors follow a consistent format:
 | `token_already_used` | 403 | Token consumed — request new approval |
 | `insufficient_scope` | 403 | Token scope doesn't match action — check `action_id` |
 | `credentials_not_found` | 404 | User hasn't set up credentials for this service |
-| `duplicate_request_id` | 409 | `request_id` already used — generate a new UUID (not yet enforced; reserved for future use) |
+| `duplicate_request_id` | 409 | `request_id` already used — the action was already executed. Treat as an idempotency success (do not retry). |
 | `no_matching_standing_approval` | 404 | No standing approval matches — use one-off flow |
 | `constraint_violation` | 403 | Parameters violate standing approval constraints |
 | `upstream_error` | 502 | External service returned an error |


### PR DESCRIPTION
## Summary
- Adds `--request-id <id>` flag to the CLI `request` command as an idempotency key for deduplication across retries
- Adds `"executed": true` to auto-approved (standing approval) responses so external tools can clearly distinguish "action already completed" from "pending approval needed"
- When `--request-id` is omitted, the previous behavior (auto-generated UUID per invocation) is preserved

## Root Cause Analysis

After tracing every code path, a single `POST /approvals/request` can only execute the connector action **once** — there are no retries, loops, or parallel executions anywhere in the chain. The 4 emails came from 4 separate HTTP requests.

The likely scenario:
1. An external tool (AI agent wrapper, MCP server) called the CLI
2. The standing approval auto-approved → email sent, response returned with `status: "approved"` but no `approval_url` (correctly omitted — there's no approval page for auto-approved requests)
3. The external tool saw `approval_url: undefined` in the JSON, interpreted it as a failure, and displayed "Waiting for approval... (approve at undefined)"
4. The tool retried 3 more times → 3 more emails (total: 4)

The **404 on standing approval** is because there is no agent-facing endpoint to access or execute a specific standing approval directly. The only way to use a standing approval is implicitly through `POST /approvals/request` — the server matches them automatically. The dashboard endpoint (`POST /standing-approvals/{id}/execute`) requires session auth, not agent signature auth.

## Changes

1. **`--request-id` flag** (`cli/src/commands/request.ts`, `cli/src/api/client.ts`): Callers can provide a stable idempotency key. The backend already rejects duplicate `request_id`s with 409 Conflict — the CLI just wasn't exposing this.

2. **`executed: true` in auto-approved responses** (`cli/src/commands/request.ts`): Makes it unambiguous that the action was already completed and no polling/approval is needed. External tools can check this field to avoid retrying.

## Test plan

### Claude Code
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] CLI unit tests pass (`npm test` — 29/29)

### Manual Testing
- [ ] Run `permission-slip request --action google.send_email --request-id test-123 --params '...'` twice — second call should return 409
- [ ] Run without `--request-id` to verify auto-generated UUID behavior is unchanged
- [ ] Verify auto-approved response includes `"executed": true` in JSON output
- [ ] Verify pending response still includes `approval_url` and `next_step`

Closes #724

https://claude.ai/code/session_019kj5Mqiq6oeGHJToKVcs7F