### PR TITLE
Allow complimentary Pro coupon for pay-as-you-go users

### DIFF
--- a/api/billing_redeem.go
+++ b/api/billing_redeem.go
@@ -62,12 +62,8 @@ func handleRedeemFreeProCoupon(deps *Deps) http.HandlerFunc {
 			RespondJSON(w, http.StatusOK, redeemCouponResponse{PlanID: db.PlanFreePro, Status: "already_redeemed"})
 			return
 		}
-		if sub.PlanID == db.PlanPayAsYouGo {
-			RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadySubscribed, "Paid subscription already active"))
-			return
-		}
-		if sub.PlanID != db.PlanFree {
-			RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Coupon can only be applied on the free plan"))
+		if sub.PlanID != db.PlanFree && sub.PlanID != db.PlanPayAsYouGo {
+			RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Coupon can only be applied on the free or pay-as-you-go plan"))
 			return
 		}
 
@@ -76,7 +72,68 @@ func handleRedeemFreeProCoupon(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		updated, err := db.UpgradeSubscriptionPlan(r.Context(), deps.DB, profile.ID, db.PlanFree, db.PlanFreePro)
+		// Paid plan: cancel Stripe first so we do not leave an active paid subscription
+		// while the app treats the user as complimentary Pro.
+		if sub.PlanID == db.PlanPayAsYouGo && sub.StripeSubscriptionID != nil {
+			if deps.Stripe == nil {
+				RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Billing provider not configured"))
+				return
+			}
+			if _, err := deps.Stripe.CancelSubscription(r.Context(), *sub.StripeSubscriptionID); err != nil {
+				log.Printf("[%s] RedeemCoupon: cancel Stripe subscription: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusBadGateway, upstreamError("Failed to cancel subscription with payment provider"))
+				return
+			}
+		}
+
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] RedeemCoupon: begin tx: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply coupon"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx)
+		}
+
+		cur, err := db.GetSubscriptionByUserID(r.Context(), tx, profile.ID)
+		if err != nil {
+			log.Printf("[%s] RedeemCoupon: reload subscription: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply coupon"))
+			return
+		}
+		if cur == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrSubscriptionNotFound, "No subscription found"))
+			return
+		}
+		if cur.PlanID == db.PlanFreePro {
+			RespondJSON(w, http.StatusOK, redeemCouponResponse{PlanID: db.PlanFreePro, Status: "already_redeemed"})
+			return
+		}
+
+		var updated *db.Subscription
+		switch cur.PlanID {
+		case db.PlanPayAsYouGo:
+			var custPtr *string
+			if cur.StripeCustomerID != nil {
+				custPtr = cur.StripeCustomerID
+			}
+			if _, err := db.UpdateSubscriptionStripe(r.Context(), tx, profile.ID, custPtr, nil); err != nil {
+				log.Printf("[%s] RedeemCoupon: clear stripe subscription id: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply coupon"))
+				return
+			}
+			updated, err = db.UpgradeSubscriptionPlan(r.Context(), tx, profile.ID, db.PlanPayAsYouGo, db.PlanFreePro)
+		case db.PlanFree:
+			updated, err = db.UpgradeSubscriptionPlan(r.Context(), tx, profile.ID, db.PlanFree, db.PlanFreePro)
+		default:
+			RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Subscription changed while redeeming coupon"))
+			return
+		}
 		if err != nil {
 			log.Printf("[%s] RedeemCoupon: upgrade plan: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -84,8 +141,36 @@ func handleRedeemFreeProCoupon(deps *Deps) http.HandlerFunc {
 			return
 		}
 		if updated == nil {
-			RespondJSON(w, http.StatusOK, redeemCouponResponse{PlanID: db.PlanFreePro, Status: "already_redeemed"})
+			again, err := db.GetSubscriptionByUserID(r.Context(), tx, profile.ID)
+			if err != nil {
+				log.Printf("[%s] RedeemCoupon: reload after no-op upgrade: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply coupon"))
+				return
+			}
+			if again != nil && again.PlanID == db.PlanFreePro {
+				if owned {
+					if err := db.CommitTx(r.Context(), tx); err != nil {
+						log.Printf("[%s] RedeemCoupon: commit: %v", TraceID(r.Context()), err)
+						CaptureError(r.Context(), err)
+						RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply coupon"))
+						return
+					}
+				}
+				RespondJSON(w, http.StatusOK, redeemCouponResponse{PlanID: db.PlanFreePro, Status: "already_redeemed"})
+				return
+			}
+			RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Subscription changed while redeeming coupon"))
 			return
+		}
+
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] RedeemCoupon: commit: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply coupon"))
+				return
+			}
 		}
 
 		log.Printf("[%s] RedeemCoupon: user %s upgraded to free_pro", TraceID(r.Context()), profile.ID)

--- a/api/billing_redeem_test.go
+++ b/api/billing_redeem_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -103,5 +104,83 @@ func TestRedeemFreeProCoupon_Idempotent(t *testing.T) {
 	}
 	if resp.Status != "already_redeemed" {
 		t.Fatalf("expected already_redeemed, got %+v", resp)
+	}
+}
+
+func TestRedeemFreeProCoupon_FromPayAsYouGo_WithoutStripeSubscription(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	username := "paidcoupon_" + uid[:8]
+	testhelper.InsertUser(t, tx, uid, username)
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+
+	secret := "test-coupon-secret-paid"
+	good := coupon.ExpectedFreeProCouponHex(username, secret)
+
+	deps := &Deps{
+		DB:                tx,
+		SupabaseJWTSecret: testJWTSecret,
+		BillingEnabled:    true,
+		CouponSecret:      secret,
+	}
+	router := NewRouter(deps)
+
+	body := `{"coupon":"` + good + `"}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/billing/redeem-coupon", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp redeemCouponResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.PlanID != db.PlanFreePro || resp.Status != "redeemed" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	sub, err := db.GetSubscriptionByUserID(context.Background(), tx, uid)
+	if err != nil {
+		t.Fatalf("GetSubscriptionByUserID: %v", err)
+	}
+	if sub.PlanID != db.PlanFreePro {
+		t.Errorf("DB plan_id: want %s, got %s", db.PlanFreePro, sub.PlanID)
+	}
+}
+
+func TestRedeemFreeProCoupon_FromPayAsYouGo_RequiresStripeClient(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	username := "needstripe_" + uid[:8]
+	testhelper.InsertUser(t, tx, uid, username)
+	testhelper.InsertSubscription(t, tx, uid, db.PlanPayAsYouGo)
+	custID := "cus_redeem_test"
+	subID := "sub_redeem_test"
+	if _, err := db.UpdateSubscriptionStripe(context.Background(), tx, uid, &custID, &subID); err != nil {
+		t.Fatalf("UpdateSubscriptionStripe: %v", err)
+	}
+
+	secret := "test-coupon-secret-stripe"
+	good := coupon.ExpectedFreeProCouponHex(username, secret)
+
+	deps := &Deps{
+		DB:                tx,
+		SupabaseJWTSecret: testJWTSecret,
+		BillingEnabled:    true,
+		CouponSecret:      secret,
+		Stripe:            nil,
+	}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPost, "/billing/redeem-coupon", uid, `{"coupon":"`+good+`"}`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -124,7 +124,7 @@ export function BillingPage() {
             pricing={billingPlan.pricing}
           />
           {billingPlan.coupon_redemption_enabled &&
-            billingPlan.plan.id === "free" && <CouponRedemptionCard />}
+            billingPlan.plan.id !== "free_pro" && <CouponRedemptionCard />}
           {billingPlan.subscription.can_upgrade && (
             <UpgradeCTA plan={billingPlan.plan} pricing={billingPlan.pricing} />
           )}

--- a/frontend/src/pages/settings/BillingSettingsPage.tsx
+++ b/frontend/src/pages/settings/BillingSettingsPage.tsx
@@ -120,7 +120,7 @@ export function BillingSettingsPage() {
             pricing={billingPlan.pricing}
           />
           {billingPlan.coupon_redemption_enabled &&
-            billingPlan.plan.id === "free" && <CouponRedemptionCard />}
+            billingPlan.plan.id !== "free_pro" && <CouponRedemptionCard />}
           {billingPlan.subscription.can_upgrade && (
             <UpgradeCTA plan={billingPlan.plan} pricing={billingPlan.pricing} />
           )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **API:** `POST /v1/billing/redeem-coupon` now accepts users on **pay-as-you-go** (after HMAC coupon validation). If they have a Stripe subscription ID, we **cancel the Stripe subscription** first, then in a DB transaction clear `stripe_subscription_id` (keeping `stripe_customer_id`) and upgrade to **free_pro**.
- **UI:** The coupon card is shown for **free** and **pay-as-you-go**; it stays hidden only when the plan is already **free_pro**.

## Test plan
### Claude Code
- [ ] `make test-backend` (includes `api` package redeem tests)
- [ ] `make build` (TypeScript)

### Manual Testing
- [ ] As a pay-as-you-go user with billing enabled, confirm the coupon field appears on Billing / Settings → Billing.
- [ ] Redeem a valid complimentary-Pro coupon: plan becomes free_pro, paid subscription is canceled in Stripe (verify in Stripe dashboard).
- [ ] As free_pro, redeem again → `already_redeemed` (200).

**Note:** Local `go test` could not be run in this agent environment (toolchain/module constraints). CI should run the full suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f62f3fa-a8f5-4c84-8226-dbb457d99bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f62f3fa-a8f5-4c84-8226-dbb457d99bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

