### PR TITLE
Calendar ID selector for Google & Microsoft connectors

### DIFF
--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	googleconnector "github.com/supersuit-tech/permission-slip-web/connectors/google"
+	"github.com/supersuit-tech/permission-slip-web/connectors/microsoft"
+)
+
+type userCalendarResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	IsPrimary   bool   `json:"is_primary"`
+}
+
+type agentConnectorCalendarsResponse struct {
+	Data []userCalendarResponse `json:"data"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentConnectorCalendarRoutes)
+}
+
+// RegisterAgentConnectorCalendarRoutes adds calendar listing for agent connector UI.
+func RegisterAgentConnectorCalendarRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /agents/{agent_id}/connectors/{connector_id}/calendars", requireProfile(handleListAgentConnectorCalendars(deps)))
+}
+
+func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if deps.Vault == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Credential vault is not configured"))
+			return
+		}
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		creds, err := resolveAgentConnectorBoundCredentials(r.Context(), deps, agentID, userID, connectorID)
+		if err != nil {
+			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorCalendars resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		var cals []connectors.UserCalendar
+		switch c := conn.(type) {
+		case *googleconnector.GoogleConnector:
+			cals, err = c.ListUserCalendars(r.Context(), creds)
+		case *microsoft.MicrosoftConnector:
+			cals, err = c.ListUserCalendars(r.Context(), creds)
+		default:
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "This connector does not support calendar listing"))
+			return
+		}
+
+		if err != nil {
+			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+				return
+			}
+			log.Printf("[%s] ListUserCalendars: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list calendars"))
+			return
+		}
+
+		data := make([]userCalendarResponse, len(cals))
+		for i, cal := range cals {
+			data[i] = userCalendarResponse{
+				ID:          cal.ID,
+				Name:        cal.Name,
+				Description: cal.Description,
+				IsPrimary:   cal.IsPrimary,
+			}
+		}
+
+		RespondJSON(w, http.StatusOK, agentConnectorCalendarsResponse{Data: data})
+	}
+}

--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -57,7 +57,7 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 
 		creds, err := resolveAgentConnectorBoundCredentials(r.Context(), deps, agentID, userID, connectorID)
 		if err != nil {
-			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+			if handleConnectorError(w, r, err, ConnectorContext{AgentID: agentID}) {
 				return
 			}
 			log.Printf("[%s] ListAgentConnectorCalendars resolve creds: %v", TraceID(r.Context()), err)
@@ -82,7 +82,7 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 		cals, err = lister.ListUserCalendars(r.Context(), creds)
 
 		if err != nil {
-			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+			if handleConnectorError(w, r, err, ConnectorContext{AgentID: agentID}) {
 				return
 			}
 			log.Printf("[%s] ListUserCalendars: %v", TraceID(r.Context()), err)

--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
-	googleconnector "github.com/supersuit-tech/permission-slip-web/connectors/google"
-	"github.com/supersuit-tech/permission-slip-web/connectors/microsoft"
 )
 
 type userCalendarResponse struct {
@@ -44,10 +42,9 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 		}
 
 		connectorID := r.PathValue("connector_id")
-		if connectorID == "" {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
-			return
-		}
+
+		// External provider calls below are bounded by the global per-IP rate limit
+		// middleware on the API router; no separate calendar-specific limiter.
 
 		if deps.Vault == nil {
 			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Credential vault is not configured"))
@@ -75,16 +72,14 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		var cals []connectors.UserCalendar
-		switch c := conn.(type) {
-		case *googleconnector.GoogleConnector:
-			cals, err = c.ListUserCalendars(r.Context(), creds)
-		case *microsoft.MicrosoftConnector:
-			cals, err = c.ListUserCalendars(r.Context(), creds)
-		default:
+		lister, ok := conn.(connectors.CalendarLister)
+		if !ok {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "This connector does not support calendar listing"))
 			return
 		}
+
+		var cals []connectors.UserCalendar
+		cals, err = lister.ListUserCalendars(r.Context(), creds)
 
 		if err != nil {
 			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {

--- a/api/agent_connector_calendars_test.go
+++ b/api/agent_connector_calendars_test.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	googleconnector "github.com/supersuit-tech/permission-slip-web/connectors/google"
+	"github.com/supersuit-tech/permission-slip-web/connectors/microsoft"
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	"github.com/supersuit-tech/permission-slip-web/vault"
+)
+
+func TestListAgentConnectorCalendars_Google(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/calendar/v3/users/me/calendarList" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"primary","summary":"Primary","primary":true},{"id":"cal_other","summary":"Work"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := "google"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	mockVault := vault.NewMockVaultStore()
+	oauthID := testhelper.GenerateID(t, "oac_")
+	accessVaultID, err := mockVault.CreateSecret(context.Background(), tx, "tok", []byte("test-access-token"))
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	testhelper.InsertOAuthConnectionFull(t, tx, oauthID, uid, "google", testhelper.OAuthConnectionOpts{
+		AccessTokenVaultID: accessVaultID,
+		Scopes:             []string{"https://www.googleapis.com/auth/calendar.events"},
+	})
+
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, bindErr := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID:                 bindingID,
+		AgentID:            agentID,
+		ConnectorID:        connID,
+		ApproverID:         uid,
+		OAuthConnectionID:  &oauthID,
+	})
+	if bindErr != nil {
+		t.Fatalf("upsert binding: %v", bindErr)
+	}
+
+	gc := googleconnector.NewCalendarForTest(srv.Client(), srv.URL+"/calendar/v3")
+
+	reg := connectors.NewRegistry()
+	reg.Register(gc)
+
+	deps := &Deps{DB: tx, Vault: mockVault, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet,
+		fmt.Sprintf("/agents/%d/connectors/google/calendars", agentID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp agentConnectorCalendarsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 calendars, got %d", len(resp.Data))
+	}
+	if resp.Data[0].ID != "primary" || !resp.Data[0].IsPrimary {
+		t.Errorf("first calendar: %+v", resp.Data[0])
+	}
+}
+
+func TestListAgentConnectorCalendars_Microsoft(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1.0/me/calendars" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[{"id":"cal-1","name":"Calendar","isDefaultCalendar":true}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := "microsoft"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	mockVault := vault.NewMockVaultStore()
+	oauthID := testhelper.GenerateID(t, "oac_")
+	accessVaultID, err := mockVault.CreateSecret(context.Background(), tx, "tok", []byte("ms-token"))
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	testhelper.InsertOAuthConnectionFull(t, tx, oauthID, uid, "microsoft", testhelper.OAuthConnectionOpts{
+		AccessTokenVaultID: accessVaultID,
+		Scopes:             []string{"Calendars.ReadWrite"},
+	})
+
+	bindingID := testhelper.GenerateID(t, "accr_")
+	_, bindErr := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID:                bindingID,
+		AgentID:           agentID,
+		ConnectorID:       connID,
+		ApproverID:        uid,
+		OAuthConnectionID: &oauthID,
+	})
+	if bindErr != nil {
+		t.Fatalf("upsert binding: %v", bindErr)
+	}
+
+	mc := microsoft.NewForTest(srv.Client(), srv.URL+"/v1.0")
+	reg := connectors.NewRegistry()
+	reg.Register(mc)
+
+	deps := &Deps{DB: tx, Vault: mockVault, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet,
+		fmt.Sprintf("/agents/%d/connectors/microsoft/calendars", agentID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp agentConnectorCalendarsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "cal-1" || !resp.Data[0].IsPrimary {
+		t.Errorf("unexpected data: %+v", resp.Data)
+	}
+}
+
+func TestListAgentConnectorCalendars_NoCredential(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnector(t, tx, "google")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, "google")
+
+	reg := connectors.NewRegistry()
+	reg.Register(googleconnector.New())
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet,
+		fmt.Sprintf("/agents/%d/connectors/google/calendars", agentID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -245,9 +245,13 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 	if len(reqCreds) == 0 {
 		return connectors.NewCredentials(nil), nil
 	}
+	return resolveAgentConnectorBoundCredentials(ctx, deps, agentID, userID, connectorID)
+}
 
-	// Require an explicit credential binding. No auto-resolve — the user must
-	// assign a credential to the agent+connector before it can execute.
+// resolveAgentConnectorBoundCredentials loads the credential bound to the
+// agent+connector pair (OAuth or static). Used for action execution and for
+// UI helpers (e.g. listing calendars) that need the same binding as execution.
+func resolveAgentConnectorBoundCredentials(ctx context.Context, deps *Deps, agentID int64, userID, connectorID string) (connectors.Credentials, error) {
 	if agentID == 0 {
 		return connectors.Credentials{}, &connectors.ValidationError{
 			Message: "no credential assigned — assign a credential to this connector before running actions",
@@ -274,7 +278,6 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 				Message: "bound OAuth connection no longer exists — reassign credentials for this connector",
 			}
 		}
-		// Verify the bound connection belongs to the executing user.
 		if conn.UserID != userID {
 			return connectors.Credentials{}, &connectors.ValidationError{
 				Message: "bound OAuth connection does not belong to this user",

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -144,11 +144,11 @@ func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, user
 // resolvedPaymentMethod holds the validated payment method state between
 // validation (pre-execution) and transaction recording (post-execution).
 type resolvedPaymentMethod struct {
-	paymentMethodID      string
+	paymentMethodID       string
 	stripePaymentMethodID string
-	brand                string
-	last4                string
-	amount               int
+	brand                 string
+	last4                 string
+	amount                int
 }
 
 // validatePaymentMethod validates the payment method, enforces ownership and
@@ -357,9 +357,6 @@ func resolveOAuthCredentialsFromConnection(ctx context.Context, deps *Deps, conn
 	if deps.Vault == nil {
 		return zero, fmt.Errorf("credential vault is not configured but connector requires OAuth credentials")
 	}
-	if deps.OAuthProviders == nil {
-		return zero, fmt.Errorf("OAuth provider registry is not configured")
-	}
 
 	return credentialsFromOAuthConnection(ctx, deps, conn)
 }
@@ -383,6 +380,9 @@ func credentialsFromOAuthConnection(ctx context.Context, deps *Deps, conn *db.OA
 
 	// Refresh the token if expired or within pre-emptive buffer.
 	if conn.TokenExpiry != nil && time.Now().After(conn.TokenExpiry.Add(-oauth.TokenExpiryBuffer)) {
+		if deps.OAuthProviders == nil {
+			return zero, fmt.Errorf("OAuth provider registry is not configured")
+		}
 		if err := refreshOAuthConnection(ctx, deps, conn, conn.Provider); err != nil {
 			return zero, err
 		}
@@ -534,5 +534,3 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 
 	return nil
 }
-
-

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -123,6 +123,11 @@ func newCalendarForTest(client *http.Client, calendarBaseURL string) *GoogleConn
 	}
 }
 
+// NewCalendarForTest is the exported test helper for calendar-only Google API calls.
+func NewCalendarForTest(client *http.Client, calendarBaseURL string) *GoogleConnector {
+	return newCalendarForTest(client, calendarBaseURL)
+}
+
 // newGmailForTest creates a GoogleConnector with only gmailBaseURL set,
 // for Gmail action tests.
 func newGmailForTest(client *http.Client, gmailBaseURL string) *GoogleConnector {

--- a/connectors/google/list_user_calendars.go
+++ b/connectors/google/list_user_calendars.go
@@ -1,0 +1,50 @@
+package google
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// googleCalendarListResponse is the response shape for calendarList.list.
+type googleCalendarListResponse struct {
+	Items []struct {
+		ID          string `json:"id"`
+		Summary     string `json:"summary"`
+		Description string `json:"description"`
+		Primary     bool   `json:"primary"`
+	} `json:"items"`
+}
+
+// ListUserCalendars returns calendars from the Google Calendar API calendarList
+// endpoint for the authenticated user.
+func (c *GoogleConnector) ListUserCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.UserCalendar, error) {
+	q := url.Values{}
+	q.Set("maxResults", "250")
+	listURL := c.calendarBaseURL + "/users/me/calendarList?" + q.Encode()
+
+	var raw googleCalendarListResponse
+	if err := c.doJSON(ctx, creds, http.MethodGet, listURL, nil, &raw); err != nil {
+		return nil, err
+	}
+
+	out := make([]connectors.UserCalendar, 0, len(raw.Items))
+	for _, it := range raw.Items {
+		if it.ID == "" {
+			continue
+		}
+		name := it.Summary
+		if name == "" {
+			name = it.ID
+		}
+		out = append(out, connectors.UserCalendar{
+			ID:          it.ID,
+			Name:        name,
+			Description: it.Description,
+			IsPrimary:   it.Primary,
+		})
+	}
+	return out, nil
+}

--- a/connectors/google/list_user_calendars.go
+++ b/connectors/google/list_user_calendars.go
@@ -20,6 +20,10 @@ type googleCalendarListResponse struct {
 
 // ListUserCalendars returns calendars from the Google Calendar API calendarList
 // endpoint for the authenticated user.
+//
+// Uses maxResults=250 (API max per page) without following nextPageToken, so
+// users with more than 250 calendars see a truncated list — rare; extend with
+// pagination if needed.
 func (c *GoogleConnector) ListUserCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.UserCalendar, error) {
 	q := url.Values{}
 	q.Set("maxResults", "250")

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -112,7 +112,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Choose calendar…"
+							}
 						}
 					}
 				}`)),
@@ -129,7 +134,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Choose calendar…"
+							}
 						},
 						"max_results": {
 							"type": "integer",
@@ -479,7 +489,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Choose calendar…"
+							}
 						}
 					}
 				}`)),
@@ -602,7 +617,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Choose calendar…"
+							}
 						},
 						"summary": {
 							"type": "string",
@@ -655,7 +675,12 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Choose calendar…"
+							}
 						}
 					}
 				}`)),

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -528,6 +528,7 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		var prop struct {
 			XUI *struct {
 				Widget      string `json:"widget"`
+				OptionsFrom string `json:"options_from"`
 				Group       string `json:"group"`
 				HelpURL     string `json:"help_url"`
 				VisibleWhen *struct {
@@ -545,12 +546,14 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
 			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, textarea, toggle, number, date", actionIdx, propName, prop.XUI.Widget)
 		}
-		// A "select" widget needs enum values to populate the dropdown.
+		// A "select" widget needs enum values or a dynamic options_from hint.
 		if prop.XUI.Widget == "select" {
 			var propObj map[string]json.RawMessage
 			if err := json.Unmarshal(propRaw, &propObj); err == nil {
-				if _, hasEnum := propObj["enum"]; !hasEnum {
-					return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget \"select\" requires an \"enum\" array on the property", actionIdx, propName)
+				_, hasEnum := propObj["enum"]
+				hasDynamic := prop.XUI.OptionsFrom != ""
+				if !hasEnum && !hasDynamic {
+					return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget \"select\" requires an \"enum\" array or x-ui.options_from", actionIdx, propName)
 				}
 			}
 		}

--- a/connectors/microsoft/calendar_paths.go
+++ b/connectors/microsoft/calendar_paths.go
@@ -1,0 +1,19 @@
+package microsoft
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// microsoftCalendarEventsBasePath returns the Graph resource path for a
+// calendar's events collection. Empty calendarID uses the signed-in user's
+// default calendar (/me/events).
+func microsoftCalendarEventsBasePath(calendarID string) string {
+	calendarID = strings.TrimSpace(calendarID)
+	if calendarID == "" {
+		return "/me/events"
+	}
+	enc := url.PathEscape(calendarID)
+	return fmt.Sprintf("/me/calendars/%s/events", enc)
+}

--- a/connectors/microsoft/calendar_paths_test.go
+++ b/connectors/microsoft/calendar_paths_test.go
@@ -1,0 +1,21 @@
+package microsoft
+
+import "testing"
+
+func TestMicrosoftCalendarEventsBasePath_Default(t *testing.T) {
+	t.Parallel()
+	if got := microsoftCalendarEventsBasePath(""); got != "/me/events" {
+		t.Errorf("empty id: got %q", got)
+	}
+	if got := microsoftCalendarEventsBasePath("   "); got != "/me/events" {
+		t.Errorf("whitespace: got %q", got)
+	}
+}
+
+func TestMicrosoftCalendarEventsBasePath_Escaped(t *testing.T) {
+	t.Parallel()
+	got := microsoftCalendarEventsBasePath("cal/with/slash")
+	if got != "/me/calendars/cal%2Fwith%2Fslash/events" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/connectors/microsoft/create_calendar_event.go
+++ b/connectors/microsoft/create_calendar_event.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )

--- a/connectors/microsoft/create_calendar_event.go
+++ b/connectors/microsoft/create_calendar_event.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -27,13 +29,14 @@ func (a *createCalendarEventAction) ParameterAliases() map[string]string {
 
 // createCalendarEventParams is the user-facing parameter schema.
 type createCalendarEventParams struct {
-	Subject   string   `json:"subject"`
-	Start     string   `json:"start"`
-	End       string   `json:"end"`
-	TimeZone  string   `json:"time_zone"`
-	Body      string   `json:"body,omitempty"`
-	Attendees []string `json:"attendees,omitempty"`
-	Location  string   `json:"location,omitempty"`
+	CalendarID string   `json:"calendar_id"`
+	Subject    string   `json:"subject"`
+	Start      string   `json:"start"`
+	End        string   `json:"end"`
+	TimeZone   string   `json:"time_zone"`
+	Body       string   `json:"body,omitempty"`
+	Attendees  []string `json:"attendees,omitempty"`
+	Location   string   `json:"location,omitempty"`
 }
 
 func (p *createCalendarEventParams) validate() error {
@@ -122,8 +125,10 @@ func (a *createCalendarEventAction) Execute(ctx context.Context, req connectors.
 		graphReq.Location = &graphEventLocation{DisplayName: params.Location}
 	}
 
+	path := microsoftCalendarEventsBasePath(params.CalendarID)
+
 	var resp graphEventResponse
-	if err := a.conn.doRequest(ctx, http.MethodPost, "/me/events", req.Credentials, graphReq, &resp); err != nil {
+	if err := a.conn.doRequest(ctx, http.MethodPost, path, req.Credentials, graphReq, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/microsoft/list_calendar_events.go
+++ b/connectors/microsoft/list_calendar_events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -17,7 +18,8 @@ type listCalendarEventsAction struct {
 
 // listCalendarEventsParams is the user-facing parameter schema.
 type listCalendarEventsParams struct {
-	Top int `json:"top"`
+	CalendarID string `json:"calendar_id"`
+	Top        int    `json:"top"`
 }
 
 func (p *listCalendarEventsParams) defaults() {
@@ -66,7 +68,12 @@ func (a *listCalendarEventsAction) Execute(ctx context.Context, req connectors.A
 	}
 	params.defaults()
 
-	path := fmt.Sprintf("/me/events?$top=%d&$orderby=start/dateTime&$select=id,subject,start,end,location,organizer,webLink,isAllDay", params.Top)
+	base := microsoftCalendarEventsBasePath(params.CalendarID)
+	q := url.Values{}
+	q.Set("$top", fmt.Sprintf("%d", params.Top))
+	q.Set("$orderby", "start/dateTime")
+	q.Set("$select", "id,subject,start,end,location,organizer,webLink,isAllDay")
+	path := base + "?" + q.Encode()
 
 	var resp graphEventsResponse
 	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {

--- a/connectors/microsoft/list_calendar_events_test.go
+++ b/connectors/microsoft/list_calendar_events_test.go
@@ -80,6 +80,37 @@ func TestListCalendarEvents_Success(t *testing.T) {
 	}
 }
 
+func TestListCalendarEvents_WithCalendarID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		wantPrefix := "/me/calendars/cal-abc123/events"
+		if r.URL.Path != wantPrefix {
+			t.Errorf("expected path %q, got %s", wantPrefix, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listCalendarEventsAction{conn: conn}
+
+	params, _ := json.Marshal(listCalendarEventsParams{CalendarID: "cal-abc123", Top: 5})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestListCalendarEvents_DefaultParams(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/list_user_calendars.go
+++ b/connectors/microsoft/list_user_calendars.go
@@ -2,14 +2,23 @@ package microsoft
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
+const (
+	msCalendarsPageSize   = 200
+	msCalendarsMaxPages   = 4
+	msCalendarsSelectCols = "id,name,isDefaultCalendar,owner"
+)
+
 type graphCalendarListResponse struct {
-	Value []struct {
+	ODataNextLink string `json:"@odata.nextLink"`
+	Value         []struct {
 		ID                string `json:"id"`
 		Name              string `json:"name"`
 		IsDefaultCalendar bool   `json:"isDefaultCalendar"`
@@ -20,37 +29,73 @@ type graphCalendarListResponse struct {
 	} `json:"value"`
 }
 
-// ListUserCalendars returns calendars from Microsoft Graph GET /me/calendars.
+// ListUserCalendars returns calendars from Microsoft Graph GET /me/calendars,
+// following @odata.nextLink until exhausted or msCalendarsMaxPages.
 func (c *MicrosoftConnector) ListUserCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.UserCalendar, error) {
 	q := url.Values{}
-	q.Set("$top", "50")
-	q.Set("$select", "id,name,isDefaultCalendar,owner")
-	path := "/me/calendars?" + q.Encode()
+	q.Set("$top", fmt.Sprintf("%d", msCalendarsPageSize))
+	q.Set("$select", msCalendarsSelectCols)
+	nextPath := "/me/calendars?" + q.Encode()
 
-	var raw graphCalendarListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &raw); err != nil {
-		return nil, err
-	}
-
-	out := make([]connectors.UserCalendar, 0, len(raw.Value))
-	for _, it := range raw.Value {
-		if it.ID == "" {
-			continue
+	var out []connectors.UserCalendar
+	for page := 0; page < msCalendarsMaxPages; page++ {
+		var raw graphCalendarListResponse
+		if err := c.doRequest(ctx, http.MethodGet, nextPath, creds, nil, &raw); err != nil {
+			return nil, err
 		}
-		name := it.Name
-		if name == "" {
-			name = it.ID
+		for _, it := range raw.Value {
+			if it.ID == "" {
+				continue
+			}
+			name := it.Name
+			if name == "" {
+				name = it.ID
+			}
+			var desc string
+			if it.Owner != nil && it.Owner.Address != "" {
+				desc = it.Owner.Address
+			}
+			out = append(out, connectors.UserCalendar{
+				ID:          it.ID,
+				Name:        name,
+				Description: desc,
+				IsPrimary:   it.IsDefaultCalendar,
+			})
 		}
-		var desc string
-		if it.Owner != nil && it.Owner.Address != "" {
-			desc = it.Owner.Address
+		if raw.ODataNextLink == "" {
+			break
 		}
-		out = append(out, connectors.UserCalendar{
-			ID:          it.ID,
-			Name:        name,
-			Description: desc,
-			IsPrimary:   it.IsDefaultCalendar,
-		})
+		var err error
+		nextPath, err = graphRelativePathFromNextLink(c.baseURL, raw.ODataNextLink)
+		if err != nil {
+			return nil, &connectors.ExternalError{Message: fmt.Sprintf("invalid Microsoft Graph nextLink: %v", err)}
+		}
 	}
 	return out, nil
+}
+
+// graphRelativePathFromNextLink converts a full nextLink URL into a path+query
+// string relative to baseURL (what doRequest expects).
+func graphRelativePathFromNextLink(baseURL, nextLink string) (string, error) {
+	base, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return "", err
+	}
+	n, err := url.Parse(nextLink)
+	if err != nil {
+		return "", err
+	}
+	if n.Scheme != base.Scheme || n.Host != base.Host {
+		return "", fmt.Errorf("nextLink host/scheme does not match connector baseURL")
+	}
+	rel := strings.TrimPrefix(n.Path, base.Path)
+	if rel == "" {
+		rel = "/"
+	} else if !strings.HasPrefix(rel, "/") {
+		rel = "/" + rel
+	}
+	if n.RawQuery != "" {
+		rel += "?" + n.RawQuery
+	}
+	return rel, nil
 }

--- a/connectors/microsoft/list_user_calendars.go
+++ b/connectors/microsoft/list_user_calendars.go
@@ -1,0 +1,56 @@
+package microsoft
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+type graphCalendarListResponse struct {
+	Value []struct {
+		ID                string `json:"id"`
+		Name              string `json:"name"`
+		IsDefaultCalendar bool   `json:"isDefaultCalendar"`
+		Owner             *struct {
+			Name    string `json:"name"`
+			Address string `json:"address"`
+		} `json:"owner,omitempty"`
+	} `json:"value"`
+}
+
+// ListUserCalendars returns calendars from Microsoft Graph GET /me/calendars.
+func (c *MicrosoftConnector) ListUserCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.UserCalendar, error) {
+	q := url.Values{}
+	q.Set("$top", "50")
+	q.Set("$select", "id,name,isDefaultCalendar,owner")
+	path := "/me/calendars?" + q.Encode()
+
+	var raw graphCalendarListResponse
+	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &raw); err != nil {
+		return nil, err
+	}
+
+	out := make([]connectors.UserCalendar, 0, len(raw.Value))
+	for _, it := range raw.Value {
+		if it.ID == "" {
+			continue
+		}
+		name := it.Name
+		if name == "" {
+			name = it.ID
+		}
+		var desc string
+		if it.Owner != nil && it.Owner.Address != "" {
+			desc = it.Owner.Address
+		}
+		out = append(out, connectors.UserCalendar{
+			ID:          it.ID,
+			Name:        name,
+			Description: desc,
+			IsPrimary:   it.IsDefaultCalendar,
+		})
+	}
+	return out, nil
+}

--- a/connectors/microsoft/list_user_calendars_test.go
+++ b/connectors/microsoft/list_user_calendars_test.go
@@ -1,0 +1,24 @@
+package microsoft
+
+import "testing"
+
+func TestGraphRelativePathFromNextLink(t *testing.T) {
+	t.Parallel()
+	base := "https://graph.microsoft.com/v1.0"
+	next := "https://graph.microsoft.com/v1.0/me/calendars?$skiptoken=abc"
+	got, err := graphRelativePathFromNextLink(base, next)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "/me/calendars?$skiptoken=abc" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGraphRelativePathFromNextLink_WrongHost(t *testing.T) {
+	t.Parallel()
+	_, err := graphRelativePathFromNextLink("https://graph.microsoft.com/v1.0", "https://evil.example/me/calendars")
+	if err == nil {
+		t.Fatal("expected error for mismatched host")
+	}
+}

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -4,9 +4,9 @@
 package microsoft
 
 import (
-	_ "embed"
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -57,11 +57,17 @@ func newForTest(client *http.Client, baseURL string) *MicrosoftConnector {
 	}
 }
 
+// NewForTest is the exported test helper for cross-package API tests.
+func NewForTest(client *http.Client, baseURL string) *MicrosoftConnector {
+	return newForTest(client, baseURL)
+}
+
 // ID returns "microsoft", matching the connectors.id in the database.
 func (c *MicrosoftConnector) ID() string { return "microsoft" }
 
 // Manifest returns the connector's metadata manifest. Used by the server to
 // auto-seed DB rows on startup, replacing manual seed.go files.
+//
 //go:embed logo.svg
 var logoSVG string
 
@@ -205,7 +211,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-			ActionType:  "microsoft.list_drive_files",
+				ActionType:  "microsoft.list_drive_files",
 				Name:        "List Drive Files",
 				Description: "List files and folders in OneDrive",
 				RiskLevel:   "low",
@@ -689,7 +695,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:  json.RawMessage(`{"top":"*","calendar_id":"*"}`),
 			},
 			{
-			ID:          "tpl_microsoft_list_drive_files",
+				ID:          "tpl_microsoft_list_drive_files",
 				ActionType:  "microsoft.list_drive_files",
 				Name:        "Browse OneDrive files",
 				Description: "Agent can list files and folders in OneDrive.",

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -164,6 +164,15 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 						"location": {
 							"type": "string",
 							"description": "Event location"
+						},
+						"calendar_id": {
+							"type": "string",
+							"description": "Microsoft Graph calendar ID (omit for default calendar)",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Default calendar"
+							}
 						}
 					}
 				}`)),
@@ -176,6 +185,15 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
+						"calendar_id": {
+							"type": "string",
+							"description": "Microsoft Graph calendar ID (omit for default calendar)",
+							"x-ui": {
+								"widget": "select",
+								"options_from": "connector_calendars",
+								"placeholder": "Default calendar"
+							}
+						},
 						"top": {
 							"type": "integer",
 							"default": 10,
@@ -661,14 +679,14 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "microsoft.create_calendar_event",
 				Name:        "Create calendar events",
 				Description: "Agent can create events on the calendar with any details.",
-				Parameters:  json.RawMessage(`{"subject":"*","start":"*","end":"*","time_zone":"*","body":"*","attendees":"*","location":"*"}`),
+				Parameters:  json.RawMessage(`{"subject":"*","start":"*","end":"*","time_zone":"*","body":"*","attendees":"*","location":"*","calendar_id":"*"}`),
 			},
 			{
 				ID:          "tpl_microsoft_list_events",
 				ActionType:  "microsoft.list_calendar_events",
 				Name:        "View calendar",
 				Description: "Agent can view upcoming calendar events.",
-				Parameters:  json.RawMessage(`{"top":"*"}`),
+				Parameters:  json.RawMessage(`{"top":"*","calendar_id":"*"}`),
 			},
 			{
 			ID:          "tpl_microsoft_list_drive_files",

--- a/connectors/user_calendar.go
+++ b/connectors/user_calendar.go
@@ -1,0 +1,10 @@
+package connectors
+
+// UserCalendar is a calendar the signed-in user can access, returned for UI
+// dropdowns when configuring action parameters (e.g. calendar_id).
+type UserCalendar struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	IsPrimary   bool   `json:"is_primary"`
+}

--- a/connectors/user_calendar.go
+++ b/connectors/user_calendar.go
@@ -1,5 +1,7 @@
 package connectors
 
+import "context"
+
 // UserCalendar is a calendar the signed-in user can access, returned for UI
 // dropdowns when configuring action parameters (e.g. calendar_id).
 type UserCalendar struct {
@@ -7,4 +9,10 @@ type UserCalendar struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	IsPrimary   bool   `json:"is_primary"`
+}
+
+// CalendarLister is implemented by connectors that can list the user's
+// calendars for dashboard configuration UI.
+type CalendarLister interface {
+	ListUserCalendars(ctx context.Context, creds Credentials) ([]UserCalendar, error)
 }

--- a/frontend/src/hooks/useActionSchema.ts
+++ b/frontend/src/hooks/useActionSchema.ts
@@ -30,6 +30,7 @@ export function useActionSchema(actionType: string): {
   displayTemplate: string | null;
   preview: ActionPreviewConfig | null;
   connectorName: string | null;
+  connectorId: string | null;
   connectorLogoSvg: string | null;
   isLoading: boolean;
 } {
@@ -44,6 +45,7 @@ export function useActionSchema(actionType: string): {
         displayTemplate: null,
         preview: null,
         connectorName: null,
+        connectorId: null,
         connectorLogoSvg: null,
       };
     }
@@ -58,6 +60,7 @@ export function useActionSchema(actionType: string): {
         displayTemplate: null,
         preview: null,
         connectorName: connector.name ?? null,
+        connectorId: connector.id ?? null,
         connectorLogoSvg: connector.logo_svg ?? null,
       };
     }
@@ -92,6 +95,7 @@ export function useActionSchema(actionType: string): {
       displayTemplate: action.display_template ?? null,
       preview,
       connectorName: connector.name ?? null,
+      connectorId: connector.id ?? null,
       connectorLogoSvg: connector.logo_svg ?? null,
     };
   }, [connector, actionType]);

--- a/frontend/src/hooks/useAgentConnectorCalendars.ts
+++ b/frontend/src/hooks/useAgentConnectorCalendars.ts
@@ -1,0 +1,96 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+
+const CALENDAR_CONNECTORS = new Set(["google", "microsoft"]);
+
+export interface UserCalendarOption {
+  id: string;
+  name: string;
+  description?: string;
+  is_primary: boolean;
+}
+
+/**
+ * Fetches calendars for the agent's bound Google or Microsoft credential.
+ * Used to populate calendar_id select fields in action config UI.
+ */
+export function useAgentConnectorCalendars(
+  connectorId: string,
+  agentId: number,
+  enabled: boolean,
+) {
+  const { session } = useAuth();
+
+  const query = useQuery({
+    queryKey: ["agent-connector-calendars", agentId, connectorId],
+    queryFn: async (): Promise<UserCalendarOption[]> => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+      const { data, error, response } = await client.GET(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+        {
+          params: {
+            path: { agent_id: agentId, connector_id: connectorId },
+          },
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(
+            error,
+            `Failed to load calendars (${response.status})`,
+          ),
+        );
+      }
+      const rows = data?.data;
+      if (!Array.isArray(rows)) return [];
+
+      const out: UserCalendarOption[] = [];
+      for (const row of rows) {
+        if (
+          row &&
+          typeof row === "object" &&
+          typeof (row as { id?: unknown }).id === "string" &&
+          typeof (row as { name?: unknown }).name === "string"
+        ) {
+          const r = row as {
+            id: string;
+            name: string;
+            description?: string | null;
+            is_primary?: boolean;
+          };
+          out.push({
+            id: r.id,
+            name: r.name,
+            description: r.description ?? undefined,
+            is_primary: Boolean(r.is_primary),
+          });
+        }
+      }
+
+      out.sort((a, b) => {
+        if (a.is_primary !== b.is_primary) return a.is_primary ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+      return out;
+    },
+    enabled:
+      enabled &&
+      !!session?.access_token &&
+      agentId > 0 &&
+      CALENDAR_CONNECTORS.has(connectorId),
+    staleTime: 60_000,
+  });
+
+  return {
+    calendars: query.data,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error instanceof Error ? query.error.message : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useAgentConnectorCalendars.ts
+++ b/frontend/src/hooks/useAgentConnectorCalendars.ts
@@ -49,28 +49,14 @@ export function useAgentConnectorCalendars(
       const rows = data?.data;
       if (!Array.isArray(rows)) return [];
 
-      const out: UserCalendarOption[] = [];
-      for (const row of rows) {
-        if (
-          row &&
-          typeof row === "object" &&
-          typeof (row as { id?: unknown }).id === "string" &&
-          typeof (row as { name?: unknown }).name === "string"
-        ) {
-          const r = row as {
-            id: string;
-            name: string;
-            description?: string | null;
-            is_primary?: boolean;
-          };
-          out.push({
-            id: r.id,
-            name: r.name,
-            description: r.description ?? undefined,
-            is_primary: Boolean(r.is_primary),
-          });
-        }
-      }
+      const out: UserCalendarOption[] = rows
+        .filter((r) => Boolean(r?.id && r?.name))
+        .map((r) => ({
+          id: r.id,
+          name: r.name,
+          description: r.description ?? undefined,
+          is_primary: Boolean(r.is_primary),
+        }));
 
       out.sort((a, b) => {
         if (a.is_primary !== b.is_primary) return a.is_primary ? -1 : 1;

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -13,6 +13,9 @@ export interface VisibleWhen {
   equals: string | boolean | number;
 }
 
+/** Dynamic option sources for select widgets (fetched at runtime). */
+export type OptionsFromSource = "connector_calendars";
+
 /** Property-level `x-ui` rendering hints for a single parameter. */
 export interface SchemaPropertyUI {
   widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date" | "datetime" | "list";
@@ -22,6 +25,8 @@ export interface SchemaPropertyUI {
   help_url?: string;
   help_text?: string;
   visible_when?: VisibleWhen;
+  /** When set with widget "select", options are loaded from the API instead of `enum`. */
+  options_from?: OptionsFromSource;
 }
 
 /** A named group for organizing related fields in the form. */
@@ -267,6 +272,9 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
   if (typeof obj.group === "string") ui.group = obj.group;
   if (typeof obj.help_url === "string") ui.help_url = obj.help_url;
   if (typeof obj.help_text === "string") ui.help_text = obj.help_text;
+  if (obj.options_from === "connector_calendars") {
+    ui.options_from = "connector_calendars";
+  }
   if (obj.visible_when && typeof obj.visible_when === "object") {
     const vw = obj.visible_when as Record<string, unknown>;
     if (

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -5,7 +5,9 @@ import { Label } from "@/components/ui/label";
 import { Asterisk, ChevronDown, ChevronRight } from "lucide-react";
 import type { ParamMode } from "./ActionConfigFormFields";
 import { ParameterFieldWidget } from "./ParameterFieldWidget";
+import type { CalendarSelectOption } from "./ParameterFieldWidget";
 import type { ParametersSchema, SchemaProperty, FieldGroup } from "@/lib/parameterSchema";
+import { useAgentConnectorCalendars } from "@/hooks/useAgentConnectorCalendars";
 import {
   getOrderedFieldKeys,
   getFieldLabel,
@@ -20,6 +22,9 @@ interface ActionConfigParameterFieldsProps {
   modes: Record<string, ParamMode>;
   onModeChange: (key: string, mode: ParamMode) => void;
   disabled?: boolean;
+  /** When set with a connector that supports calendar listing, calendar_id selects load options from the API. */
+  agentId?: number;
+  connectorId?: string;
 }
 
 /**
@@ -38,7 +43,29 @@ export function ActionConfigParameterFields({
   modes,
   onModeChange,
   disabled,
+  agentId = 0,
+  connectorId,
 }: ActionConfigParameterFieldsProps) {
+  const needsConnectorCalendars =
+    !!connectorId &&
+    agentId > 0 &&
+    !!parametersSchema?.properties &&
+    Object.values(parametersSchema.properties).some(
+      (p) => p["x-ui"]?.options_from === "connector_calendars",
+    );
+
+  const {
+    calendars,
+    isLoading: calendarsLoading,
+    error: calendarsError,
+  } = useAgentConnectorCalendars(connectorId ?? "", agentId, needsConnectorCalendars);
+
+  const calendarSelectOptions: CalendarSelectOption[] | undefined =
+    calendars?.map((c) => ({
+      value: c.id,
+      label: c.is_primary ? `${c.name} (primary)` : c.name,
+    }));
+
   if (!parametersSchema?.properties) {
     return (
       <p className="text-muted-foreground text-sm">
@@ -78,6 +105,9 @@ export function ActionConfigParameterFields({
         disabled={disabled}
         onValueChange={onValueChange}
         onModeChange={onModeChange}
+        calendarSelectOptions={calendarSelectOptions}
+        calendarsLoading={calendarsLoading}
+        calendarsError={calendarsError}
       />
     );
   }
@@ -152,6 +182,9 @@ function ParameterField({
   disabled,
   onValueChange,
   onModeChange,
+  calendarSelectOptions,
+  calendarsLoading,
+  calendarsError,
 }: {
   paramKey: string;
   property: SchemaProperty;
@@ -162,6 +195,9 @@ function ParameterField({
   disabled?: boolean;
   onValueChange: (key: string, value: string) => void;
   onModeChange: (key: string, mode: ParamMode) => void;
+  calendarSelectOptions?: CalendarSelectOption[];
+  calendarsLoading?: boolean;
+  calendarsError?: string | null;
 }) {
   const isWildcard = mode === "wildcard";
   const widgetValue = isWildcard ? "" : value;
@@ -170,6 +206,8 @@ function ParameterField({
   const widgetPlaceholder = isWildcard ? "Agent can use any value" : undefined;
   const effectiveWidget = property["x-ui"]?.widget ?? inferWidgetFromProperty(property);
   const isMultiRow = effectiveWidget === "list";
+  const useCalendarOptions =
+    property["x-ui"]?.options_from === "connector_calendars";
 
   // In constraint context, datetime fields render as plain text so users can
   // enter patterns like "2026-*" rather than being forced to use a date picker.
@@ -231,6 +269,8 @@ function ParameterField({
             disabled={widgetDisabled}
             className={widgetClassName}
             placeholder={widgetPlaceholder}
+            dynamicSelectOptions={useCalendarOptions ? calendarSelectOptions : undefined}
+            dynamicSelectLoading={useCalendarOptions ? calendarsLoading : false}
           />
         )
       ) : (
@@ -242,7 +282,12 @@ function ParameterField({
           disabled={widgetDisabled}
           className={widgetClassName}
           placeholder={widgetPlaceholder}
+          dynamicSelectOptions={useCalendarOptions ? calendarSelectOptions : undefined}
+          dynamicSelectLoading={useCalendarOptions ? calendarsLoading : false}
         />
+      )}
+      {useCalendarOptions && calendarsError && !isWildcard && (
+        <p className="text-destructive text-xs">{calendarsError}</p>
       )}
       {!isWildcard && value.includes("*") && (
         <div className="rounded-lg border border-dashed bg-muted/40 px-3 py-2">

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Asterisk, ChevronDown, ChevronRight } from "lucide-react";
 import type { ParamMode } from "./ActionConfigFormFields";
 import { ParameterFieldWidget } from "./ParameterFieldWidget";
-import type { CalendarSelectOption } from "./ParameterFieldWidget";
+import type { DynamicSelectOption } from "./ParameterFieldWidget";
 import type { ParametersSchema, SchemaProperty, FieldGroup } from "@/lib/parameterSchema";
 import { useAgentConnectorCalendars } from "@/hooks/useAgentConnectorCalendars";
 import {
@@ -60,7 +60,7 @@ export function ActionConfigParameterFields({
     error: calendarsError,
   } = useAgentConnectorCalendars(connectorId ?? "", agentId, needsConnectorCalendars);
 
-  const calendarSelectOptions: CalendarSelectOption[] | undefined =
+  const calendarSelectOptions: DynamicSelectOption[] | undefined =
     calendars?.map((c) => ({
       value: c.id,
       label: c.is_primary ? `${c.name} (primary)` : c.name,
@@ -195,7 +195,7 @@ function ParameterField({
   disabled?: boolean;
   onValueChange: (key: string, value: string) => void;
   onModeChange: (key: string, mode: ParamMode) => void;
-  calendarSelectOptions?: CalendarSelectOption[];
+  calendarSelectOptions?: DynamicSelectOption[];
   calendarsLoading?: boolean;
   calendarsError?: string | null;
 }) {

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -223,6 +223,8 @@ export function AddActionConfigDialog({
                   modes={paramModes}
                   onModeChange={(key, mode) => setParamModes((prev) => ({ ...prev, [key]: mode }))}
                   disabled={isPending}
+                  agentId={agentId}
+                  connectorId={connectorId}
                 />
               </div>
             )}

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -187,6 +187,8 @@ export function EditActionConfigDialog({
                   modes={paramModes}
                   onModeChange={(key, mode) => setParamModes((prev) => ({ ...prev, [key]: mode }))}
                   disabled={isPending}
+                  agentId={agentId}
+                  connectorId={config.connector_id}
                 />
               </div>
             ) : null}

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -6,6 +6,11 @@ import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
 import { inferWidgetFromProperty } from "@/lib/parameterSchema";
 
+export interface CalendarSelectOption {
+  value: string;
+  label: string;
+}
+
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
   paramKey: string;
@@ -21,6 +26,10 @@ export interface ParameterFieldWidgetProps {
   className?: string;
   /** Override the placeholder from x-ui (e.g. for constraint mode hints). */
   placeholder?: string;
+  /** Runtime options for `x-ui.options_from` select widgets. */
+  dynamicSelectOptions?: CalendarSelectOption[];
+  /** True while dynamic options are loading. */
+  dynamicSelectLoading?: boolean;
 }
 
 /**
@@ -35,11 +44,15 @@ export function ParameterFieldWidget({
   disabled,
   className,
   placeholder: placeholderOverride,
+  dynamicSelectOptions,
+  dynamicSelectLoading,
 }: ParameterFieldWidgetProps) {
   const ui = property["x-ui"];
   const widget: WidgetType = ui?.widget ?? inferWidgetFromProperty(property);
   const placeholder = placeholderOverride ?? ui?.placeholder;
   const inputId = `param-${paramKey}`;
+  const useDynamicCalendars =
+    widget === "select" && ui?.options_from === "connector_calendars";
 
   return (
     <div className="space-y-1">
@@ -51,6 +64,8 @@ export function ParameterFieldWidget({
         placeholder,
         className,
         enumValues: property.enum,
+        dynamicOptions: useDynamicCalendars ? dynamicSelectOptions : undefined,
+        dynamicLoading: useDynamicCalendars ? dynamicSelectLoading : false,
       })}
       <FieldHints ui={ui} />
     </div>
@@ -65,6 +80,8 @@ interface WidgetRenderProps {
   placeholder?: string;
   className?: string;
   enumValues?: string[];
+  dynamicOptions?: CalendarSelectOption[];
+  dynamicLoading?: boolean;
 }
 
 function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
@@ -103,22 +120,49 @@ function TextWidget({ inputId, value, onChange, disabled, placeholder, className
   );
 }
 
-function SelectWidget({ inputId, value, onChange, disabled, placeholder, enumValues, className }: WidgetRenderProps) {
+function SelectWidget({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  enumValues,
+  className,
+  dynamicOptions,
+  dynamicLoading,
+}: WidgetRenderProps) {
+  const usingDynamic = dynamicOptions !== undefined;
+  const opts = usingDynamic
+    ? dynamicOptions
+    : (enumValues ?? []).filter((opt) => opt !== "").map((v) => ({ value: v, label: v }));
+
+  const showCustom =
+    usingDynamic &&
+    value !== "" &&
+    !opts.some((o) => o.value === value);
+
   return (
     <select
       id={inputId}
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      disabled={disabled}
+      disabled={disabled || dynamicLoading}
       className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
       data-testid={`select-${inputId}`}
     >
-      <option value="">{placeholder ?? "Select…"}</option>
-      {(enumValues ?? []).filter((opt) => opt !== "").map((opt) => (
-        <option key={opt} value={opt}>
-          {opt}
+      <option value="">
+        {dynamicLoading ? "Loading calendars…" : (placeholder ?? "Select…")}
+      </option>
+      {opts.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
         </option>
       ))}
+      {showCustom && (
+        <option value={value}>
+          {value} (custom)
+        </option>
+      )}
     </select>
   );
 }

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -6,7 +6,7 @@ import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
 import { inferWidgetFromProperty } from "@/lib/parameterSchema";
 
-export interface CalendarSelectOption {
+export interface DynamicSelectOption {
   value: string;
   label: string;
 }
@@ -27,7 +27,7 @@ export interface ParameterFieldWidgetProps {
   /** Override the placeholder from x-ui (e.g. for constraint mode hints). */
   placeholder?: string;
   /** Runtime options for `x-ui.options_from` select widgets. */
-  dynamicSelectOptions?: CalendarSelectOption[];
+  dynamicSelectOptions?: DynamicSelectOption[];
   /** True while dynamic options are loading. */
   dynamicSelectLoading?: boolean;
 }
@@ -80,7 +80,7 @@ interface WidgetRenderProps {
   placeholder?: string;
   className?: string;
   enumValues?: string[];
-  dynamicOptions?: CalendarSelectOption[];
+  dynamicOptions?: DynamicSelectOption[];
   dynamicLoading?: boolean;
 }
 

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -108,6 +108,56 @@ describe("ParameterFieldWidget", () => {
 
       expect(onChange).toHaveBeenCalledWith("eur");
     });
+
+    it("renders dynamic calendar options when options_from is connector_calendars", () => {
+      const calendarProp: SchemaProperty = {
+        type: "string",
+        "x-ui": {
+          widget: "select",
+          options_from: "connector_calendars",
+          placeholder: "Pick one",
+        },
+      };
+
+      renderWithProviders(
+        <ParameterFieldWidget
+          paramKey="calendar_id"
+          property={calendarProp}
+          value=""
+          onChange={vi.fn()}
+          dynamicSelectOptions={[
+            { value: "primary", label: "Primary (primary)" },
+            { value: "other", label: "Other" },
+          ]}
+          dynamicSelectLoading={false}
+        />,
+      );
+
+      const select = screen.getByTestId("select-param-calendar_id");
+      expect(select).toBeInTheDocument();
+      expect(screen.getByText("Primary (primary)")).toBeInTheDocument();
+      expect(screen.getByText("Other")).toBeInTheDocument();
+    });
+
+    it("shows loading placeholder for dynamic calendar select", () => {
+      const calendarProp: SchemaProperty = {
+        type: "string",
+        "x-ui": { widget: "select", options_from: "connector_calendars" },
+      };
+
+      renderWithProviders(
+        <ParameterFieldWidget
+          paramKey="calendar_id"
+          property={calendarProp}
+          value=""
+          onChange={vi.fn()}
+          dynamicSelectOptions={[]}
+          dynamicSelectLoading
+        />,
+      );
+
+      expect(screen.getByText("Loading calendars…")).toBeInTheDocument();
+    });
   });
 
   describe("textarea widget", () => {

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -186,6 +186,7 @@ export function CreateStandingApprovalDialog({
     schema: fetchedSchema,
     isLoading: schemaLoading,
     connectorName,
+    connectorId: schemaConnectorId,
     actionName,
     connectorLogoSvg,
   } = useActionSchema(effectiveActionType);
@@ -552,6 +553,8 @@ export function CreateStandingApprovalDialog({
               manualConstraintsJson={manualConstraintsJson}
               onManualConstraintsJsonChange={setManualConstraintsJson}
               isPending={isPending}
+              agentId={typeof agentId === "number" ? agentId : undefined}
+              connectorId={schemaConnectorId ?? undefined}
             />
           )}
 

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -133,6 +133,8 @@ export function StepConstraints({
   manualConstraintsJson,
   onManualConstraintsJsonChange,
   isPending,
+  agentId,
+  connectorId,
 }: {
   configSchema: ParametersSchema | null;
   schemaLoading: boolean;
@@ -143,6 +145,8 @@ export function StepConstraints({
   manualConstraintsJson: string;
   onManualConstraintsJsonChange: (value: string) => void;
   isPending: boolean;
+  agentId?: number;
+  connectorId?: string;
 }) {
   if (schemaLoading) {
     return (
@@ -175,6 +179,8 @@ export function StepConstraints({
             modes={paramModes}
             onModeChange={onParamModeChange}
             disabled={isPending}
+            agentId={agentId}
+            connectorId={connectorId}
           />
         </div>
       ) : (

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -357,3 +357,56 @@ agentConnectorCredential:
 
       '500':
         $ref: '../responses/errors.yaml#/InternalServerError'
+
+agentConnectorCalendars:
+  get:
+    operationId: listAgentConnectorCalendars
+    summary: List Calendars for Agent Connector
+    description: |
+      Returns calendars from the external provider (Google Calendar or Microsoft Graph) using
+      the credential bound to this agent+connector. Used by the dashboard to populate calendar
+      ID dropdowns when configuring actions.
+
+      Requires a credential assignment for the connector — the same binding used at action
+      execution time.
+
+    tags:
+      - Agents
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+
+    responses:
+      '200':
+        description: Calendars listed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorCalendarListResponse'
+
+      '400':
+        description: Connector does not support calendar listing or validation error
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Agent not found, not owned by user, or connector not registered
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'

--- a/spec/openapi/components/schemas/agent_connectors.yaml
+++ b/spec/openapi/components/schemas/agent_connectors.yaml
@@ -170,3 +170,48 @@ AgentConnectorCredentialResponse:
     agent_id: 42
     connector_id: "gmail"
     oauth_connection_id: "oc_def456"
+
+UserCalendar:
+  type: object
+  required:
+    - id
+    - name
+    - is_primary
+  properties:
+    id:
+      type: string
+      description: |
+        Provider calendar identifier. For Google Calendar this may be `primary` or an
+        email-style calendar ID. For Microsoft Graph this is the calendar object ID.
+    name:
+      type: string
+      description: Human-readable calendar name.
+    description:
+      type: string
+      description: Optional subtitle (e.g. owner address for shared calendars).
+    is_primary:
+      type: boolean
+      description: True when this is the user's primary or default calendar.
+
+AgentConnectorCalendarListResponse:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: '#/UserCalendar'
+      description: |
+        Calendars visible to the connected account, sorted for display. Used to populate
+        action configuration UI for Google and Microsoft calendar actions.
+
+  example:
+    data:
+      - id: "primary"
+        name: "Primary"
+        is_primary: true
+      - id: "work@group.calendar.google.com"
+        name: "Team Calendar"
+        description: "work@example.com"
+        is_primary: false

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1634,6 +1634,49 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /v1/agents/{agent_id}/connectors/{connector_id}/calendars:
+    get:
+      operationId: listAgentConnectorCalendars
+      summary: List Calendars for Agent Connector
+      description: |
+        Returns calendars from the external provider (Google Calendar or Microsoft Graph) using
+        the credential bound to this agent+connector. Used by the dashboard to populate calendar
+        ID dropdowns when configuring actions.
+
+        Requires a credential assignment for the connector — the same binding used at action
+        execution time.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Calendars listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCalendarListResponse'
+        '400':
+          description: Connector does not support calendar listing or validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent not found, not owned by user, or connector not registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/registration-invites:
     post:
       operationId: createRegistrationInvite
@@ -11596,6 +11639,48 @@ components:
           type: string
           description: OAuth connection ID to assign.
           example: oc_def456
+    UserCalendar:
+      type: object
+      required:
+        - id
+        - name
+        - is_primary
+      properties:
+        id:
+          type: string
+          description: |
+            Provider calendar identifier. For Google Calendar this may be `primary` or an
+            email-style calendar ID. For Microsoft Graph this is the calendar object ID.
+        name:
+          type: string
+          description: Human-readable calendar name.
+        description:
+          type: string
+          description: Optional subtitle (e.g. owner address for shared calendars).
+        is_primary:
+          type: boolean
+          description: True when this is the user's primary or default calendar.
+    AgentConnectorCalendarListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserCalendar'
+          description: |
+            Calendars visible to the connected account, sorted for display. Used to populate
+            action configuration UI for Google and Microsoft calendar actions.
+      example:
+        data:
+          - id: primary
+            name: Primary
+            is_primary: true
+          - id: work@group.calendar.google.com
+            name: Team Calendar
+            description: work@example.com
+            is_primary: false
     RetentionMeta:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -156,6 +156,9 @@ paths:
   /v1/agents/{agent_id}/connectors/{connector_id}/credential:
     $ref: './components/paths/agent_connectors.yaml#/agentConnectorCredential'
 
+  /v1/agents/{agent_id}/connectors/{connector_id}/calendars:
+    $ref: './components/paths/agent_connectors.yaml#/agentConnectorCalendars'
+
   /v1/registration-invites:
     $ref: './components/paths/registration_invites.yaml#/createRegistrationInvite'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a **calendar picker** for action configuration and standing-approval constraints when a parameter schema marks `calendar_id` with `x-ui.options_from: "connector_calendars"`.

- **Backend:** `GET /v1/agents/{agent_id}/connectors/{connector_id}/calendars` lists calendars using the **same agent+connector credential binding** as execution (Google Calendar `calendarList.list`, Microsoft Graph `GET /me/calendars`). Credential resolution is refactored so a binding is always required for this path, even if the connector has no `required_credentials` rows (previously returned empty creds).
- **Microsoft:** Optional `calendar_id` on `create_calendar_event` and `list_calendar_events` routes to `/me/calendars/{id}/events` when set; empty keeps default `/me/events` behavior.
- **Manifests:** Google calendar actions and Microsoft calendar actions expose `calendar_id` with `x-ui` hints for the dashboard.
- **Frontend:** `useAgentConnectorCalendars` + dynamic options in `ParameterFieldWidget`; wired from Add/Edit action config dialogs and standing approval constraints (`useActionSchema` now returns `connectorId`).

Closes supersuit-tech/permission-slip-private#4 (issue body was not reachable from this environment; aligned with expected scope).

## Test plan

### Developer

- [ ] `make test-backend` (includes new `api` tests and connector tests)
- [ ] `make test-frontend`
- [ ] `make build`
- [ ] After merge / in environments with real OAuth: spot-check `GET .../calendars` for `google` and `microsoft` with a bound OAuth connection

### Manual Testing

- [ ] Agent connector: assign Google OAuth → add/edit action config for a calendar action → `calendar_id` shows loaded calendars; save config and confirm execution still works
- [ ] Same for Microsoft OAuth and `microsoft.create_calendar_event` / `microsoft.list_calendar_events`
- [ ] Standing approval flow (step 3 constraints): calendar fields load when agent is selected and action schema includes `connector_calendars`
- [ ] No credential assigned: UI shows error under field; API returns validation-style 400 with clear message
- [ ] Wildcard mode on `calendar_id` still works (dropdown disabled per existing behavior)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a57d223d-d8c7-406c-a002-9550f895533b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a57d223d-d8c7-406c-a002-9550f895533b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

