### PR TITLE
Fix visuals for enabled vs disabled action configurations

### DIFF
--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -98,7 +98,12 @@ PR_NUMBER_FILE="$WORK_DIR/pr-number.txt"
 echo "$PR_NUMBER" > "$PR_NUMBER_FILE"
 
 # Bot username(s) to filter out
-BOT_USERS=("claude-code[bot]" "github-actions[bot]" "claude[bot]")
+BOT_USERS=(
+  "claude-code[bot]"
+  "github-actions[bot]"
+  "claude[bot]"
+  "greptile-apps[bot]"
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -167,7 +172,7 @@ fetch_new_comments() {
 
   local new_rcs
   new_rcs=$(echo "$review_comments" | jq -r --argjson last "$last_rc_id" '
-    [.[] | select(.id > $last)] | sort_by(.id)')
+    [.[] | select(.id > $last and .in_reply_to_id == null)] | sort_by(.id)')
 
   new_rcs=$(echo "$new_rcs" | jq -r --argjson bots "$(printf '%s\n' "${BOT_USERS[@]}" | jq -R . | jq -s .)" '
     [.[] | select(.user.login as $u | $bots | index($u) | not)]')

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -1,3 +1,4 @@
+import { type KeyboardEvent, useRef } from "react";
 import { Ban, Check } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -75,9 +76,29 @@ export function StatusSelect({
   onChange,
   disabled,
 }: StatusSelectProps) {
+  const activeRef = useRef<HTMLButtonElement>(null);
+  const disabledRef = useRef<HTMLButtonElement>(null);
+
   const segmentBase =
     "flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
   const labelId = `${id}-label`;
+
+  function handleActiveKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      onChange("disabled");
+      queueMicrotask(() => disabledRef.current?.focus());
+    }
+  }
+
+  function handleDisabledKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      onChange("active");
+      queueMicrotask(() => activeRef.current?.focus());
+    }
+  }
+
   return (
     <fieldset className="space-y-2" disabled={disabled}>
       <Label id={labelId} className="text-sm font-medium">
@@ -89,9 +110,11 @@ export function StatusSelect({
         className="bg-muted/60 flex gap-1 rounded-lg border p-1"
       >
         <button
+          ref={activeRef}
           type="button"
           role="radio"
           aria-checked={value === "active"}
+          tabIndex={value === "active" ? 0 : -1}
           className={cn(
             segmentBase,
             value === "active"
@@ -99,14 +122,17 @@ export function StatusSelect({
               : "text-muted-foreground hover:text-foreground",
           )}
           onClick={() => onChange("active")}
+          onKeyDown={handleActiveKeyDown}
         >
           <Check className="size-3.5 shrink-0" aria-hidden />
           Active
         </button>
         <button
+          ref={disabledRef}
           type="button"
           role="radio"
           aria-checked={value === "disabled"}
+          tabIndex={value === "disabled" ? 0 : -1}
           className={cn(
             segmentBase,
             value === "disabled"
@@ -114,6 +140,7 @@ export function StatusSelect({
               : "text-muted-foreground hover:text-foreground",
           )}
           onClick={() => onChange("disabled")}
+          onKeyDown={handleDisabledKeyDown}
         >
           <Ban className="size-3.5 shrink-0" aria-hidden />
           Disabled

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -1,5 +1,7 @@
+import { Ban, Check } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import validation from "@/lib/validation";
 
 /** Reserved action_type value meaning "all actions on this connector". */
@@ -73,21 +75,56 @@ export function StatusSelect({
   onChange,
   disabled,
 }: StatusSelectProps) {
+  const segmentBase =
+    "flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
+  const labelId = `${id}-label`;
   return (
-    <div className="space-y-2">
-      <Label htmlFor={id}>Status</Label>
-      <select
-        id={id}
-        className={selectClassName}
-        value={value}
-        // Cast is safe: the only <option> values are "active" and "disabled"
-        onChange={(e) => onChange(e.target.value as "active" | "disabled")}
-        disabled={disabled}
+    <fieldset className="space-y-2" disabled={disabled}>
+      <Label id={labelId} className="text-sm font-medium">
+        Status
+      </Label>
+      <div
+        role="radiogroup"
+        aria-labelledby={labelId}
+        className="bg-muted/60 flex gap-1 rounded-lg border p-1"
       >
-        <option value="active">Active</option>
-        <option value="disabled">Disabled</option>
-      </select>
-    </div>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === "active"}
+          className={cn(
+            segmentBase,
+            value === "active"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          onClick={() => onChange("active")}
+        >
+          <Check className="size-3.5 shrink-0" aria-hidden />
+          Active
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === "disabled"}
+          className={cn(
+            segmentBase,
+            value === "disabled"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          onClick={() => onChange("disabled")}
+        >
+          <Ban className="size-3.5 shrink-0" aria-hidden />
+          Disabled
+        </button>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {value === "disabled"
+          ? "Disabled configurations stay in the list but do not allow new requests for this action."
+          : "Active configurations allow the agent to request this action (subject to approval)."}
+      </p>
+    </fieldset>
   );
 }
 

--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -39,9 +39,7 @@ export function ActionConfigRow({
     >
       <TableCell>
         <div>
-          <p className={`font-medium ${isDisabled ? "text-muted-foreground" : ""}`}>
-            {config.name}
-          </p>
+          <p className="font-medium">{config.name}</p>
           {config.description && (
             <p className="text-muted-foreground text-sm">
               {config.description}
@@ -59,9 +57,7 @@ export function ActionConfigRow({
           </div>
         ) : (
           <div>
-            <p className={`text-sm ${isDisabled ? "text-muted-foreground" : ""}`}>
-              {action?.name ?? config.action_type}
-            </p>
+            <p className="text-sm">{action?.name ?? config.action_type}</p>
             <p className="text-muted-foreground font-mono text-xs">
               {config.action_type}
             </p>

--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from "lucide-react";
+import { Ban, Check, Pencil, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TableRow, TableCell } from "@/components/ui/table";
@@ -26,12 +26,22 @@ export function ActionConfigRow({
     : actions.find((a) => a.action_type === config.action_type);
 
   const paramEntries = Object.entries(config.parameters);
+  const isDisabled = config.status === "disabled";
 
   return (
-    <TableRow>
+    <TableRow
+      className={
+        isDisabled
+          ? "bg-muted/40 text-muted-foreground [&_td]:opacity-90"
+          : undefined
+      }
+      data-status={config.status}
+    >
       <TableCell>
         <div>
-          <p className="font-medium">{config.name}</p>
+          <p className={`font-medium ${isDisabled ? "text-muted-foreground" : ""}`}>
+            {config.name}
+          </p>
           {config.description && (
             <p className="text-muted-foreground text-sm">
               {config.description}
@@ -49,7 +59,9 @@ export function ActionConfigRow({
           </div>
         ) : (
           <div>
-            <p className="text-sm">{action?.name ?? config.action_type}</p>
+            <p className={`text-sm ${isDisabled ? "text-muted-foreground" : ""}`}>
+              {action?.name ?? config.action_type}
+            </p>
             <p className="text-muted-foreground font-mono text-xs">
               {config.action_type}
             </p>
@@ -120,16 +132,15 @@ function ParameterPill({ name, value }: { name: string; value: unknown }) {
 function StatusBadge({ status }: { status: "active" | "disabled" }) {
   if (status === "active") {
     return (
-      <Badge
-        variant="secondary"
-        className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-      >
+      <Badge variant="success-soft" className="gap-1 pr-2">
+        <Check className="size-3 shrink-0" aria-hidden />
         Active
       </Badge>
     );
   }
   return (
-    <Badge variant="secondary" className="text-muted-foreground">
+    <Badge variant="destructive-soft" className="gap-1 pr-2">
+      <Ban className="size-3 shrink-0" aria-hidden />
       Disabled
     </Badge>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Improves how **active** vs **disabled** action configurations read in the agent connector UI (addresses supersuit-tech/permission-slip#749).

- **Table:** Disabled rows use a muted background and softer text so they read as inactive at a glance; `data-status` is set for styling hooks.
- **Status column:** Active uses `success-soft` with a check icon; disabled uses `destructive-soft` with a ban icon (clearer than plain gray text).
- **Edit dialog:** Replaced the native `<select>` with a two-option segmented control plus short helper copy explaining what each status means.

## Test plan
### Claude Code
- [x] `npm test -- --run src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx`
- [x] `npx tsc -b --noEmit` (frontend)

### Manual Testing
- [ ] Open an agent’s connector → Action Configurations: confirm disabled rows look visually subdued vs active.
- [ ] Edit a configuration: toggle Active / Disabled in the new control and save; confirm API still updates as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f1affdb-c92c-4b61-aaa3-590d29535a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f1affdb-c92c-4b61-aaa3-590d29535a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

