### PR TITLE
Preserve paid plan quotas until billing period ends after downgrade

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -13,11 +13,12 @@ import (
 // ── Response types ──────────────────────────────────────────────────────────
 
 type subscriptionResponse struct {
-	PlanID   string `json:"plan_id"`
-	PlanName string `json:"plan_name"`
+	PlanID          string     `json:"plan_id"`
+	PlanName        string     `json:"plan_name"`
 	billingSubscription
-	PlanLimits planLimits `json:"plan_limits"`
-	Usage      *usageInfo `json:"usage,omitempty"`
+	PlanLimits      planLimits `json:"plan_limits"`
+	EffectiveLimits planLimits `json:"effective_limits"`
+	Usage           *usageInfo `json:"usage,omitempty"`
 }
 
 type planLimits struct {
@@ -117,6 +118,7 @@ func toAPIInvoice(s pstripe.InvoiceSummary) apiInvoice {
 
 type billingPlanResponse struct {
 	Plan                    billingPlan         `json:"plan"`
+	EffectiveLimits         planLimits          `json:"effective_limits"`
 	Subscription            billingSubscription `json:"subscription"`
 	Usage                   billingUsageSummary `json:"usage"`
 	Pricing                 *billingPricing     `json:"pricing,omitempty"`
@@ -136,13 +138,14 @@ type billingPlan struct {
 }
 
 type billingSubscription struct {
-	Status             string     `json:"status"`
-	CurrentPeriodStart time.Time  `json:"current_period_start"`
-	CurrentPeriodEnd   time.Time  `json:"current_period_end"`
-	HasPaymentMethod   bool       `json:"has_payment_method"`
-	CanUpgrade         bool       `json:"can_upgrade"`
-	CanDowngrade       bool       `json:"can_downgrade"`
-	GracePeriodEndsAt  *time.Time `json:"grace_period_ends_at"`
+	Status                   string     `json:"status"`
+	CurrentPeriodStart       time.Time  `json:"current_period_start"`
+	CurrentPeriodEnd         time.Time  `json:"current_period_end"`
+	HasPaymentMethod         bool       `json:"has_payment_method"`
+	CanUpgrade               bool       `json:"can_upgrade"`
+	CanDowngrade             bool       `json:"can_downgrade"`
+	GracePeriodEndsAt        *time.Time `json:"grace_period_ends_at"`
+	QuotaEntitlementsUntil   *time.Time `json:"quota_entitlements_until"`
 }
 
 type billingUsageSummary struct {
@@ -154,14 +157,19 @@ type billingUsageSummary struct {
 
 // newBillingSubscription builds subscription status fields from a DB subscription.
 func newBillingSubscription(sub *db.SubscriptionWithPlan) billingSubscription {
+	var quotaUntil *time.Time
+	if sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil && time.Now().Before(*sub.QuotaEntitlementsUntil) {
+		quotaUntil = sub.QuotaEntitlementsUntil
+	}
 	return billingSubscription{
-		Status:             string(sub.Status),
-		CurrentPeriodStart: sub.CurrentPeriodStart,
-		CurrentPeriodEnd:   sub.CurrentPeriodEnd,
-		HasPaymentMethod:   false,
-		CanUpgrade:         sub.PlanID == db.PlanFree || sub.PlanID == db.PlanFreePro,
-		CanDowngrade:       sub.PlanID == db.PlanPayAsYouGo,
-		GracePeriodEndsAt:  sub.GracePeriodEndsAt(),
+		Status:                 string(sub.Status),
+		CurrentPeriodStart:     sub.CurrentPeriodStart,
+		CurrentPeriodEnd:       sub.CurrentPeriodEnd,
+		HasPaymentMethod:       false,
+		CanUpgrade:             sub.PlanID == db.PlanFree || sub.PlanID == db.PlanFreePro,
+		CanDowngrade:           sub.PlanID == db.PlanPayAsYouGo,
+		GracePeriodEndsAt:      sub.GracePeriodEndsAt(),
+		QuotaEntitlementsUntil: quotaUntil,
 	}
 }
 
@@ -176,11 +184,19 @@ func newPlanLimits(p *db.Plan) planLimits {
 	}
 }
 
+type downgradeLimitWarning struct {
+	Resource   string `json:"resource"`
+	Current    int    `json:"current"`
+	MaxAllowed int    `json:"max_allowed"`
+}
+
 type downgradeResponse struct {
-	Status            string     `json:"status"`
-	PlanID            string     `json:"plan_id"`
-	DowngradedAt      *time.Time `json:"downgraded_at"`
-	GracePeriodEndsAt *time.Time `json:"grace_period_ends_at"`
+	Status                   string                    `json:"status"`
+	PlanID                   string                    `json:"plan_id"`
+	DowngradedAt             *time.Time                `json:"downgraded_at"`
+	GracePeriodEndsAt        *time.Time                `json:"grace_period_ends_at"`
+	QuotaEntitlementsUntil   *time.Time                `json:"quota_entitlements_until"`
+	Warnings                 []downgradeLimitWarning   `json:"warnings,omitempty"`
 }
 
 // gracePeriodEnd returns the time when the 7-day grace period expires for a
@@ -237,13 +253,15 @@ func handleGetBillingPlan(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		eff := sub.EffectiveQuotaPlan()
 		resp := billingPlanResponse{
 			Plan: billingPlan{
 				ID:         sub.PlanID,
 				Name:       sub.Plan.Name,
 				planLimits: newPlanLimits(&sub.Plan),
 			},
-			Subscription: newBillingSubscription(sub),
+			EffectiveLimits: newPlanLimits(eff),
+			Subscription:  newBillingSubscription(sub),
 		}
 
 		// Include pricing info for all plans so the upgrade flow can show
@@ -321,11 +339,13 @@ func handleGetSubscription(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		eff := sub.EffectiveQuotaPlan()
 		resp := subscriptionResponse{
 			PlanID:              sub.PlanID,
 			PlanName:            sub.Plan.Name,
 			billingSubscription: newBillingSubscription(sub),
 			PlanLimits:          newPlanLimits(&sub.Plan),
+			EffectiveLimits:     newPlanLimits(eff),
 		}
 
 		// A user "has a payment method" if they have local payment methods
@@ -352,9 +372,9 @@ func handleGetSubscription(deps *Deps) http.HandlerFunc {
 			ui := &usageInfo{
 				RequestCount: usage.RequestCount,
 				SMSCount:     usage.SMSCount,
-				RequestLimit: sub.Plan.MaxRequestsPerMonth,
+				RequestLimit: eff.MaxRequestsPerMonth,
 			}
-			if sub.Plan.MaxRequestsPerMonth != nil && usage.RequestCount > *sub.Plan.MaxRequestsPerMonth {
+			if eff.MaxRequestsPerMonth != nil && usage.RequestCount > *eff.MaxRequestsPerMonth {
 				ui.OverLimit = true
 			}
 			resp.Usage = ui
@@ -474,13 +494,14 @@ func handleGetUsage(deps *Deps) http.HandlerFunc {
 			PeriodEnd:   sub.CurrentPeriodEnd,
 		}
 
+		eff := sub.EffectiveQuotaPlan()
 		// Determine included request allowance.
 		// Paid plans get the same free allowance as the free tier (1000 requests).
 		included := int(pstripe.FreeRequestAllowance())
-		if sub.Plan.MaxRequestsPerMonth != nil {
-			included = *sub.Plan.MaxRequestsPerMonth
+		if eff.MaxRequestsPerMonth != nil {
+			included = *eff.MaxRequestsPerMonth
 		}
-		unlimitedRequests := sub.Plan.MaxRequestsPerMonth == nil
+		unlimitedRequests := eff.MaxRequestsPerMonth == nil
 		if sub.PlanID == db.PlanFreePro {
 			included = 0
 		}
@@ -569,12 +590,11 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		if limitErr := validateDowngradeLimits(r.Context(), deps, profile.ID, freePlan); limitErr != nil {
-			status := http.StatusConflict
-			if limitErr.Error.Code == ErrInternalError {
-				status = http.StatusInternalServerError
-			}
-			RespondError(w, r, status, *limitErr)
+		warnings, warnErr := buildDowngradeLimitWarnings(r.Context(), deps, profile.ID, freePlan)
+		if warnErr != nil {
+			log.Printf("[%s] Downgrade: limit warnings: %v", TraceID(r.Context()), warnErr)
+			CaptureError(r.Context(), warnErr)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify plan limits"))
 			return
 		}
 
@@ -588,8 +608,46 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		// Downgrade plan locally.
-		updated, err := db.UpdateSubscriptionPlan(r.Context(), deps.DB, profile.ID, db.PlanFree)
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] Downgrade: begin tx: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to downgrade plan"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx)
+		}
+
+		cur, err := db.GetSubscriptionByUserID(r.Context(), tx, profile.ID)
+		if err != nil {
+			log.Printf("[%s] Downgrade: reload subscription: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to downgrade plan"))
+			return
+		}
+		if cur == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrSubscriptionNotFound, "No subscription found"))
+			return
+		}
+		if cur.PlanID != db.PlanPayAsYouGo {
+			RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Subscription changed during downgrade"))
+			return
+		}
+
+		periodEnd := cur.CurrentPeriodEnd
+		var custPtr *string
+		if cur.StripeCustomerID != nil {
+			custPtr = cur.StripeCustomerID
+		}
+		if _, err := db.UpdateSubscriptionStripe(r.Context(), tx, profile.ID, custPtr, nil); err != nil {
+			log.Printf("[%s] Downgrade: clear stripe subscription id: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to downgrade plan"))
+			return
+		}
+
+		updated, err := db.DowngradeSubscriptionToFreeWithQuotaGrace(r.Context(), tx, profile.ID, db.PlanPayAsYouGo, periodEnd)
 		if err != nil {
 			log.Printf("[%s] Downgrade: update plan: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -601,77 +659,63 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] Downgrade: commit: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to downgrade plan"))
+				return
+			}
+		}
+
+		var quotaUntil *time.Time
+		if updated.QuotaEntitlementsUntil != nil {
+			quotaUntil = updated.QuotaEntitlementsUntil
+		}
+
 		RespondJSON(w, http.StatusOK, downgradeResponse{
-			Status:            string(updated.Status),
-			PlanID:            updated.PlanID,
-			DowngradedAt:      updated.DowngradedAt,
-			GracePeriodEndsAt: gracePeriodEnd(updated.DowngradedAt),
+			Status:                 string(updated.Status),
+			PlanID:                 updated.PlanID,
+			DowngradedAt:           updated.DowngradedAt,
+			GracePeriodEndsAt:      gracePeriodEnd(updated.DowngradedAt),
+			QuotaEntitlementsUntil: quotaUntil,
+			Warnings:               warnings,
 		})
 	}
 }
 
-// validateDowngradeLimits checks that the user's current resource counts are
-// within the free plan's limits. Returns an ErrorResponse if any limit is
-// exceeded or if a count cannot be verified (fail-closed), nil otherwise.
-func validateDowngradeLimits(ctx context.Context, deps *Deps, userID string, freePlan *db.Plan) *ErrorResponse {
+// buildDowngradeLimitWarnings returns non-blocking warnings when the user
+// exceeds free-tier caps (they apply after quota_entitlements_until).
+func buildDowngradeLimitWarnings(ctx context.Context, deps *Deps, userID string, freePlan *db.Plan) ([]downgradeLimitWarning, error) {
+	var out []downgradeLimitWarning
 	if freePlan.MaxAgents != nil {
 		count, err := db.CountRegisteredAgentsByUser(ctx, deps.DB, userID)
 		if err != nil {
-			log.Printf("[%s] Downgrade: count agents: %v", TraceID(ctx), err)
-			CaptureError(ctx, err)
-			resp := InternalError("Unable to verify agent count")
-			return &resp
+			return nil, err
 		}
 		if count > *freePlan.MaxAgents {
-			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active agents for the free plan")
-			resp.Error.Details = map[string]any{
-				"resource":    "agents",
-				"current":     count,
-				"max_allowed": *freePlan.MaxAgents,
-			}
-			return &resp
+			out = append(out, downgradeLimitWarning{Resource: "agents", Current: count, MaxAllowed: *freePlan.MaxAgents})
 		}
 	}
-
 	if freePlan.MaxStandingApprovals != nil {
 		count, err := db.CountActiveStandingApprovalsByUser(ctx, deps.DB, userID)
 		if err != nil {
-			log.Printf("[%s] Downgrade: count standing approvals: %v", TraceID(ctx), err)
-			CaptureError(ctx, err)
-			resp := InternalError("Unable to verify standing approval count")
-			return &resp
+			return nil, err
 		}
 		if count > *freePlan.MaxStandingApprovals {
-			resp := Conflict(ErrDowngradeLimitExceeded, "Too many active standing approvals for the free plan")
-			resp.Error.Details = map[string]any{
-				"resource":    "standing_approvals",
-				"current":     count,
-				"max_allowed": *freePlan.MaxStandingApprovals,
-			}
-			return &resp
+			out = append(out, downgradeLimitWarning{Resource: "standing_approvals", Current: count, MaxAllowed: *freePlan.MaxStandingApprovals})
 		}
 	}
-
 	if freePlan.MaxCredentials != nil {
 		count, err := db.CountCredentialsByUser(ctx, deps.DB, userID)
 		if err != nil {
-			log.Printf("[%s] Downgrade: count credentials: %v", TraceID(ctx), err)
-			CaptureError(ctx, err)
-			resp := InternalError("Unable to verify credential count")
-			return &resp
+			return nil, err
 		}
 		if count > *freePlan.MaxCredentials {
-			resp := Conflict(ErrDowngradeLimitExceeded, "Too many stored credentials for the free plan")
-			resp.Error.Details = map[string]any{
-				"resource":    "credentials",
-				"current":     count,
-				"max_allowed": *freePlan.MaxCredentials,
-			}
-			return &resp
+			out = append(out, downgradeLimitWarning{Resource: "credentials", Current: count, MaxAllowed: *freePlan.MaxCredentials})
 		}
 	}
-
-	return nil
+	return out, nil
 }
 
 // ── GET /billing/invoices ─────────────────────────────────────────────────

--- a/api/billing.go
+++ b/api/billing.go
@@ -631,6 +631,19 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			return
 		}
 		if cur.PlanID != db.PlanPayAsYouGo {
+			// Stripe webhook may have already downgraded (subscription.deleted) before this
+			// transaction opened — return success instead of a spurious 409.
+			if cur.PlanID == db.PlanFree && cur.QuotaPlanID != nil && cur.QuotaEntitlementsUntil != nil {
+				RespondJSON(w, http.StatusOK, downgradeResponse{
+					Status:                 string(cur.Status),
+					PlanID:                 cur.PlanID,
+					DowngradedAt:           cur.DowngradedAt,
+					GracePeriodEndsAt:      gracePeriodEnd(cur.DowngradedAt),
+					QuotaEntitlementsUntil: cur.QuotaEntitlementsUntil,
+					Warnings:               warnings,
+				})
+				return
+			}
 			RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Subscription changed during downgrade"))
 			return
 		}
@@ -668,17 +681,12 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		var quotaUntil *time.Time
-		if updated.QuotaEntitlementsUntil != nil {
-			quotaUntil = updated.QuotaEntitlementsUntil
-		}
-
 		RespondJSON(w, http.StatusOK, downgradeResponse{
 			Status:                 string(updated.Status),
 			PlanID:                 updated.PlanID,
 			DowngradedAt:           updated.DowngradedAt,
 			GracePeriodEndsAt:      gracePeriodEnd(updated.DowngradedAt),
-			QuotaEntitlementsUntil: quotaUntil,
+			QuotaEntitlementsUntil: updated.QuotaEntitlementsUntil,
 			Warnings:               warnings,
 		})
 	}

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -90,6 +90,9 @@ func TestGetBillingPlan_ReturnsPlanSubscriptionUsage(t *testing.T) {
 	if resp.CouponRedemptionEnabled {
 		t.Error("expected coupon_redemption_enabled=false when COUPON_SECRET unset")
 	}
+	if resp.EffectiveLimits.MaxAgents == nil || *resp.EffectiveLimits.MaxAgents != *resp.Plan.MaxAgents {
+		t.Errorf("effective_limits should match plan for non-grace user: plan max_agents=%v effective=%v", resp.Plan.MaxAgents, resp.EffectiveLimits.MaxAgents)
+	}
 }
 
 func TestGetBillingPlan_CouponRedemptionEnabled(t *testing.T) {
@@ -172,6 +175,51 @@ func TestGetBillingPlan_ZeroUsage(t *testing.T) {
 	if resp.Usage.Credentials != 0 {
 		t.Errorf("expected usage.credentials=0, got %d", resp.Usage.Credentials)
 	}
+}
+
+func TestGetBillingPlan_QuotaGraceEffectiveLimits(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	future := time.Now().Add(48 * time.Hour)
+	paid := db.PlanPayAsYouGo
+	testhelper.MustExec(t, tx,
+		`UPDATE subscriptions SET quota_plan_id = $2, quota_entitlements_until = $3 WHERE user_id = $1`,
+		uid, paid, future)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/billing/plan", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp billingPlanResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Plan.ID != db.PlanFree {
+		t.Errorf("expected plan.id=free, got %s", resp.Plan.ID)
+	}
+	if resp.EffectiveLimits.MaxRequestsPerMonth != nil {
+		t.Error("expected effective unlimited requests during quota grace")
+	}
+	if resp.Subscription.QuotaEntitlementsUntil == nil {
+		t.Fatal("expected subscription.quota_entitlements_until during grace")
+	}
+	if !resp.Subscription.QuotaEntitlementsUntil.Equal(future) {
+		t.Errorf("quota_entitlements_until mismatch: want %v got %v", future, resp.Subscription.QuotaEntitlementsUntil)
+	}
+	_ = ctx
 }
 
 func TestGetBillingPlan_PaidPlan(t *testing.T) {
@@ -848,9 +896,18 @@ func TestDowngrade_Success_NoStripe(t *testing.T) {
 	if sub.DowngradedAt == nil {
 		t.Error("expected downgraded_at to be set after downgrade")
 	}
+	if sub.StripeSubscriptionID != nil {
+		t.Error("expected stripe_subscription_id cleared after downgrade")
+	}
+	if sub.QuotaPlanID == nil || *sub.QuotaPlanID != db.PlanPayAsYouGo {
+		t.Errorf("expected quota_plan_id=pay_as_you_go, got %v", sub.QuotaPlanID)
+	}
+	if sub.QuotaEntitlementsUntil == nil {
+		t.Fatal("expected quota_entitlements_until set after downgrade")
+	}
 }
 
-func TestDowngrade_TooManyAgents(t *testing.T) {
+func TestDowngrade_WarnsWhenOverFreeAgentLimit(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -858,9 +915,7 @@ func TestDowngrade_TooManyAgents(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	// Create more registered agents than the free plan allows.
-	// Free plan limit is 5 agents (from seed data).
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 4; i++ {
 		testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
 	}
 
@@ -871,23 +926,20 @@ func TestDowngrade_TooManyAgents(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var errResp ErrorResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
-		t.Fatalf("failed to parse error response: %v", err)
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
 	}
-	if errResp.Error.Code != ErrDowngradeLimitExceeded {
-		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
-	}
-	if errResp.Error.Details["resource"] != "agents" {
-		t.Errorf("expected resource=agents, got %v", errResp.Error.Details["resource"])
+	if len(resp.Warnings) != 1 || resp.Warnings[0].Resource != "agents" {
+		t.Fatalf("expected one agents warning, got %+v", resp.Warnings)
 	}
 }
 
-func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
+func TestDowngrade_WarnsWhenOverFreeStandingApprovalLimit(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -897,8 +949,7 @@ func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
 
 	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
 
-	// Free plan limit is 10 active standing approvals (from seed data).
-	for i := 0; i < 11; i++ {
+	for i := 0; i < 6; i++ {
 		saID := testhelper.GenerateID(t, "sa_")
 		testhelper.InsertStandingApproval(t, tx, saID, agentID, uid)
 	}
@@ -910,23 +961,27 @@ func TestDowngrade_TooManyStandingApprovals(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var errResp ErrorResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
-		t.Fatalf("failed to parse error response: %v", err)
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
 	}
-	if errResp.Error.Code != ErrDowngradeLimitExceeded {
-		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	var found bool
+	for _, wn := range resp.Warnings {
+		if wn.Resource == "standing_approvals" {
+			found = true
+			break
+		}
 	}
-	if errResp.Error.Details["resource"] != "standing_approvals" {
-		t.Errorf("expected resource=standing_approvals, got %v", errResp.Error.Details["resource"])
+	if !found {
+		t.Fatalf("expected standing_approvals warning, got %+v", resp.Warnings)
 	}
 }
 
-func TestDowngrade_TooManyCredentials(t *testing.T) {
+func TestDowngrade_WarnsWhenOverFreeCredentialLimit(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -934,7 +989,6 @@ func TestDowngrade_TooManyCredentials(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
 
-	// Free plan limit is 5 credentials (from seed data).
 	for i := 0; i < 6; i++ {
 		credID := testhelper.GenerateID(t, "cred_")
 		service := testhelper.GenerateID(t, "svc_")
@@ -948,19 +1002,23 @@ func TestDowngrade_TooManyCredentials(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var errResp ErrorResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
-		t.Fatalf("failed to parse error response: %v", err)
+	var resp downgradeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
 	}
-	if errResp.Error.Code != ErrDowngradeLimitExceeded {
-		t.Errorf("expected error code %s, got %s", ErrDowngradeLimitExceeded, errResp.Error.Code)
+	var found bool
+	for _, wn := range resp.Warnings {
+		if wn.Resource == "credentials" {
+			found = true
+			break
+		}
 	}
-	if errResp.Error.Details["resource"] != "credentials" {
-		t.Errorf("expected resource=credentials, got %v", errResp.Error.Details["resource"])
+	if !found {
+		t.Fatalf("expected credentials warning, got %+v", resp.Warnings)
 	}
 }
 

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -219,7 +219,6 @@ func TestGetBillingPlan_QuotaGraceEffectiveLimits(t *testing.T) {
 	if !resp.Subscription.QuotaEntitlementsUntil.Equal(future) {
 		t.Errorf("quota_entitlements_until mismatch: want %v got %v", future, resp.Subscription.QuotaEntitlementsUntil)
 	}
-	_ = ctx
 }
 
 func TestGetBillingPlan_PaidPlan(t *testing.T) {

--- a/api/billing_webhook.go
+++ b/api/billing_webhook.go
@@ -286,15 +286,25 @@ func handleSubscriptionDeleted(r *http.Request, deps *Deps, event *pstripe.Webho
 	if cur != nil && cur.PlanID == db.PlanFreePro {
 		targetPlan = db.PlanFreePro
 	}
-	if _, err := db.UpdateSubscriptionPlan(r.Context(), tx, sub2.UserID, targetPlan); err != nil {
-		return fmt.Errorf("downgrade plan for %s: %w", sub2.UserID, err)
-	}
 	nextStatus := db.SubscriptionStatusCancelled
 	if targetPlan == db.PlanFreePro {
 		nextStatus = db.SubscriptionStatusActive
 	}
-	if _, err := db.UpdateSubscriptionStatus(r.Context(), tx, sub2.UserID, nextStatus); err != nil {
-		return fmt.Errorf("update status for %s: %w", sub2.UserID, err)
+	var quotaPlanID *string
+	var quotaUntil *time.Time
+	if targetPlan == db.PlanFree && cur != nil && cur.PlanID == db.PlanPayAsYouGo {
+		qp := db.PlanPayAsYouGo
+		quotaPlanID = &qp
+		if u, ok := pstripe.SubscriptionCurrentPeriodEndUnix(event.Raw.Data.Raw); ok {
+			t := time.Unix(u, 0)
+			quotaUntil = &t
+		} else {
+			pe := cur.CurrentPeriodEnd
+			quotaUntil = &pe
+		}
+	}
+	if _, err := db.ApplyStripeSubscriptionDeletedToFree(r.Context(), tx, sub2.UserID, targetPlan, nextStatus, quotaPlanID, quotaUntil); err != nil {
+		return fmt.Errorf("downgrade plan for %s: %w", sub2.UserID, err)
 	}
 	if owned {
 		if err := db.CommitTx(r.Context(), tx); err != nil {

--- a/api/billing_webhook_test.go
+++ b/api/billing_webhook_test.go
@@ -319,9 +319,11 @@ func TestWebhook_SubscriptionDeleted_DowngradesToFree(t *testing.T) {
 	ctx := context.Background()
 
 	subID := "sub_" + uid[:8]
+	periodEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC).Unix()
 	payload := stripeEventPayload(t, "evt_sub_deleted_1", "customer.subscription.deleted", map[string]interface{}{
-		"id":     subID,
-		"status": "canceled",
+		"id":                  subID,
+		"status":              "canceled",
+		"current_period_end":  periodEnd,
 	})
 
 	r := signedWebhookRequest(t, payload)
@@ -341,6 +343,15 @@ func TestWebhook_SubscriptionDeleted_DowngradesToFree(t *testing.T) {
 	}
 	if sub.Status != db.SubscriptionStatusCancelled {
 		t.Errorf("expected status=cancelled, got %s", sub.Status)
+	}
+	if sub.StripeSubscriptionID != nil {
+		t.Errorf("expected stripe_subscription_id cleared, got %v", *sub.StripeSubscriptionID)
+	}
+	if sub.QuotaPlanID == nil || *sub.QuotaPlanID != db.PlanPayAsYouGo {
+		t.Errorf("expected quota_plan_id=%s, got %v", db.PlanPayAsYouGo, sub.QuotaPlanID)
+	}
+	if sub.QuotaEntitlementsUntil == nil || !sub.QuotaEntitlementsUntil.Equal(time.Unix(periodEnd, 0)) {
+		t.Errorf("expected quota_entitlements_until=%v, got %v", time.Unix(periodEnd, 0), sub.QuotaEntitlementsUntil)
 	}
 }
 

--- a/api/plan_limits.go
+++ b/api/plan_limits.go
@@ -34,7 +34,8 @@ func checkResourceLimit(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return false // no subscription — bypass limits
 	}
 
-	limit := cfg.getLimit(&sp.Plan)
+	eff := sp.EffectiveQuotaPlan()
+	limit := cfg.getLimit(eff)
 	if limit == nil {
 		return false // unlimited plan
 	}
@@ -50,12 +51,12 @@ func checkResourceLimit(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	if count >= *limit {
 		resp := Forbidden(cfg.errorCode, fmt.Sprintf(
 			"%s plan allows up to %d %s. Upgrade your plan to add more.",
-			sp.Plan.Name, *limit, cfg.resourceName,
+			eff.Name, *limit, cfg.resourceName,
 		))
 		resp.Error.Details = map[string]any{
 			"current_count": count,
 			"limit":         *limit,
-			"plan_id":       sp.Plan.ID,
+			"plan_id":       eff.ID,
 		}
 		RespondError(w, r, http.StatusForbidden, resp)
 		return true
@@ -97,7 +98,8 @@ func checkRequestQuota(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		return r, false // no subscription — bypass limits
 	}
 
-	limit := sp.Plan.MaxRequestsPerMonth
+	eff := sp.EffectiveQuotaPlan()
+	limit := eff.MaxRequestsPerMonth
 	if limit == nil {
 		return r, false // unlimited plan (paid tier)
 	}
@@ -138,7 +140,7 @@ func checkRequestQuota(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		resp.Error.Details = map[string]any{
 			"current_usage": currentCount,
 			"limit":         *limit,
-			"plan_id":       sp.Plan.ID,
+			"plan_id":       eff.ID,
 			"reset_at":      resetAt,
 		}
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))

--- a/db/migrations/20260321215737_add_subscription_quota_grace_columns.sql
+++ b/db/migrations/20260321215737_add_subscription_quota_grace_columns.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+-- Quota grace after downgrade to free: paid plan limits apply until quota_entitlements_until.
+ALTER TABLE subscriptions
+    ADD COLUMN quota_plan_id text,
+    ADD COLUMN quota_entitlements_until timestamptz;
+
+ALTER TABLE subscriptions
+    ADD CONSTRAINT subscriptions_quota_grace_pair_chk CHECK (
+        (quota_plan_id IS NULL AND quota_entitlements_until IS NULL)
+        OR (quota_plan_id IS NOT NULL AND quota_entitlements_until IS NOT NULL)
+    );
+
+-- +goose Down
+
+ALTER TABLE subscriptions DROP CONSTRAINT IF EXISTS subscriptions_quota_grace_pair_chk;
+
+ALTER TABLE subscriptions
+    DROP COLUMN IF EXISTS quota_plan_id,
+    DROP COLUMN IF EXISTS quota_entitlements_until;

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -35,20 +35,22 @@ func IsValidSubscriptionStatus(s SubscriptionStatus) bool {
 // Each user has at most one subscription (enforced by UNIQUE on user_id).
 // Billing periods are aligned to calendar months (via date_trunc defaults).
 type Subscription struct {
-	ID                   string
-	UserID               string
-	PlanID               string
-	Status               SubscriptionStatus
-	StripeCustomerID     *string // nil for free-tier users (no Stripe setup)
-	StripeSubscriptionID *string // nil for free-tier users
-	CurrentPeriodStart   time.Time
-	CurrentPeriodEnd     time.Time
-	DowngradedAt         *time.Time // set when plan changes from paid to free; nil otherwise
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+	ID                     string
+	UserID                 string
+	PlanID                 string
+	Status                 SubscriptionStatus
+	StripeCustomerID       *string // nil for free-tier users (no Stripe setup)
+	StripeSubscriptionID   *string // nil for free-tier users
+	CurrentPeriodStart     time.Time
+	CurrentPeriodEnd       time.Time
+	DowngradedAt           *time.Time // set when plan changes from paid to free; nil otherwise
+	QuotaPlanID            *string    // plan whose quotas apply during post-downgrade grace; nil when not in quota grace
+	QuotaEntitlementsUntil *time.Time // paid quotas apply until this instant (exclusive convention matches billing period end)
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
 }
 
-const subscriptionColumns = `id, user_id, plan_id, status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end, downgraded_at, created_at, updated_at`
+const subscriptionColumns = `id, user_id, plan_id, status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end, downgraded_at, quota_plan_id, quota_entitlements_until, created_at, updated_at`
 
 func scanSubscription(row pgx.Row) (*Subscription, error) {
 	var s Subscription
@@ -62,6 +64,8 @@ func scanSubscription(row pgx.Row) (*Subscription, error) {
 		&s.CurrentPeriodStart,
 		&s.CurrentPeriodEnd,
 		&s.DowngradedAt,
+		&s.QuotaPlanID,
+		&s.QuotaEntitlementsUntil,
 		&s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -95,6 +99,9 @@ func CreateSubscription(ctx context.Context, db DBTX, userID, planID string) (*S
 // When downgrading (moving to a plan with shorter retention), sets downgraded_at
 // to trigger a grace period before the shorter retention window takes effect.
 // When upgrading, clears downgraded_at since the longer retention applies immediately.
+// When moving to a paid plan, clears quota grace columns.
+// For pay-as-you-go → free with paid quotas until period end, use
+// DowngradeSubscriptionToFreeWithQuotaGrace instead.
 func UpdateSubscriptionPlan(ctx context.Context, db DBTX, userID, planID string) (*Subscription, error) {
 	s, err := scanSubscription(db.QueryRow(ctx,
 		`UPDATE subscriptions
@@ -103,11 +110,79 @@ func UpdateSubscriptionPlan(ctx context.Context, db DBTX, userID, planID string)
 		         WHEN $2 != 'free' THEN NULL
 		         ELSE downgraded_at
 		     END,
+		     quota_plan_id = CASE WHEN $2 != 'free' THEN NULL ELSE quota_plan_id END,
+		     quota_entitlements_until = CASE WHEN $2 != 'free' THEN NULL ELSE quota_entitlements_until END,
 		     plan_id = $2,
 		     updated_at = now()
 		 WHERE user_id = $1
 		 RETURNING `+subscriptionColumns,
 		userID, planID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return s, err
+}
+
+// DowngradeSubscriptionToFreeWithQuotaGrace sets plan to free, records
+// downgraded_at, and snapshots paid quota entitlements until periodEnd.
+// paidPlanID must be the plan the user is leaving (e.g. PlanPayAsYouGo).
+func DowngradeSubscriptionToFreeWithQuotaGrace(ctx context.Context, db DBTX, userID, paidPlanID string, periodEnd time.Time) (*Subscription, error) {
+	s, err := scanSubscription(db.QueryRow(ctx,
+		`UPDATE subscriptions
+		 SET plan_id = 'free',
+		     downgraded_at = CASE WHEN plan_id != 'free' THEN now() ELSE downgraded_at END,
+		     quota_plan_id = $2,
+		     quota_entitlements_until = $3,
+		     updated_at = now()
+		 WHERE user_id = $1
+		 RETURNING `+subscriptionColumns,
+		userID, paidPlanID, periodEnd))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return s, err
+}
+
+// ApplyStripeSubscriptionDeletedToFree downgrades to free (or keeps free_pro),
+// syncs status, and ensures quota grace columns are set from Stripe's period
+// end when missing (idempotent with user-initiated downgrade).
+func ApplyStripeSubscriptionDeletedToFree(ctx context.Context, db DBTX, userID string, targetPlan string, nextStatus SubscriptionStatus, quotaPlanID *string, periodEnd *time.Time) (*Subscription, error) {
+	if quotaPlanID != nil && periodEnd != nil {
+		s, err := scanSubscription(db.QueryRow(ctx,
+			`UPDATE subscriptions
+			 SET plan_id = $2,
+			     status = $3,
+			     stripe_subscription_id = CASE WHEN $2 = 'free' THEN NULL ELSE stripe_subscription_id END,
+			     downgraded_at = CASE
+			             WHEN $2 = 'free' AND plan_id != 'free' THEN now()
+			             WHEN $2 = 'free' THEN downgraded_at
+			             ELSE NULL
+			         END,
+			     quota_plan_id = COALESCE(quota_plan_id, $4),
+			     quota_entitlements_until = COALESCE(quota_entitlements_until, $5),
+			     updated_at = now()
+			 WHERE user_id = $1
+			 RETURNING `+subscriptionColumns,
+			userID, targetPlan, nextStatus, *quotaPlanID, *periodEnd))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return s, err
+	}
+	s, err := scanSubscription(db.QueryRow(ctx,
+		`UPDATE subscriptions
+		 SET plan_id = $2,
+		     status = $3,
+		     stripe_subscription_id = CASE WHEN $2 = 'free' THEN NULL ELSE stripe_subscription_id END,
+		     downgraded_at = CASE
+		             WHEN $2 = 'free' AND plan_id != 'free' THEN now()
+		             WHEN $2 = 'free' THEN downgraded_at
+		             ELSE NULL
+		         END,
+		     updated_at = now()
+		 WHERE user_id = $1
+		 RETURNING `+subscriptionColumns,
+		userID, targetPlan, nextStatus))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -124,6 +199,8 @@ func UpgradeSubscriptionPlan(ctx context.Context, db DBTX, userID, expectedOldPl
 		`UPDATE subscriptions
 		 SET plan_id = $3,
 		     downgraded_at = NULL,
+		     quota_plan_id = NULL,
+		     quota_entitlements_until = NULL,
 		     updated_at = now()
 		 WHERE user_id = $1 AND plan_id = $2
 		 RETURNING `+subscriptionColumns,
@@ -311,6 +388,34 @@ func (sp *SubscriptionWithPlan) GracePeriodEndsAt() *time.Time {
 	return nil
 }
 
+// ClearExpiredSubscriptionQuotaGrace clears quota grace columns when the
+// entitlement window has ended (lazy expiration on read paths).
+func ClearExpiredSubscriptionQuotaGrace(ctx context.Context, db DBTX, userID string) error {
+	_, err := db.Exec(ctx,
+		`UPDATE subscriptions
+		 SET quota_plan_id = NULL,
+		     quota_entitlements_until = NULL,
+		     updated_at = now()
+		 WHERE user_id = $1
+		   AND quota_plan_id IS NOT NULL
+		   AND quota_entitlements_until IS NOT NULL
+		   AND quota_entitlements_until <= now()`,
+		userID)
+	return err
+}
+
+// EffectiveQuotaPlan returns the plan whose resource/request quotas should
+// apply. During an active quota grace period after downgrade, this is the
+// snapshotted paid plan; otherwise the current plan row.
+func (sp *SubscriptionWithPlan) EffectiveQuotaPlan() *Plan {
+	if sp.QuotaPlanID != nil && sp.QuotaEntitlementsUntil != nil && time.Now().Before(*sp.QuotaEntitlementsUntil) {
+		if p := GetPlan(*sp.QuotaPlanID); p != nil {
+			return p
+		}
+	}
+	return &sp.Plan
+}
+
 // GetSubscriptionWithPlan returns the user's subscription with plan details
 // attached from config (no DB join needed), or nil if the user has no subscription.
 func GetSubscriptionWithPlan(ctx context.Context, db DBTX, userID string) (*SubscriptionWithPlan, error) {
@@ -320,6 +425,18 @@ func GetSubscriptionWithPlan(ctx context.Context, db DBTX, userID string) (*Subs
 	}
 	if sub == nil {
 		return nil, nil
+	}
+	if sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil && !time.Now().Before(*sub.QuotaEntitlementsUntil) {
+		if err := ClearExpiredSubscriptionQuotaGrace(ctx, db, userID); err != nil {
+			return nil, err
+		}
+		sub, err = GetSubscriptionByUserID(ctx, db, userID)
+		if err != nil {
+			return nil, err
+		}
+		if sub == nil {
+			return nil, nil
+		}
 	}
 	plan := GetPlan(sub.PlanID)
 	if plan == nil {

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -131,8 +131,8 @@ func DowngradeSubscriptionToFreeWithQuotaGrace(ctx context.Context, db DBTX, use
 		`UPDATE subscriptions
 		 SET plan_id = 'free',
 		     downgraded_at = CASE WHEN plan_id != 'free' THEN now() ELSE downgraded_at END,
-		     quota_plan_id = $2,
-		     quota_entitlements_until = $3,
+		     quota_plan_id = COALESCE(quota_plan_id, $2),
+		     quota_entitlements_until = COALESCE(quota_entitlements_until, $3),
 		     updated_at = now()
 		 WHERE user_id = $1
 		 RETURNING `+subscriptionColumns,

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -147,27 +147,13 @@ func DowngradeSubscriptionToFreeWithQuotaGrace(ctx context.Context, db DBTX, use
 // syncs status, and ensures quota grace columns are set from Stripe's period
 // end when missing (idempotent with user-initiated downgrade).
 func ApplyStripeSubscriptionDeletedToFree(ctx context.Context, db DBTX, userID string, targetPlan string, nextStatus SubscriptionStatus, quotaPlanID *string, periodEnd *time.Time) (*Subscription, error) {
-	if quotaPlanID != nil && periodEnd != nil {
-		s, err := scanSubscription(db.QueryRow(ctx,
-			`UPDATE subscriptions
-			 SET plan_id = $2,
-			     status = $3,
-			     stripe_subscription_id = CASE WHEN $2 = 'free' THEN NULL ELSE stripe_subscription_id END,
-			     downgraded_at = CASE
-			             WHEN $2 = 'free' AND plan_id != 'free' THEN now()
-			             WHEN $2 = 'free' THEN downgraded_at
-			             ELSE NULL
-			         END,
-			     quota_plan_id = COALESCE(quota_plan_id, $4),
-			     quota_entitlements_until = COALESCE(quota_entitlements_until, $5),
-			     updated_at = now()
-			 WHERE user_id = $1
-			 RETURNING `+subscriptionColumns,
-			userID, targetPlan, nextStatus, *quotaPlanID, *periodEnd))
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil
-		}
-		return s, err
+	var qPlan any
+	if quotaPlanID != nil {
+		qPlan = *quotaPlanID
+	}
+	var qEnd any
+	if periodEnd != nil {
+		qEnd = *periodEnd
 	}
 	s, err := scanSubscription(db.QueryRow(ctx,
 		`UPDATE subscriptions
@@ -179,10 +165,18 @@ func ApplyStripeSubscriptionDeletedToFree(ctx context.Context, db DBTX, userID s
 		             WHEN $2 = 'free' THEN downgraded_at
 		             ELSE NULL
 		         END,
+		     quota_plan_id = CASE
+		             WHEN $4::text IS NOT NULL THEN COALESCE(quota_plan_id, $4::text)
+		             ELSE quota_plan_id
+		         END,
+		     quota_entitlements_until = CASE
+		             WHEN $5::timestamptz IS NOT NULL THEN COALESCE(quota_entitlements_until, $5::timestamptz)
+		             ELSE quota_entitlements_until
+		         END,
 		     updated_at = now()
 		 WHERE user_id = $1
 		 RETURNING `+subscriptionColumns,
-		userID, targetPlan, nextStatus))
+		userID, targetPlan, nextStatus, qPlan, qEnd))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}

--- a/db/subscriptions_test.go
+++ b/db/subscriptions_test.go
@@ -3,6 +3,7 @@ package db_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
@@ -15,7 +16,8 @@ func TestSubscriptionsSchema(t *testing.T) {
 		"id", "user_id", "plan_id", "status",
 		"stripe_customer_id", "stripe_subscription_id",
 		"current_period_start", "current_period_end",
-		"downgraded_at", "created_at", "updated_at",
+		"downgraded_at", "quota_plan_id", "quota_entitlements_until",
+		"created_at", "updated_at",
 	})
 }
 
@@ -247,6 +249,48 @@ func TestUpdateSubscriptionPeriod(t *testing.T) {
 	}
 	if !updated.CurrentPeriodEnd.Equal(newEnd) {
 		t.Errorf("expected period_end=%v, got %v", newEnd, updated.CurrentPeriodEnd)
+	}
+}
+
+func TestEffectiveQuotaPlan(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	_, err := db.CreateSubscription(ctx, tx, uid, db.PlanFree)
+	if err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	future := time.Now().Add(24 * time.Hour)
+	paid := db.PlanPayAsYouGo
+	testhelper.MustExec(t, tx,
+		`UPDATE subscriptions SET quota_plan_id = $2, quota_entitlements_until = $3 WHERE user_id = $1`,
+		uid, paid, future)
+
+	sp, err := db.GetSubscriptionWithPlan(ctx, tx, uid)
+	if err != nil {
+		t.Fatalf("GetSubscriptionWithPlan: %v", err)
+	}
+	if sp.EffectiveQuotaPlan().ID != db.PlanPayAsYouGo {
+		t.Errorf("expected effective quota plan pay_as_you_go, got %s", sp.EffectiveQuotaPlan().ID)
+	}
+
+	past := time.Now().Add(-time.Hour)
+	testhelper.MustExec(t, tx,
+		`UPDATE subscriptions SET quota_entitlements_until = $2 WHERE user_id = $1`,
+		uid, past)
+
+	sp2, err := db.GetSubscriptionWithPlan(ctx, tx, uid)
+	if err != nil {
+		t.Fatalf("GetSubscriptionWithPlan: %v", err)
+	}
+	if sp2.QuotaPlanID != nil || sp2.QuotaEntitlementsUntil != nil {
+		t.Fatal("expected quota columns cleared after expiry")
+	}
+	if sp2.EffectiveQuotaPlan().ID != db.PlanFree {
+		t.Errorf("expected effective quota plan free after expiry, got %s", sp2.EffectiveQuotaPlan().ID)
 	}
 }
 

--- a/frontend/src/hooks/__tests__/useResourceLimit.test.tsx
+++ b/frontend/src/hooks/__tests__/useResourceLimit.test.tsx
@@ -8,30 +8,40 @@ import { useResourceLimit } from "../useResourceLimit";
 vi.mock("../../lib/supabaseClient");
 vi.mock("../../api/client");
 
+const freePlanLimits = {
+  max_requests_per_month: 1000,
+  max_agents: 3,
+  max_standing_approvals: 5,
+  max_credentials: 5,
+  audit_retention_days: 7,
+};
+
 const freePlan = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 1000,
-    max_agents: 3,
-    max_standing_approvals: 5,
-    max_credentials: 5,
-    audit_retention_days: 7,
+    ...freePlanLimits,
   },
+  effective_limits: freePlanLimits,
   subscription: { status: "active" },
   usage: { requests: 10, agents: 2, standing_approvals: 4, credentials: 5 },
+};
+
+const paidPlanLimits = {
+  max_requests_per_month: null,
+  max_agents: null,
+  max_standing_approvals: null,
+  max_credentials: null,
+  audit_retention_days: 90,
 };
 
 const paidPlan = {
   plan: {
     id: "pay_as_you_go",
     name: "Pay as you go",
-    max_requests_per_month: null,
-    max_agents: null,
-    max_standing_approvals: null,
-    max_credentials: null,
-    audit_retention_days: 90,
+    ...paidPlanLimits,
   },
+  effective_limits: paidPlanLimits,
   subscription: { status: "active" },
   usage: { requests: 100, agents: 10, standing_approvals: 20, credentials: 15 },
 };

--- a/frontend/src/hooks/useBillingPlan.ts
+++ b/frontend/src/hooks/useBillingPlan.ts
@@ -6,6 +6,7 @@ import type { components } from "@/api/schema";
 
 export type BillingPlanResponse = components["schemas"]["BillingPlanResponse"];
 export type Plan = components["schemas"]["Plan"];
+export type PlanLimits = components["schemas"]["PlanLimits"];
 export type Subscription = components["schemas"]["Subscription"];
 export type UsageSummary = components["schemas"]["UsageSummary"];
 export type BillingPricing = components["schemas"]["BillingPricing"];

--- a/frontend/src/hooks/useResourceLimit.ts
+++ b/frontend/src/hooks/useResourceLimit.ts
@@ -33,10 +33,11 @@ export function useResourceLimit(
   const { billingPlan } = useBillingPlan();
 
   const usageKey = LIMIT_TO_USAGE[limitKey];
-  const max = billingPlan?.plan?.[limitKey] ?? null;
+  const max =
+    billingPlan?.effective_limits?.[limitKey] ?? billingPlan?.plan?.[limitKey] ?? null;
   const current = billingPlan?.usage?.[usageKey] ?? fallbackCount;
   const atLimit = max != null && current >= max;
-  const hasData = billingPlan?.plan != null;
+  const hasData = billingPlan?.plan != null && billingPlan?.effective_limits != null;
 
   return { max, current, atLimit, hasData };
 }

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -107,16 +107,19 @@ export function BillingPage() {
         <>
           <PlanCard
             plan={billingPlan.plan}
+            effectiveLimits={billingPlan.effective_limits}
             subscription={billingPlan.subscription}
             pricing={billingPlan.pricing}
           />
           <UsageSummaryCard
             usage={billingPlan.usage}
             plan={billingPlan.plan}
+            effectiveLimits={billingPlan.effective_limits}
             pricing={billingPlan.pricing}
           />
           <UsageDashboard
             plan={billingPlan.plan}
+            effectiveLimits={billingPlan.effective_limits}
             subscription={billingPlan.subscription}
             pricing={billingPlan.pricing}
           />

--- a/frontend/src/pages/billing/DowngradeConfirmDialog.tsx
+++ b/frontend/src/pages/billing/DowngradeConfirmDialog.tsx
@@ -20,6 +20,8 @@ interface DowngradeConfirmDialogProps {
   isPending: boolean;
   error: string | null;
   usage: UsageSummary | null;
+  /** When free-tier resource caps start applying after downgrade (end of current billing period). */
+  freeLimitsApplyDate: string;
 }
 
 interface LimitWarning {
@@ -67,6 +69,7 @@ export function DowngradeConfirmDialog({
   isPending,
   error,
   usage,
+  freeLimitsApplyDate,
 }: DowngradeConfirmDialogProps) {
   const warnings = buildLimitWarnings(usage);
   const hasWarnings = warnings.length > 0;
@@ -94,7 +97,7 @@ export function DowngradeConfirmDialog({
               <ul className="ml-6 space-y-1.5">
                 {warnings.map((w) => (
                   <li key={w.resource} className="text-sm text-amber-800 dark:text-amber-200">
-                    You have {w.current} {w.resource}. Free tier allows {w.limit}.{" "}
+                    You have {w.current} {w.resource}. Free tier allows {w.limit} after {freeLimitsApplyDate}.{" "}
                     <Link
                       to={w.managePath}
                       className="underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
@@ -110,18 +113,22 @@ export function DowngradeConfirmDialog({
           <div className="rounded-lg border p-4 space-y-1">
             <p className="text-sm font-medium">What changes</p>
             <ul className="space-y-1 text-sm text-muted-foreground">
-              <li>Audit retention drops from {paidPlan.audit_retention_days} days to {freePlan.audit_retention_days} days</li>
               <li>
-                Resource limits will be enforced ({FREE_PLAN_LIMITS.agents.limit} agents,{" "}
-                {FREE_PLAN_LIMITS.standing_approvals.limit} approvals,{" "}
-                {FREE_PLAN_LIMITS.credentials.limit} credentials)
+                Until {freeLimitsApplyDate}, paid-plan usage limits still apply (unlimited requests and resources on
+                your current plan).
               </li>
-              <li>{formatLimit(freePlan.max_requests_per_month)} request/month limit</li>
+              <li>
+                After {freeLimitsApplyDate}, free tier caps apply to new usage ({FREE_PLAN_LIMITS.agents.limit}{" "}
+                agents, {FREE_PLAN_LIMITS.standing_approvals.limit} approvals,{" "}
+                {FREE_PLAN_LIMITS.credentials.limit} credentials, {formatLimit(freePlan.max_requests_per_month)}{" "}
+                requests/month). Existing resources are kept; reduce them before adding new ones if you are over the cap.
+              </li>
+              <li>
+                A separate 7-day window after downgrade keeps extended audit log retention ({paidPlan.audit_retention_days}{" "}
+                days) so you can export older activity before it matches the free plan ({freePlan.audit_retention_days}{" "}
+                days).
+              </li>
             </ul>
-            <p className="mt-2 text-xs text-muted-foreground">
-              A 7-day grace period preserves your {paidPlan.audit_retention_days}-day audit retention so you
-              can export data before it reverts.
-            </p>
           </div>
 
           {error && (
@@ -140,7 +147,7 @@ export function DowngradeConfirmDialog({
           <Button
             variant="destructive"
             onClick={onConfirm}
-            disabled={isPending || hasWarnings}
+            disabled={isPending}
           >
             {isPending && <Loader2 className="animate-spin" aria-hidden="true" />}
             Confirm Downgrade

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -7,12 +7,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { BillingPricing, Plan, Subscription } from "@/hooks/useBillingPlan";
+import type { BillingPricing, Plan, PlanLimits, Subscription } from "@/hooks/useBillingPlan";
 import { DetailRow } from "./DetailRow";
 import { formatDate } from "./formatters";
 
 interface PlanCardProps {
   plan: Plan;
+  effectiveLimits: PlanLimits;
   subscription: Subscription;
   pricing?: BillingPricing;
 }
@@ -27,7 +28,7 @@ function StatusBadge({ status }: { status: Subscription["status"] }) {
   return <Badge variant="secondary">Cancelled</Badge>;
 }
 
-export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
+export function PlanCard({ plan, effectiveLimits, subscription, pricing }: PlanCardProps) {
   const isFree = plan.id === "free";
   const isFreePro = plan.id === "free_pro";
 
@@ -78,11 +79,19 @@ export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
               Your payment method failed. Please update it to avoid service interruption.
             </p>
           )}
+          {subscription.quota_entitlements_until && (
+            <p className="text-amber-700 dark:text-amber-300 text-xs">
+              Paid-plan usage limits (requests, agents, approvals, credentials) stay in
+              effect until {formatDate(subscription.quota_entitlements_until)}. After that,
+              free plan limits apply to new usage; existing resources are not removed.
+            </p>
+          )}
           {subscription.grace_period_ends_at && (
             <p className="text-amber-700 dark:text-amber-300 text-xs">
-              Your paid plan features are preserved until{" "}
-              {formatDate(subscription.grace_period_ends_at)}. After that,
-              your account will revert to free plan limits.
+              Extended audit log retention stays available until{" "}
+              {formatDate(subscription.grace_period_ends_at)} so you can export older
+              activity. After that, retention matches the free plan ({effectiveLimits.audit_retention_days}{" "}
+              days).
             </p>
           )}
         </div>

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -90,7 +90,7 @@ export function PlanCard({ plan, effectiveLimits, subscription, pricing }: PlanC
             <p className="text-amber-700 dark:text-amber-300 text-xs">
               Extended audit log retention stays available until{" "}
               {formatDate(subscription.grace_period_ends_at)} so you can export older
-              activity. After that, retention matches the free plan ({effectiveLimits.audit_retention_days}{" "}
+              activity. After that, retention matches the free plan ({plan.audit_retention_days}{" "}
               days).
             </p>
           )}

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -125,9 +125,10 @@ function InvoicesList() {
 
 interface DowngradeSectionProps {
   usage: UsageSummary;
+  subscription: Subscription;
 }
 
-function DowngradeSection({ usage }: DowngradeSectionProps) {
+function DowngradeSection({ usage, subscription }: DowngradeSectionProps) {
   const { downgrade, isDowngrading } = useDowngradePlan();
   const [showConfirm, setShowConfirm] = useState(false);
   const [downgradeError, setDowngradeError] = useState<string | null>(null);
@@ -137,10 +138,13 @@ function DowngradeSection({ usage }: DowngradeSectionProps) {
     try {
       const result = await downgrade();
       setShowConfirm(false);
-      const graceMsg = result?.grace_period_ends_at
-        ? ` Your paid features remain active until ${formatDate(result.grace_period_ends_at)}.`
+      const quotaMsg = result?.quota_entitlements_until
+        ? ` Paid-plan limits apply until ${formatDate(result.quota_entitlements_until)}.`
         : "";
-      toast.success(`Your plan has been downgraded to Free.${graceMsg}`);
+      const retentionMsg = result?.grace_period_ends_at
+        ? ` Extended audit retention until ${formatDate(result.grace_period_ends_at)}.`
+        : "";
+      toast.success(`Your plan has been downgraded to Free.${quotaMsg}${retentionMsg}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to downgrade. Please try again.";
       setDowngradeError(message);
@@ -166,6 +170,7 @@ function DowngradeSection({ usage }: DowngradeSectionProps) {
         isPending={isDowngrading}
         error={downgradeError}
         usage={usage}
+        freeLimitsApplyDate={formatDate(subscription.current_period_end)}
       />
     </>
   );
@@ -199,7 +204,7 @@ export function PlanDetailsCard({ subscription, usage }: PlanDetailsCardProps) {
 
           {subscription.can_downgrade && (
             <div className="border-t pt-4">
-              <DowngradeSection usage={usage} />
+              <DowngradeSection usage={usage} subscription={subscription} />
             </div>
           )}
         </div>

--- a/frontend/src/pages/billing/UsageDashboard.tsx
+++ b/frontend/src/pages/billing/UsageDashboard.tsx
@@ -7,13 +7,14 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
-import type { BillingPricing, Plan, Subscription } from "@/hooks/useBillingPlan";
+import type { BillingPricing, Plan, PlanLimits, Subscription } from "@/hooks/useBillingPlan";
 import { formatCents, formatDate } from "./formatters";
 import { RequestUsageBar } from "./RequestUsageBar";
 import { AgentBreakdownTable } from "./AgentBreakdownTable";
 
 interface UsageDashboardProps {
   plan: Plan;
+  effectiveLimits: PlanLimits;
   subscription: Subscription;
   pricing?: BillingPricing;
 }
@@ -25,9 +26,10 @@ function daysRemaining(periodEnd: string): number {
   return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
 }
 
-export function UsageDashboard({ plan, subscription, pricing }: UsageDashboardProps) {
+export function UsageDashboard({ plan, effectiveLimits, subscription, pricing }: UsageDashboardProps) {
   const { usage, isLoading, error } = useBillingUsage();
-  const isFree = plan.id === "free" || plan.id === "free_pro";
+  const showPaidUsageDetails =
+    effectiveLimits.max_requests_per_month == null && plan.id !== "free_pro";
   const days = daysRemaining(subscription.current_period_end);
   const periodLabel = `${formatDate(subscription.current_period_start)} — ${formatDate(subscription.current_period_end)}`;
 
@@ -86,7 +88,7 @@ export function UsageDashboard({ plan, subscription, pricing }: UsageDashboardPr
           <div className="space-y-4">
             <RequestUsageBar
               total={usage.requests.total}
-              limit={plan.max_requests_per_month ?? null}
+              limit={effectiveLimits.max_requests_per_month ?? null}
               included={usage.requests.included}
               priceDisplay={pricing?.price_per_request_display}
             />
@@ -100,16 +102,16 @@ export function UsageDashboard({ plan, subscription, pricing }: UsageDashboardPr
                 <p className="text-lg font-semibold tabular-nums">{days}</p>
               </div>
 
-              {isFree ? (
+              {!showPaidUsageDetails ? (
                 <div className="rounded-lg border p-3 space-y-1">
                   <p className="text-xs text-muted-foreground">
                     Requests remaining
                   </p>
                   <p className="text-lg font-semibold tabular-nums">
-                    {plan.max_requests_per_month != null
+                    {effectiveLimits.max_requests_per_month != null
                       ? Math.max(
                           0,
-                          plan.max_requests_per_month - usage.requests.total,
+                          effectiveLimits.max_requests_per_month - usage.requests.total,
                         ).toLocaleString()
                       : "—"}
                   </p>
@@ -132,7 +134,7 @@ export function UsageDashboard({ plan, subscription, pricing }: UsageDashboardPr
             </div>
 
             {/* Overage notice for free tier */}
-            {isFree && usage.requests.overage > 0 && (
+            {!showPaidUsageDetails && usage.requests.overage > 0 && plan.id !== "free_pro" && (
               <p className="text-sm text-destructive">
                 You have exceeded your monthly limit by{" "}
                 {usage.requests.overage.toLocaleString()} requests. Upgrade to
@@ -148,14 +150,14 @@ export function UsageDashboard({ plan, subscription, pricing }: UsageDashboardPr
               <AgentBreakdownTable
                 byAgent={byAgent}
                 totalRequests={usage.requests.total}
-                showCost={!isFree}
+                showCost={showPaidUsageDetails}
                 costCents={totalCostCents}
               />
             </div>
           )}
 
           {/* SMS usage (paid tier only) */}
-          {!isFree && usage.sms.total > 0 && (
+          {showPaidUsageDetails && usage.sms.total > 0 && (
             <div className="space-y-2">
               <h3 className="flex items-center gap-1.5 text-sm font-medium">
                 <MessageSquare className="size-4" />

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -6,7 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { BillingPricing, Plan, UsageSummary } from "@/hooks/useBillingPlan";
+import type { BillingPricing, Plan, PlanLimits, UsageSummary } from "@/hooks/useBillingPlan";
 import { useBillingUsage } from "@/hooks/useBillingUsage";
 import { FREE_REQUEST_ALLOWANCE, PRICE_PER_REQUEST } from "./constants";
 import { DetailRow } from "./DetailRow";
@@ -14,6 +14,7 @@ import { DetailRow } from "./DetailRow";
 interface UsageSummaryCardProps {
   usage: UsageSummary;
   plan: Plan;
+  effectiveLimits: PlanLimits;
   pricing?: BillingPricing;
 }
 
@@ -93,8 +94,9 @@ function PaidRequestRow({ current, included, priceDisplay }: { current: number; 
   );
 }
 
-export function UsageSummaryCard({ usage, plan, pricing }: UsageSummaryCardProps) {
-  const isPaid = plan.id !== "free" && plan.id !== "free_pro";
+export function UsageSummaryCard({ usage, plan, effectiveLimits, pricing }: UsageSummaryCardProps) {
+  const showPaidRequestRow =
+    plan.id !== "free_pro" && effectiveLimits.max_requests_per_month == null;
   const { usage: usageDetail } = useBillingUsage();
   // Use server-provided included value, fall back to config constant.
   const included = usageDetail?.requests.included ?? FREE_REQUEST_ALLOWANCE;
@@ -113,32 +115,32 @@ export function UsageSummaryCard({ usage, plan, pricing }: UsageSummaryCardProps
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          {isPaid ? (
+          {showPaidRequestRow ? (
             <PaidRequestRow current={usage.requests} included={included} priceDisplay={priceDisplay} />
           ) : (
             <UsageRow
               label="Requests"
               current={usage.requests}
-              limit={plan.max_requests_per_month ?? null}
+              limit={effectiveLimits.max_requests_per_month ?? null}
             />
           )}
           <UsageRow
             label="Agents"
             current={usage.agents}
-            limit={plan.max_agents ?? null}
+            limit={effectiveLimits.max_agents ?? null}
           />
           <UsageRow
             label="Standing Approvals"
             current={usage.standing_approvals}
-            limit={plan.max_standing_approvals ?? null}
+            limit={effectiveLimits.max_standing_approvals ?? null}
           />
           <UsageRow
             label="Credentials"
             current={usage.credentials}
-            limit={plan.max_credentials ?? null}
+            limit={effectiveLimits.max_credentials ?? null}
           />
           <DetailRow label="Audit Retention">
-            <span className="text-muted-foreground">{plan.audit_retention_days} days</span>
+            <span className="text-muted-foreground">{effectiveLimits.audit_retention_days} days</span>
           </DetailRow>
         </div>
       </CardContent>

--- a/frontend/src/pages/billing/UsageSummaryCard.tsx
+++ b/frontend/src/pages/billing/UsageSummaryCard.tsx
@@ -140,7 +140,7 @@ export function UsageSummaryCard({ usage, plan, effectiveLimits, pricing }: Usag
             limit={effectiveLimits.max_credentials ?? null}
           />
           <DetailRow label="Audit Retention">
-            <span className="text-muted-foreground">{effectiveLimits.audit_retention_days} days</span>
+            <span className="text-muted-foreground">{plan.audit_retention_days} days</span>
           </DetailRow>
         </div>
       </CardContent>

--- a/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -294,7 +294,7 @@ describe("BillingPage", () => {
       });
       // Paid plan shows requests against the 1000 free allowance with billed count
       expect(screen.getByText(/billed/)).toBeInTheDocument();
-      expect(screen.getByText(/\$0.005\/request/)).toBeInTheDocument();
+      expect(screen.getAllByText(/\$0.005\/request/).length).toBeGreaterThanOrEqual(1);
     });
 
     it("does not show upgrade CTA for paid plan", async () => {
@@ -368,8 +368,8 @@ describe("BillingPage", () => {
       expect(screen.getByText(/You have 25 standing approvals/)).toBeInTheDocument();
       expect(screen.getByText(/You have 20 credentials/)).toBeInTheDocument();
 
-      // Confirm button should be disabled when over limits
-      expect(screen.getByRole("button", { name: "Confirm Downgrade" })).toBeDisabled();
+      // Over-limit is a warning only — user can still confirm downgrade.
+      expect(screen.getByRole("button", { name: "Confirm Downgrade" })).toBeEnabled();
 
       // Should show "Manage" links for each over-limit resource
       expect(screen.getByText("Manage agents")).toBeInTheDocument();
@@ -400,7 +400,7 @@ describe("BillingPage", () => {
       mockBillingApi(atLimitPaidPlanResponse);
       mockPost.mockResolvedValue({
         data: undefined,
-        error: { error: { code: "downgrade_limit_exceeded", message: "Too many active agents" } },
+        error: { error: { code: "upstream_error", message: "Failed to cancel subscription with payment provider" } },
       });
 
       const user = userEvent.setup();
@@ -418,7 +418,9 @@ describe("BillingPage", () => {
       await user.click(screen.getByRole("button", { name: "Confirm Downgrade" }));
 
       await waitFor(() => {
-        expect(screen.getByText("Too many active agents")).toBeInTheDocument();
+        expect(
+          screen.getByText(/Failed to cancel subscription with payment provider/),
+        ).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/pages/billing/__tests__/fixtures.ts
+++ b/frontend/src/pages/billing/__tests__/fixtures.ts
@@ -5,16 +5,21 @@
  * test files don't duplicate boilerplate.
  */
 
+const freePlanLimits = {
+  max_requests_per_month: 1000,
+  max_agents: 3,
+  max_standing_approvals: 5,
+  max_credentials: 5,
+  audit_retention_days: 7,
+};
+
 export const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 1000,
-    max_agents: 3,
-    max_standing_approvals: 5,
-    max_credentials: 5,
-    audit_retention_days: 7,
+    ...freePlanLimits,
   },
+  effective_limits: freePlanLimits,
   subscription: {
     status: "active" as const,
     current_period_start: "2026-03-01T00:00:00Z",
@@ -23,6 +28,7 @@ export const freePlanResponse = {
     can_upgrade: true,
     can_downgrade: false,
     grace_period_ends_at: null,
+    quota_entitlements_until: null,
   },
   usage: {
     requests: 150,
@@ -30,18 +36,28 @@ export const freePlanResponse = {
     standing_approvals: 3,
     credentials: 1,
   },
+  pricing: {
+    free_request_allowance: 1000,
+    price_per_request_display: "$0.005",
+  },
+  coupon_redemption_enabled: false,
+};
+
+const paidPlanLimits = {
+  max_requests_per_month: null as number | null,
+  max_agents: null as number | null,
+  max_standing_approvals: null as number | null,
+  max_credentials: null as number | null,
+  audit_retention_days: 90,
 };
 
 export const paidPlanResponse = {
   plan: {
     id: "pay_as_you_go",
     name: "Pay As You Go",
-    max_requests_per_month: null,
-    max_agents: null,
-    max_standing_approvals: null,
-    max_credentials: null,
-    audit_retention_days: 90,
+    ...paidPlanLimits,
   },
+  effective_limits: paidPlanLimits,
   subscription: {
     status: "active" as const,
     current_period_start: "2026-03-01T00:00:00Z",
@@ -50,6 +66,7 @@ export const paidPlanResponse = {
     can_upgrade: false,
     can_downgrade: true,
     grace_period_ends_at: null,
+    quota_entitlements_until: null,
   },
   usage: {
     requests: 1542,
@@ -57,6 +74,11 @@ export const paidPlanResponse = {
     standing_approvals: 10,
     credentials: 8,
   },
+  pricing: {
+    free_request_allowance: 1000,
+    price_per_request_display: "$0.005",
+  },
+  coupon_redemption_enabled: false,
 };
 
 /** Paid plan where usage exceeds all free plan limits. */

--- a/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
@@ -31,18 +31,31 @@ const mockAgentsResponse = {
 
 const emptyResponse = { data: [], has_more: false };
 
+const freePlanLimits = {
+  max_requests_per_month: 1000 as number | null,
+  max_agents: 3 as number | null,
+  max_standing_approvals: 5 as number | null,
+  max_credentials: 5 as number | null,
+  audit_retention_days: 7,
+};
+
 const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 1000 as number | null,
-    max_agents: 3 as number | null,
-    max_standing_approvals: 5 as number | null,
-    max_credentials: 5 as number | null,
-    audit_retention_days: 7,
+    ...freePlanLimits,
   },
+  effective_limits: freePlanLimits,
   subscription: { status: "active", can_upgrade: true, can_downgrade: false },
   usage: { requests: 10, agents: 2, standing_approvals: 1, credentials: 0 },
+};
+
+const paidEffectiveLimits = {
+  max_requests_per_month: null as number | null,
+  max_agents: null as number | null,
+  max_standing_approvals: null as number | null,
+  max_credentials: null as number | null,
+  audit_retention_days: 90,
 };
 
 function mockAgentsFetch(response = mockAgentsResponse, billingPlan = freePlanResponse) {
@@ -408,6 +421,7 @@ describe("RegisteredAgentsCard", () => {
   it("shows no limit badge for paid plan", async () => {
     const paidPlan = {
       plan: { ...freePlanResponse.plan, id: "pay_as_you_go", max_agents: null },
+      effective_limits: paidEffectiveLimits,
       subscription: { status: "active", can_upgrade: false, can_downgrade: true },
       usage: { requests: 10, agents: 5, standing_approvals: 1, credentials: 0 },
     };

--- a/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
@@ -44,18 +44,31 @@ const mockActionConfigs = [
   },
 ];
 
+const freePlanLimits = {
+  max_requests_per_month: 1000 as number | null,
+  max_agents: 3 as number | null,
+  max_standing_approvals: 5 as number | null,
+  max_credentials: 5 as number | null,
+  audit_retention_days: 7,
+};
+
 const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 1000 as number | null,
-    max_agents: 3 as number | null,
-    max_standing_approvals: 5 as number | null,
-    max_credentials: 5 as number | null,
-    audit_retention_days: 7,
+    ...freePlanLimits,
   },
+  effective_limits: freePlanLimits,
   subscription: { status: "active", can_upgrade: true, can_downgrade: false },
   usage: { requests: 10, agents: 2, standing_approvals: 1, credentials: 0 },
+};
+
+const paidEffectiveLimits = {
+  max_requests_per_month: null as number | null,
+  max_agents: null as number | null,
+  max_standing_approvals: null as number | null,
+  max_credentials: null as number | null,
+  audit_retention_days: 90,
 };
 
 function mockApiFetch(
@@ -121,6 +134,7 @@ describe("StandingApprovalsCard", () => {
     const paidPlan = {
       ...freePlanResponse,
       plan: { ...freePlanResponse.plan, id: "pay_as_you_go", max_standing_approvals: null },
+      effective_limits: paidEffectiveLimits,
       usage: { ...freePlanResponse.usage, standing_approvals: 10 },
     };
     mockApiFetch(mockStandingApprovals, paidPlan);

--- a/frontend/src/pages/settings/BillingSettingsPage.tsx
+++ b/frontend/src/pages/settings/BillingSettingsPage.tsx
@@ -103,16 +103,19 @@ export function BillingSettingsPage() {
         <>
           <PlanCard
             plan={billingPlan.plan}
+            effectiveLimits={billingPlan.effective_limits}
             subscription={billingPlan.subscription}
             pricing={billingPlan.pricing}
           />
           <UsageSummaryCard
             usage={billingPlan.usage}
             plan={billingPlan.plan}
+            effectiveLimits={billingPlan.effective_limits}
             pricing={billingPlan.pricing}
           />
           <UsageDashboard
             plan={billingPlan.plan}
+            effectiveLimits={billingPlan.effective_limits}
             subscription={billingPlan.subscription}
             pricing={billingPlan.pricing}
           />

--- a/frontend/src/pages/settings/__tests__/CredentialSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/CredentialSection.test.tsx
@@ -13,16 +13,21 @@ import { CredentialSection } from "../CredentialSection";
 vi.mock("../../../lib/supabaseClient");
 vi.mock("../../../api/client");
 
+const freePlanLimits = {
+  max_requests_per_month: 1000,
+  max_agents: 3,
+  max_standing_approvals: 5,
+  max_credentials: 5,
+  audit_retention_days: 7,
+};
+
 const freePlanResponse = {
   plan: {
     id: "free",
     name: "Free",
-    max_requests_per_month: 1000,
-    max_agents: 3,
-    max_standing_approvals: 5,
-    max_credentials: 5,
-    audit_retention_days: 7,
+    ...freePlanLimits,
   },
+  effective_limits: freePlanLimits,
   subscription: { status: "active", can_upgrade: true, can_downgrade: false },
   usage: { requests: 10, agents: 2, standing_approvals: 1, credentials: 0 },
 };

--- a/spec/openapi/components/schemas/billing.yaml
+++ b/spec/openapi/components/schemas/billing.yaml
@@ -9,6 +9,7 @@ SubscriptionResponse:
     - has_payment_method
     - can_upgrade
     - plan_limits
+    - effective_limits
   properties:
     plan_id:
       type: string
@@ -41,6 +42,11 @@ SubscriptionResponse:
       example: true
     plan_limits:
       $ref: '#/PlanLimits'
+    effective_limits:
+      $ref: '#/PlanLimits'
+      description: |
+        Resource and request limits currently enforced (may match a paid plan during
+        quota grace after downgrade while `plan_id` is already `free`).
     usage:
       $ref: '#/UsageInfo'
 
@@ -347,10 +353,18 @@ Subscription:
       format: date-time
       nullable: true
       description: |
-        When the downgrade grace period expires, or null if no grace period is active.
-        During the grace period (7 days after downgrade), the user retains the longer
-        audit retention window (90 days) to export their data. After this timestamp,
-        retention drops to the free plan's window (7 days).
+        When the 7-day audit retention grace period expires after downgrade, or null
+        if not active. During this window the user keeps the longer paid-plan audit
+        retention (e.g. 90 days) to export data; afterward retention matches the
+        free plan. This is separate from quota entitlements (`quota_entitlements_until`).
+    quota_entitlements_until:
+      type: string
+      format: date-time
+      nullable: true
+      description: |
+        When paid-plan quotas stop applying after a downgrade to free, or null if not
+        in quota grace. Until this instant, API enforcement uses the snapshotted paid
+        plan limits even though `plan_id` is `free`.
 
 UsageSummary:
   type: object
@@ -386,6 +400,7 @@ BillingPlanResponse:
     prompts, and gate features like SMS notifications.
   required:
     - plan
+    - effective_limits
     - subscription
     - usage
     - pricing
@@ -393,6 +408,12 @@ BillingPlanResponse:
   properties:
     plan:
       $ref: '#/Plan'
+    effective_limits:
+      $ref: '#/PlanLimits'
+      description: |
+        Limits currently enforced for quotas and resource caps. During quota grace
+        after downgrade, this reflects the previous paid plan while `plan` reflects
+        the billing plan (`free`).
     subscription:
       $ref: '#/Subscription'
     usage:
@@ -596,6 +617,26 @@ ActivateResponse:
         - `pending`: Checkout session is not yet complete (payment still processing).
       example: activated
 
+DowngradeLimitWarning:
+  type: object
+  required:
+    - resource
+    - current
+    - max_allowed
+  properties:
+    resource:
+      type: string
+      description: Resource type over the free-tier cap (e.g. agents, credentials)
+      example: agents
+    current:
+      type: integer
+      description: Current count for that resource
+      example: 5
+    max_allowed:
+      type: integer
+      description: Maximum allowed on the free plan (applies after quota grace ends)
+      example: 3
+
 DowngradeResponse:
   type: object
   required:
@@ -621,9 +662,22 @@ DowngradeResponse:
       type: string
       format: date-time
       description: |
-        When the 7-day grace period expires. Until this time, the user retains
-        the 90-day audit retention window from their paid plan. Show this to the
-        user so they know how long they have to export their data.
+        When the 7-day audit retention grace period expires. Until this time, the user
+        retains the longer paid-plan audit retention window to export data.
+    quota_entitlements_until:
+      type: string
+      format: date-time
+      nullable: true
+      description: |
+        When paid-plan resource and request quotas stop applying. Until then, limits
+        match the previous paid plan even though the billing plan is now free.
+    warnings:
+      type: array
+      items:
+        $ref: '#/DowngradeLimitWarning'
+      description: |
+        Non-blocking notices when the user exceeds free-tier caps; those limits apply
+        after `quota_entitlements_until`.
 
 Invoice:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -9963,6 +9963,7 @@ components:
         - has_payment_method
         - can_upgrade
         - plan_limits
+        - effective_limits
       properties:
         plan_id:
           type: string
@@ -9998,6 +9999,11 @@ components:
           example: true
         plan_limits:
           $ref: '#/components/schemas/PlanLimits'
+        effective_limits:
+          $ref: '#/components/schemas/PlanLimits'
+          description: |
+            Resource and request limits currently enforced (may match a paid plan during
+            quota grace after downgrade while `plan_id` is already `free`).
         usage:
           $ref: '#/components/schemas/UsageInfo'
     UsageInfo:
@@ -10219,10 +10225,18 @@ components:
           format: date-time
           nullable: true
           description: |
-            When the downgrade grace period expires, or null if no grace period is active.
-            During the grace period (7 days after downgrade), the user retains the longer
-            audit retention window (90 days) to export their data. After this timestamp,
-            retention drops to the free plan's window (7 days).
+            When the 7-day audit retention grace period expires after downgrade, or null
+            if not active. During this window the user keeps the longer paid-plan audit
+            retention (e.g. 90 days) to export data; afterward retention matches the
+            free plan. This is separate from quota entitlements (`quota_entitlements_until`).
+        quota_entitlements_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When paid-plan quotas stop applying after a downgrade to free, or null if not
+            in quota grace. Until this instant, API enforcement uses the snapshotted paid
+            plan limits even though `plan_id` is `free`.
     UsageSummary:
       type: object
       required:
@@ -10256,6 +10270,7 @@ components:
         prompts, and gate features like SMS notifications.
       required:
         - plan
+        - effective_limits
         - subscription
         - usage
         - pricing
@@ -10263,6 +10278,12 @@ components:
       properties:
         plan:
           $ref: '#/components/schemas/Plan'
+        effective_limits:
+          $ref: '#/components/schemas/PlanLimits'
+          description: |
+            Limits currently enforced for quotas and resource caps. During quota grace
+            after downgrade, this reflects the previous paid plan while `plan` reflects
+            the billing plan (`free`).
         subscription:
           $ref: '#/components/schemas/Subscription'
         usage:
@@ -11637,6 +11658,25 @@ components:
           type: integer
           description: Number of days audit logs are retained
           example: 7
+    DowngradeLimitWarning:
+      type: object
+      required:
+        - resource
+        - current
+        - max_allowed
+      properties:
+        resource:
+          type: string
+          description: Resource type over the free-tier cap (e.g. agents, credentials)
+          example: agents
+        current:
+          type: integer
+          description: Current count for that resource
+          example: 5
+        max_allowed:
+          type: integer
+          description: Maximum allowed on the free plan (applies after quota grace ends)
+          example: 3
     DowngradeResponse:
       type: object
       required:
@@ -11665,9 +11705,22 @@ components:
           type: string
           format: date-time
           description: |
-            When the 7-day grace period expires. Until this time, the user retains
-            the 90-day audit retention window from their paid plan. Show this to the
-            user so they know how long they have to export their data.
+            When the 7-day audit retention grace period expires. Until this time, the user
+            retains the longer paid-plan audit retention window to export data.
+        quota_entitlements_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When paid-plan resource and request quotas stop applying. Until then, limits
+            match the previous paid plan even though the billing plan is now free.
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/DowngradeLimitWarning'
+          description: |
+            Non-blocking notices when the user exceeds free-tier caps; those limits apply
+            after `quota_entitlements_until`.
     InvoiceListResponse:
       type: object
       required:

--- a/stripe/webhook.go
+++ b/stripe/webhook.go
@@ -76,6 +76,19 @@ func ParseSubscriptionEvent(event *WebhookEvent) (*StripeSubscription, error) {
 	return &sub, nil
 }
 
+// SubscriptionCurrentPeriodEndUnix returns current_period_end from raw subscription
+// webhook JSON when present. stripe-go v82's Subscription struct omits this field,
+// but Stripe still includes it in subscription event payloads.
+func SubscriptionCurrentPeriodEndUnix(raw json.RawMessage) (unix int64, ok bool) {
+	var v struct {
+		CurrentPeriodEnd int64 `json:"current_period_end"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil || v.CurrentPeriodEnd == 0 {
+		return 0, false
+	}
+	return v.CurrentPeriodEnd, true
+}
+
 // ParseInvoicePaid extracts invoice data from invoice.paid events.
 func ParseInvoicePaid(event *WebhookEvent) (*gostripe.Invoice, error) {
 	var inv gostripe.Invoice


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [issue #731](https://github.com/supersuit-tech/permission-slip/issues/731).

### Summary
- Adds `quota_plan_id` and `quota_entitlements_until` on `subscriptions` (nullable pair with CHECK) to snapshot paid quotas through the end of the billing period at downgrade.
- Introduces `SubscriptionWithPlan.EffectiveQuotaPlan()` and uses it in `checkRequestQuota` / `checkResourceLimit`; clears expired grace lazily on `GetSubscriptionWithPlan`.
- `POST /billing/downgrade` runs in a transaction: cancels Stripe, clears `stripe_subscription_id`, applies quota snapshot from `current_period_end`, returns non-blocking `warnings` when over free caps.
- `customer.subscription.deleted` uses `ApplyStripeSubscriptionDeletedToFree` to set quota columns idempotently; parses `current_period_end` from raw webhook JSON (stripe-go v82 omits it on the struct).
- API: `GET /billing/plan` and deprecated subscription response include `effective_limits` and `subscription.quota_entitlements_until`. OpenAPI bundle regenerated.
- Frontend: usage cards and dashboard use `effective_limits`; PlanCard separates quota grace vs 7-day audit retention; downgrade dialog allows confirm with warnings.

### Claude Code
- [x] Migration + Go models/queries
- [x] Enforcement + billing/webhook wiring
- [x] OpenAPI + frontend + tests
- [x] `make build` and `npm test` (frontend) in this environment

### Manual Testing
- [ ] Downgrade pay-as-you-go → free: Usage reflects paid limits until `quota_entitlements_until`
- [ ] After period end: free limits; re-upgrade clears grace columns
- [ ] Downgrade with >3 agents: warning only, downgrade succeeds

**Note:** `go test ./...` was not run here (Postgres not available in agent environment). CI should run `make test-backend` with DB.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b15fed1-c8c7-4814-a35e-5be2a3852bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b15fed1-c8c7-4814-a35e-5be2a3852bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

