### PR TITLE
feat: add free pro coupon redemption system

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -142,6 +142,7 @@ type billingSubscription struct {
 	CanUpgrade         bool       `json:"can_upgrade"`
 	CanDowngrade       bool       `json:"can_downgrade"`
 	GracePeriodEndsAt  *time.Time `json:"grace_period_ends_at"`
+	IsFreePro          bool       `json:"is_free_pro"`
 }
 
 type billingUsageSummary struct {
@@ -158,9 +159,10 @@ func newBillingSubscription(sub *db.SubscriptionWithPlan) billingSubscription {
 		CurrentPeriodStart: sub.CurrentPeriodStart,
 		CurrentPeriodEnd:   sub.CurrentPeriodEnd,
 		HasPaymentMethod:   false,
-		CanUpgrade:         sub.PlanID == db.PlanFree,
-		CanDowngrade:       sub.PlanID == db.PlanPayAsYouGo,
+		CanUpgrade:         sub.PlanID == db.PlanFree && !sub.IsFreePro,
+		CanDowngrade:       sub.PlanID == db.PlanPayAsYouGo && !sub.IsFreePro,
 		GracePeriodEndsAt:  sub.GracePeriodEndsAt(),
+		IsFreePro:          sub.IsFreePro,
 	}
 }
 
@@ -235,10 +237,15 @@ func handleGetBillingPlan(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		planName := sub.Plan.Name
+		if sub.IsFreePro {
+			planName = "Free Pro"
+		}
+
 		resp := billingPlanResponse{
 			Plan: billingPlan{
 				ID:         sub.PlanID,
-				Name:       sub.Plan.Name,
+				Name:       planName,
 				planLimits: newPlanLimits(&sub.Plan),
 			},
 			Subscription: newBillingSubscription(sub),
@@ -377,9 +384,13 @@ func handleCreateCheckout(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// If already on paid plan, reject.
+		// If already on paid plan or free pro, reject.
 		if sub != nil && sub.PlanID == db.PlanPayAsYouGo {
 			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadySubscribed, "Already subscribed to a paid plan"))
+			return
+		}
+		if sub != nil && sub.IsFreePro {
+			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadySubscribed, "Already on a free pro plan"))
 			return
 		}
 
@@ -544,6 +555,12 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 		// Can only downgrade from a paid plan.
 		if sub.PlanID == db.PlanFree {
 			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadyDowngraded, "Already on the free plan"))
+			return
+		}
+
+		// Free pro users cannot downgrade — their plan is managed via coupon.
+		if sub.IsFreePro {
+			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadySubscribed, "Free pro accounts cannot be downgraded"))
 			return
 		}
 
@@ -760,6 +777,11 @@ func ReportPeriodUsage(ctx context.Context, deps *Deps, userID string, usage *db
 		return
 	}
 	if sub == nil || sub.StripeCustomerID == nil {
+		return
+	}
+
+	// Free pro users are not billed.
+	if sub.IsFreePro {
 		return
 	}
 

--- a/api/billing_coupon.go
+++ b/api/billing_coupon.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// ── POST /billing/redeem-coupon ────────────────────────────────────────────
+
+type redeemCouponRequest struct {
+	CouponCode string `json:"coupon_code"`
+}
+
+type redeemCouponResponse struct {
+	Status string `json:"status"`
+	PlanID string `json:"plan_id"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterCouponRoutes)
+}
+
+func RegisterCouponRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("POST /billing/redeem-coupon", requireProfile(handleRedeemCoupon(deps)))
+}
+
+func handleRedeemCoupon(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		var req redeemCouponRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Invalid request body"))
+			return
+		}
+
+		if strings.TrimSpace(req.CouponCode) == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Coupon code is required"))
+			return
+		}
+
+		// Check if user already has free pro.
+		sub, err := db.GetSubscriptionByUserID(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] RedeemCoupon: subscription lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to fetch subscription"))
+			return
+		}
+		if sub == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrSubscriptionNotFound, "No subscription found"))
+			return
+		}
+		if sub.IsFreePro {
+			// Already a free pro user — idempotent success.
+			RespondJSON(w, http.StatusOK, redeemCouponResponse{
+				Status: "already_redeemed",
+				PlanID: sub.PlanID,
+			})
+			return
+		}
+
+		// Validate the coupon code: MD5(username + "-" + COUPON_SECRET)
+		couponSecret := os.Getenv("COUPON_SECRET")
+		if couponSecret == "" {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Coupon redemption is not available"))
+			return
+		}
+
+		expected := md5Hash(profile.Username + "-" + couponSecret)
+		if !strings.EqualFold(strings.TrimSpace(req.CouponCode), expected) {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidCode, "Invalid coupon code"))
+			return
+		}
+
+		// Grant free pro.
+		updated, err := db.GrantFreePro(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] RedeemCoupon: grant free pro: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to activate free pro"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, redeemCouponResponse{
+			Status: "redeemed",
+			PlanID: updated.PlanID,
+		})
+	}
+}
+
+func md5Hash(s string) string {
+	h := md5.Sum([]byte(s))
+	return hex.EncodeToString(h[:])
+}

--- a/db/migrations/20260321133215_add_free_pro_to_subscriptions.sql
+++ b/db/migrations/20260321133215_add_free_pro_to_subscriptions.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE subscriptions ADD COLUMN is_free_pro boolean NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE subscriptions DROP COLUMN is_free_pro;

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -44,11 +44,12 @@ type Subscription struct {
 	CurrentPeriodStart   time.Time
 	CurrentPeriodEnd     time.Time
 	DowngradedAt         *time.Time // set when plan changes from paid to free; nil otherwise
+	IsFreePro            bool       // true when user redeemed a free pro coupon; grants pay_as_you_go limits with no billing
 	CreatedAt            time.Time
 	UpdatedAt            time.Time
 }
 
-const subscriptionColumns = `id, user_id, plan_id, status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end, downgraded_at, created_at, updated_at`
+const subscriptionColumns = `id, user_id, plan_id, status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end, downgraded_at, is_free_pro, created_at, updated_at`
 
 func scanSubscription(row pgx.Row) (*Subscription, error) {
 	var s Subscription
@@ -62,6 +63,7 @@ func scanSubscription(row pgx.Row) (*Subscription, error) {
 		&s.CurrentPeriodStart,
 		&s.CurrentPeriodEnd,
 		&s.DowngradedAt,
+		&s.IsFreePro,
 		&s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -224,6 +226,21 @@ func EnsureAllUsersSubscribed(ctx context.Context, db DBTX, billingEnabled bool)
 	}
 
 	return total, nil
+}
+
+// GrantFreePro upgrades a user to the pay_as_you_go plan with is_free_pro=true.
+// This gives them unlimited usage with no billing. Idempotent — returns the
+// existing subscription if already a free pro user.
+func GrantFreePro(ctx context.Context, db DBTX, userID string) (*Subscription, error) {
+	return scanSubscription(db.QueryRow(ctx,
+		`UPDATE subscriptions
+		 SET plan_id = $2,
+		     is_free_pro = true,
+		     downgraded_at = NULL,
+		     updated_at = now()
+		 WHERE user_id = $1
+		 RETURNING `+subscriptionColumns,
+		userID, PlanPayAsYouGo))
 }
 
 // GetSubscriptionByStripeCustomerID returns the subscription with the given

--- a/frontend/src/hooks/useRedeemCoupon.ts
+++ b/frontend/src/hooks/useRedeemCoupon.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+
+export function useRedeemCoupon() {
+  const { session } = useAuth();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function redeemCoupon(couponCode: string): Promise<boolean> {
+    const token = session?.access_token;
+    if (!token) {
+      setError("Not authenticated");
+      return false;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const { data, error: apiError } = await client.POST(
+        "/v1/billing/redeem-coupon",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          body: { coupon_code: couponCode },
+        },
+      );
+
+      if (apiError) {
+        const message =
+          (apiError as { error?: { message?: string } })?.error?.message ??
+          "Failed to redeem coupon";
+        setError(message);
+        return false;
+      }
+
+      return data?.status === "redeemed" || data?.status === "already_redeemed";
+    } catch {
+      setError("Failed to redeem coupon. Please try again.");
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return { redeemCoupon, isLoading, error };
+}

--- a/frontend/src/pages/billing/CouponRedemptionCard.tsx
+++ b/frontend/src/pages/billing/CouponRedemptionCard.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Ticket } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { FormError } from "@/components/FormError";
+import { useRedeemCoupon } from "@/hooks/useRedeemCoupon";
+
+interface CouponRedemptionCardProps {
+  onRedeemed: () => void;
+}
+
+export function CouponRedemptionCard({ onRedeemed }: CouponRedemptionCardProps) {
+  const [couponCode, setCouponCode] = useState("");
+  const { redeemCoupon, isLoading, error } = useRedeemCoupon();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const success = await redeemCoupon(couponCode.trim());
+    if (success) {
+      onRedeemed();
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Ticket className="text-muted-foreground size-5" />
+          <CardTitle>Redeem Coupon</CardTitle>
+        </div>
+        <CardDescription>
+          Have a coupon code? Enter it below to activate your free pro account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <Input
+            type="text"
+            placeholder="Enter coupon code"
+            value={couponCode}
+            onChange={(e) => setCouponCode(e.target.value)}
+            disabled={isLoading}
+          />
+          {error && <FormError error={error} />}
+          <Button
+            type="submit"
+            disabled={isLoading || couponCode.trim().length === 0}
+            size="sm"
+          >
+            {isLoading ? "Redeeming..." : "Redeem Coupon"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -29,6 +29,7 @@ function StatusBadge({ status }: { status: Subscription["status"] }) {
 
 export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
   const isFree = plan.id === "free";
+  const isFreePro = subscription.is_free_pro === true;
 
   return (
     <Card>
@@ -48,11 +49,11 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
               <div className="flex items-center gap-2">
                 <span>{plan.name}</span>
                 <Badge variant={isFree ? "outline" : "default"}>
-                  {isFree ? "Free" : "Pay-as-you-go"}
+                  {isFreePro ? "Free Pro" : isFree ? "Free" : "Pay-as-you-go"}
                 </Badge>
               </div>
             </DetailRow>
-            {!isFree && pricing && (
+            {!isFree && !isFreePro && pricing && (
               <DetailRow label="Pricing">
                 <span className="text-muted-foreground">{pricing.free_request_allowance.toLocaleString()} requests/month included, then {pricing.price_per_request_display}/request</span>
               </DetailRow>

--- a/frontend/src/pages/policy/TermsOfServicePage.tsx
+++ b/frontend/src/pages/policy/TermsOfServicePage.tsx
@@ -130,7 +130,40 @@ export function TermsOfServicePage() {
         <li>Pass-through carrier costs with no markup</li>
       </ul>
 
-      <h3>5.5 Payment Terms</h3>
+      <h3>5.5 Free Pro Accounts</h3>
+      <p>
+        We may, at our sole discretion, grant certain users a &quot;Free
+        Pro&quot; account via a promotional coupon code. Free Pro accounts
+        receive the same resource limits and features as the Pay-as-You-Go tier
+        at no charge.
+      </p>
+      <ul>
+        <li>
+          Free Pro accounts are granted on a per-user basis and are
+          non-transferable
+        </li>
+        <li>
+          <strong>
+            We reserve the right to revoke, limit, or modify Free Pro accounts
+            at any time, for any reason, with or without notice
+          </strong>
+        </li>
+        <li>
+          Abuse of Free Pro access (e.g., excessive automated usage,
+          circumventing intended limits, or sharing coupon codes) may result in
+          immediate revocation
+        </li>
+        <li>
+          Free Pro accounts do not include any service level agreement (SLA),
+          priority support, or guaranteed availability
+        </li>
+        <li>
+          If a Free Pro account is revoked, the user will be downgraded to the
+          Free tier
+        </li>
+      </ul>
+
+      <h3>5.6 Payment Terms</h3>
       <ul>
         <li>Payments are processed via Stripe</li>
         <li>Usage is invoiced monthly based on actual consumption</li>

--- a/frontend/src/pages/settings/BillingSettingsPage.tsx
+++ b/frontend/src/pages/settings/BillingSettingsPage.tsx
@@ -13,6 +13,7 @@ import { BillingPageSkeleton } from "../billing/BillingPageSkeleton";
 import { UpgradeSuccessBanner } from "../billing/UpgradeSuccessBanner";
 import { activateUpgrade } from "../billing/activateUpgrade";
 import { DataRetentionSection } from "./DataRetentionSection";
+import { CouponRedemptionCard } from "../billing/CouponRedemptionCard";
 
 const RETRY_DELAYS = [1000, 2000, 3000];
 const ACTIVATION_KEY = "ps-billing-activation-done";
@@ -106,7 +107,10 @@ export function BillingSettingsPage() {
             pricing={billingPlan.pricing}
           />
           {billingPlan.subscription.can_upgrade && (
-            <UpgradeCTA plan={billingPlan.plan} pricing={billingPlan.pricing} />
+            <>
+              <UpgradeCTA plan={billingPlan.plan} pricing={billingPlan.pricing} />
+              <CouponRedemptionCard onRedeemed={() => refetch()} />
+            </>
           )}
           {billingPlan.subscription.can_downgrade && (
             <PlanDetailsCard

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/components/paths/billing.yaml
+++ b/spec/openapi/components/paths/billing.yaml
@@ -510,6 +510,48 @@ invoices:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+redeem-coupon:
+  post:
+    summary: Redeem a free pro coupon
+    description: |
+      Validates a coupon code and grants the user a free pro account with
+      unlimited usage and no billing. The coupon code is an MD5 hash of
+      `{username}-{COUPON_SECRET}`. Once redeemed, the free pro status is
+      permanent (though it may be revoked per the Terms of Service).
+
+      Idempotent — if the user already has free pro, returns `already_redeemed`.
+    operationId: redeemCoupon
+    tags:
+      - Billing
+    security:
+      - SupabaseSession: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/billing.yaml#/RedeemCouponRequest'
+    responses:
+      '200':
+        description: Coupon redeemed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/billing.yaml#/RedeemCouponResponse'
+            example:
+              status: redeemed
+              plan_id: pay_as_you_go
+      '400':
+        description: Invalid or missing coupon code
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
 portal:
   post:
     summary: Create billing portal session

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -317,6 +317,39 @@ Subscription:
         During the grace period (7 days after downgrade), the user retains the longer
         audit retention window (90 days) to export their data. After this timestamp,
         retention drops to the free plan's window (7 days).
+    is_free_pro:
+      type: boolean
+      description: Whether the user has a free pro account (granted via coupon). Free pro users get unlimited usage with no billing.
+      example: false
+
+RedeemCouponRequest:
+  type: object
+  required:
+    - coupon_code
+  properties:
+    coupon_code:
+      type: string
+      description: The coupon code to redeem for a free pro account
+      example: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+
+RedeemCouponResponse:
+  type: object
+  required:
+    - status
+    - plan_id
+  properties:
+    status:
+      type: string
+      enum: [redeemed, already_redeemed]
+      description: |
+        Redemption result:
+        - `redeemed`: Coupon was accepted and free pro was activated.
+        - `already_redeemed`: User already has a free pro account.
+      example: redeemed
+    plan_id:
+      type: string
+      description: The user's plan after redemption
+      example: pay_as_you_go
 
 UsageSummary:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -5381,6 +5381,47 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/redeem-coupon:
+    post:
+      summary: Redeem a free pro coupon
+      description: |
+        Validates a coupon code and grants the user a free pro account with
+        unlimited usage and no billing. The coupon code is an MD5 hash of
+        `{username}-{COUPON_SECRET}`. Once redeemed, the free pro status is
+        permanent (though it may be revoked per the Terms of Service).
+
+        Idempotent — if the user already has free pro, returns `already_redeemed`.
+      operationId: redeemCoupon
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedeemCouponRequest'
+      responses:
+        '200':
+          description: Coupon redeemed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedeemCouponResponse'
+              example:
+                status: redeemed
+                plan_id: pay_as_you_go
+        '400':
+          description: Invalid or missing coupon code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/admin/usage:
     get:
       summary: Get your usage for a billing period
@@ -10159,6 +10200,10 @@ components:
             During the grace period (7 days after downgrade), the user retains the longer
             audit retention window (90 days) to export their data. After this timestamp,
             retention drops to the free plan's window (7 days).
+        is_free_pro:
+          type: boolean
+          description: Whether the user has a free pro account (granted via coupon). Free pro users get unlimited usage with no billing.
+          example: false
     UsageSummary:
       type: object
       required:
@@ -11638,6 +11683,35 @@ components:
           pattern: ^https://
           description: Stripe Billing Portal URL — redirect the user here to manage their subscription. Always HTTPS.
           example: https://billing.stripe.com/p/session/test_...
+    RedeemCouponRequest:
+      type: object
+      required:
+        - coupon_code
+      properties:
+        coupon_code:
+          type: string
+          description: The coupon code to redeem for a free pro account
+          example: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+    RedeemCouponResponse:
+      type: object
+      required:
+        - status
+        - plan_id
+      properties:
+        status:
+          type: string
+          enum:
+            - redeemed
+            - already_redeemed
+          description: |
+            Redemption result:
+            - `redeemed`: Coupon was accepted and free pro was activated.
+            - `already_redeemed`: User already has a free pro account.
+          example: redeemed
+        plan_id:
+          type: string
+          description: The user's plan after redemption
+          example: pay_as_you_go
   parameters:
     ActionConfigId:
       name: config_id

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -281,6 +281,9 @@ paths:
   /v1/billing/portal:
     $ref: './components/paths/billing.yaml#/portal'
 
+  /v1/billing/redeem-coupon:
+    $ref: './components/paths/billing.yaml#/redeem-coupon'
+
   /v1/admin/usage:
     $ref: './components/paths/admin_usage.yaml#/adminUsage'
 


### PR DESCRIPTION
## Summary
- Add coupon-based free pro account system: users enter an MD5 hash of `{username}-{COUPON_SECRET}` to unlock unlimited usage with no billing
- Free pro users get `pay_as_you_go` plan limits (unlimited everything) but are excluded from Stripe billing, upgrade/downgrade flows
- Add Section 5.5 to Terms of Service establishing that free pro accounts can be revoked or limited at any time

## Changes

### Backend
- **Migration**: Add `is_free_pro` boolean column to `subscriptions` table
- **API**: New `POST /billing/redeem-coupon` endpoint validates coupon against `COUPON_SECRET` env var
- **Billing guards**: Block free pro users from checkout, downgrade, and Stripe usage reporting

### Frontend
- **CouponRedemptionCard**: Shown on billing page for free plan users to enter coupon codes
- **PlanCard**: Shows "Free Pro" badge, hides pricing for free pro users
- **useRedeemCoupon hook**: Handles coupon redemption API call

### OpenAPI
- Add `is_free_pro` to Subscription schema
- Add `RedeemCouponRequest`/`RedeemCouponResponse` schemas
- Add `/v1/billing/redeem-coupon` path

### Legal
- Terms of Service Section 5.5: Free Pro accounts are non-transferable, can be revoked at any time, no SLA

## Configuration
Set `COUPON_SECRET` environment variable. Generate a coupon for any user with:
```
echo -n "{username}-{COUPON_SECRET}" | md5sum
```

## Test plan

### Claude Code
- [ ] Verify backend tests pass (config, shared packages)
- [ ] Verify frontend tests pass (all 959 tests passing)
- [ ] Verify TypeScript compilation succeeds

### Manual Testing
- [ ] Set `COUPON_SECRET` env var and test coupon redemption with valid code
- [ ] Verify invalid coupon codes are rejected
- [ ] Verify free pro users see "Free Pro" badge on billing page
- [ ] Verify free pro users cannot upgrade or downgrade
- [ ] Verify free pro users are not billed via Stripe
- [ ] Verify coupon card only appears for free plan users
- [ ] Run migration against dev database

https://claude.ai/code/session_013wdArxQmzeG6Tvg6XYxNTC