### PR TITLE
Apply Slack connector UX patterns across built-in connectors

### DIFF
--- a/connectors/airtable/manifest.go
+++ b/connectors/airtable/manifest.go
@@ -29,7 +29,8 @@ func (c *AirtableConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"offset": {
 							"type": "string",
-							"description": "Pagination offset from a previous response"
+							"description": "Pagination offset from a previous response",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),
@@ -86,7 +87,8 @@ func (c *AirtableConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"offset": {
 							"type": "string",
-							"description": "Pagination offset from a previous response"
+							"description": "Pagination offset from a previous response",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),
@@ -259,6 +261,11 @@ func (c *AirtableConnector) Manifest() *connectors.ConnectorManifest {
 								}
 							},
 							"description": "Sort order for results"
+						},
+						"offset": {
+							"type": "string",
+							"description": "Pagination offset from a previous response",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),

--- a/connectors/airtable/search_records.go
+++ b/connectors/airtable/search_records.go
@@ -22,6 +22,7 @@ type searchRecordsParams struct {
 	Fields     []string    `json:"fields,omitempty"`
 	MaxRecords int         `json:"max_records,omitempty"`
 	Sort       []sortField `json:"sort,omitempty"`
+	Offset     string      `json:"offset,omitempty"`
 }
 
 func (p searchRecordsParams) validate() error {
@@ -66,6 +67,9 @@ func (a *searchRecordsAction) Execute(ctx context.Context, req connectors.Action
 		if s.Direction != "" {
 			q.Set(fmt.Sprintf("sort[%d][direction]", i), s.Direction)
 		}
+	}
+	if params.Offset != "" {
+		q.Set("offset", params.Offset)
 	}
 
 	reqURL += "?" + q.Encode()

--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -26,20 +26,13 @@ var knownMissingAnnotations = map[string]bool{
 	"sendgrid.sendgrid.send_transactional_email:html_content": true,
 
 	// datetime — various connectors with ISO 8601 fields missing format
-	"asana.asana.create_task:due_at":                         true,
-	"asana.asana.update_task:due_at":                         true,
-	"dropbox.dropbox.share_file:expires":                     true,
-	"hubspot.hubspot.create_deal:closedate":                  true,
-	"hubspot.hubspot.update_deal_stage:close_date":           true,
-	"jira.jira.create_sprint:start_date":                     true,
-	"jira.jira.create_sprint:end_date":                       true,
-	"microsoft.microsoft.create_calendar_event:start":        true,
-	"microsoft.microsoft.create_calendar_event:end":          true,
-	"pagerduty.pagerduty.list_on_call:since":                 true,
-	"pagerduty.pagerduty.list_on_call:until":                 true,
-	"trello.trello.create_card:due":                          true,
-	"zoom.zoom.create_meeting:start_time":                    true,
-	"zoom.zoom.update_meeting:start_time":                    true,
+	"hubspot.hubspot.create_deal:closedate":           true,
+	"hubspot.hubspot.update_deal_stage:close_date":    true,
+	"microsoft.microsoft.create_calendar_event:start": true,
+	"microsoft.microsoft.create_calendar_event:end":   true,
+	"pagerduty.pagerduty.list_on_call:since":          true,
+	"pagerduty.pagerduty.list_on_call:until":          true,
+	"trello.trello.create_card:due":                   true,
 }
 
 // annotationIssue describes a single missing annotation found by the lint.

--- a/connectors/amadeus/manifest.go
+++ b/connectors/amadeus/manifest.go
@@ -43,8 +43,18 @@ func (c *AmadeusConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"origin": {"type": "string", "description": "Origin IATA code (e.g. 'SFO')"},
 						"destination": {"type": "string", "description": "Destination IATA code (e.g. 'LAX')"},
-						"departure_date": {"type": "string", "format": "date", "description": "Departure date (YYYY-MM-DD)"},
-						"return_date": {"type": "string", "format": "date", "description": "Return date for round trip (YYYY-MM-DD)"},
+						"departure_date": {
+							"type": "string",
+							"format": "date",
+							"description": "Departure date (YYYY-MM-DD)",
+							"x-ui": {"widget": "date", "datetime_range_pair": "return_date", "datetime_range_role": "lower"}
+						},
+						"return_date": {
+							"type": "string",
+							"format": "date",
+							"description": "Return date for round trip (YYYY-MM-DD)",
+							"x-ui": {"widget": "date", "datetime_range_pair": "departure_date", "datetime_range_role": "upper"}
+						},
 						"adults": {"type": "integer", "minimum": 1, "maximum": 9, "default": 1, "description": "Number of adult travelers (1-9)"},
 						"cabin": {"type": "string", "enum": ["ECONOMY", "PREMIUM_ECONOMY", "BUSINESS", "FIRST"], "description": "Cabin class"},
 						"nonstop": {"type": "boolean", "default": false, "description": "Only show nonstop flights"},
@@ -121,8 +131,18 @@ func (c *AmadeusConnector) Manifest() *connectors.ConnectorManifest {
 						"city_code": {"type": "string", "description": "City IATA code (e.g. 'PAR')"},
 						"latitude": {"type": "string", "description": "Latitude for geo search"},
 						"longitude": {"type": "string", "description": "Longitude for geo search"},
-						"check_in_date": {"type": "string", "format": "date", "description": "Check-in date (YYYY-MM-DD)"},
-						"check_out_date": {"type": "string", "format": "date", "description": "Check-out date (YYYY-MM-DD)"},
+						"check_in_date": {
+							"type": "string",
+							"format": "date",
+							"description": "Check-in date (YYYY-MM-DD)",
+							"x-ui": {"widget": "date", "datetime_range_pair": "check_out_date", "datetime_range_role": "lower"}
+						},
+						"check_out_date": {
+							"type": "string",
+							"format": "date",
+							"description": "Check-out date (YYYY-MM-DD)",
+							"x-ui": {"widget": "date", "datetime_range_pair": "check_in_date", "datetime_range_role": "upper"}
+						},
 						"adults": {"type": "integer", "default": 1, "description": "Number of adults"},
 						"room_quantity": {"type": "integer", "default": 1, "description": "Number of rooms"},
 						"ratings": {"type": "array", "items": {"type": "integer", "minimum": 1, "maximum": 5}, "description": "Hotel star ratings to filter by"},

--- a/connectors/asana/manifest.go
+++ b/connectors/asana/manifest.go
@@ -46,11 +46,15 @@ func (c *AsanaConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_on": {
 							"type": "string",
-							"description": "Due date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Due date (YYYY-MM-DD)",
+							"x-ui": {"widget": "date"}
 						},
 						"due_at": {
 							"type": "string",
-							"description": "Due date and time (ISO 8601)"
+							"format": "date-time",
+							"description": "Due date and time (ISO 8601)",
+							"x-ui": {"widget": "datetime"}
 						},
 						"tags": {
 							"type": "array",
@@ -91,11 +95,15 @@ func (c *AsanaConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_on": {
 							"type": "string",
-							"description": "Due date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Due date (YYYY-MM-DD)",
+							"x-ui": {"widget": "date"}
 						},
 						"due_at": {
 							"type": "string",
-							"description": "Due date and time (ISO 8601)"
+							"format": "date-time",
+							"description": "Due date and time (ISO 8601)",
+							"x-ui": {"widget": "datetime"}
 						},
 						"completed": {
 							"type": "boolean",
@@ -175,7 +183,9 @@ func (c *AsanaConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_on": {
 							"type": "string",
-							"description": "Due date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Due date (YYYY-MM-DD)",
+							"x-ui": {"widget": "date"}
 						}
 					}
 				}`)),
@@ -212,11 +222,23 @@ func (c *AsanaConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_on_before": {
 							"type": "string",
-							"description": "Filter tasks due before this date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Filter tasks due before this date (YYYY-MM-DD)",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "due_on_after",
+								"datetime_range_role": "upper"
+							}
 						},
 						"due_on_after": {
 							"type": "string",
-							"description": "Filter tasks due after this date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Filter tasks due after this date (YYYY-MM-DD)",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "due_on_before",
+								"datetime_range_role": "lower"
+							}
 						},
 						"limit": {
 							"type": "integer",

--- a/connectors/doordash/manifest.go
+++ b/connectors/doordash/manifest.go
@@ -251,7 +251,8 @@ func listDeliveriesManifest() connectors.ManifestAction {
 			},
 			"starting_after": {
 				"type": "string",
-				"description": "Pagination cursor from a previous list_deliveries response"
+				"description": "Pagination cursor from a previous list_deliveries response",
+				"x-ui": {"hidden": true}
 			},
 			"status": {
 				"type": "string",

--- a/connectors/dropbox/manifest.go
+++ b/connectors/dropbox/manifest.go
@@ -109,7 +109,9 @@ func (c *DropboxConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"expires": {
 							"type": "string",
-							"description": "Expiration date for the shared link (ISO 8601 format)"
+							"format": "date-time",
+							"description": "Expiration date for the shared link (ISO 8601 format)",
+							"x-ui": {"widget": "datetime"}
 						}
 					}
 				}`)),

--- a/connectors/expedia/manifest.go
+++ b/connectors/expedia/manifest.go
@@ -36,11 +36,23 @@ func (c *ExpediaConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"checkin": {
 							"type": "string",
-							"description": "Check-in date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Check-in date (YYYY-MM-DD)",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "checkout",
+								"datetime_range_role": "lower"
+							}
 						},
 						"checkout": {
 							"type": "string",
-							"description": "Check-out date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Check-out date (YYYY-MM-DD)",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "checkin",
+								"datetime_range_role": "upper"
+							}
 						},
 						"region_id": {
 							"type": "string",
@@ -99,11 +111,23 @@ func (c *ExpediaConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"checkin": {
 							"type": "string",
-							"description": "Check-in date (YYYY-MM-DD) for rate information"
+							"format": "date",
+							"description": "Check-in date (YYYY-MM-DD) for rate information",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "checkout",
+								"datetime_range_role": "lower"
+							}
 						},
 						"checkout": {
 							"type": "string",
-							"description": "Check-out date (YYYY-MM-DD) for rate information"
+							"format": "date",
+							"description": "Check-out date (YYYY-MM-DD) for rate information",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "checkin",
+								"datetime_range_role": "upper"
+							}
 						},
 						"occupancy": {
 							"type": "string",

--- a/connectors/hubspot/README.md
+++ b/connectors/hubspot/README.md
@@ -126,6 +126,8 @@ Creates a marketing email campaign and optionally sends it immediately. When `se
 
 Fetches marketing and sales analytics reports with configurable time period granularity. Optional date range filtering via `start` and `end` parameters.
 
+`start` and `end` accept YYYY-MM-DD, RFC 3339, Unix seconds, or epoch milliseconds; values are normalized to UTC calendar dates (`YYYY-MM-DD`) before calling the HubSpot API.
+
 **HubSpot API:** `GET /analytics/v2/reports/{object_type}/{time_period}`
 **Required scopes:** `analytics.read`
 

--- a/connectors/hubspot/get_analytics.go
+++ b/connectors/hubspot/get_analytics.go
@@ -74,12 +74,21 @@ func (a *getAnalyticsAction) Execute(ctx context.Context, req connectors.ActionR
 		url.PathEscape(params.TimePeriod),
 	)
 
-	query := url.Values{}
-	if params.Start != "" {
-		query.Set("start", params.Start)
+	startNorm, err := connectors.NormalizeHubSpotAnalyticsTimeParam(params.Start)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid start: %v", err)}
 	}
-	if params.End != "" {
-		query.Set("end", params.End)
+	endNorm, err := connectors.NormalizeHubSpotAnalyticsTimeParam(params.End)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid end: %v", err)}
+	}
+
+	query := url.Values{}
+	if startNorm != "" {
+		query.Set("start", startNorm)
+	}
+	if endNorm != "" {
+		query.Set("end", endNorm)
 	}
 	if len(query) > 0 {
 		path += "?" + query.Encode()

--- a/connectors/hubspot/get_analytics_test.go
+++ b/connectors/hubspot/get_analytics_test.go
@@ -41,8 +41,8 @@ func TestGetAnalytics_Success(t *testing.T) {
 	params, _ := json.Marshal(getAnalyticsParams{
 		ObjectType: "deals",
 		TimePeriod: "monthly",
-		Start:      "2026-01-01",
-		End:        "2026-03-01",
+		Start:      "2026-01-01T00:00:00Z",
+		End:        "2026-03-01T23:59:59Z",
 	})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/hubspot/manifest.go
+++ b/connectors/hubspot/manifest.go
@@ -361,11 +361,23 @@ func (c *HubSpotConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start": {
 							"type": "string",
-							"description": "Start date/time (ISO 8601 or epoch milliseconds)"
+							"format": "date-time",
+							"description": "Start of range (YYYY-MM-DD, RFC 3339, Unix seconds, or epoch milliseconds — normalized to UTC date for the API)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "end",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end": {
 							"type": "string",
-							"description": "End date/time (ISO 8601 or epoch milliseconds)"
+							"format": "date-time",
+							"description": "End of range (YYYY-MM-DD, RFC 3339, Unix seconds, or epoch milliseconds — normalized to UTC date for the API)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "start",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),

--- a/connectors/intercom/manifest.go
+++ b/connectors/intercom/manifest.go
@@ -149,7 +149,7 @@ func (c *IntercomConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "intercom.search_tickets",
 				Name:        "Search Tickets",
-				Description: "Search tickets using a single-field filter. Use '=' for exact match, '~' for contains, 'IN' for multiple values.",
+				Description: "Search tickets using a single-field filter. Use '=' for exact match, '~' for contains, 'IN' for multiple values. Optional created_at / updated_at bounds are combined with AND.",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -167,6 +167,46 @@ func (c *IntercomConnector) Manifest() *connectors.ConnectorManifest {
 						"value": {
 							"type": "string",
 							"description": "Value to search for (e.g. 'submitted', 'billing issue')"
+						},
+						"created_at_after": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Only tickets with created_at strictly after this time (RFC 3339 or Unix timestamp)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "created_at_before",
+								"datetime_range_role": "lower"
+							}
+						},
+						"created_at_before": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Only tickets with created_at strictly before this time (RFC 3339 or Unix timestamp)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "created_at_after",
+								"datetime_range_role": "upper"
+							}
+						},
+						"updated_at_after": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Only tickets with updated_at strictly after this time (RFC 3339 or Unix timestamp)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "updated_at_before",
+								"datetime_range_role": "lower"
+							}
+						},
+						"updated_at_before": {
+							"type": "string",
+							"format": "date-time",
+							"description": "Only tickets with updated_at strictly before this time (RFC 3339 or Unix timestamp)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "updated_at_after",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),

--- a/connectors/intercom/search_tickets.go
+++ b/connectors/intercom/search_tickets.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -19,6 +20,11 @@ type searchTicketsParams struct {
 	Field    string `json:"field"`
 	Operator string `json:"operator"`
 	Value    string `json:"value"`
+	// Optional bounds for ticket search — combined with the primary filter via AND.
+	CreatedAtAfter  string `json:"created_at_after,omitempty"`
+	CreatedAtBefore string `json:"created_at_before,omitempty"`
+	UpdatedAtAfter  string `json:"updated_at_after,omitempty"`
+	UpdatedAtBefore string `json:"updated_at_before,omitempty"`
 }
 
 var validOperators = map[string]bool{
@@ -50,13 +56,57 @@ func (a *searchTicketsAction) Execute(ctx context.Context, req connectors.Action
 		return nil, err
 	}
 
-	body := map[string]any{
-		"query": map[string]any{
+	predicates := []map[string]any{
+		{
 			"field":    params.Field,
 			"operator": params.Operator,
 			"value":    params.Value,
 		},
 	}
+
+	appendTimePredicate := func(field, op, raw string) error {
+		if raw == "" {
+			return nil
+		}
+		sec, err := connectors.ParseUnixTimestampOrRFC3339(raw)
+		if err != nil {
+			return err
+		}
+		v := strconv.FormatInt(sec, 10)
+		if err != nil {
+			return err
+		}
+		predicates = append(predicates, map[string]any{
+			"field":    field,
+			"operator": op,
+			"value":    v,
+		})
+		return nil
+	}
+	if err := appendTimePredicate("created_at", ">", params.CreatedAtAfter); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid created_at_after: %v", err)}
+	}
+	if err := appendTimePredicate("created_at", "<", params.CreatedAtBefore); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid created_at_before: %v", err)}
+	}
+	if err := appendTimePredicate("updated_at", ">", params.UpdatedAtAfter); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid updated_at_after: %v", err)}
+	}
+	if err := appendTimePredicate("updated_at", "<", params.UpdatedAtBefore); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid updated_at_before: %v", err)}
+	}
+
+	var query any
+	if len(predicates) == 1 {
+		query = predicates[0]
+	} else {
+		query = map[string]any{
+			"operator": "AND",
+			"value":    predicates,
+		}
+	}
+
+	body := map[string]any{"query": query}
 
 	var resp searchTicketsResponse
 	if err := a.conn.do(ctx, req.Credentials, http.MethodPost, "/tickets/search", body, &resp); err != nil {

--- a/connectors/intercom/search_tickets_test.go
+++ b/connectors/intercom/search_tickets_test.go
@@ -20,6 +20,15 @@ func TestSearchTickets_Success(t *testing.T) {
 			t.Errorf("expected path /tickets/search, got %s", r.URL.Path)
 		}
 
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		q, ok := body["query"].(map[string]any)
+		if !ok || q["field"] != "state" {
+			t.Errorf("expected simple query with field state, got %#v", body["query"])
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(searchTicketsResponse{
@@ -56,6 +65,56 @@ func TestSearchTickets_Success(t *testing.T) {
 	}
 	if data.TotalCount != 1 {
 		t.Errorf("expected total_count 1, got %d", data.TotalCount)
+	}
+}
+
+func TestSearchTickets_WithCreatedAtBounds_ANDQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		top, ok := body["query"].(map[string]any)
+		if !ok || top["operator"] != "AND" {
+			t.Fatalf("expected AND query, got %#v", body["query"])
+		}
+		vals, ok := top["value"].([]any)
+		if !ok || len(vals) != 2 {
+			t.Fatalf("expected 2 predicates, got %#v", top["value"])
+		}
+		p0 := vals[0].(map[string]any)
+		if p0["field"] != "state" || p0["operator"] != "=" {
+			t.Errorf("unexpected first predicate: %#v", p0)
+		}
+		p1 := vals[1].(map[string]any)
+		if p1["field"] != "created_at" || p1["operator"] != ">" || p1["value"] != "1709251200" {
+			t.Errorf("unexpected second predicate: %#v", p1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searchTicketsResponse{Type: "ticket.list", TotalCount: 0, Data: []intercomTicket{}})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &searchTicketsAction{conn: conn}
+
+	params, _ := json.Marshal(searchTicketsParams{
+		Field:          "state",
+		Operator:       "=",
+		Value:          "submitted",
+		CreatedAtAfter: "1709251200",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "intercom.search_tickets",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/connectors/jira/manifest.go
+++ b/connectors/jira/manifest.go
@@ -279,11 +279,23 @@ func (c *JiraConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_date": {
 							"type": "string",
-							"description": "Sprint start date (ISO 8601, e.g. 2024-01-15T09:00:00.000Z)"
+							"format": "date-time",
+							"description": "Sprint start date (ISO 8601, e.g. 2024-01-15T09:00:00.000Z)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "end_date",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end_date": {
 							"type": "string",
-							"description": "Sprint end date (ISO 8601, e.g. 2024-01-29T09:00:00.000Z)"
+							"format": "date-time",
+							"description": "Sprint end date (ISO 8601, e.g. 2024-01-29T09:00:00.000Z)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "start_date",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),

--- a/connectors/kroger/manifest.go
+++ b/connectors/kroger/manifest.go
@@ -46,7 +46,8 @@ func (c *KrogerConnector) Manifest() *connectors.ConnectorManifest {
 						"start": {
 							"type": "integer",
 							"minimum": 1,
-							"description": "Starting index for pagination (use with limit for paging through results)"
+							"description": "Starting index for pagination (use with limit for paging through results)",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),

--- a/connectors/linkedin/manifest.go
+++ b/connectors/linkedin/manifest.go
@@ -209,7 +209,8 @@ func (c *LinkedInConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "integer",
 							"minimum": 0,
 							"default": 0,
-							"description": "Pagination offset"
+							"description": "Pagination offset",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),
@@ -238,7 +239,8 @@ func (c *LinkedInConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "integer",
 							"minimum": 0,
 							"default": 0,
-							"description": "Pagination offset"
+							"description": "Pagination offset",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),
@@ -278,7 +280,8 @@ func (c *LinkedInConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "integer",
 							"minimum": 0,
 							"default": 0,
-							"description": "Pagination offset"
+							"description": "Pagination offset",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),

--- a/connectors/meta/README.md
+++ b/connectors/meta/README.md
@@ -199,8 +199,8 @@ Lists recent posts on a Facebook Page with engagement metrics (likes, comments, 
 |------|------|----------|---------|-------------|
 | `page_id` | string | Yes | — | Facebook Page ID |
 | `limit` | integer | No | `10` | Maximum number of posts to return (1-100) |
-| `since` | integer | No | — | Unix timestamp — only return posts after this time |
-| `until` | integer | No | — | Unix timestamp — only return posts before this time |
+| `since` | string | No | — | Unix seconds, epoch milliseconds, or RFC 3339 — only return posts after this time |
+| `until` | string | No | — | Same formats as `since` — only return posts before this time |
 
 **Response:**
 

--- a/connectors/meta/get_page_insights.go
+++ b/connectors/meta/get_page_insights.go
@@ -20,19 +20,19 @@ type getPageInsightsParams struct {
 	PageID string `json:"page_id"`
 	Metric string `json:"metric,omitempty"`
 	Period string `json:"period,omitempty"`
-	Since  int64  `json:"since,omitempty"`
-	Until  int64  `json:"until,omitempty"`
+	Since  string `json:"since,omitempty"`
+	Until  string `json:"until,omitempty"`
 }
 
 var validPageInsightMetrics = map[string]bool{
-	"page_impressions":                   true,
-	"page_impressions_unique":            true,
-	"page_engaged_users":                 true,
-	"page_post_engagements":              true,
-	"page_fan_adds":                      true,
-	"page_fan_removes":                   true,
-	"page_views_total":                   true,
-	"page_reach":                         true,
+	"page_impressions":        true,
+	"page_impressions_unique": true,
+	"page_engaged_users":      true,
+	"page_post_engagements":   true,
+	"page_fan_adds":           true,
+	"page_fan_removes":        true,
+	"page_views_total":        true,
+	"page_reach":              true,
 }
 
 var validPageInsightPeriods = map[string]bool{
@@ -63,16 +63,16 @@ type pageInsightsResponse struct {
 }
 
 type pageInsightDataPoint struct {
-	ID     string              `json:"id"`
-	Name   string              `json:"name"`
-	Period string              `json:"period"`
-	Values []pageInsightValue  `json:"values"`
-	Title  string              `json:"title"`
+	ID     string             `json:"id"`
+	Name   string             `json:"name"`
+	Period string             `json:"period"`
+	Values []pageInsightValue `json:"values"`
+	Title  string             `json:"title"`
 }
 
 type pageInsightValue struct {
-	Value     interface{} `json:"value"`
-	EndTime   string      `json:"end_time"`
+	Value   interface{} `json:"value"`
+	EndTime string      `json:"end_time"`
 }
 
 func (a *getPageInsightsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
@@ -96,11 +96,19 @@ func (a *getPageInsightsAction) Execute(ctx context.Context, req connectors.Acti
 	q := url.Values{}
 	q.Set("metric", metric)
 	q.Set("period", period)
-	if params.Since > 0 {
-		q.Set("since", strconv.FormatInt(params.Since, 10))
+	sinceUnix, err := connectors.ParseUnixTimestampOrRFC3339(params.Since)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid since: %v", err)}
 	}
-	if params.Until > 0 {
-		q.Set("until", strconv.FormatInt(params.Until, 10))
+	untilUnix, err := connectors.ParseUnixTimestampOrRFC3339(params.Until)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid until: %v", err)}
+	}
+	if sinceUnix > 0 {
+		q.Set("since", strconv.FormatInt(sinceUnix, 10))
+	}
+	if untilUnix > 0 {
+		q.Set("until", strconv.FormatInt(untilUnix, 10))
 	}
 
 	reqURL := fmt.Sprintf("%s/%s/insights?%s", a.conn.baseURL, params.PageID, q.Encode())

--- a/connectors/meta/list_page_posts.go
+++ b/connectors/meta/list_page_posts.go
@@ -18,8 +18,8 @@ type listPagePostsAction struct {
 type listPagePostsParams struct {
 	PageID string `json:"page_id"`
 	Limit  int    `json:"limit,omitempty"`
-	Since  int64  `json:"since,omitempty"`
-	Until  int64  `json:"until,omitempty"`
+	Since  string `json:"since,omitempty"`
+	Until  string `json:"until,omitempty"`
 }
 
 func (p *listPagePostsParams) validate() error {
@@ -80,11 +80,19 @@ func (a *listPagePostsAction) Execute(ctx context.Context, req connectors.Action
 	reqURL := fmt.Sprintf("%s/%s/posts?fields=id,message,created_time,shares,likes.summary(true),comments.summary(true)&limit=%d",
 		a.conn.baseURL, params.PageID, limit)
 
-	if params.Since > 0 {
-		reqURL += "&since=" + strconv.FormatInt(params.Since, 10)
+	sinceUnix, err := connectors.ParseUnixTimestampOrRFC3339(params.Since)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid since: %v", err)}
 	}
-	if params.Until > 0 {
-		reqURL += "&until=" + strconv.FormatInt(params.Until, 10)
+	untilUnix, err := connectors.ParseUnixTimestampOrRFC3339(params.Until)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid until: %v", err)}
+	}
+	if sinceUnix > 0 {
+		reqURL += "&since=" + strconv.FormatInt(sinceUnix, 10)
+	}
+	if untilUnix > 0 {
+		reqURL += "&until=" + strconv.FormatInt(untilUnix, 10)
 	}
 
 	var resp listPagePostsResponse

--- a/connectors/meta/list_page_posts_test.go
+++ b/connectors/meta/list_page_posts_test.go
@@ -91,8 +91,8 @@ func TestListPagePosts_WithTimeRange(t *testing.T) {
 
 	params, _ := json.Marshal(listPagePostsParams{
 		PageID: "page_123",
-		Since:  1709251200,
-		Until:  1709337600,
+		Since:  "1709251200",
+		Until:  "1709337600",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/meta/manifest.go
+++ b/connectors/meta/manifest.go
@@ -162,12 +162,24 @@ func (c *MetaConnector) Manifest() *connectors.ConnectorManifest {
 							"description": "Maximum number of posts to return (1-100, default 10)"
 						},
 						"since": {
-							"type": "integer",
-							"description": "Unix timestamp — only return posts after this time"
+							"type": "string",
+							"format": "date-time",
+							"description": "Only return posts after this time. Unix seconds, epoch milliseconds, or RFC 3339 (e.g. 2024-03-01T00:00:00Z).",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "until",
+								"datetime_range_role": "lower"
+							}
 						},
 						"until": {
-							"type": "integer",
-							"description": "Unix timestamp — only return posts before this time"
+							"type": "string",
+							"format": "date-time",
+							"description": "Only return posts before this time. Unix seconds, epoch milliseconds, or RFC 3339.",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "since",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),
@@ -218,12 +230,24 @@ func (c *MetaConnector) Manifest() *connectors.ConnectorManifest {
 							"description": "Time period for the metric (default: day)"
 						},
 						"since": {
-							"type": "integer",
-							"description": "Unix timestamp — only return data after this time"
+							"type": "string",
+							"format": "date-time",
+							"description": "Only return data after this time. Unix seconds, epoch milliseconds, or RFC 3339.",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "until",
+								"datetime_range_role": "lower"
+							}
 						},
 						"until": {
-							"type": "integer",
-							"description": "Unix timestamp — only return data before this time"
+							"type": "string",
+							"format": "date-time",
+							"description": "Only return data before this time. Unix seconds, epoch milliseconds, or RFC 3339.",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "since",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),

--- a/connectors/plaid/list_transactions.go
+++ b/connectors/plaid/list_transactions.go
@@ -36,15 +36,19 @@ func (p *listTransactionsParams) validate() error {
 	if p.StartDate == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: start_date"}
 	}
-	if !datePattern.MatchString(p.StartDate) {
-		return &connectors.ValidationError{Message: fmt.Sprintf("start_date must be in YYYY-MM-DD format, got %q", p.StartDate)}
+	startNorm, err := connectors.NormalizePlaidDateParam(p.StartDate)
+	if err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid start_date: %v", err)}
 	}
+	p.StartDate = startNorm
 	if p.EndDate == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: end_date"}
 	}
-	if !datePattern.MatchString(p.EndDate) {
-		return &connectors.ValidationError{Message: fmt.Sprintf("end_date must be in YYYY-MM-DD format, got %q", p.EndDate)}
+	endNorm, err := connectors.NormalizePlaidDateParam(p.EndDate)
+	if err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid end_date: %v", err)}
 	}
+	p.EndDate = endNorm
 	if p.StartDate > p.EndDate {
 		return &connectors.ValidationError{Message: "start_date must be before or equal to end_date"}
 	}

--- a/connectors/plaid/manifest.go
+++ b/connectors/plaid/manifest.go
@@ -85,13 +85,23 @@ func (c *PlaidConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_date": {
 							"type": "string",
-							"pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-							"description": "Start date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Start date (YYYY-MM-DD). RFC 3339 datetimes are accepted and normalized to the UTC calendar date.",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "end_date",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end_date": {
 							"type": "string",
-							"pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-							"description": "End date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "End date (YYYY-MM-DD). RFC 3339 datetimes are accepted and normalized to the UTC calendar date.",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "start_date",
+								"datetime_range_role": "upper"
+							}
 						},
 						"account_ids": {
 							"type": "array",
@@ -107,7 +117,8 @@ func (c *PlaidConnector) Manifest() *connectors.ConnectorManifest {
 						"offset": {
 							"type": "integer",
 							"minimum": 0,
-							"description": "Number of transactions to skip (for pagination)"
+							"description": "Number of transactions to skip (for pagination)",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),

--- a/connectors/plaid/manifest.go
+++ b/connectors/plaid/manifest.go
@@ -86,7 +86,7 @@ func (c *PlaidConnector) Manifest() *connectors.ConnectorManifest {
 						"start_date": {
 							"type": "string",
 							"format": "date",
-							"description": "Start date (YYYY-MM-DD). RFC 3339 datetimes are accepted and normalized to the UTC calendar date.",
+							"description": "Start date (YYYY-MM-DD). Unix seconds or epoch milliseconds are also accepted and normalized to the UTC calendar date.",
 							"x-ui": {
 								"widget": "date",
 								"datetime_range_pair": "end_date",
@@ -96,7 +96,7 @@ func (c *PlaidConnector) Manifest() *connectors.ConnectorManifest {
 						"end_date": {
 							"type": "string",
 							"format": "date",
-							"description": "End date (YYYY-MM-DD). RFC 3339 datetimes are accepted and normalized to the UTC calendar date.",
+							"description": "End date (YYYY-MM-DD). Unix seconds or epoch milliseconds are also accepted and normalized to the UTC calendar date.",
 							"x-ui": {
 								"widget": "date",
 								"datetime_range_pair": "start_date",

--- a/connectors/quickbooks/manifest.go
+++ b/connectors/quickbooks/manifest.go
@@ -34,7 +34,9 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_date": {
 							"type": "string",
-							"description": "Invoice due date in YYYY-MM-DD format (e.g. \"2025-12-31\")"
+							"format": "date",
+							"description": "Invoice due date in YYYY-MM-DD format (e.g. \"2025-12-31\")",
+							"x-ui": {"widget": "date"}
 						},
 						"line_items": {
 							"type": "array",
@@ -148,7 +150,9 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"txn_date": {
 							"type": "string",
-							"description": "Transaction date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Transaction date in YYYY-MM-DD format",
+							"x-ui": {"widget": "date"}
 						}
 					}
 				}`)),
@@ -164,11 +168,23 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"start_date": {
 							"type": "string",
-							"description": "Report start date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Report start date in YYYY-MM-DD format",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "end_date",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end_date": {
 							"type": "string",
-							"description": "Report end date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Report end date in YYYY-MM-DD format",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "start_date",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),
@@ -184,11 +200,23 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 					"properties": {
 						"start_date": {
 							"type": "string",
-							"description": "Report start date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Report start date in YYYY-MM-DD format",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "end_date",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end_date": {
 							"type": "string",
-							"description": "Report end date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Report end date in YYYY-MM-DD format",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "start_date",
+								"datetime_range_role": "upper"
+							}
 						}
 					}
 				}`)),
@@ -214,7 +242,9 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"txn_date": {
 							"type": "string",
-							"description": "Transaction date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Transaction date in YYYY-MM-DD format",
+							"x-ui": {"widget": "date"}
 						},
 						"description": {
 							"type": "string",
@@ -354,11 +384,15 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_date": {
 							"type": "string",
-							"description": "Payment due date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Payment due date in YYYY-MM-DD format",
+							"x-ui": {"widget": "date"}
 						},
 						"txn_date": {
 							"type": "string",
-							"description": "Bill date in YYYY-MM-DD format (defaults to today)"
+							"format": "date",
+							"description": "Bill date in YYYY-MM-DD format (defaults to today)",
+							"x-ui": {"widget": "date"}
 						}
 					}
 				}`)),
@@ -378,11 +412,23 @@ func (c *QuickBooksConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_date": {
 							"type": "string",
-							"description": "Filter invoices on or after this date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Filter invoices on or after this date (YYYY-MM-DD)",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "end_date",
+								"datetime_range_role": "lower"
+							}
 						},
 						"end_date": {
 							"type": "string",
-							"description": "Filter invoices on or before this date (YYYY-MM-DD)"
+							"format": "date",
+							"description": "Filter invoices on or before this date (YYYY-MM-DD)",
+							"x-ui": {
+								"widget": "date",
+								"datetime_range_pair": "start_date",
+								"datetime_range_role": "upper"
+							}
 						},
 						"max_results": {
 							"type": "integer",

--- a/connectors/salesforce/manifest.go
+++ b/connectors/salesforce/manifest.go
@@ -120,7 +120,9 @@ func (c *SalesforceConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"due_date": {
 							"type": "string",
-							"description": "Due date in YYYY-MM-DD format"
+							"format": "date",
+							"description": "Due date in YYYY-MM-DD format",
+							"x-ui": {"widget": "date"}
 						},
 						"description": {
 							"type": "string",

--- a/connectors/sendgrid/manifest.go
+++ b/connectors/sendgrid/manifest.go
@@ -103,7 +103,8 @@ func (c *SendGridConnector) Manifest() *connectors.ConnectorManifest {
 						"send_at": {
 							"type": "string",
 							"format": "date-time",
-							"description": "ISO 8601 timestamp for when to send (must be in the future, e.g. 2026-03-15T10:00:00Z)"
+							"description": "ISO 8601 timestamp for when to send (must be in the future, e.g. 2026-03-15T10:00:00Z)",
+							"x-ui": {"widget": "datetime"}
 						},
 						"suppression_group_id": {
 							"type": "integer",

--- a/connectors/shopify/manifest.go
+++ b/connectors/shopify/manifest.go
@@ -41,22 +41,42 @@ func (c *ShopifyConnector) Manifest() *connectors.ConnectorManifest {
 						"created_at_min": {
 							"type": "string",
 							"format": "date-time",
-							"description": "Show orders created at or after this date (ISO 8601, e.g. 2024-01-01T00:00:00Z)"
+							"description": "Show orders created at or after this date (ISO 8601, e.g. 2024-01-01T00:00:00Z)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "created_at_max",
+								"datetime_range_role": "lower"
+							}
 						},
 						"created_at_max": {
 							"type": "string",
 							"format": "date-time",
-							"description": "Show orders created at or before this date (ISO 8601, e.g. 2024-12-31T23:59:59Z)"
+							"description": "Show orders created at or before this date (ISO 8601, e.g. 2024-12-31T23:59:59Z)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "created_at_min",
+								"datetime_range_role": "upper"
+							}
 						},
 						"updated_at_min": {
 							"type": "string",
 							"format": "date-time",
-							"description": "Show orders updated at or after this date (ISO 8601)"
+							"description": "Show orders updated at or after this date (ISO 8601)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "updated_at_max",
+								"datetime_range_role": "lower"
+							}
 						},
 						"updated_at_max": {
 							"type": "string",
 							"format": "date-time",
-							"description": "Show orders updated at or before this date (ISO 8601)"
+							"description": "Show orders updated at or before this date (ISO 8601)",
+							"x-ui": {
+								"widget": "datetime",
+								"datetime_range_pair": "updated_at_min",
+								"datetime_range_role": "upper"
+							}
 						},
 						"fields": {
 							"type": "string",

--- a/connectors/timestamp.go
+++ b/connectors/timestamp.go
@@ -1,0 +1,80 @@
+package connectors
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var yyyymmddPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// ParseUnixTimestampOrRFC3339 parses a value that may be a Unix timestamp in seconds
+// (optionally fractional), epoch milliseconds, or an RFC 3339 datetime. Empty string returns (0, nil).
+func ParseUnixTimestampOrRFC3339(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return unixSecondsFromNumeric(f), nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0, fmt.Errorf("expected Unix timestamp or RFC 3339 datetime, got %q", s)
+	}
+	return t.Unix(), nil
+}
+
+// NormalizeHubSpotAnalyticsTimeParam converts start/end query values for HubSpot analytics.
+// Accepts YYYY-MM-DD, RFC 3339, Unix seconds, or epoch milliseconds. Returns YYYY-MM-DD in UTC.
+func NormalizeHubSpotAnalyticsTimeParam(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", nil
+	}
+	if yyyymmddPattern.MatchString(s) {
+		return s, nil
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		sec := unixSecondsFromNumeric(f)
+		t := time.Unix(sec, 0).UTC()
+		return t.Format("2006-01-02"), nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "", fmt.Errorf("expected YYYY-MM-DD, RFC 3339, or Unix timestamp, got %q", s)
+	}
+	return t.UTC().Format("2006-01-02"), nil
+}
+
+// NormalizePlaidDateParam accepts YYYY-MM-DD or RFC 3339 / Unix timestamps and returns YYYY-MM-DD (UTC calendar date).
+func NormalizePlaidDateParam(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("empty date")
+	}
+	if yyyymmddPattern.MatchString(s) {
+		return s, nil
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		sec := unixSecondsFromNumeric(f)
+		t := time.Unix(sec, 0).UTC()
+		return t.Format("2006-01-02"), nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "", fmt.Errorf("expected YYYY-MM-DD, RFC 3339, or Unix timestamp, got %q", s)
+	}
+	return t.UTC().Format("2006-01-02"), nil
+}
+
+// unixSecondsFromNumeric interprets a JSON-unmarshaled time as Unix seconds or epoch millis.
+// Values >= 1e11 are treated as milliseconds (covers epoch-ms through year ~5138 in seconds).
+func unixSecondsFromNumeric(f float64) int64 {
+	if f >= 1e11 {
+		return time.UnixMilli(int64(f)).Unix()
+	}
+	return int64(f)
+}

--- a/connectors/timestamp_test.go
+++ b/connectors/timestamp_test.go
@@ -1,0 +1,59 @@
+package connectors
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestParseUnixTimestampOrRFC3339(t *testing.T) {
+	t.Parallel()
+	mar1 := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC).Unix()
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"", 0},
+		{"1709251200", 1709251200},
+		{"1709251200000", 1709251200},
+		{"2024-03-01T00:00:00Z", mar1},
+	}
+	for _, tc := range cases {
+		got, err := ParseUnixTimestampOrRFC3339(tc.in)
+		if err != nil {
+			t.Fatalf("ParseUnixTimestampOrRFC3339(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("ParseUnixTimestampOrRFC3339(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeHubSpotAnalyticsTimeParam(t *testing.T) {
+	t.Parallel()
+	got, err := NormalizeHubSpotAnalyticsTimeParam("2026-01-01")
+	if err != nil || got != "2026-01-01" {
+		t.Fatalf("date-only: got %q err %v", got, err)
+	}
+	got, err = NormalizeHubSpotAnalyticsTimeParam("2026-01-01T12:00:00Z")
+	if err != nil || got != "2026-01-01" {
+		t.Fatalf("rfc3339: got %q err %v", got, err)
+	}
+	ms := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	got, err = NormalizeHubSpotAnalyticsTimeParam(strconv.FormatInt(ms, 10))
+	if err != nil || got != "2025-02-01" {
+		t.Fatalf("epoch ms: got %q err %v", got, err)
+	}
+}
+
+func TestNormalizePlaidDateParam(t *testing.T) {
+	t.Parallel()
+	got, err := NormalizePlaidDateParam("2025-06-15")
+	if err != nil || got != "2025-06-15" {
+		t.Fatalf("date: got %q err %v", got, err)
+	}
+	got, err = NormalizePlaidDateParam("2025-06-15T23:59:59Z")
+	if err != nil || got != "2025-06-15" {
+		t.Fatalf("rfc3339: got %q err %v", got, err)
+	}
+}

--- a/connectors/walmart/manifest.go
+++ b/connectors/walmart/manifest.go
@@ -49,7 +49,8 @@ func (c *WalmartConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "integer",
 							"minimum": 0,
 							"default": 0,
-							"description": "Starting index for pagination"
+							"description": "Starting index for pagination",
+							"x-ui": {"hidden": true}
 						},
 						"limit": {
 							"type": "integer",

--- a/connectors/zoom/manifest.go
+++ b/connectors/zoom/manifest.go
@@ -64,7 +64,9 @@ func (c *ZoomConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_time": {
 							"type": "string",
-							"description": "Start time in ISO 8601 format (e.g. '2024-01-15T09:00:00Z')"
+							"format": "date-time",
+							"description": "Start time in ISO 8601 format (e.g. '2024-01-15T09:00:00Z')",
+							"x-ui": {"widget": "datetime"}
 						},
 						"duration": {
 							"type": "integer",
@@ -130,7 +132,9 @@ func (c *ZoomConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"start_time": {
 							"type": "string",
-							"description": "Updated start time in ISO 8601 format"
+							"format": "date-time",
+							"description": "Updated start time in ISO 8601 format",
+							"x-ui": {"widget": "datetime"}
 						},
 						"duration": {
 							"type": "integer",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [GitHub issue #784](https://github.com/supersuit-tech/permission-slip/issues/784): extends the Slack connector UX patterns (`x-ui.hidden`, `format` + `x-ui.widget` for datetime/date, range pairing) to other built-in connectors, with backend normalization where APIs still expect Unix timestamps or strict date strings.

Closes #784

### Developer

- [x] Hide pagination cursors/offsets where listed in the issue (airtable, doordash, linkedin, kroger, walmart, plaid)
- [x] Meta `since` / `until`: string + `date-time` + datetime widgets; execution accepts RFC 3339, Unix seconds, and epoch ms
- [x] HubSpot `get_analytics` `start` / `end`: datetime widgets + normalize to `YYYY-MM-DD` for the API (still accepts plain dates and legacy numeric forms)
- [x] Plaid `list_transactions` dates: `format: date`, `widget: date`, range pairing; normalize RFC 3339 / epoch to `YYYY-MM-DD` before calling Plaid
- [x] Intercom `search_tickets`: optional `created_at_*` / `updated_at_*` bounds with AND-combined search query; datetime widgets + pairing
- [x] Airtable `search_records`: add hidden `offset` + wire through to list API (issue listed Search Records)
- [x] Shared helpers in `connectors/timestamp.go` + unit tests

### Manual Testing

- [ ] Confirm hidden pagination fields do not appear in agent connector action config UI for updated connectors
- [ ] Spot-check datetime and date pickers (Shopify order filters, Meta time range, Jira sprint dates, Plaid transaction range, etc.)
- [ ] Confirm datetime/date range min/max pairing behaves as expected
- [ ] Execute Meta / HubSpot / Plaid / Intercom actions with RFC 3339 values from an agent path (not only the config form)

## Test plan

Could not run `make test-backend` in this agent environment: local Go is 1.22.2 while module dependencies require Go ≥ 1.24, so the toolchain cannot load modules here. Please run `make test-backend` (or `make test`) on a machine with the repository’s expected Go version.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96426622-be4a-4ba0-8df1-7a2793be82c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96426622-be4a-4ba0-8df1-7a2793be82c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

