### PR TITLE
Remove custom action type from standing approval UI

### DIFF
--- a/frontend/src/hooks/useActionConfigs.ts
+++ b/frontend/src/hooks/useActionConfigs.ts
@@ -33,6 +33,8 @@ export function useActionConfigs(agentId: number) {
   return {
     configs: query.data?.data ?? [],
     isLoading: query.isLoading,
+    /** True after this query has finished a fetch (success or error), including empty results. */
+    isFetched: query.isFetched,
     error: query.isError
       ? "Unable to load action configurations. Please try again later."
       : null,

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
@@ -26,7 +26,6 @@ import {
   StepPickAgent,
   StepPickAction,
   StepLimits,
-  CUSTOM_ACTION_SENTINEL,
 } from "./StandingApprovalSteps";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
 import type { ParametersSchema, SchemaProperty } from "@/lib/parameterSchema";
@@ -396,7 +395,6 @@ function CreateStandingApprovalWizard({
   const [selectedConfigId, setSelectedConfigId] = useState(
     initialStep > 1 ? "cfg-1" : "",
   );
-  const [customActionType, setCustomActionType] = useState("");
   const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
   const [manualConstraintsJson, setManualConstraintsJson] = useState("");
@@ -404,7 +402,6 @@ function CreateStandingApprovalWizard({
   const [noExpiry, setNoExpiry] = useState(true);
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
-  const isCustomAction = selectedConfigId === CUSTOM_ACTION_SENTINEL;
   const effectiveSchema = schema ?? (step >= 3 ? CALENDAR_SCHEMA : null);
 
   const effectiveActionType =
@@ -412,7 +409,7 @@ function CreateStandingApprovalWizard({
       ? "google_calendar.create_event"
       : selectedConfigId === "cfg-3"
         ? "github.create_issue"
-        : customActionType;
+        : "";
 
   return (
     <Dialog open>
@@ -475,11 +472,8 @@ function CreateStandingApprovalWizard({
             <StepPickAction
               selectedConfigId={selectedConfigId}
               onConfigChange={setSelectedConfigId}
-              customActionType={customActionType}
-              onCustomActionTypeChange={setCustomActionType}
               configsByConnector={MOCK_CONFIGS_BY_CONNECTOR}
               configsLoading={false}
-              isCustomAction={isCustomAction}
             />
           )}
 

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState, useMemo } from "react";
+import { type FormEvent, useState, useMemo, useEffect } from "react";
 import { Loader2, ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -24,7 +24,6 @@ import {
   type ParamMode,
 } from "@/pages/agents/connectors/ActionConfigFormFields";
 import {
-  CUSTOM_ACTION_SENTINEL,
   StepPickAgent,
   StepPickAction,
   StepConstraints,
@@ -108,12 +107,7 @@ export function CreateStandingApprovalDialog({
   const [step, setStep] = useState<Step>(hasInitialContext ? 3 : 1);
   const [agentId, setAgentId] = useState<number | "">(ctxAgentId ?? "");
   const [selectedConfigId, setSelectedConfigId] = useState<string>(
-    isEditMode
-      ? (editTarget.source_action_configuration_id ?? CUSTOM_ACTION_SENTINEL)
-      : (ctxActionType ? CUSTOM_ACTION_SENTINEL : ""),
-  );
-  const [customActionType, setCustomActionType] = useState(
-    ctxActionType ?? "",
+    isEditMode ? (editTarget.source_action_configuration_id ?? "") : "",
   );
   // Pre-populate constraint form values when initial constraints are provided
   const [paramValues, setParamValues] = useState<Record<string, string>>(() => {
@@ -170,17 +164,40 @@ export function CreateStandingApprovalDialog({
 
   const selectedConfig = useMemo(
     () =>
-      selectedConfigId && selectedConfigId !== CUSTOM_ACTION_SENTINEL
+      selectedConfigId
         ? activeConfigs.find((c) => c.id === selectedConfigId) ?? null
         : null,
     [activeConfigs, selectedConfigId],
   );
 
-  const isCustomAction = selectedConfigId === CUSTOM_ACTION_SENTINEL;
+  const matchingConfigForContext = useMemo(() => {
+    if (!ctxActionType) return null;
+    return activeConfigs.find((c) => c.action_type === ctxActionType) ?? null;
+  }, [activeConfigs, ctxActionType]);
 
-  const effectiveActionType = selectedConfig
-    ? selectedConfig.action_type
-    : customActionType;
+  useEffect(() => {
+    if (!open) return;
+    if (isEditMode && editTarget) {
+      if (editTarget.source_action_configuration_id) {
+        setSelectedConfigId(editTarget.source_action_configuration_id);
+      } else {
+        setSelectedConfigId(matchingConfigForContext?.id ?? "");
+      }
+      return;
+    }
+    if (hasInitialContext) {
+      setSelectedConfigId(matchingConfigForContext?.id ?? "");
+    }
+  }, [
+    open,
+    isEditMode,
+    editTarget,
+    hasInitialContext,
+    matchingConfigForContext?.id,
+  ]);
+
+  const effectiveActionType =
+    selectedConfig?.action_type ?? ctxActionType ?? "";
 
   const {
     schema: fetchedSchema,
@@ -205,12 +222,16 @@ export function CreateStandingApprovalDialog({
   function resetForm() {
     setStep(hasInitialContext ? 3 : 1);
     setAgentId(ctxAgentId ?? "");
-    setSelectedConfigId(
-      isEditMode
-        ? (editTarget.source_action_configuration_id ?? CUSTOM_ACTION_SENTINEL)
-        : (ctxActionType ? CUSTOM_ACTION_SENTINEL : ""),
-    );
-    setCustomActionType(ctxActionType ?? "");
+    let nextConfigId = "";
+    if (isEditMode && editTarget) {
+      nextConfigId =
+        editTarget.source_action_configuration_id ??
+        matchingConfigForContext?.id ??
+        "";
+    } else if (hasInitialContext) {
+      nextConfigId = matchingConfigForContext?.id ?? "";
+    }
+    setSelectedConfigId(nextConfigId);
     if (hasInitialContext && ctxConstraints) {
       const values: Record<string, string> = {};
       const modes: Record<string, ParamMode> = {};
@@ -279,25 +300,12 @@ export function CreateStandingApprovalDialog({
         toast.error("Please wait for configurations to finish loading");
         return;
       }
-      if (!selectedConfigId) {
-        toast.error("Please select an action configuration or choose custom");
+      if (!selectedConfigId || !selectedConfig) {
+        toast.error("Please select an action configuration");
         return;
       }
-      if (isCustomAction && !customActionType.trim()) {
-        toast.error("Please enter an action type");
-        return;
-      }
-      if (selectedConfig) {
-        initConstraintsFromRecord(selectedConfig.parameters);
-        setManualConstraintsJson("");
-      } else if (ctxConstraints && isCustomAction) {
-        initConstraintsFromRecord(ctxConstraints);
-        setManualConstraintsJson(JSON.stringify(ctxConstraints, null, 2));
-      } else {
-        setParamValues({});
-        setParamModes({});
-        setManualConstraintsJson("");
-      }
+      initConstraintsFromRecord(selectedConfig.parameters);
+      setManualConstraintsJson("");
       setStep(3);
     } else if (step === 3) {
       if (schemaLoading) {
@@ -517,7 +525,6 @@ export function CreateStandingApprovalDialog({
               onAgentChange={(id) => {
                 setAgentId(id);
                 setSelectedConfigId("");
-                setCustomActionType(ctxActionType ?? "");
                 setParamValues({});
                 setParamModes({});
               }}
@@ -529,11 +536,8 @@ export function CreateStandingApprovalDialog({
             <StepPickAction
               selectedConfigId={selectedConfigId}
               onConfigChange={setSelectedConfigId}
-              customActionType={customActionType}
-              onCustomActionTypeChange={setCustomActionType}
               configsByConnector={configsByConnector}
               configsLoading={configsLoading}
-              isCustomAction={isCustomAction}
             />
           )}
 

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState, useMemo, useEffect } from "react";
+import { type FormEvent, useState, useMemo, useEffect, useRef } from "react";
 import { Loader2, ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -153,9 +153,8 @@ export function CreateStandingApprovalDialog({
 
   const activeAgents = agents.filter((a) => a.status !== "deactivated");
 
-  const { configs, isLoading: configsLoading } = useActionConfigs(
-    typeof agentId === "number" ? agentId : 0,
-  );
+  const { configs, isLoading: configsLoading, isFetched: configsFetched } =
+    useActionConfigs(typeof agentId === "number" ? agentId : 0);
 
   const activeConfigs = useMemo(
     () => configs.filter((c) => c.status === "active"),
@@ -175,25 +174,40 @@ export function CreateStandingApprovalDialog({
     return activeConfigs.find((c) => c.action_type === ctxActionType) ?? null;
   }, [activeConfigs, ctxActionType]);
 
+  /** Avoid resetting selectedConfigId when configs refetch mid-wizard (e.g. refetchOnWindowFocus). */
+  const didApplyInitialConfigSelectionRef = useRef(false);
+
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      didApplyInitialConfigSelectionRef.current = false;
+      return;
+    }
+    const shouldSyncFromContext =
+      (isEditMode && !!editTarget) || hasInitialContext;
+    if (!shouldSyncFromContext) return;
+    if (configsLoading) return;
+    if (typeof agentId === "number" && agentId > 0 && !configsFetched) return;
+    if (didApplyInitialConfigSelectionRef.current) return;
+
     if (isEditMode && editTarget) {
       if (editTarget.source_action_configuration_id) {
         setSelectedConfigId(editTarget.source_action_configuration_id);
       } else {
         setSelectedConfigId(matchingConfigForContext?.id ?? "");
       }
-      return;
-    }
-    if (hasInitialContext) {
+    } else if (hasInitialContext) {
       setSelectedConfigId(matchingConfigForContext?.id ?? "");
     }
+    didApplyInitialConfigSelectionRef.current = true;
   }, [
     open,
+    configsLoading,
+    configsFetched,
+    agentId,
     isEditMode,
     editTarget,
     hasInitialContext,
-    matchingConfigForContext?.id,
+    matchingConfigForContext,
   ]);
 
   const effectiveActionType =

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -69,6 +69,13 @@ export function StepPickAction({
             Loading configurations...
           </span>
         </div>
+      ) : connectorIds.length === 0 ? (
+        <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            No active action configurations found for this agent. Configure an
+            action in the agent settings before creating a standing approval.
+          </p>
+        </div>
       ) : (
         <>
           <select

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -9,8 +9,6 @@ import type { ParametersSchema } from "@/lib/parameterSchema";
 import { ActionConfigParameterFields } from "@/pages/agents/connectors/ActionConfigParameterFields";
 import type { ParamMode } from "@/pages/agents/connectors/ActionConfigFormFields";
 
-export const CUSTOM_ACTION_SENTINEL = "__custom__";
-
 const selectClassName =
   "border-input bg-background ring-offset-background focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
 
@@ -51,19 +49,13 @@ export function StepPickAgent({
 export function StepPickAction({
   selectedConfigId,
   onConfigChange,
-  customActionType,
-  onCustomActionTypeChange,
   configsByConnector,
   configsLoading,
-  isCustomAction,
 }: {
   selectedConfigId: string;
   onConfigChange: (id: string) => void;
-  customActionType: string;
-  onCustomActionTypeChange: (value: string) => void;
   configsByConnector: Record<string, ActionConfiguration[]>;
   configsLoading: boolean;
-  isCustomAction: boolean;
 }) {
   const connectorIds = Object.keys(configsByConnector);
 
@@ -95,29 +87,13 @@ export function StepPickAction({
                 ))}
               </optgroup>
             ))}
-            <option value={CUSTOM_ACTION_SENTINEL}>
-              Custom action type...
-            </option>
           </select>
           <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">
             <p className="text-muted-foreground text-xs leading-relaxed">
-              Select an action configuration to pre-populate constraints, or
-              choose &quot;Custom action type&quot; for manual entry.
+              Select an action configuration to pre-populate constraints.
             </p>
           </div>
         </>
-      )}
-
-      {isCustomAction && (
-        <div className="space-y-2">
-          <Label htmlFor="sa-custom-action">Action Type</Label>
-          <Input
-            id="sa-custom-action"
-            placeholder="e.g. github.create_issue"
-            value={customActionType}
-            onChange={(e) => onCustomActionTypeChange(e.target.value)}
-          />
-        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setupAuthMocks } from "../../../auth/__tests__/fixtures";
 import { createAuthWrapper } from "../../../test-helpers";
-import { mockGet, resetClientMocks } from "../../../api/__mocks__/client";
+import { mockGet, mockPost, resetClientMocks } from "../../../api/__mocks__/client";
 import { CreateStandingApprovalDialog } from "../CreateStandingApprovalDialog";
 import type { Agent } from "../../../hooks/useAgents";
 
@@ -288,6 +288,76 @@ describe("CreateStandingApprovalDialog", () => {
     // Should skip to step 3 (constraints), shown as step 1 of 2
     expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
     expect(screen.getByText(/Set Constraints/)).toBeInTheDocument();
+  });
+
+  it("auto-selected matching config submits create with source_action_configuration_id", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({ data: { standing_approval_id: "sa_test" } });
+
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+        initialAgentId={1}
+        initialActionType="github.create_issue"
+        initialConstraints={mockConfigs[0].parameters}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Standing approvals require parameter constraints/),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 2/)).toBeInTheDocument();
+      expect(screen.getByText(/Set Limits/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/v1/standing-approvals/create",
+        expect.objectContaining({
+          body: expect.objectContaining({
+            agent_id: 1,
+            action_type: "github.create_issue",
+            source_action_configuration_id: "ac_config1",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("shows empty state on step 2 when agent has no action configurations", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateStandingApprovalDialog
+        agents={mockAgents}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await user.selectOptions(screen.getByLabelText("Agent"), "2");
+    await user.click(screen.getByText("Next"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        /No active action configurations found for this agent/,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("filters out deactivated agents", () => {

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -184,35 +184,9 @@ describe("CreateStandingApprovalDialog", () => {
       ).toBeInTheDocument();
     });
 
-    // Custom option should be present
-    expect(screen.getByText("Custom action type...")).toBeInTheDocument();
-  });
-
-  it("shows custom action type input when custom is selected", async () => {
-    const user = userEvent.setup();
-    render(
-      <CreateStandingApprovalDialog
-        agents={mockAgents}
-        open={true}
-        onOpenChange={vi.fn()}
-      />,
-      { wrapper },
-    );
-
-    await user.selectOptions(screen.getByLabelText("Agent"), "1");
-    await user.click(screen.getByText("Next"));
-
-    await waitFor(() => {
-      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
-    });
-
-    // Select custom action type
-    await user.selectOptions(
-      screen.getByLabelText("Action Configuration"),
-      "__custom__",
-    );
-
-    expect(screen.getByLabelText("Action Type")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Custom action type..."),
+    ).not.toBeInTheDocument();
   });
 
   it("navigates back from step 2 to step 1", async () => {

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -301,7 +301,11 @@ describe("CreateStandingApprovalDialog", () => {
         onOpenChange={vi.fn()}
         initialAgentId={1}
         initialActionType="github.create_issue"
-        initialConstraints={mockConfigs[0].parameters}
+        initialConstraints={{
+          repo: "supersuit-tech/webapp",
+          title: "*",
+          body: "*",
+        }}
       />,
       { wrapper },
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "Custom action type" manual entry path from the create/edit standing approval wizard (`StepPickAction` + `CreateStandingApprovalDialog`). Users must choose an action configuration when creating a standing approval from the dashboard.

When the dialog is opened with pre-filled context (e.g. **Always allow this action** from the review flow, or edit mode for an approval without `source_action_configuration_id`), we auto-select an active action configuration whose `action_type` matches the context when one exists, so constraints and submission stay aligned with a real config.

Closes supersuit-tech/permission-slip#746

## Test plan

- `make test-frontend` (passes)
- `make build`: frontend `tsc` + `vite build` succeed; Go step fails in this environment (go.mod requires Go 1.26.1, runner has 1.22.2)

### Claude Code

- [x] Update unit tests and Storybook wizard parity for `StepPickAction`
- [x] Run frontend tests

### Manual Testing

- [ ] Create standing approval from dashboard: step 2 shows only configured actions, no custom type option
- [ ] **Always allow this action** from approval review: wizard still loads constraints and creates approval when a matching action config exists for that agent
- [ ] Edit an existing standing approval that has no source config: dialog still shows correct action type and allows saving constraint/limit updates
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17e199f4-59d3-4874-9729-ac9bb13eb0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17e199f4-59d3-4874-9729-ac9bb13eb0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

