### PR TITLE
Add Slack user OAuth scopes for users.conversations

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -708,10 +708,14 @@ When connecting via OAuth, scopes are requested automatically. If you're creatin
 | `users:read` | List workspace users |
 | `users:read.email` | Access user email addresses (needed for identity verification) |
 
-**User token scopes (`xoxp-`)** — only needed for `search_messages`:
+**User token scopes (`xoxp-`)** — needed for `search_messages` and for `users.conversations` when filtering private channels / DMs to the installing user’s memberships:
 
 | Scope | Purpose |
 |-------|---------|
+| `channels:read` | List public channels the user is in (`users.conversations`) |
+| `groups:read` | Include private channels in `users.conversations` |
+| `im:read` | Include DMs in `users.conversations` |
+| `mpim:read` | Include group DMs in `users.conversations` |
 | `search:read.public` | Search public channel messages |
 | `search:read.private` | Search private channel messages |
 | `search:read.im` | Search DM messages |

--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -256,19 +256,34 @@ const maxUserConversationPages = 50
 // filtered to the given channel types (e.g., "private_channel,mpim,im"). This is
 // more efficient than per-channel isUserInChannel calls when filtering a list of
 // channels, as it makes one paginated API call instead of N.
+//
+// When a user OAuth token (xoxp-) is present, Slack documents users.conversations
+// as returning the calling user's channels; the optional "user" filter applies
+// to the bot case. We therefore call with the user token and omit "user".
+// Otherwise we use the bot token and pass slackUserID so the bot's shared
+// conversations with that user are listed (legacy / partial coverage).
 func (c *SlackConnector) getUserChannelIDs(ctx context.Context, creds connectors.Credentials, slackUserID, types string) (map[string]bool, error) {
+	apiCreds := creds
+	useUserToken := false
+	if ut, ok := creds.Get(credKeyUserAccessToken); ok && ut != "" {
+		apiCreds = connectors.NewCredentials(map[string]string{credKeyAccessToken: ut})
+		useUserToken = true
+	}
+
 	channelSet := make(map[string]bool)
 	cursor := ""
 	for page := 0; page < maxUserConversationPages; page++ {
 		body := usersConversationsRequest{
-			User:   slackUserID,
 			Types:  types,
 			Limit:  200,
 			Cursor: cursor,
 		}
+		if !useUserToken {
+			body.User = slackUserID
+		}
 
 		var resp usersConversationsResponse
-		if err := c.doPost(ctx, "users.conversations", creds, body, &resp); err != nil {
+		if err := c.doPost(ctx, "users.conversations", apiCreds, body, &resp); err != nil {
 			return nil, err
 		}
 		if !resp.OK {

--- a/connectors/slack/channel_membership_test.go
+++ b/connectors/slack/channel_membership_test.go
@@ -439,6 +439,79 @@ func TestSearchMessages_FiltersPrivateResults(t *testing.T) {
 	}
 }
 
+func TestGetUserChannelIDs_UserTokenOmitsUserParameter(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	var gotBody usersConversationsRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/users.conversations" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":       true,
+			"channels": []map[string]any{{"id": "G123"}},
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	creds := connectors.NewCredentials(map[string]string{
+		"access_token":      "xoxb-bot-token",
+		"user_access_token": "xoxp-user-token",
+	})
+	ids, err := conn.getUserChannelIDs(t.Context(), creds, "U_SHOULD_NOT_BE_SENT", "private_channel")
+	if err != nil {
+		t.Fatalf("getUserChannelIDs: %v", err)
+	}
+	if gotAuth != "Bearer xoxp-user-token" {
+		t.Errorf("expected user token in Authorization, got %q", gotAuth)
+	}
+	if gotBody.User != "" {
+		t.Errorf("users.conversations with user token should omit user field, got User=%q", gotBody.User)
+	}
+	if gotBody.Types != "private_channel" {
+		t.Errorf("types: got %q", gotBody.Types)
+	}
+	if !ids["G123"] {
+		t.Errorf("expected G123 in result set, got %v", ids)
+	}
+}
+
+func TestGetUserChannelIDs_BotTokenSendsUserParameter(t *testing.T) {
+	t.Parallel()
+
+	var gotBody usersConversationsRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "channels": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	creds := validCreds()
+	_, err := conn.getUserChannelIDs(t.Context(), creds, "U_TARGET", "im")
+	if err != nil {
+		t.Fatalf("getUserChannelIDs: %v", err)
+	}
+	if gotBody.User != "U_TARGET" {
+		t.Errorf("expected User U_TARGET for bot token call, got %q", gotBody.User)
+	}
+	if gotBody.Types != "im" {
+		t.Errorf("types: got %q", gotBody.Types)
+	}
+}
+
 func TestFilterPrivateTypes(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -65,9 +65,18 @@ var OAuthScopes = []string{
 // OAuthUserScopes is the list of user-level OAuth scopes requested via the
 // "user_scope" parameter in the Slack OAuth v2 authorization URL. These
 // result in a user token (xoxp-) returned in the authed_user field of the
-// OAuth response. The search:read.* scopes are here because Slack's
-// search.messages endpoint requires a user token — bot tokens are not supported.
+// OAuth response.
+//
+// - search:read.* — search.messages accepts only user tokens, not bot tokens.
+// - channels:read, groups:read, im:read, mpim:read — users.conversations
+//   requires one of these on the token used for the call. We call that method
+//   with the user token (listing the installing user's memberships) so private
+//   channel / DM filtering in list_channels and search_messages works reliably.
 var OAuthUserScopes = []string{
+	"channels:read",
+	"groups:read",
+	"im:read",
+	"mpim:read",
 	"search:read.public",
 	"search:read.private",
 	"search:read.im",

--- a/connectors/slack/user_token_test.go
+++ b/connectors/slack/user_token_test.go
@@ -114,11 +114,16 @@ func TestSearchMessages_FallsBackToBotToken(t *testing.T) {
 	}
 }
 
-func TestOAuthUserScopes_AreSearchScopes(t *testing.T) {
+func TestOAuthUserScopes_ContainsRequiredUserScopes(t *testing.T) {
 	t.Parallel()
 
-	// Verify OAuthUserScopes contains all search:read.* scopes.
+	// User token must include search:read.* (search.messages) and
+	// channels/groups/im/mpim read (users.conversations when called with xoxp-).
 	expected := map[string]bool{
+		"channels:read":       true,
+		"groups:read":         true,
+		"im:read":             true,
+		"mpim:read":           true,
 		"search:read.public":  true,
 		"search:read.private": true,
 		"search:read.im":      true,

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -545,8 +545,9 @@ Under **Scopes**, add **Bot Token Scopes** and **User Token Scopes** to match wh
 - `reactions:write`
 - `users:read`, `users:read.email`
 
-**User Token Scopes** (required for search actions that only work with user tokens)
+**User Token Scopes** (required for search and for listing the installing user’s private conversations via `users.conversations`)
 
+- `channels:read`, `groups:read`, `im:read`, `mpim:read`
 - `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`
 
 ### 4. Configure environment


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #759 (Slack user scopes): `users.conversations` requires `channels:read`, `groups:read`, `im:read`, or `mpim:read` on the **token used for the call**. We were using the bot token with a `user` filter, which does not reliably reflect the installing human’s private channel / DM memberships for `list_channels` and `search_messages` filtering.

- Extended `OAuthUserScopes` with `channels:read`, `groups:read`, `im:read`, `mpim:read` (alongside existing `search:read.*`).
- `getUserChannelIDs` now uses `user_access_token` when present, calls `users.conversations` with that token, and **omits** the `user` field (Slack documents user-token calls as returning the caller’s conversations).
- Updated `docs/oauth-setup.md` and `connectors/slack/README.md`. CLI unchanged: `permission-slip connectors` reads scopes from the API/manifest.

## Test plan

- `go test ./connectors/slack/...` (not run here: local Go 1.22.2 vs `go.mod` toolchain / module resolution in this environment).

### Developer

- [ ] Run `go test ./connectors/slack/...` and `make build` in a full dev environment.

### Manual Testing

- [ ] Re-authorize Slack after deploy; confirm **User Token Scopes** in the Slack app include the new read scopes.
- [ ] With OAuth + profile email set, run `slack.list_channels` including private types and confirm expected channels appear.
- [ ] Run `slack.search_messages` and confirm results still respect membership filtering.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0d79464-ad38-42d0-820e-17bc58782418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0d79464-ad38-42d0-820e-17bc58782418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

