### PR TITLE
Fix CI build: remove unused effectiveLimits destructuring

### DIFF
--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -28,7 +28,7 @@ function StatusBadge({ status }: { status: Subscription["status"] }) {
   return <Badge variant="secondary">Cancelled</Badge>;
 }
 
-export function PlanCard({ plan, effectiveLimits, subscription, pricing }: PlanCardProps) {
+export function PlanCard({ plan, subscription, pricing }: PlanCardProps) {
   const isFree = plan.id === "free";
   const isFreePro = plan.id === "free_pro";
 


### PR DESCRIPTION
## Summary
- Removes unused `effectiveLimits` from destructuring in `PlanCard` component, which was causing TypeScript's `noUnusedLocals` check to fail the CI build step
- The prop remains in the interface for API compatibility — callers still pass it, but the component doesn't use it internally

## Test plan

### Claude Code
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] All 959 frontend tests pass (`make test-frontend`)
- [x] CI pipeline passes: https://github.com/supersuit-tech/permission-slip/actions/runs/23392048950

### Manual Testing
- [ ] Verify billing page renders correctly in the browser

https://claude.ai/code/session_018DWfD3jsEtKjE97ferFfTQ