### PR TITLE
Re-enable QuickBooks built-in connector

### DIFF
--- a/connectors/disabled_built_in_test.go
+++ b/connectors/disabled_built_in_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 )
 
-func TestDisabledBuiltInConnectorIDs_IncludesKrogerAndQuickBooks(t *testing.T) {
+func TestDisabledBuiltInConnectorIDs_IncludesKrogerExcludesQuickBooks(t *testing.T) {
 	t.Parallel()
 	ids := DisabledBuiltInConnectorIDs()
-	for _, want := range []string{"kroger", "quickbooks"} {
-		if !slices.Contains(ids, want) {
-			t.Errorf("expected disabled list to include %q, got %v", want, ids)
-		}
+	if !slices.Contains(ids, "kroger") {
+		t.Errorf("expected disabled list to include %q, got %v", "kroger", ids)
+	}
+	if slices.Contains(ids, "quickbooks") {
+		t.Errorf("expected disabled list to exclude %q (connector re-enabled), got %v", "quickbooks", ids)
 	}
 }

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -34,10 +34,10 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 47 active built-in connector packages; kroger and quickbooks are
-	// disabled via connectors/<id>/disabled (embedded in the binary via //go:embed).
+	// There are 48 active built-in connector packages; kroger is disabled via
+	// connectors/kroger/disabled (embedded in the binary via //go:embed).
 	// Update this number when adding, removing, or re-enabling connectors.
-	const expected = 47
+	const expected = 48
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -7,18 +7,19 @@ import (
 	_ "github.com/supersuit-tech/permission-slip-web/oauth/providers"
 )
 
-func TestBuiltInOAuthDisabledForKrogerAndQuickBooks(t *testing.T) {
+func TestBuiltInOAuthDisabledForKrogerNotQuickBooks(t *testing.T) {
 	t.Parallel()
-	for _, id := range []string{"kroger", "quickbooks"} {
-		if !oauth.IsBuiltInOAuthProviderDisabled(id) {
-			t.Errorf("expected %q to be disabled when connectors/%s/disabled exists", id, id)
-		}
+	if !oauth.IsBuiltInOAuthProviderDisabled("kroger") {
+		t.Errorf("expected %q to be disabled when connectors/%s/disabled exists", "kroger", "kroger")
+	}
+	if oauth.IsBuiltInOAuthProviderDisabled("quickbooks") {
+		t.Errorf("expected %q not to be disabled (connector re-enabled)", "quickbooks")
 	}
 }
 
 func TestBuiltInProviders_OmitsDisabledConnectors(t *testing.T) {
 	t.Parallel()
-	disabled := map[string]bool{"kroger": true, "quickbooks": true}
+	disabled := map[string]bool{"kroger": true}
 	for _, p := range oauth.BuiltInProviders() {
 		if disabled[p.ID] {
 			t.Errorf("%q should not appear in BuiltInProviders when connector is disabled", p.ID)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

QuickBooks was turned off via the embedded `connectors/quickbooks/disabled` marker (see `connectors/disabled_built_in.go`). Removing that file re-registers the QuickBooks connector and the Intuit OAuth built-in provider. Kroger remains disabled.

## Test plan

### Developer

- [x] `make build` (with Go 1.24 toolchain and frontend/mobile deps installed)
- [x] `go test ./connectors/... ./oauth/...` — passed as part of `make test-backend` run (connectors/quickbooks, oauth packages OK); full `make test-backend` failed here only where Postgres was unavailable (`db`, `notify` DB-backed tests)

### Manual Testing

- [ ] Confirm QuickBooks appears in connector/OAuth listings and OAuth connect flow works with `QUICKBOOKS_CLIENT_ID` / `QUICKBOOKS_CLIENT_SECRET` set
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0aa04ef-3536-4180-956e-41faffbfb4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0aa04ef-3536-4180-956e-41faffbfb4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

