### PR TITLE
Include @github.actor in webhook notifications

### DIFF
--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
 
-          ACTOR="@${{ github.actor }}"
+          ACTOR="@${GITHUB_ACTOR}"
 
           if [ -n "$MESSAGE_OVERRIDE" ]; then
             MESSAGE="permission-slip: ${MESSAGE_OVERRIDE}"

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -32,14 +32,16 @@ jobs:
             exit 1
           fi
 
+          ACTOR="@${{ github.actor }}"
+
           if [ -n "$MESSAGE_OVERRIDE" ]; then
             MESSAGE="permission-slip: ${MESSAGE_OVERRIDE}"
           elif [ -n "$PR_URL" ] && [ -n "$PR_TITLE" ]; then
-            MESSAGE="permission-slip: ${PR_TITLE} — ${PR_URL}"
+            MESSAGE="permission-slip: ${ACTOR} — ${PR_TITLE} — ${PR_URL}"
           elif [ -n "$PR_URL" ]; then
-            MESSAGE="permission-slip: PR needs attention — ${PR_URL}"
+            MESSAGE="permission-slip: ${ACTOR} — PR needs attention — ${PR_URL}"
           else
-            MESSAGE="permission-slip: @${{ github.actor }} needs your attention"
+            MESSAGE="permission-slip: ${ACTOR} needs your attention"
           fi
 
           PAYLOAD=$(jq -n --arg msg "$MESSAGE" --arg secret "$NOTIFY_WEBHOOK_SECRET" \


### PR DESCRIPTION
## Summary

- Webhook notifications from `trigger-webhook.yml` now include `@github.actor` in all message variants, not just the fallback case
- Previously, the most common path (PR URL provided via `/watch`) produced `"permission-slip: PR needs attention — <url>"` with no actor — now it says `"permission-slip: @actor — PR needs attention — <url>"`

## Test plan

### Developer
- [ ] Verify workflow YAML is valid
- [ ] Trigger webhook with `pr_url` only → message should include actor
- [ ] Trigger webhook with `pr_url` + `pr_title` → message should include actor
- [ ] Trigger webhook with no inputs → message should include actor
- [ ] Trigger webhook with `message` override → no actor (custom message unchanged)

### Manual Testing
- [ ] Receive a real notification from `/watch` and confirm actor name appears

https://claude.ai/code/session_01UNH5AM2ztaxNhcBcYgRAkn