### PR TITLE
watch skill: CI/audit remediation loop and wrap-up updates

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -352,7 +352,7 @@ The action log is a JSON array. Each entry has a `type` field and type-specific 
 ]
 ```
 
-Use **`ci_remediation`** / **`audit_remediation`** after each failed post-session run you fix (one object per fix round is enough; add both if you fixed issues revealed by both workflows in one push). **`ci_fix_exhausted`** is only for hitting the 15-attempt limit. These types appear in the **next** full wrap-up if you re-run poll with a fresh session; within the same session, **`watch-append-wrapup-ci.sh`** appends a **## 🔧 CI / audit remediation** section to the **existing** wrap-up comment so the PR thread shows what changed after each fix.
+Use **`ci_remediation`** / **`audit_remediation`** after each failed post-session run you fix (one object per fix round is enough; add both if you fixed issues revealed by both workflows in one push). **`ci_fix_exhausted`** is only for hitting the 15-attempt limit. These types appear in the **next** full wrap-up if you re-run poll with a fresh session; within the same session, **`watch-append-wrapup-ci.sh`** appends under a single **## 🔧 CI / audit remediation** heading: the first batch adds that heading plus **### Remediation round 1**, and later batches add **### Remediation round N** only (no duplicate H2).
 
 ### Step 4: Loop back to polling
 
@@ -366,15 +366,15 @@ When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has alrea
 
 **Loop (run until both CI and audit report `success`, or you exhaust retries):**
 
-1. Run post-session. On the **first** iteration of this loop after wrap-up, pass **`--skip-webhook`** so the webhook does not fire until CI is actually green:
+1. Run post-session. Always pass **`--work-dir "$WORK_DIR"`** (same session directory as `watch-poll.sh`) so CI/audit logs are written under that directory (avoids `/tmp` clashes between concurrent watch sessions) and so the webhook sentinel file is session-scoped. On the **first** iteration of this loop after wrap-up, pass **`--skip-webhook`** so the webhook does not fire until CI is actually green (this creates **`${WORK_DIR}/post-webhook-pending`** on success):
    ```bash
-   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --skip-webhook 2>&1
+   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" --work-dir "$WORK_DIR" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --skip-webhook 2>&1
    ```
-   On **subsequent** iterations (after you pushed fixes), omit `--skip-webhook` so each successful pass can notify as usual, **or** keep using `--skip-webhook` until the final successful iteration and then run once with `--webhook-only` (see step 4 below).
+   On **subsequent** iterations (after you pushed fixes), omit `--skip-webhook` so each successful pass can notify as usual, **or** keep using `--skip-webhook` until the final successful iteration and then run once with **`--webhook-only`** (see step 2b below).
 
-2. **Exit code 0** — Both workflows concluded `success`. If you used `--skip-webhook` on prior successful attempts, run once with **`--webhook-only`** (and without `--skip-webhook`) to trigger the webhook if `NO_NOTIFY` is false:
+2. **Exit code 0** — Both workflows concluded `success`. If the webhook was sent this run (no `--skip-webhook`), **`post-webhook-pending`** is removed automatically. If you used **`--skip-webhook`** and `NO_NOTIFY` is false, run once with **`--webhook-only`** — this **requires** `--work-dir` and an existing **`post-webhook-pending`** file (otherwise exit **2**); on success the webhook runs and the sentinel is removed:
    ```bash
-   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --webhook-only 2>&1
+   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" --work-dir "$WORK_DIR" $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --webhook-only 2>&1
    ```
    Read merge result from stdout (`PR merged successfully`, etc.).
 
@@ -387,7 +387,7 @@ When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has alrea
      ```bash
      bash "${SKILL_DIR}/watch-append-wrapup-ci.sh" --work-dir "$WORK_DIR"
      ```
-   - **Go back to step 1** and re-run `watch-post.sh` to trigger fresh workflow runs and wait again.
+   - **Go back to step 1** and re-run `watch-post.sh` with the same **`--work-dir "$WORK_DIR"`** so log paths stay session-isolated.
 
 4. **Retry limit** — Repeat step 3 **until CI and audit both succeed**, or until **15** failed post-session attempts (101/102) **in this loop** for the same PR session. If you hit the limit, append an `ci_fix_exhausted` entry to `action-log.json`, run `watch-append-wrapup-ci.sh` again, post a short PR comment that automated remediation stopped after 15 attempts and summarize what is still failing, then stop.
 

--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -26,7 +26,9 @@ watch-post.sh          — Post-session tasks (no AI needed)
   ├── Triggers CI and audit workflows
   ├── Waits for completion
   ├── Auto-merges if enabled and checks pass
-  └── Triggers webhook notification
+  └── Triggers webhook notification (unless --skip-webhook)
+
+watch-append-wrapup-ci.sh — Appends CI/audit remediation bullets to the wrap-up PR comment
 
 Agent (this skill)     — Only invoked when reasoning is needed
   ├── Implements review comment requests
@@ -59,6 +61,8 @@ Set these variables for the session:
 - `NO_NOTIFY` — `true` if `--no-notify` was passed, `false` otherwise
 - `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
 - `SKILL_DIR` — the directory containing this skill file (`.claude/skills/watch`)
+
+Preserve `WORK_DIR` from `watch-poll.sh` session JSON for the whole session — it holds `action-log.json`, the wrap-up comment id file, and other state. The poll script writes `pr-number.txt` and `wrapup-comment-id` when it posts the wrap-up.
 
 ## Orchestration Loop
 
@@ -117,7 +121,7 @@ The script communicates via stdout signals and exit codes:
 }
 ```
 
-**Exit code 0 + `IDLE_TIMEOUT`**: The session ended due to inactivity or the `--max-turns` limit being reached. The script already posted the wrap-up comment. Proceed to Step 4 (post-session).
+**Exit code 0 + `IDLE_TIMEOUT`**: The session ended due to inactivity or the `--max-turns` limit being reached. The script already posted the wrap-up comment (and recorded its id under `WORK_DIR` for later edits). Proceed to Step 5 (post-session / CI loop).
 
 **Exit code 100**: Pre-poll merge conflict. The script detected conflicts before the polling loop started. Read `WORK_ITEMS_FILE` for conflict details and resolve them (see Step 3), then re-run the polling script.
 
@@ -325,9 +329,30 @@ The action log is a JSON array. Each entry has a `type` field and type-specific 
   {
     "type": "open_question",
     "description": "Should we also add rate limiting to this endpoint?"
+  },
+  {
+    "type": "ci_remediation",
+    "workflow": "ci.yml",
+    "conclusion": "failure",
+    "detail": "go test ./db/... failed: missing migration grant — added GRANT in migration 20260320…",
+    "commit": "abc1234"
+  },
+  {
+    "type": "audit_remediation",
+    "workflow": "audit.yml",
+    "conclusion": "failure",
+    "detail": "gosec flagged unsafe usage — refactored to use sanitized input",
+    "commit": "def5678"
+  },
+  {
+    "type": "ci_fix_exhausted",
+    "workflow": "ci.yml",
+    "detail": "Stopped after 15 remediation attempts; integration test still flakes on job X — needs human triage"
   }
 ]
 ```
+
+Use **`ci_remediation`** / **`audit_remediation`** after each failed post-session run you fix (one object per fix round is enough; add both if you fixed issues revealed by both workflows in one push). **`ci_fix_exhausted`** is only for hitting the 15-attempt limit. These types appear in the **next** full wrap-up if you re-run poll with a fresh session; within the same session, **`watch-append-wrapup-ci.sh`** appends a **## 🔧 CI / audit remediation** section to the **existing** wrap-up comment so the PR thread shows what changed after each fix.
 
 ### Step 4: Loop back to polling
 
@@ -335,42 +360,47 @@ After the agent finishes processing work items, go back to **Step 1** and run th
 
 **Important**: Pass the same work directory to the script on subsequent runs so it preserves last-seen IDs and the action log. The script's `WORK_DIR` is printed in its session context output — capture it on the first run and reuse it.
 
-### Step 5: Post-session tasks
+### Step 5: Post-session tasks — CI / audit loop until green
 
-When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has already been posted by the script. Run the post-session script:
+When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has already been posted. You must then **drive CI to success** (and audit to success) in a loop: fix, push, re-run workflows, repeat. **Do not stop after a single failed post-session run** unless you hit the exhaustion limit below.
 
-```bash
-bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") 2>&1
-```
+**Loop (run until both CI and audit report `success`, or you exhaust retries):**
 
-This handles:
-- Triggering CI and audit workflows
-- Waiting for them to complete
-- Auto-merging if enabled and checks pass
-- Triggering the webhook notification
+1. Run post-session. On the **first** iteration of this loop after wrap-up, pass **`--skip-webhook`** so the webhook does not fire until CI is actually green:
+   ```bash
+   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --skip-webhook 2>&1
+   ```
+   On **subsequent** iterations (after you pushed fixes), omit `--skip-webhook` so each successful pass can notify as usual, **or** keep using `--skip-webhook` until the final successful iteration and then run once with `--webhook-only` (see step 4 below).
+
+2. **Exit code 0** — Both workflows concluded `success`. If you used `--skip-webhook` on prior successful attempts, run once with **`--webhook-only`** (and without `--skip-webhook`) to trigger the webhook if `NO_NOTIFY` is false:
+   ```bash
+   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --webhook-only 2>&1
+   ```
+   Read merge result from stdout (`PR merged successfully`, etc.).
+
+3. **Exit code 101 (CI)** or **102 (audit)** — This is expected while fixing. **Automatically:**
+   - Read logs from `CI_LOGS_FILE` or `AUDIT_LOGS_FILE` in the script output.
+   - Diagnose and **implement fixes** (same rigor as review comments): run relevant tests (`make test`, `make build` before push when the failure could be compile-related).
+   - **Append to `action-log.json`** at least one object describing what you did (see **CI remediation** types below). Use a real summary in `detail` (root cause + fix), not placeholders.
+   - **Push** commits to the PR branch.
+   - **Patch the wrap-up comment** with the new remediation entry:
+     ```bash
+     bash "${SKILL_DIR}/watch-append-wrapup-ci.sh" --work-dir "$WORK_DIR"
+     ```
+   - **Go back to step 1** and re-run `watch-post.sh` to trigger fresh workflow runs and wait again.
+
+4. **Retry limit** — Repeat step 3 **until CI and audit both succeed**, or until **15** failed post-session attempts (101/102) **in this loop** for the same PR session. If you hit the limit, append an `ci_fix_exhausted` entry to `action-log.json`, run `watch-append-wrapup-ci.sh` again, post a short PR comment that automated remediation stopped after 15 attempts and summarize what is still failing, then stop.
+
+`watch-post.sh` treats any workflow **conclusion other than `success`** (including `failure`, `cancelled`, `skipped`, `timed_out`, or **`timeout`** when the wait window expires) as needing remediation — exit **101** for CI, **102** for audit.
 
 **After the script completes successfully (exit code 0) with `AUTO_MERGE=true`:**
 
-Check the script output for the merge result. The script prints clear signals:
-- `"[post] PR merged successfully."` → The merge completed. Report it as **merged**, not "attempted". Do NOT say "may need human approval" — if the script printed this, the PR is merged.
-- `"[post] Auto-merge failed."` → The merge failed. The script already posted a comment on the PR. Report the failure and suggest the user merge manually.
-- `"[post] Auto-merge enabled but checks did not pass."` → CI or audit failed, merge was skipped. Report which checks failed.
+Check the script output for the merge result:
+- `"[post] PR merged successfully."` → The merge completed. Report it as **merged**, not "attempted".
+- `"[post] Auto-merge failed."` → The merge failed. The script already posted a comment on the PR.
+- `"[post] Auto-merge enabled but checks did not pass."` → Should not occur on exit 0; if it does, treat as inconsistent and re-run post-session.
 
-**Do NOT hedge or use vague language like "attempted" or "may need human approval" when the script output clearly indicates success or failure.** Read the output and report what actually happened.
-
-**If the post-session script exits with code 101 (CI failure) or 102 (audit failure):**
-
-1. Read the failure logs from the file path in the script output.
-2. Reproduce locally by running the relevant commands.
-3. Fix the issue, commit, and push.
-4. Post an addendum comment:
-   ```markdown
-   ## 🔧 Post-Session Check Fixes
-
-   Fixed failing checks after watch session ended:
-   - **`<description>`** (`<commit hash>`) — <what was failing and how it was fixed>
-   ```
-5. Re-run the post-session script. Repeat up to 3 times before posting a comment that CI cannot be fixed automatically.
+**Do NOT hedge** when the script output clearly indicates success or failure.
 
 ## Important Rules
 

--- a/.claude/skills/watch/watch-append-wrapup-ci.sh
+++ b/.claude/skills/watch/watch-append-wrapup-ci.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Append CI/audit remediation notes to the existing watch wrap-up PR comment.
+#
+# Usage: bash watch-append-wrapup-ci.sh --work-dir <WORK_DIR>
+#
+# Reads action-log.json for entries of type ci_remediation, audit_remediation,
+# and ci_fix_exhausted that have not yet been appended (tracks count in work dir).
+
+set -euo pipefail
+
+WORK_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --work-dir) WORK_DIR="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "ERROR: --work-dir must point to an existing watch session directory." >&2
+  exit 1
+fi
+
+ACTION_LOG_FILE="$WORK_DIR/action-log.json"
+WRAPUP_COMMENT_ID_FILE="$WORK_DIR/wrapup-comment-id"
+PR_NUMBER_FILE="$WORK_DIR/pr-number.txt"
+APPENDED_COUNT_FILE="$WORK_DIR/wrapup-ci-remediations-appended-count"
+
+OWNER="supersuit-tech"
+REPO="permission-slip"
+export GH_HOST="${GH_HOST:-github.com}"
+export GH_REPO="${GH_REPO:-${OWNER}/${REPO}}"
+
+gh_api() {
+  GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh api "$@"
+}
+
+if [[ ! -f "$ACTION_LOG_FILE" ]]; then
+  echo "[append-wrapup-ci] No action log; nothing to append."
+  exit 0
+fi
+
+PR_NUMBER=$(cat "$PR_NUMBER_FILE" 2>/dev/null || echo "")
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "[append-wrapup-ci] ERROR: missing pr-number.txt in work dir." >&2
+  exit 1
+fi
+
+COMMENT_ID=$(cat "$WRAPUP_COMMENT_ID_FILE" 2>/dev/null | tr -d '[:space:]' || echo "")
+stored=0
+if [[ -f "$APPENDED_COUNT_FILE" ]]; then
+  stored=$(tr -d '[:space:]' < "$APPENDED_COUNT_FILE" || echo "0")
+fi
+[[ -z "$stored" || ! "$stored" =~ ^[0-9]+$ ]] && stored=0
+
+remediations_json=$(jq '[.[] | select(.type == "ci_remediation" or .type == "audit_remediation" or .type == "ci_fix_exhausted")]' "$ACTION_LOG_FILE")
+total=$(echo "$remediations_json" | jq 'length')
+
+if [[ "$total" -le "$stored" ]]; then
+  echo "[append-wrapup-ci] No new remediation entries to append (${stored}/${total})."
+  exit 0
+fi
+
+new_slice=$(echo "$remediations_json" | jq ".[$stored:]")
+
+append_md=$(echo "$new_slice" | jq -r '
+  map(
+    (if (.commit != null and .commit != "") then " (`\(.commit)`)" else "" end) as $c |
+    if .type == "ci_fix_exhausted" then
+      "- **\(.workflow // "workflow")** — stopped: \(.detail)"
+    else
+      "- **\(.workflow // "workflow")** — conclusion `\(.conclusion // "?")` — \(.detail)\($c)"
+    end
+  ) | join("\n")
+')
+
+block="## 🔧 CI / audit remediation
+
+${append_md}"
+
+posted=false
+if [[ -z "$COMMENT_ID" ]]; then
+  echo "[append-wrapup-ci] No wrap-up comment id; posting remediation as a new PR comment."
+  if gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$block" > /dev/null 2>&1; then
+    posted=true
+  fi
+else
+  current_body=$(gh_api "/repos/${OWNER}/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body' 2>/dev/null || echo "")
+  if [[ -z "$current_body" ]]; then
+    echo "[append-wrapup-ci] Could not fetch comment ${COMMENT_ID}; posting new comment instead."
+    if gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$block" > /dev/null 2>&1; then
+      posted=true
+    fi
+  else
+    new_body="${current_body}
+
+${block}"
+    if gh_api "/repos/${OWNER}/${REPO}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$new_body" > /dev/null 2>&1; then
+      posted=true
+    else
+      echo "[append-wrapup-ci] PATCH failed; posting remediation as a new PR comment."
+      if gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$block" > /dev/null 2>&1; then
+        posted=true
+      fi
+    fi
+  fi
+fi
+
+if [[ "$posted" != "true" ]]; then
+  echo "[append-wrapup-ci] ERROR: Could not update or post remediation on PR #${PR_NUMBER}." >&2
+  exit 1
+fi
+
+echo "$total" > "$APPENDED_COUNT_FILE"
+echo "[append-wrapup-ci] Appended $((total - stored)) remediation block(s). Total logged: ${total}."

--- a/.claude/skills/watch/watch-append-wrapup-ci.sh
+++ b/.claude/skills/watch/watch-append-wrapup-ci.sh
@@ -26,6 +26,7 @@ ACTION_LOG_FILE="$WORK_DIR/action-log.json"
 WRAPUP_COMMENT_ID_FILE="$WORK_DIR/wrapup-comment-id"
 PR_NUMBER_FILE="$WORK_DIR/pr-number.txt"
 APPENDED_COUNT_FILE="$WORK_DIR/wrapup-ci-remediations-appended-count"
+ROUND_FILE="$WORK_DIR/wrapup-ci-remediation-last-round"
 
 OWNER="supersuit-tech"
 REPO="permission-slip"
@@ -75,9 +76,24 @@ append_md=$(echo "$new_slice" | jq -r '
   ) | join("\n")
 ')
 
-block="## 🔧 CI / audit remediation
+last_round=0
+if [[ -f "$ROUND_FILE" ]]; then
+  last_round=$(tr -d '[:space:]' < "$ROUND_FILE" || echo "0")
+fi
+[[ -z "$last_round" || ! "$last_round" =~ ^[0-9]+$ ]] && last_round=0
+next_round=$((last_round + 1))
+
+if [[ "$stored" -eq 0 ]]; then
+  block="## 🔧 CI / audit remediation
+
+### Remediation round ${next_round}
 
 ${append_md}"
+else
+  block="### Remediation round ${next_round}
+
+${append_md}"
+fi
 
 posted=false
 if [[ -z "$COMMENT_ID" ]]; then
@@ -113,4 +129,5 @@ if [[ "$posted" != "true" ]]; then
 fi
 
 echo "$total" > "$APPENDED_COUNT_FILE"
-echo "[append-wrapup-ci] Appended $((total - stored)) remediation block(s). Total logged: ${total}."
+echo "$next_round" > "$ROUND_FILE"
+echo "[append-wrapup-ci] Appended round ${next_round} ($((total - stored)) entr(y/ies)). Total logged: ${total}."

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -580,7 +580,7 @@ if [[ "$MAX_TURNS" -gt 0 && "$CURRENT_TURNS" -ge "$MAX_TURNS" ]]; then
   echo "[wrap-up] Generating session summary..."
   wrapup=$(generate_wrapup "$CURRENT_TURNS")
   echo "[wrap-up] Posting to PR..."
-  post_wrapup_comment "$wrapup"
+  post_wrapup_comment "$wrapup" || true
 
   echo "IDLE_TIMEOUT"
   echo "REASON=turn limit reached (${CURRENT_TURNS}/${MAX_TURNS})"
@@ -691,7 +691,7 @@ while true; do
     echo "[wrap-up] Generating session summary..."
     wrapup=$(generate_wrapup "$CYCLE")
     echo "[wrap-up] Posting to PR..."
-    post_wrapup_comment "$wrapup"
+    post_wrapup_comment "$wrapup" || true
 
     # CI triggering is handled by watch-post.sh (Step 5 in SKILL.md)
     echo "IDLE_TIMEOUT"

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -86,6 +86,8 @@ WORK_ITEMS_FILE="$WORK_DIR/work-items.json"
 ACTION_LOG_FILE="$WORK_DIR/action-log.json"
 CHECKLIST_CACHE_FILE="$WORK_DIR/checklist-cache.txt"
 TURNS_FILE="$WORK_DIR/turns-count"
+WRAPUP_COMMENT_ID_FILE="$WORK_DIR/wrapup-comment-id"
+PR_NUMBER_FILE="$WORK_DIR/pr-number.txt"
 
 # Only initialize state files if they don't already exist (fresh session)
 [[ -f "$LAST_REVIEW_ID_FILE" ]] || echo "0" > "$LAST_REVIEW_ID_FILE"
@@ -93,6 +95,7 @@ TURNS_FILE="$WORK_DIR/turns-count"
 [[ -f "$LAST_ISSUE_COMMENT_ID_FILE" ]] || echo "0" > "$LAST_ISSUE_COMMENT_ID_FILE"
 [[ -f "$ACTION_LOG_FILE" ]] || echo "[]" > "$ACTION_LOG_FILE"
 [[ -f "$TURNS_FILE" ]] || echo "0" > "$TURNS_FILE"
+echo "$PR_NUMBER" > "$PR_NUMBER_FILE"
 
 # Bot username(s) to filter out
 BOT_USERS=("claude-code[bot]" "github-actions[bot]" "claude[bot]")
@@ -424,6 +427,25 @@ generate_wrapup() {
     else map("- " + .description) | join("\n")
     end')
 
+  local ci_audit_fixes ci_fix_exhausted
+  ci_audit_fixes=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "ci_remediation" or .type == "audit_remediation")] |
+    if length == 0 then ""
+    else "### CI / audit fixes (logged)\n" + (map(
+        "- **" + .workflow + "** (" + .conclusion + ")"
+        + (if .commit != null and .commit != "" then " — `" + .commit + "`" else "" end)
+        + " — " + .detail
+      ) | join("\n"))
+    end')
+
+  ci_fix_exhausted=$(echo "$action_log" | jq -r '
+    [.[] | select(.type == "ci_fix_exhausted")] |
+    if length == 0 then ""
+    else "### CI / audit remediation stopped\n" + (map(
+        "- **" + .workflow + "** — " + .detail
+      ) | join("\n"))
+    end')
+
   local comment_count
   comment_count=$(echo "$action_log" | jq '[.[] | select(.type == "implemented" or .type == "declined")] | length')
 
@@ -480,6 +502,18 @@ ${open_questions}
 "
   fi
 
+  if [[ -n "$ci_audit_fixes" ]]; then
+    wrapup="${wrapup}
+${ci_audit_fixes}
+"
+  fi
+
+  if [[ -n "$ci_fix_exhausted" ]]; then
+    wrapup="${wrapup}
+${ci_fix_exhausted}
+"
+  fi
+
   wrapup="${wrapup}
 ---
 *Watch session ended after $((MAX_IDLE_CYCLES * POLL_INTERVAL / 60)) minutes of inactivity. Processed ${comment_count} comments across ${total_cycles} poll cycles.*"
@@ -493,7 +527,13 @@ ${open_questions}
 # ---------------------------------------------------------------------------
 post_wrapup_comment() {
   local body="$1"
-  gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body" > /dev/null 2>&1
+  local resp
+  if ! resp=$(gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body" 2>/dev/null); then
+    echo "[wrap-up] WARNING: Failed to post wrap-up comment" >&2
+    echo -n "" > "$WRAPUP_COMMENT_ID_FILE"
+    return 1
+  fi
+  echo "$resp" | jq -r '.id // empty' | tr -d '\n' > "$WRAPUP_COMMENT_ID_FILE"
 }
 
 # ---------------------------------------------------------------------------
@@ -508,7 +548,9 @@ print_session_context() {
   "auto_merge": ${AUTO_MERGE},
   "work_dir": "${WORK_DIR}",
   "work_items_file": "${WORK_ITEMS_FILE}",
-  "action_log_file": "${ACTION_LOG_FILE}"
+  "action_log_file": "${ACTION_LOG_FILE}",
+  "wrapup_comment_id_file": "${WRAPUP_COMMENT_ID_FILE}",
+  "pr_number_file": "${PR_NUMBER_FILE}"
 }
 EOF
 }

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 PR_URL=""
 AUTO_MERGE=true
 NO_NOTIFY=false
+SKIP_WEBHOOK=false
+WEBHOOK_ONLY=false
 
 # Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
 while [[ $# -gt 0 ]]; do
@@ -26,6 +28,8 @@ while [[ $# -gt 0 ]]; do
     --automerge) AUTO_MERGE=true; shift ;;  # kept for backwards compat
     --no-automerge) AUTO_MERGE=false; shift ;;
     --no-notify) NO_NOTIFY=true; shift ;;
+    --skip-webhook) SKIP_WEBHOOK=true; shift ;;
+    --webhook-only) WEBHOOK_ONLY=true; shift ;;
     https://*) PR_URL="$1"; shift ;;
     *) shift ;;
   esac
@@ -57,6 +61,20 @@ gh_api() {
 gh_cmd() {
   GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh "$@"
 }
+
+# ---------------------------------------------------------------------------
+# Webhook-only mode (after a successful --skip-webhook run)
+# ---------------------------------------------------------------------------
+if [[ "$WEBHOOK_ONLY" == "true" ]]; then
+  if [[ "$NO_NOTIFY" == "true" ]]; then
+    echo "[post] --webhook-only with --no-notify: nothing to do."
+    exit 0
+  fi
+  echo "[post] Triggering webhook notification only..."
+  gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
+  echo "POST_WEBHOOK_ONLY=true"
+  exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # Snapshot latest run IDs before triggering (to detect new runs)
@@ -125,31 +143,49 @@ audit_run_id="${audit_result##*:}"
 echo "[post] Audit result: ${audit_conclusion} (run ${audit_run_id})"
 
 # ---------------------------------------------------------------------------
-# Report CI results
+# Report CI results (anything other than success needs remediation)
 # ---------------------------------------------------------------------------
-if [[ "$ci_conclusion" == "failure" ]]; then
+if [[ "$ci_conclusion" != "success" ]]; then
   echo ""
   echo "CI_FAILED"
   echo "CI_RUN_ID=${ci_run_id}"
-  # Fetch failed logs for the agent
-  echo "[post] Fetching failed CI logs..."
-  gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "/tmp/ci-failed-logs.txt" || true
+  echo "CI_CONCLUSION=${ci_conclusion}"
+  echo "[post] Fetching CI logs (failed jobs if any)..."
+  if [[ "$ci_run_id" != "unknown" ]]; then
+    gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "/tmp/ci-failed-logs.txt" || true
+    gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "/tmp/ci-failed-logs.txt" || true
+  else
+    : > "/tmp/ci-failed-logs.txt"
+  fi
   echo "CI_LOGS_FILE=/tmp/ci-failed-logs.txt"
   echo "AGENT_NEEDED"
-  echo "REASON=CI failure needs diagnosis and fix"
-  # Exit with special code — caller invokes agent to fix
+  if [[ "$ci_conclusion" == "timeout" ]]; then
+    echo "REASON=CI workflow did not complete within wait window — re-trigger or investigate GitHub Actions"
+  else
+    echo "REASON=CI did not succeed (conclusion=${ci_conclusion}) — fix and re-run"
+  fi
   exit 101
 fi
 
-if [[ "$audit_conclusion" == "failure" ]]; then
+if [[ "$audit_conclusion" != "success" ]]; then
   echo ""
   echo "AUDIT_FAILED"
   echo "AUDIT_RUN_ID=${audit_run_id}"
-  echo "[post] Fetching failed audit logs..."
-  gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "/tmp/audit-failed-logs.txt" || true
+  echo "AUDIT_CONCLUSION=${audit_conclusion}"
+  echo "[post] Fetching audit logs (failed jobs if any)..."
+  if [[ "$audit_run_id" != "unknown" ]]; then
+    gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "/tmp/audit-failed-logs.txt" || true
+    gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "/tmp/audit-failed-logs.txt" || true
+  else
+    : > "/tmp/audit-failed-logs.txt"
+  fi
   echo "AUDIT_LOGS_FILE=/tmp/audit-failed-logs.txt"
   echo "AGENT_NEEDED"
-  echo "REASON=Audit failure needs diagnosis and fix"
+  if [[ "$audit_conclusion" == "timeout" ]]; then
+    echo "REASON=Audit workflow did not complete within wait window — re-trigger or investigate GitHub Actions"
+  else
+    echo "REASON=Audit did not succeed (conclusion=${audit_conclusion}) — fix and re-run"
+  fi
   exit 102
 fi
 
@@ -171,10 +207,10 @@ elif [[ "$AUTO_MERGE" == "true" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Trigger webhook notification (skipped with --no-notify)
+# Trigger webhook notification (skipped with --no-notify or --skip-webhook)
 # ---------------------------------------------------------------------------
-if [[ "$NO_NOTIFY" == "true" ]]; then
-  echo "[post] Skipping webhook notification (--no-notify)."
+if [[ "$NO_NOTIFY" == "true" || "$SKIP_WEBHOOK" == "true" ]]; then
+  echo "[post] Skipping webhook notification (--no-notify or --skip-webhook)."
 else
   echo "[post] Triggering webhook notification..."
   gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -4,7 +4,7 @@
 # Invoked after the polling loop ends (idle timeout) and the agent has
 # finished all its work.
 #
-# Usage: bash watch-post.sh [PR_URL] [--no-automerge]
+# Usage: bash watch-post.sh [PR_URL] [--work-dir DIR] [--no-automerge] [--skip-webhook] [--webhook-only]
 #
 # This script handles steps 11-13 from the original SKILL.md:
 #   11. Trigger CI and audit, wait, fix failures (signals agent for fixes)
@@ -21,6 +21,7 @@ AUTO_MERGE=true
 NO_NOTIFY=false
 SKIP_WEBHOOK=false
 WEBHOOK_ONLY=false
+WORK_DIR=""
 
 # Parse arguments — PR URL is optional (auto-detected from current branch if omitted)
 while [[ $# -gt 0 ]]; do
@@ -30,6 +31,7 @@ while [[ $# -gt 0 ]]; do
     --no-notify) NO_NOTIFY=true; shift ;;
     --skip-webhook) SKIP_WEBHOOK=true; shift ;;
     --webhook-only) WEBHOOK_ONLY=true; shift ;;
+    --work-dir) WORK_DIR="$2"; shift 2 ;;
     https://*) PR_URL="$1"; shift ;;
     *) shift ;;
   esac
@@ -70,11 +72,25 @@ if [[ "$WEBHOOK_ONLY" == "true" ]]; then
     echo "[post] --webhook-only with --no-notify: nothing to do."
     exit 0
   fi
+  pending_file="${WORK_DIR}/post-webhook-pending"
+  if [[ -z "$WORK_DIR" || ! -f "$pending_file" ]]; then
+    echo "[post] ERROR: --webhook-only requires --work-dir and a prior successful watch-post run with --skip-webhook (missing ${pending_file})." >&2
+    exit 2
+  fi
   echo "[post] Triggering webhook notification only..."
-  gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
+  if gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null; then
+    rm -f "$pending_file"
+  else
+    echo "[post] WARNING: Failed to trigger webhook (sentinel kept for retry)." >&2
+    exit 1
+  fi
   echo "POST_WEBHOOK_ONLY=true"
   exit 0
 fi
+
+LOG_ROOT="${WORK_DIR:-/tmp}"
+CI_LOGS_FILE="${LOG_ROOT}/ci-failed-logs.txt"
+AUDIT_LOGS_FILE="${LOG_ROOT}/audit-failed-logs.txt"
 
 # ---------------------------------------------------------------------------
 # Snapshot latest run IDs before triggering (to detect new runs)
@@ -152,12 +168,12 @@ if [[ "$ci_conclusion" != "success" ]]; then
   echo "CI_CONCLUSION=${ci_conclusion}"
   echo "[post] Fetching CI logs (failed jobs if any)..."
   if [[ "$ci_run_id" != "unknown" ]]; then
-    gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "/tmp/ci-failed-logs.txt" || true
-    gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "/tmp/ci-failed-logs.txt" || true
+    gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
+    gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
   else
-    : > "/tmp/ci-failed-logs.txt"
+    : > "$CI_LOGS_FILE"
   fi
-  echo "CI_LOGS_FILE=/tmp/ci-failed-logs.txt"
+  echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
   echo "AGENT_NEEDED"
   if [[ "$ci_conclusion" == "timeout" ]]; then
     echo "REASON=CI workflow did not complete within wait window — re-trigger or investigate GitHub Actions"
@@ -174,12 +190,12 @@ if [[ "$audit_conclusion" != "success" ]]; then
   echo "AUDIT_CONCLUSION=${audit_conclusion}"
   echo "[post] Fetching audit logs (failed jobs if any)..."
   if [[ "$audit_run_id" != "unknown" ]]; then
-    gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "/tmp/audit-failed-logs.txt" || true
-    gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "/tmp/audit-failed-logs.txt" || true
+    gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
+    gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
   else
-    : > "/tmp/audit-failed-logs.txt"
+    : > "$AUDIT_LOGS_FILE"
   fi
-  echo "AUDIT_LOGS_FILE=/tmp/audit-failed-logs.txt"
+  echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
   echo "AGENT_NEEDED"
   if [[ "$audit_conclusion" == "timeout" ]]; then
     echo "REASON=Audit workflow did not complete within wait window — re-trigger or investigate GitHub Actions"
@@ -214,6 +230,14 @@ if [[ "$NO_NOTIFY" == "true" || "$SKIP_WEBHOOK" == "true" ]]; then
 else
   echo "[post] Triggering webhook notification..."
   gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
+  if [[ -n "$WORK_DIR" && -f "${WORK_DIR}/post-webhook-pending" ]]; then
+    rm -f "${WORK_DIR}/post-webhook-pending"
+  fi
+fi
+
+if [[ -n "$WORK_DIR" && "$SKIP_WEBHOOK" == "true" && "$NO_NOTIFY" == "false" ]]; then
+  touch "${WORK_DIR}/post-webhook-pending"
+  echo "[post] Wrote ${WORK_DIR}/post-webhook-pending (use --webhook-only after final green run to notify)."
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Updates the `/watch` skill so the orchestrating agent is instructed to **automatically fix CI and audit failures in a loop** until both GitHub Actions workflows succeed (or a 15-attempt cap is hit), and to **record what changed** on the PR.

- **watch-post.sh**: Any workflow conclusion other than `success` exits 101/102 (not only `failure`); logs include full run log when useful; `--skip-webhook` / `--webhook-only` support a remediation loop without duplicate webhook pings.
- **watch-poll.sh**: Saves wrap-up comment id + PR number under `WORK_DIR`; session JSON exposes those paths; wrap-up markdown includes `ci_remediation` / `audit_remediation` / `ci_fix_exhausted` from the action log.
- **watch-append-wrapup-ci.sh**: Appends a `## 🔧 CI / audit remediation` section to the existing wrap-up comment (fallback: new comment) so fixes are visible in the same thread.
- **SKILL.md**: Documents the loop, new action-log types, append script, and exhaustion behavior.

## Test plan

### Claude Code
- [x] `bash -n` on modified shell scripts

### Manual Testing
- [ ] Run a real watch session on a PR with a deliberate CI failure and confirm: post-session re-runs, agent pushes fix, wrap-up comment gains remediation section, CI eventually green
- [ ] Confirm `--webhook-only` fires webhook after a successful `--skip-webhook` pass when desired