### PR TITLE
Improve min/max time inputs for action parameter constraints

### DIFF
--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -28,10 +28,6 @@ var knownMissingAnnotations = map[string]bool{
 	// datetime — various connectors with ISO 8601 fields missing format
 	"asana.asana.create_task:due_at":                         true,
 	"asana.asana.update_task:due_at":                         true,
-	"calendly.calendly.list_scheduled_events:min_start_time": true,
-	"calendly.calendly.list_scheduled_events:max_start_time": true,
-	"calendly.calendly.list_available_times:start_time":      true,
-	"calendly.calendly.list_available_times:end_time":        true,
 	"dropbox.dropbox.share_file:expires":                     true,
 	"hubspot.hubspot.create_deal:closedate":                  true,
 	"hubspot.hubspot.update_deal_stage:close_date":           true,

--- a/connectors/calendly/manifest.go
+++ b/connectors/calendly/manifest.go
@@ -80,11 +80,23 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"min_start_time": {
 							"type": "string",
-							"description": "Only return events starting at or after this time (ISO 8601 format)"
+							"format": "date-time",
+							"description": "Only return events starting at or after this time (ISO 8601 format)",
+							"x-ui": {
+								"label": "Start of range (min start time)",
+								"datetime_range_pair": "max_start_time",
+								"datetime_range_role": "lower"
+							}
 						},
 						"max_start_time": {
 							"type": "string",
-							"description": "Only return events starting before this time (ISO 8601 format)"
+							"format": "date-time",
+							"description": "Only return events starting before this time (ISO 8601 format)",
+							"x-ui": {
+								"label": "End of range (max start time)",
+								"datetime_range_pair": "min_start_time",
+								"datetime_range_role": "upper"
+							}
 						},
 						"status": {
 							"type": "string",
@@ -152,11 +164,21 @@ func (c *CalendlyConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_time": {
 							"type": "string",
-							"description": "Start of the time range to check (ISO 8601 format)"
+							"format": "date-time",
+							"description": "Start of the time range to check (ISO 8601 format)",
+							"x-ui": {
+								"datetime_range_pair": "end_time",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end_time": {
 							"type": "string",
-							"description": "End of the time range to check (ISO 8601 format)"
+							"format": "date-time",
+							"description": "End of the time range to check (ISO 8601 format)",
+							"x-ui": {
+								"datetime_range_pair": "start_time",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -141,12 +141,22 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"time_min": {
 							"type": "string",
 							"format": "date-time",
-							"description": "Lower bound (inclusive) for event start time in RFC 3339 format. Defaults to now."
+							"description": "Lower bound (inclusive) for event start time in RFC 3339 format. Defaults to now.",
+							"x-ui": {
+								"label": "Start of range (time min)",
+								"datetime_range_pair": "time_max",
+								"datetime_range_role": "lower"
+							}
 						},
 						"time_max": {
 							"type": "string",
 							"format": "date-time",
-							"description": "Upper bound (exclusive) for event start time in RFC 3339 format"
+							"description": "Upper bound (exclusive) for event start time in RFC 3339 format",
+							"x-ui": {
+								"label": "End of range (time max)",
+								"datetime_range_pair": "time_min",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -22,6 +22,13 @@ export interface SchemaPropertyUI {
   help_url?: string;
   help_text?: string;
   visible_when?: VisibleWhen;
+  /**
+   * Sibling parameter key for datetime range pairing (e.g. time_min ↔ time_max).
+   * Use with `datetime_range_role` so the sibling's fixed value sets HTML min/max on this input.
+   */
+  datetime_range_pair?: string;
+  /** Whether this field is the lower or upper bound of the pair. */
+  datetime_range_role?: "lower" | "upper";
 }
 
 /** A named group for organizing related fields in the form. */
@@ -275,6 +282,13 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
     ) {
       ui.visible_when = { field: vw.field, equals: vw.equals as string | boolean | number };
     }
+  }
+
+  if (typeof obj.datetime_range_pair === "string" && obj.datetime_range_pair.length > 0) {
+    ui.datetime_range_pair = obj.datetime_range_pair;
+  }
+  if (obj.datetime_range_role === "lower" || obj.datetime_range_role === "upper") {
+    ui.datetime_range_role = obj.datetime_range_role;
   }
 
   // Return undefined if no valid fields were parsed

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -74,6 +74,7 @@ export function ActionConfigParameterFields({
         label={label}
         isRequired={isRequired}
         value={currentValue}
+        allValues={values}
         mode={mode}
         disabled={disabled}
         onValueChange={onValueChange}
@@ -148,6 +149,7 @@ function ParameterField({
   label,
   isRequired,
   value,
+  allValues,
   mode,
   disabled,
   onValueChange,
@@ -158,6 +160,7 @@ function ParameterField({
   label: string;
   isRequired: boolean;
   value: string;
+  allValues: Record<string, string>;
   mode: ParamMode;
   disabled?: boolean;
   onValueChange: (key: string, value: string) => void;
@@ -171,18 +174,17 @@ function ParameterField({
   const effectiveWidget = property["x-ui"]?.widget ?? inferWidgetFromProperty(property);
   const isMultiRow = effectiveWidget === "list";
 
-  // In constraint context, datetime fields render as plain text so users can
-  // enter patterns like "2026-*" rather than being forced to use a date picker.
+  // In constraint context, use plain text only when the value needs freeform entry
+  // (wildcards / patterns). Otherwise keep datetime-local so bounds like time_min /
+  // time_max are easy to set; pair hints still apply via x-ui.datetime_range_*.
   const constraintProperty: typeof property =
-    property.format === "date-time" ||
-    property["x-ui"]?.widget === "datetime" ||
-    (property.type === "string" && property.description &&
-      (() => {
-        const d = property.description.toLowerCase();
-        return (d.includes("rfc 3339") || d.includes("rfc3339") || d.includes("iso 8601")) && !d.includes("epoch");
-      })())
+    isDatetimeLikeProperty(property) && shouldUseTextDatetimeConstraint(value)
       ? { ...property, "x-ui": { ...(property["x-ui"] ?? {}), widget: "text" } }
       : property;
+
+  const pairKey = property["x-ui"]?.datetime_range_pair;
+  const siblingDatetimeValue =
+    pairKey && allValues[pairKey] !== undefined ? allValues[pairKey] : undefined;
 
   const anyValueCheckbox = (
     <label
@@ -231,6 +233,7 @@ function ParameterField({
             disabled={widgetDisabled}
             className={widgetClassName}
             placeholder={widgetPlaceholder}
+            siblingDatetimeValue={siblingDatetimeValue}
           />
         )
       ) : (
@@ -242,6 +245,7 @@ function ParameterField({
           disabled={widgetDisabled}
           className={widgetClassName}
           placeholder={widgetPlaceholder}
+          siblingDatetimeValue={siblingDatetimeValue}
         />
       )}
       {!isWildcard && value.includes("*") && (
@@ -292,6 +296,33 @@ function CollapsibleFieldGroup({
   );
 }
 
+
+function isDatetimeLikeProperty(prop: SchemaProperty): boolean {
+  if (prop.format === "date-time") return true;
+  if (prop["x-ui"]?.widget === "datetime") return true;
+  if (prop.type === "string" && prop.description) {
+    const d = prop.description.toLowerCase();
+    return (
+      (d.includes("rfc 3339") || d.includes("rfc3339") || d.includes("iso 8601")) &&
+      !d.includes("epoch")
+    );
+  }
+  return false;
+}
+
+/** True when the value is a single concrete instant (not a wildcard pattern). */
+function isConcreteDatetimeString(value: string): boolean {
+  if (!value || value.includes("*")) return false;
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return true;
+  const t = new Date(value).getTime();
+  return !Number.isNaN(t);
+}
+
+function shouldUseTextDatetimeConstraint(value: string): boolean {
+  if (value.includes("*")) return true;
+  if (value !== "" && !isConcreteDatetimeString(value)) return true;
+  return false;
+}
 
 // Re-export the shared parseParametersSchema so callers don't break.
 export { parseParametersSchema } from "@/lib/parameterSchema";

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -21,6 +21,11 @@ export interface ParameterFieldWidgetProps {
   className?: string;
   /** Override the placeholder from x-ui (e.g. for constraint mode hints). */
   placeholder?: string;
+  /**
+   * Sibling field value for paired datetime bounds (e.g. time_max when editing time_min).
+   * When both sides are concrete datetimes, sets HTML min/max on the datetime-local input.
+   */
+  siblingDatetimeValue?: string;
 }
 
 /**
@@ -35,6 +40,7 @@ export function ParameterFieldWidget({
   disabled,
   className,
   placeholder: placeholderOverride,
+  siblingDatetimeValue,
 }: ParameterFieldWidgetProps) {
   const ui = property["x-ui"];
   const widget: WidgetType = ui?.widget ?? inferWidgetFromProperty(property);
@@ -51,6 +57,8 @@ export function ParameterFieldWidget({
         placeholder,
         className,
         enumValues: property.enum,
+        siblingDatetimeValue,
+        datetimeRangeRole: ui?.datetime_range_role,
       })}
       <FieldHints ui={ui} />
     </div>
@@ -65,6 +73,8 @@ interface WidgetRenderProps {
   placeholder?: string;
   className?: string;
   enumValues?: string[];
+  siblingDatetimeValue?: string;
+  datetimeRangeRole?: "lower" | "upper";
 }
 
 function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
@@ -184,14 +194,33 @@ function DateWidget({ inputId, value, onChange, disabled, placeholder, className
   );
 }
 
-function DateTimeWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
+function DateTimeWidget({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  siblingDatetimeValue,
+  datetimeRangeRole,
+}: WidgetRenderProps) {
   const localValue = toDatetimeLocalValue(value);
+  const siblingLocal =
+    siblingDatetimeValue && isConcreteDatetimeString(siblingDatetimeValue)
+      ? toDatetimeLocalValue(siblingDatetimeValue)
+      : undefined;
+  const minAttr =
+    datetimeRangeRole === "upper" && siblingLocal ? siblingLocal : undefined;
+  const maxAttr =
+    datetimeRangeRole === "lower" && siblingLocal ? siblingLocal : undefined;
 
   return (
     <Input
       id={inputId}
       type="datetime-local"
       value={localValue}
+      min={minAttr}
+      max={maxAttr}
       onChange={(e) => {
         const dtLocal = e.target.value;
         if (!dtLocal) {
@@ -322,6 +351,14 @@ function toDatetimeLocalValue(value: string): string {
   const hrs = String(d.getHours()).padStart(2, "0");
   const mins = String(d.getMinutes()).padStart(2, "0");
   return `${year}-${month}-${day}T${hrs}:${mins}`;
+}
+
+/** True when the value is a single concrete instant (not a wildcard pattern). */
+function isConcreteDatetimeString(value: string): boolean {
+  if (!value || value.includes("*")) return false;
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return true;
+  const t = new Date(value).getTime();
+  return !Number.isNaN(t);
 }
 
 /** Renders help_text and help_url hints below the input. */

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx
@@ -537,6 +537,58 @@ describe("ActionConfigParameterFields", () => {
 
       expect(screen.queryByText("matches any text")).not.toBeInTheDocument();
     });
+
+    it("uses datetime-local for paired range fields when value is empty (fixed mode)", () => {
+      const schema: ParametersSchema = {
+        type: "object",
+        properties: {
+          time_min: {
+            type: "string",
+            format: "date-time",
+            description: "Lower bound in RFC 3339 format",
+            "x-ui": {
+              datetime_range_pair: "time_max",
+              datetime_range_role: "lower",
+            },
+          },
+          time_max: {
+            type: "string",
+            format: "date-time",
+            description: "Upper bound in RFC 3339 format",
+            "x-ui": {
+              datetime_range_pair: "time_min",
+              datetime_range_role: "upper",
+            },
+          },
+        },
+      };
+
+      renderFields(schema, { values: { time_min: "", time_max: "" } });
+
+      const minInput = document.getElementById("param-time_min") as HTMLInputElement;
+      const maxInput = document.getElementById("param-time_max") as HTMLInputElement;
+      expect(minInput.type).toBe("datetime-local");
+      expect(maxInput.type).toBe("datetime-local");
+    });
+
+    it("uses text input for datetime field when value contains a wildcard pattern", () => {
+      const schema: ParametersSchema = {
+        type: "object",
+        properties: {
+          time_min: {
+            type: "string",
+            format: "date-time",
+            description: "Lower bound in RFC 3339 format",
+          },
+        },
+      };
+
+      renderFields(schema, { values: { time_min: "2026-*" } });
+
+      const input = screen.getByLabelText("Time Min");
+      expect(input).toHaveAttribute("type", "text");
+      expect(input).toHaveValue("2026-*");
+    });
   });
 
   describe("auto-mapping", () => {

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -12,6 +12,7 @@ function renderWidget(
   value = "",
   onChange = vi.fn(),
   disabled = false,
+  opts?: { siblingDatetimeValue?: string },
 ) {
   return {
     onChange,
@@ -22,6 +23,7 @@ function renderWidget(
         value={value}
         onChange={onChange}
         disabled={disabled}
+        siblingDatetimeValue={opts?.siblingDatetimeValue}
       />,
     ),
   };
@@ -283,6 +285,60 @@ describe("ParameterFieldWidget", () => {
 
       const input = document.getElementById("param-test_field") as HTMLInputElement;
       expect(input).toBeDisabled();
+    });
+
+    it("sets min from sibling when datetime_range_role is upper", () => {
+      const prop: SchemaProperty = {
+        type: "string",
+        "x-ui": {
+          widget: "datetime",
+          datetime_range_role: "upper",
+          datetime_range_pair: "time_min",
+        },
+      };
+
+      renderWidget(prop, "", vi.fn(), false, {
+        siblingDatetimeValue: "2026-03-16T12:00:00-05:00",
+      });
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input.min).toMatch(/^2026-03-16T\d{2}:\d{2}$/);
+    });
+
+    it("sets max from sibling when datetime_range_role is lower", () => {
+      const prop: SchemaProperty = {
+        type: "string",
+        "x-ui": {
+          widget: "datetime",
+          datetime_range_role: "lower",
+          datetime_range_pair: "time_max",
+        },
+      };
+
+      renderWidget(prop, "", vi.fn(), false, {
+        siblingDatetimeValue: "2026-03-20T15:00:00Z",
+      });
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input.max).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    });
+
+    it("does not set min/max when sibling is a wildcard pattern", () => {
+      const prop: SchemaProperty = {
+        type: "string",
+        "x-ui": {
+          widget: "datetime",
+          datetime_range_role: "upper",
+        },
+      };
+
+      renderWidget(prop, "", vi.fn(), false, {
+        siblingDatetimeValue: "2026-*",
+      });
+
+      const input = document.getElementById("param-test_field") as HTMLInputElement;
+      expect(input.min).toBe("");
+      expect(input.max).toBe("");
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [issue #752](https://github.com/supersuit-tech/permission-slip/issues/752) by improving how paired time bounds (`time_min` / `time_max`, Calendly range fields, etc.) behave in **standing approval / constraint** flows.

- **Datetime pickers in constraints:** Previously every datetime-like field was forced to a plain text input in constraint mode. Now we keep `datetime-local` when the value is empty or a concrete instant, and only fall back to text when the user needs patterns (e.g. `*` wildcards) or a non-parseable string.
- **HTML min/max pairing:** New optional `x-ui` hints `datetime_range_pair` and `datetime_range_role` (`lower` | `upper`). When the sibling field holds a concrete datetime, the widget sets `min` / `max` on the native input so the browser enforces ordering.
- **Manifests:** Google `list_calendar_events` and Calendly list/availability actions now declare `format: date-time` where appropriate, clearer labels for min/max fields, and the pairing metadata above.

## Test plan

### Developer
- [x] `cd frontend && npm test -- --run src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx src/pages/agents/connectors/__tests__/ActionConfigParameterFields.test.tsx`

### Manual testing
- [ ] Create or edit a standing approval for **Google → List Calendar Events**: confirm **Time min** / **Time max** show datetime pickers when values are empty or full timestamps; entering both should constrain the second field relative to the first (browser-dependent UI).
- [ ] Enter a wildcard pattern in one bound (e.g. `2026-*`) and confirm the field switches to a text input so patterns remain possible.
- [ ] Spot-check **Calendly → List Scheduled Events** (min/max start time) and **List Available Times** (start/end) for the same behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efaa06c9-cd79-40e0-aeb6-2dc74b91254a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efaa06c9-cd79-40e0-aeb6-2dc74b91254a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

