### PR TITLE
Add Dropbox OAuth PKCE support (closes #91)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,6 +292,7 @@ Or copy the component source manually into `src/components/ui/` from the [shadcn
 
 The OpenAPI spec (`spec/openapi/`) is the single source of truth for all API types. The typed client uses `openapi-fetch`, and types are generated via `openapi-typescript`.
 
+- **`frontend/src/api/schema.d.ts` and `mobile/src/api/schema.d.ts` are gitignored** — they are produced locally when you run `make generate` (or `npm run generate:api` per package). PRs that change the spec should include the updated YAML and bundled `openapi.bundle.yaml`; reviewers run `make generate` to refresh their working copies.
 - **Never hand-write API types or request functions.** Generate from the spec with `make generate`. If a type doesn't exist in the generated output, the spec needs updating — not a manual type.
 - Import all request/response types from the generated client (`api/schema.d.ts`).
 - New API calls must use the `openapi-fetch` client in `api/client.ts` — never raw `fetch` for our API.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Permission Slip solves this with a **secure proxy + human-in-the-loop approval**
 - 🔐 **Cryptographic agent identity** — Ed25519 key pairs for tamper-proof request signing
 - 🙈 **Zero credential exposure** — agents never see your API keys or passwords
 - 📋 **Full audit trail** — every request, approval, and execution logged
-- 🔌 **OAuth 2.0 connections** — Google, Microsoft, and custom providers; tokens encrypted at rest with automatic refresh
+- 🔌 **OAuth 2.0 connections** — Google, Microsoft, Dropbox, and custom providers; PKCE where required; tokens encrypted at rest with automatic refresh
 - 🏠 **Self-hostable** — your data, your infrastructure
 - 📦 **Single binary deployment** — Go server with embedded React frontend
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -72,6 +72,7 @@ type oauthProviderResponse struct {
 	Scopes         []string `json:"scopes"`
 	Source         string   `json:"source"`
 	HasCredentials bool     `json:"has_credentials"`
+	PKCE           bool     `json:"pkce"`
 }
 
 type oauthProviderListResponse struct {
@@ -405,6 +406,7 @@ func handleListOAuthProviders(deps *Deps) http.HandlerFunc {
 				Scopes:         p.Scopes,
 				Source:         string(p.Source),
 				HasCredentials: p.HasClientCredentials(),
+				PKCE:           p.PKCE,
 			}
 		}
 		RespondJSON(w, http.StatusOK, oauthProviderListResponse{Providers: data})

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -148,7 +148,11 @@ func oauthStateSecret(deps *Deps) string {
 //
 // The returnTo parameter is the frontend path the user should be sent back
 // to after the callback (e.g. "/agents/1"). Pass "" to redirect to "/".
-func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop, returnTo, replaceID string) (string, error) {
+//
+// pkceVerifier, when non-empty, is stored in the state JWT and passed to the
+// token endpoint on callback (RFC 7636). Must be paired with S256 challenge
+// on the authorization request.
+func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop, returnTo, replaceID, pkceVerifier string) (string, error) {
 	secret := oauthStateSecret(deps)
 	if secret == "" {
 		return "", fmt.Errorf("no OAuth state secret configured")
@@ -169,6 +173,9 @@ func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop
 	}
 	if replaceID != "" {
 		claims["replace_id"] = replaceID
+	}
+	if pkceVerifier != "" {
+		claims["pkce_verifier"] = pkceVerifier
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(secret))
@@ -193,6 +200,9 @@ type oauthState struct {
 	// set, storeOAuthTokens deletes only that specific connection. When empty,
 	// a new connection is created alongside any existing ones.
 	ReplaceID string
+	// PKCEVerifier is the RFC 7636 code verifier when PKCE is used for this
+	// flow. Empty when the provider does not require PKCE.
+	PKCEVerifier string
 }
 
 // verifyOAuthState validates the signed state JWT and returns the encoded
@@ -234,7 +244,8 @@ func verifyOAuthState(deps *Deps, stateStr string) (*oauthState, error) {
 	shop, _ := claims["shop"].(string)
 	returnTo, _ := claims["return_to"].(string)
 	replaceID, _ := claims["replace_id"].(string)
-	return &oauthState{UserID: sub, Provider: prov, Scopes: scopes, Shop: shop, ReturnTo: returnTo, ReplaceID: replaceID}, nil
+	pkceVerifier, _ := claims["pkce_verifier"].(string)
+	return &oauthState{UserID: sub, Provider: prov, Scopes: scopes, Shop: shop, ReturnTo: returnTo, ReplaceID: replaceID, PKCEVerifier: pkceVerifier}, nil
 }
 
 // --- Helpers ---
@@ -482,7 +493,11 @@ func handleOAuthAuthorize(deps *Deps) http.HandlerFunc {
 		// Optional: replace an existing connection instead of creating alongside.
 		replaceID := r.URL.Query().Get("replace")
 		profile := Profile(r.Context())
-		state, err := createOAuthState(deps, profile.ID, providerID, storedOAuthScopes, instanceID, returnTo, replaceID)
+		var pkceVerifier string
+		if provider.PKCE {
+			pkceVerifier = oauth2.GenerateVerifier()
+		}
+		state, err := createOAuthState(deps, profile.ID, providerID, storedOAuthScopes, instanceID, returnTo, replaceID, pkceVerifier)
 		if err != nil {
 			log.Printf("[%s] OAuthAuthorize: create state: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -500,6 +515,9 @@ func handleOAuthAuthorize(deps *Deps) http.HandlerFunc {
 				continue
 			}
 			authOpts = append(authOpts, oauth2.SetAuthURLParam(k, v))
+		}
+		if pkceVerifier != "" {
+			authOpts = append(authOpts, oauth2.S256ChallengeOption(pkceVerifier))
 		}
 		authURL := cfg.AuthCodeURL(state, authOpts...)
 		http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
@@ -609,7 +627,11 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		// Exchange authorization code for tokens.
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		token, err := cfg.Exchange(ctx, code)
+		var exchangeOpts []oauth2.AuthCodeOption
+		if state.PKCEVerifier != "" {
+			exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(state.PKCEVerifier))
+		}
+		token, err := cfg.Exchange(ctx, code, exchangeOpts...)
 		if err != nil {
 			log.Printf("[%s] OAuthCallback: token exchange failed: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -16,6 +16,8 @@
 //   - CSRF protection via signed JWT state tokens (HS256, 10-min TTL)
 //   - State encodes user ID + provider to prevent session fixation
 //   - Callback derives user identity from the signed state token (no session required)
+//   - PKCE verifiers are AES-256-GCM sealed with the state signing key before embedding
+//     in the JWT payload so they are not exposed in browser history or logs (JWT is only signed)
 //   - Tokens stored server-side in Supabase Vault (AES-256-GCM)
 //   - Provider path params validated against ProviderIDPattern
 //   - No tokens or secrets are ever returned in API responses
@@ -23,6 +25,11 @@ package api
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,6 +50,60 @@ import (
 
 // oauthStateTTL is the maximum lifetime of an OAuth CSRF state token.
 const oauthStateTTL = 10 * time.Minute
+
+// oauthStatePKCENonceSize is the GCM nonce length for sealing PKCE verifiers in state JWTs.
+const oauthStatePKCENonceSize = 12
+
+func oauthStateAEAD(secret string) (cipher.AEAD, error) {
+	sum := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+// sealOAuthStatePKCE encrypts the PKCE verifier for storage inside the signed state JWT.
+// The JWT is only signed (not encrypted), so the verifier must not appear in plaintext in the payload.
+func sealOAuthStatePKCE(secret, verifier string) (string, error) {
+	if verifier == "" {
+		return "", nil
+	}
+	aead, err := oauthStateAEAD(secret)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, oauthStatePKCENonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nonce, nonce, []byte(verifier), nil)
+	return base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func openOAuthStatePKCE(secret, encoded string) (string, error) {
+	if encoded == "" {
+		return "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("decode pkce blob: %w", err)
+	}
+	if len(raw) < oauthStatePKCENonceSize {
+		return "", fmt.Errorf("pkce blob too short")
+	}
+	aead, err := oauthStateAEAD(secret)
+	if err != nil {
+		return "", err
+	}
+	nonce := raw[:oauthStatePKCENonceSize]
+	ciphertext := raw[oauthStatePKCENonceSize:]
+	plain, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt pkce blob: %w", err)
+	}
+	return string(plain), nil
+}
 
 // subdomainPattern matches valid RFC 1123-style subdomains: lowercase
 // alphanumeric and hyphens, not starting or ending with a hyphen, max 63 chars.
@@ -150,9 +211,9 @@ func oauthStateSecret(deps *Deps) string {
 // The returnTo parameter is the frontend path the user should be sent back
 // to after the callback (e.g. "/agents/1"). Pass "" to redirect to "/".
 //
-// pkceVerifier, when non-empty, is stored in the state JWT and passed to the
-// token endpoint on callback (RFC 7636). Must be paired with S256 challenge
-// on the authorization request.
+// pkceVerifier, when non-empty, is sealed and stored in the state JWT, then
+// recovered on callback for the token exchange (RFC 7636). Must be paired with
+// S256 challenge on the authorization request.
 func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop, returnTo, replaceID, pkceVerifier string) (string, error) {
 	secret := oauthStateSecret(deps)
 	if secret == "" {
@@ -176,7 +237,11 @@ func createOAuthState(deps *Deps, userID, provider string, scopes []string, shop
 		claims["replace_id"] = replaceID
 	}
 	if pkceVerifier != "" {
-		claims["pkce_verifier"] = pkceVerifier
+		sealed, err := sealOAuthStatePKCE(secret, pkceVerifier)
+		if err != nil {
+			return "", fmt.Errorf("seal pkce verifier: %w", err)
+		}
+		claims["pkce_sealed"] = sealed
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(secret))
@@ -245,7 +310,17 @@ func verifyOAuthState(deps *Deps, stateStr string) (*oauthState, error) {
 	shop, _ := claims["shop"].(string)
 	returnTo, _ := claims["return_to"].(string)
 	replaceID, _ := claims["replace_id"].(string)
-	pkceVerifier, _ := claims["pkce_verifier"].(string)
+	var pkceVerifier string
+	if sealed, ok := claims["pkce_sealed"].(string); ok && sealed != "" {
+		v, err := openOAuthStatePKCE(secret, sealed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid state token pkce: %w", err)
+		}
+		pkceVerifier = v
+	} else if legacy, ok := claims["pkce_verifier"].(string); ok && legacy != "" {
+		// In-flight tokens from before pkce_sealed (plaintext in JWT payload).
+		pkceVerifier = legacy
+	}
 	return &oauthState{UserID: sub, Provider: prov, Scopes: scopes, Shop: shop, ReturnTo: returnTo, ReplaceID: replaceID, PKCEVerifier: pkceVerifier}, nil
 }
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -25,11 +25,6 @@ package api
 
 import (
 	"context"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,60 +45,6 @@ import (
 
 // oauthStateTTL is the maximum lifetime of an OAuth CSRF state token.
 const oauthStateTTL = 10 * time.Minute
-
-// oauthStatePKCENonceSize is the GCM nonce length for sealing PKCE verifiers in state JWTs.
-const oauthStatePKCENonceSize = 12
-
-func oauthStateAEAD(secret string) (cipher.AEAD, error) {
-	sum := sha256.Sum256([]byte(secret))
-	block, err := aes.NewCipher(sum[:])
-	if err != nil {
-		return nil, err
-	}
-	return cipher.NewGCM(block)
-}
-
-// sealOAuthStatePKCE encrypts the PKCE verifier for storage inside the signed state JWT.
-// The JWT is only signed (not encrypted), so the verifier must not appear in plaintext in the payload.
-func sealOAuthStatePKCE(secret, verifier string) (string, error) {
-	if verifier == "" {
-		return "", nil
-	}
-	aead, err := oauthStateAEAD(secret)
-	if err != nil {
-		return "", err
-	}
-	nonce := make([]byte, oauthStatePKCENonceSize)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", err
-	}
-	sealed := aead.Seal(nonce, nonce, []byte(verifier), nil)
-	return base64.RawURLEncoding.EncodeToString(sealed), nil
-}
-
-func openOAuthStatePKCE(secret, encoded string) (string, error) {
-	if encoded == "" {
-		return "", nil
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(encoded)
-	if err != nil {
-		return "", fmt.Errorf("decode pkce blob: %w", err)
-	}
-	if len(raw) < oauthStatePKCENonceSize {
-		return "", fmt.Errorf("pkce blob too short")
-	}
-	aead, err := oauthStateAEAD(secret)
-	if err != nil {
-		return "", err
-	}
-	nonce := raw[:oauthStatePKCENonceSize]
-	ciphertext := raw[oauthStatePKCENonceSize:]
-	plain, err := aead.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return "", fmt.Errorf("decrypt pkce blob: %w", err)
-	}
-	return string(plain), nil
-}
 
 // subdomainPattern matches valid RFC 1123-style subdomains: lowercase
 // alphanumeric and hyphens, not starting or ending with a hyphen, max 63 chars.

--- a/api/oauth_state_pkce.go
+++ b/api/oauth_state_pkce.go
@@ -1,3 +1,5 @@
+// AES-256-GCM helpers for sealing the PKCE code verifier inside the OAuth state JWT.
+// JWTs are signed but not encrypted; without this, the verifier would be readable from the base64url-encoded payload.
 package api
 
 import (

--- a/api/oauth_state_pkce.go
+++ b/api/oauth_state_pkce.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// oauthStatePKCENonceSize is the GCM nonce length for sealing PKCE verifiers in state JWTs.
+const oauthStatePKCENonceSize = 12
+
+func oauthStateAEAD(secret string) (cipher.AEAD, error) {
+	sum := sha256.Sum256([]byte(secret))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+// sealOAuthStatePKCE encrypts the PKCE verifier for storage inside the signed state JWT.
+// The JWT is only signed (not encrypted), so the verifier must not appear in plaintext in the payload.
+func sealOAuthStatePKCE(secret, verifier string) (string, error) {
+	if verifier == "" {
+		return "", nil
+	}
+	aead, err := oauthStateAEAD(secret)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, oauthStatePKCENonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nonce, nonce, []byte(verifier), nil)
+	return base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func openOAuthStatePKCE(secret, encoded string) (string, error) {
+	if encoded == "" {
+		return "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("decode pkce blob: %w", err)
+	}
+	if len(raw) < oauthStatePKCENonceSize {
+		return "", fmt.Errorf("pkce blob too short")
+	}
+	aead, err := oauthStateAEAD(secret)
+	if err != nil {
+		return "", err
+	}
+	nonce := raw[:oauthStatePKCENonceSize]
+	ciphertext := raw[oauthStatePKCENonceSize:]
+	plain, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt pkce blob: %w", err)
+	}
+	return string(plain), nil
+}

--- a/api/oauth_state_pkce_test.go
+++ b/api/oauth_state_pkce_test.go
@@ -1,0 +1,58 @@
+package api
+
+import "testing"
+
+func TestSealOpenOAuthStatePKCE_RoundTrip(t *testing.T) {
+	t.Parallel()
+	secret := "test-oauth-state-secret-at-least-32-chars"
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+	sealed, err := sealOAuthStatePKCE(secret, verifier)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if sealed == "" {
+		t.Fatal("expected non-empty sealed blob")
+	}
+	got, err := openOAuthStatePKCE(secret, sealed)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if got != verifier {
+		t.Errorf("got %q, want %q", got, verifier)
+	}
+}
+
+func TestOpenOAuthStatePKCE_WrongSecret(t *testing.T) {
+	t.Parallel()
+	secret := "test-oauth-state-secret-at-least-32-chars"
+	wrong := "different-secret-at-least-32-chars-long"
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+	sealed, err := sealOAuthStatePKCE(secret, verifier)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	_, err = openOAuthStatePKCE(wrong, sealed)
+	if err == nil {
+		t.Fatal("expected error opening with wrong secret")
+	}
+}
+
+func TestSealOpenOAuthStatePKCE_EmptyVerifier(t *testing.T) {
+	t.Parallel()
+	s, err := sealOAuthStatePKCE("any-secret-at-least-32-chars-long!!", "")
+	if err != nil {
+		t.Fatalf("seal empty: %v", err)
+	}
+	if s != "" {
+		t.Errorf("expected empty sealed string, got %q", s)
+	}
+	got, err := openOAuthStatePKCE("any-secret-at-least-32-chars-long!!", "")
+	if err != nil {
+		t.Fatalf("open empty: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty open, got %q", got)
+	}
+}

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -231,7 +232,7 @@ func TestCreateAndVerifyOAuthState(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
+	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -254,11 +255,29 @@ func TestCreateAndVerifyOAuthState(t *testing.T) {
 	}
 }
 
+func TestCreateAndVerifyOAuthState_WithPKCEVerifier(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
+	verifier := oauth2.GenerateVerifier()
+
+	state, err := createOAuthState(deps, "user-123", "dropbox", []string{"files.content.read"}, "", "", "", verifier)
+	if err != nil {
+		t.Fatalf("createOAuthState: %v", err)
+	}
+	verified, err := verifyOAuthState(deps, state)
+	if err != nil {
+		t.Fatalf("verifyOAuthState: %v", err)
+	}
+	if verified.PKCEVerifier != verifier {
+		t.Errorf("PKCEVerifier round-trip: got %q, want %q", verified.PKCEVerifier, verifier)
+	}
+}
+
 func TestVerifyOAuthState_InvalidSignature(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
+	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -319,7 +338,7 @@ func TestVerifyOAuthState_MissingClaims(t *testing.T) {
 func TestVerifyOAuthState_NoSecret(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{}
-	_, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
+	_, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "", "")
 	if err == nil {
 		t.Fatal("expected error when no secret configured")
 	}
@@ -363,6 +382,60 @@ func TestOAuthAuthorize_Redirect(t *testing.T) {
 	}
 	if !strings.Contains(parsed.Query().Get("redirect_uri"), "/api/v1/oauth/google/callback") {
 		t.Errorf("expected callback URL in redirect_uri, got %s", parsed.Query().Get("redirect_uri"))
+	}
+}
+
+func TestOAuthAuthorize_Dropbox_IncludesPKCE(t *testing.T) {
+	t.Parallel()
+	reg := oauth.NewRegistry()
+	_ = reg.Register(oauth.Provider{
+		ID:           "dropbox",
+		AuthorizeURL: "https://www.dropbox.com/oauth2/authorize",
+		TokenURL:     "https://api.dropboxapi.com/oauth2/token",
+		Scopes:       []string{"files.content.read"},
+		PKCE:         true,
+		AuthorizeParams: map[string]string{
+			"token_access_type": "offline",
+		},
+		ClientID:     "test-dropbox-client-id",
+		ClientSecret: "test-dropbox-client-secret",
+		Source:       oauth.SourceBuiltIn,
+	})
+	deps := &Deps{
+		OAuthProviders:   reg,
+		OAuthStateSecret: testOAuthStateSecret,
+		BaseURL:          "http://localhost:3000",
+	}
+
+	uid := "user-dropbox-pkce-test"
+	r := httptest.NewRequest(http.MethodGet, "/oauth/dropbox/authorize", nil)
+	r.SetPathValue("provider", "dropbox")
+	ctx := context.WithValue(r.Context(), profileKey{}, &db.Profile{ID: uid})
+	r = r.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handleOAuthAuthorize(deps)(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("expected Location header")
+	}
+	parsed, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("expected code_challenge_method=S256, got %q", q.Get("code_challenge_method"))
+	}
+	if q.Get("code_challenge") == "" {
+		t.Error("expected non-empty code_challenge")
+	}
+	if q.Get("token_access_type") != "offline" {
+		t.Errorf("expected token_access_type=offline from AuthorizeParams, got %q", q.Get("token_access_type"))
 	}
 }
 
@@ -736,7 +809,7 @@ func TestOAuthCallback_ProviderMismatch(t *testing.T) {
 	router := NewRouter(deps)
 
 	// Create state for "microsoft" but hit google callback
-	state, err := createOAuthState(deps, uid, "microsoft", []string{"openid"}, "", "", "")
+	state, err := createOAuthState(deps, uid, "microsoft", []string{"openid"}, "", "", "", "")
 	if err != nil {
 		t.Fatalf("create state: %v", err)
 	}
@@ -765,7 +838,7 @@ func TestOAuthCallback_ProviderError(t *testing.T) {
 
 	// State validation now runs before the provider error check, so we need a
 	// valid state token to reach the error-handling branch.
-	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "", "")
+	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -820,7 +893,7 @@ func TestOAuthCallback_MissingCode(t *testing.T) {
 	deps := oauthDeps(tx)
 	router := NewRouter(deps)
 
-	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "", "")
+	state, err := createOAuthState(deps, uid, "google", []string{"openid"}, "", "", "", "")
 	if err != nil {
 		t.Fatalf("create state: %v", err)
 	}
@@ -1165,7 +1238,7 @@ func TestCreateAndVerifyOAuthState_WithShop(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-456", "shopify", []string{"write_orders"}, "mystore", "", "")
+	state, err := createOAuthState(deps, "user-456", "shopify", []string{"write_orders"}, "mystore", "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}
@@ -1192,7 +1265,7 @@ func TestCreateAndVerifyOAuthState_EmptyShop(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 
-	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "")
+	state, err := createOAuthState(deps, "user-123", "google", []string{"openid"}, "", "", "", "")
 	if err != nil {
 		t.Fatalf("createOAuthState: %v", err)
 	}

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -273,6 +274,49 @@ func TestCreateAndVerifyOAuthState_WithPKCEVerifier(t *testing.T) {
 	}
 	if verified.PKCEVerifier != verifier {
 		t.Errorf("PKCEVerifier round-trip: got %q, want %q", verified.PKCEVerifier, verifier)
+	}
+
+	// JWT payload is only base64url-encoded (not encrypted); verifier must not appear in plaintext.
+	parts := strings.Split(state, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected JWT with 3 segments, got %d", len(parts))
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode JWT payload: %v", err)
+	}
+	if strings.Contains(string(payloadJSON), verifier) {
+		t.Error("PKCE verifier must not appear in plaintext JWT payload")
+	}
+	if !strings.Contains(string(payloadJSON), "pkce_sealed") {
+		t.Error("expected pkce_sealed claim in JWT payload")
+	}
+}
+
+func TestVerifyOAuthState_LegacyPlaintextPKCEClaim(t *testing.T) {
+	t.Parallel()
+	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
+	verifier := "legacy-plaintext-verifier-43charsxxxxxxxxxxxxxxxxxxxxx"
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub":           "user-legacy",
+		"provider":      "dropbox",
+		"scopes":        []any{"files.content.read"},
+		"iat":           now.Unix(),
+		"exp":           now.Add(10 * time.Minute).Unix(),
+		"pkce_verifier": verifier,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	stateStr, err := token.SignedString([]byte(testOAuthStateSecret))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	verified, err := verifyOAuthState(deps, stateStr)
+	if err != nil {
+		t.Fatalf("verifyOAuthState: %v", err)
+	}
+	if verified.PKCEVerifier != verifier {
+		t.Errorf("legacy PKCE: got %q, want %q", verified.PKCEVerifier, verifier)
 	}
 }
 

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -157,6 +157,9 @@ func TestListOAuthProviders_ReturnsRegistered(t *testing.T) {
 			if p.Source != "built_in" {
 				t.Errorf("expected built_in source, got %s", p.Source)
 			}
+			if p.PKCE {
+				t.Error("expected google PKCE false in provider list")
+			}
 		}
 		if p.ID == "unconfigured" {
 			if p.HasCredentials {

--- a/connectors/dropbox/manifest.go
+++ b/connectors/dropbox/manifest.go
@@ -192,6 +192,7 @@ func (c *DropboxConnector) Manifest() *connectors.ConnectorManifest {
 				AuthorizeParams: map[string]string{
 					"token_access_type": "offline",
 				},
+				PKCE: true,
 			},
 		},
 		Templates: []connectors.ManifestTemplate{

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -72,6 +72,7 @@ type ManifestOAuthProvider struct {
 	TokenURL        string            `json:"token_url"`
 	Scopes          []string          `json:"scopes,omitempty"`
 	AuthorizeParams map[string]string `json:"authorize_params,omitempty"`
+	PKCE            bool              `json:"pkce,omitempty"`
 }
 
 // ManifestTemplate describes a predefined configuration preset for an action.
@@ -141,13 +142,16 @@ var validAuthTypes = map[string]bool{
 // manifest override security-critical values (redirect_uri, state, client_id)
 // that the platform manages.
 var ReservedAuthorizeParams = map[string]bool{
-	"redirect_uri":  true,
-	"state":         true,
-	"client_id":     true,
-	"client_secret": true,
-	"response_type": true,
-	"code":          true,
-	"grant_type":    true,
+	"redirect_uri":            true,
+	"state":                   true,
+	"client_id":               true,
+	"client_secret":           true,
+	"response_type":           true,
+	"code":                    true,
+	"grant_type":              true,
+	"code_challenge":          true,
+	"code_challenge_method":   true,
+	"code_verifier":           true,
 }
 
 // validateURL parses a URL and checks scheme and host. allowedSchemes specifies

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -234,6 +234,32 @@ func TestParseManifest_OAuthProviders(t *testing.T) {
 	}
 }
 
+func TestParseManifest_OAuthProviders_PKCE(t *testing.T) {
+	input := `{
+		"id": "example",
+		"name": "Example",
+		"actions": [{"action_type": "example.do", "name": "Do"}],
+		"required_credentials": [
+			{"service": "example", "auth_type": "oauth2", "oauth_provider": "example"}
+		],
+		"oauth_providers": [
+			{
+				"id": "example",
+				"authorize_url": "https://auth.example.com/authorize",
+				"token_url": "https://auth.example.com/token",
+				"pkce": true
+			}
+		]
+	}`
+	m, err := ParseManifest([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.OAuthProviders) != 1 || !m.OAuthProviders[0].PKCE {
+		t.Fatalf("expected pkce true, got %+v", m.OAuthProviders)
+	}
+}
+
 func TestParseManifest_OAuthProviderCrossReference(t *testing.T) {
 	// Built-in providers (google, microsoft) should be accepted without declaration.
 	t.Run("built-in provider accepted", func(t *testing.T) {
@@ -520,7 +546,10 @@ func TestManifestValidation_ReservedAuthorizeParams(t *testing.T) {
 		}
 	})
 
-	for _, reserved := range []string{"redirect_uri", "state", "client_id", "client_secret", "response_type", "code", "grant_type"} {
+	for _, reserved := range []string{
+		"redirect_uri", "state", "client_id", "client_secret", "response_type", "code", "grant_type",
+		"code_challenge", "code_challenge_method", "code_verifier",
+	} {
 		t.Run("rejects_"+reserved, func(t *testing.T) {
 			input := fmt.Sprintf(base, fmt.Sprintf(`"%s": "evil-value"`, reserved))
 			_, err := ParseManifest([]byte(input))

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -113,7 +113,7 @@ OAuth provider credentials are configured via environment variables on the serve
 | `DROPBOX_CLIENT_ID` | App key from the [Dropbox App Console](https://www.dropbox.com/developers/apps) |
 | `DROPBOX_CLIENT_SECRET` | App secret from the Dropbox App Console |
 
-The platform uses **PKCE** for Dropbox automatically (verifier is stored in the server-side OAuth state token). `GET /v1/oauth/providers` returns `"pkce": true` for providers that use it.
+The platform uses **PKCE** for Dropbox automatically: the server sends an S256 code challenge to Dropbox and keeps the code verifier only in the **signed OAuth state JWT** (the verifier is **sealed** in the JWT payload so it is not plaintext in browser history or logs). `GET /v1/oauth/providers` returns `"pkce": true` for providers that use PKCE.
 
 ### OAuth Infrastructure
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -113,6 +113,8 @@ OAuth provider credentials are configured via environment variables on the serve
 | `DROPBOX_CLIENT_ID` | App key from the [Dropbox App Console](https://www.dropbox.com/developers/apps) |
 | `DROPBOX_CLIENT_SECRET` | App secret from the Dropbox App Console |
 
+The platform uses **PKCE** for Dropbox automatically (verifier is stored in the server-side OAuth state token). `GET /v1/oauth/providers` returns `"pkce": true` for providers that use it.
+
 ### OAuth Infrastructure
 
 | Variable | Description | Default / Notes |

--- a/main.go
+++ b/main.go
@@ -655,6 +655,7 @@ func registerManifestOAuthProviders(oauthReg *poauth.Registry, connReg *connecto
 				TokenURL:        p.TokenURL,
 				Scopes:          p.Scopes,
 				AuthorizeParams: p.AuthorizeParams,
+				PKCE:            p.PKCE,
 			}
 		}
 		if err := poauth.RegisterFromManifest(oauthReg, providers); err != nil {

--- a/oauth/builtin.go
+++ b/oauth/builtin.go
@@ -98,6 +98,7 @@ func RegisterFromManifest(r *Registry, providers []ManifestProvider) error {
 			TokenURL:        mp.TokenURL,
 			Scopes:          mp.Scopes,
 			AuthorizeParams: mp.AuthorizeParams,
+			PKCE:            mp.PKCE,
 			Source:          SourceManifest,
 		}); err != nil {
 			return fmt.Errorf("registering manifest OAuth provider %q: %w", mp.ID, err)
@@ -114,4 +115,5 @@ type ManifestProvider struct {
 	TokenURL        string
 	Scopes          []string
 	AuthorizeParams map[string]string
+	PKCE            bool
 }

--- a/oauth/builtin_test.go
+++ b/oauth/builtin_test.go
@@ -188,6 +188,28 @@ func TestBuiltInProviders(t *testing.T) {
 			t.Errorf("expected 6 scopes, got %d: %v", len(a.Scopes), a.Scopes)
 		}
 	})
+
+	t.Run("dropbox", func(t *testing.T) {
+		d, ok := byID["dropbox"]
+		if !ok {
+			t.Fatal("dropbox provider not found")
+		}
+		if d.AuthorizeURL != "https://www.dropbox.com/oauth2/authorize" {
+			t.Errorf("AuthorizeURL = %q", d.AuthorizeURL)
+		}
+		if d.TokenURL != "https://api.dropboxapi.com/oauth2/token" {
+			t.Errorf("TokenURL = %q", d.TokenURL)
+		}
+		if d.Source != oauth.SourceBuiltIn {
+			t.Errorf("Source = %q, want %q", d.Source, oauth.SourceBuiltIn)
+		}
+		if !d.PKCE {
+			t.Error("expected PKCE enabled for Dropbox")
+		}
+		if d.AuthorizeParams["token_access_type"] != "offline" {
+			t.Errorf("token_access_type = %q, want offline", d.AuthorizeParams["token_access_type"])
+		}
+	})
 }
 
 func TestNewRegistryWithBuiltIns(t *testing.T) {
@@ -203,6 +225,9 @@ func TestNewRegistryWithBuiltIns(t *testing.T) {
 	}
 	if _, ok := r.Get("discord"); !ok {
 		t.Error("discord not found in registry")
+	}
+	if _, ok := r.Get("dropbox"); !ok {
+		t.Error("dropbox not found in registry")
 	}
 	if _, ok := r.Get("figma"); !ok {
 		t.Error("figma not found in registry")

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -65,6 +65,11 @@ type Provider struct {
 	// because auto-detect never sees a 401 and never retries.
 	AuthStyle oauth2.AuthStyle
 
+	// PKCE when true enables RFC 7636 proof key for code exchange: the server
+	// generates a verifier, sends an S256 challenge on authorize, and passes
+	// the verifier on token exchange. Required by some providers (e.g. Dropbox).
+	PKCE bool
+
 	// Source indicates where the provider configuration originated.
 	Source ProviderSource
 }

--- a/oauth/provider.go
+++ b/oauth/provider.go
@@ -152,6 +152,7 @@ func (p Provider) MarshalJSON() ([]byte, error) {
 		Scopes       []string       `json:"scopes,omitempty"`
 		ClientID     string         `json:"client_id,omitempty"`
 		ClientSecret string         `json:"client_secret,omitempty"`
+		PKCE         bool           `json:"pkce"`
 		Source       ProviderSource `json:"source"`
 	}
 	safe := safeProvider{
@@ -160,6 +161,7 @@ func (p Provider) MarshalJSON() ([]byte, error) {
 		TokenURL:     p.TokenURL,
 		Scopes:       p.Scopes,
 		ClientID:     p.ClientID,
+		PKCE:         p.PKCE,
 		Source:       p.Source,
 	}
 	if p.ClientSecret != "" {

--- a/oauth/provider_test.go
+++ b/oauth/provider_test.go
@@ -300,6 +300,25 @@ func TestProvider_MarshalJSON_NoSecretOmitted(t *testing.T) {
 	}
 }
 
+func TestProvider_MarshalJSON_IncludesPKCE(t *testing.T) {
+	p := Provider{
+		ID:     "dropbox",
+		PKCE:   true,
+		Source: SourceBuiltIn,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(m["pkce"]) != "true" {
+		t.Errorf("expected pkce true in JSON, got %s", string(m["pkce"]))
+	}
+}
+
 func TestTokenSet_StringRedactsTokens(t *testing.T) {
 	ts := TokenSet{
 		AccessToken:  "secret-access-token",

--- a/oauth/providers/dropbox.go
+++ b/oauth/providers/dropbox.go
@@ -19,6 +19,7 @@ func init() {
 			AuthorizeParams: map[string]string{
 				"token_access_type": "offline",
 			},
+			PKCE:         true,
 			ClientID:     os.Getenv("DROPBOX_CLIENT_ID"),
 			ClientSecret: os.Getenv("DROPBOX_CLIENT_SECRET"),
 			Source:       oauth.SourceBuiltIn,

--- a/spec/openapi/components/paths/oauth.yaml
+++ b/spec/openapi/components/paths/oauth.yaml
@@ -30,10 +30,17 @@ oauthProviders:
                   scopes: ["openid", "https://www.googleapis.com/auth/userinfo.email"]
                   source: "built_in"
                   has_credentials: true
+                  pkce: false
                 - id: "microsoft"
                   scopes: ["openid", "offline_access", "User.Read"]
                   source: "built_in"
                   has_credentials: true
+                  pkce: false
+                - id: "dropbox"
+                  scopes: ["files.content.read", "files.content.write", "sharing.write"]
+                  source: "built_in"
+                  has_credentials: true
+                  pkce: true
 
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
@@ -68,6 +75,13 @@ oauthAuthorize:
       the `user_scope` query parameter and does **not** send a bot `scope` parameter.
       After consent, the stored connection uses the Slack user token (`xoxp-`) as the
       primary secret. Workspace bot install is not required.
+
+      ### PKCE (`pkce: true` on the provider)
+
+      For providers that require PKCE (e.g. Dropbox), the server adds an S256 code
+      challenge to the provider authorization URL and stores the verifier only inside
+      the signed state token (encrypted at rest in the JWT payload). No client-side
+      PKCE logic is required.
 
     tags:
       - OAuth
@@ -148,6 +162,11 @@ oauthCallback:
       When Slack token rotation is enabled, user `refresh_token` and expiry may be
       nested under `authed_user` in the token response; the server normalizes these
       before persisting.
+
+      ### PKCE
+
+      When the provider uses PKCE, the callback recovers the code verifier from the
+      validated state token and passes it to the token exchange per RFC 7636.
 
     tags:
       - OAuth

--- a/spec/openapi/components/schemas/oauth.yaml
+++ b/spec/openapi/components/schemas/oauth.yaml
@@ -29,10 +29,12 @@ OAuthProvider:
       type: boolean
       description: >
         When true, the platform uses PKCE (RFC 7636) for this provider's authorize
-        and token exchange. Clients only need to start the usual browser redirect;
-        the verifier is stored server-side in the OAuth state token.
+        and token exchange. The browser still follows the normal redirect to
+        `GET /v1/oauth/{provider}/authorize`; the code verifier is generated and
+        recovered server-side inside the signed OAuth state JWT (sealed so the JWT
+        payload does not contain the verifier in plaintext).
       default: false
-      example: false
+      example: true
 
 OAuthProviderListResponse:
   type: object

--- a/spec/openapi/components/schemas/oauth.yaml
+++ b/spec/openapi/components/schemas/oauth.yaml
@@ -25,6 +25,14 @@ OAuthProvider:
       type: boolean
       description: Whether the provider has client credentials configured and is ready to use
       example: true
+    pkce:
+      type: boolean
+      description: >
+        When true, the platform uses PKCE (RFC 7636) for this provider's authorize
+        and token exchange. Clients only need to start the usual browser redirect;
+        the verifier is stored server-side in the OAuth state token.
+      default: false
+      example: false
 
 OAuthProviderListResponse:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -10660,6 +10660,12 @@ components:
           type: boolean
           description: Whether the provider has client credentials configured and is ready to use
           example: true
+        pkce:
+          type: boolean
+          description: |
+            When true, the platform uses PKCE (RFC 7636) for this provider's authorize and token exchange. Clients only need to start the usual browser redirect; the verifier is stored server-side in the OAuth state token.
+          default: false
+          example: false
     OAuthProviderListResponse:
       type: object
       required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -5677,6 +5677,7 @@ paths:
                       - https://www.googleapis.com/auth/userinfo.email
                     source: built_in
                     has_credentials: true
+                    pkce: false
                   - id: microsoft
                     scopes:
                       - openid
@@ -5684,6 +5685,15 @@ paths:
                       - User.Read
                     source: built_in
                     has_credentials: true
+                    pkce: false
+                  - id: dropbox
+                    scopes:
+                      - files.content.read
+                      - files.content.write
+                      - sharing.write
+                    source: built_in
+                    has_credentials: true
+                    pkce: true
         '401':
           $ref: '#/components/responses/Unauthorized'
         '429':
@@ -5714,6 +5724,13 @@ paths:
         the `user_scope` query parameter and does **not** send a bot `scope` parameter.
         After consent, the stored connection uses the Slack user token (`xoxp-`) as the
         primary secret. Workspace bot install is not required.
+
+        ### PKCE (`pkce: true` on the provider)
+
+        For providers that require PKCE (e.g. Dropbox), the server adds an S256 code
+        challenge to the provider authorization URL and stores the verifier only inside
+        the signed state token (encrypted at rest in the JWT payload). No client-side
+        PKCE logic is required.
       tags:
         - OAuth
       security:
@@ -5779,6 +5796,11 @@ paths:
         When Slack token rotation is enabled, user `refresh_token` and expiry may be
         nested under `authed_user` in the token response; the server normalizes these
         before persisting.
+
+        ### PKCE
+
+        When the provider uses PKCE, the callback recovers the code verifier from the
+        validated state token and passes it to the token exchange per RFC 7636.
       tags:
         - OAuth
       security:
@@ -10663,9 +10685,9 @@ components:
         pkce:
           type: boolean
           description: |
-            When true, the platform uses PKCE (RFC 7636) for this provider's authorize and token exchange. Clients only need to start the usual browser redirect; the verifier is stored server-side in the OAuth state token.
+            When true, the platform uses PKCE (RFC 7636) for this provider's authorize and token exchange. The browser still follows the normal redirect to `GET /v1/oauth/{provider}/authorize`; the code verifier is generated and recovered server-side inside the signed OAuth state JWT (sealed so the JWT payload does not contain the verifier in plaintext).
           default: false
-          example: false
+          example: true
     OAuthProviderListResponse:
       type: object
       required:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #91 calls for Dropbox OAuth with PKCE (`pkce: true`), `token_access_type=offline`, and the documented scopes. The Dropbox connector, manifest, and built-in provider were already on `main`; this change completes the OAuth side by **implementing RFC 7636 PKCE** in the platform OAuth handlers when a provider sets `PKCE: true`.

- `oauth.Provider` and connector manifest `oauth_providers` gain optional `pkce` / `PKCE`.
- Authorize: generate a verifier, add S256 challenge to the auth URL, store the verifier in the signed state JWT.
- Callback: pass `oauth2.VerifierOption` to `Exchange`.
- Manifest validation reserves `code_challenge`, `code_challenge_method`, and `code_verifier` so connector manifests cannot override platform-controlled PKCE params.
- Built-in Dropbox provider and `connectors/dropbox` manifest set `PKCE: true`; `main.go` passes `PKCE` when registering manifest providers.

Closes #91

### Developer

- [x] Add PKCE plumbing and tests (`api`, `oauth`, `connectors` manifest)
- [x] `make build` (frontend + Go)

### Manual Testing

- [ ] End-to-end: authorize → callback → token storage for Dropbox with a real app (redirect `https://<domain>/v1/oauth/dropbox/callback`)
- [ ] Confirm refresh tokens are issued (`token_access_type=offline` still present on authorize URL)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f8ee827-6ab2-437e-b988-9884f2e0b1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f8ee827-6ab2-437e-b988-9884f2e0b1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

