### PR TITLE
Slack: user-token-only OAuth (issue #772)

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -404,6 +404,12 @@ func credentialsFromOAuthConnection(ctx context.Context, deps *Deps, conn *db.OA
 		}
 	}
 
+	// Legacy Slack connections stored user_access_token_vault_id in extra_data.
+	// User-token-only OAuth uses a single vault secret; never expose the old key as a credential.
+	if conn.Provider == "slack" {
+		delete(creds, "user_access_token_vault_id")
+	}
+
 	// Set access_token AFTER merging extra_data so that a tampered extra_data
 	// field cannot overwrite the vault-sourced access token.
 	creds["access_token"] = string(accessTokenBytes)

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -144,11 +144,11 @@ func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, user
 // resolvedPaymentMethod holds the validated payment method state between
 // validation (pre-execution) and transaction recording (post-execution).
 type resolvedPaymentMethod struct {
-	paymentMethodID      string
+	paymentMethodID       string
 	stripePaymentMethodID string
-	brand                string
-	last4                string
-	amount               int
+	brand                 string
+	last4                 string
+	amount                int
 }
 
 // validatePaymentMethod validates the payment method, enforces ownership and
@@ -404,22 +404,6 @@ func credentialsFromOAuthConnection(ctx context.Context, deps *Deps, conn *db.OA
 		}
 	}
 
-	// Resolve the user access token from vault if present (e.g. Slack OAuth v2
-	// stores both a bot token and a user token). The vault ID is stored in
-	// extra_data and must not leak into the credential map.
-	if userVaultID, ok := creds[userTokenVaultIDKey]; ok {
-		delete(creds, userTokenVaultIDKey)
-		userTokenBytes, readErr := deps.Vault.ReadSecret(ctx, deps.DB, userVaultID)
-		if readErr != nil {
-			// Log but don't fail — the user token is optional for most actions.
-			// Actions that require it (e.g. search_messages) will return a clear
-			// error when the credential is missing.
-			log.Printf("failed to read user access token from vault %s: %v", userVaultID, readErr)
-		} else {
-			creds["user_access_token"] = string(userTokenBytes)
-		}
-	}
-
 	// Set access_token AFTER merging extra_data so that a tampered extra_data
 	// field cannot overwrite the vault-sourced access token.
 	creds["access_token"] = string(accessTokenBytes)
@@ -531,5 +515,3 @@ func refreshOAuthConnection(ctx context.Context, deps *Deps, conn *db.OAuthConne
 
 	return nil
 }
-
-

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -226,8 +226,8 @@ func TestExecuteConnectorAction_OAuthPath_Success(t *testing.T) {
 	f := setupOAuthExecutionTest(t, oauthExecOpts{
 		OnExec: func(creds connectors.Credentials) { capturedCreds = creds },
 		Connection: &testhelper.OAuthConnectionOpts{
-			Scopes:  []string{"https://www.googleapis.com/auth/gmail.send"},
-			Status:  "active",
+			Scopes: []string{"https://www.googleapis.com/auth/gmail.send"},
+			Status: "active",
 		},
 	})
 
@@ -1563,5 +1563,50 @@ func TestHandleConnectorError_PaymentError_InvalidAmount(t *testing.T) {
 	}
 	if code, _ := errObj["code"].(string); code != string(ErrInvalidRequest) {
 		t.Errorf("expected error code %q, got %q", ErrInvalidRequest, code)
+	}
+}
+
+func TestCredentialsFromOAuthConnection_SlackStripsLegacyUserVaultKey(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	v := vault.NewMockVaultStore()
+	vaultID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	v.SeedSecretForTest(vaultID, []byte("xoxp-secret"))
+
+	connID := testhelper.GenerateID(t, "oconn_")
+	extra := []byte(`{"user_access_token_vault_id":"should-not-leak","team_name":"Acme"}`)
+	testhelper.InsertOAuthConnectionFull(t, tx, connID, uid, "slack", testhelper.OAuthConnectionOpts{
+		AccessTokenVaultID: vaultID,
+		Scopes:             []string{"chat:write"},
+		ExtraData:          extra,
+	})
+
+	conn, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, "slack")
+	if err != nil {
+		t.Fatalf("get connection: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("expected oauth connection")
+	}
+
+	deps := &Deps{DB: tx, Vault: v}
+	creds, err := credentialsFromOAuthConnection(t.Context(), deps, conn)
+	if err != nil {
+		t.Fatalf("credentialsFromOAuthConnection: %v", err)
+	}
+
+	if _, ok := creds.Get("user_access_token_vault_id"); ok {
+		t.Error("legacy user_access_token_vault_id must not be passed to connectors for Slack")
+	}
+	team, _ := creds.Get("team_name")
+	if team != "Acme" {
+		t.Errorf("team_name = %q, want Acme", team)
+	}
+	tok, _ := creds.Get("access_token")
+	if tok != "xoxp-secret" {
+		t.Errorf("access_token = %q, want xoxp-secret", tok)
 	}
 }

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -621,13 +621,13 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		// is likely still configured for bot scopes only — fail with a clear
 		// message instead of storing a bot token the connector cannot use.
 		if providerID == "slack" {
-			if extractSlackUserToken(token) == "" {
+			if oauth.SlackAuthedUserAccessToken(token) == "" {
 				redirectToFrontend(w, r, deps, providerID, "error",
 					"Slack did not return a user OAuth token. In your Slack app settings, add the required User Token Scopes, remove Bot Token Scopes from the install flow, then connect again.",
 					state.ReturnTo, "")
 				return
 			}
-			token = slackUserTokenAsPrimary(token)
+			token = oauth.NormalizeSlackUserOAuthToken(token)
 		}
 
 		// Store tokens in vault within a transaction. Use scopes from the
@@ -1224,31 +1224,6 @@ func redirectToFrontend(w http.ResponseWriter, r *http.Request, deps *Deps, prov
 	}
 	parsedURL.RawQuery = q.Encode()
 	http.Redirect(w, r, parsedURL.String(), http.StatusTemporaryRedirect)
-}
-
-// extractSlackUserToken extracts the user access token from a Slack OAuth v2
-// token response (authed_user.access_token). Returns "" if absent.
-func extractSlackUserToken(token *oauth2.Token) string {
-	authedUser, ok := token.Extra("authed_user").(map[string]any)
-	if !ok {
-		return ""
-	}
-	userToken, _ := authedUser["access_token"].(string)
-	return userToken
-}
-
-// slackUserTokenAsPrimary returns a token whose AccessToken is the Slack user
-// token when authed_user.access_token is present; otherwise returns token unchanged.
-func slackUserTokenAsPrimary(token *oauth2.Token) *oauth2.Token {
-	if token == nil {
-		return token
-	}
-	if u := extractSlackUserToken(token); u != "" {
-		t := *token
-		t.AccessToken = u
-		return &t
-	}
-	return token
 }
 
 // extractSlackTeamName extracts the workspace name from a Slack OAuth v2

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -460,6 +460,13 @@ func handleOAuthAuthorize(deps *Deps) http.HandlerFunc {
 			cfg.Scopes = deduplicateScopes(append(cfg.Scopes, extraScopes...))
 		}
 
+		// Slack user-token-only OAuth: scopes are sent as user_scope via
+		// AuthorizeParams; the oauth2 library must not add a bot "scope" query param.
+		storedOAuthScopes := cfg.Scopes
+		if providerID == "slack" {
+			cfg.Scopes = nil
+		}
+
 		// Create the CSRF state token after computing the final scope list so
 		// the callback can store exactly which scopes were requested.
 		returnTo := r.URL.Query().Get("return_to")
@@ -470,7 +477,7 @@ func handleOAuthAuthorize(deps *Deps) http.HandlerFunc {
 		// Optional: replace an existing connection instead of creating alongside.
 		replaceID := r.URL.Query().Get("replace")
 		profile := Profile(r.Context())
-		state, err := createOAuthState(deps, profile.ID, providerID, cfg.Scopes, instanceID, returnTo, replaceID)
+		state, err := createOAuthState(deps, profile.ID, providerID, storedOAuthScopes, instanceID, returnTo, replaceID)
 		if err != nil {
 			log.Printf("[%s] OAuthAuthorize: create state: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -605,13 +612,11 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Slack-specific: extract the user access token from the OAuth v2
-		// response. Slack returns both a bot token (access_token) and a user
-		// token (authed_user.access_token). The user token is needed for
-		// endpoints like search.messages that don't support bot tokens.
-		var userAccessToken string
+		// Slack user-token-only OAuth: the Web API user token is nested under
+		// authed_user.access_token; promote it to the primary access_token we
+		// store and use for all connector actions.
 		if providerID == "slack" {
-			userAccessToken = extractSlackUserToken(token)
+			token = slackUserTokenAsPrimary(token)
 		}
 
 		// Store tokens in vault within a transaction. Use scopes from the
@@ -674,12 +679,7 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 
 		// Run best-effort email enrichers (fetches user email from provider
 		// userinfo endpoints). Failures are logged but don't block the flow.
-		// For Slack, the OIDC userinfo endpoint requires the user token (not
-		// the bot token returned as the primary access_token).
 		enricherToken := token.AccessToken
-		if providerID == "slack" && userAccessToken != "" {
-			enricherToken = userAccessToken
-		}
 		if softExtra := runSoftEnrichers(ctx, providerID, enricherToken); softExtra != nil {
 			if stateExtraData == nil {
 				stateExtraData = make(map[string]string)
@@ -694,7 +694,7 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		connID, err := storeOAuthTokens(r.Context(), deps, profile.ID, providerID, storedScopes, token, stateExtraData, state.ReplaceID, userAccessToken)
+		connID, err := storeOAuthTokens(r.Context(), deps, profile.ID, providerID, storedScopes, token, stateExtraData, state.ReplaceID)
 		if err != nil {
 			log.Printf("[%s] OAuthCallback: store tokens: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -718,12 +718,7 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 // replaceID, if non-empty, is the ID of an existing connection to replace.
 // When set, only that specific connection is deleted. When empty, a new
 // connection is created alongside any existing ones for the same provider.
-//
-// userAccessToken, if non-empty, is a user-level access token returned by
-// providers that issue both bot and user tokens (e.g. Slack OAuth v2). It
-// is stored in a separate vault secret and its vault ID is persisted in
-// extra_data as "user_access_token_vault_id" for resolution at execution time.
-func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string, scopes []string, token *oauth2.Token, stateExtra map[string]string, replaceID string, userAccessToken string) (string, error) {
+func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string, scopes []string, token *oauth2.Token, stateExtra map[string]string, replaceID string) (string, error) {
 	tx, owned, err := db.BeginOrContinue(ctx, deps.DB)
 	if err != nil {
 		return "", fmt.Errorf("begin tx: %w", err)
@@ -784,16 +779,6 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 		}
 	}
 
-	// Clean up old user access token vault secret from the replaced connection.
-	if oldConn != nil {
-		if oldUserVaultID := userTokenVaultIDFromExtraData(oldConn.ExtraData); oldUserVaultID != "" {
-			if err := deps.Vault.DeleteSecret(ctx, tx, oldUserVaultID); err != nil {
-				log.Printf("[%s] storeOAuthTokens: failed to delete old user access token vault secret %q: %v", TraceID(ctx), oldUserVaultID, err)
-				// Non-fatal: orphaned vault secrets are cleaned up eventually.
-			}
-		}
-	}
-
 	connID, err := generatePrefixedID("oconn_", 16)
 	if err != nil {
 		return "", fmt.Errorf("generate connection ID: %w", err)
@@ -822,19 +807,6 @@ func storeOAuthTokens(ctx context.Context, deps *Deps, userID, providerID string
 	var tokenExpiry *time.Time
 	if !token.Expiry.IsZero() {
 		tokenExpiry = &token.Expiry
-	}
-
-	// Store the user access token in vault if provided (e.g. Slack OAuth v2).
-	// The vault ID is persisted in extra_data and resolved at execution time.
-	if userAccessToken != "" {
-		userVaultID, vaultErr := deps.Vault.CreateSecret(ctx, tx, connID+"_user_access", []byte(userAccessToken))
-		if vaultErr != nil {
-			return "", fmt.Errorf("vault create user access token: %w", vaultErr)
-		}
-		if stateExtra == nil {
-			stateExtra = make(map[string]string)
-		}
-		stateExtra[userTokenVaultIDKey] = userVaultID
 	}
 
 	// Extract provider-specific extra data from the token response.
@@ -1184,14 +1156,6 @@ func handleDeleteOAuthConnection(deps *Deps) http.HandlerFunc {
 				return
 			}
 		}
-		// Clean up user access token vault secret if present (e.g. Slack).
-		if userVaultID := userTokenVaultIDFromExtraData(conn.ExtraData); userVaultID != "" {
-			if err := deps.Vault.DeleteSecret(r.Context(), tx, userVaultID); err != nil {
-				log.Printf("[%s] DeleteOAuthConnection: vault delete user access token: %v", TraceID(r.Context()), err)
-				// Non-fatal: the connection row is already deleted. Log and continue.
-			}
-		}
-
 		if owned {
 			if err := db.CommitTx(r.Context(), tx); err != nil {
 				log.Printf("[%s] DeleteOAuthConnection: commit: %v", TraceID(r.Context()), err)
@@ -1251,14 +1215,8 @@ func redirectToFrontend(w http.ResponseWriter, r *http.Request, deps *Deps, prov
 	http.Redirect(w, r, parsedURL.String(), http.StatusTemporaryRedirect)
 }
 
-// userTokenVaultIDKey is the extra_data key used to store the vault secret ID
-// for a user-level access token (e.g., Slack's authed_user.access_token).
-const userTokenVaultIDKey = "user_access_token_vault_id"
-
 // extractSlackUserToken extracts the user access token from a Slack OAuth v2
-// token response. Slack returns both a bot token (the primary access_token)
-// and a user token nested under authed_user.access_token. Returns "" if the
-// user token is not present in the response.
+// token response (authed_user.access_token). Returns "" if absent.
 func extractSlackUserToken(token *oauth2.Token) string {
 	authedUser, ok := token.Extra("authed_user").(map[string]any)
 	if !ok {
@@ -1266,6 +1224,20 @@ func extractSlackUserToken(token *oauth2.Token) string {
 	}
 	userToken, _ := authedUser["access_token"].(string)
 	return userToken
+}
+
+// slackUserTokenAsPrimary returns a token whose AccessToken is the Slack user
+// token when authed_user.access_token is present; otherwise returns token unchanged.
+func slackUserTokenAsPrimary(token *oauth2.Token) *oauth2.Token {
+	if token == nil {
+		return token
+	}
+	if u := extractSlackUserToken(token); u != "" {
+		t := *token
+		t.AccessToken = u
+		return &t
+	}
+	return token
 }
 
 // extractSlackTeamName extracts the workspace name from a Slack OAuth v2
@@ -1277,17 +1249,4 @@ func extractSlackTeamName(token *oauth2.Token) string {
 	}
 	name, _ := team["name"].(string)
 	return name
-}
-
-// userTokenVaultIDFromExtraData extracts the user access token vault ID from
-// an OAuth connection's extra_data JSON. Returns "" if not present.
-func userTokenVaultIDFromExtraData(extraData json.RawMessage) string {
-	if len(extraData) == 0 {
-		return ""
-	}
-	var extra map[string]string
-	if err := json.Unmarshal(extraData, &extra); err != nil {
-		return ""
-	}
-	return extra[userTokenVaultIDKey]
 }

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -9,6 +9,9 @@
 //     and creates an oauth_connections row
 //  6. Server redirects to /settings?oauth_status=success (or error)
 //
+// Slack uses user-token-only OAuth: the callback requires authed_user.access_token
+// and rejects exchanges that only return a bot token (misconfigured Slack app).
+//
 // Security:
 //   - CSRF protection via signed JWT state tokens (HS256, 10-min TTL)
 //   - State encodes user ID + provider to prevent session fixation
@@ -614,8 +617,16 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 
 		// Slack user-token-only OAuth: the Web API user token is nested under
 		// authed_user.access_token; promote it to the primary access_token we
-		// store and use for all connector actions.
+		// store and use for all connector actions. If Slack omits it, the app
+		// is likely still configured for bot scopes only — fail with a clear
+		// message instead of storing a bot token the connector cannot use.
 		if providerID == "slack" {
+			if extractSlackUserToken(token) == "" {
+				redirectToFrontend(w, r, deps, providerID, "error",
+					"Slack did not return a user OAuth token. In your Slack app settings, add the required User Token Scopes, remove Bot Token Scopes from the install flow, then connect again.",
+					state.ReturnTo, "")
+				return
+			}
 			token = slackUserTokenAsPrimary(token)
 		}
 

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -804,7 +804,7 @@ func TestStoreOAuthTokens_CreateNew(t *testing.T) {
 		TokenType:    "Bearer",
 	}
 
-	_, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token, nil, "", "")
+	_, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token, nil, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}
@@ -843,7 +843,7 @@ func TestStoreOAuthTokens_ReplacesExisting(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, "", ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -860,7 +860,7 @@ func TestStoreOAuthTokens_ReplacesExisting(t *testing.T) {
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID, ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -892,7 +892,7 @@ func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, "", ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -914,7 +914,7 @@ func TestStoreOAuthTokens_ReauthWithoutRefreshToken_PreservesOld(t *testing.T) {
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID, ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid", "email"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -965,7 +965,7 @@ func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
 		Expiry:       time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}
-	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, "", ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token1, nil, ""); err != nil {
 		t.Fatalf("first storeOAuthTokens: %v", err)
 	}
 
@@ -982,7 +982,7 @@ func TestStoreOAuthTokens_ReauthWithNewRefreshToken_ReplacesOld(t *testing.T) {
 		Expiry:       time.Now().Add(2 * time.Hour),
 		TokenType:    "Bearer",
 	}
-	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil, conn1.ID, ""); err != nil {
+	if _, err := storeOAuthTokens(t.Context(), deps, uid, "google", []string{"openid"}, token2, nil, conn1.ID); err != nil {
 		t.Fatalf("second storeOAuthTokens: %v", err)
 	}
 
@@ -1307,7 +1307,7 @@ func TestStoreOAuthTokens_WithStateExtra(t *testing.T) {
 	}
 
 	stateExtra := map[string]string{"shop_domain": "mystore.myshopify.com"}
-	_, err := storeOAuthTokens(t.Context(), deps, uid, "shopify", []string{"write_orders"}, token, stateExtra, "", "")
+	_, err := storeOAuthTokens(t.Context(), deps, uid, "shopify", []string{"write_orders"}, token, stateExtra, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}
@@ -1564,7 +1564,7 @@ func TestIsURLExtraKey(t *testing.T) {
 		want bool
 	}{
 		{"instance_url", true},
-		{"base_url", false},  // validated in fetchDocuSignUserInfo, not here
+		{"base_url", false}, // validated in fetchDocuSignUserInfo, not here
 		{"shop_domain", false},
 		{"account_id", false},
 	}
@@ -1818,7 +1818,7 @@ func TestStoreOAuthTokens_WithZendeskSubdomain(t *testing.T) {
 	}
 
 	stateExtra := map[string]string{"subdomain": "mycompany"}
-	_, err := storeOAuthTokens(t.Context(), deps, uid, "zendesk", []string{"read", "write"}, token, stateExtra, "", "")
+	_, err := storeOAuthTokens(t.Context(), deps, uid, "zendesk", []string{"read", "write"}, token, stateExtra, "")
 	if err != nil {
 		t.Fatalf("storeOAuthTokens: %v", err)
 	}

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	slackconnector "github.com/supersuit-tech/permission-slip-web/connectors/slack"
 	"github.com/supersuit-tech/permission-slip-web/db"
 	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
 	"github.com/supersuit-tech/permission-slip-web/oauth"
@@ -81,6 +82,31 @@ func oauthDeps(tx db.DBTX) *Deps {
 		Scopes:       []string{"read"},
 		Source:       oauth.SourceManifest,
 		// No client credentials
+	})
+	return &Deps{
+		DB:                tx,
+		Vault:             vault.NewMockVaultStore(),
+		SupabaseJWTSecret: testJWTSecret,
+		OAuthProviders:    reg,
+		OAuthStateSecret:  testOAuthStateSecret,
+		BaseURL:           "http://localhost:3000",
+	}
+}
+
+// oauthDepsWithSlack registers the Slack provider like production (user_scope only).
+func oauthDepsWithSlack(tx db.DBTX) *Deps {
+	reg := oauth.NewRegistry()
+	_ = reg.Register(oauth.Provider{
+		ID:           "slack",
+		AuthorizeURL: "https://slack.com/oauth/v2/authorize",
+		TokenURL:     "https://slack.com/api/oauth.v2.access",
+		Scopes:       slackconnector.OAuthScopes,
+		AuthorizeParams: map[string]string{
+			"user_scope": strings.Join(slackconnector.OAuthScopes, ","),
+		},
+		ClientID:     "test-slack-client-id",
+		ClientSecret: "test-slack-client-secret",
+		Source:       oauth.SourceBuiltIn,
 	})
 	return &Deps{
 		DB:                tx,
@@ -337,6 +363,42 @@ func TestOAuthAuthorize_Redirect(t *testing.T) {
 	}
 	if !strings.Contains(parsed.Query().Get("redirect_uri"), "/api/v1/oauth/google/callback") {
 		t.Errorf("expected callback URL in redirect_uri, got %s", parsed.Query().Get("redirect_uri"))
+	}
+}
+
+func TestOAuthAuthorize_Slack_NoBotScopeQueryParam(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := oauthDepsWithSlack(tx)
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/oauth/slack/authorize", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("expected Location header")
+	}
+	parsed, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	q := parsed.Query()
+	if _, hasScope := q["scope"]; hasScope {
+		t.Errorf("Slack authorize URL must not include bot \"scope\" query key; got scope=%q", q.Get("scope"))
+	}
+	if us := q.Get("user_scope"); us == "" {
+		t.Fatal("expected user_scope query param")
+	}
+	if !strings.Contains(us, "chat:write") {
+		t.Errorf("user_scope should include chat:write, got %q", us)
 	}
 }
 

--- a/api/oauth_user_token_test.go
+++ b/api/oauth_user_token_test.go
@@ -3,86 +3,35 @@ package api
 import (
 	"testing"
 
+	"github.com/supersuit-tech/permission-slip-web/oauth"
 	"golang.org/x/oauth2"
 )
 
-func TestExtractSlackUserToken(t *testing.T) {
+func TestExtractSlackTeamName(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name     string
-		extra    map[string]any
-		wantUser string
-	}{
-		{
-			name: "has authed_user with access_token",
-			extra: map[string]any{
-				"authed_user": map[string]any{
-					"id":           "U12345",
-					"access_token": "xoxp-user-token-value",
-					"scope":        "search:read",
-					"token_type":   "user",
-				},
-			},
-			wantUser: "xoxp-user-token-value",
-		},
-		{
-			name:     "no authed_user field",
-			extra:    map[string]any{},
-			wantUser: "",
-		},
-		{
-			name: "authed_user without access_token",
-			extra: map[string]any{
-				"authed_user": map[string]any{
-					"id": "U12345",
-				},
-			},
-			wantUser: "",
-		},
-		{
-			name: "authed_user is not a map",
-			extra: map[string]any{
-				"authed_user": "string-value",
-			},
-			wantUser: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			token := &oauth2.Token{AccessToken: "xoxb-bot-token"}
-			token = token.WithExtra(tt.extra)
-
-			got := extractSlackUserToken(token)
-			if got != tt.wantUser {
-				t.Errorf("extractSlackUserToken() = %q, want %q", got, tt.wantUser)
-			}
-		})
+	tok := (&oauth2.Token{}).WithExtra(map[string]any{
+		"team": map[string]any{"name": "Acme Corp"},
+	})
+	if got := extractSlackTeamName(tok); got != "Acme Corp" {
+		t.Errorf("extractSlackTeamName() = %q", got)
 	}
 }
 
-func TestSlackUserTokenAsPrimary(t *testing.T) {
+func TestOAuthSlackNormalizationUsesPackage(t *testing.T) {
 	t.Parallel()
-
-	tok := (&oauth2.Token{AccessToken: "xoxb-app"}).WithExtra(map[string]any{
+	// Regression: callback path must use oauth.NormalizeSlackUserOAuthToken for
+	// user refresh_token alignment (see oauth/slack_token_test.go).
+	tok := (&oauth2.Token{
+		AccessToken:  "xoxb",
+		RefreshToken: "bot-rt",
+	}).WithExtra(map[string]any{
 		"authed_user": map[string]any{
-			"access_token": "xoxp-user",
+			"access_token":  "xoxp",
+			"refresh_token": "user-rt",
 		},
 	})
-	out := slackUserTokenAsPrimary(tok)
-	if out.AccessToken != "xoxp-user" {
-		t.Errorf("AccessToken = %q, want xoxp-user", out.AccessToken)
-	}
-
-	if slackUserTokenAsPrimary(nil) != nil {
-		t.Error("nil input should return nil")
-	}
-
-	plain := &oauth2.Token{AccessToken: "only"}
-	if got := slackUserTokenAsPrimary(plain); got != plain {
-		t.Error("without authed_user, should return same token pointer")
+	n := oauth.NormalizeSlackUserOAuthToken(tok)
+	if n.AccessToken != "xoxp" || n.RefreshToken != "user-rt" {
+		t.Fatalf("normalize: %+v", n)
 	}
 }

--- a/api/oauth_user_token_test.go
+++ b/api/oauth_user_token_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"testing"
 
 	"golang.org/x/oauth2"
@@ -54,77 +53,36 @@ func TestExtractSlackUserToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Build an oauth2.Token with extras. The oauth2 library stores
-			// extras in a special way — we simulate this via the raw JSON approach.
-			rawJSON, err := json.Marshal(map[string]any{
-				"access_token": "xoxb-bot-token",
-				"token_type":   "bot",
-				"authed_user":  tt.extra["authed_user"],
-			})
-			if err != nil {
-				t.Fatalf("marshal: %v", err)
-			}
-
-			// Use the oauth2 internal token unmarshaling to get extras populated.
-			// The oauth2.Token.Extra method reads from the raw JSON field.
 			token := &oauth2.Token{AccessToken: "xoxb-bot-token"}
-			// We need to use the internal method — set raw directly.
-			// The simplest way is to construct via Token response parsing.
 			token = token.WithExtra(tt.extra)
 
 			got := extractSlackUserToken(token)
 			if got != tt.wantUser {
 				t.Errorf("extractSlackUserToken() = %q, want %q", got, tt.wantUser)
 			}
-
-			// Verify the raw JSON approach also works (secondary check).
-			_ = rawJSON
 		})
 	}
 }
 
-func TestUserTokenVaultIDFromExtraData(t *testing.T) {
+func TestSlackUserTokenAsPrimary(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		extraData json.RawMessage
-		want      string
-	}{
-		{
-			name:      "nil extra data",
-			extraData: nil,
-			want:      "",
+	tok := (&oauth2.Token{AccessToken: "xoxb-app"}).WithExtra(map[string]any{
+		"authed_user": map[string]any{
+			"access_token": "xoxp-user",
 		},
-		{
-			name:      "empty extra data",
-			extraData: json.RawMessage(`{}`),
-			want:      "",
-		},
-		{
-			name:      "has user_access_token_vault_id",
-			extraData: json.RawMessage(`{"user_access_token_vault_id":"vault-123","email":"test@example.com"}`),
-			want:      "vault-123",
-		},
-		{
-			name:      "invalid JSON",
-			extraData: json.RawMessage(`{invalid`),
-			want:      "",
-		},
-		{
-			name:      "other keys only",
-			extraData: json.RawMessage(`{"shop_domain":"mystore.myshopify.com"}`),
-			want:      "",
-		},
+	})
+	out := slackUserTokenAsPrimary(tok)
+	if out.AccessToken != "xoxp-user" {
+		t.Errorf("AccessToken = %q, want xoxp-user", out.AccessToken)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := userTokenVaultIDFromExtraData(tt.extraData)
-			if got != tt.want {
-				t.Errorf("userTokenVaultIDFromExtraData() = %q, want %q", got, tt.want)
-			}
-		})
+	if slackUserTokenAsPrimary(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+
+	plain := &oauth2.Token{AccessToken: "only"}
+	if got := slackUserTokenAsPrimary(plain); got != plain {
+		t.Error("without authed_user, should return same token pointer")
 	}
 }

--- a/api/slack_events.go
+++ b/api/slack_events.go
@@ -21,6 +21,11 @@ const eventDeduplicationTTL = 1 * time.Hour
 // RegisterSlackEventRoutes adds the Slack Events API webhook endpoint to the mux.
 // Like the Stripe webhook, this lives outside /api/v1/ to bypass auth middleware.
 // Slack authenticates requests via HMAC-SHA256 signature verification.
+//
+// Note: Slack event subscriptions are configured per Slack app and typically
+// require a bot/app install. User-token-only OAuth does not replace Events API
+// setup; disable event subscriptions in the Slack app if you rely solely on
+// user OAuth without a bot.
 func RegisterSlackEventRoutes(mux *http.ServeMux, deps *Deps) {
 	mux.Handle("POST /api/webhooks/slack/events", handleSlackEvent(deps))
 }

--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -8,27 +8,19 @@ The Slack connector integrates Permission Slip with the [Slack Web API](https://
 
 ## Credentials
 
-The Slack connector supports two authentication methods. OAuth is the recommended default; bot tokens are supported as an alternative.
+Slack uses **user OAuth only** (Slack user token `xoxp-...`). There is no workspace bot install or manual bot token path.
 
-### OAuth (recommended)
-
-| Key | Source | Description |
-|-----|--------|-------------|
-| `access_token` | OAuth connection | Automatically managed via the platform's OAuth flow. |
-
-The credential `auth_type` is `oauth2` with provider `slack`. Users connect via **Settings > Connected Accounts > Connect Slack**. The platform handles token exchange, encrypted storage, and automatic refresh.
-
-### Bot Token (alternative)
+### OAuth
 
 | Key | Source | Description |
 |-----|--------|-------------|
-| `bot_token` | Manual entry | A Slack bot token (`xoxb-...`) with appropriate scopes. |
+| `access_token` | OAuth connection | User token from Slack OAuth v2 (`authed_user.access_token`), stored as the connection primary secret. |
 
-The credential `auth_type` is `custom` under service `slack_bot`. Tokens are stored encrypted in Supabase Vault and decrypted only at execution time. The connector validates that the token starts with the `xoxb-` prefix.
+The credential `auth_type` is `oauth2` with provider `slack`. Users connect via **Settings > Connected Accounts > Connect Slack**. The platform handles token exchange, encrypted storage, and refresh when Slack issues a refresh token.
 
-### Credential Resolution
+### Credential resolution
 
-At execution time, the connector accepts either `access_token` or `bot_token`. If the user has an OAuth connection, it takes priority. If not, the platform falls back to stored bot token credentials. Both token types use Bearer auth with the Slack API.
+At execution time, the connector uses the OAuth `access_token` (Bearer) for all Web API calls.
 
 ## Actions
 

--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -22,6 +22,13 @@ The credential `auth_type` is `oauth2` with provider `slack`. Users connect via 
 
 At execution time, the connector uses the OAuth `access_token` (Bearer) for all Web API calls.
 
+### Re-authorization after scope changes
+
+If you previously connected with the old bot+user dual-token flow, disconnect and
+connect again (or wait for the connection status `needs_reauth` after deploy). The
+platform stores a single user token per connection; bot-only primary tokens are no
+longer supported.
+
 ## Actions
 
 ### `slack.send_message`

--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -56,7 +56,7 @@ type conversationsMembersRequest struct {
 
 type conversationsMembersResponse struct {
 	slackResponse
-	Members []string       `json:"members"`
+	Members []string        `json:"members"`
 	Meta    *paginationMeta `json:"response_metadata,omitempty"`
 }
 
@@ -69,7 +69,6 @@ const maxMembershipPages = 50
 // isUserInChannel checks whether the given Slack user ID is a member of the
 // specified channel. Paginates through the member list up to maxMembershipPages.
 func (c *SlackConnector) isUserInChannel(ctx context.Context, creds connectors.Credentials, channelID, slackUserID string) (bool, error) {
-	membersCreds := credentialsForUserTokenIfDirectOrGroupDM(creds, channelID)
 	cursor := ""
 	for page := 0; page < maxMembershipPages; page++ {
 		body := conversationsMembersRequest{
@@ -79,7 +78,7 @@ func (c *SlackConnector) isUserInChannel(ctx context.Context, creds connectors.C
 		}
 
 		var resp conversationsMembersResponse
-		if err := c.doPost(ctx, "conversations.members", membersCreds, body, &resp); err != nil {
+		if err := c.doPost(ctx, "conversations.members", creds, body, &resp); err != nil {
 			return false, err
 		}
 		if !resp.OK {
@@ -236,9 +235,9 @@ func describeChannelType(channelID string) string {
 
 // usersConversationsRequest is the Slack API request for users.conversations.
 type usersConversationsRequest struct {
-	User  string `json:"user"`
-	Types string `json:"types,omitempty"`
-	Limit int    `json:"limit,omitempty"`
+	User   string `json:"user"`
+	Types  string `json:"types,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
 	Cursor string `json:"cursor,omitempty"`
 }
 
@@ -252,10 +251,8 @@ type usersConversationsResponse struct {
 const maxUserConversationPages = 50
 
 // getUserPrivateConversations returns conversation objects for the given Slack user
-// and types via users.conversations, using the authorizing user's OAuth token when
-// present so 1:1 DMs (where the bot is not a participant) are included.
+// and types via users.conversations.
 func (c *SlackConnector) getUserPrivateConversations(ctx context.Context, creds connectors.Credentials, slackUserID, types string) ([]listChannelEntry, error) {
-	creds = credentialsForChat(creds)
 	var out []listChannelEntry
 	cursor := ""
 	for page := 0; page < maxUserConversationPages; page++ {

--- a/connectors/slack/chat_user_token_test.go
+++ b/connectors/slack/chat_user_token_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
-func TestSendMessage_PrefersUserAccessToken(t *testing.T) {
+func TestSendMessage_UsesAccessToken(t *testing.T) {
 	t.Parallel()
 
 	var auth string
@@ -32,8 +32,7 @@ func TestSendMessage_PrefersUserAccessToken(t *testing.T) {
 
 	params, _ := json.Marshal(sendMessageParams{Channel: "#general", Message: "hi"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -49,7 +48,7 @@ func TestSendMessage_PrefersUserAccessToken(t *testing.T) {
 	}
 }
 
-func TestSendDM_PrefersUserAccessTokenOnBothCalls(t *testing.T) {
+func TestSendDM_UsesAccessTokenOnBothCalls(t *testing.T) {
 	t.Parallel()
 
 	var auths []string
@@ -79,8 +78,7 @@ func TestSendDM_PrefersUserAccessTokenOnBothCalls(t *testing.T) {
 
 	params, _ := json.Marshal(sendDMParams{UserID: "U01234567", Message: "hi"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -101,7 +99,7 @@ func TestSendDM_PrefersUserAccessTokenOnBothCalls(t *testing.T) {
 	}
 }
 
-func TestUpdateMessage_PrefersUserAccessToken(t *testing.T) {
+func TestUpdateMessage_UsesAccessToken(t *testing.T) {
 	t.Parallel()
 
 	var auth string
@@ -116,8 +114,7 @@ func TestUpdateMessage_PrefersUserAccessToken(t *testing.T) {
 	action := &updateMessageAction{conn: conn}
 	params, _ := json.Marshal(updateMessageParams{Channel: "C01234567", TS: "1.0", Message: "x"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -133,7 +130,7 @@ func TestUpdateMessage_PrefersUserAccessToken(t *testing.T) {
 	}
 }
 
-func TestDeleteMessage_PrefersUserAccessToken(t *testing.T) {
+func TestDeleteMessage_UsesAccessToken(t *testing.T) {
 	t.Parallel()
 
 	var auth string
@@ -148,8 +145,7 @@ func TestDeleteMessage_PrefersUserAccessToken(t *testing.T) {
 	action := &deleteMessageAction{conn: conn}
 	params, _ := json.Marshal(deleteMessageParams{Channel: "C01234567", TS: "1.0"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -165,7 +161,7 @@ func TestDeleteMessage_PrefersUserAccessToken(t *testing.T) {
 	}
 }
 
-func TestScheduleMessage_PrefersUserAccessToken(t *testing.T) {
+func TestScheduleMessage_UsesAccessToken(t *testing.T) {
 	t.Parallel()
 
 	var auth string
@@ -189,8 +185,7 @@ func TestScheduleMessage_PrefersUserAccessToken(t *testing.T) {
 		PostAt:  "2029-12-31T00:00:00Z",
 	})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -206,7 +201,7 @@ func TestScheduleMessage_PrefersUserAccessToken(t *testing.T) {
 	}
 }
 
-func TestSendMessage_UserTokenMissingScopeReturnsClearAuthError(t *testing.T) {
+func TestSendMessage_MissingScopeReturnsClearAuthError(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -219,8 +214,7 @@ func TestSendMessage_UserTokenMissingScopeReturnsClearAuthError(t *testing.T) {
 	action := &sendMessageAction{conn: conn}
 	params, _ := json.Marshal(sendMessageParams{Channel: "C01234567", Message: "hi"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-stale-user",
+		"access_token": "xoxp-stale-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -235,8 +229,8 @@ func TestSendMessage_UserTokenMissingScopeReturnsClearAuthError(t *testing.T) {
 		t.Fatalf("expected AuthError, got %T", err)
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "chat:write") || !strings.Contains(msg, "re-authorize") {
-		t.Errorf("expected message to mention chat:write and re-authorize, got: %s", msg)
+	if !strings.Contains(msg, "re-authorize") {
+		t.Errorf("expected message to mention re-authorize, got: %s", msg)
 	}
 }
 
@@ -253,8 +247,7 @@ func TestSendMessage_NotAllowedTokenTypeReturnsAuthError(t *testing.T) {
 	action := &sendMessageAction{conn: conn}
 	params, _ := json.Marshal(sendMessageParams{Channel: "C01234567", Message: "hi"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -270,7 +263,7 @@ func TestSendMessage_NotAllowedTokenTypeReturnsAuthError(t *testing.T) {
 	}
 }
 
-func TestReadChannelMessages_DMUsesUserTokenForMembersAndHistory(t *testing.T) {
+func TestReadChannelMessages_DMUsesAccessTokenForMembersAndHistory(t *testing.T) {
 	t.Parallel()
 
 	var membersAuth, historyAuth string
@@ -305,8 +298,7 @@ func TestReadChannelMessages_DMUsesUserTokenForMembersAndHistory(t *testing.T) {
 	action := &readChannelMessagesAction{conn: conn}
 	params, _ := json.Marshal(readChannelMessagesParams{Channel: "D01234567"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -319,14 +311,14 @@ func TestReadChannelMessages_DMUsesUserTokenForMembersAndHistory(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if membersAuth != "Bearer xoxp-user" {
-		t.Errorf("conversations.members: expected user token, got %q", membersAuth)
+		t.Errorf("conversations.members: expected access token, got %q", membersAuth)
 	}
 	if historyAuth != "Bearer xoxp-user" {
-		t.Errorf("conversations.history: expected user token, got %q", historyAuth)
+		t.Errorf("conversations.history: expected access token, got %q", historyAuth)
 	}
 }
 
-func TestReadChannelMessages_PublicChannelKeepsBotTokenForHistory(t *testing.T) {
+func TestReadChannelMessages_PublicChannelUsesAccessTokenForHistory(t *testing.T) {
 	t.Parallel()
 
 	var historyAuth string
@@ -355,8 +347,7 @@ func TestReadChannelMessages_PublicChannelKeepsBotTokenForHistory(t *testing.T) 
 	action := &readChannelMessagesAction{conn: conn}
 	params, _ := json.Marshal(readChannelMessagesParams{Channel: "C01234567"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -367,12 +358,12 @@ func TestReadChannelMessages_PublicChannelKeepsBotTokenForHistory(t *testing.T) 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if historyAuth != "Bearer xoxb-bot" {
-		t.Errorf("conversations.history: expected bot token for public C-channel, got %q", historyAuth)
+	if historyAuth != "Bearer xoxp-user" {
+		t.Errorf("conversations.history: expected access token for public C-channel, got %q", historyAuth)
 	}
 }
 
-func TestReadThread_DMUsesUserTokenForReplies(t *testing.T) {
+func TestReadThread_DMUsesAccessTokenForReplies(t *testing.T) {
 	t.Parallel()
 
 	var repliesAuth string
@@ -408,8 +399,7 @@ func TestReadThread_DMUsesUserTokenForReplies(t *testing.T) {
 	action := &readThreadAction{conn: conn}
 	params, _ := json.Marshal(readThreadParams{Channel: "D01234567", ThreadTS: "1.0"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -422,6 +412,6 @@ func TestReadThread_DMUsesUserTokenForReplies(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if repliesAuth != "Bearer xoxp-user" {
-		t.Errorf("conversations.replies: expected user token, got %q", repliesAuth)
+		t.Errorf("conversations.replies: expected access token, got %q", repliesAuth)
 	}
 }

--- a/connectors/slack/delete_message.go
+++ b/connectors/slack/delete_message.go
@@ -52,9 +52,8 @@ func (a *deleteMessageAction) Execute(ctx context.Context, req connectors.Action
 		TS:      params.TS,
 	}
 
-	creds := credentialsForChat(req.Credentials)
 	var resp deleteMessageResponse
-	if err := a.conn.doPost(ctx, "chat.delete", creds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "chat.delete", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/helpers_test.go
+++ b/connectors/slack/helpers_test.go
@@ -2,9 +2,9 @@ package slack
 
 import "github.com/supersuit-tech/permission-slip-web/connectors"
 
-// validCreds returns a Credentials value with a valid bot token for tests.
+// validCreds returns a Credentials value with a valid user OAuth token for tests.
 func validCreds() connectors.Credentials {
 	return connectors.NewCredentials(map[string]string{
-		"bot_token": "xoxb-test-token-123",
+		"access_token": "xoxp-test-token-123",
 	})
 }

--- a/connectors/slack/list_channels_dm_merge_test.go
+++ b/connectors/slack/list_channels_dm_merge_test.go
@@ -36,10 +36,10 @@ func TestListChannels_MergesHumanDMNotVisibleToBot(t *testing.T) {
 				},
 			})
 		case "/conversations.list":
-			if got := r.Header.Get("Authorization"); got != "Bearer xoxb-bot" {
-				t.Errorf("conversations.list: expected bot token, got %q", got)
+			if got := r.Header.Get("Authorization"); got != "Bearer xoxp-user" {
+				t.Errorf("conversations.list: expected user token, got %q", got)
 			}
-			// Bot is not in the human-to-human DM — only public channel.
+			// User token list may omit a human-to-human DM — only public channel here.
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,
 				"channels": []map[string]any{
@@ -56,8 +56,7 @@ func TestListChannels_MergesHumanDMNotVisibleToBot(t *testing.T) {
 	action := &listChannelsAction{conn: conn}
 	params, _ := json.Marshal(listChannelsParams{Types: "public_channel,im"})
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot",
-		"user_access_token": "xoxp-user",
+		"access_token": "xoxp-user",
 	})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -9,6 +9,7 @@ import (
 
 // Manifest returns the connector's metadata manifest. Used by the server to
 // auto-seed DB rows on startup, replacing manual seed.go files.
+//
 //go:embed logo.svg
 var logoSVG string
 
@@ -16,14 +17,14 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "slack",
 		Name:        "Slack",
-		Description: "Slack integration for team communication. OAuth connections may include a user token for search, posting as the authorizing user, and reading DMs the bot cannot see.",
+		Description: "Slack integration for team communication via user OAuth (xoxp-). Actions run as the authorizing Slack user.",
 		Status:      "early_preview",
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "slack.send_message",
 				Name:        "Send Message",
-				Description: "Send a message to a Slack channel. When the connection has a Slack user OAuth token with chat:write, the message is sent as the authorizing user; otherwise it is sent as the app bot.",
+				Description: "Send a message to a Slack channel as the authorizing user.",
 				RiskLevel:   "low",
 				Preview: &connectors.ActionPreview{
 					Layout: "message",
@@ -69,7 +70,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.list_channels",
 				Name:        "List Channels",
-				Description: "List Slack channels. Uses the bot token for conversations.list and, when a user OAuth token is present, merges in the authorizing user's DMs and private conversations from users.conversations (so 1:1 DMs the bot is not in still appear). Returns all channel types (public, private, group DMs, DMs) by default when a matching profile email is available.",
+				Description: "List Slack channels via conversations.list, merged with the authorizing user's DMs and private conversations from users.conversations when a matching profile email is available. Returns all channel types (public, private, group DMs, DMs) by default when email is set.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -99,7 +100,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.read_channel_messages",
 				Name:        "Read Channel Messages",
-				Description: "Read recent messages from a Slack channel, DM (D…), or group DM (G…). For D and G channels, uses the authorizing user's OAuth token when available so history matches the human participant.",
+				Description: "Read recent messages from a Slack channel, DM (D…), or group DM (G…).",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -161,7 +162,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.schedule_message",
 				Name:        "Schedule Message",
-				Description: "Schedule a message for future delivery to a Slack channel. When a user OAuth token with chat:write is present, schedules as the authorizing user.",
+				Description: "Schedule a message for future delivery to a Slack channel as the authorizing user.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -280,7 +281,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.send_dm",
 				Name:        "Send Direct Message",
-				Description: "Send a direct message to a Slack user. When a user OAuth token with chat:write is present, opens and posts as the authorizing user.",
+				Description: "Send a direct message to a Slack user as the authorizing user.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -301,7 +302,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.update_message",
 				Name:        "Update Message",
-				Description: "Edit an existing message. With a user OAuth token, only messages sent as that user can be updated.",
+				Description: "Edit an existing message you are allowed to change.",
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -326,7 +327,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.delete_message",
 				Name:        "Delete Message",
-				Description: "Delete a message. With a user OAuth token, only messages that user may delete can be removed.",
+				Description: "Delete a message you are allowed to remove.",
 				RiskLevel:   "high",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -346,7 +347,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.list_users",
 				Name:        "List Users",
-				Description: "List workspace users visible to the bot",
+				Description: "List workspace users visible to the authorizing user",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -366,7 +367,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "slack.search_messages",
 				Name:        "Search Messages",
-				Description: "Search messages across Slack channels (requires a user token with search:read.* scopes; bot tokens are not supported by Slack for this endpoint)",
+				Description: "Search messages across Slack channels (requires search:read)",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -399,23 +400,22 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				Service:       "slack",
 				AuthType:      "oauth2",
 				OAuthProvider: "slack",
-				OAuthScopes:   append(OAuthScopes, OAuthUserScopes...),
+				OAuthScopes:   OAuthScopes,
 			},
-			{Service: "slack_bot", AuthType: "custom", InstructionsURL: "https://api.slack.com/tutorials/tracks/getting-a-token"},
 		},
 		Templates: []connectors.ManifestTemplate{
 			{
 				ID:          "tpl_slack_send_to_channel",
 				ActionType:  "slack.send_message",
 				Name:        "Post to a channel",
-				Description: "Locks the channel and lets the agent choose the message content (as the authorizing user when user OAuth token has chat:write).",
+				Description: "Locks the channel and lets the agent choose the message content as the authorizing user.",
 				Parameters:  json.RawMessage(`{"channel":"#general","message":"*"}`),
 			},
 			{
 				ID:          "tpl_slack_send_any",
 				ActionType:  "slack.send_message",
 				Name:        "Send messages freely",
-				Description: "Agent can send any message to any channel (as the authorizing user when user OAuth token has chat:write).",
+				Description: "Agent can send any message to any channel as the authorizing user.",
 				Parameters:  json.RawMessage(`{"channel":"*","message":"*"}`),
 			},
 			{
@@ -429,28 +429,28 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				ID:          "tpl_slack_list_channels",
 				ActionType:  "slack.list_channels",
 				Name:        "List channels",
-				Description: "Agent can list channels; user OAuth token merges in the authorizing user's DMs when present.",
+				Description: "Agent can list channels, including the authorizing user's DMs when profile email matches Slack.",
 				Parameters:  json.RawMessage(`{"types":"*","limit":"*","cursor":"*"}`),
 			},
 			{
 				ID:          "tpl_slack_read_channel",
 				ActionType:  "slack.read_channel_messages",
 				Name:        "Read channel messages",
-				Description: "Agent can read messages from channels, DMs, or group DMs (user token used for D/G when available).",
+				Description: "Agent can read messages from channels, DMs, or group DMs.",
 				Parameters:  json.RawMessage(`{"channel":"*","limit":"*","oldest":"*","latest":"*","cursor":"*"}`),
 			},
 			{
 				ID:          "tpl_slack_read_thread",
 				ActionType:  "slack.read_thread",
 				Name:        "Read thread replies",
-				Description: "Agent can read thread replies (user token for DM/group-DM threads when available).",
+				Description: "Agent can read thread replies.",
 				Parameters:  json.RawMessage(`{"channel":"*","thread_ts":"*","limit":"*","cursor":"*"}`),
 			},
 			{
 				ID:          "tpl_slack_schedule_message",
 				ActionType:  "slack.schedule_message",
 				Name:        "Schedule messages",
-				Description: "Agent can schedule messages (as the authorizing user when user OAuth token has chat:write).",
+				Description: "Agent can schedule messages as the authorizing user.",
 				Parameters:  json.RawMessage(`{"channel":"*","message":"*","post_at":"*"}`),
 			},
 			{
@@ -485,21 +485,21 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				ID:          "tpl_slack_send_dm",
 				ActionType:  "slack.send_dm",
 				Name:        "Send direct messages",
-				Description: "Agent can send DMs (as the authorizing user when user OAuth token has chat:write).",
+				Description: "Agent can send DMs as the authorizing user.",
 				Parameters:  json.RawMessage(`{"user_id":"*","message":"*"}`),
 			},
 			{
 				ID:          "tpl_slack_update_message",
 				ActionType:  "slack.update_message",
 				Name:        "Update messages",
-				Description: "Agent can edit messages the authorizing user or bot is allowed to change.",
+				Description: "Agent can edit messages the authorizing user is allowed to change.",
 				Parameters:  json.RawMessage(`{"channel":"*","ts":"*","message":"*"}`),
 			},
 			{
 				ID:          "tpl_slack_delete_message",
 				ActionType:  "slack.delete_message",
 				Name:        "Delete messages",
-				Description: "Agent can delete messages the authorizing user or bot is allowed to remove.",
+				Description: "Agent can delete messages the authorizing user is allowed to remove.",
 				Parameters:  json.RawMessage(`{"channel":"*","ts":"*"}`),
 			},
 			{

--- a/connectors/slack/read_channel_messages.go
+++ b/connectors/slack/read_channel_messages.go
@@ -67,9 +67,8 @@ func (a *readChannelMessagesAction) Execute(ctx context.Context, req connectors.
 		body.Limit = 20
 	}
 
-	historyCreds := credentialsForUserTokenIfDirectOrGroupDM(req.Credentials, params.Channel)
 	var resp messagesResponse
-	if err := a.conn.doPost(ctx, "conversations.history", historyCreds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "conversations.history", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/read_thread.go
+++ b/connectors/slack/read_thread.go
@@ -65,9 +65,8 @@ func (a *readThreadAction) Execute(ctx context.Context, req connectors.ActionReq
 		body.Limit = 50
 	}
 
-	repliesCreds := credentialsForUserTokenIfDirectOrGroupDM(req.Credentials, params.Channel)
 	var resp messagesResponse
-	if err := a.conn.doPost(ctx, "conversations.replies", repliesCreds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "conversations.replies", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -147,9 +147,8 @@ func (a *scheduleMessageAction) Execute(ctx context.Context, req connectors.Acti
 		PostAt:  postAtUnix,
 	}
 
-	creds := credentialsForChat(req.Credentials)
 	var resp scheduleMessageResponse
-	if err := a.conn.doPost(ctx, "chat.scheduleMessage", creds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "chat.scheduleMessage", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -10,11 +10,7 @@ import (
 // searchMessagesAction implements connectors.Action for slack.search_messages.
 // It searches messages across channels via POST /search.messages.
 //
-// This Slack endpoint requires a user token (xoxp-) with the search:read.*
-// scopes. Bot tokens (xoxb-) do NOT support search.messages. The action
-// automatically uses the user_access_token credential (populated by the Slack
-// OAuth v2 flow) when available, falling back to the default access_token
-// with a clear error if search fails due to missing permissions.
+// This Slack endpoint requires a user token (xoxp-) with search:read.
 type searchMessagesAction struct {
 	conn *SlackConnector
 }
@@ -136,13 +132,8 @@ func (a *searchMessagesAction) Execute(ctx context.Context, req connectors.Actio
 		body.Page = 1
 	}
 
-	// Use the user access token for search (bot tokens don't support search.messages).
-	// If no user token is available, fall back to the default token — the Slack API
-	// will return a clear permission error.
-	creds := credentialsForChat(req.Credentials)
-
 	var resp searchMessagesResponse
-	if err := a.conn.doPost(ctx, "search.messages", creds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "search.messages", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/send_dm.go
+++ b/connectors/slack/send_dm.go
@@ -49,12 +49,10 @@ func (a *sendDMAction) Execute(ctx context.Context, req connectors.ActionRequest
 		return nil, err
 	}
 
-	creds := credentialsForChat(req.Credentials)
-
 	// Step 1: Open (or reuse) a DM channel with the user.
 	openBody := conversationsOpenRequest{Users: params.UserID}
 	var openResp conversationsOpenResponse
-	if err := a.conn.doPost(ctx, "conversations.open", creds, openBody, &openResp); err != nil {
+	if err := a.conn.doPost(ctx, "conversations.open", req.Credentials, openBody, &openResp); err != nil {
 		return nil, err
 	}
 	if !openResp.OK {
@@ -69,7 +67,7 @@ func (a *sendDMAction) Execute(ctx context.Context, req connectors.ActionRequest
 		Text:    params.Message,
 	}
 	var msgResp sendMessageResponse
-	if err := a.conn.doPost(ctx, "chat.postMessage", creds, msgBody, &msgResp); err != nil {
+	if err := a.conn.doPost(ctx, "chat.postMessage", req.Credentials, msgBody, &msgResp); err != nil {
 		return nil, err
 	}
 	if !msgResp.OK {

--- a/connectors/slack/send_message.go
+++ b/connectors/slack/send_message.go
@@ -53,9 +53,8 @@ func (a *sendMessageAction) Execute(ctx context.Context, req connectors.ActionRe
 		Text:    params.Message,
 	}
 
-	creds := credentialsForChat(req.Credentials)
 	var resp sendMessageResponse
-	if err := a.conn.doPost(ctx, "chat.postMessage", creds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "chat.postMessage", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -18,12 +18,9 @@ import (
 )
 
 const (
-	defaultBaseURL           = "https://slack.com/api"
-	defaultTimeout           = 30 * time.Second
-	credKeyAccessToken       = "access_token"
-	credKeyUserAccessToken   = "user_access_token"
-	credKeyBotToken          = "bot_token"
-	botTokenPrefix           = "xoxb-"
+	defaultBaseURL     = "https://slack.com/api"
+	defaultTimeout     = 30 * time.Second
+	credKeyAccessToken = "access_token"
 
 	// defaultRetryAfter is used when the Slack API returns a rate limit
 	// response without a Retry-After header (or an unparseable one).
@@ -36,53 +33,32 @@ const (
 	maxResponseBytes = 10 << 20 // 10 MB
 )
 
-// OAuthScopes is the canonical list of bot-level OAuth scopes required by
-// Slack connector actions. These are requested via the "scope" parameter in
-// the Slack OAuth v2 authorization URL and result in a bot token (xoxb-).
-//
-// Note: search:read.* scopes have been moved to OAuthUserScopes because
-// Slack's search.messages endpoint only supports user tokens (xoxp-).
+// OAuthScopes is the canonical list of user-level OAuth scopes for Slack.
+// These are requested via the "user_scope" parameter in the Slack OAuth v2
+// authorization URL (no bot "scope" param). The resulting user token (xoxp-)
+// is stored as the connection's primary access_token.
 var OAuthScopes = []string{
 	"channels:history",
-	"channels:join",
-	"channels:manage",
 	"channels:read",
+	"channels:write",
+	"channels:write.topic",
 	"chat:write",
+	"files:read",
 	"files:write",
 	"groups:history",
 	"groups:read",
+	"groups:write",
 	"im:history",
 	"im:read",
 	"im:write",
 	"mpim:history",
 	"mpim:read",
 	"mpim:write",
+	"reactions:read",
 	"reactions:write",
+	"search:read",
 	"users:read",
 	"users:read.email",
-}
-
-// OAuthUserScopes is the list of user-level OAuth scopes requested via the
-// "user_scope" parameter in the Slack OAuth v2 authorization URL. These
-// result in a user token (xoxp-) returned in the authed_user field of the
-// OAuth response. Scope groups are labeled inline below.
-var OAuthUserScopes = []string{
-	// Search (search.messages does not accept bot tokens)
-	"search:read.public",
-	"search:read.private",
-	"search:read.im",
-	"search:read.mpim",
-	"search:read.files",
-	// Chat actions as the authorizing user
-	"chat:write",
-	// DM/MPIM history (conversations.history / conversations.replies on user token)
-	"im:history",
-	"mpim:history",
-	// users.conversations — list DMs / private convos the bot is not in
-	"channels:read",
-	"groups:read",
-	"im:read",
-	"mpim:read",
 }
 
 // SlackConnector owns the shared HTTP client and base URL used by all
@@ -134,23 +110,13 @@ func (c *SlackConnector) Actions() map[string]connectors.Action {
 	}
 }
 
-// ValidateCredentials checks that the provided credentials contain either a
-// non-empty access_token (OAuth) or a bot_token with the xoxb- prefix.
-// OAuth access tokens are accepted without format validation since they are
-// managed by the platform's OAuth infrastructure.
+// ValidateCredentials checks that the provided credentials contain a non-empty
+// access_token (Slack user OAuth token from the platform).
 func (c *SlackConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
-	// Prefer access_token (OAuth path).
 	if token, ok := creds.Get(credKeyAccessToken); ok && token != "" {
 		return nil
 	}
-	// Fall back to bot_token (legacy path).
-	if token, ok := creds.Get(credKeyBotToken); ok && token != "" {
-		if len(token) < len(botTokenPrefix) || token[:len(botTokenPrefix)] != botTokenPrefix {
-			return &connectors.ValidationError{Message: "bot_token must start with \"xoxb-\""}
-		}
-		return nil
-	}
-	return &connectors.ValidationError{Message: "missing required credential: access_token or bot_token"}
+	return &connectors.ValidationError{Message: "missing required credential: access_token"}
 }
 
 // slackResponse is the common envelope for Slack Web API responses.
@@ -261,46 +227,12 @@ func validateLimit(limit int) error {
 	return nil
 }
 
-// getToken extracts the auth token from credentials, preferring access_token
-// (OAuth) over bot_token (legacy). Both token types use Bearer auth with the
-// Slack API.
+// getToken extracts the Slack user OAuth access_token from credentials.
 func (c *SlackConnector) getToken(creds connectors.Credentials) (string, error) {
 	if token, ok := creds.Get(credKeyAccessToken); ok && token != "" {
 		return token, nil
 	}
-	if token, ok := creds.Get(credKeyBotToken); ok && token != "" {
-		return token, nil
-	}
-	return "", &connectors.ValidationError{Message: "credential is missing: access_token or bot_token"}
-}
-
-// credentialsForChat returns credentials for Slack chat.* and conversations.open
-// calls: when user_access_token is set (OAuth user token / xoxp-), it is swapped
-// into access_token so doPost posts as the authorizing user; otherwise the
-// original credentials are used (bot token path).
-func credentialsForChat(creds connectors.Credentials) connectors.Credentials {
-	if userToken, ok := creds.Get(credKeyUserAccessToken); ok && userToken != "" {
-		return connectors.NewCredentials(map[string]string{credKeyAccessToken: userToken})
-	}
-	return creds
-}
-
-// credentialsForUserTokenIfDirectOrGroupDM selects the user OAuth token for API
-// calls scoped to a DM (D…) or group DM (G…) when user_access_token is present.
-// The bot is often not a member of the user’s 1:1 and MPIM conversations, so
-// conversations.members and conversations.history fail with the bot token even
-// when the authorizing human is a participant.
-func credentialsForUserTokenIfDirectOrGroupDM(creds connectors.Credentials, channelID string) connectors.Credentials {
-	if channelID == "" {
-		return creds
-	}
-	switch channelID[0] {
-	case 'D', 'G':
-		if userToken, ok := creds.Get(credKeyUserAccessToken); ok && userToken != "" {
-			return connectors.NewCredentials(map[string]string{credKeyAccessToken: userToken})
-		}
-	}
-	return creds
+	return "", &connectors.ValidationError{Message: "credential is missing: access_token"}
 }
 
 // doPost is the shared request lifecycle for all Slack actions. It marshals
@@ -408,9 +340,9 @@ func mapSlackError(slackErr string) error {
 	case "not_authed", "invalid_auth", "token_revoked", "token_expired", "account_inactive":
 		return &connectors.AuthError{Message: fmt.Sprintf("Slack auth error: %s", slackErr)}
 	case "missing_scope":
-		return &connectors.AuthError{Message: "Slack token is missing a required OAuth scope — if posting as yourself, re-authorize the Slack connection so your user token includes chat:write; otherwise check bot scopes at https://api.slack.com/apps"}
+		return &connectors.AuthError{Message: "Slack token is missing a required OAuth scope — re-authorize the Slack connection at https://api.slack.com/apps"}
 	case "not_allowed_token_type":
-		return &connectors.AuthError{Message: "Slack rejected this request for the token type in use — reconnect Slack or use an action that supports your current token (user vs bot)"}
+		return &connectors.AuthError{Message: "Slack rejected this request for the token type in use — reconnect Slack"}
 
 	// Rate limiting
 	case "ratelimited":
@@ -418,9 +350,9 @@ func mapSlackError(slackErr string) error {
 
 	// Channel errors
 	case "channel_not_found":
-		return &connectors.ExternalError{StatusCode: 200, Message: "Slack channel not found — verify the channel ID exists and the bot has access"}
+		return &connectors.ExternalError{StatusCode: 200, Message: "Slack channel not found — verify the channel ID exists and you have access"}
 	case "not_in_channel":
-		return &connectors.ExternalError{StatusCode: 200, Message: "bot is not a member of this channel — invite the bot first"}
+		return &connectors.ExternalError{StatusCode: 200, Message: "you are not a member of this channel"}
 	case "is_archived":
 		return &connectors.ExternalError{StatusCode: 200, Message: "cannot perform this action on an archived channel"}
 
@@ -434,7 +366,7 @@ func mapSlackError(slackErr string) error {
 	case "already_in_channel":
 		return &connectors.ExternalError{StatusCode: 200, Message: "one or more users are already members of this channel"}
 	case "cant_invite_self":
-		return &connectors.ExternalError{StatusCode: 200, Message: "the bot cannot invite itself to a channel"}
+		return &connectors.ExternalError{StatusCode: 200, Message: "you cannot invite yourself to a channel"}
 	case "user_not_found":
 		return &connectors.ExternalError{StatusCode: 200, Message: "one or more user IDs were not found — verify the user IDs are correct"}
 
@@ -442,11 +374,11 @@ func mapSlackError(slackErr string) error {
 	case "message_not_found":
 		return &connectors.ExternalError{StatusCode: 200, Message: "message not found — verify the channel ID and message timestamp are correct"}
 	case "cant_delete_message":
-		return &connectors.ExternalError{StatusCode: 200, Message: "cannot delete this message — bots can only delete their own messages"}
+		return &connectors.ExternalError{StatusCode: 200, Message: "cannot delete this message — you can only delete your own messages"}
 	case "edit_window_closed":
 		return &connectors.ExternalError{StatusCode: 200, Message: "the message editing window has closed — messages can only be edited within a limited time"}
 	case "cant_update_message":
-		return &connectors.ExternalError{StatusCode: 200, Message: "cannot update this message — bots can only edit their own messages"}
+		return &connectors.ExternalError{StatusCode: 200, Message: "cannot update this message — you can only edit your own messages"}
 
 	// Message errors
 	case "time_in_past":

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -61,53 +61,18 @@ func TestSlackConnector_ValidateCredentials(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid bot_token",
-			creds:   connectors.NewCredentials(map[string]string{"bot_token": "xoxb-1234567890-abcdef"}),
+			name:    "valid access_token (OAuth user)",
+			creds:   connectors.NewCredentials(map[string]string{"access_token": "xoxp-1234567890-abcdef"}),
 			wantErr: false,
 		},
 		{
-			name:    "valid access_token (OAuth)",
-			creds:   connectors.NewCredentials(map[string]string{"access_token": "xoxb-oauth-token-value"}),
-			wantErr: false,
-		},
-		{
-			name:    "access_token preferred over bot_token",
-			creds:   connectors.NewCredentials(map[string]string{"access_token": "oauth-tok", "bot_token": "xoxb-bot-tok"}),
-			wantErr: false,
-		},
-		{
-			name:    "missing both tokens",
+			name:    "missing token",
 			creds:   connectors.NewCredentials(map[string]string{}),
-			wantErr: true,
-		},
-		{
-			name:    "empty bot_token",
-			creds:   connectors.NewCredentials(map[string]string{"bot_token": ""}),
 			wantErr: true,
 		},
 		{
 			name:    "empty access_token",
 			creds:   connectors.NewCredentials(map[string]string{"access_token": ""}),
-			wantErr: true,
-		},
-		{
-			name:    "wrong prefix xoxp",
-			creds:   connectors.NewCredentials(map[string]string{"bot_token": "xoxp-user-token"}),
-			wantErr: true,
-		},
-		{
-			name:    "wrong prefix xoxa",
-			creds:   connectors.NewCredentials(map[string]string{"bot_token": "xoxa-app-token"}),
-			wantErr: true,
-		},
-		{
-			name:    "wrong prefix bearer",
-			creds:   connectors.NewCredentials(map[string]string{"bot_token": "bearer-123"}),
-			wantErr: true,
-		},
-		{
-			name:    "wrong prefix sk",
-			creds:   connectors.NewCredentials(map[string]string{"bot_token": "sk-123"}),
 			wantErr: true,
 		},
 		{
@@ -160,11 +125,10 @@ func TestSlackConnector_Manifest(t *testing.T) {
 			t.Errorf("Manifest().Actions missing %q", want)
 		}
 	}
-	if len(m.RequiredCredentials) != 2 {
-		t.Fatalf("Manifest().RequiredCredentials has %d items, want 2", len(m.RequiredCredentials))
+	if len(m.RequiredCredentials) != 1 {
+		t.Fatalf("Manifest().RequiredCredentials has %d items, want 1", len(m.RequiredCredentials))
 	}
 
-	// First credential: OAuth2 (primary / recommended)
 	oauthCred := m.RequiredCredentials[0]
 	if oauthCred.Service != "slack" {
 		t.Errorf("oauth credential service = %q, want %q", oauthCred.Service, "slack")
@@ -178,17 +142,8 @@ func TestSlackConnector_Manifest(t *testing.T) {
 	if len(oauthCred.OAuthScopes) == 0 {
 		t.Error("oauth credential oauth_scopes is empty, want at least one scope")
 	}
-
-	// Second credential: bot token (legacy / alternative)
-	botCred := m.RequiredCredentials[1]
-	if botCred.Service != "slack_bot" {
-		t.Errorf("bot credential service = %q, want %q", botCred.Service, "slack_bot")
-	}
-	if botCred.AuthType != "custom" {
-		t.Errorf("bot credential auth_type = %q, want %q", botCred.AuthType, "custom")
-	}
-	if botCred.InstructionsURL == "" {
-		t.Error("bot credential instructions_url is empty, want a URL")
+	if len(oauthCred.OAuthScopes) != len(OAuthScopes) {
+		t.Errorf("oauth credential oauth_scopes has %d entries, want %d (OAuthScopes var)", len(oauthCred.OAuthScopes), len(OAuthScopes))
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/slack/update_message.go
+++ b/connectors/slack/update_message.go
@@ -58,9 +58,8 @@ func (a *updateMessageAction) Execute(ctx context.Context, req connectors.Action
 		Text:    params.Message,
 	}
 
-	creds := credentialsForChat(req.Credentials)
 	var resp updateMessageResponse
-	if err := a.conn.doPost(ctx, "chat.update", creds, body, &resp); err != nil {
+	if err := a.conn.doPost(ctx, "chat.update", req.Credentials, body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/user_token_test.go
+++ b/connectors/slack/user_token_test.go
@@ -9,10 +9,9 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
-func TestSearchMessages_PrefersUserToken(t *testing.T) {
+func TestSearchMessages_UsesAccessToken(t *testing.T) {
 	t.Parallel()
 
-	// Track which token was used in the search request.
 	var receivedToken string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -40,11 +39,8 @@ func TestSearchMessages_PrefersUserToken(t *testing.T) {
 	action := &searchMessagesAction{conn: conn}
 
 	params, _ := json.Marshal(searchMessagesParams{Query: "test"})
-
-	// Provide both bot token (access_token) and user token.
 	creds := connectors.NewCredentials(map[string]string{
-		"access_token":      "xoxb-bot-token",
-		"user_access_token": "xoxp-user-token",
+		"access_token": "xoxp-user-token",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -57,109 +53,41 @@ func TestSearchMessages_PrefersUserToken(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// The user token should have been used, not the bot token.
 	if receivedToken != "Bearer xoxp-user-token" {
-		t.Errorf("expected user token in Authorization header, got %q", receivedToken)
+		t.Errorf("expected access token in Authorization header, got %q", receivedToken)
 	}
 }
 
-func TestSearchMessages_FallsBackToBotToken(t *testing.T) {
+func TestOAuthScopes_IncludesRequiredUserScopes(t *testing.T) {
 	t.Parallel()
 
-	var receivedToken string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/users.lookupByEmail" {
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]any{"id": "U_TEST"},
-			})
-			return
-		}
-		if r.URL.Path == "/search.messages" {
-			receivedToken = r.Header.Get("Authorization")
-		}
-		json.NewEncoder(w).Encode(map[string]any{
-			"ok": true,
-			"messages": map[string]any{
-				"matches": []any{},
-				"paging":  map[string]int{"count": 20, "total": 0, "page": 1, "pages": 0},
-			},
-		})
-	}))
-	defer srv.Close()
-
-	conn := newForTest(srv.Client(), srv.URL)
-	action := &searchMessagesAction{conn: conn}
-
-	params, _ := json.Marshal(searchMessagesParams{Query: "test"})
-
-	// Only bot token, no user token.
-	creds := connectors.NewCredentials(map[string]string{
-		"access_token": "xoxb-bot-token",
-	})
-
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
-		ActionType:  "slack.search_messages",
-		Parameters:  params,
-		Credentials: creds,
-		UserEmail:   "test@example.com",
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	want := map[string]struct{}{
+		"channels:history":     {},
+		"channels:read":        {},
+		"channels:write":       {},
+		"channels:write.topic": {},
+		"chat:write":           {},
+		"files:read":           {},
+		"files:write":          {},
+		"groups:history":       {},
+		"groups:read":          {},
+		"groups:write":         {},
+		"im:history":           {},
+		"im:read":              {},
+		"im:write":             {},
+		"mpim:history":         {},
+		"mpim:read":            {},
+		"mpim:write":           {},
+		"reactions:read":       {},
+		"reactions:write":      {},
+		"search:read":          {},
+		"users:read":           {},
+		"users:read.email":     {},
 	}
-
-	if receivedToken != "Bearer xoxb-bot-token" {
-		t.Errorf("expected bot token in Authorization header, got %q", receivedToken)
-	}
-}
-
-func TestOAuthUserScopes_IncludesSearchChatWriteAndDMHistory(t *testing.T) {
-	t.Parallel()
-
-	// Verify OAuthUserScopes: search, chat:write, DM history, and users.conversations read scopes.
-	expectedSearch := map[string]struct{}{
-		"search:read.public":  {},
-		"search:read.private": {},
-		"search:read.im":      {},
-		"search:read.mpim":    {},
-		"search:read.files":   {},
-	}
-	wantExact := map[string]struct{}{
-		"chat:write":    {},
-		"im:history":    {},
-		"mpim:history":  {},
-		"channels:read": {},
-		"groups:read":   {},
-		"im:read":       {},
-		"mpim:read":     {},
-	}
-	for _, s := range OAuthUserScopes {
-		if _, ok := expectedSearch[s]; ok {
-			delete(expectedSearch, s)
-			continue
-		}
-		if _, ok := wantExact[s]; ok {
-			delete(wantExact, s)
-			continue
-		}
-		t.Errorf("unexpected user scope: %q", s)
-	}
-	for s := range expectedSearch {
-		t.Errorf("missing user scope: %q", s)
-	}
-	for s := range wantExact {
-		t.Errorf("missing user scope: %q", s)
-	}
-}
-
-func TestOAuthScopes_DoNotContainSearchScopes(t *testing.T) {
-	t.Parallel()
-
-	// Verify search scopes have been removed from bot scopes.
 	for _, s := range OAuthScopes {
-		if len(s) >= 11 && s[:11] == "search:read" {
-			t.Errorf("bot OAuthScopes should not contain search scope %q (moved to OAuthUserScopes)", s)
-		}
+		delete(want, s)
+	}
+	for s := range want {
+		t.Errorf("missing OAuth scope: %q", s)
 	}
 }

--- a/db/migrations/20260323155910_slack_user_oauth_mark_needs_reauth.sql
+++ b/db/migrations/20260323155910_slack_user_oauth_mark_needs_reauth.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+-- Slack OAuth is now user-token-only (issue #772). Existing connections may
+-- still store a bot token as the primary vault secret; force re-authorization.
+UPDATE oauth_connections
+SET status = 'needs_reauth', updated_at = now()
+WHERE provider = 'slack' AND status = 'active';
+
+-- +goose Down
+
+-- Not reversible: we cannot distinguish Slack rows that were marked by this
+-- migration from those already in needs_reauth for other reasons.

--- a/db/testhelper/fixtures_oauth.go
+++ b/db/testhelper/fixtures_oauth.go
@@ -24,6 +24,8 @@ type OAuthConnectionOpts struct {
 	Scopes              []string
 	TokenExpiry         *time.Time
 	Status              string
+	// ExtraData is optional JSON for oauth_connections.extra_data (nil = NULL).
+	ExtraData []byte
 }
 
 // InsertOAuthConnectionFull creates an OAuth connection with full control over all fields.
@@ -38,9 +40,9 @@ func InsertOAuthConnectionFull(t *testing.T, d db.DBTX, connID, userID, provider
 		accessVaultID = "00000000-0000-0000-0000-000000000001"
 	}
 	mustExec(t, d,
-		`INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, refresh_token_vault_id, scopes, token_expiry, status)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		connID, userID, provider, accessVaultID, opts.RefreshTokenVaultID, opts.Scopes, opts.TokenExpiry, status)
+		`INSERT INTO oauth_connections (id, user_id, provider, access_token_vault_id, refresh_token_vault_id, scopes, token_expiry, status, extra_data)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		connID, userID, provider, accessVaultID, opts.RefreshTokenVaultID, opts.Scopes, opts.TokenExpiry, status, opts.ExtraData)
 }
 
 // InsertConnectorRequiredCredentialOAuth creates an OAuth-type required credential entry.

--- a/oauth/providers/slack.go
+++ b/oauth/providers/slack.go
@@ -15,13 +15,10 @@ func init() {
 			AuthorizeURL: "https://slack.com/oauth/v2/authorize",
 			TokenURL:     "https://slack.com/api/oauth.v2.access",
 			Scopes:       slackconnector.OAuthScopes,
-			// Slack V2 OAuth requires comma-separated scopes instead of the
-			// standard space-separated format. User scopes (for endpoints
-			// like search.messages that require a user token) are passed via
-			// the separate "user_scope" parameter.
+			// Slack V2 OAuth requires comma-separated scopes. User-token-only
+			// apps request scopes via "user_scope" only (no bot "scope" param).
 			AuthorizeParams: map[string]string{
-				"scope":      strings.Join(slackconnector.OAuthScopes, ","),
-				"user_scope": strings.Join(slackconnector.OAuthUserScopes, ","),
+				"user_scope": strings.Join(slackconnector.OAuthScopes, ","),
 			},
 			ClientID:     os.Getenv("SLACK_CLIENT_ID"),
 			ClientSecret: os.Getenv("SLACK_CLIENT_SECRET"),

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -64,5 +64,23 @@ func RefreshTokens(ctx context.Context, provider Provider, refreshToken string) 
 		result.RefreshToken = refreshToken
 	}
 
+	// Slack oauth.v2.access nests rotated user tokens under authed_user; the
+	// top-level refresh_token often refers to the bot. Normalize so we persist
+	// and rotate the user refresh_token with the user access_token.
+	if provider.ID == "slack" {
+		norm := NormalizeSlackUserOAuthToken(newToken)
+		result.AccessToken = norm.AccessToken
+		if norm.RefreshToken != "" {
+			result.RefreshToken = norm.RefreshToken
+		} else {
+			result.RefreshToken = refreshToken
+		}
+		if !norm.Expiry.IsZero() {
+			result.Expiry = norm.Expiry
+		} else if !newToken.Expiry.IsZero() {
+			result.Expiry = newToken.Expiry
+		}
+	}
+
 	return result, nil
 }

--- a/oauth/slack_token.go
+++ b/oauth/slack_token.go
@@ -1,0 +1,78 @@
+package oauth
+
+import (
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// SlackAuthedUserAccessToken returns authed_user.access_token from a Slack
+// oauth.v2.access response, or "" if absent.
+func SlackAuthedUserAccessToken(tok *oauth2.Token) string {
+	if tok == nil {
+		return ""
+	}
+	authedUser, ok := tok.Extra("authed_user").(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := authedUser["access_token"].(string)
+	return s
+}
+
+// NormalizeSlackUserOAuthToken rewrites a Slack oauth.v2.access (or refresh)
+// token so AccessToken, RefreshToken, and Expiry match the authorizing user
+// when authed_user is present.
+//
+// Slack nests user refresh_token and expires_in under authed_user when token
+// rotation is enabled; the top-level refresh_token refers to the bot token.
+// Without this normalization, we would store a user access_token with a bot
+// refresh_token and refresh would fail or return the wrong token type.
+func NormalizeSlackUserOAuthToken(tok *oauth2.Token) *oauth2.Token {
+	if tok == nil {
+		return nil
+	}
+	authedUser, ok := tok.Extra("authed_user").(map[string]any)
+	if !ok {
+		return tok
+	}
+	userAccess, _ := authedUser["access_token"].(string)
+	if userAccess == "" {
+		return tok
+	}
+	t := *tok
+	t.AccessToken = userAccess
+	if rt, ok := authedUser["refresh_token"].(string); ok && rt != "" {
+		t.RefreshToken = rt
+	}
+	// If authed_user has no refresh_token, keep the top-level value (user-only
+	// apps may issue the refresh at the root). When both bot and user tokens
+	// are returned with rotation, Slack puts the user refresh under authed_user.
+	if exp := slackAuthedUserExpiry(authedUser); exp != nil {
+		t.Expiry = *exp
+	}
+	return &t
+}
+
+func slackAuthedUserExpiry(authedUser map[string]any) *time.Time {
+	v, ok := authedUser["expires_in"]
+	if !ok {
+		return nil
+	}
+	var secs int64
+	switch x := v.(type) {
+	case float64:
+		secs = int64(x)
+	case int:
+		secs = int64(x)
+	case int64:
+		secs = x
+	default:
+		return nil
+	}
+	if secs <= 0 {
+		return nil
+	}
+	e := time.Now().Add(time.Duration(secs) * time.Second)
+	return &e
+}

--- a/oauth/slack_token_test.go
+++ b/oauth/slack_token_test.go
@@ -1,0 +1,72 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestSlackAuthedUserAccessToken(t *testing.T) {
+	t.Parallel()
+	tok := (&oauth2.Token{AccessToken: "xoxb-bot"}).WithExtra(map[string]any{
+		"authed_user": map[string]any{"access_token": "xoxp-user"},
+	})
+	if got := SlackAuthedUserAccessToken(tok); got != "xoxp-user" {
+		t.Errorf("got %q, want xoxp-user", got)
+	}
+	if SlackAuthedUserAccessToken(nil) != "" {
+		t.Error("nil token should return empty")
+	}
+}
+
+func TestNormalizeSlackUserOAuthToken_UserRotation(t *testing.T) {
+	t.Parallel()
+	tok := (&oauth2.Token{
+		AccessToken:  "xoxe.xoxb-bot",
+		RefreshToken: "xoxe-bot-refresh",
+	}).WithExtra(map[string]any{
+		"authed_user": map[string]any{
+			"access_token":  "xoxe.xoxp-user",
+			"refresh_token": "xoxe-user-refresh",
+			"expires_in":    float64(3600),
+		},
+	})
+	out := NormalizeSlackUserOAuthToken(tok)
+	if out.AccessToken != "xoxe.xoxp-user" {
+		t.Errorf("AccessToken = %q", out.AccessToken)
+	}
+	if out.RefreshToken != "xoxe-user-refresh" {
+		t.Errorf("RefreshToken = %q, want user refresh", out.RefreshToken)
+	}
+	if out.Expiry.IsZero() {
+		t.Fatal("expected Expiry from authed_user.expires_in")
+	}
+	if d := time.Until(out.Expiry); d < 3500*time.Second || d > 3700*time.Second {
+		t.Errorf("Expiry not ~1h from now: %v", d)
+	}
+}
+
+func TestNormalizeSlackUserOAuthToken_UserOnlyKeepsTopLevelRefresh(t *testing.T) {
+	t.Parallel()
+	tok := (&oauth2.Token{
+		AccessToken:  "xoxb-ignored",
+		RefreshToken: "top-refresh",
+	}).WithExtra(map[string]any{
+		"authed_user": map[string]any{
+			"access_token": "xoxp-only",
+		},
+	})
+	out := NormalizeSlackUserOAuthToken(tok)
+	if out.AccessToken != "xoxp-only" || out.RefreshToken != "top-refresh" {
+		t.Errorf("got access=%q refresh=%q", out.AccessToken, out.RefreshToken)
+	}
+}
+
+func TestNormalizeSlackUserOAuthToken_NoAuthedUserPassthrough(t *testing.T) {
+	t.Parallel()
+	tok := &oauth2.Token{AccessToken: "plain"}
+	if got := NormalizeSlackUserOAuthToken(tok); got != tok {
+		t.Error("expected same pointer when no authed_user")
+	}
+}

--- a/spec/openapi/components/paths/oauth.yaml
+++ b/spec/openapi/components/paths/oauth.yaml
@@ -63,6 +63,13 @@ oauthAuthorize:
       - A signed state token prevents CSRF and session-fixation attacks
       - The provider must have client credentials configured (built-in or BYOA)
 
+      ### Slack (`provider=slack`)
+
+      Slack uses **user-token-only** OAuth: the server sends Slack **user** scopes via
+      the `user_scope` query parameter and does **not** send a bot `scope` parameter.
+      After consent, the stored connection uses the Slack user token (`xoxp-`) as the
+      primary secret. Workspace bot install is not required.
+
     tags:
       - OAuth
 
@@ -73,7 +80,7 @@ oauthAuthorize:
       - name: provider
         in: path
         required: true
-        description: The OAuth provider ID (e.g. "google", "microsoft", "zoom")
+        description: The OAuth provider ID (e.g. "google", "microsoft", "slack", "zoom")
         schema:
           type: string
       - name: scope
@@ -133,6 +140,15 @@ oauthCallback:
       `?oauth_status=success`. On failure, redirects with `?oauth_status=error`.
 
       This endpoint is called by the OAuth provider, not directly by the frontend.
+
+      ### Slack (`provider=slack`)
+
+      The callback requires Slack to return `authed_user.access_token` (user token).
+      If that field is missing (e.g. app still configured for bot-only scopes), the
+      user is redirected with `oauth_status=error` and an actionable message.
+      When Slack token rotation is enabled, user `refresh_token` and expiry may be
+      nested under `authed_user` in the token response; the server normalizes these
+      before persisting.
 
     tags:
       - OAuth

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -5668,6 +5668,13 @@ paths:
         - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
         - A signed state token prevents CSRF and session-fixation attacks
         - The provider must have client credentials configured (built-in or BYOA)
+
+        ### Slack (`provider=slack`)
+
+        Slack uses **user-token-only** OAuth: the server sends Slack **user** scopes via
+        the `user_scope` query parameter and does **not** send a bot `scope` parameter.
+        After consent, the stored connection uses the Slack user token (`xoxp-`) as the
+        primary secret. Workspace bot install is not required.
       tags:
         - OAuth
       security:
@@ -5676,7 +5683,7 @@ paths:
         - name: provider
           in: path
           required: true
-          description: The OAuth provider ID (e.g. "google", "microsoft", "zoom")
+          description: The OAuth provider ID (e.g. "google", "microsoft", "slack", "zoom")
           schema:
             type: string
         - name: scope
@@ -5724,6 +5731,15 @@ paths:
         `?oauth_status=success`. On failure, redirects with `?oauth_status=error`.
 
         This endpoint is called by the OAuth provider, not directly by the frontend.
+
+        ### Slack (`provider=slack`)
+
+        The callback requires Slack to return `authed_user.access_token` (user token).
+        If that field is missing (e.g. app still configured for bot-only scopes), the
+        user is redirected with `oauth_status=error` and an actionable message.
+        When Slack token rotation is enabled, user `refresh_token` and expiry may be
+        nested under `authed_user` in the token response; the server normalizes these
+        before persisting.
       tags:
         - OAuth
       security:


### PR DESCRIPTION
## Summary

Implements [issue supersuit-tech/permission-slip#772](https://github.com/supersuit-tech/permission-slip/issues/772): Slack connects with **user OAuth only** (no bot/workspace install path). User scopes are requested via `user_scope` only; `authed_user.access_token` is stored as the primary vault secret. Removes dual-token storage, `user_access_token_vault_id`, `credentialsForChat` / DM token switching, and manual `slack_bot` credential.

### Existing Slack connections (release / deploy note)

- Migration `20260323155910_slack_user_oauth_mark_needs_reauth.sql` sets **`status = needs_reauth`** for all **active** `provider = slack` rows so the UI can prompt reconnect.
- Connections created under the old dual-token model may still have a **bot token** in the primary vault secret; they **must complete OAuth again** so the vault holds a user token (`xoxp-`). There is no automatic in-place swap of vault contents.

### Developer
- [x] OAuth provider + connector scopes aligned with issue list
- [x] Callback promotes user token; single `access_token` in vault
- [x] Execution path: no `user_access_token` injection from extra_data
- [x] Manifest: OAuth only; templates/descriptions updated
- [x] Tests updated for single-token behavior
- [ ] CI / `make test-backend` (local Go 1.22.2 cannot satisfy pgx Go 1.24 requirement — please run in CI)

### Manual Testing
- [ ] OAuth as non-admin on workspace without prior app install
- [ ] Spot-check Slack actions post as the human user
- [ ] Re-auth after scope change
- [ ] Slack app dashboard: User Token Scopes only; Events API note in code if using webhooks without bot

## Test plan
- Run `make test-backend` and `make build` in an environment with Go ≥ 1.24 as required by `go.mod` dependencies.

