### PR TITLE
Add hook to enforce non-draft PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -q 'gh.*pr.*create' && echo \"$CMD\" | grep -qE '(^|\\s)--draft(\\s|$)'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Draft PRs are not allowed per CLAUDE.md. Remove --draft to open as ready for review.\"}}'; fi",
+            "statusMessage": "Checking PR draft policy..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` hook in `.claude/settings.json` that intercepts `gh pr create` commands containing `--draft`
- Blocks the command with a clear error message referencing CLAUDE.md policy
- Non-draft `gh pr create` commands pass through unaffected

## Test plan

### Developer
- [ ] Verify `gh pr create --draft` is blocked by the hook with the expected error message
- [ ] Verify `gh pr create` (without `--draft`) passes through normally
- [ ] Verify other Bash commands are unaffected by the hook

### Manual Testing
- [ ] Confirm the hook fires in a fresh Claude Code session after pulling this branch

https://claude.ai/code/session_01EGCKV4Dv9zoeWwcJqYYpke