### PR TITLE
fix(slack): use GET for conversations.info and users.info endpoints

### DIFF
--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -195,17 +195,15 @@ func (c *SlackConnector) hasChannelAccess(ctx context.Context, creds connectors.
 // isChannelPrivate checks whether a C-prefixed channel is private by calling
 // conversations.info and inspecting the is_private field.
 func (c *SlackConnector) isChannelPrivate(ctx context.Context, creds connectors.Credentials, channelID string) (bool, error) {
-	body := struct {
-		Channel string `json:"channel"`
-	}{Channel: channelID}
-
 	var resp struct {
 		slackResponse
 		Channel struct {
 			IsPrivate bool `json:"is_private"`
 		} `json:"channel"`
 	}
-	if err := c.doPost(ctx, "conversations.info", creds, body, &resp); err != nil {
+	// conversations.info only accepts GET / form-encoded POST, not JSON body.
+	// Using doGet avoids the "invalid_arguments" error with user tokens.
+	if err := c.doGet(ctx, "conversations.info", creds, map[string]string{"channel": channelID}, &resp); err != nil {
 		return false, err
 	}
 	if !resp.OK {

--- a/connectors/slack/resolve_resource_details.go
+++ b/connectors/slack/resolve_resource_details.go
@@ -56,8 +56,8 @@ func (c *SlackConnector) resolveChannel(ctx context.Context, creds connectors.Cr
 		Channel channelInfo `json:"channel"`
 	}
 
-	body := map[string]string{"channel": p.Channel}
-	if err := c.doPost(ctx, "conversations.info", creds, body, &resp); err != nil {
+	// conversations.info only accepts GET / form-encoded POST, not JSON body.
+	if err := c.doGet(ctx, "conversations.info", creds, map[string]string{"channel": p.Channel}, &resp); err != nil {
 		return nil, err
 	}
 	if !resp.OK {
@@ -105,8 +105,8 @@ func (c *SlackConnector) resolveUser(ctx context.Context, creds connectors.Crede
 		User userInfo `json:"user"`
 	}
 
-	body := map[string]string{"user": p.UserID}
-	if err := c.doPost(ctx, "users.info", creds, body, &resp); err != nil {
+	// users.info only accepts GET / form-encoded POST, not JSON body.
+	if err := c.doGet(ctx, "users.info", creds, map[string]string{"user": p.UserID}, &resp); err != nil {
 		return nil, err
 	}
 	if !resp.OK {

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
 
@@ -289,6 +290,24 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 	}
 
 	return nil
+}
+
+// doGet sends a GET request to a Slack API method with query parameters.
+// Used for endpoints like conversations.info and users.info that only accept
+// application/x-www-form-urlencoded (not JSON body). The params map is
+// encoded as URL query parameters.
+func (c *SlackConnector) doGet(ctx context.Context, method string, creds connectors.Credentials, params map[string]string, dest any) error {
+	token, err := c.getToken(creds)
+	if err != nil {
+		return err
+	}
+
+	query := neturl.Values{}
+	for k, v := range params {
+		query.Set(k, v)
+	}
+	url := c.baseURL + "/" + method + "?" + query.Encode()
+	return c.doGetURL(ctx, url, token, dest)
 }
 
 // doGetURL sends a GET request to the given full URL with Bearer auth and


### PR DESCRIPTION
## Summary

- **Root cause:** After switching Slack OAuth to user-token-only (xoxp-), `conversations.info` and `users.info` calls started returning `invalid_arguments` because these endpoints only accept GET or form-encoded POST — not `application/json` POST bodies. Bot tokens were more permissive; user tokens enforce this strictly.
- **Fix:** Added a `doGet` helper to the Slack connector that sends parameters as URL query params via GET, and switched `conversations.info` (in `isChannelPrivate` and `resolveChannel`) and `users.info` (in `resolveUser`) to use it.
- **Impact:** This caused two failures: (1) resource detail resolution failed during approval creation (Sentry PERMISSION-SLIP-GO-E), and (2) channel access verification failed during approval execution, giving users an error when they approved read_channel_messages requests.

Fixes: PERMISSION-SLIP-GO-E

## Test plan

### Developer
- [x] All existing Slack connector tests pass (90+ tests)
- [x] `go vet ./connectors/slack/...` clean

### Manual Testing
- [ ] Approve a `slack.read_channel_messages` request and verify messages are returned successfully
- [ ] Verify resource details (channel name) appear on approval cards in the dashboard
- [ ] Test with both public and private channels

https://claude.ai/code/session_01D9Yfr56DPoVbEYiQdnVZAa