### PR TITLE
Update webhook message to use github.actor instead of hardcoded username

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -39,7 +39,7 @@ jobs:
           elif [ -n "$PR_URL" ]; then
             MESSAGE="permission-slip: PR needs attention — ${PR_URL}"
           else
-            MESSAGE="permission-slip: Claude Code needs your attention"
+            MESSAGE="permission-slip: @${{ github.actor }} needs your attention"
           fi
 
           PAYLOAD=$(jq -n --arg msg "$MESSAGE" --arg secret "$NOTIFY_WEBHOOK_SECRET" \


### PR DESCRIPTION
Use ${{ github.actor }} in the trigger-webhook workflow so it dynamically mentions whoever triggered it, instead of hardcoding a name.