### PR TITLE
fix(ci): resolve Slack OAuth test failures

### DIFF
--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -394,7 +394,8 @@ func TestOAuthAuthorize_Slack_NoBotScopeQueryParam(t *testing.T) {
 	if _, hasScope := q["scope"]; hasScope {
 		t.Errorf("Slack authorize URL must not include bot \"scope\" query key; got scope=%q", q.Get("scope"))
 	}
-	if us := q.Get("user_scope"); us == "" {
+	us := q.Get("user_scope")
+	if us == "" {
 		t.Fatal("expected user_scope query param")
 	}
 	if !strings.Contains(us, "chat:write") {

--- a/connectors/slack/send_message_test.go
+++ b/connectors/slack/send_message_test.go
@@ -19,7 +19,7 @@ func TestSendMessage_Success(t *testing.T) {
 		if r.URL.Path != "/chat.postMessage" {
 			t.Errorf("expected path /chat.postMessage, got %s", r.URL.Path)
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer xoxb-test-token-123" {
+		if got := r.Header.Get("Authorization"); got != "Bearer xoxp-test-token-123" {
 			t.Errorf("expected Bearer token in Authorization header, got %q", got)
 		}
 		if got := r.Header.Get("Content-Type"); got != "application/json; charset=utf-8" {


### PR DESCRIPTION
## Summary

- Fix undefined variable `us` in `TestOAuthAuthorize_Slack_NoBotScopeQueryParam` — variable was scoped inside an `if` block but referenced outside it
- Fix `TestSendMessage_Success` expecting old `xoxb-` bot token prefix instead of `xoxp-` user token after the Slack user-token-only migration

## Test plan

### Developer
- [x] `go test ./connectors/slack/...` passes locally
- [x] `go test ./db/...` passes locally
- [x] CI (backend tests) green
- [x] Audit green

### Manual Testing
- None required — test-only changes

https://claude.ai/code/session_01PWD2Bh36ueQqkfHc6GPKVq