### PR TITLE
Disable connectors via connectors/<id>/disabled (Kroger + QuickBooks)

### DIFF
--- a/connectors/builtin_oauth_providers.go
+++ b/connectors/builtin_oauth_providers.go
@@ -22,7 +22,7 @@ func init() {
 		"airtable", "atlassian", "calendly", "datadog", "discord",
 		"docusign", "dropbox", "figma", "github", "google", "hubspot", "kroger",
 		"linear", "linkedin", "meta", "microsoft", "netlify", "notion",
-		"pagerduty", "salesforce", "sendgrid", "shopify", "slack",
+		"pagerduty", "quickbooks", "salesforce", "sendgrid", "shopify", "slack",
 		"square", "stripe", "vercel", "zendesk", "zoom",
 	} {
 		builtInOAuthProviders[id] = true

--- a/connectors/builtin_oauth_providers.go
+++ b/connectors/builtin_oauth_providers.go
@@ -47,11 +47,16 @@ func RegisterBuiltInOAuthProvider(id string) {
 
 // BuiltInOAuthProviderIDs returns all registered built-in OAuth provider IDs.
 // Order is not guaranteed. Intended for testing and diagnostics.
+// Connectors turned off via connectors/<id>/disabled are omitted when the
+// provider id matches the connector id (the usual case for built-ins).
 func BuiltInOAuthProviderIDs() []string {
 	builtInOAuthMu.Lock()
 	defer builtInOAuthMu.Unlock()
 	ids := make([]string, 0, len(builtInOAuthProviders))
 	for id := range builtInOAuthProviders {
+		if IsBuiltInConnectorDisabled(id) {
+			continue
+		}
 		ids = append(ids, id)
 	}
 	return ids

--- a/connectors/disabled_built_in.go
+++ b/connectors/disabled_built_in.go
@@ -1,0 +1,80 @@
+package connectors
+
+import (
+	"embed"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Embedded marker files for built-in connectors that should not register,
+// seed the database, or appear in connector/OAuth listings. Add an empty file
+// at connectors/<connector_id>/disabled (this path is next to this .go file).
+//
+//go:embed kroger/disabled quickbooks/disabled
+var disabledBuiltInMarkerFS embed.FS
+
+const disabledMarkerFile = "disabled"
+
+var (
+	disabledBuiltInMu     sync.RWMutex
+	disabledBuiltInIDs    map[string]bool
+	disabledBuiltInReason map[string]string
+)
+
+func init() {
+	ids := make(map[string]bool)
+	reasons := make(map[string]string)
+	entries, err := disabledBuiltInMarkerFS.ReadDir(".")
+	if err != nil {
+		disabledBuiltInIDs = ids
+		disabledBuiltInReason = reasons
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		data, err := disabledBuiltInMarkerFS.ReadFile(path.Join(id, disabledMarkerFile))
+		if err != nil {
+			continue
+		}
+		ids[id] = true
+		if s := strings.TrimSpace(string(data)); s != "" {
+			reasons[id] = s
+		}
+	}
+	disabledBuiltInIDs = ids
+	disabledBuiltInReason = reasons
+}
+
+// IsBuiltInConnectorDisabled reports whether the built-in connector with the
+// given id is turned off via connectors/<id>/disabled.
+func IsBuiltInConnectorDisabled(id string) bool {
+	disabledBuiltInMu.RLock()
+	defer disabledBuiltInMu.RUnlock()
+	return disabledBuiltInIDs[id]
+}
+
+// DisabledBuiltInConnectorReason returns optional explanation text from the
+// disabled marker file, or "" if the connector is not disabled or the file was empty.
+func DisabledBuiltInConnectorReason(id string) string {
+	disabledBuiltInMu.RLock()
+	defer disabledBuiltInMu.RUnlock()
+	return disabledBuiltInReason[id]
+}
+
+// DisabledBuiltInConnectorIDs returns connector ids with a disabled marker,
+// sorted for stable tests and logs.
+func DisabledBuiltInConnectorIDs() []string {
+	disabledBuiltInMu.RLock()
+	defer disabledBuiltInMu.RUnlock()
+	out := make([]string, 0, len(disabledBuiltInIDs))
+	for id := range disabledBuiltInIDs {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/connectors/disabled_built_in.go
+++ b/connectors/disabled_built_in.go
@@ -12,7 +12,7 @@ import (
 // seed the database, or appear in connector/OAuth listings. Add an empty file
 // at connectors/<connector_id>/disabled (this path is next to this .go file).
 //
-//go:embed kroger/disabled quickbooks/disabled salesforce/disabled
+//go:embed kroger/disabled quickbooks/disabled
 var disabledBuiltInMarkerFS embed.FS
 
 const disabledMarkerFile = "disabled"

--- a/connectors/disabled_built_in.go
+++ b/connectors/disabled_built_in.go
@@ -12,7 +12,7 @@ import (
 // seed the database, or appear in connector/OAuth listings. Add an empty file
 // at connectors/<connector_id>/disabled (this path is next to this .go file).
 //
-//go:embed kroger/disabled quickbooks/disabled
+//go:embed kroger/disabled quickbooks/disabled salesforce/disabled
 var disabledBuiltInMarkerFS embed.FS
 
 const disabledMarkerFile = "disabled"

--- a/connectors/disabled_built_in_test.go
+++ b/connectors/disabled_built_in_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestDisabledBuiltInConnectorIDs_IncludesKrogerAndQuickBooks(t *testing.T) {
+func TestDisabledBuiltInConnectorIDs_IncludesKrogerQuickBooksSalesforce(t *testing.T) {
 	t.Parallel()
 	ids := DisabledBuiltInConnectorIDs()
-	for _, want := range []string{"kroger", "quickbooks"} {
+	for _, want := range []string{"kroger", "quickbooks", "salesforce"} {
 		if !slices.Contains(ids, want) {
 			t.Errorf("expected disabled list to include %q, got %v", want, ids)
 		}

--- a/connectors/disabled_built_in_test.go
+++ b/connectors/disabled_built_in_test.go
@@ -1,0 +1,16 @@
+package connectors
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDisabledBuiltInConnectorIDs_IncludesKrogerAndQuickBooks(t *testing.T) {
+	t.Parallel()
+	ids := DisabledBuiltInConnectorIDs()
+	for _, want := range []string{"kroger", "quickbooks"} {
+		if !slices.Contains(ids, want) {
+			t.Errorf("expected disabled list to include %q, got %v", want, ids)
+		}
+	}
+}

--- a/connectors/disabled_built_in_test.go
+++ b/connectors/disabled_built_in_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestDisabledBuiltInConnectorIDs_IncludesKrogerQuickBooksSalesforce(t *testing.T) {
+func TestDisabledBuiltInConnectorIDs_IncludesKrogerAndQuickBooks(t *testing.T) {
 	t.Parallel()
 	ids := DisabledBuiltInConnectorIDs()
-	for _, want := range []string{"kroger", "quickbooks", "salesforce"} {
+	for _, want := range []string{"kroger", "quickbooks"} {
 		if !slices.Contains(ids, want) {
 			t.Errorf("expected disabled list to include %q, got %v", want, ids)
 		}

--- a/connectors/kroger/register.go
+++ b/connectors/kroger/register.go
@@ -3,5 +3,8 @@ package kroger
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
+	if connectors.IsBuiltInConnectorDisabled("kroger") {
+		return
+	}
 	connectors.RegisterBuiltIn(New())
 }

--- a/connectors/providers/kroger.go
+++ b/connectors/providers/kroger.go
@@ -3,5 +3,8 @@ package providers
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
+	if connectors.IsBuiltInConnectorDisabled("kroger") {
+		return
+	}
 	connectors.RegisterBuiltInOAuthProvider("kroger")
 }

--- a/connectors/providers/quickbooks.go
+++ b/connectors/providers/quickbooks.go
@@ -3,5 +3,8 @@ package providers
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
+	if connectors.IsBuiltInConnectorDisabled("quickbooks") {
+		return
+	}
 	connectors.RegisterBuiltInOAuthProvider("quickbooks")
 }

--- a/connectors/providers/salesforce.go
+++ b/connectors/providers/salesforce.go
@@ -3,5 +3,8 @@ package providers
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
+	if connectors.IsBuiltInConnectorDisabled("salesforce") {
+		return
+	}
 	connectors.RegisterBuiltInOAuthProvider("salesforce")
 }

--- a/connectors/providers/salesforce.go
+++ b/connectors/providers/salesforce.go
@@ -3,8 +3,5 @@ package providers
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
-	if connectors.IsBuiltInConnectorDisabled("salesforce") {
-		return
-	}
 	connectors.RegisterBuiltInOAuthProvider("salesforce")
 }

--- a/connectors/quickbooks/register.go
+++ b/connectors/quickbooks/register.go
@@ -3,5 +3,8 @@ package quickbooks
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
+	if connectors.IsBuiltInConnectorDisabled("quickbooks") {
+		return
+	}
 	connectors.RegisterBuiltIn(New())
 }

--- a/connectors/registry.go
+++ b/connectors/registry.go
@@ -64,3 +64,14 @@ func (r *Registry) GetAction(actionType string) (Action, bool) {
 	action, ok := conn.Actions()[actionType]
 	return action, ok
 }
+
+// Remove deletes a connector from the registry. Returns false if id was not present.
+func (r *Registry) Remove(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.connectors[id]; !ok {
+		return false
+	}
+	delete(r.connectors, id)
+	return true
+}

--- a/connectors/registry_test.go
+++ b/connectors/registry_test.go
@@ -20,8 +20,8 @@ type stubConnector struct {
 	actions map[string]Action
 }
 
-func (c *stubConnector) ID() string                  { return c.id }
-func (c *stubConnector) Actions() map[string]Action   { return c.actions }
+func (c *stubConnector) ID() string                 { return c.id }
+func (c *stubConnector) Actions() map[string]Action { return c.actions }
 func (c *stubConnector) ValidateCredentials(_ context.Context, _ Credentials) error {
 	return nil
 }
@@ -206,5 +206,20 @@ func TestRegistry_GetActionMultipleDots(t *testing.T) {
 	}
 	if action == nil {
 		t.Fatal("expected non-nil action")
+	}
+}
+
+func TestRegistry_Remove(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(newStubConnector("tmp", "tmp.ping"))
+	if !r.Remove("tmp") {
+		t.Fatal("Remove: expected true for existing id")
+	}
+	if _, ok := r.Get("tmp"); ok {
+		t.Error("expected connector removed")
+	}
+	if r.Remove("tmp") {
+		t.Error("Remove: expected false for missing id")
 	}
 }

--- a/connectors/salesforce/register.go
+++ b/connectors/salesforce/register.go
@@ -3,8 +3,5 @@ package salesforce
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
-	if connectors.IsBuiltInConnectorDisabled("salesforce") {
-		return
-	}
 	connectors.RegisterBuiltIn(New())
 }

--- a/connectors/salesforce/register.go
+++ b/connectors/salesforce/register.go
@@ -3,5 +3,8 @@ package salesforce
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 func init() {
+	if connectors.IsBuiltInConnectorDisabled("salesforce") {
+		return
+	}
 	connectors.RegisterBuiltIn(New())
 }

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -27,9 +27,9 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 46 active built-in connector packages (some may be disabled via
+	// There are 47 active built-in connector packages (two may be disabled via
 	// connectors/<id>/disabled). Update this number when adding or removing connectors.
-	const expected = 46
+	const expected = 47
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -27,9 +27,9 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 47 active built-in connector packages (two may be disabled via
+	// There are 46 active built-in connector packages (some may be disabled via
 	// connectors/<id>/disabled). Update this number when adding or removing connectors.
-	const expected = 47
+	const expected = 46
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -27,9 +27,9 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 49 built-in connector packages. Update this number when
-	// adding or removing connectors.
-	const expected = 49
+	// There are 47 active built-in connector packages (two may be disabled via
+	// connectors/<id>/disabled). Update this number when adding or removing connectors.
+	const expected = 47
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -213,6 +213,13 @@ func ListConnectorIDs(ctx context.Context, db DBTX) ([]string, error) {
 	return ids, rows.Err()
 }
 
+// DeleteConnectorByID removes a connector and dependent rows (actions,
+// credentials, templates, agent links) via ON DELETE CASCADE.
+func DeleteConnectorByID(ctx context.Context, db DBTX, connectorID string) error {
+	_, err := db.Exec(ctx, `DELETE FROM connectors WHERE id = $1`, connectorID)
+	return err
+}
+
 // GetActionRequiresPaymentMethod checks whether the given action type requires
 // a payment method. Returns (true, nil) if the action exists and requires payment,
 // (false, nil) if it exists but doesn't require payment, and (false, error) if

--- a/db/connectors_test.go
+++ b/db/connectors_test.go
@@ -142,6 +142,23 @@ func TestListConnectorIDs_Empty(t *testing.T) {
 	}
 }
 
+func TestDeleteConnectorByID(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	testhelper.InsertConnector(t, tx, "gone")
+	if err := db.DeleteConnectorByID(context.Background(), tx, "gone"); err != nil {
+		t.Fatalf("DeleteConnectorByID: %v", err)
+	}
+	ids, err := db.ListConnectorIDs(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("ListConnectorIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected connector deleted, still have %v", ids)
+	}
+}
+
 func TestListConnectorIDs_ReturnsAll(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/main.go
+++ b/main.go
@@ -302,6 +302,27 @@ func main() {
 	// Load external connectors from CONNECTORS_DIR (or ~/.permission_slip/connectors/).
 	loadExternalConnectors(registry, deps.DB)
 
+	// Built-in connectors with connectors/<id>/disabled are omitted from the registry
+	// above; purge their DB rows so list APIs stay consistent.
+	for _, id := range connectors.DisabledBuiltInConnectorIDs() {
+		registry.Remove(id)
+		if deps.DB == nil {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := db.DeleteConnectorByID(ctx, deps.DB, id)
+		cancel()
+		if err != nil {
+			log.Printf("Warning: failed to delete disabled connector %q from database: %v", id, err)
+			continue
+		}
+		if msg := connectors.DisabledBuiltInConnectorReason(id); msg != "" {
+			log.Printf("Connector %q is disabled (%s) — removed from database", id, msg)
+		} else {
+			log.Printf("Connector %q is disabled — removed from database", id)
+		}
+	}
+
 	deps.Connectors = registry
 
 	// Initialize Slack event infrastructure.
@@ -342,6 +363,10 @@ func main() {
 	// so BYOA credentials survive server restarts.
 	if deps.DB != nil && deps.Vault != nil {
 		loadBYOAProviderConfigs(oauthRegistry, deps.DB, deps.Vault)
+	}
+
+	for _, id := range connectors.DisabledBuiltInConnectorIDs() {
+		_ = oauthRegistry.Remove(id)
 	}
 
 	// Start all registered background jobs.
@@ -558,6 +583,10 @@ func loadExternalConnectors(registry *connectors.Registry, d db.DBTX) {
 		// real GitHub connector and receive users' decrypted credentials.
 		if _, exists := registry.Get(ext.ID()); exists {
 			log.Printf("Warning: external connector %q conflicts with an already-registered connector — skipping", ext.ID())
+			continue
+		}
+		if connectors.IsBuiltInConnectorDisabled(ext.ID()) {
+			log.Printf("Warning: external connector %q uses a reserved id (built-in connector disabled in tree) — skipping", ext.ID())
 			continue
 		}
 

--- a/oauth/builtin_test.go
+++ b/oauth/builtin_test.go
@@ -78,25 +78,6 @@ func TestBuiltInProviders(t *testing.T) {
 		}
 	})
 
-	t.Run("kroger", func(t *testing.T) {
-		k, ok := byID["kroger"]
-		if !ok {
-			t.Fatal("kroger provider not found")
-		}
-		if k.AuthorizeURL != "https://api.kroger.com/v1/connect/oauth2/authorize" {
-			t.Errorf("AuthorizeURL = %q", k.AuthorizeURL)
-		}
-		if k.TokenURL != "https://api.kroger.com/v1/connect/oauth2/token" {
-			t.Errorf("TokenURL = %q", k.TokenURL)
-		}
-		if k.Source != oauth.SourceBuiltIn {
-			t.Errorf("Source = %q, want %q", k.Source, oauth.SourceBuiltIn)
-		}
-		if len(k.Scopes) == 0 {
-			t.Error("expected default scopes")
-		}
-	})
-
 	t.Run("netlify", func(t *testing.T) {
 		n, ok := byID["netlify"]
 		if !ok {
@@ -231,9 +212,6 @@ func TestNewRegistryWithBuiltIns(t *testing.T) {
 	}
 	if _, ok := r.Get("google"); !ok {
 		t.Error("google not found in registry")
-	}
-	if _, ok := r.Get("kroger"); !ok {
-		t.Error("kroger not found in registry")
 	}
 	if _, ok := r.Get("microsoft"); !ok {
 		t.Error("microsoft not found in registry")

--- a/oauth/disabled_built_in.go
+++ b/oauth/disabled_built_in.go
@@ -1,0 +1,62 @@
+package oauth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	disabledBuiltInOAuthMu  sync.RWMutex
+	disabledBuiltInOAuthIDs map[string]bool
+)
+
+func init() {
+	ids := make(map[string]bool)
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		disabledBuiltInOAuthIDs = ids
+		return
+	}
+	root := filepath.Dir(file)
+	connRoot := filepath.Join(root, "..", "connectors")
+	entries, err := os.ReadDir(connRoot)
+	if err != nil {
+		disabledBuiltInOAuthIDs = ids
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		p := filepath.Join(connRoot, id, "disabled")
+		b, err := os.ReadFile(p)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			continue
+		}
+		if strings.TrimSpace(string(b)) == "" {
+			ids[id] = true
+		}
+	}
+	disabledBuiltInOAuthIDs = ids
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
+}
+
+// IsBuiltInOAuthProviderDisabled reports whether the built-in OAuth provider
+// with this id is turned off alongside its connector (empty file at
+// connectors/<id>/disabled). Defined here so oauth/providers avoids importing
+// connectors (import cycle).
+func IsBuiltInOAuthProviderDisabled(id string) bool {
+	disabledBuiltInOAuthMu.RLock()
+	defer disabledBuiltInOAuthMu.RUnlock()
+	return disabledBuiltInOAuthIDs[id]
+}

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -1,0 +1,26 @@
+package oauth_test
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/oauth"
+	_ "github.com/supersuit-tech/permission-slip-web/oauth/providers"
+)
+
+func TestBuiltInOAuthDisabledForKrogerAndQuickBooks(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{"kroger", "quickbooks"} {
+		if !oauth.IsBuiltInOAuthProviderDisabled(id) {
+			t.Errorf("expected %q to be disabled when connectors/%s/disabled exists", id, id)
+		}
+	}
+}
+
+func TestBuiltInProviders_OmitsDisabledKroger(t *testing.T) {
+	t.Parallel()
+	for _, p := range oauth.BuiltInProviders() {
+		if p.ID == "kroger" {
+			t.Fatal("kroger should not appear in BuiltInProviders when connector is disabled")
+		}
+	}
+}

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -7,20 +7,21 @@ import (
 	_ "github.com/supersuit-tech/permission-slip-web/oauth/providers"
 )
 
-func TestBuiltInOAuthDisabledForKrogerAndQuickBooks(t *testing.T) {
+func TestBuiltInOAuthDisabledForKrogerQuickBooksSalesforce(t *testing.T) {
 	t.Parallel()
-	for _, id := range []string{"kroger", "quickbooks"} {
+	for _, id := range []string{"kroger", "quickbooks", "salesforce"} {
 		if !oauth.IsBuiltInOAuthProviderDisabled(id) {
 			t.Errorf("expected %q to be disabled when connectors/%s/disabled exists", id, id)
 		}
 	}
 }
 
-func TestBuiltInProviders_OmitsDisabledKroger(t *testing.T) {
+func TestBuiltInProviders_OmitsDisabledConnectors(t *testing.T) {
 	t.Parallel()
 	for _, p := range oauth.BuiltInProviders() {
-		if p.ID == "kroger" {
-			t.Fatal("kroger should not appear in BuiltInProviders when connector is disabled")
+		switch p.ID {
+		case "kroger", "quickbooks", "salesforce":
+			t.Fatalf("%q should not appear in BuiltInProviders when connector is disabled", p.ID)
 		}
 	}
 }

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -7,21 +7,20 @@ import (
 	_ "github.com/supersuit-tech/permission-slip-web/oauth/providers"
 )
 
-func TestBuiltInOAuthDisabledForKrogerQuickBooksSalesforce(t *testing.T) {
+func TestBuiltInOAuthDisabledForKrogerAndQuickBooks(t *testing.T) {
 	t.Parallel()
-	for _, id := range []string{"kroger", "quickbooks", "salesforce"} {
+	for _, id := range []string{"kroger", "quickbooks"} {
 		if !oauth.IsBuiltInOAuthProviderDisabled(id) {
 			t.Errorf("expected %q to be disabled when connectors/%s/disabled exists", id, id)
 		}
 	}
 }
 
-func TestBuiltInProviders_OmitsDisabledConnectors(t *testing.T) {
+func TestBuiltInProviders_OmitsDisabledKroger(t *testing.T) {
 	t.Parallel()
 	for _, p := range oauth.BuiltInProviders() {
-		switch p.ID {
-		case "kroger", "quickbooks", "salesforce":
-			t.Fatalf("%q should not appear in BuiltInProviders when connector is disabled", p.ID)
+		if p.ID == "kroger" {
+			t.Fatal("kroger should not appear in BuiltInProviders when connector is disabled")
 		}
 	}
 }

--- a/oauth/providers/kroger.go
+++ b/oauth/providers/kroger.go
@@ -7,6 +7,9 @@ import (
 )
 
 func init() {
+	if oauth.IsBuiltInOAuthProviderDisabled("kroger") {
+		return
+	}
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
 			ID:           "kroger",

--- a/oauth/providers/quickbooks.go
+++ b/oauth/providers/quickbooks.go
@@ -7,6 +7,9 @@ import (
 )
 
 func init() {
+	if oauth.IsBuiltInOAuthProviderDisabled("quickbooks") {
+		return
+	}
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
 			ID:           "quickbooks",

--- a/oauth/providers/salesforce.go
+++ b/oauth/providers/salesforce.go
@@ -7,6 +7,9 @@ import (
 )
 
 func init() {
+	if oauth.IsBuiltInOAuthProviderDisabled("salesforce") {
+		return
+	}
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
 			ID:           "salesforce",

--- a/oauth/providers/salesforce.go
+++ b/oauth/providers/salesforce.go
@@ -7,9 +7,6 @@ import (
 )
 
 func init() {
-	if oauth.IsBuiltInOAuthProviderDisabled("salesforce") {
-		return
-	}
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
 			ID:           "salesforce",


### PR DESCRIPTION
## Summary

Add an empty marker file at `connectors/<connector_id>/disabled` to fully turn off a **built-in** connector: it is not registered, not listed under `GET /connectors`, OAuth providers `kroger` / `quickbooks` are omitted, and on server startup the connector row is deleted from Postgres (cascading related rows).

Applied for **kroger** and **quickbooks** (Intuit QuickBooks).

Optional: put a one-line message in the `disabled` file; it is logged at startup.

## Developer

- [x] Implementation and unit test expectation updates
- [ ] Run `make test-backend` in CI (local sandbox Go version mismatch with `go.mod`)

## Manual Testing

- [ ] Start server, confirm Kroger and QuickBooks are absent from connector and OAuth provider APIs
- [ ] Confirm existing DB rows for those connectors are removed after one startup