### PR TITLE
Preserve paid plan quotas until billing period ends after downgrade

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -119,6 +120,7 @@ type billingPlanResponse struct {
 	Plan                    billingPlan         `json:"plan"`
 	Subscription            billingSubscription `json:"subscription"`
 	Usage                   billingUsageSummary `json:"usage"`
+	EffectiveLimits         *planLimits         `json:"effective_limits,omitempty"`
 	Pricing                 *billingPricing     `json:"pricing,omitempty"`
 	CouponRedemptionEnabled bool                `json:"coupon_redemption_enabled"`
 }
@@ -136,13 +138,14 @@ type billingPlan struct {
 }
 
 type billingSubscription struct {
-	Status             string     `json:"status"`
-	CurrentPeriodStart time.Time  `json:"current_period_start"`
-	CurrentPeriodEnd   time.Time  `json:"current_period_end"`
-	HasPaymentMethod   bool       `json:"has_payment_method"`
-	CanUpgrade         bool       `json:"can_upgrade"`
-	CanDowngrade       bool       `json:"can_downgrade"`
-	GracePeriodEndsAt  *time.Time `json:"grace_period_ends_at"`
+	Status                 string     `json:"status"`
+	CurrentPeriodStart     time.Time  `json:"current_period_start"`
+	CurrentPeriodEnd       time.Time  `json:"current_period_end"`
+	HasPaymentMethod       bool       `json:"has_payment_method"`
+	CanUpgrade             bool       `json:"can_upgrade"`
+	CanDowngrade           bool       `json:"can_downgrade"`
+	GracePeriodEndsAt      *time.Time `json:"grace_period_ends_at"`
+	QuotaEntitlementsUntil *time.Time `json:"quota_entitlements_until"`
 }
 
 type billingUsageSummary struct {
@@ -155,13 +158,14 @@ type billingUsageSummary struct {
 // newBillingSubscription builds subscription status fields from a DB subscription.
 func newBillingSubscription(sub *db.SubscriptionWithPlan) billingSubscription {
 	return billingSubscription{
-		Status:             string(sub.Status),
-		CurrentPeriodStart: sub.CurrentPeriodStart,
-		CurrentPeriodEnd:   sub.CurrentPeriodEnd,
-		HasPaymentMethod:   false,
-		CanUpgrade:         sub.PlanID == db.PlanFree || sub.PlanID == db.PlanFreePro,
-		CanDowngrade:       sub.PlanID == db.PlanPayAsYouGo,
-		GracePeriodEndsAt:  sub.GracePeriodEndsAt(),
+		Status:                 string(sub.Status),
+		CurrentPeriodStart:     sub.CurrentPeriodStart,
+		CurrentPeriodEnd:       sub.CurrentPeriodEnd,
+		HasPaymentMethod:       false,
+		CanUpgrade:             sub.PlanID == db.PlanFree || sub.PlanID == db.PlanFreePro,
+		CanDowngrade:           sub.PlanID == db.PlanPayAsYouGo,
+		GracePeriodEndsAt:      sub.GracePeriodEndsAt(),
+		QuotaEntitlementsUntil: sub.QuotaGracePeriodEndsAt(),
 	}
 }
 
@@ -177,10 +181,19 @@ func newPlanLimits(p *db.Plan) planLimits {
 }
 
 type downgradeResponse struct {
-	Status            string     `json:"status"`
-	PlanID            string     `json:"plan_id"`
-	DowngradedAt      *time.Time `json:"downgraded_at"`
-	GracePeriodEndsAt *time.Time `json:"grace_period_ends_at"`
+	Status                 string              `json:"status"`
+	PlanID                 string              `json:"plan_id"`
+	DowngradedAt           *time.Time          `json:"downgraded_at"`
+	GracePeriodEndsAt      *time.Time          `json:"grace_period_ends_at"`
+	QuotaEntitlementsUntil *time.Time          `json:"quota_entitlements_until"`
+	Warnings               []downgradeWarning  `json:"warnings,omitempty"`
+}
+
+type downgradeWarning struct {
+	Resource   string `json:"resource"`
+	Current    int    `json:"current"`
+	MaxAllowed int    `json:"max_allowed"`
+	Message    string `json:"message"`
 }
 
 // gracePeriodEnd returns the time when the 7-day grace period expires for a
@@ -244,6 +257,14 @@ func handleGetBillingPlan(deps *Deps) http.HandlerFunc {
 				planLimits: newPlanLimits(&sub.Plan),
 			},
 			Subscription: newBillingSubscription(sub),
+		}
+
+		// When in a quota grace period, include the effective (paid) limits
+		// so the frontend can show users the limits actually in effect.
+		effectivePlan := sub.EffectiveQuotaPlan()
+		if effectivePlan.ID != sub.Plan.ID {
+			el := newPlanLimits(effectivePlan)
+			resp.EffectiveLimits = &el
 		}
 
 		// Include pricing info for all plans so the upgrade flow can show
@@ -349,12 +370,13 @@ func handleGetSubscription(deps *Deps) http.HandlerFunc {
 			CaptureError(r.Context(), err)
 		}
 		if usage != nil {
+			effectiveQuotaPlan := sub.EffectiveQuotaPlan()
 			ui := &usageInfo{
 				RequestCount: usage.RequestCount,
 				SMSCount:     usage.SMSCount,
-				RequestLimit: sub.Plan.MaxRequestsPerMonth,
+				RequestLimit: effectiveQuotaPlan.MaxRequestsPerMonth,
 			}
-			if sub.Plan.MaxRequestsPerMonth != nil && usage.RequestCount > *sub.Plan.MaxRequestsPerMonth {
+			if effectiveQuotaPlan.MaxRequestsPerMonth != nil && usage.RequestCount > *effectiveQuotaPlan.MaxRequestsPerMonth {
 				ui.OverLimit = true
 			}
 			resp.Usage = ui
@@ -561,21 +583,12 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Check plan limits: count agents, standing approvals, credentials.
+		// Collect warnings about resources over free plan limits.
+		// These are informational — the user can always downgrade.
 		freePlan := db.GetPlan(db.PlanFree)
-		if freePlan == nil {
-			log.Printf("[%s] Downgrade: free plan not found in config", TraceID(r.Context()))
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Free plan not configured"))
-			return
-		}
-
-		if limitErr := validateDowngradeLimits(r.Context(), deps, profile.ID, freePlan); limitErr != nil {
-			status := http.StatusConflict
-			if limitErr.Error.Code == ErrInternalError {
-				status = http.StatusInternalServerError
-			}
-			RespondError(w, r, status, *limitErr)
-			return
+		var warnings []downgradeWarning
+		if freePlan != nil {
+			warnings = collectDowngradeWarnings(r.Context(), deps, profile.ID, freePlan, sub.CurrentPeriodEnd)
 		}
 
 		// Cancel Stripe subscription if one exists.
@@ -602,76 +615,55 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusOK, downgradeResponse{
-			Status:            string(updated.Status),
-			PlanID:            updated.PlanID,
-			DowngradedAt:      updated.DowngradedAt,
-			GracePeriodEndsAt: gracePeriodEnd(updated.DowngradedAt),
+			Status:                 string(updated.Status),
+			PlanID:                 updated.PlanID,
+			DowngradedAt:           updated.DowngradedAt,
+			GracePeriodEndsAt:      gracePeriodEnd(updated.DowngradedAt),
+			QuotaEntitlementsUntil: updated.QuotaEntitlementsUntil,
+			Warnings:               warnings,
 		})
 	}
 }
 
-// validateDowngradeLimits checks that the user's current resource counts are
-// within the free plan's limits. Returns an ErrorResponse if any limit is
-// exceeded or if a count cannot be verified (fail-closed), nil otherwise.
-func validateDowngradeLimits(ctx context.Context, deps *Deps, userID string, freePlan *db.Plan) *ErrorResponse {
-	if freePlan.MaxAgents != nil {
-		count, err := db.CountRegisteredAgentsByUser(ctx, deps.DB, userID)
-		if err != nil {
-			log.Printf("[%s] Downgrade: count agents: %v", TraceID(ctx), err)
-			CaptureError(ctx, err)
-			resp := InternalError("Unable to verify agent count")
-			return &resp
-		}
-		if count > *freePlan.MaxAgents {
-			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active agents for the free plan")
-			resp.Error.Details = map[string]any{
-				"resource":    "agents",
-				"current":     count,
-				"max_allowed": *freePlan.MaxAgents,
-			}
-			return &resp
-		}
+// collectDowngradeWarnings checks resource counts against free plan limits and
+// returns informational warnings for any that exceed the limit. These are
+// advisory — the user can always proceed with the downgrade. Free plan limits
+// will be enforced after quota_entitlements_until (the end of the paid billing period).
+func collectDowngradeWarnings(ctx context.Context, deps *Deps, userID string, freePlan *db.Plan, periodEnd time.Time) []downgradeWarning {
+	var warnings []downgradeWarning
+	periodEndStr := periodEnd.Format("Jan 2, 2006")
+
+	type check struct {
+		name    string
+		limit   *int
+		countFn func(context.Context, db.DBTX, string) (int, error)
+	}
+	checks := []check{
+		{"agents", freePlan.MaxAgents, db.CountRegisteredAgentsByUser},
+		{"standing_approvals", freePlan.MaxStandingApprovals, db.CountActiveStandingApprovalsByUser},
+		{"credentials", freePlan.MaxCredentials, db.CountCredentialsByUser},
 	}
 
-	if freePlan.MaxStandingApprovals != nil {
-		count, err := db.CountActiveStandingApprovalsByUser(ctx, deps.DB, userID)
-		if err != nil {
-			log.Printf("[%s] Downgrade: count standing approvals: %v", TraceID(ctx), err)
-			CaptureError(ctx, err)
-			resp := InternalError("Unable to verify standing approval count")
-			return &resp
+	for _, c := range checks {
+		if c.limit == nil {
+			continue
 		}
-		if count > *freePlan.MaxStandingApprovals {
-			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active standing approvals for the free plan")
-			resp.Error.Details = map[string]any{
-				"resource":    "standing_approvals",
-				"current":     count,
-				"max_allowed": *freePlan.MaxStandingApprovals,
-			}
-			return &resp
+		count, err := c.countFn(ctx, deps.DB, userID)
+		if err != nil {
+			log.Printf("[%s] Downgrade warning: count %s: %v", TraceID(ctx), c.name, err)
+			CaptureError(ctx, err)
+			continue
+		}
+		if count > *c.limit {
+			warnings = append(warnings, downgradeWarning{
+				Resource:   c.name,
+				Current:    count,
+				MaxAllowed: *c.limit,
+				Message:    fmt.Sprintf("You have %d %s (free limit: %d). Free plan limits apply after %s.", count, c.name, *c.limit, periodEndStr),
+			})
 		}
 	}
-
-	if freePlan.MaxCredentials != nil {
-		count, err := db.CountCredentialsByUser(ctx, deps.DB, userID)
-		if err != nil {
-			log.Printf("[%s] Downgrade: count credentials: %v", TraceID(ctx), err)
-			CaptureError(ctx, err)
-			resp := InternalError("Unable to verify credential count")
-			return &resp
-		}
-		if count > *freePlan.MaxCredentials {
-			resp := Conflict(ErrDowngradeLimitExceeded, "Too many stored credentials for the free plan")
-			resp.Error.Details = map[string]any{
-				"resource":    "credentials",
-				"current":     count,
-				"max_allowed": *freePlan.MaxCredentials,
-			}
-			return &resp
-		}
-	}
-
-	return nil
+	return warnings
 }
 
 // ── GET /billing/invoices ─────────────────────────────────────────────────

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -850,7 +850,7 @@ func TestDowngrade_Success_NoStripe(t *testing.T) {
 	}
 }
 
-func TestDowngrade_TooManyAgents(t *testing.T) {
+func TestDowngrade_TooManyAgents_SucceedsWithWarning(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -859,7 +859,6 @@ func TestDowngrade_TooManyAgents(t *testing.T) {
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
 	// Create more registered agents than the free plan allows.
-	// Free plan limit is 5 agents (from seed data).
 	for i := 0; i < 6; i++ {
 		testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
 	}
@@ -871,23 +870,27 @@ func TestDowngrade_TooManyAgents(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	// Downgrade now succeeds with warnings instead of blocking.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var errResp ErrorResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
-		t.Fatalf("failed to parse error response: %v", err)
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
 	}
-	if errResp.Error.Code != ErrDowngradeLimitExceeded {
-		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	if len(resp.Warnings) == 0 {
+		t.Error("expected warnings about agent limit, got none")
 	}
-	if errResp.Error.Details["resource"] != "agents" {
-		t.Errorf("expected resource=agents, got %v", errResp.Error.Details["resource"])
+	if resp.Warnings[0].Resource != "agents" {
+		t.Errorf("expected warning resource=agents, got %s", resp.Warnings[0].Resource)
+	}
+	if resp.QuotaEntitlementsUntil == nil {
+		t.Error("expected quota_entitlements_until to be set")
 	}
 }
 
-func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
+func TestDowngrade_TooManyStandingApprovals_SucceedsWithWarning(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -897,7 +900,6 @@ func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
 
 	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
 
-	// Free plan limit is 10 active standing approvals (from seed data).
 	for i := 0; i < 11; i++ {
 		saID := testhelper.GenerateID(t, "sa_")
 		testhelper.InsertStandingApproval(t, tx, saID, agentID, uid)
@@ -910,23 +912,23 @@ func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var errResp ErrorResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
-		t.Fatalf("failed to parse error response: %v", err)
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
 	}
-	if errResp.Error.Code != ErrDowngradeLimitExceeded {
-		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	if len(resp.Warnings) == 0 {
+		t.Error("expected warnings about standing approval limit, got none")
 	}
-	if errResp.Error.Details["resource"] != "standing_approvals" {
-		t.Errorf("expected resource=standing_approvals, got %v", errResp.Error.Details["resource"])
+	if resp.Warnings[0].Resource != "standing_approvals" {
+		t.Errorf("expected warning resource=standing_approvals, got %s", resp.Warnings[0].Resource)
 	}
 }
 
-func TestDowngrade_TooManyCredentials(t *testing.T) {
+func TestDowngrade_TooManyCredentials_SucceedsWithWarning(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -934,7 +936,6 @@ func TestDowngrade_TooManyCredentials(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	// Free plan limit is 5 credentials (from seed data).
 	for i := 0; i < 6; i++ {
 		credID := testhelper.GenerateID(t, "cred_")
 		service := testhelper.GenerateID(t, "svc_")
@@ -948,19 +949,19 @@ func TestDowngrade_TooManyCredentials(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var errResp ErrorResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
-		t.Fatalf("failed to parse error response: %v", err)
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
 	}
-	if errResp.Error.Code != ErrDowngradeLimitExceeded {
-		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	if len(resp.Warnings) == 0 {
+		t.Error("expected warnings about credential limit, got none")
 	}
-	if errResp.Error.Details["resource"] != "credentials" {
-		t.Errorf("expected resource=credentials, got %v", errResp.Error.Details["resource"])
+	if resp.Warnings[0].Resource != "credentials" {
+		t.Errorf("expected warning resource=credentials, got %s", resp.Warnings[0].Resource)
 	}
 }
 

--- a/api/plan_limits.go
+++ b/api/plan_limits.go
@@ -34,9 +34,10 @@ func checkResourceLimit(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return false // no subscription — bypass limits
 	}
 
-	limit := cfg.getLimit(&sp.Plan)
+	effectivePlan := sp.EffectiveQuotaPlan()
+	limit := cfg.getLimit(effectivePlan)
 	if limit == nil {
-		return false // unlimited plan
+		return false // unlimited plan (or quota grace period active)
 	}
 
 	count, err := cfg.countFn(ctx, d, userID)
@@ -50,12 +51,12 @@ func checkResourceLimit(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	if count >= *limit {
 		resp := Forbidden(cfg.errorCode, fmt.Sprintf(
 			"%s plan allows up to %d %s. Upgrade your plan to add more.",
-			sp.Plan.Name, *limit, cfg.resourceName,
+			effectivePlan.Name, *limit, cfg.resourceName,
 		))
 		resp.Error.Details = map[string]any{
 			"current_count": count,
 			"limit":         *limit,
-			"plan_id":       sp.Plan.ID,
+			"plan_id":       effectivePlan.ID,
 		}
 		RespondError(w, r, http.StatusForbidden, resp)
 		return true
@@ -97,9 +98,10 @@ func checkRequestQuota(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		return r, false // no subscription — bypass limits
 	}
 
-	limit := sp.Plan.MaxRequestsPerMonth
+	effectivePlan := sp.EffectiveQuotaPlan()
+	limit := effectivePlan.MaxRequestsPerMonth
 	if limit == nil {
-		return r, false // unlimited plan (paid tier)
+		return r, false // unlimited plan (paid tier or quota grace period)
 	}
 
 	now := time.Now()
@@ -138,7 +140,7 @@ func checkRequestQuota(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		resp.Error.Details = map[string]any{
 			"current_usage": currentCount,
 			"limit":         *limit,
-			"plan_id":       sp.Plan.ID,
+			"plan_id":       effectivePlan.ID,
 			"reset_at":      resetAt,
 		}
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))

--- a/db/migrations/20260321215437_add_quota_entitlement_columns.sql
+++ b/db/migrations/20260321215437_add_quota_entitlement_columns.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- Add columns to track paid quota entitlements after downgrade.
+-- quota_plan_id: the plan whose quotas still apply (e.g. 'pay_as_you_go')
+-- quota_entitlements_until: when the quota grace period ends (snapshot of current_period_end at downgrade time)
+ALTER TABLE subscriptions
+    ADD COLUMN quota_plan_id TEXT,
+    ADD COLUMN quota_entitlements_until TIMESTAMPTZ;
+
+-- +goose Down
+ALTER TABLE subscriptions
+    DROP COLUMN IF EXISTS quota_entitlements_until,
+    DROP COLUMN IF EXISTS quota_plan_id;

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -35,20 +35,22 @@ func IsValidSubscriptionStatus(s SubscriptionStatus) bool {
 // Each user has at most one subscription (enforced by UNIQUE on user_id).
 // Billing periods are aligned to calendar months (via date_trunc defaults).
 type Subscription struct {
-	ID                   string
-	UserID               string
-	PlanID               string
-	Status               SubscriptionStatus
-	StripeCustomerID     *string // nil for free-tier users (no Stripe setup)
-	StripeSubscriptionID *string // nil for free-tier users
-	CurrentPeriodStart   time.Time
-	CurrentPeriodEnd     time.Time
-	DowngradedAt         *time.Time // set when plan changes from paid to free; nil otherwise
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+	ID                    string
+	UserID                string
+	PlanID                string
+	Status                SubscriptionStatus
+	StripeCustomerID      *string // nil for free-tier users (no Stripe setup)
+	StripeSubscriptionID  *string // nil for free-tier users
+	CurrentPeriodStart    time.Time
+	CurrentPeriodEnd      time.Time
+	DowngradedAt          *time.Time // set when plan changes from paid to free; nil otherwise
+	QuotaPlanID           *string    // plan whose quotas apply during grace period; nil when not in grace
+	QuotaEntitlementsUntil *time.Time // when quota grace expires; nil when not in grace
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
-const subscriptionColumns = `id, user_id, plan_id, status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end, downgraded_at, created_at, updated_at`
+const subscriptionColumns = `id, user_id, plan_id, status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end, downgraded_at, quota_plan_id, quota_entitlements_until, created_at, updated_at`
 
 func scanSubscription(row pgx.Row) (*Subscription, error) {
 	var s Subscription
@@ -62,6 +64,8 @@ func scanSubscription(row pgx.Row) (*Subscription, error) {
 		&s.CurrentPeriodStart,
 		&s.CurrentPeriodEnd,
 		&s.DowngradedAt,
+		&s.QuotaPlanID,
+		&s.QuotaEntitlementsUntil,
 		&s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -94,7 +98,9 @@ func CreateSubscription(ctx context.Context, db DBTX, userID, planID string) (*S
 // UpdateSubscriptionPlan changes the plan for a user's subscription.
 // When downgrading (moving to a plan with shorter retention), sets downgraded_at
 // to trigger a grace period before the shorter retention window takes effect.
-// When upgrading, clears downgraded_at since the longer retention applies immediately.
+// Also sets quota_plan_id and quota_entitlements_until so paid quotas are
+// preserved until the end of the billing period the user already paid for.
+// When upgrading, clears downgraded_at and quota columns since paid features apply immediately.
 func UpdateSubscriptionPlan(ctx context.Context, db DBTX, userID, planID string) (*Subscription, error) {
 	s, err := scanSubscription(db.QueryRow(ctx,
 		`UPDATE subscriptions
@@ -102,6 +108,16 @@ func UpdateSubscriptionPlan(ctx context.Context, db DBTX, userID, planID string)
 		         WHEN $2 = 'free' AND plan_id != 'free' THEN now()
 		         WHEN $2 != 'free' THEN NULL
 		         ELSE downgraded_at
+		     END,
+		     quota_plan_id = CASE
+		         WHEN $2 = 'free' AND plan_id != 'free' THEN plan_id
+		         WHEN $2 != 'free' THEN NULL
+		         ELSE quota_plan_id
+		     END,
+		     quota_entitlements_until = CASE
+		         WHEN $2 = 'free' AND plan_id != 'free' THEN current_period_end
+		         WHEN $2 != 'free' THEN NULL
+		         ELSE quota_entitlements_until
 		     END,
 		     plan_id = $2,
 		     updated_at = now()
@@ -124,6 +140,8 @@ func UpgradeSubscriptionPlan(ctx context.Context, db DBTX, userID, expectedOldPl
 		`UPDATE subscriptions
 		 SET plan_id = $3,
 		     downgraded_at = NULL,
+		     quota_plan_id = NULL,
+		     quota_entitlements_until = NULL,
 		     updated_at = now()
 		 WHERE user_id = $1 AND plan_id = $2
 		 RETURNING `+subscriptionColumns,
@@ -307,6 +325,34 @@ func (sp *SubscriptionWithPlan) GracePeriodEndsAt() *time.Time {
 	if sp.DowngradedAt != nil && time.Since(*sp.DowngradedAt) < DowngradeGracePeriod {
 		t := sp.DowngradedAt.Add(DowngradeGracePeriod)
 		return &t
+	}
+	return nil
+}
+
+// EffectiveQuotaPlan returns the plan whose resource limits should be enforced.
+// During the quota grace period (after downgrade, before the paid billing period
+// ends), this returns the previous paid plan so users keep paid quotas until the
+// period they already paid for expires. Outside the grace period, returns the
+// current plan.
+func (sp *SubscriptionWithPlan) EffectiveQuotaPlan() *Plan {
+	if sp.QuotaPlanID != nil && sp.QuotaEntitlementsUntil != nil {
+		if time.Now().Before(*sp.QuotaEntitlementsUntil) {
+			if p := GetPlan(*sp.QuotaPlanID); p != nil {
+				return p
+			}
+		}
+	}
+	return &sp.Plan
+}
+
+// QuotaGracePeriodEndsAt returns the timestamp when the quota grace period
+// expires, or nil if no quota grace period is active. This is separate from
+// the audit retention grace period (GracePeriodEndsAt).
+func (sp *SubscriptionWithPlan) QuotaGracePeriodEndsAt() *time.Time {
+	if sp.QuotaPlanID != nil && sp.QuotaEntitlementsUntil != nil {
+		if time.Now().Before(*sp.QuotaEntitlementsUntil) {
+			return sp.QuotaEntitlementsUntil
+		}
 	}
 	return nil
 }

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -114,6 +114,7 @@ export function BillingPage() {
             usage={billingPlan.usage}
             plan={billingPlan.plan}
             pricing={billingPlan.pricing}
+            effectiveLimits={billingPlan.effective_limits}
           />
           <UsageDashboard
             plan={billingPlan.plan}

--- a/frontend/src/pages/billing/DowngradeConfirmDialog.tsx
+++ b/frontend/src/pages/billing/DowngradeConfirmDialog.tsx
@@ -88,7 +88,7 @@ export function DowngradeConfirmDialog({
               <div className="flex items-start gap-2">
                 <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
                 <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
-                  You&apos;re over free plan limits
+                  You&apos;re over free plan limits (enforced after your billing period ends)
                 </p>
               </div>
               <ul className="ml-6 space-y-1.5">
@@ -110,18 +110,15 @@ export function DowngradeConfirmDialog({
           <div className="rounded-lg border p-4 space-y-1">
             <p className="text-sm font-medium">What changes</p>
             <ul className="space-y-1 text-sm text-muted-foreground">
-              <li>Audit retention drops from {paidPlan.audit_retention_days} days to {freePlan.audit_retention_days} days</li>
+              <li>Your paid plan resource limits are preserved until the end of your current billing period</li>
               <li>
-                Resource limits will be enforced ({FREE_PLAN_LIMITS.agents.limit} agents,{" "}
+                After that, free plan limits apply ({FREE_PLAN_LIMITS.agents.limit} agents,{" "}
                 {FREE_PLAN_LIMITS.standing_approvals.limit} approvals,{" "}
-                {FREE_PLAN_LIMITS.credentials.limit} credentials)
+                {FREE_PLAN_LIMITS.credentials.limit} credentials,{" "}
+                {formatLimit(freePlan.max_requests_per_month)} requests/month)
               </li>
-              <li>{formatLimit(freePlan.max_requests_per_month)} request/month limit</li>
+              <li>Audit retention drops from {paidPlan.audit_retention_days} to {freePlan.audit_retention_days} days after a 7-day grace period</li>
             </ul>
-            <p className="mt-2 text-xs text-muted-foreground">
-              A 7-day grace period preserves your {paidPlan.audit_retention_days}-day audit retention so you
-              can export data before it reverts.
-            </p>
           </div>
 
           {error && (
@@ -140,7 +137,7 @@ export function DowngradeConfirmDialog({
           <Button
             variant="destructive"
             onClick={onConfirm}
-            disabled={isPending || hasWarnings}
+            disabled={isPending}
           >
             {isPending && <Loader2 className="animate-spin" aria-hidden="true" />}
             Confirm Downgrade

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -78,11 +78,18 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
               Your payment method failed. Please update it to avoid service interruption.
             </p>
           )}
-          {subscription.grace_period_ends_at && (
+          {subscription.quota_entitlements_until && (
             <p className="text-amber-700 dark:text-amber-300 text-xs">
-              Your paid plan features are preserved until{" "}
+              Your paid plan resource limits are preserved until{" "}
+              {formatDate(subscription.quota_entitlements_until)}. After that,
+              free plan limits will apply.
+            </p>
+          )}
+          {subscription.grace_period_ends_at && !subscription.quota_entitlements_until && (
+            <p className="text-amber-700 dark:text-amber-300 text-xs">
+              Your {90}-day audit retention is preserved until{" "}
               {formatDate(subscription.grace_period_ends_at)}. After that,
-              your account will revert to free plan limits.
+              retention drops to 7 days.
             </p>
           )}
         </div>

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -6,15 +6,18 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { BillingPricing, Plan, UsageSummary } from "@/hooks/useBillingPlan";
+import type { BillingPlanResponse, BillingPricing, Plan, UsageSummary } from "@/hooks/useBillingPlan";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { FREE_REQUEST_ALLOWANCE, PRICE_PER_REQUEST } from "./constants";
 import { DetailRow } from "./DetailRow";
+
+type EffectiveLimits = BillingPlanResponse["effective_limits"];
 
 interface UsageSummaryCardProps {
   usage: UsageSummary;
   plan: Plan;
   pricing?: BillingPricing;
+  effectiveLimits?: EffectiveLimits;
 }
 
 interface UsageRowProps {
@@ -93,12 +96,20 @@ function PaidRequestRow({ current, included, priceDisplay }: { current: number; 
   );
 }
 
-export function UsageSummaryCard({ usage, plan, pricing }: UsageSummaryCardProps) {
+export function UsageSummaryCard({ usage, plan, pricing, effectiveLimits }: UsageSummaryCardProps) {
   const isPaid = plan.id !== "free" && plan.id !== "free_pro";
   const { usage: usageDetail } = useBillingUsage();
   // Use server-provided included value, fall back to config constant.
   const included = usageDetail?.requests.included ?? FREE_REQUEST_ALLOWANCE;
   const priceDisplay = pricing?.price_per_request_display ?? PRICE_PER_REQUEST;
+
+  // During quota grace period, use effective limits (paid plan limits) instead of
+  // the current plan's limits. This ensures the UI shows the limits actually enforced.
+  const limits = effectiveLimits ?? plan;
+  const hasGrace = !!effectiveLimits;
+  // Show paid-style request row when user is on paid plan OR in quota grace period
+  // (effective limits have no request cap).
+  const showPaidRequests = isPaid || (hasGrace && limits.max_requests_per_month == null);
 
   return (
     <Card>
@@ -108,34 +119,34 @@ export function UsageSummaryCard({ usage, plan, pricing }: UsageSummaryCardProps
           <CardTitle>Usage</CardTitle>
         </div>
         <CardDescription>
-          Current resource usage against your plan limits.
+          Current resource usage against your {hasGrace ? "effective" : "plan"} limits.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          {isPaid ? (
+          {showPaidRequests ? (
             <PaidRequestRow current={usage.requests} included={included} priceDisplay={priceDisplay} />
           ) : (
             <UsageRow
               label="Requests"
               current={usage.requests}
-              limit={plan.max_requests_per_month ?? null}
+              limit={limits.max_requests_per_month ?? null}
             />
           )}
           <UsageRow
             label="Agents"
             current={usage.agents}
-            limit={plan.max_agents ?? null}
+            limit={limits.max_agents ?? null}
           />
           <UsageRow
             label="Standing Approvals"
             current={usage.standing_approvals}
-            limit={plan.max_standing_approvals ?? null}
+            limit={limits.max_standing_approvals ?? null}
           />
           <UsageRow
             label="Credentials"
             current={usage.credentials}
-            limit={plan.max_credentials ?? null}
+            limit={limits.max_credentials ?? null}
           />
           <DetailRow label="Audit Retention">
             <span className="text-muted-foreground">{plan.audit_retention_days} days</span>

--- a/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -368,8 +368,8 @@ describe("BillingPage", () => {
       expect(screen.getByText(/You have 25 standing approvals/)).toBeInTheDocument();
       expect(screen.getByText(/You have 20 credentials/)).toBeInTheDocument();
 
-      // Confirm button should be disabled when over limits
-      expect(screen.getByRole("button", { name: "Confirm Downgrade" })).toBeDisabled();
+      // Confirm button should be enabled — warnings are informational, not blockers
+      expect(screen.getByRole("button", { name: "Confirm Downgrade" })).toBeEnabled();
 
       // Should show "Manage" links for each over-limit resource
       expect(screen.getByText("Manage agents")).toBeInTheDocument();

--- a/frontend/src/pages/settings/BillingSettingsPage.tsx
+++ b/frontend/src/pages/settings/BillingSettingsPage.tsx
@@ -110,6 +110,7 @@ export function BillingSettingsPage() {
             usage={billingPlan.usage}
             plan={billingPlan.plan}
             pricing={billingPlan.pricing}
+            effectiveLimits={billingPlan.effective_limits}
           />
           <UsageDashboard
             plan={billingPlan.plan}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -351,6 +351,15 @@ Subscription:
         During the grace period (7 days after downgrade), the user retains the longer
         audit retention window (90 days) to export their data. After this timestamp,
         retention drops to the free plan's window (7 days).
+    quota_entitlements_until:
+      type: string
+      format: date-time
+      nullable: true
+      description: |
+        When paid quota entitlements expire after a downgrade, or null if no quota
+        grace period is active. During this period, the user retains their previous
+        paid plan's resource limits (unlimited agents, approvals, credentials, and
+        no request cap). After this timestamp, free plan limits are enforced.
 
 UsageSummary:
   type: object
@@ -397,6 +406,15 @@ BillingPlanResponse:
       $ref: '#/Subscription'
     usage:
       $ref: '#/UsageSummary'
+    effective_limits:
+      $ref: '#/PlanLimits'
+      nullable: true
+      description: |
+        The resource limits currently in effect, or null when they match the plan's
+        limits. Present only during a quota grace period (after downgrade, before
+        `quota_entitlements_until`), when the user retains their previous paid plan's
+        limits. The frontend should use these values for limit displays and progress
+        bars instead of `plan.max_*` when present.
     pricing:
       $ref: '#/BillingPricing'
     coupon_redemption_enabled:
@@ -624,6 +642,47 @@ DowngradeResponse:
         When the 7-day grace period expires. Until this time, the user retains
         the 90-day audit retention window from their paid plan. Show this to the
         user so they know how long they have to export their data.
+    quota_entitlements_until:
+      type: string
+      format: date-time
+      nullable: true
+      description: |
+        When paid quota entitlements expire. Until this time, the user retains
+        their previous paid plan's resource limits (unlimited agents, approvals,
+        credentials, and no request cap). Null if no quota grace period applies.
+    warnings:
+      type: array
+      items:
+        $ref: '#/DowngradeWarning'
+      description: |
+        Warnings about resources that exceed free plan limits. Informational only —
+        the downgrade proceeds regardless. Free plan limits are enforced after
+        `quota_entitlements_until`.
+
+DowngradeWarning:
+  type: object
+  required:
+    - resource
+    - current
+    - max_allowed
+    - message
+  properties:
+    resource:
+      type: string
+      description: The resource type that exceeds the free plan limit
+      example: agents
+    current:
+      type: integer
+      description: Current count of this resource
+      example: 6
+    max_allowed:
+      type: integer
+      description: Maximum allowed on the free plan
+      example: 3
+    message:
+      type: string
+      description: Human-readable warning message
+      example: "You have 6 agents (free limit: 3). Free plan limits apply after Apr 1, 2026."
 
 Invoice:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -10223,6 +10223,15 @@ components:
             During the grace period (7 days after downgrade), the user retains the longer
             audit retention window (90 days) to export their data. After this timestamp,
             retention drops to the free plan's window (7 days).
+        quota_entitlements_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When paid quota entitlements expire after a downgrade, or null if no quota
+            grace period is active. During this period, the user retains their previous
+            paid plan's resource limits (unlimited agents, approvals, credentials, and
+            no request cap). After this timestamp, free plan limits are enforced.
     UsageSummary:
       type: object
       required:
@@ -10267,6 +10276,15 @@ components:
           $ref: '#/components/schemas/Subscription'
         usage:
           $ref: '#/components/schemas/UsageSummary'
+        effective_limits:
+          $ref: '#/components/schemas/PlanLimits'
+          nullable: true
+          description: |
+            The resource limits currently in effect, or null when they match the plan's
+            limits. Present only during a quota grace period (after downgrade, before
+            `quota_entitlements_until`), when the user retains their previous paid plan's
+            limits. The frontend should use these values for limit displays and progress
+            bars instead of `plan.max_*` when present.
         pricing:
           $ref: '#/components/schemas/BillingPricing'
         coupon_redemption_enabled:
@@ -11637,6 +11655,30 @@ components:
           type: integer
           description: Number of days audit logs are retained
           example: 7
+    DowngradeWarning:
+      type: object
+      required:
+        - resource
+        - current
+        - max_allowed
+        - message
+      properties:
+        resource:
+          type: string
+          description: The resource type that exceeds the free plan limit
+          example: agents
+        current:
+          type: integer
+          description: Current count of this resource
+          example: 6
+        max_allowed:
+          type: integer
+          description: Maximum allowed on the free plan
+          example: 3
+        message:
+          type: string
+          description: Human-readable warning message
+          example: 'You have 6 agents (free limit: 3). Free plan limits apply after Apr 1, 2026.'
     DowngradeResponse:
       type: object
       required:
@@ -11668,6 +11710,22 @@ components:
             When the 7-day grace period expires. Until this time, the user retains
             the 90-day audit retention window from their paid plan. Show this to the
             user so they know how long they have to export their data.
+        quota_entitlements_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When paid quota entitlements expire. Until this time, the user retains
+            their previous paid plan's resource limits (unlimited agents, approvals,
+            credentials, and no request cap). Null if no quota grace period applies.
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/DowngradeWarning'
+          description: |
+            Warnings about resources that exceed free plan limits. Informational only —
+            the downgrade proceeds regardless. Free plan limits are enforced after
+            `quota_entitlements_until`.
     InvoiceListResponse:
       type: object
       required:


### PR DESCRIPTION
## Summary

- Adds `quota_plan_id` and `quota_entitlements_until` columns to `subscriptions` — set at downgrade time to snapshot the paid plan and billing period end
- All limit enforcement (`checkRequestQuota`, `checkResourceLimit`, `checkAgentLimit`, etc.) now uses `EffectiveQuotaPlan()` which returns the paid plan's limits during the grace period
- Downgrade no longer blocks when user is over free plan limits — `validateDowngradeLimits` converted to informational warnings returned in the response
- `GET /billing/plan` includes `effective_limits` (when in grace) and `quota_entitlements_until` on the subscription object
- Frontend `UsageSummaryCard` uses effective limits for progress bars during grace period
- `PlanCard` shows accurate messaging about when paid limits expire
- `DowngradeConfirmDialog` allows downgrade with warnings instead of blocking

## Test plan

### Claude Code
- [x] Go build passes (`go build ./...`)
- [x] Go API + DB tests pass (`go test ./api/... ./db/...`)
- [x] Frontend TypeScript check passes (`tsc --noEmit`)
- [x] Frontend tests pass (959/959, including updated billing page test)
- [x] OpenAPI spec regenerated from component schemas

### Manual Testing
- [ ] Downgrade pay-as-you-go → free: Usage and API should show paid limits until `quota_entitlements_until`
- [ ] After period end: limits match free; no stale paid quotas
- [ ] Re-upgrade during grace: quotas immediately reflect paid plan, grace columns cleared
- [ ] Downgrade with >3 agents: warning shown (not blocked), agents preserved but can't create new ones after grace

https://claude.ai/code/session_01C8fFtJ9phgdKkGNLuu9CwX