### PR TITLE
Add /fix-ci Claude skill for CI + audit remediation (closes #743)

### DIFF
--- a/.claude/skills/fix-ci/SKILL.md
+++ b/.claude/skills/fix-ci/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: fix-ci
+description: Automate the CI fix loop — trigger GitHub Actions (CI + audit), read failure logs, fix locally, push, and repeat until green. Use when CI is red and you want a hands-off remediation loop.
+argument-hint: "[BRANCH] [--max-rounds <N>] [--work-dir DIR]"
+---
+
+# Fix CI — CI + audit remediation loop
+
+Automates the workflow from PR #742 manually: detect branch, trigger **ci.yml** and **audit.yml**, wait for results, parse failures, fix locally with validation, push, and re-run until both pass or the iteration cap is hit.
+
+## Architecture
+
+```
+fix-ci-trigger.sh   — One cycle: trigger both workflows, wait (~10 min max each), write logs on failure
+Agent (this skill)  — Parse logs, edit code, run local checks, commit, push, PR bookkeeping
+```
+
+## Setup
+
+Parse arguments from: `$ARGUMENTS`
+
+Supported forms:
+
+- (empty) — use current branch
+- `my-feature-branch` — `git fetch` and checkout that branch before looping
+- `--max-rounds 3` — cap fix iterations (default **5**)
+- `--work-dir /path` — state directory for log files (default: `/tmp/fix-ci-<pid>` or a fresh dir under `/tmp`)
+
+Set for the session:
+
+- `BRANCH` — target branch name (after optional checkout)
+- `MAX_ROUNDS` — default `5`, override with `--max-rounds <N>` (minimum 1)
+- `WORK_DIR` — optional; if unset, create `/tmp/fix-ci-$$` once at start and reuse for all rounds
+- `GH_CMD` — `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh`
+- `SKILL_DIR` — `.claude/skills/fix-ci`
+- `TRIGGER_SCRIPT` — `"${SKILL_DIR}/fix-ci-trigger.sh"`
+
+### Optional branch argument
+
+If the first token is not a flag and not `--max-rounds` / `--work-dir`, treat it as a branch name:
+
+```bash
+git fetch origin "<branch>" && git checkout "<branch>"
+```
+
+If checkout fails, stop with a clear error.
+
+If no branch argument, use `git branch --show-current`. If empty (detached HEAD), stop with an error.
+
+## Preconditions
+
+- `gh` authenticated for `supersuit-tech/permission-slip`
+- Clean enough tree to commit: uncommitted fixes are fine; if you cannot commit (e.g. merge in progress), stop and tell the user
+
+## Main loop
+
+For `round` from 1 through `MAX_ROUNDS`:
+
+### 1. Record local HEAD (optional sanity check)
+
+```bash
+LOCAL_SHA=$(git rev-parse HEAD)
+```
+
+### 2. Run the trigger script
+
+```bash
+bash "${TRIGGER_SCRIPT}" --work-dir "$WORK_DIR"
+```
+
+The script **probes** GitHub first: if the latest completed **ci.yml** and **audit.yml** runs for this branch already target **current `HEAD`** and both **succeeded**, it prints `FIX_CI_COMPLETE` and exits 0 without re-triggering. Otherwise it triggers fresh runs (or returns failure logs from the latest failed run for this SHA).
+
+Capture stdout. Parse:
+
+- **`FIX_CI_COMPLETE`** — CI and audit **success** for this push. Go to **Success** (below).
+- **Exit 101 + `CI_FAILED`** — read `CI_LOGS_FILE=...` from output, then read that file.
+- **Exit 102 + `AUDIT_FAILED`** — read `AUDIT_LOGS_FILE=...`, then read that file.
+- **Exit 1** — configuration or `gh` error; stop and report.
+
+### 3. Diagnose (AI)
+
+From the log file(s), determine the **root cause**. Categories to handle:
+
+- TypeScript / build errors (`make build`)
+- Go compile or test failures (`make test-backend`, `go test ./...`)
+- Frontend tests / lint (`make test-frontend`, eslint output in CI)
+- Mobile (`make mobile-test`) if the failing job is mobile
+- Database tests / migrations (`go test ./db/... -v`) when indicated
+- Lockfile or dependency drift
+- **gosec / audit** findings in **audit** logs
+
+**Stop and ask the user** if:
+
+- The failure is ambiguous, flaky without a clear repro, or needs a product/design decision
+- Multiple incompatible fixes are possible and logs do not point to one
+
+Do **not** guess on ambiguous security or behavior changes.
+
+### 4. Fix and validate locally
+
+Apply minimal, focused code changes. Then run **relevant** checks before pushing (from `CLAUDE.md`):
+
+| Change area | Run |
+|-------------|-----|
+| Go only | `make test-backend` |
+| Frontend only | `make test-frontend` |
+| Mobile only | `make mobile-test` |
+| Migrations / `db/` | `go test ./db/... -v` (needs Postgres) |
+| Unsure | `make test` |
+| Any compile-sensitive change | `make build` |
+
+### 5. Commit and push
+
+One **atomic** commit per fix round with a descriptive message (e.g. `fix(ci): resolve unused import in handler`).
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+### 6. Next round
+
+If not yet at `MAX_ROUNDS`, go to step 2. The trigger script always starts **new** workflow runs after your push.
+
+## Success
+
+When `fix-ci-trigger.sh` exits 0:
+
+1. Print the **CI run URL** and **audit run URL** from script output (`CI_RUN_URL=`, `AUDIT_RUN_URL=`).
+2. **Pull request:** If there is no PR for the current branch, create one (same conventions as `/yolo` Step 5 — ready for review, link context in body). If a PR already exists, note its URL.
+
+```bash
+PR_URL=$(GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+```
+
+If `PR_URL` is empty and the branch is not the default branch (`main`), create the PR with `gh pr create` (non-draft, per `CLAUDE.md`).
+
+End the session with: `Pull request: <url>` when a PR exists (plain text, per `CLAUDE.md`).
+
+## Exhausted rounds
+
+If you reach `MAX_ROUNDS` with CI or audit still failing:
+
+- Summarize what failed, last log hints, and last run URLs
+- Suggest manual triage; do not keep looping
+
+## Guardrails
+
+- **Default `MAX_ROUNDS`:** 5
+- **No auto-merge** — this skill only fixes CI/audit; it does not merge PRs
+- **No webhook** — do not run `trigger-webhook.yml` unless the user explicitly asked for notification outside this skill
+- **Minimal diffs** — follow merge-conflict minimization rules in `CLAUDE.md`
+
+## Example invocations
+
+```
+/fix-ci
+/fix-ci my-feature-branch
+/fix-ci --max-rounds 3
+/fix-ci cursor/some-branch --max-rounds 8 --work-dir /tmp/fix-ci-session
+```

--- a/.claude/skills/fix-ci/fix-ci-trigger.sh
+++ b/.claude/skills/fix-ci/fix-ci-trigger.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# fix-ci-trigger.sh — Trigger ci.yml + audit.yml on a branch, wait, fetch logs on failure.
+# Used by the /fix-ci skill for one round of remote validation.
+#
+# Usage: bash fix-ci-trigger.sh [--work-dir DIR]
+#
+# Environment:
+#   GH_HOST, GH_REPO — passed through to gh (defaults match permission-slip)
+#
+# Exit codes:
+#   0 — both workflows succeeded
+#   101 — CI did not succeed (logs in CI_LOGS_FILE)
+#   102 — Audit did not succeed (logs in AUDIT_LOGS_FILE)
+#   1 — usage / missing branch / gh error
+
+set -euo pipefail
+
+WORK_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --work-dir) WORK_DIR="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+export GH_HOST="${GH_HOST:-github.com}"
+export GH_REPO="${GH_REPO:-supersuit-tech/permission-slip}"
+
+BRANCH=$(git branch --show-current 2>/dev/null || true)
+if [[ -z "$BRANCH" ]]; then
+  echo "ERROR: Not on a named branch (detached HEAD?). Checkout a branch first." >&2
+  exit 1
+fi
+
+gh_cmd() {
+  GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh "$@"
+}
+
+LOG_ROOT="${WORK_DIR:-/tmp}"
+mkdir -p "$LOG_ROOT"
+CI_LOGS_FILE="${LOG_ROOT}/fix-ci-ci-failed-logs.txt"
+AUDIT_LOGS_FILE="${LOG_ROOT}/fix-ci-audit-failed-logs.txt"
+
+LOCAL_SHA=$(git rev-parse HEAD)
+
+# Fast path: latest completed CI + audit on this branch already refer to this commit and passed.
+latest_completed_for_sha() {
+  local workflow="$1"
+  gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 25 \
+    --json databaseId,status,conclusion,headSha 2>/dev/null \
+    | jq -r --arg sha "$LOCAL_SHA" '
+        [.[] | select(.headSha == $sha and .status == "completed")]
+        | if length == 0 then empty
+          elif .[0].conclusion == "success" then "success:\(.[0].databaseId)"
+          else "failed:\(.[0].databaseId):\(.[0].conclusion)" end'
+}
+
+ci_fast=$(latest_completed_for_sha "ci.yml" || true)
+audit_fast=$(latest_completed_for_sha "audit.yml" || true)
+
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" ]]; then
+  ci_fid="${ci_fast#success:}"
+  if [[ -n "$audit_fast" && "${audit_fast%%:*}" == "success" ]]; then
+    audit_fid="${audit_fast#success:}"
+    echo "[fix-ci] CI and audit already green for HEAD ${LOCAL_SHA}; skipping trigger."
+    echo ""
+    echo "FIX_CI_COMPLETE"
+    echo "BRANCH=${BRANCH}"
+    echo "LOCAL_HEAD=${LOCAL_SHA}"
+    echo "CI_RUN_URL=$(gh_cmd run view "$ci_fid" --json url --jq -r '.url')"
+    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_fid" --json url --jq -r '.url')"
+    exit 0
+  fi
+fi
+
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "failed" ]]; then
+  # rest: failed:id:conclusion
+  rest="${ci_fast#failed:}"
+  ci_run_id="${rest%%:*}"
+  ci_conclusion="${rest##*:}"
+  echo "[fix-ci] Latest CI for HEAD ${LOCAL_SHA} already completed with ${ci_conclusion} (run ${ci_run_id})."
+  echo ""
+  echo "CI_FAILED"
+  echo "CI_RUN_ID=${ci_run_id}"
+  echo "CI_CONCLUSION=${ci_conclusion}"
+  gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
+  gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+  echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
+  echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq -r '.url')"
+  echo "AGENT_NEEDED"
+  exit 101
+fi
+
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" && -n "$audit_fast" && "${audit_fast%%:*}" == "failed" ]]; then
+  rest="${audit_fast#failed:}"
+  audit_run_id="${rest%%:*}"
+  audit_conclusion="${rest##*:}"
+  echo "[fix-ci] Latest audit for HEAD ${LOCAL_SHA} already completed with ${audit_conclusion} (run ${audit_run_id})."
+  echo ""
+  echo "AUDIT_FAILED"
+  echo "AUDIT_RUN_ID=${audit_run_id}"
+  echo "AUDIT_CONCLUSION=${audit_conclusion}"
+  gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
+  gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+  echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
+  echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq -r '.url')"
+  echo "AGENT_NEEDED"
+  exit 102
+fi
+
+get_latest_run_id() {
+  local workflow="$1"
+  gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 1 --json databaseId 2>/dev/null \
+    | jq -r '.[0].databaseId // "0"'
+}
+
+ci_prev_run_id=$(get_latest_run_id "ci.yml")
+audit_prev_run_id=$(get_latest_run_id "audit.yml")
+
+echo "[fix-ci] Triggering ci.yml on ${BRANCH}..."
+gh_cmd workflow run ci.yml --ref "$BRANCH" 2>/dev/null || {
+  echo "[fix-ci] ERROR: Failed to trigger ci.yml" >&2
+  exit 1
+}
+
+echo "[fix-ci] Triggering audit.yml on ${BRANCH}..."
+gh_cmd workflow run audit.yml --ref "$BRANCH" 2>/dev/null || {
+  echo "[fix-ci] ERROR: Failed to trigger audit.yml" >&2
+  exit 1
+}
+
+wait_for_workflow() {
+  local workflow="$1"
+  local prev_run_id="$2"
+  local max_wait=600
+  local elapsed=0
+
+  sleep 5
+
+  while [[ $elapsed -lt $max_wait ]]; do
+    local result
+    result=$(gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 1 --json databaseId,status,conclusion 2>/dev/null || echo "[]")
+
+    local status conclusion run_id
+    status=$(echo "$result" | jq -r '.[0].status // "unknown"')
+    conclusion=$(echo "$result" | jq -r '.[0].conclusion // "unknown"')
+    run_id=$(echo "$result" | jq -r '.[0].databaseId // "unknown"')
+
+    if [[ "$run_id" != "unknown" && "$run_id" != "$prev_run_id" && "$status" == "completed" ]]; then
+      echo "${conclusion}:${run_id}"
+      return
+    fi
+
+    sleep 30
+    elapsed=$((elapsed + 30))
+  done
+
+  echo "timeout:unknown"
+}
+
+echo "[fix-ci] Waiting for CI..."
+ci_result=$(wait_for_workflow "ci.yml" "$ci_prev_run_id")
+ci_conclusion="${ci_result%%:*}"
+ci_run_id="${ci_result##*:}"
+echo "[fix-ci] CI result: ${ci_conclusion} (run ${ci_run_id})"
+
+if [[ "$ci_conclusion" != "success" ]]; then
+  echo ""
+  echo "CI_FAILED"
+  echo "CI_RUN_ID=${ci_run_id}"
+  echo "CI_CONCLUSION=${ci_conclusion}"
+  echo "[fix-ci] Fetching CI logs..."
+  if [[ "$ci_run_id" != "unknown" ]]; then
+    gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
+    gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+  else
+    : > "$CI_LOGS_FILE"
+  fi
+  echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
+  if [[ -n "$ci_run_id" && "$ci_run_id" != "unknown" ]]; then
+    echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq -r '.url')"
+  fi
+  echo "AGENT_NEEDED"
+  exit 101
+fi
+
+echo "[fix-ci] Waiting for audit..."
+audit_result=$(wait_for_workflow "audit.yml" "$audit_prev_run_id")
+audit_conclusion="${audit_result%%:*}"
+audit_run_id="${audit_result##*:}"
+echo "[fix-ci] Audit result: ${audit_conclusion} (run ${audit_run_id})"
+
+if [[ "$audit_conclusion" != "success" ]]; then
+  echo ""
+  echo "AUDIT_FAILED"
+  echo "AUDIT_RUN_ID=${audit_run_id}"
+  echo "AUDIT_CONCLUSION=${audit_conclusion}"
+  echo "[fix-ci] Fetching audit logs..."
+  if [[ "$audit_run_id" != "unknown" ]]; then
+    gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
+    gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+  else
+    : > "$AUDIT_LOGS_FILE"
+  fi
+  echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
+  if [[ -n "$audit_run_id" && "$audit_run_id" != "unknown" ]]; then
+    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq -r '.url')"
+  fi
+  echo "AGENT_NEEDED"
+  exit 102
+fi
+
+echo ""
+echo "FIX_CI_COMPLETE"
+echo "BRANCH=${BRANCH}"
+echo "LOCAL_HEAD=$(git rev-parse HEAD)"
+if [[ -n "$ci_run_id" && "$ci_run_id" != "unknown" ]]; then
+  echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq -r '.url')"
+fi
+if [[ -n "$audit_run_id" && "$audit_run_id" != "unknown" ]]; then
+  echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq -r '.url')"
+fi

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Permission Slip needs agents that can **(1) make HTTP requests to arbitrary URLs
 | [v0](https://v0.dev) (Vercel) | Sandboxed, focused on UI generation |
 | [Bolt](https://bolt.new) | Sandboxed WebContainer with limited network |
 
+### Claude Code skills
+
+This repo includes [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) skills under [`.claude/skills/`](.claude/skills/). For example, **`/fix-ci`** (see [`fix-ci/SKILL.md`](.claude/skills/fix-ci/SKILL.md)) triggers **CI + audit** on the current branch, pulls failure logs, and loops on fix → push → re-run until green (with a round cap).
+
 ### ❓ Uncertain (needs testing)
 
 | Agent | Concern |


### PR DESCRIPTION
## Summary

- Add `/fix-ci` Claude Code skill under `.claude/skills/fix-ci/` with `fix-ci-trigger.sh` to trigger `ci.yml` and `audit.yml`, wait for completion, and capture failure logs (`gh run view --log-failed`).
- Fast path: if the latest completed CI and audit runs for the branch already match current `HEAD` and succeeded, skip re-triggering and report run URLs.
- Document arguments (`--max-rounds`, optional branch, `--work-dir`), the fix loop, guardrails (no auto-merge, ambiguous failures stop), and PR creation in `SKILL.md`.
- Link the skill from the README Agent Compatibility section.

Closes #743

## Test plan

### Claude Code
- [x] `bash -n` on `fix-ci-trigger.sh` passes

### Manual Testing
- [ ] Run `/fix-ci` (or invoke the skill) on a branch with failing CI and confirm logs are fetched and the loop behaves as documented
- [ ] Confirm `gh` can trigger `ci.yml` / `audit.yml` from your environment

https://claude.ai/code