### PR TITLE
fix(connectors): follow-up on PR 771 review (DRY disabled state, tests, logging)

### DIFF
--- a/connectors/disabled_built_in.go
+++ b/connectors/disabled_built_in.go
@@ -12,7 +12,7 @@ import (
 // seed the database, or appear in connector/OAuth listings. Add an empty file
 // at connectors/<connector_id>/disabled (this path is next to this .go file).
 //
-//go:embed kroger/disabled quickbooks/disabled
+//go:embed */disabled
 var disabledBuiltInMarkerFS embed.FS
 
 const disabledMarkerFile = "disabled"

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -19,6 +19,13 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 	if len(ids) == 0 {
 		t.Fatal("no built-in OAuth providers registered — connectors/providers blank import may not have run")
 	}
+	for _, disabledID := range connectors.DisabledBuiltInConnectorIDs() {
+		for _, id := range ids {
+			if id == disabledID {
+				t.Errorf("BuiltInOAuthProviderIDs: disabled connector %q should not appear", disabledID)
+			}
+		}
+	}
 }
 
 // TestBuiltInConnectorsAreRegistered verifies that importing connectors/all
@@ -27,8 +34,9 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 47 active built-in connector packages (two may be disabled via
-	// connectors/<id>/disabled). Update this number when adding or removing connectors.
+	// There are 47 active built-in connector packages; kroger and quickbooks are
+	// disabled via connectors/<id>/disabled (embedded in the binary via //go:embed).
+	// Update this number when adding, removing, or re-enabling connectors.
 	const expected = 47
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -215,9 +215,13 @@ func ListConnectorIDs(ctx context.Context, db DBTX) ([]string, error) {
 
 // DeleteConnectorByID removes a connector and dependent rows (actions,
 // credentials, templates, agent links) via ON DELETE CASCADE.
-func DeleteConnectorByID(ctx context.Context, db DBTX, connectorID string) error {
-	_, err := db.Exec(ctx, `DELETE FROM connectors WHERE id = $1`, connectorID)
-	return err
+// Returns how many rows were deleted (0 if the id was not present).
+func DeleteConnectorByID(ctx context.Context, db DBTX, connectorID string) (int64, error) {
+	ct, err := db.Exec(ctx, `DELETE FROM connectors WHERE id = $1`, connectorID)
+	if err != nil {
+		return 0, err
+	}
+	return ct.RowsAffected(), nil
 }
 
 // GetActionRequiresPaymentMethod checks whether the given action type requires

--- a/db/connectors_test.go
+++ b/db/connectors_test.go
@@ -147,8 +147,12 @@ func TestDeleteConnectorByID(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 
 	testhelper.InsertConnector(t, tx, "gone")
-	if err := db.DeleteConnectorByID(context.Background(), tx, "gone"); err != nil {
+	n, err := db.DeleteConnectorByID(context.Background(), tx, "gone")
+	if err != nil {
 		t.Fatalf("DeleteConnectorByID: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("DeleteConnectorByID: expected 1 row deleted, got %d", n)
 	}
 	ids, err := db.ListConnectorIDs(context.Background(), tx)
 	if err != nil {
@@ -156,6 +160,14 @@ func TestDeleteConnectorByID(t *testing.T) {
 	}
 	if len(ids) != 0 {
 		t.Fatalf("expected connector deleted, still have %v", ids)
+	}
+	// Second delete: idempotent when the row is already gone.
+	n2, err := db.DeleteConnectorByID(context.Background(), tx, "gone")
+	if err != nil {
+		t.Fatalf("DeleteConnectorByID idempotent: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("DeleteConnectorByID idempotent: expected 0 rows, got %d", n2)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -302,18 +302,20 @@ func main() {
 	// Load external connectors from CONNECTORS_DIR (or ~/.permission_slip/connectors/).
 	loadExternalConnectors(registry, deps.DB)
 
-	// Built-in connectors with connectors/<id>/disabled are omitted from the registry
-	// above; purge their DB rows so list APIs stay consistent.
+	// Built-in connectors with connectors/<id>/disabled never register above, so the
+	// in-memory registry is already clean; purge any stale DB rows so list APIs stay consistent.
 	for _, id := range connectors.DisabledBuiltInConnectorIDs() {
-		registry.Remove(id)
 		if deps.DB == nil {
 			continue
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err := db.DeleteConnectorByID(ctx, deps.DB, id)
+		n, err := db.DeleteConnectorByID(ctx, deps.DB, id)
 		cancel()
 		if err != nil {
 			log.Printf("Warning: failed to delete disabled connector %q from database: %v", id, err)
+			continue
+		}
+		if n == 0 {
 			continue
 		}
 		if msg := connectors.DisabledBuiltInConnectorReason(id); msg != "" {

--- a/oauth/disabled_built_in.go
+++ b/oauth/disabled_built_in.go
@@ -1,62 +1,10 @@
 package oauth
 
-import (
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"sync"
-)
-
-var (
-	disabledBuiltInOAuthMu  sync.RWMutex
-	disabledBuiltInOAuthIDs map[string]bool
-)
-
-func init() {
-	ids := make(map[string]bool)
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		disabledBuiltInOAuthIDs = ids
-		return
-	}
-	root := filepath.Dir(file)
-	connRoot := filepath.Join(root, "..", "connectors")
-	entries, err := os.ReadDir(connRoot)
-	if err != nil {
-		disabledBuiltInOAuthIDs = ids
-		return
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		id := e.Name()
-		p := filepath.Join(connRoot, id, "disabled")
-		b, err := os.ReadFile(p)
-		if err != nil {
-			if errorsIsNotExist(err) {
-				continue
-			}
-			continue
-		}
-		if strings.TrimSpace(string(b)) == "" {
-			ids[id] = true
-		}
-	}
-	disabledBuiltInOAuthIDs = ids
-}
-
-func errorsIsNotExist(err error) bool {
-	return err != nil && os.IsNotExist(err)
-}
+import "github.com/supersuit-tech/permission-slip-web/connectors"
 
 // IsBuiltInOAuthProviderDisabled reports whether the built-in OAuth provider
-// with this id is turned off alongside its connector (empty file at
-// connectors/<id>/disabled). Defined here so oauth/providers avoids importing
-// connectors (import cycle).
+// with this id is turned off alongside its connector (marker file at
+// connectors/<id>/disabled, embedded in the binary with the connectors package).
 func IsBuiltInOAuthProviderDisabled(id string) bool {
-	disabledBuiltInOAuthMu.RLock()
-	defer disabledBuiltInOAuthMu.RUnlock()
-	return disabledBuiltInOAuthIDs[id]
+	return connectors.IsBuiltInConnectorDisabled(id)
 }

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -16,11 +16,12 @@ func TestBuiltInOAuthDisabledForKrogerAndQuickBooks(t *testing.T) {
 	}
 }
 
-func TestBuiltInProviders_OmitsDisabledKroger(t *testing.T) {
+func TestBuiltInProviders_OmitsDisabledConnectors(t *testing.T) {
 	t.Parallel()
+	disabled := map[string]bool{"kroger": true, "quickbooks": true}
 	for _, p := range oauth.BuiltInProviders() {
-		if p.ID == "kroger" {
-			t.Fatal("kroger should not appear in BuiltInProviders when connector is disabled")
+		if disabled[p.ID] {
+			t.Errorf("%q should not appear in BuiltInProviders when connector is disabled", p.ID)
 		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses outstanding review feedback on [PR #771](https://github.com/supersuit-tech/permission-slip/pull/771): duplicate / fragile disabled-connector discovery in `oauth`, misleading startup logs after DB cleanup, missing test coverage, and the hardcoded `//go:embed` list.

## Changes

- **`oauth/disabled_built_in.go`** — `IsBuiltInOAuthProviderDisabled` now delegates to `connectors.IsBuiltInConnectorDisabled` (single source of truth, embed-based, production-safe; fixes `runtime.Caller` and aligns semantics with connector disable markers).
- **`connectors/disabled_built_in.go`** — `//go:embed */disabled` so new `connectors/<id>/disabled` files are embedded without editing the directive.
- **`db.DeleteConnectorByID`** — returns `(rowsAffected, error)` so callers can distinguish no-op deletes.
- **`main.go`** — log "removed from database" only when a row was deleted; removed redundant `registry.Remove` in the disabled loop (registry is already clean); comment updated.
- **Tests** — assert disabled IDs never appear in `BuiltInOAuthProviderIDs()`; `BuiltInProviders` test covers quickbooks; `TestDeleteConnectorByID` checks idempotent second delete; clarified built-in connector count comment in `testsetup_test.go`.

## Developer

- [x] `go test ./connectors/... ./oauth/...`
- [x] `GOTOOLCHAIN=go1.24.2 make build` (toolchain pin for local Go 1.22)
- [ ] `make test-backend` with Postgres (`TestDeleteConnectorByID` lives under `db/`)

## Manual Testing

- [ ] Start server with DB: confirm disabled connector rows are deleted once and logs are not noisy on subsequent restarts
- [ ] Confirm Kroger / QuickBooks OAuth providers stay absent from listings in a production-style binary (no source tree)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14aecb6-5a47-4ee3-9d59-7e076c73922a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14aecb6-5a47-4ee3-9d59-7e076c73922a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

