### PR TITLE
Calendar ID remote select for Google & Microsoft (issue #753)

### DIFF
--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+type calendarListResponse struct {
+	Data []connectors.CalendarListItem `json:"data"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentConnectorCalendarRoutes)
+}
+
+// RegisterAgentConnectorCalendarRoutes registers session-authenticated endpoints
+// that proxy calendar metadata for action configuration UIs.
+func RegisterAgentConnectorCalendarRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /agents/{agent_id}/connectors/{connector_id}/calendars", requireProfile(handleListAgentConnectorCalendars(deps)))
+}
+
+func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		lister, ok := conn.(connectors.CalendarLister)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "This connector does not support calendar listing"))
+			return
+		}
+
+		listAction := fmt.Sprintf("%s.list_calendar_events", connectorID)
+		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorCalendars required creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to look up connector credentials"))
+			return
+		}
+
+		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
+		if err != nil {
+			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorCalendars resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
+			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+				return
+			}
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
+
+		items, err := lister.ListCalendars(r.Context(), creds)
+		if err != nil {
+			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+				return
+			}
+			log.Printf("[%s] ListCalendars: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list calendars"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, calendarListResponse{Data: items})
+	}
+}

--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 
@@ -59,7 +58,12 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		listAction := fmt.Sprintf("%s.list_calendar_events", connectorID)
+		listAction := lister.CalendarListCredentialActionType()
+		connErrCtx := ConnectorContext{
+			ConnectorID: connectorID,
+			ActionType:  listAction,
+			AgentID:     agentID,
+		}
 		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
 		if err != nil {
 			log.Printf("[%s] ListAgentConnectorCalendars required creds: %v", TraceID(r.Context()), err)
@@ -70,7 +74,7 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 
 		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
 		if err != nil {
-			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+			if handleConnectorError(w, r, err, connErrCtx) {
 				return
 			}
 			log.Printf("[%s] ListAgentConnectorCalendars resolve creds: %v", TraceID(r.Context()), err)
@@ -80,7 +84,7 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 		}
 
 		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
-			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+			if handleConnectorError(w, r, err, connErrCtx) {
 				return
 			}
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
@@ -89,7 +93,7 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 
 		items, err := lister.ListCalendars(r.Context(), creds)
 		if err != nil {
-			if handleConnectorError(w, r, err, ConnectorContext{ConnectorID: connectorID}) {
+			if handleConnectorError(w, r, err, connErrCtx) {
 				return
 			}
 			log.Printf("[%s] ListCalendars: %v", TraceID(r.Context()), err)

--- a/api/agent_connector_calendars_test.go
+++ b/api/agent_connector_calendars_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	"github.com/supersuit-tech/permission-slip-web/oauth"
 	"github.com/supersuit-tech/permission-slip-web/vault"
 )
 
@@ -68,7 +69,22 @@ func TestListAgentConnectorCalendars_NoCredentialBinding(t *testing.T) {
 	reg.Register(&stubCalendarConnector{id: connID})
 
 	v := vault.NewMockVaultStore()
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	oauthReg := oauth.NewRegistry()
+	_ = oauthReg.Register(oauth.Provider{
+		ID:           connID,
+		AuthorizeURL: "https://example.com/oauth/authorize",
+		TokenURL:     "https://example.com/oauth/token",
+		ClientID:     "test",
+		ClientSecret: "test",
+		Source:       oauth.SourceBuiltIn,
+	})
+	deps := &Deps{
+		DB:             tx,
+		Vault:          v,
+		Connectors:     reg,
+		OAuthProviders: oauthReg,
+		SupabaseJWTSecret: testJWTSecret,
+	}
 	router := NewRouter(deps)
 
 	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/calendars", agentID, connID), uid)
@@ -125,7 +141,22 @@ func TestListAgentConnectorCalendars_Success(t *testing.T) {
 	v := vault.NewMockVaultStore()
 	v.SeedSecretForTest(oauthRow.AccessTokenVaultID, []byte(`{"access_token":"tok-test"}`))
 
-	deps := &Deps{DB: tx, Vault: v, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	oauthReg := oauth.NewRegistry()
+	_ = oauthReg.Register(oauth.Provider{
+		ID:           connID,
+		AuthorizeURL: "https://example.com/oauth/authorize",
+		TokenURL:     "https://example.com/oauth/token",
+		ClientID:     "test",
+		ClientSecret: "test",
+		Source:       oauth.SourceBuiltIn,
+	})
+	deps := &Deps{
+		DB:             tx,
+		Vault:          v,
+		Connectors:     reg,
+		OAuthProviders: oauthReg,
+		SupabaseJWTSecret: testJWTSecret,
+	}
 	router := NewRouter(deps)
 
 	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/calendars", agentID, connID), uid)

--- a/api/agent_connector_calendars_test.go
+++ b/api/agent_connector_calendars_test.go
@@ -38,6 +38,10 @@ func (s *stubCalendarConnector) ListCalendars(ctx context.Context, creds connect
 	}, nil
 }
 
+func (s *stubCalendarConnector) CalendarListCredentialActionType() string {
+	return s.id + ".list_calendar_events"
+}
+
 func decodeCalendarList(t *testing.T, body []byte) calendarListResponse {
 	t.Helper()
 	var resp calendarListResponse

--- a/api/agent_connector_calendars_test.go
+++ b/api/agent_connector_calendars_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	"github.com/supersuit-tech/permission-slip-web/vault"
+)
+
+type stubCalendarConnector struct {
+	id       string
+	listFunc func(context.Context, connectors.Credentials) ([]connectors.CalendarListItem, error)
+}
+
+func (s *stubCalendarConnector) ID() string { return s.id }
+
+func (s *stubCalendarConnector) Actions() map[string]connectors.Action {
+	return nil
+}
+
+func (s *stubCalendarConnector) ValidateCredentials(_ context.Context, _ connectors.Credentials) error {
+	return nil
+}
+
+func (s *stubCalendarConnector) ListCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.CalendarListItem, error) {
+	if s.listFunc != nil {
+		return s.listFunc(ctx, creds)
+	}
+	return []connectors.CalendarListItem{
+		{ID: "cal-1", Summary: "Work", Primary: true},
+	}, nil
+}
+
+func decodeCalendarList(t *testing.T, body []byte) calendarListResponse {
+	t.Helper()
+	var resp calendarListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal calendar list: %v", err)
+	}
+	return resp
+}
+
+func TestListAgentConnectorCalendars_NoCredentialBinding(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+
+	connID := "calstub"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_calendar_events", "List events")
+	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID, connID, nil)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	reg := connectors.NewRegistry()
+	reg.Register(&stubCalendarConnector{id: connID})
+
+	v := vault.NewMockVaultStore()
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/calendars", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAgentConnectorCalendars_Success(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+
+	connID := "calstub"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_calendar_events", "List events")
+	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID, connID, nil)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	oauthConnID := testhelper.GenerateID(t, "oconn_")
+	testhelper.InsertOAuthConnection(t, tx, oauthConnID, uid, connID)
+	oauthRow, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, connID)
+	if err != nil {
+		t.Fatalf("GetOAuthConnectionByProvider: %v", err)
+	}
+	bindingID := testhelper.GenerateID(t, "accr_")
+	if _, err := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: connID,
+		ApproverID: uid, OAuthConnectionID: &oauthRow.ID,
+	}); err != nil {
+		t.Fatalf("UpsertAgentConnectorCredential: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(&stubCalendarConnector{
+		id: connID,
+		listFunc: func(_ context.Context, creds connectors.Credentials) ([]connectors.CalendarListItem, error) {
+			tok, _ := creds.Get("access_token")
+			if tok == "" {
+				t.Error("expected non-empty access_token in credentials")
+			}
+			return []connectors.CalendarListItem{
+				{ID: "primary", Summary: "Primary", Primary: true},
+				{ID: "work@group.calendar.google.com", Summary: "Team"},
+			}, nil
+		},
+	})
+
+	v := vault.NewMockVaultStore()
+	v.SeedSecretForTest(oauthRow.AccessTokenVaultID, []byte(`{"access_token":"tok-test"}`))
+
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/calendars", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeCalendarList(t, w.Body.Bytes())
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 calendars, got %d", len(resp.Data))
+	}
+	if resp.Data[0].ID != "primary" || !resp.Data[0].Primary {
+		t.Errorf("unexpected first item: %+v", resp.Data[0])
+	}
+}

--- a/api/sentry.go
+++ b/api/sentry.go
@@ -50,8 +50,9 @@ func CaptureError(ctx context.Context, err error) {
 
 // ConnectorContext carries connector-specific metadata for Sentry error reports.
 type ConnectorContext struct {
-	ActionType string
-	AgentID    int64
+	ConnectorID string
+	ActionType  string
+	AgentID     int64
 }
 
 // CaptureConnectorError reports a connector execution error to Sentry with
@@ -69,6 +70,10 @@ func CaptureConnectorError(ctx context.Context, err error, cc ConnectorContext) 
 		}
 		if cc.ActionType != "" {
 			scope.SetTag("action_type", cc.ActionType)
+		}
+		if cc.ConnectorID != "" {
+			scope.SetTag("connector_id", cc.ConnectorID)
+		} else if cc.ActionType != "" {
 			if connID := connectorIDFromActionType(cc.ActionType); connID != nil {
 				scope.SetTag("connector_id", *connID)
 			}

--- a/api/sentry_test.go
+++ b/api/sentry_test.go
@@ -210,6 +210,44 @@ func TestCaptureConnectorError_NoHubDoesNotPanic(t *testing.T) {
 	CaptureConnectorError(context.Background(), errors.New("test"), ConnectorContext{ActionType: "test.action"})
 }
 
+func TestCaptureConnectorError_ExplicitConnectorID(t *testing.T) {
+	t.Parallel()
+
+	transport := &sentryTestTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@sentry.example.com/1",
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("failed to create sentry client: %v", err)
+	}
+
+	scope := sentry.NewScope()
+	hub := sentry.NewHub(client, scope)
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	CaptureConnectorError(ctx, errors.New("list calendars"), ConnectorContext{
+		ConnectorID: "google",
+		ActionType:  "google.list_calendar_events",
+		AgentID:     7,
+	})
+
+	events := transport.getEvents()
+	if len(events) == 0 {
+		t.Fatal("expected at least one event to be captured")
+	}
+	event := events[0]
+	if got := event.Tags["connector_id"]; got != "google" {
+		t.Errorf("connector_id tag = %q, want google", got)
+	}
+	if got := event.Tags["action_type"]; got != "google.list_calendar_events" {
+		t.Errorf("action_type tag = %q", got)
+	}
+	if got := event.Tags["agent_id"]; got != "7" {
+		t.Errorf("agent_id tag = %q, want 7", got)
+	}
+}
+
 func TestClassifyConnectorError(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -124,5 +124,8 @@ type CalendarListItem struct {
 // user's calendars for UI configuration (session-authenticated proxy endpoints).
 type CalendarLister interface {
 	ListCalendars(ctx context.Context, creds Credentials) ([]CalendarListItem, error)
+	// CalendarListCredentialActionType is the connector_actions.action_type used
+	// to look up required credentials for this list call (must exist in the DB).
+	CalendarListCredentialActionType() string
 }
 

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -110,3 +110,19 @@ type ManifestProvider interface {
 	Manifest() *ConnectorManifest
 }
 
+// CalendarListItem is one calendar row for dashboard selectors (Google Calendar
+// and Microsoft Graph). Fields are populated depending on the provider.
+type CalendarListItem struct {
+	ID                string `json:"id"`
+	Summary           string `json:"summary,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Primary           bool   `json:"primary,omitempty"`
+	IsDefaultCalendar bool   `json:"isDefaultCalendar,omitempty"`
+}
+
+// CalendarLister is optionally implemented by connectors that can list the
+// user's calendars for UI configuration (session-authenticated proxy endpoints).
+type CalendarLister interface {
+	ListCalendars(ctx context.Context, creds Credentials) ([]CalendarListItem, error)
+}
+

--- a/connectors/google/list_calendars.go
+++ b/connectors/google/list_calendars.go
@@ -16,9 +16,10 @@ func (c *GoogleConnector) ListCalendars(ctx context.Context, creds connectors.Cr
 	}
 
 	const pageSize = 250
+	const maxPages = 20
 	var out []connectors.CalendarListItem
 	var pageToken string
-	for {
+	for page := 0; page < maxPages; page++ {
 		q := url.Values{}
 		q.Set("maxResults", fmt.Sprintf("%d", pageSize))
 		if pageToken != "" {
@@ -54,9 +55,14 @@ func (c *GoogleConnector) ListCalendars(ctx context.Context, creds connectors.Cr
 			})
 		}
 		if payload.NextPageToken == "" {
-			break
+			return out, nil
 		}
 		pageToken = payload.NextPageToken
 	}
 	return out, nil
+}
+
+// CalendarListCredentialActionType implements connectors.CalendarLister.
+func (c *GoogleConnector) CalendarListCredentialActionType() string {
+	return "google.list_calendar_events"
 }

--- a/connectors/google/list_calendars.go
+++ b/connectors/google/list_calendars.go
@@ -1,0 +1,62 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// ListCalendars returns calendars visible to the user (Google Calendar API
+// calendarList). Implements connectors.CalendarLister.
+func (c *GoogleConnector) ListCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.CalendarListItem, error) {
+	if err := c.ValidateCredentials(ctx, creds); err != nil {
+		return nil, err
+	}
+
+	const pageSize = 250
+	var out []connectors.CalendarListItem
+	var pageToken string
+	for {
+		q := url.Values{}
+		q.Set("maxResults", fmt.Sprintf("%d", pageSize))
+		if pageToken != "" {
+			q.Set("pageToken", pageToken)
+		}
+		rawURL := c.calendarBaseURL + "/users/me/calendarList?" + q.Encode()
+
+		var payload struct {
+			Items         []struct {
+				ID       string `json:"id"`
+				Summary  string `json:"summary"`
+				Primary  *bool  `json:"primary"`
+				SummaryO string `json:"summaryOverride"`
+			} `json:"items"`
+			NextPageToken string `json:"nextPageToken"`
+		}
+		if err := c.doJSON(ctx, creds, "GET", rawURL, nil, &payload); err != nil {
+			return nil, err
+		}
+		for _, it := range payload.Items {
+			label := it.Summary
+			if label == "" {
+				label = it.SummaryO
+			}
+			if label == "" {
+				label = it.ID
+			}
+			primary := it.Primary != nil && *it.Primary
+			out = append(out, connectors.CalendarListItem{
+				ID:      it.ID,
+				Summary: label,
+				Primary: primary,
+			})
+		}
+		if payload.NextPageToken == "" {
+			break
+		}
+		pageToken = payload.NextPageToken
+	}
+	return out, nil
+}

--- a/connectors/google/list_calendars_test.go
+++ b/connectors/google/list_calendars_test.go
@@ -1,0 +1,50 @@
+package google
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestListCalendars_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/users/me/calendarList" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": "primary", "summary": "Personal", "primary": true},
+				{"id": "work@group.calendar.google.com", "summary": "Work"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newCalendarForTest(srv.Client(), srv.URL)
+	items, err := c.ListCalendars(t.Context(), validGoogleCreds())
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].ID != "primary" || items[0].Summary != "Personal" || !items[0].Primary {
+		t.Errorf("item 0: %+v", items[0])
+	}
+	if items[1].ID != "work@group.calendar.google.com" || items[1].Summary != "Work" {
+		t.Errorf("item 1: %+v", items[1])
+	}
+}
+
+func validGoogleCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{"access_token": "t"})
+}

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -112,7 +112,16 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "summary",
+								"remote_select_fallback_placeholder": "Enter calendar ID (e.g. primary)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
 						}
 					}
 				}`)),
@@ -129,7 +138,16 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "summary",
+								"remote_select_fallback_placeholder": "Enter calendar ID (e.g. primary)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
 						},
 						"max_results": {
 							"type": "integer",
@@ -489,7 +507,16 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "summary",
+								"remote_select_fallback_placeholder": "Enter calendar ID (e.g. primary)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
 						}
 					}
 				}`)),
@@ -612,7 +639,16 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "summary",
+								"remote_select_fallback_placeholder": "Enter calendar ID (e.g. primary)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
 						},
 						"summary": {
 							"type": "string",
@@ -665,7 +701,16 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						"calendar_id": {
 							"type": "string",
 							"default": "primary",
-							"description": "Calendar ID (defaults to 'primary')"
+							"description": "Calendar ID (defaults to 'primary')",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "summary",
+								"remote_select_fallback_placeholder": "Enter calendar ID (e.g. primary)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
 						}
 					}
 				}`)),

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -115,14 +115,15 @@ var validPreviewLayouts = map[string]bool{
 
 // validWidgets are the allowed values for x-ui.widget on schema properties.
 var validWidgets = map[string]bool{
-	"text":     true,
-	"select":   true,
-	"textarea": true,
-	"toggle":   true,
-	"number":   true,
-	"date":     true,
-	"datetime": true,
-	"list":     true,
+	"text":           true,
+	"select":         true,
+	"remote-select":  true,
+	"textarea":       true,
+	"toggle":         true,
+	"number":         true,
+	"date":           true,
+	"datetime":       true,
+	"list":           true,
 }
 
 // validAuthTypes are the allowed values for credential auth types.
@@ -543,7 +544,7 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			continue
 		}
 		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
-			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, textarea, toggle, number, date", actionIdx, propName, prop.XUI.Widget)
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, remote-select, textarea, toggle, number, date, datetime, list", actionIdx, propName, prop.XUI.Widget)
 		}
 		// A "select" widget needs enum values to populate the dropdown.
 		if prop.XUI.Widget == "select" {

--- a/connectors/microsoft/create_calendar_event.go
+++ b/connectors/microsoft/create_calendar_event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -27,13 +28,14 @@ func (a *createCalendarEventAction) ParameterAliases() map[string]string {
 
 // createCalendarEventParams is the user-facing parameter schema.
 type createCalendarEventParams struct {
-	Subject   string   `json:"subject"`
-	Start     string   `json:"start"`
-	End       string   `json:"end"`
-	TimeZone  string   `json:"time_zone"`
-	Body      string   `json:"body,omitempty"`
-	Attendees []string `json:"attendees,omitempty"`
-	Location  string   `json:"location,omitempty"`
+	CalendarID string   `json:"calendar_id,omitempty"`
+	Subject    string   `json:"subject"`
+	Start      string   `json:"start"`
+	End        string   `json:"end"`
+	TimeZone   string   `json:"time_zone"`
+	Body       string   `json:"body,omitempty"`
+	Attendees  []string `json:"attendees,omitempty"`
+	Location   string   `json:"location,omitempty"`
 }
 
 func (p *createCalendarEventParams) validate() error {
@@ -122,8 +124,13 @@ func (a *createCalendarEventAction) Execute(ctx context.Context, req connectors.
 		graphReq.Location = &graphEventLocation{DisplayName: params.Location}
 	}
 
+	path := "/me/events"
+	if params.CalendarID != "" {
+		path = "/me/calendars/" + url.PathEscape(params.CalendarID) + "/events"
+	}
+
 	var resp graphEventResponse
-	if err := a.conn.doRequest(ctx, http.MethodPost, "/me/events", req.Credentials, graphReq, &resp); err != nil {
+	if err := a.conn.doRequest(ctx, http.MethodPost, path, req.Credentials, graphReq, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/microsoft/create_calendar_event_test.go
+++ b/connectors/microsoft/create_calendar_event_test.go
@@ -73,6 +73,45 @@ func TestCreateCalendarEvent_Success(t *testing.T) {
 	}
 }
 
+func TestCreateCalendarEvent_WithCalendarID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/me/calendars/cal-xyz/events" {
+			t.Errorf("expected calendar-scoped path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "event-cal",
+			"subject": "X",
+			"start":   map[string]string{"dateTime": "2024-01-15T09:00:00", "timeZone": "UTC"},
+			"end":     map[string]string{"dateTime": "2024-01-15T10:00:00", "timeZone": "UTC"},
+			"webLink": "https://example.com",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		CalendarID: "cal-xyz",
+		Subject:    "X",
+		Start:      "2024-01-15T09:00:00",
+		End:        "2024-01-15T10:00:00",
+		TimeZone:   "UTC",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCreateCalendarEvent_WithAttendees(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/list_calendar_events.go
+++ b/connectors/microsoft/list_calendar_events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -17,7 +18,8 @@ type listCalendarEventsAction struct {
 
 // listCalendarEventsParams is the user-facing parameter schema.
 type listCalendarEventsParams struct {
-	Top int `json:"top"`
+	CalendarID string `json:"calendar_id,omitempty"`
+	Top        int    `json:"top"`
 }
 
 func (p *listCalendarEventsParams) defaults() {
@@ -66,7 +68,13 @@ func (a *listCalendarEventsAction) Execute(ctx context.Context, req connectors.A
 	}
 	params.defaults()
 
-	path := fmt.Sprintf("/me/events?$top=%d&$orderby=start/dateTime&$select=id,subject,start,end,location,organizer,webLink,isAllDay", params.Top)
+	var path string
+	if params.CalendarID == "" {
+		path = fmt.Sprintf("/me/events?$top=%d&$orderby=start/dateTime&$select=id,subject,start,end,location,organizer,webLink,isAllDay", params.Top)
+	} else {
+		path = fmt.Sprintf("/me/calendars/%s/events?$top=%d&$orderby=start/dateTime&$select=id,subject,start,end,location,organizer,webLink,isAllDay",
+			url.PathEscape(params.CalendarID), params.Top)
+	}
 
 	var resp graphEventsResponse
 	if err := a.conn.doRequest(ctx, http.MethodGet, path, req.Credentials, nil, &resp); err != nil {

--- a/connectors/microsoft/list_calendar_events_test.go
+++ b/connectors/microsoft/list_calendar_events_test.go
@@ -90,6 +90,32 @@ func TestListCalendarEvents_DefaultParams(t *testing.T) {
 	}
 }
 
+func TestListCalendarEvents_WithCalendarID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/me/calendars/cal-abc/events" {
+			t.Errorf("expected calendar path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listCalendarEventsAction{conn: conn}
+	params, _ := json.Marshal(listCalendarEventsParams{CalendarID: "cal-abc", Top: 5})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.list_calendar_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestListCalendarEvents_TopClamped(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/list_calendars.go
+++ b/connectors/microsoft/list_calendars.go
@@ -46,6 +46,11 @@ func (c *MicrosoftConnector) ListCalendars(ctx context.Context, creds connectors
 	return out, nil
 }
 
+// CalendarListCredentialActionType implements connectors.CalendarLister.
+func (c *MicrosoftConnector) CalendarListCredentialActionType() string {
+	return "microsoft.list_calendar_events"
+}
+
 // graphNextRelativePath turns an absolute @odata.nextLink into a path+query
 // relative to the connector base URL, or empty if parsing fails.
 func graphNextRelativePath(baseURL, nextLink string) string {

--- a/connectors/microsoft/list_calendars.go
+++ b/connectors/microsoft/list_calendars.go
@@ -1,0 +1,69 @@
+package microsoft
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// ListCalendars returns the user's calendars (Microsoft Graph GET /me/calendars).
+// Implements connectors.CalendarLister.
+func (c *MicrosoftConnector) ListCalendars(ctx context.Context, creds connectors.Credentials) ([]connectors.CalendarListItem, error) {
+	if err := c.ValidateCredentials(ctx, creds); err != nil {
+		return nil, err
+	}
+
+	var out []connectors.CalendarListItem
+	nextPath := "/me/calendars?$select=id,name,isDefaultCalendar&$top=100"
+	for i := 0; i < 20 && nextPath != ""; i++ {
+		var payload struct {
+			Value []struct {
+				ID                string `json:"id"`
+				Name              string `json:"name"`
+				IsDefaultCalendar bool   `json:"isDefaultCalendar"`
+			} `json:"value"`
+			NextLink string `json:"@odata.nextLink"`
+		}
+		if err := c.doRequest(ctx, http.MethodGet, nextPath, creds, nil, &payload); err != nil {
+			return nil, err
+		}
+		for _, it := range payload.Value {
+			label := it.Name
+			if label == "" {
+				label = it.ID
+			}
+			out = append(out, connectors.CalendarListItem{
+				ID:                it.ID,
+				Name:              label,
+				IsDefaultCalendar: it.IsDefaultCalendar,
+			})
+		}
+		nextPath = graphNextRelativePath(c.baseURL, payload.NextLink)
+	}
+	return out, nil
+}
+
+// graphNextRelativePath turns an absolute @odata.nextLink into a path+query
+// relative to the connector base URL, or empty if parsing fails.
+func graphNextRelativePath(baseURL, nextLink string) string {
+	if nextLink == "" {
+		return ""
+	}
+	u, err := url.Parse(nextLink)
+	if err != nil {
+		return ""
+	}
+	base := strings.TrimSuffix(baseURL, "/")
+	full := strings.TrimSuffix(u.String(), "/")
+	if !strings.HasPrefix(full, base) {
+		return ""
+	}
+	rel := strings.TrimPrefix(full[len(base):], "/")
+	if rel == "" {
+		return ""
+	}
+	return "/" + rel
+}

--- a/connectors/microsoft/list_calendars_test.go
+++ b/connectors/microsoft/list_calendars_test.go
@@ -1,0 +1,52 @@
+package microsoft
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestGraphNextRelativePath(t *testing.T) {
+	t.Parallel()
+	base := "https://graph.microsoft.com/v1.0"
+	next := "https://graph.microsoft.com/v1.0/me/calendars?$skiptoken=abc"
+	got := graphNextRelativePath(base, next)
+	if got != "/me/calendars?$skiptoken=abc" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestListCalendars_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/me/calendars" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"value": []map[string]any{
+				{"id": "cal-1", "name": "Calendar", "isDefaultCalendar": true},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newForTest(srv.Client(), srv.URL)
+	items, err := c.ListCalendars(t.Context(), validCreds())
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].ID != "cal-1" || items[0].Name != "Calendar" || !items[0].IsDefaultCalendar {
+		t.Errorf("unexpected item: %+v", items[0])
+	}
+}

--- a/connectors/microsoft/list_calendars_test.go
+++ b/connectors/microsoft/list_calendars_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
 func TestGraphNextRelativePath(t *testing.T) {

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -164,6 +164,19 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 						"location": {
 							"type": "string",
 							"description": "Event location"
+						},
+						"calendar_id": {
+							"type": "string",
+							"description": "Microsoft Graph calendar ID. Leave empty to use the default calendar.",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "name",
+								"remote_select_fallback_placeholder": "Enter calendar ID (optional)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
 						}
 					}
 				}`)),
@@ -176,6 +189,19 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
+						"calendar_id": {
+							"type": "string",
+							"description": "Microsoft Graph calendar ID. Leave empty to use the default calendar.",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "name",
+								"remote_select_fallback_placeholder": "Enter calendar ID (optional)",
+								"help_text": "Connect a credential to select a calendar.",
+								"label": "Calendar"
+							}
+						},
 						"top": {
 							"type": "integer",
 							"default": 10,
@@ -661,14 +687,14 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "microsoft.create_calendar_event",
 				Name:        "Create calendar events",
 				Description: "Agent can create events on the calendar with any details.",
-				Parameters:  json.RawMessage(`{"subject":"*","start":"*","end":"*","time_zone":"*","body":"*","attendees":"*","location":"*"}`),
+				Parameters:  json.RawMessage(`{"subject":"*","start":"*","end":"*","time_zone":"*","body":"*","attendees":"*","location":"*","calendar_id":""}`),
 			},
 			{
 				ID:          "tpl_microsoft_list_events",
 				ActionType:  "microsoft.list_calendar_events",
 				Name:        "View calendar",
 				Description: "Agent can view upcoming calendar events.",
-				Parameters:  json.RawMessage(`{"top":"*"}`),
+				Parameters:  json.RawMessage(`{"top":"*","calendar_id":""}`),
 			},
 			{
 			ID:          "tpl_microsoft_list_drive_files",

--- a/frontend/src/hooks/useAgentConnectorCalendars.ts
+++ b/frontend/src/hooks/useAgentConnectorCalendars.ts
@@ -8,7 +8,8 @@ export type RemoteCalendarRow = Record<string, unknown>;
 export function useAgentConnectorCalendars(agentId: number, connectorId: string) {
   const { session } = useAuth();
   const accessToken = session?.access_token;
-  const { binding } = useAgentConnectorCredential(agentId, connectorId);
+  const { binding, isCredentialBindingPending } =
+    useAgentConnectorCredential(agentId, connectorId);
 
   const hasCredential = !!(
     binding?.oauth_connection_id ?? binding?.credential_id
@@ -41,6 +42,7 @@ export function useAgentConnectorCalendars(agentId: number, connectorId: string)
     isFetching: query.isFetching,
     error: query.isError ? query.error : null,
     hasCredential,
+    isCredentialBindingPending,
     refetch: query.refetch,
   };
 }

--- a/frontend/src/hooks/useAgentConnectorCalendars.ts
+++ b/frontend/src/hooks/useAgentConnectorCalendars.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { useAgentConnectorCredential } from "./useAgentConnectorCredential";
+
+export type RemoteCalendarRow = Record<string, unknown>;
+
+export function useAgentConnectorCalendars(agentId: number, connectorId: string) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const { binding } = useAgentConnectorCredential(agentId, connectorId);
+
+  const hasCredential = !!(
+    binding?.oauth_connection_id ?? binding?.credential_id
+  );
+
+  const query = useQuery({
+    queryKey: ["agent-connector-calendars", agentId, connectorId],
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.GET(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: {
+            path: { agent_id: agentId, connector_id: connectorId },
+          },
+        },
+      );
+      if (error) throw new Error("Failed to load calendars");
+      const rows = data?.data;
+      if (!Array.isArray(rows)) return [] as RemoteCalendarRow[];
+      return rows as RemoteCalendarRow[];
+    },
+    enabled: !!accessToken && agentId > 0 && !!connectorId && hasCredential,
+  });
+
+  return {
+    calendars: query.data ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.isError ? query.error : null,
+    hasCredential,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/hooks/useAgentConnectorCalendars.ts
+++ b/frontend/src/hooks/useAgentConnectorCalendars.ts
@@ -17,6 +17,7 @@ export function useAgentConnectorCalendars(agentId: number, connectorId: string)
 
   const query = useQuery({
     queryKey: ["agent-connector-calendars", agentId, connectorId],
+    staleTime: 60_000,
     queryFn: async () => {
       if (!accessToken) throw new Error("Missing access token");
       const { data, error } = await client.GET(

--- a/frontend/src/hooks/useAgentConnectorCredential.ts
+++ b/frontend/src/hooks/useAgentConnectorCredential.ts
@@ -33,6 +33,8 @@ export function useAgentConnectorCredential(
   return {
     binding: query.data ?? null,
     isLoading: query.isLoading,
+    /** True while the first credential binding fetch is in flight (avoids UI flash). */
+    isCredentialBindingPending: query.isPending,
     error: query.isError
       ? "Unable to load credential binding."
       : null,
@@ -84,6 +86,13 @@ export function useAssignAgentConnectorCredential() {
           variables.connectorId,
         ],
       });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "agent-connector-calendars",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
     },
   });
 
@@ -126,6 +135,13 @@ export function useRemoveAgentConnectorCredential() {
       queryClient.invalidateQueries({
         queryKey: [
           "agent-connector-credential",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "agent-connector-calendars",
           variables.agentId,
           variables.connectorId,
         ],

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -15,12 +15,29 @@ export interface VisibleWhen {
 
 /** Property-level `x-ui` rendering hints for a single parameter. */
 export interface SchemaPropertyUI {
-  widget?: "text" | "select" | "textarea" | "toggle" | "number" | "date" | "datetime" | "list";
+  widget?:
+    | "text"
+    | "select"
+    | "remote-select"
+    | "textarea"
+    | "toggle"
+    | "number"
+    | "date"
+    | "datetime"
+    | "list";
   label?: string;
   placeholder?: string;
   group?: string;
   help_url?: string;
   help_text?: string;
+  /** Path template for openapi-fetch, e.g. `/v1/agents/{agent_id}/connectors/{connector_id}/calendars`. */
+  remote_select_options_path?: string;
+  /** JSON key for option value (default `id`). */
+  remote_select_id_key?: string;
+  /** JSON key for option label (default `summary`, then `name`). */
+  remote_select_label_key?: string;
+  /** Placeholder for manual entry when user toggles fallback. */
+  remote_select_fallback_placeholder?: string;
   visible_when?: VisibleWhen;
   /**
    * Sibling parameter key for datetime range pairing (e.g. time_min ↔ time_max).
@@ -122,7 +139,17 @@ export function parseParametersSchema(
 }
 
 /** All valid widget type values. */
-export const VALID_WIDGETS = ["text", "select", "textarea", "toggle", "number", "date", "datetime", "list"] as const;
+export const VALID_WIDGETS = [
+  "text",
+  "select",
+  "remote-select",
+  "textarea",
+  "toggle",
+  "number",
+  "date",
+  "datetime",
+  "list",
+] as const;
 
 /** Widget type as a union — useful for exhaustive switch checks. */
 export type WidgetType = (typeof VALID_WIDGETS)[number];
@@ -274,6 +301,18 @@ function parsePropertyUI(raw: unknown): SchemaPropertyUI | undefined {
   if (typeof obj.group === "string") ui.group = obj.group;
   if (typeof obj.help_url === "string") ui.help_url = obj.help_url;
   if (typeof obj.help_text === "string") ui.help_text = obj.help_text;
+  if (typeof obj.remote_select_options_path === "string" && obj.remote_select_options_path.length > 0) {
+    ui.remote_select_options_path = obj.remote_select_options_path;
+  }
+  if (typeof obj.remote_select_id_key === "string" && obj.remote_select_id_key.length > 0) {
+    ui.remote_select_id_key = obj.remote_select_id_key;
+  }
+  if (typeof obj.remote_select_label_key === "string" && obj.remote_select_label_key.length > 0) {
+    ui.remote_select_label_key = obj.remote_select_label_key;
+  }
+  if (typeof obj.remote_select_fallback_placeholder === "string") {
+    ui.remote_select_fallback_placeholder = obj.remote_select_fallback_placeholder;
+  }
   if (obj.visible_when && typeof obj.visible_when === "object") {
     const vw = obj.visible_when as Record<string, unknown>;
     if (

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -20,6 +20,8 @@ interface ActionConfigParameterFieldsProps {
   modes: Record<string, ParamMode>;
   onModeChange: (key: string, mode: ParamMode) => void;
   disabled?: boolean;
+  agentId?: number;
+  connectorId?: string;
 }
 
 /**
@@ -38,6 +40,8 @@ export function ActionConfigParameterFields({
   modes,
   onModeChange,
   disabled,
+  agentId,
+  connectorId,
 }: ActionConfigParameterFieldsProps) {
   if (!parametersSchema?.properties) {
     return (
@@ -79,6 +83,8 @@ export function ActionConfigParameterFields({
         disabled={disabled}
         onValueChange={onValueChange}
         onModeChange={onModeChange}
+        agentId={agentId}
+        connectorId={connectorId}
       />
     );
   }
@@ -154,6 +160,8 @@ function ParameterField({
   disabled,
   onValueChange,
   onModeChange,
+  agentId,
+  connectorId,
 }: {
   paramKey: string;
   property: SchemaProperty;
@@ -165,6 +173,8 @@ function ParameterField({
   disabled?: boolean;
   onValueChange: (key: string, value: string) => void;
   onModeChange: (key: string, mode: ParamMode) => void;
+  agentId?: number;
+  connectorId?: string;
 }) {
   const isWildcard = mode === "wildcard";
   const widgetValue = isWildcard ? "" : value;
@@ -234,6 +244,8 @@ function ParameterField({
             className={widgetClassName}
             placeholder={widgetPlaceholder}
             siblingDatetimeValue={siblingDatetimeValue}
+            agentId={agentId}
+            connectorId={connectorId}
           />
         )
       ) : (
@@ -246,6 +258,8 @@ function ParameterField({
           className={widgetClassName}
           placeholder={widgetPlaceholder}
           siblingDatetimeValue={siblingDatetimeValue}
+          agentId={agentId}
+          connectorId={connectorId}
         />
       )}
       {!isWildcard && value.includes("*") && (

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -188,6 +188,7 @@ export function ActionConfigurationsSection({
           }}
           config={editTarget}
           agentId={agentId}
+          connectorId={connectorId}
           actions={actions}
         />
       )}

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -223,6 +223,8 @@ export function AddActionConfigDialog({
                   modes={paramModes}
                   onModeChange={(key, mode) => setParamModes((prev) => ({ ...prev, [key]: mode }))}
                   disabled={isPending}
+                  agentId={agentId}
+                  connectorId={connectorId}
                 />
               </div>
             )}

--- a/frontend/src/pages/agents/connectors/CalendarRemoteSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/CalendarRemoteSelectWidget.tsx
@@ -4,7 +4,12 @@ import { Button } from "@/components/ui/button";
 import type { SchemaPropertyUI } from "@/lib/parameterSchema";
 import { useAgentConnectorCalendars } from "@/hooks/useAgentConnectorCalendars";
 
-export interface RemoteSelectWidgetProps {
+/**
+ * Calendar picker backed by GET .../calendars (agent-bound OAuth).
+ * The manifest uses x-ui.widget "remote-select"; this component is calendar-specific until
+ * a generic path-driven fetch exists.
+ */
+export interface CalendarRemoteSelectWidgetProps {
   inputId: string;
   value: string;
   onChange: (value: string) => void;
@@ -26,7 +31,7 @@ export interface RemoteSelectWidgetProps {
 const DEFAULT_NO_CREDENTIAL =
   "Connect a credential to select a calendar.";
 
-function optionKeys(ui: RemoteSelectWidgetProps["ui"]): {
+function optionKeys(ui: CalendarRemoteSelectWidgetProps["ui"]): {
   idKey: string;
   labelKey: string;
 } {
@@ -62,10 +67,7 @@ function formatOptionLabel(
   return baseLabel;
 }
 
-/**
- * Select populated from a session-authenticated API path, with manual entry fallback.
- */
-export function RemoteSelectWidget({
+export function CalendarRemoteSelectWidget({
   inputId,
   value,
   onChange,
@@ -75,7 +77,7 @@ export function RemoteSelectWidget({
   agentId,
   connectorId,
   ui,
-}: RemoteSelectWidgetProps) {
+}: CalendarRemoteSelectWidgetProps) {
   const [manual, setManual] = useState(false);
   const {
     calendars,
@@ -215,7 +217,7 @@ export function RemoteSelectWidget({
         id={inputId}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        disabled={selectDisabled || disabled}
+        disabled={selectDisabled}
         aria-busy={isLoading || isFetching ? "true" : undefined}
         className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
         data-testid={`remote-select-${inputId}`}

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -34,6 +34,7 @@ interface EditActionConfigDialogProps {
   onOpenChange: (open: boolean) => void;
   config: ActionConfiguration;
   agentId: number;
+  connectorId: string;
   actions: ConnectorAction[];
 }
 
@@ -42,6 +43,7 @@ export function EditActionConfigDialog({
   onOpenChange,
   config,
   agentId,
+  connectorId,
   actions,
 }: EditActionConfigDialogProps) {
   const { updateActionConfig, isPending } = useUpdateActionConfig();
@@ -187,6 +189,8 @@ export function EditActionConfigDialog({
                   modes={paramModes}
                   onModeChange={(key, mode) => setParamModes((prev) => ({ ...prev, [key]: mode }))}
                   disabled={isPending}
+                  agentId={agentId}
+                  connectorId={connectorId}
                 />
               </div>
             ) : null}

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -5,6 +5,7 @@ import { Switch } from "@/components/ui/switch";
 import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
 import { inferWidgetFromProperty } from "@/lib/parameterSchema";
+import { RemoteSelectWidget } from "./RemoteSelectWidget";
 
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
@@ -19,6 +20,9 @@ export interface ParameterFieldWidgetProps {
   disabled?: boolean;
   /** Extra className for the input element. */
   className?: string;
+  /** Agent and connector context for `remote-select` widgets. */
+  agentId?: number;
+  connectorId?: string;
   /** Override the placeholder from x-ui (e.g. for constraint mode hints). */
   placeholder?: string;
   /**
@@ -39,6 +43,8 @@ export function ParameterFieldWidget({
   onChange,
   disabled,
   className,
+  agentId,
+  connectorId,
   placeholder: placeholderOverride,
   siblingDatetimeValue,
 }: ParameterFieldWidgetProps) {
@@ -59,8 +65,11 @@ export function ParameterFieldWidget({
         enumValues: property.enum,
         siblingDatetimeValue,
         datetimeRangeRole: ui?.datetime_range_role,
+        agentId,
+        connectorId,
+        propertyUI: ui,
       })}
-      <FieldHints ui={ui} />
+      <FieldHints ui={ui} omitHelpText={widget === "remote-select"} />
     </div>
   );
 }
@@ -75,10 +84,15 @@ interface WidgetRenderProps {
   enumValues?: string[];
   siblingDatetimeValue?: string;
   datetimeRangeRole?: "lower" | "upper";
+  agentId?: number;
+  connectorId?: string;
+  propertyUI?: SchemaPropertyUI;
 }
 
 function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
   switch (widget) {
+    case "remote-select":
+      return <RemoteSelectField {...props} />;
     case "select":
       return <SelectWidget {...props} />;
     case "textarea":
@@ -97,6 +111,49 @@ function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
     default:
       return <TextWidget {...props} />;
   }
+}
+
+function RemoteSelectField({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  agentId,
+  connectorId,
+  propertyUI,
+}: WidgetRenderProps) {
+  if (
+    !propertyUI ||
+    agentId === undefined ||
+    agentId <= 0 ||
+    !connectorId
+  ) {
+    return (
+      <TextWidget
+        inputId={inputId}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className}
+      />
+    );
+  }
+  return (
+    <RemoteSelectWidget
+      inputId={inputId}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
+      agentId={agentId}
+      connectorId={connectorId}
+      ui={propertyUI}
+    />
+  );
 }
 
 function TextWidget({ inputId, value, onChange, disabled, placeholder, className }: WidgetRenderProps) {
@@ -362,14 +419,14 @@ function isConcreteDatetimeString(value: string): boolean {
 }
 
 /** Renders help_text and help_url hints below the input. */
-function FieldHints({ ui }: { ui?: SchemaPropertyUI }) {
+function FieldHints({ ui, omitHelpText }: { ui?: SchemaPropertyUI; omitHelpText?: boolean }) {
   const validHelpUrl =
     ui?.help_url && /^https?:\/\//i.test(ui.help_url) ? ui.help_url : null;
-  if (!ui?.help_text && !validHelpUrl) return null;
+  if ((!ui?.help_text || omitHelpText) && !validHelpUrl) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-x-2">
-      {ui?.help_text && (
+      {ui?.help_text && !omitHelpText && (
         <p className="text-muted-foreground text-sm">{ui.help_text}</p>
       )}
       {validHelpUrl && (

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -5,7 +5,7 @@ import { Switch } from "@/components/ui/switch";
 import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
 import { inferWidgetFromProperty } from "@/lib/parameterSchema";
-import { RemoteSelectWidget } from "./RemoteSelectWidget";
+import { CalendarRemoteSelectWidget } from "./CalendarRemoteSelectWidget";
 
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
@@ -142,7 +142,7 @@ function RemoteSelectField({
     );
   }
   return (
-    <RemoteSelectWidget
+    <CalendarRemoteSelectWidget
       inputId={inputId}
       value={value}
       onChange={onChange}

--- a/frontend/src/pages/agents/connectors/RemoteSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/RemoteSelectWidget.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { SchemaPropertyUI } from "@/lib/parameterSchema";
+import { useAgentConnectorCalendars } from "@/hooks/useAgentConnectorCalendars";
+
+export interface RemoteSelectWidgetProps {
+  inputId: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  agentId: number;
+  connectorId: string;
+  ui: Pick<
+    SchemaPropertyUI,
+    | "help_text"
+    | "remote_select_options_path"
+    | "remote_select_id_key"
+    | "remote_select_label_key"
+    | "remote_select_fallback_placeholder"
+  >;
+}
+
+const DEFAULT_NO_CREDENTIAL =
+  "Connect a credential to select a calendar.";
+
+function optionKeys(ui: RemoteSelectWidgetProps["ui"]): {
+  idKey: string;
+  labelKey: string;
+} {
+  return {
+    idKey: ui.remote_select_id_key ?? "id",
+    labelKey: ui.remote_select_label_key ?? "summary",
+  };
+}
+
+function readLabel(row: Record<string, unknown>, labelKey: string): string {
+  const direct = row[labelKey];
+  if (typeof direct === "string" && direct.length > 0) return direct;
+  const summary = row.summary;
+  if (typeof summary === "string" && summary.length > 0) return summary;
+  const name = row.name;
+  if (typeof name === "string" && name.length > 0) return name;
+  const id = row.id;
+  return typeof id === "string" ? id : "";
+}
+
+/**
+ * Select populated from a session-authenticated API path, with manual entry fallback.
+ */
+export function RemoteSelectWidget({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  agentId,
+  connectorId,
+  ui,
+}: RemoteSelectWidgetProps) {
+  const [manual, setManual] = useState(false);
+  const { calendars, isLoading, isFetching, error, hasCredential } =
+    useAgentConnectorCalendars(agentId, connectorId);
+
+  const { idKey, labelKey } = optionKeys(ui);
+
+  const options = useMemo(() => {
+    const rows = calendars.map((row) => {
+      const idRaw = row[idKey];
+      const id = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
+      const label = readLabel(row, labelKey);
+      return { id, label: label || id };
+    });
+    if (value && !rows.some((r) => r.id === value)) {
+      return [{ id: value, label: value }, ...rows];
+    }
+    return rows;
+  }, [calendars, idKey, labelKey, value]);
+
+  const noCredentialText = ui.help_text?.trim() || DEFAULT_NO_CREDENTIAL;
+  const selectDisabled = disabled || isLoading || isFetching;
+
+  if (manual) {
+    return (
+      <div className="space-y-2">
+        <Input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={
+            ui.remote_select_fallback_placeholder ??
+            placeholder ??
+            "Enter value"
+          }
+          className={className}
+          data-testid={`remote-select-manual-${inputId}`}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(false)}
+        >
+          Use list
+        </Button>
+      </div>
+    );
+  }
+
+  if (!hasCredential) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          className={`border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+          data-testid={`remote-select-disabled-${inputId}`}
+        >
+          <option value="">{noCredentialText}</option>
+        </select>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">
+          Could not load options.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter manually
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <select
+        id={inputId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={selectDisabled || disabled}
+        className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+        data-testid={`remote-select-${inputId}`}
+      >
+        <option value="">
+          {isLoading || isFetching ? "Loading…" : placeholder ?? "Select…"}
+        </option>
+        {options.map((opt) => (
+          <option key={opt.id} value={opt.id}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-auto px-0 text-xs"
+        disabled={disabled}
+        onClick={() => setManual(true)}
+      >
+        Enter manually
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/RemoteSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/RemoteSelectWidget.tsx
@@ -47,6 +47,21 @@ function readLabel(row: Record<string, unknown>, labelKey: string): string {
   return typeof id === "string" ? id : "";
 }
 
+function formatOptionLabel(
+  baseLabel: string,
+  row: Record<string, unknown>,
+): string {
+  if (row.primary === true) {
+    return baseLabel.includes("(primary)") ? baseLabel : `${baseLabel} (primary)`;
+  }
+  if (row.isDefaultCalendar === true) {
+    return baseLabel.includes("(default)")
+      ? baseLabel
+      : `${baseLabel} (default)`;
+  }
+  return baseLabel;
+}
+
 /**
  * Select populated from a session-authenticated API path, with manual entry fallback.
  */
@@ -62,8 +77,15 @@ export function RemoteSelectWidget({
   ui,
 }: RemoteSelectWidgetProps) {
   const [manual, setManual] = useState(false);
-  const { calendars, isLoading, isFetching, error, hasCredential } =
-    useAgentConnectorCalendars(agentId, connectorId);
+  const {
+    calendars,
+    isLoading,
+    isFetching,
+    error,
+    hasCredential,
+    isCredentialBindingPending,
+    refetch,
+  } = useAgentConnectorCalendars(agentId, connectorId);
 
   const { idKey, labelKey } = optionKeys(ui);
 
@@ -71,8 +93,9 @@ export function RemoteSelectWidget({
     const rows = calendars.map((row) => {
       const idRaw = row[idKey];
       const id = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
-      const label = readLabel(row, labelKey);
-      return { id, label: label || id };
+      const raw = readLabel(row, labelKey);
+      const base = raw || id;
+      return { id, label: formatOptionLabel(base, row) };
     });
     if (value && !rows.some((r) => r.id === value)) {
       return [{ id: value, label: value }, ...rows];
@@ -82,6 +105,8 @@ export function RemoteSelectWidget({
 
   const noCredentialText = ui.help_text?.trim() || DEFAULT_NO_CREDENTIAL;
   const selectDisabled = disabled || isLoading || isFetching;
+  const calendarsReady =
+    hasCredential && !isLoading && !isFetching && !error;
 
   if (manual) {
     return (
@@ -114,6 +139,23 @@ export function RemoteSelectWidget({
     );
   }
 
+  if (isCredentialBindingPending) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          aria-busy="true"
+          className={`border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+          data-testid={`remote-select-binding-pending-${inputId}`}
+        >
+          <option value="">Checking credentials…</option>
+        </select>
+      </div>
+    );
+  }
+
   if (!hasCredential) {
     return (
       <div className="space-y-2">
@@ -126,6 +168,16 @@ export function RemoteSelectWidget({
         >
           <option value="">{noCredentialText}</option>
         </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(true)}
+        >
+          Enter calendar ID manually
+        </Button>
       </div>
     );
   }
@@ -134,7 +186,16 @@ export function RemoteSelectWidget({
     return (
       <div className="space-y-2">
         <p className="text-muted-foreground text-xs">
-          Could not load options.{" "}
+          Could not load calendars.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => void refetch()}
+          >
+            Retry
+          </button>
+          {" · "}
           <button
             type="button"
             className="text-foreground underline"
@@ -155,6 +216,7 @@ export function RemoteSelectWidget({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={selectDisabled || disabled}
+        aria-busy={isLoading || isFetching ? "true" : undefined}
         className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
         data-testid={`remote-select-${inputId}`}
       >
@@ -167,6 +229,20 @@ export function RemoteSelectWidget({
           </option>
         ))}
       </select>
+
+      {calendarsReady && options.length === 0 && (
+        <p className="text-muted-foreground text-xs">
+          No calendars returned.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter a calendar ID manually
+          </button>
+        </p>
+      )}
 
       <Button
         type="button"

--- a/frontend/src/pages/agents/connectors/__tests__/RemoteSelectWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RemoteSelectWidget.test.tsx
@@ -1,0 +1,109 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders } from "../../../../test-helpers";
+import { RemoteSelectWidget } from "../RemoteSelectWidget";
+
+vi.mock("../../../../lib/supabaseClient");
+
+const mockUseCalendars = vi.fn();
+
+vi.mock("@/hooks/useAgentConnectorCalendars", () => ({
+  useAgentConnectorCalendars: () => mockUseCalendars(),
+}));
+
+const baseUi = {
+  remote_select_options_path:
+    "/v1/agents/{agent_id}/connectors/{connector_id}/calendars",
+  remote_select_id_key: "id",
+  remote_select_label_key: "summary",
+  help_text: "Connect a credential to select a calendar.",
+} as const;
+
+describe("RemoteSelectWidget", () => {
+  it("shows disabled helper when no credential", () => {
+    mockUseCalendars.mockReturnValue({
+      calendars: [],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      hasCredential: false,
+      refetch: vi.fn(),
+    });
+
+    renderWithProviders(
+      <RemoteSelectWidget
+        inputId="param-calendar_id"
+        value=""
+        onChange={vi.fn()}
+        agentId={1}
+        connectorId="google"
+        ui={baseUi}
+      />,
+    );
+
+    expect(screen.getByTestId("remote-select-disabled-param-calendar_id")).toBeDisabled();
+    expect(
+      screen.getByText("Connect a credential to select a calendar."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders options when credential exists", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockUseCalendars.mockReturnValue({
+      calendars: [
+        { id: "primary", summary: "Primary" },
+        { id: "work@x", summary: "Work" },
+      ],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      hasCredential: true,
+      refetch: vi.fn(),
+    });
+
+    renderWithProviders(
+      <RemoteSelectWidget
+        inputId="param-calendar_id"
+        value=""
+        onChange={onChange}
+        agentId={1}
+        connectorId="google"
+        ui={baseUi}
+      />,
+    );
+
+    const select = screen.getByTestId("remote-select-param-calendar_id");
+    await user.selectOptions(select, "work@x");
+    expect(onChange).toHaveBeenCalledWith("work@x");
+  });
+
+  it("switches to manual entry on button click", async () => {
+    const user = userEvent.setup();
+    mockUseCalendars.mockReturnValue({
+      calendars: [{ id: "a", summary: "A" }],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      hasCredential: true,
+      refetch: vi.fn(),
+    });
+
+    renderWithProviders(
+      <RemoteSelectWidget
+        inputId="param-calendar_id"
+        value=""
+        onChange={vi.fn()}
+        agentId={1}
+        connectorId="google"
+        ui={baseUi}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /enter manually/i }));
+    expect(
+      screen.getByTestId("remote-select-manual-param-calendar_id"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/agents/connectors/__tests__/RemoteSelectWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RemoteSelectWidget.test.tsx
@@ -28,6 +28,7 @@ describe("RemoteSelectWidget", () => {
       isFetching: false,
       error: null,
       hasCredential: false,
+      isCredentialBindingPending: false,
       refetch: vi.fn(),
     });
 
@@ -53,13 +54,14 @@ describe("RemoteSelectWidget", () => {
     const onChange = vi.fn();
     mockUseCalendars.mockReturnValue({
       calendars: [
-        { id: "primary", summary: "Primary" },
+        { id: "primary", summary: "Primary", primary: true },
         { id: "work@x", summary: "Work" },
       ],
       isLoading: false,
       isFetching: false,
       error: null,
       hasCredential: true,
+      isCredentialBindingPending: false,
       refetch: vi.fn(),
     });
 
@@ -77,6 +79,7 @@ describe("RemoteSelectWidget", () => {
     const select = screen.getByTestId("remote-select-param-calendar_id");
     await user.selectOptions(select, "work@x");
     expect(onChange).toHaveBeenCalledWith("work@x");
+    expect(screen.getByRole("option", { name: /Primary \(primary\)/ })).toBeInTheDocument();
   });
 
   it("switches to manual entry on button click", async () => {
@@ -87,6 +90,7 @@ describe("RemoteSelectWidget", () => {
       isFetching: false,
       error: null,
       hasCredential: true,
+      isCredentialBindingPending: false,
       refetch: vi.fn(),
     });
 
@@ -105,5 +109,33 @@ describe("RemoteSelectWidget", () => {
     expect(
       screen.getByTestId("remote-select-manual-param-calendar_id"),
     ).toBeInTheDocument();
+  });
+
+  it("shows checking credentials while binding is loading", () => {
+    mockUseCalendars.mockReturnValue({
+      calendars: [],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      hasCredential: false,
+      isCredentialBindingPending: true,
+      refetch: vi.fn(),
+    });
+
+    renderWithProviders(
+      <RemoteSelectWidget
+        inputId="param-calendar_id"
+        value=""
+        onChange={vi.fn()}
+        agentId={1}
+        connectorId="google"
+        ui={baseUi}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("remote-select-binding-pending-param-calendar_id"),
+    ).toBeDisabled();
+    expect(screen.getByText("Checking credentials…")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/RemoteSelectWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RemoteSelectWidget.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { renderWithProviders } from "../../../../test-helpers";
-import { RemoteSelectWidget } from "../RemoteSelectWidget";
+import { CalendarRemoteSelectWidget } from "../CalendarRemoteSelectWidget";
 
 vi.mock("../../../../lib/supabaseClient");
 
@@ -33,7 +33,7 @@ describe("RemoteSelectWidget", () => {
     });
 
     renderWithProviders(
-      <RemoteSelectWidget
+      <CalendarRemoteSelectWidget
         inputId="param-calendar_id"
         value=""
         onChange={vi.fn()}
@@ -66,7 +66,7 @@ describe("RemoteSelectWidget", () => {
     });
 
     renderWithProviders(
-      <RemoteSelectWidget
+      <CalendarRemoteSelectWidget
         inputId="param-calendar_id"
         value=""
         onChange={onChange}
@@ -95,7 +95,7 @@ describe("RemoteSelectWidget", () => {
     });
 
     renderWithProviders(
-      <RemoteSelectWidget
+      <CalendarRemoteSelectWidget
         inputId="param-calendar_id"
         value=""
         onChange={vi.fn()}
@@ -123,7 +123,7 @@ describe("RemoteSelectWidget", () => {
     });
 
     renderWithProviders(
-      <RemoteSelectWidget
+      <CalendarRemoteSelectWidget
         inputId="param-calendar_id"
         value=""
         onChange={vi.fn()}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -357,3 +357,53 @@ agentConnectorCredential:
 
       '500':
         $ref: '../responses/errors.yaml#/InternalServerError'
+
+agentConnectorCalendars:
+  get:
+    operationId: listAgentConnectorCalendars
+    summary: List calendars for agent connector
+    description: |
+      Returns calendars visible to the OAuth credential assigned to this agent–connector pair.
+      Used by the dashboard to populate calendar pickers for Google and Microsoft calendar actions.
+
+      Requires session authentication (Supabase JWT). The agent must belong to the current user.
+
+    tags:
+      - Agents
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+
+    responses:
+      '200':
+        description: Calendars listed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorCalendarListResponse'
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Agent, connector, or calendar listing not supported
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'

--- a/spec/openapi/components/schemas/agent_connectors.yaml
+++ b/spec/openapi/components/schemas/agent_connectors.yaml
@@ -139,6 +139,37 @@ AssignCredentialRequest:
       description: OAuth connection ID to assign.
       example: "oc_def456"
 
+CalendarListItem:
+  type: object
+  required:
+    - id
+  properties:
+    id:
+      type: string
+      description: Provider calendar identifier (Google calendar ID or Microsoft Graph calendar id).
+    summary:
+      type: string
+      description: Human-readable name (Google Calendar `summary`).
+    name:
+      type: string
+      description: Human-readable name (Microsoft Graph `name`).
+    primary:
+      type: boolean
+      description: True when this is the user's primary Google calendar.
+    isDefaultCalendar:
+      type: boolean
+      description: True when this is the default Microsoft Graph calendar.
+
+AgentConnectorCalendarListResponse:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: '../schemas/agent_connectors.yaml#/CalendarListItem'
+
 AgentConnectorCredentialResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1634,6 +1634,45 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /v1/agents/{agent_id}/connectors/{connector_id}/calendars:
+    get:
+      operationId: listAgentConnectorCalendars
+      summary: List calendars for agent connector
+      description: |
+        Returns calendars visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate calendar pickers for Google and Microsoft calendar actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Calendars listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCalendarListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or calendar listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/registration-invites:
     post:
       operationId: createRegistrationInvite
@@ -11598,6 +11637,35 @@ components:
           type: string
           description: OAuth connection ID to assign.
           example: oc_def456
+    CalendarListItem:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Provider calendar identifier (Google calendar ID or Microsoft Graph calendar id).
+        summary:
+          type: string
+          description: Human-readable name (Google Calendar `summary`).
+        name:
+          type: string
+          description: Human-readable name (Microsoft Graph `name`).
+        primary:
+          type: boolean
+          description: True when this is the user's primary Google calendar.
+        isDefaultCalendar:
+          type: boolean
+          description: True when this is the default Microsoft Graph calendar.
+    AgentConnectorCalendarListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarListItem'
     RetentionMeta:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -156,6 +156,9 @@ paths:
   /v1/agents/{agent_id}/connectors/{connector_id}/credential:
     $ref: './components/paths/agent_connectors.yaml#/agentConnectorCredential'
 
+  /v1/agents/{agent_id}/connectors/{connector_id}/calendars:
+    $ref: './components/paths/agent_connectors.yaml#/agentConnectorCalendars'
+
   /v1/registration-invites:
     $ref: './components/paths/registration_invites.yaml#/createRegistrationInvite'
 

--- a/vault/mock.go
+++ b/vault/mock.go
@@ -84,6 +84,16 @@ func (m *MockVaultStore) HasSecret(id string) bool {
 	return ok
 }
 
+// SeedSecretForTest stores plaintext at an explicit secret ID. Use when OAuth
+// fixtures reference a fixed access_token_vault_id (tests only).
+func (m *MockVaultStore) SeedSecretForTest(secretID string, secret []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	stored := make([]byte, len(secret))
+	copy(stored, secret)
+	m.secrets[secretID] = stored
+}
+
 // randomUUID generates a v4 UUID string.
 func randomUUID() (string, error) {
 	var b [16]byte


### PR DESCRIPTION
## Summary

Implements [issue supersuit-tech/permission-slip-private#4](https://github.com/supersuit-tech/permission-slip-private/issues/4): replace raw Calendar ID text fields with a **remote-loaded select** backed by the user’s OAuth credential, plus **manual entry** for power users.

### Backend
- New optional `connectors.CalendarLister` and `ListCalendars` on Google (Calendar API `users/me/calendarList`) and Microsoft (Graph `GET /me/calendars` with pagination).
- Session-authenticated **`GET /v1/agents/{agent_id}/connectors/{connector_id}/calendars`** — resolves credentials the same way as action execution (agent–connector binding).
- Microsoft **`microsoft.create_calendar_event`** and **`microsoft.list_calendar_events`** accept optional `calendar_id`; when set, Graph calls use `/me/calendars/{id}/events` (create/list).
- OpenAPI: `CalendarListItem`, `AgentConnectorCalendarListResponse`, `listAgentConnectorCalendars`.

### Frontend
- New **`remote-select`** `x-ui` widget with `RemoteSelectWidget` + `useAgentConnectorCalendars`.
- Google and Microsoft manifests: `calendar_id` fields get `x-ui` hints (labels, `help_text`, optional `remote_select_*` keys).
- Disabled grayed select + helper when no credential is assigned; **Enter manually** toggles a text field.

### Developer
- [x] OpenAPI bundle regenerated (`make bundle`); run `npm install` in `frontend/` (and `mobile/` if you run full `make build`) so `openapi-typescript` is available locally.
- [x] `make test-frontend` passes (971 tests).
- [ ] `make test-backend` / `make build` — **not run here**: environment Go is 1.22.2 while `go.mod` dependencies require Go ≥ 1.24; CI should validate.

### Manual Testing
- [ ] Google: assign OAuth, open action config for a calendar action — dropdown shows calendar names; save config and confirm stored `calendar_id`.
- [ ] Microsoft: same with optional calendar; empty calendar = default calendar behavior.
- [ ] No credential: dropdown disabled with “Connect a credential to select a calendar.”
- [ ] Manual entry fallback and mobile viewport.