### PR TITLE
Fix CI: timestamp precision and mobile lockfile sync

### DIFF
--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -185,7 +185,7 @@ func TestGetBillingPlan_QuotaGraceEffectiveLimits(t *testing.T) {
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
 	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
 
-	future := time.Now().Add(48 * time.Hour)
+	future := time.Now().Add(48 * time.Hour).Truncate(time.Microsecond)
 	paid := db.PlanPayAsYouGo
 	testhelper.MustExec(t, tx,
 		`UPDATE subscriptions SET quota_plan_id = $2, quota_entitlements_until = $3 WHERE user_id = $1`,

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary
- **Backend test fix**: `TestGetBillingPlan_QuotaGraceEffectiveLimits` compared `time.Now()` (nanosecond precision) against a value round-tripped through PostgreSQL (microsecond precision), causing a consistent timestamp mismatch. Fixed by truncating to microsecond before inserting.
- **Mobile CI fix**: `npm ci` failed because `mobile/package-lock.json` was missing three transitive dependencies (`minimatch@5.1.9`, `brace-expansion@2.0.2`, `balanced-match@1.0.2`) required by `@oclif/core`. Regenerated the lock file.

## Test plan
### Claude Code
- [x] Backend tests pass (`go test ./...`)
- [x] Mobile tests pass (`make mobile-test` — 184 tests, 20 suites)
- [x] Frontend tests pass (`make test-frontend` — 959 tests, 100 suites)
- [ ] CI passes on this branch

### Manual Testing
- No manual testing needed — one-line test fix and lock file regeneration

https://claude.ai/code/session_01GWFaYsSTYbpsE2BtFHVZ4g