### PR TITLE
Slack channel names in UI + channel picker API

### DIFF
--- a/api/agent_connector_channels.go
+++ b/api/agent_connector_channels.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+type channelListResponse struct {
+	Data []connectors.ChannelListItem `json:"data"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentConnectorChannelRoutes)
+}
+
+// RegisterAgentConnectorChannelRoutes registers session-authenticated endpoints
+// that proxy channel metadata for action configuration UIs (e.g. Slack).
+func RegisterAgentConnectorChannelRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /agents/{agent_id}/connectors/{connector_id}/channels", requireProfile(handleListAgentConnectorChannels(deps)))
+}
+
+func handleListAgentConnectorChannels(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		userEmail := UserEmail(r.Context())
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		lister, ok := conn.(connectors.ChannelLister)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "This connector does not support channel listing"))
+			return
+		}
+
+		listAction := lister.ChannelListCredentialActionType()
+		connErrCtx := ConnectorContext{
+			ConnectorID: connectorID,
+			ActionType:  listAction,
+			AgentID:     agentID,
+		}
+		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorChannels required creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to look up connector credentials"))
+			return
+		}
+
+		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorChannels resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorChannels validate creds: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
+
+		items, err := lister.ListChannels(r.Context(), creds, userEmail)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListChannels: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list channels"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, channelListResponse{Data: items})
+	}
+}

--- a/api/agent_connector_channels_test.go
+++ b/api/agent_connector_channels_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/db"
+	"github.com/supersuit-tech/permission-slip-web/db/testhelper"
+	"github.com/supersuit-tech/permission-slip-web/oauth"
+	"github.com/supersuit-tech/permission-slip-web/vault"
+)
+
+type stubChannelConnector struct {
+	id       string
+	listFunc func(context.Context, connectors.Credentials, string) ([]connectors.ChannelListItem, error)
+}
+
+func (s *stubChannelConnector) ID() string { return s.id }
+
+func (s *stubChannelConnector) Actions() map[string]connectors.Action {
+	return nil
+}
+
+func (s *stubChannelConnector) ValidateCredentials(_ context.Context, _ connectors.Credentials) error {
+	return nil
+}
+
+func (s *stubChannelConnector) ListChannels(ctx context.Context, creds connectors.Credentials, userEmail string) ([]connectors.ChannelListItem, error) {
+	if s.listFunc != nil {
+		return s.listFunc(ctx, creds, userEmail)
+	}
+	return []connectors.ChannelListItem{
+		{ID: "C1", DisplayLabel: "#general", NumMembers: 10},
+	}, nil
+}
+
+func (s *stubChannelConnector) ChannelListCredentialActionType() string {
+	return s.id + ".list_channels"
+}
+
+func decodeChannelList(t *testing.T, body []byte) channelListResponse {
+	t.Helper()
+	var resp channelListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal channel list: %v", err)
+	}
+	return resp
+}
+
+func TestListAgentConnectorChannels_NoCredentialBinding(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+
+	connID := "chstub"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_channels", "List channels")
+	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID, connID, nil)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	reg := connectors.NewRegistry()
+	reg.Register(&stubChannelConnector{id: connID})
+
+	v := vault.NewMockVaultStore()
+	oauthReg := oauth.NewRegistry()
+	_ = oauthReg.Register(oauth.Provider{
+		ID:           connID,
+		AuthorizeURL: "https://example.com/oauth/authorize",
+		TokenURL:     "https://example.com/oauth/token",
+		ClientID:     "test",
+		ClientSecret: "test",
+		Source:       oauth.SourceBuiltIn,
+	})
+	deps := &Deps{
+		DB:                tx,
+		Vault:             v,
+		Connectors:        reg,
+		OAuthProviders:    oauthReg,
+		SupabaseJWTSecret: testJWTSecret,
+	}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/channels", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAgentConnectorChannels_Success(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+
+	connID := "chstub"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".list_channels", "List channels")
+	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, connID, connID, nil)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	oauthConnID := testhelper.GenerateID(t, "oconn_")
+	testhelper.InsertOAuthConnection(t, tx, oauthConnID, uid, connID)
+	oauthRow, err := db.GetOAuthConnectionByProvider(t.Context(), tx, uid, connID)
+	if err != nil {
+		t.Fatalf("GetOAuthConnectionByProvider: %v", err)
+	}
+	bindingID := testhelper.GenerateID(t, "accr_")
+	if _, err := db.UpsertAgentConnectorCredential(t.Context(), tx, db.UpsertAgentConnectorCredentialParams{
+		ID: bindingID, AgentID: agentID, ConnectorID: connID,
+		ApproverID: uid, OAuthConnectionID: &oauthRow.ID,
+	}); err != nil {
+		t.Fatalf("UpsertAgentConnectorCredential: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(&stubChannelConnector{
+		id: connID,
+		listFunc: func(_ context.Context, creds connectors.Credentials, email string) ([]connectors.ChannelListItem, error) {
+			tok, _ := creds.Get("access_token")
+			if tok == "" {
+				t.Error("expected non-empty access_token in credentials")
+			}
+			if email != "test@example.com" {
+				t.Errorf("expected user email test@example.com, got %q", email)
+			}
+			return []connectors.ChannelListItem{
+				{ID: "C111", DisplayLabel: "#announcements", IsPrivate: false, NumMembers: 5},
+				{ID: "G222", DisplayLabel: "private-team", IsPrivate: true},
+			}, nil
+		},
+	})
+
+	v := vault.NewMockVaultStore()
+	v.SeedSecretForTest(oauthRow.AccessTokenVaultID, []byte(`{"access_token":"tok-test"}`))
+
+	oauthReg := oauth.NewRegistry()
+	_ = oauthReg.Register(oauth.Provider{
+		ID:           connID,
+		AuthorizeURL: "https://example.com/oauth/authorize",
+		TokenURL:     "https://example.com/oauth/token",
+		ClientID:     "test",
+		ClientSecret: "test",
+		Source:       oauth.SourceBuiltIn,
+	})
+	deps := &Deps{
+		DB:                tx,
+		Vault:             v,
+		Connectors:        reg,
+		OAuthProviders:    oauthReg,
+		SupabaseJWTSecret: testJWTSecret,
+	}
+	router := NewRouter(deps)
+
+	r := authenticatedRequestWithEmail(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/channels", agentID, connID), uid, "test@example.com")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeChannelList(t, w.Body.Bytes())
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(resp.Data))
+	}
+	if resp.Data[0].ID != "C111" || resp.Data[0].DisplayLabel != "#announcements" {
+		t.Errorf("unexpected first item: %+v", resp.Data[0])
+	}
+}

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -41,6 +41,21 @@ func authenticatedRequest(t *testing.T, method, path, userID string) *http.Reque
 	return r
 }
 
+// authenticatedRequestWithEmail is like authenticatedRequest but sets the JWT
+// email claim (used by endpoints that pass UserEmail to connectors).
+func authenticatedRequestWithEmail(t *testing.T, method, path, userID, email string) *http.Request {
+	t.Helper()
+	token := makeToken(t, testJWTSecret, jwt.MapClaims{
+		"sub":   userID,
+		"email": email,
+		"aud":   SupabaseAudAuthenticated,
+		"exp":   time.Now().Add(time.Hour).Unix(),
+	})
+	r := httptest.NewRequest(method, path, nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	return r
+}
+
 // authenticatedJSONRequest creates an authenticated HTTP request with a JSON body.
 // Use this for POST/PUT/PATCH endpoints that accept JSON payloads.
 func authenticatedJSONRequest(t *testing.T, method, path, userID, body string) *http.Request {

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -129,3 +129,24 @@ type CalendarLister interface {
 	CalendarListCredentialActionType() string
 }
 
+// ChannelListItem is one Slack (or similar) channel row for dashboard pickers.
+type ChannelListItem struct {
+	ID           string `json:"id"`
+	Name         string `json:"name,omitempty"`
+	User         string `json:"user,omitempty"`
+	IsPrivate    bool   `json:"is_private,omitempty"`
+	IsIM         bool   `json:"is_im,omitempty"`
+	IsMPIM       bool   `json:"is_mpim,omitempty"`
+	NumMembers   int    `json:"num_members,omitempty"`
+	DisplayLabel string `json:"display_label"`
+}
+
+// ChannelLister is optionally implemented by connectors that can list channels
+// for UI configuration (session-authenticated proxy endpoints).
+type ChannelLister interface {
+	ListChannels(ctx context.Context, creds Credentials, userEmail string) ([]ChannelListItem, error)
+	// ChannelListCredentialActionType is the connector_actions.action_type used
+	// to look up required credentials for this list call (must exist in the DB).
+	ChannelListCredentialActionType() string
+}
+

--- a/connectors/slack/channel_lister.go
+++ b/connectors/slack/channel_lister.go
@@ -1,0 +1,91 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+var _ connectors.ChannelLister = (*SlackConnector)(nil)
+
+const slackChannelListMaxPages = 50
+
+// ChannelListCredentialActionType returns the action type used for credential
+// resolution on the agent connector channels API.
+func (c *SlackConnector) ChannelListCredentialActionType() string {
+	return "slack.list_channels"
+}
+
+// ListChannels returns channels for dashboard pickers, using the same listing
+// rules as slack.list_channels. Paginates until Slack returns no next_cursor
+// or a safety cap is hit.
+func (c *SlackConnector) ListChannels(ctx context.Context, creds connectors.Credentials, userEmail string) ([]connectors.ChannelListItem, error) {
+	var all []listChannelSummary
+	cursor := ""
+	for page := 0; page < slackChannelListMaxPages; page++ {
+		params := listChannelsParams{
+			Limit:           200,
+			Cursor:          cursor,
+			ExcludeArchived: boolPtr(true),
+		}
+		batch, err := c.listChannelsMerged(ctx, creds, userEmail, params)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch.Channels...)
+		if batch.NextCursor == "" {
+			break
+		}
+		cursor = batch.NextCursor
+	}
+	if cursor != "" {
+		return nil, fmt.Errorf("slack channel list exceeded max pages (%d)", slackChannelListMaxPages)
+	}
+	out := make([]connectors.ChannelListItem, 0, len(all))
+	for _, ch := range all {
+		out = append(out, connectors.ChannelListItem{
+			ID:           ch.ID,
+			Name:         ch.Name,
+			User:         ch.User,
+			IsPrivate:    ch.IsPrivate,
+			IsIM:         ch.IsIM,
+			IsMPIM:       ch.IsMPIM,
+			NumMembers:   ch.NumMembers,
+			DisplayLabel: slackChannelPickerLabel(ch),
+		})
+	}
+	return out, nil
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+// slackChannelPickerLabel matches approval-time resolution: # prefix for public
+// channels, bare name for private, human-readable labels for DMs.
+func slackChannelPickerLabel(ch listChannelSummary) string {
+	if ch.IsIM || (len(ch.ID) > 0 && ch.ID[0] == 'D') {
+		if ch.Name != "" {
+			return ch.Name
+		}
+		if ch.User != "" {
+			return "DM · " + ch.User
+		}
+		return "Direct message"
+	}
+	if ch.IsMPIM {
+		if ch.Name != "" {
+			return ch.Name
+		}
+		return "Group DM"
+	}
+	if ch.IsPrivate {
+		if ch.Name != "" {
+			return ch.Name
+		}
+		return ch.ID
+	}
+	if ch.Name != "" {
+		return "#" + ch.Name
+	}
+	return ch.ID
+}

--- a/connectors/slack/channel_lister_test.go
+++ b/connectors/slack/channel_lister_test.go
@@ -1,0 +1,51 @@
+package slack
+
+import "testing"
+
+func TestSlackChannelPickerLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ch   listChannelSummary
+		want string
+	}{
+		{
+			name: "public with name",
+			ch:   listChannelSummary{ID: "C1", Name: "general", IsPrivate: false},
+			want: "#general",
+		},
+		{
+			name: "private with name",
+			ch:   listChannelSummary{ID: "G1", Name: "secret", IsPrivate: true},
+			want: "secret",
+		},
+		{
+			name: "im with user fallback",
+			ch:   listChannelSummary{ID: "D1", User: "U99"},
+			want: "DM · U99",
+		},
+		{
+			name: "im with display name",
+			ch:   listChannelSummary{ID: "D1", Name: "alice", User: "U99"},
+			want: "alice",
+		},
+		{
+			name: "mpim without name",
+			ch:   listChannelSummary{ID: "G2", IsMPIM: true},
+			want: "Group DM",
+		},
+		{
+			name: "empty name falls back to id",
+			ch:   listChannelSummary{ID: "C9", IsPrivate: false},
+			want: "C9",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := slackChannelPickerLabel(tc.ch); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -81,6 +80,8 @@ type listChannelSummary struct {
 	Name       string `json:"name,omitempty"`
 	User       string `json:"user,omitempty"`
 	IsPrivate  bool   `json:"is_private"`
+	IsIM       bool   `json:"is_im,omitempty"`
+	IsMPIM     bool   `json:"is_mpim,omitempty"`
 	Topic      string `json:"topic,omitempty"`
 	Purpose    string `json:"purpose,omitempty"`
 	NumMembers int    `json:"num_members"`
@@ -95,133 +96,11 @@ func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionR
 		return nil, err
 	}
 
-	excludeArchived := true
-	if params.ExcludeArchived != nil {
-		excludeArchived = *params.ExcludeArchived
-	}
-
-	types := params.Types
-	explicitTypes := types != ""
-	if types == "" {
-		types = "public_channel,private_channel,mpim,im"
-	}
-
-	// When listing private channels, group DMs, or DMs, resolve the user's
-	// Slack identity and pre-fetch their channel memberships so we can filter
-	// results efficiently. Uses users.conversations (one paginated call) instead
-	// of per-channel isUserInChannel to avoid N+1 API calls.
-	//
-	// If the caller didn't explicitly request private types (using the default)
-	// and has no email set, gracefully fall back to public_channel only instead
-	// of returning an error. This preserves backward compatibility for callers
-	// that previously relied on the old public_channel-only default.
-	var userChannelIDs map[string]bool
-	var userPrivateMerge []listChannelEntry
-	if channelTypesIncludePrivate(types) {
-		if req.UserEmail == "" {
-			if explicitTypes {
-				return nil, &connectors.ValidationError{
-					Message: "listing private channels, group DMs, or DMs requires your Permission Slip profile to have an email address matching your Slack account",
-				}
-			}
-			// Graceful fallback: caller used the default, so fall back to
-			// public channels only rather than breaking existing integrations.
-			types = "public_channel"
-		} else {
-			slackUserID, err := a.conn.lookupSlackUserByEmail(ctx, req.Credentials, req.UserEmail)
-			if err != nil {
-				return nil, fmt.Errorf("unable to verify Slack identity: %w", err)
-			}
-			if slackUserID == "" {
-				return nil, &connectors.ValidationError{
-					Message: fmt.Sprintf("no Slack user found matching email %q — ensure your Permission Slip email matches your Slack account", req.UserEmail),
-				}
-			}
-			// Only fetch memberships for private channel types — public channels
-			// are never filtered, so including them wastes API quota.
-			privateTypes := filterPrivateTypes(types)
-			userPrivateChs, err := a.conn.getUserPrivateConversations(ctx, req.Credentials, slackUserID, privateTypes)
-			if err != nil {
-				return nil, fmt.Errorf("fetching user channel memberships: %w", err)
-			}
-			userPrivateMerge = userPrivateChs
-			userChannelIDs = make(map[string]bool, len(userPrivateChs))
-			for _, ch := range userPrivateChs {
-				userChannelIDs[ch.ID] = true
-			}
-		}
-	}
-
-	body := listChannelsRequest{
-		Types:           types,
-		Limit:           params.Limit,
-		Cursor:          params.Cursor,
-		ExcludeArchived: excludeArchived,
-	}
-	if body.Limit == 0 {
-		body.Limit = 100
-	}
-
-	var resp listChannelsResponse
-	if err := a.conn.doPost(ctx, "conversations.list", req.Credentials, body, &resp); err != nil {
+	result, err := a.conn.listChannelsMerged(ctx, req.Credentials, req.UserEmail, params)
+	if err != nil {
 		return nil, err
 	}
-
-	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
-	}
-
-	seen := make(map[string]bool)
-	result := listChannelsResult{
-		Channels: make([]listChannelSummary, 0, len(resp.Channels)+len(userPrivateMerge)),
-	}
-	for _, ch := range resp.Channels {
-		// For private channel types, filter to only channels the user is a member of.
-		// Uses the pre-fetched userChannelIDs set for O(1) lookups instead of per-channel API calls.
-		if userChannelIDs != nil && (ch.IsPrivate || strings.HasPrefix(ch.ID, "D") || strings.HasPrefix(ch.ID, "G")) {
-			if !userChannelIDs[ch.ID] {
-				continue
-			}
-		}
-		seen[ch.ID] = true
-		result.Channels = append(result.Channels, listChannelSummary{
-			ID:         ch.ID,
-			Name:       ch.Name,
-			User:       ch.User,
-			IsPrivate:  ch.IsPrivate,
-			Topic:      ch.Topic.Value,
-			Purpose:    ch.Purpose.Value,
-			NumMembers: ch.NumMembers,
-		})
-	}
-	// Add human-only DMs / MPIMs / private channels from users.conversations that
-	// conversations.list (bot token) did not return.
-	for _, ch := range userPrivateMerge {
-		if excludeArchived && ch.IsArchived {
-			continue
-		}
-		if !listChannelEntryMatchesTypes(types, ch) {
-			continue
-		}
-		if seen[ch.ID] {
-			continue
-		}
-		seen[ch.ID] = true
-		result.Channels = append(result.Channels, listChannelSummary{
-			ID:         ch.ID,
-			Name:       ch.Name,
-			User:       ch.User,
-			IsPrivate:  ch.IsPrivate,
-			Topic:      ch.Topic.Value,
-			Purpose:    ch.Purpose.Value,
-			NumMembers: ch.NumMembers,
-		})
-	}
-	if resp.Meta != nil {
-		result.NextCursor = resp.Meta.NextCursor
-	}
-
-	return connectors.JSONResult(result)
+	return connectors.JSONResult(*result)
 }
 
 // listChannelEntryMatchesTypes returns whether ch should be included for the

--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -1,0 +1,128 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listChannelsMerged lists Slack channels using the same merge logic as
+// slack.list_channels (conversations.list + users.conversations when needed).
+func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connectors.Credentials, userEmail string, params listChannelsParams) (*listChannelsResult, error) {
+	excludeArchived := true
+	if params.ExcludeArchived != nil {
+		excludeArchived = *params.ExcludeArchived
+	}
+
+	types := params.Types
+	explicitTypes := types != ""
+	if types == "" {
+		types = "public_channel,private_channel,mpim,im"
+	}
+
+	var userChannelIDs map[string]bool
+	var userPrivateMerge []listChannelEntry
+	if channelTypesIncludePrivate(types) {
+		if userEmail == "" {
+			if explicitTypes {
+				return nil, &connectors.ValidationError{
+					Message: "listing private channels, group DMs, or DMs requires your Permission Slip profile to have an email address matching your Slack account",
+				}
+			}
+			types = "public_channel"
+		} else {
+			slackUserID, err := c.lookupSlackUserByEmail(ctx, creds, userEmail)
+			if err != nil {
+				return nil, fmt.Errorf("unable to verify Slack identity: %w", err)
+			}
+			if slackUserID == "" {
+				return nil, &connectors.ValidationError{
+					Message: fmt.Sprintf("no Slack user found matching email %q — ensure your Permission Slip email matches your Slack account", userEmail),
+				}
+			}
+			privateTypes := filterPrivateTypes(types)
+			userPrivateChs, err := c.getUserPrivateConversations(ctx, creds, slackUserID, privateTypes)
+			if err != nil {
+				return nil, fmt.Errorf("fetching user channel memberships: %w", err)
+			}
+			userPrivateMerge = userPrivateChs
+			userChannelIDs = make(map[string]bool, len(userPrivateChs))
+			for _, ch := range userPrivateChs {
+				userChannelIDs[ch.ID] = true
+			}
+		}
+	}
+
+	body := listChannelsRequest{
+		Types:           types,
+		Limit:           params.Limit,
+		Cursor:          params.Cursor,
+		ExcludeArchived: excludeArchived,
+	}
+	if body.Limit == 0 {
+		body.Limit = 100
+	}
+
+	var resp listChannelsResponse
+	if err := c.doPost(ctx, "conversations.list", creds, body, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, mapSlackError(resp.Error)
+	}
+
+	seen := make(map[string]bool)
+	result := listChannelsResult{
+		Channels: make([]listChannelSummary, 0, len(resp.Channels)+len(userPrivateMerge)),
+	}
+	for _, ch := range resp.Channels {
+		if userChannelIDs != nil && (ch.IsPrivate || strings.HasPrefix(ch.ID, "D") || strings.HasPrefix(ch.ID, "G")) {
+			if !userChannelIDs[ch.ID] {
+				continue
+			}
+		}
+		seen[ch.ID] = true
+		result.Channels = append(result.Channels, listChannelSummary{
+			ID:         ch.ID,
+			Name:       ch.Name,
+			User:       ch.User,
+			IsPrivate:  ch.IsPrivate,
+			IsIM:       ch.IsIM,
+			IsMPIM:     ch.IsMPIM,
+			Topic:      ch.Topic.Value,
+			Purpose:    ch.Purpose.Value,
+			NumMembers: ch.NumMembers,
+		})
+	}
+	for _, ch := range userPrivateMerge {
+		if excludeArchived && ch.IsArchived {
+			continue
+		}
+		if !listChannelEntryMatchesTypes(types, ch) {
+			continue
+		}
+		if seen[ch.ID] {
+			continue
+		}
+		seen[ch.ID] = true
+		result.Channels = append(result.Channels, listChannelSummary{
+			ID:         ch.ID,
+			Name:       ch.Name,
+			User:       ch.User,
+			IsPrivate:  ch.IsPrivate,
+			IsIM:       ch.IsIM,
+			IsMPIM:     ch.IsMPIM,
+			Topic:      ch.Topic.Value,
+			Purpose:    ch.Purpose.Value,
+			NumMembers: ch.NumMembers,
+		})
+	}
+	if resp.Meta != nil {
+		result.NextCursor = resp.Meta.NextCursor
+	}
+
+	return &result, nil
+}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -36,7 +36,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel name (e.g. #general) or ID (e.g. C01234567)"
+							"description": "Slack channel to post to (picker uses channel ID)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"message": {
 							"type": "string",
@@ -108,7 +116,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID: C… (channel), D… (DM), or G… (group DM)"
+							"description": "Channel ID: C… (channel), D… (DM), or G… (group DM)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"limit": {
 							"type": "integer",
@@ -141,7 +157,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID containing the thread: C…, D…, or G…"
+							"description": "Channel ID containing the thread: C…, D…, or G…",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"thread_ts": {
 							"type": "string",
@@ -170,7 +194,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel name (e.g. #general) or ID (e.g. C01234567)"
+							"description": "Slack channel to schedule in (picker uses channel ID)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"message": {
 							"type": "string",
@@ -196,7 +228,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID (e.g. C01234567)"
+							"description": "Channel ID (e.g. C01234567)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"topic": {
 							"type": "string",
@@ -216,7 +256,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID (e.g. C01234567)"
+							"description": "Channel ID (e.g. C01234567)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"users": {
 							"type": "string",
@@ -236,7 +284,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID (e.g. C01234567)"
+							"description": "Channel ID (e.g. C01234567)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"filename": {
 							"type": "string",
@@ -265,7 +321,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID containing the message (e.g. C01234567)"
+							"description": "Channel ID containing the message (e.g. C01234567)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"timestamp": {
 							"type": "string",
@@ -310,7 +374,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID containing the message (e.g. C01234567)"
+							"description": "Channel ID containing the message (e.g. C01234567)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"ts": {
 							"type": "string",
@@ -335,7 +407,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"channel": {
 							"type": "string",
-							"description": "Channel ID containing the message (e.g. C01234567)"
+							"description": "Channel ID containing the message (e.g. C01234567)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)",
+								"help_text": "Choose a channel or enter an ID. Private channels and DMs need your profile email to match Slack."
+							}
 						},
 						"ts": {
 							"type": "string",

--- a/frontend/src/components/SchemaParameterDetails.tsx
+++ b/frontend/src/components/SchemaParameterDetails.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import type { ParametersSchema } from "@/lib/parameterSchema";
 import { friendlyTypeLabel } from "@/lib/parameterSchema";
 import { formatParameterValue, humanizeKey } from "@/lib/formatValues";
+import { slackResolvedDisplayValue } from "@/lib/slackParameterDisplay";
 
 export type { ParametersSchema } from "@/lib/parameterSchema";
 export { parseParametersSchema } from "@/lib/parameterSchema";
@@ -11,6 +12,10 @@ interface SchemaParameterDetailsProps {
   parameters: Record<string, unknown>;
   /** JSON Schema describing the parameters (from connector action). */
   schema: ParametersSchema | null;
+  /** e.g. "slack.send_message" — used with resourceDetails for Slack ID resolution. */
+  actionType?: string;
+  /** Resolved names from the backend (channel_name, user_name, …). */
+  resourceDetails?: Record<string, unknown> | null;
 }
 
 /**
@@ -28,9 +33,17 @@ interface SchemaParameterDetailsProps {
 export function SchemaParameterDetails({
   parameters,
   schema,
+  actionType,
+  resourceDetails,
 }: SchemaParameterDetailsProps) {
   if (!schema?.properties) {
-    return <FallbackDetails parameters={parameters} />;
+    return (
+      <FallbackDetails
+        parameters={parameters}
+        actionType={actionType}
+        resourceDetails={resourceDetails}
+      />
+    );
   }
 
   const properties = schema.properties;
@@ -67,6 +80,8 @@ export function SchemaParameterDetails({
             defaultValue={prop.default}
             isRequired={isRequired}
             isProvided={key in parameters}
+            actionType={actionType}
+            resourceDetails={resourceDetails}
           />
         );
       })}
@@ -77,6 +92,8 @@ export function SchemaParameterDetails({
           label={humanizeKey(key)}
           value={parameters[key]}
           isProvided
+          actionType={actionType}
+          resourceDetails={resourceDetails}
         />
       ))}
     </div>
@@ -92,6 +109,8 @@ function ParameterRow({
   defaultValue,
   isRequired,
   isProvided,
+  actionType,
+  resourceDetails,
 }: {
   name: string;
   label: string;
@@ -101,8 +120,14 @@ function ParameterRow({
   defaultValue?: unknown;
   isRequired?: boolean;
   isProvided: boolean;
+  actionType?: string;
+  resourceDetails?: Record<string, unknown> | null;
 }) {
-  const displayValue = formatParameterValue(value);
+  const resolved =
+    actionType != null
+      ? slackResolvedDisplayValue(actionType, name, value, resourceDetails)
+      : null;
+  const displayValue = resolved ?? formatParameterValue(value);
   const isDefault =
     defaultValue !== undefined && String(value) === String(defaultValue);
   const isMultiline = typeof value === "string" && value.includes("\n");
@@ -163,13 +188,21 @@ function ParameterRow({
 
 function FallbackDetails({
   parameters,
+  actionType,
+  resourceDetails,
 }: {
   parameters: Record<string, unknown>;
+  actionType?: string;
+  resourceDetails?: Record<string, unknown> | null;
 }) {
   return (
     <dl className="divide-border divide-y">
       {Object.entries(parameters).map(([key, value]) => {
-        const displayValue = formatParameterValue(value);
+        const resolved =
+          actionType != null
+            ? slackResolvedDisplayValue(actionType, key, value, resourceDetails)
+            : null;
+        const displayValue = resolved ?? formatParameterValue(value);
         const isMultiline = typeof value === "string" && value.includes("\n");
         return (
           <div key={key} className="space-y-1.5 py-3 first:pt-0 last:pb-0">

--- a/frontend/src/components/__tests__/SchemaParameterDetails.test.tsx
+++ b/frontend/src/components/__tests__/SchemaParameterDetails.test.tsx
@@ -166,4 +166,25 @@ describe("SchemaParameterDetails", () => {
 
     expect(screen.getByText("\u2014")).toBeInTheDocument();
   });
+
+  it("shows resolved Slack channel name with raw ID for slack.send_message", () => {
+    const slackSchema: ParametersSchema = {
+      type: "object",
+      required: ["channel", "message"],
+      properties: {
+        channel: { type: "string", description: "Channel" },
+        message: { type: "string", description: "Message" },
+      },
+    };
+    render(
+      <SchemaParameterDetails
+        parameters={{ channel: "C0123", message: "hi" }}
+        schema={slackSchema}
+        actionType="slack.send_message"
+        resourceDetails={{ channel_name: "#general" }}
+      />,
+    );
+
+    expect(screen.getByText("#general (C0123)")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/hooks/useAgentConnectorChannels.ts
+++ b/frontend/src/hooks/useAgentConnectorChannels.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { useAgentConnectorCredential } from "./useAgentConnectorCredential";
+
+export type RemoteChannelRow = Record<string, unknown>;
+
+export function useAgentConnectorChannels(agentId: number, connectorId: string) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const { binding, isCredentialBindingPending } =
+    useAgentConnectorCredential(agentId, connectorId);
+
+  const hasCredential = !!(
+    binding?.oauth_connection_id ?? binding?.credential_id
+  );
+
+  const query = useQuery({
+    queryKey: ["agent-connector-channels", agentId, connectorId],
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.GET(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: {
+            path: { agent_id: agentId, connector_id: connectorId },
+          },
+        },
+      );
+      if (error) throw new Error("Failed to load channels");
+      const rows = data?.data;
+      if (!Array.isArray(rows)) return [] as RemoteChannelRow[];
+      return rows as RemoteChannelRow[];
+    },
+    enabled: !!accessToken && agentId > 0 && !!connectorId && hasCredential,
+  });
+
+  return {
+    channels: query.data ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.isError ? query.error : null,
+    hasCredential,
+    isCredentialBindingPending,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/lib/slackParameterDisplay.ts
+++ b/frontend/src/lib/slackParameterDisplay.ts
@@ -1,0 +1,30 @@
+/**
+ * Maps action parameters to human-readable display when backend resource_details
+ * resolved Slack IDs (e.g. channel_name for slack.send_message).
+ */
+export function slackResolvedDisplayValue(
+  actionType: string,
+  paramKey: string,
+  rawValue: unknown,
+  resourceDetails?: Record<string, unknown> | null,
+): string | null {
+  if (resourceDetails == null) return null;
+  if (typeof rawValue !== "string" || rawValue.length === 0) return null;
+
+  if (paramKey === "channel") {
+    const name = resourceDetails.channel_name;
+    if (typeof name === "string" && name.length > 0 && name !== rawValue) {
+      return `${name} (${rawValue})`;
+    }
+    return null;
+  }
+
+  if (paramKey === "user_id" && actionType === "slack.send_dm") {
+    const name = resourceDetails.user_name;
+    if (typeof name === "string" && name.length > 0 && name !== rawValue) {
+      return `${name} (${rawValue})`;
+    }
+  }
+
+  return null;
+}

--- a/frontend/src/pages/activity/ActivityDetailSheet.tsx
+++ b/frontend/src/pages/activity/ActivityDetailSheet.tsx
@@ -255,6 +255,8 @@ function ApprovalSupplementalContent({
             <SchemaParameterDetails
               parameters={parameters}
               schema={schema}
+              actionType={actionType}
+              resourceDetails={resourceDetails}
             />
           </div>
         </div>
@@ -361,6 +363,8 @@ function ApprovalContent({
             <SchemaParameterDetails
               parameters={parameters}
               schema={schema}
+              actionType={actionType}
+              resourceDetails={resourceDetails}
             />
           </div>
         </div>

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, Plus, X } from "lucide-react";
 import type { SchemaProperty, SchemaPropertyUI, WidgetType } from "@/lib/parameterSchema";
 import { inferWidgetFromProperty } from "@/lib/parameterSchema";
 import { CalendarRemoteSelectWidget } from "./CalendarRemoteSelectWidget";
+import { SlackChannelRemoteSelectWidget } from "./SlackChannelRemoteSelectWidget";
 
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
@@ -138,6 +139,22 @@ function RemoteSelectField({
         disabled={disabled}
         placeholder={placeholder}
         className={className}
+      />
+    );
+  }
+  const path = propertyUI.remote_select_options_path ?? "";
+  if (path.includes("/channels")) {
+    return (
+      <SlackChannelRemoteSelectWidget
+        inputId={inputId}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className}
+        agentId={agentId}
+        connectorId={connectorId}
+        ui={propertyUI}
       />
     );
   }

--- a/frontend/src/pages/agents/connectors/SlackChannelRemoteSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/SlackChannelRemoteSelectWidget.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { SchemaPropertyUI } from "@/lib/parameterSchema";
+import { useAgentConnectorChannels } from "@/hooks/useAgentConnectorChannels";
+
+export interface SlackChannelRemoteSelectWidgetProps {
+  inputId: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  agentId: number;
+  connectorId: string;
+  ui: Pick<
+    SchemaPropertyUI,
+    | "help_text"
+    | "remote_select_options_path"
+    | "remote_select_id_key"
+    | "remote_select_label_key"
+    | "remote_select_fallback_placeholder"
+  >;
+}
+
+const DEFAULT_NO_CREDENTIAL =
+  "Connect a Slack credential to select a channel.";
+
+function optionKeys(ui: SlackChannelRemoteSelectWidgetProps["ui"]): {
+  idKey: string;
+  labelKey: string;
+} {
+  return {
+    idKey: ui.remote_select_id_key ?? "id",
+    labelKey: ui.remote_select_label_key ?? "display_label",
+  };
+}
+
+function readLabel(row: Record<string, unknown>, labelKey: string): string {
+  const direct = row[labelKey];
+  if (typeof direct === "string" && direct.length > 0) return direct;
+  const displayLabel = row.display_label;
+  if (typeof displayLabel === "string" && displayLabel.length > 0)
+    return displayLabel;
+  const id = row.id;
+  return typeof id === "string" ? id : "";
+}
+
+function slackChannelTypeSuffix(row: Record<string, unknown>): string {
+  if (row.is_im === true) return "DM";
+  if (row.is_mpim === true) return "group DM";
+  if (row.is_private === true) return "private";
+  return "public";
+}
+
+function formatSlackOptionLabel(
+  baseLabel: string,
+  row: Record<string, unknown>,
+): string {
+  const parts: string[] = [baseLabel];
+  const kind = slackChannelTypeSuffix(row);
+  parts.push(`(${kind})`);
+  const n = row.num_members;
+  if (typeof n === "number" && Number.isFinite(n) && n > 0) {
+    parts.push(`· ${n} members`);
+  }
+  return parts.join(" ");
+}
+
+export function SlackChannelRemoteSelectWidget({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  agentId,
+  connectorId,
+  ui,
+}: SlackChannelRemoteSelectWidgetProps) {
+  const [manual, setManual] = useState(false);
+  const {
+    channels,
+    isLoading,
+    isFetching,
+    error,
+    hasCredential,
+    isCredentialBindingPending,
+    refetch,
+  } = useAgentConnectorChannels(agentId, connectorId);
+
+  const { idKey, labelKey } = optionKeys(ui);
+
+  const options = useMemo(() => {
+    const rows = channels.map((row) => {
+      const idRaw = row[idKey];
+      const id = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
+      const raw = readLabel(row, labelKey);
+      const base = raw || id;
+      return { id, label: formatSlackOptionLabel(base, row) };
+    });
+    if (value && !rows.some((r) => r.id === value)) {
+      return [{ id: value, label: value }, ...rows];
+    }
+    return rows;
+  }, [channels, idKey, labelKey, value]);
+
+  const noCredentialText = ui.help_text?.trim() || DEFAULT_NO_CREDENTIAL;
+  const selectDisabled = disabled || isLoading || isFetching;
+  const channelsReady =
+    hasCredential && !isLoading && !isFetching && !error;
+
+  if (manual) {
+    return (
+      <div className="space-y-2">
+        <Input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={
+            ui.remote_select_fallback_placeholder ??
+            placeholder ??
+            "Channel ID (e.g. C01234567)"
+          }
+          className={className}
+          data-testid={`slack-remote-select-manual-${inputId}`}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(false)}
+        >
+          Use list
+        </Button>
+      </div>
+    );
+  }
+
+  if (isCredentialBindingPending) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          aria-busy="true"
+          className={`border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+          data-testid={`slack-remote-select-binding-pending-${inputId}`}
+        >
+          <option value="">Checking credentials…</option>
+        </select>
+      </div>
+    );
+  }
+
+  if (!hasCredential) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          className={`border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+          data-testid={`slack-remote-select-disabled-${inputId}`}
+        >
+          <option value="">{noCredentialText}</option>
+        </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(true)}
+        >
+          Enter channel ID manually
+        </Button>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">
+          Could not load channels.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => void refetch()}
+          >
+            Retry
+          </button>
+          {" · "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter manually
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <select
+        id={inputId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={selectDisabled}
+        aria-busy={isLoading || isFetching ? "true" : undefined}
+        className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+        data-testid={`slack-remote-select-${inputId}`}
+      >
+        <option value="">
+          {isLoading || isFetching ? "Loading…" : placeholder ?? "Select channel…"}
+        </option>
+        {options.map((opt) => (
+          <option key={opt.id} value={opt.id}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      {channelsReady && options.length === 0 && (
+        <p className="text-muted-foreground text-xs">
+          No channels returned.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter a channel ID manually
+          </button>
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-auto px-0 text-xs"
+        disabled={disabled}
+        onClick={() => setManual(true)}
+      >
+        Enter manually
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ParameterFieldWidget.test.tsx
@@ -1,11 +1,17 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderWithProviders } from "../../../../test-helpers";
 import { ParameterFieldWidget } from "../ParameterFieldWidget";
 import type { SchemaProperty } from "@/lib/parameterSchema";
 
 vi.mock("../../../../lib/supabaseClient");
+
+const mockUseSlackChannels = vi.fn();
+
+vi.mock("@/hooks/useAgentConnectorChannels", () => ({
+  useAgentConnectorChannels: () => mockUseSlackChannels(),
+}));
 
 function renderWidget(
   property: SchemaProperty,
@@ -456,6 +462,57 @@ describe("ParameterFieldWidget", () => {
       expect(screen.getByRole("textbox")).toBeDisabled();
       expect(screen.getByRole("button", { name: /remove item/i })).toBeDisabled();
       expect(screen.getByRole("button", { name: /add item/i })).toBeDisabled();
+    });
+  });
+
+  describe("remote-select Slack channels", () => {
+    const slackRemoteProp: SchemaProperty = {
+      type: "string",
+      "x-ui": {
+        widget: "remote-select",
+        remote_select_options_path:
+          "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+        remote_select_id_key: "id",
+        remote_select_label_key: "display_label",
+      },
+    };
+
+    beforeEach(() => {
+      mockUseSlackChannels.mockReturnValue({
+        channels: [
+          {
+            id: "C1",
+            display_label: "#general",
+            is_private: false,
+            num_members: 3,
+          },
+        ],
+        isLoading: false,
+        isFetching: false,
+        error: null,
+        hasCredential: true,
+        isCredentialBindingPending: false,
+        refetch: vi.fn(),
+      });
+    });
+
+    it("uses Slack channel widget when remote path includes /channels", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithProviders(
+        <ParameterFieldWidget
+          paramKey="channel"
+          property={slackRemoteProp}
+          value=""
+          onChange={onChange}
+          agentId={1}
+          connectorId="slack"
+        />,
+      );
+
+      const select = screen.getByTestId("slack-remote-select-param-channel");
+      await user.selectOptions(select, "C1");
+      expect(onChange).toHaveBeenCalledWith("C1");
     });
   });
 

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -368,6 +368,10 @@ export function ReviewApprovalDialog({
                     <SchemaParameterDetails
                       parameters={params}
                       schema={schema}
+                      actionType={approval.action.type}
+                      resourceDetails={
+                        approval.resource_details as Record<string, unknown> | undefined
+                      }
                     />
                   </div>
                 )}

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -407,3 +407,54 @@ agentConnectorCalendars:
 
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+agentConnectorChannels:
+  get:
+    operationId: listAgentConnectorChannels
+    summary: List channels for agent connector
+    description: |
+      Returns Slack channels visible to the OAuth credential assigned to this agent–connector pair.
+      Used by the dashboard to populate channel pickers for Slack actions.
+
+      Requires session authentication (Supabase JWT). The agent must belong to the current user.
+      Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+
+    tags:
+      - Agents
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+
+    responses:
+      '200':
+        description: Channels listed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorChannelListResponse'
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Agent, connector, or channel listing not supported
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'

--- a/spec/openapi/components/schemas/agent_connectors.yaml
+++ b/spec/openapi/components/schemas/agent_connectors.yaml
@@ -170,6 +170,47 @@ AgentConnectorCalendarListResponse:
       items:
         $ref: '../schemas/agent_connectors.yaml#/CalendarListItem'
 
+ChannelListItem:
+  type: object
+  required:
+    - id
+    - display_label
+  properties:
+    id:
+      type: string
+      description: Slack channel ID (C…, G…, or D…).
+    name:
+      type: string
+      description: Channel name when available (may be empty for some DMs).
+    user:
+      type: string
+      description: For IM channels, the other participant's user ID when present.
+    is_private:
+      type: boolean
+      description: True for private channels (no # prefix in display_label).
+    is_im:
+      type: boolean
+      description: True for direct messages.
+    is_mpim:
+      type: boolean
+      description: True for group direct messages.
+    num_members:
+      type: integer
+      description: Member count when provided by Slack.
+    display_label:
+      type: string
+      description: Human-readable label for pickers (#public-name, private name, DM label).
+
+AgentConnectorChannelListResponse:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: '../schemas/agent_connectors.yaml#/ChannelListItem'
+
 AgentConnectorCredentialResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1673,6 +1673,46 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/channels:
+    get:
+      operationId: listAgentConnectorChannels
+      summary: List channels for agent connector
+      description: |
+        Returns Slack channels visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate channel pickers for Slack actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Channels listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorChannelListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or channel listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/registration-invites:
     post:
       operationId: createRegistrationInvite
@@ -11351,6 +11391,45 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CalendarListItem'
+    ChannelListItem:
+      type: object
+      required:
+        - id
+        - display_label
+      properties:
+        id:
+          type: string
+          description: Slack channel ID (C…, G…, or D…).
+        name:
+          type: string
+          description: Channel name when available (may be empty for some DMs).
+        user:
+          type: string
+          description: For IM channels, the other participant's user ID when present.
+        is_private:
+          type: boolean
+          description: True for private channels (no
+        is_im:
+          type: boolean
+          description: True for direct messages.
+        is_mpim:
+          type: boolean
+          description: True for group direct messages.
+        num_members:
+          type: integer
+          description: Member count when provided by Slack.
+        display_label:
+          type: string
+          description: Human-readable label for pickers (#public-name, private name, DM label).
+    AgentConnectorChannelListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelListItem'
     RetentionMeta:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -159,6 +159,9 @@ paths:
   /v1/agents/{agent_id}/connectors/{connector_id}/calendars:
     $ref: './components/paths/agent_connectors.yaml#/agentConnectorCalendars'
 
+  /v1/agents/{agent_id}/connectors/{connector_id}/channels:
+    $ref: './components/paths/agent_connectors.yaml#/agentConnectorChannels'
+
   /v1/registration-invites:
     $ref: './components/paths/registration_invites.yaml#/createRegistrationInvite'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #780](https://github.com/supersuit-tech/permission-slip/issues/780): show resolved Slack channel names in approval/parameter views and add a Slack channel picker for action configuration (same pattern as calendar remote-select).

### Backend
- New `connectors.ChannelLister` + `ChannelListItem` with `display_label` (public `#name`, private bare name, DM/group labels).
- `SlackConnector` implements it; reuses merged `conversations.list` + `users.conversations` logic via extracted `listChannelsMerged`; `ListChannels` paginates (200/page, max 50 pages).
- `GET /v1/agents/{agent_id}/connectors/{connector_id}/channels` (session auth, same credential resolution as calendars).

### Web
- `SlackChannelRemoteSelectWidget` + `useAgentConnectorChannels`; `ParameterFieldWidget` routes `remote-select` when `remote_select_options_path` contains `/channels`.
- `SchemaParameterDetails` accepts optional `actionType` + `resourceDetails` and shows `#channel (C…)` / DM user display when resolution exists; wired from `ReviewApprovalDialog` and `ActivityDetailSheet`.

### Connector manifest
- Slack actions that take `channel` now use `x-ui.widget: remote-select` pointing at the new endpoint.

### Developer
- [x] Backend tests: `api/agent_connector_channels_test.go`, `connectors/slack/channel_lister_test.go`
- [x] Frontend tests: `ParameterFieldWidget`, `SchemaParameterDetails`
- [ ] `make test-backend` / `make build` in CI (local agent Go 1.22 could not compile repo; CI uses project Go version)

### Manual Testing
- [ ] Approve a `slack.send_message` request: preview + parameters show resolved channel; expand parameters still shows raw ID in parentheses when name resolved
- [ ] Configure a Slack action: channel dropdown loads; public shows `#`, private without `#`; manual entry still works
- [ ] Large workspace: channel list completes or surfaces error (50-page cap)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fff897ae-994d-4152-82af-92662684c0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fff897ae-994d-4152-82af-92662684c0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

