### PR TITLE
Fix credentials_ready to honor agent_connector_credentials bindings

### DIFF
--- a/api/capabilities_test.go
+++ b/api/capabilities_test.go
@@ -35,7 +35,8 @@ func TestGetCapabilities_HappyPath(t *testing.T) {
 	testhelper.InsertConnectorWithDescription(t, tx, conn1, "Gmail", "Send and manage emails")
 	svc1 := testhelper.GenerateID(t, "svc_")
 	testhelper.InsertConnectorRequiredCredential(t, tx, conn1, svc1, "api_key")
-	testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, svc1)
+	cred1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredential(t, tx, cred1, uid, svc1)
 
 	riskLow := "low"
 	sendDesc := "Send an email"
@@ -46,6 +47,7 @@ func TestGetCapabilities_HappyPath(t *testing.T) {
 		ParametersSchema: schema,
 	})
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn1)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, conn1, cred1)
 
 	// Add a standing approval.
 	saID := testhelper.GenerateID(t, "sa_")
@@ -359,10 +361,12 @@ func TestGetCapabilities_MultipleConnectorsAndActions(t *testing.T) {
 	testhelper.InsertConnectorWithDescription(t, tx, conn1, "Gmail", "Email service")
 	svc1 := testhelper.GenerateID(t, "svc_")
 	testhelper.InsertConnectorRequiredCredential(t, tx, conn1, svc1, "api_key")
-	testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, svc1)
+	cred1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredential(t, tx, cred1, uid, svc1)
 	testhelper.InsertConnectorAction(t, tx, conn1, "email.send", "Send Email")
 	testhelper.InsertConnectorAction(t, tx, conn1, "email.read", "Read Email")
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn1)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, conn1, cred1)
 
 	// Connector 2: Stripe without credentials.
 	conn2 := testhelper.GenerateID(t, "conn_")
@@ -441,6 +445,7 @@ func TestGetCapabilities_WithActionConfigurations(t *testing.T) {
 	testhelper.InsertCredential(t, tx, credID, uid, svc)
 	testhelper.InsertConnectorAction(t, tx, conn, "github.create_issue", "Create Issue")
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, conn, credID)
 
 	// Insert an action configuration with credential bound.
 	cfgID := testhelper.GenerateID(t, "ac_")

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -68,26 +68,40 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 
 	// 1. Enabled connectors with credential readiness.
 	//
-	// For each enabled connector, check if ALL required credential services
-	// have a matching row in the credentials table (for api_key/basic/custom)
-	// or the oauth_connections table (for oauth2) for this user. If a
-	// connector has no required credentials, it's considered ready.
+	// When a connector declares required credentials, readiness is determined only
+	// via agent_connector_credentials: each required row must be satisfied by the
+	// single bound credential or OAuth connection for that agent+connector (the same
+	// binding execution uses). Static credentials match when credentials.service equals
+	// connector_required_credentials.service or the connector id (assign-credential
+	// stores service = connector id). OAuth matches on provider and scopes.
+	//
+	// Connectors with no connector_required_credentials rows are always ready.
 	connRows, err := db.Query(ctx, `
 		SELECT c.id, c.name, c.description,
 		       NOT EXISTS (
 		           SELECT 1 FROM connector_required_credentials crc
 		           WHERE crc.connector_id = c.id
-		             AND NOT EXISTS (
-		               SELECT 1 FROM credentials cr
-		               WHERE cr.user_id = ac.approver_id
-		                 AND cr.service = crc.service
-		             )
-		             AND NOT EXISTS (
-		               SELECT 1 FROM oauth_connections oc
-		               WHERE oc.user_id = ac.approver_id
-		                 AND oc.provider = crc.oauth_provider
-		                 AND oc.status = 'active'
-		                 AND crc.oauth_scopes <@ oc.scopes
+		             AND NOT (
+		                 (crc.auth_type <> 'oauth2' AND EXISTS (
+		                     SELECT 1 FROM agent_connector_credentials acc
+		                     INNER JOIN credentials cr ON cr.id = acc.credential_id
+		                     WHERE acc.agent_id = ac.agent_id
+		                       AND acc.connector_id = c.id
+		                       AND acc.approver_id = ac.approver_id
+		                       AND cr.user_id = ac.approver_id
+		                       AND (cr.service = crc.service OR cr.service = c.id)
+		                 ))
+		                 OR (crc.auth_type = 'oauth2' AND EXISTS (
+		                     SELECT 1 FROM agent_connector_credentials acc
+		                     INNER JOIN oauth_connections oc ON oc.id = acc.oauth_connection_id
+		                     WHERE acc.agent_id = ac.agent_id
+		                       AND acc.connector_id = c.id
+		                       AND acc.approver_id = ac.approver_id
+		                       AND oc.user_id = ac.approver_id
+		                       AND oc.provider = crc.oauth_provider
+		                       AND oc.status = 'active'
+		                       AND crc.oauth_scopes <@ oc.scopes
+		                 ))
 		             )
 		       ) AS credentials_ready
 		FROM agent_connectors ac

--- a/db/capabilities_test.go
+++ b/db/capabilities_test.go
@@ -41,12 +41,13 @@ func TestGetAgentCapabilities_MultipleConnectors(t *testing.T) {
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 
-	// Connector 1: with credentials stored
+	// Connector 1: with credentials stored and bound to this agent+connector
 	conn1 := testhelper.GenerateID(t, "conn_")
 	testhelper.InsertConnectorWithDescription(t, tx, conn1, "Gmail", "Send and manage emails")
 	svc1 := testhelper.GenerateID(t, "svc_")
 	testhelper.InsertConnectorRequiredCredential(t, tx, conn1, svc1, "api_key")
-	testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, svc1)
+	cred1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredential(t, tx, cred1, uid, svc1)
 
 	riskLow := "low"
 	schema := json.RawMessage(`{"type":"object","required":["to","subject"]}`)
@@ -78,6 +79,7 @@ func TestGetAgentCapabilities_MultipleConnectors(t *testing.T) {
 	// Enable both connectors for the agent
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn1)
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn2)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, conn1, cred1)
 
 	// Add a standing approval for email.send
 	maxExec := 100
@@ -322,18 +324,17 @@ func TestGetAgentCapabilities_CredentialsReady_NoRequiredCredentials(t *testing.
 	}
 }
 
-func TestGetAgentCapabilities_CredentialsReady_PartialCredentials(t *testing.T) {
+func TestGetAgentCapabilities_CredentialsReady_UnboundGlobalCredentialNotReady(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 
-	// Connector requiring 2 credential services, only 1 provided
+	// User has a matching global credential but no agent_connector_credentials binding.
 	connID := testhelper.GenerateID(t, "conn_")
-	testhelper.InsertConnectorWithDescription(t, tx, connID, "Partial", "Needs two creds")
+	testhelper.InsertConnectorWithDescription(t, tx, connID, "API", "Needs bound credential")
 	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_a", "api_key")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_b", "api_key")
 	testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, "svc_a")
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
 
@@ -345,25 +346,26 @@ func TestGetAgentCapabilities_CredentialsReady_PartialCredentials(t *testing.T) 
 		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
 	}
 	if caps.Connectors[0].CredentialsReady {
-		t.Error("expected credentials_ready=false when only partial credentials stored")
+		t.Error("expected credentials_ready=false when credential exists but is not bound to this agent+connector")
 	}
 }
 
-func TestGetAgentCapabilities_CredentialsReady_AllCredentials(t *testing.T) {
+func TestGetAgentCapabilities_CredentialsReady_BoundCredentialServiceNameMismatch(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 
-	// Connector requiring 2 credential services, both provided
+	// Required row uses an internal service label; stored credential uses connector id
+	// (same rule as assign-credential API: cred.service must match connector id).
 	connID := testhelper.GenerateID(t, "conn_")
 	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_x", "api_key")
-	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_y", "api_key")
-	testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, "svc_x")
-	testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, "svc_y")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "google", "api_key")
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredential(t, tx, credID, uid, connID)
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, credID)
 
 	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
 	if err != nil {
@@ -373,7 +375,7 @@ func TestGetAgentCapabilities_CredentialsReady_AllCredentials(t *testing.T) {
 		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
 	}
 	if !caps.Connectors[0].CredentialsReady {
-		t.Error("expected credentials_ready=true when all credentials stored")
+		t.Error("expected credentials_ready=true when bound credential service matches connector id while required row uses a different service label")
 	}
 }
 
@@ -430,11 +432,13 @@ func TestGetAgentCapabilities_CredentialsReady_OAuth2Connected(t *testing.T) {
 	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, "google_drive", "google", []string{"https://www.googleapis.com/auth/drive"})
 
 	// User has an active OAuth connection for Google with the required scope
-	testhelper.InsertOAuthConnectionFull(t, tx, testhelper.GenerateID(t, "oc_"), uid, "google", testhelper.OAuthConnectionOpts{
+	ocID := testhelper.GenerateID(t, "oc_")
+	testhelper.InsertOAuthConnectionFull(t, tx, ocID, uid, "google", testhelper.OAuthConnectionOpts{
 		Scopes: []string{"https://www.googleapis.com/auth/drive"},
 	})
 
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	testhelper.InsertAgentConnectorCredentialOAuth(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, ocID)
 
 	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
 	if err != nil {
@@ -444,7 +448,7 @@ func TestGetAgentCapabilities_CredentialsReady_OAuth2Connected(t *testing.T) {
 		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
 	}
 	if !caps.Connectors[0].CredentialsReady {
-		t.Error("expected credentials_ready=true when OAuth2 connection is active with required scopes")
+		t.Error("expected credentials_ready=true when bound OAuth2 connection is active with required scopes")
 	}
 }
 
@@ -461,11 +465,13 @@ func TestGetAgentCapabilities_CredentialsReady_OAuth2InsufficientScopes(t *testi
 	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, "google_drive", "google", []string{"https://www.googleapis.com/auth/drive"})
 
 	// User connected Google but only with email scope (insufficient)
-	testhelper.InsertOAuthConnectionFull(t, tx, testhelper.GenerateID(t, "oc_"), uid, "google", testhelper.OAuthConnectionOpts{
+	ocID := testhelper.GenerateID(t, "oc_")
+	testhelper.InsertOAuthConnectionFull(t, tx, ocID, uid, "google", testhelper.OAuthConnectionOpts{
 		Scopes: []string{"https://www.googleapis.com/auth/gmail.readonly"},
 	})
 
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	testhelper.InsertAgentConnectorCredentialOAuth(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, ocID)
 
 	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
 	if err != nil {
@@ -475,7 +481,7 @@ func TestGetAgentCapabilities_CredentialsReady_OAuth2InsufficientScopes(t *testi
 		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
 	}
 	if caps.Connectors[0].CredentialsReady {
-		t.Error("expected credentials_ready=false when OAuth2 connection has insufficient scopes")
+		t.Error("expected credentials_ready=false when bound OAuth2 connection has insufficient scopes")
 	}
 }
 
@@ -517,12 +523,14 @@ func TestGetAgentCapabilities_CredentialsReady_OAuth2Revoked(t *testing.T) {
 	testhelper.InsertConnector(t, tx, connID)
 	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, "google_drive", "google", []string{"https://www.googleapis.com/auth/drive"})
 
-	testhelper.InsertOAuthConnectionFull(t, tx, testhelper.GenerateID(t, "oc_"), uid, "google", testhelper.OAuthConnectionOpts{
+	ocID := testhelper.GenerateID(t, "oc_")
+	testhelper.InsertOAuthConnectionFull(t, tx, ocID, uid, "google", testhelper.OAuthConnectionOpts{
 		Status: "revoked",
 		Scopes: []string{},
 	})
 
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	testhelper.InsertAgentConnectorCredentialOAuth(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, ocID)
 
 	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
 	if err != nil {
@@ -532,7 +540,7 @@ func TestGetAgentCapabilities_CredentialsReady_OAuth2Revoked(t *testing.T) {
 		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
 	}
 	if caps.Connectors[0].CredentialsReady {
-		t.Error("expected credentials_ready=false when OAuth2 connection is revoked")
+		t.Error("expected credentials_ready=false when bound OAuth2 connection is revoked")
 	}
 }
 

--- a/db/testhelper/fixtures_agent_connector_credentials.go
+++ b/db/testhelper/fixtures_agent_connector_credentials.go
@@ -1,0 +1,27 @@
+package testhelper
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+// InsertAgentConnectorCredential binds a static credential to an agent+connector pair.
+// The agent_connectors row must already exist.
+func InsertAgentConnectorCredential(t *testing.T, d db.DBTX, id string, agentID int64, approverID, connectorID, credentialID string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO agent_connector_credentials (id, agent_id, connector_id, approver_id, credential_id)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		id, agentID, connectorID, approverID, credentialID)
+}
+
+// InsertAgentConnectorCredentialOAuth binds an OAuth connection to an agent+connector pair.
+// The agent_connectors row must already exist.
+func InsertAgentConnectorCredentialOAuth(t *testing.T, d db.DBTX, id string, agentID int64, approverID, connectorID, oauthConnectionID string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO agent_connector_credentials (id, agent_id, connector_id, approver_id, oauth_connection_id)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		id, agentID, connectorID, approverID, oauthConnectionID)
+}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -327,6 +327,8 @@ X-Permission-Slip-Signature: agent_id="42", algorithm="Ed25519", ...
 }
 ```
 
+`credentials_ready` is `true` only when a credential or OAuth connection is **bound** to this agent for that connector (the same binding used at execution time). Storing credentials on the account without assigning them to the agent still yields `credentials_ready: false`.
+
 #### Action Configurations
 
 **Action configurations are the core unit of permission.** A user creates configurations that define exactly how an agent is allowed to use an action — which parameters are locked to specific values, which are free (wildcard `"*"`), and which credential to use. The agent selects from these pre-configured options rather than composing requests from scratch.

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -777,7 +777,7 @@ X-Permission-Slip-Signature: agent_id="42", algorithm="Ed25519", timestamp="1707
   - `id` (string): Connector identifier
   - `name` (string): Human-readable name
   - `description` (string or null): Connector description
-  - `credentials_ready` (boolean): Whether the user has stored the required credentials. `true` means actions can be executed; `false` means execution will fail with `credentials_not_found`. No credential values are ever exposed.
+  - `credentials_ready` (boolean): Whether a credential or OAuth connection is **bound** to this agent+connector (not merely stored on the user account). `true` means actions can be executed; `false` means execution will fail with `credentials_not_found`. No credential values are ever exposed.
   - `credentials_setup_url` (string or null): URL where the user can set up credentials. Only included when `credentials_ready` is `false`.
   - `actions` (array): Available actions with full schemas
     - `action_type` (string): Action type identifier (use as `action.type` in approval requests)

--- a/spec/openapi/components/schemas/capabilities.yaml
+++ b/spec/openapi/components/schemas/capabilities.yaml
@@ -147,10 +147,12 @@ ConnectorCapability:
     credentials_ready:
       type: boolean
       description: |
-        Whether the user has stored the required credentials for this connector.
+        Whether required credentials for this connector are assigned to this
+        agent+connector pair (via `agent_connector_credentials`). Unassigned
+        global credentials alone do not make this `true`.
 
-        - `true`: Credentials are stored — actions can be executed.
-        - `false`: Credentials are missing — action execution will fail with
+        - `true`: A credential or OAuth connection is bound — actions can be executed.
+        - `false`: No valid binding — action execution will fail with
           `404 credentials_not_found`. The agent should direct the user to
           `credentials_setup_url` to connect their account.
 

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -9090,10 +9090,12 @@ components:
         credentials_ready:
           type: boolean
           description: |
-            Whether the user has stored the required credentials for this connector.
+            Whether required credentials for this connector are assigned to this
+            agent+connector pair (via `agent_connector_credentials`). Unassigned
+            global credentials alone do not make this `true`.
 
-            - `true`: Credentials are stored — actions can be executed.
-            - `false`: Credentials are missing — action execution will fail with
+            - `true`: A credential or OAuth connection is bound — actions can be executed.
+            - `false`: No valid binding — action execution will fail with
               `404 credentials_not_found`. The agent should direct the user to
               `credentials_setup_url` to connect their account.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [issue #760](https://github.com/supersuit-tech/permission-slip/issues/760): `credentials_ready` in capabilities no longer relied on global `credentials` / `oauth_connections` lookups alone. It now requires a row in `agent_connector_credentials` for the agent+connector, with the bound credential validated against `connector_required_credentials` (static: `credentials.service` equals the required `service` **or** the connector id, aligned with assign-credential validation; OAuth: provider + scopes on the **bound** connection).

Documentation and OpenAPI descriptions were updated so agents understand that “stored on the account” is not enough without an assignment.

## Test plan

- `make build` (passes locally)
- `go test -c ./api/... ./db/...` (packages compile)
- **Not run here:** `make test-backend` / DB tests — PostgreSQL was unavailable in this environment; CI should run the full suite.

### Developer

- [ ] Confirm CI green (`make test-backend`, integration as applicable)

### Manual Testing

- [ ] Enable a connector for an agent, assign credentials via the binding flow, call `GET /agents/{id}/capabilities` and confirm `credentials_ready: true`
- [ ] With the same user credential stored but **not** assigned to the agent, confirm `credentials_ready: false` and `credentials_setup_url` present
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c5fbaf3-9406-4bd3-a3cf-b8e6ec970782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c5fbaf3-9406-4bd3-a3cf-b8e6ec970782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

