### PR TITLE
Always show Enable All Actions when wildcard config is missing (#747)

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -105,6 +105,7 @@ export function ActionConfigurationsSection({
               </Button>
             )}
             <Button
+              type="button"
               size="sm"
               className="shrink-0"
               onClick={() => setAddDialogOpen(true)}

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardTitle,
   CardContent,
-  CardFooter,
 } from "@/components/ui/card";
 import {
   Table,
@@ -53,6 +52,10 @@ export function ActionConfigurationsSection({
   );
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  const hasWildcardConfig = configs.some(
+    (c) => c.action_type === WILDCARD_ACTION_TYPE,
+  );
+
   const { createActionConfig, isPending: isEnablingAll } =
     useCreateActionConfig();
 
@@ -83,15 +86,34 @@ export function ActionConfigurationsSection({
           <CardTitle>Action Configurations</CardTitle>
         </div>
         {configs.length > 0 && (
-          <Button
-            size="sm"
-            className="shrink-0 self-start sm:self-center"
-            onClick={() => setAddDialogOpen(true)}
-            disabled={actions.length === 0}
-          >
-            <Plus className="size-4" />
-            Add Configuration
-          </Button>
+          <div className="flex flex-wrap items-center gap-2 self-start sm:self-center">
+            {!hasWildcardConfig && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={handleEnableAll}
+                disabled={isEnablingAll || actions.length === 0}
+              >
+                {isEnablingAll ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Zap className="size-4" aria-hidden="true" />
+                )}
+                Enable All Actions
+              </Button>
+            )}
+            <Button
+              size="sm"
+              className="shrink-0"
+              onClick={() => setAddDialogOpen(true)}
+              disabled={actions.length === 0}
+            >
+              <Plus className="size-4" />
+              Add Configuration
+            </Button>
+          </div>
         )}
       </CardHeader>
       <CardContent>
@@ -148,25 +170,6 @@ export function ActionConfigurationsSection({
           </div>
         )}
       </CardContent>
-
-      {configs.length > 0 &&
-        !configs.some((c) => c.action_type === WILDCARD_ACTION_TYPE) && (
-          <CardFooter className="justify-center border-t pt-4">
-            <button
-              type="button"
-              onClick={handleEnableAll}
-              disabled={isEnablingAll || actions.length === 0}
-              className="text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1 text-xs transition-colors"
-            >
-              {isEnablingAll ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Zap className="size-3" />
-              )}
-              Enable All Actions
-            </button>
-          </CardFooter>
-        )}
 
       <AddActionConfigDialog
         open={addDialogOpen}

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -360,14 +360,15 @@ describe("ActionConfigurationsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows Enable All Actions footer link when configs exist and none are wildcard", () => {
+  it("shows Enable All Actions in the header when configs exist and none are wildcard", () => {
     renderSection({ configs: mockConfigs });
-    // The table has configs, so a footer link should appear
-    const footerLink = screen.getByRole("button", { name: /Enable All Actions/ });
-    expect(footerLink).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Enable All Actions/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Add Configuration")).toBeInTheDocument();
   });
 
-  it("hides Enable All Actions footer link when a wildcard config exists", () => {
+  it("hides Enable All Actions header button when a wildcard config exists", () => {
     const wildcardConfig: ActionConfiguration[] = [
       {
         id: "ac_wildcard",
@@ -383,7 +384,6 @@ describe("ActionConfigurationsSection", () => {
       },
     ];
     renderSection({ configs: wildcardConfig });
-    // Footer button must not be rendered
     expect(
       screen.queryByRole("button", { name: /Enable All Actions/ }),
     ).not.toBeInTheDocument();
@@ -391,7 +391,7 @@ describe("ActionConfigurationsSection", () => {
     expect(screen.getByText("All Actions")).toBeInTheDocument();
   });
 
-  it("calls create with wildcard action_type when clicking footer Enable All Actions", async () => {
+  it("calls create with wildcard action_type when clicking header Enable All Actions with existing configs", async () => {
     const user = userEvent.setup();
     mockPost.mockResolvedValue({
       data: {

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -368,6 +368,29 @@ describe("ActionConfigurationsSection", () => {
     expect(screen.getByText("Add Configuration")).toBeInTheDocument();
   });
 
+  it("hides header Enable All Actions when wildcard and non-wildcard configs coexist", () => {
+    const mixedConfigs: ActionConfiguration[] = [
+      ...mockConfigs,
+      {
+        id: "ac_wildcard",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "*",
+        parameters: {},
+        status: "active",
+        name: "All GitHub Actions",
+        description: null,
+        created_at: "2026-03-11T10:00:00Z",
+        updated_at: "2026-03-11T10:00:00Z",
+      },
+    ];
+    renderSection({ configs: mixedConfigs });
+    expect(
+      screen.queryByRole("button", { name: /Enable All Actions/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Add Configuration")).toBeInTheDocument();
+  });
+
   it("hides Enable All Actions header button when a wildcard config exists", () => {
     const wildcardConfig: ActionConfiguration[] = [
       {
@@ -421,6 +444,40 @@ describe("ActionConfigurationsSection", () => {
           parameters: {},
         },
       });
+    });
+  });
+
+  it("shows loading spinner and disables header Enable All Actions while create is pending", async () => {
+    const user = userEvent.setup();
+    let resolvePost: (value: unknown) => void;
+    const pending = new Promise((resolve) => {
+      resolvePost = resolve;
+    });
+    mockPost.mockReturnValue(pending);
+
+    renderSection({ configs: mockConfigs });
+    await user.click(screen.getByRole("button", { name: /Enable All Actions/ }));
+
+    const btn = screen.getByRole("button", { name: /Enable All Actions/ });
+    expect(btn).toBeDisabled();
+    expect(btn.querySelector(".animate-spin")).toBeTruthy();
+
+    resolvePost!({
+      data: {
+        id: "ac_wildcard",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "*",
+        parameters: {},
+        status: "active",
+        name: "All GitHub Actions",
+        created_at: "2026-03-11T10:00:00Z",
+        updated_at: "2026-03-11T10:00:00Z",
+      },
+    });
+
+    await waitFor(() => {
+      expect(btn).not.toBeDisabled();
     });
   });
 


### PR DESCRIPTION
## Summary

Implements [issue #747](https://github.com/supersuit-tech/permission-slip/issues/747): when a connector already has individual action configurations but no wildcard (`*`) config, **Enable All Actions** is shown as an outline button in the **Action Configurations** card header next to **Add Configuration**, instead of a small footer link. The empty-state primary CTA is unchanged. The header button is hidden once a wildcard config exists.

## Test plan

### Claude Code
- [x] `npx vitest run src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx` — all 20 tests pass

### Manual Testing
- [ ] Open a connector with at least one non-wildcard config and confirm **Enable All Actions** appears in the section header beside **Add Configuration**
- [ ] Click it and confirm wildcard config is created and the button disappears
- [ ] Empty state: confirm primary **Enable All Actions** and advanced flow unchanged

Closes #747