### PR TITLE
Fix unused variable breaking CI on main

### DIFF
--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -180,7 +180,6 @@ func TestGetBillingPlan_ZeroUsage(t *testing.T) {
 func TestGetBillingPlan_QuotaGraceEffectiveLimits(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
-	ctx := context.Background()
 	uid := testhelper.GenerateUID(t)
 
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])


### PR DESCRIPTION
## Summary
- Remove unused `ctx` variable in `TestGetBillingPlan_QuotaGraceEffectiveLimits` (`api/billing_test.go:183`) that caused `declared and not used` compilation error on main CI.

## Test plan
### Claude Code
- [ ] Verify CI passes on this branch

### Manual Testing
- No manual testing needed — this is a one-line deletion of an unused variable

https://claude.ai/code/session_018ZDKFKQSaPqWXifqB5P552