### PR TITLE
Add Ticketmaster Discovery API connector

### DIFF
--- a/connectors/all/all.go
+++ b/connectors/all/all.go
@@ -51,6 +51,7 @@ import (
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/square"
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/stripe"
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/supabase"
+	_ "github.com/supersuit-tech/permission-slip-web/connectors/ticketmaster"
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/trello"
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/twilio"
 	_ "github.com/supersuit-tech/permission-slip-web/connectors/vercel"

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -34,10 +34,10 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 48 active built-in connector packages; kroger is disabled via
+	// There are 49 active built-in connector packages; kroger is disabled via
 	// connectors/kroger/disabled (embedded in the binary via //go:embed).
 	// Update this number when adding, removing, or re-enabling connectors.
-	const expected = 48
+	const expected = 49
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}

--- a/connectors/ticketmaster/get_attraction.go
+++ b/connectors/ticketmaster/get_attraction.go
@@ -1,0 +1,40 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getAttractionAction implements connectors.Action for ticketmaster.get_attraction.
+type getAttractionAction struct {
+	conn *TicketmasterConnector
+}
+
+type getAttractionParams struct {
+	AttractionID string `json:"attraction_id"`
+	Locale       string `json:"locale"`
+}
+
+func (a *getAttractionAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getAttractionParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := validateTicketmasterID(trimString(params.AttractionID), "attraction_id"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "locale", trimString(params.Locale))
+
+	path := fmt.Sprintf("attractions/%s.json", url.PathEscape(trimString(params.AttractionID)))
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, path, q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/get_event.go
+++ b/connectors/ticketmaster/get_event.go
@@ -1,0 +1,40 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getEventAction implements connectors.Action for ticketmaster.get_event.
+type getEventAction struct {
+	conn *TicketmasterConnector
+}
+
+type getEventParams struct {
+	EventID string `json:"event_id"`
+	Locale  string `json:"locale"`
+}
+
+func (a *getEventAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getEventParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := validateTicketmasterID(trimString(params.EventID), "event_id"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "locale", trimString(params.Locale))
+
+	path := fmt.Sprintf("events/%s.json", url.PathEscape(trimString(params.EventID)))
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, path, q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/get_venue.go
+++ b/connectors/ticketmaster/get_venue.go
@@ -1,0 +1,40 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// getVenueAction implements connectors.Action for ticketmaster.get_venue.
+type getVenueAction struct {
+	conn *TicketmasterConnector
+}
+
+type getVenueParams struct {
+	VenueID string `json:"venue_id"`
+	Locale  string `json:"locale"`
+}
+
+func (a *getVenueAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params getVenueParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := validateTicketmasterID(trimString(params.VenueID), "venue_id"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "locale", trimString(params.Locale))
+
+	path := fmt.Sprintf("venues/%s.json", url.PathEscape(trimString(params.VenueID)))
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, path, q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/list_classifications.go
+++ b/connectors/ticketmaster/list_classifications.go
@@ -1,0 +1,46 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// listClassificationsAction implements connectors.Action for ticketmaster.list_classifications.
+type listClassificationsAction struct {
+	conn *TicketmasterConnector
+}
+
+type listClassificationsParams struct {
+	ClassificationID string `json:"classification_id"`
+	Locale           string `json:"locale"`
+	Source           string `json:"source"`
+}
+
+func (a *listClassificationsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listClassificationsParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "locale", trimString(params.Locale))
+	appendNonEmpty(q, "source", trimString(params.Source))
+
+	path := "classifications.json"
+	if id := trimString(params.ClassificationID); id != "" {
+		if err := validateTicketmasterID(id, "classification_id"); err != nil {
+			return nil, err
+		}
+		path = fmt.Sprintf("classifications/%s.json", url.PathEscape(id))
+	}
+
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, path, q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/logo.svg
+++ b/connectors/ticketmaster/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Ticketmaster"><rect width="24" height="24" rx="4" fill="#026cdf"/><path fill="#fff" d="M6 8.5c0-.83.67-1.5 1.5-1.5h9c.83 0 1.5.67 1.5 1.5v7c0 .83-.67 1.5-1.5 1.5h-9A1.5 1.5 0 0 1 6 15.5v-7Zm2 .5v6h8V9H8Zm2.5 1.5h3v1h-3v-1Zm0 2h3v1h-3v-1Z"/></svg>

--- a/connectors/ticketmaster/manifest.go
+++ b/connectors/ticketmaster/manifest.go
@@ -1,0 +1,194 @@
+package ticketmaster
+
+import (
+	_ "embed"
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+//go:embed logo.svg
+var logoSVG string
+
+// Manifest returns connector metadata for DB seeding.
+func (c *TicketmasterConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "ticketmaster",
+		Name:        "Ticketmaster",
+		Description: "Ticketmaster Discovery API for event search, venues, attractions, genres, and purchase links",
+		LogoSVG:     logoSVG,
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "ticketmaster.search_events",
+				Name:        "Search events",
+				Description: "Search events by keyword, location (lat/long, city, DMA, postal code), date range, and genre filters. Returns Ticketmaster event payloads including purchase URLs.",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"keyword": {"type": "string", "description": "Free-text search keyword"},
+						"latlong": {"type": "string", "description": "Latitude and longitude as \"lat,long\" (e.g. \"34.0522,-118.2437\")"},
+						"radius": {"type": "string", "description": "Search radius (use with latlong)"},
+						"unit": {"type": "string", "enum": ["miles", "km"], "description": "Radius unit"},
+						"city": {"type": "string", "description": "City name"},
+						"state_code": {"type": "string", "description": "State or region code (e.g. CA)"},
+						"country_code": {"type": "string", "description": "ISO country code (e.g. US)"},
+						"postal_code": {"type": "string", "description": "Postal or ZIP code"},
+						"dma_id": {"type": "string", "description": "Designated Market Area ID"},
+						"start_date_time": {"type": "string", "description": "Start of date/time range (ISO-8601 with offset, e.g. 2026-06-01T00:00:00Z)"},
+						"end_date_time": {"type": "string", "description": "End of date/time range (ISO-8601 with offset)"},
+						"classification_name": {"type": "string", "description": "Filter by classification name (e.g. music, sports)"},
+						"classification_id": {"type": "string", "description": "Filter by classification ID"},
+						"segment_id": {"type": "string", "description": "Filter by segment ID"},
+						"genre_id": {"type": "string", "description": "Filter by genre ID"},
+						"sub_genre_id": {"type": "string", "description": "Filter by sub-genre ID"},
+						"source": {"type": "string", "description": "Ticket source filter (e.g. ticketmaster, universe, frontgate, tmr)"},
+						"sort": {"type": "string", "description": "Sort order (e.g. date,asc)"},
+						"size": {"type": "integer", "description": "Page size (1–200; omit for API default)"},
+						"page": {"type": "integer", "description": "Zero-based page number"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.get_event",
+				Name:        "Get event",
+				Description: "Get full event details: performers, venue, dates, price ranges, on-sale dates, and Ticketmaster purchase URL",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["event_id"],
+					"properties": {
+						"event_id": {"type": "string", "description": "Ticketmaster event ID"},
+						"locale": {"type": "string", "description": "Locale (e.g. en-us)"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.search_venues",
+				Name:        "Search venues",
+				Description: "Search venues by keyword or location (lat/long, city, postal code)",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"keyword": {"type": "string", "description": "Venue name or keyword"},
+						"latlong": {"type": "string", "description": "\"lat,long\" pair"},
+						"radius": {"type": "string", "description": "Search radius"},
+						"unit": {"type": "string", "enum": ["miles", "km"]},
+						"country_code": {"type": "string"},
+						"state_code": {"type": "string"},
+						"city": {"type": "string"},
+						"postal_code": {"type": "string"},
+						"source": {"type": "string"},
+						"sort": {"type": "string"},
+						"size": {"type": "integer"},
+						"page": {"type": "integer"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.get_venue",
+				Name:        "Get venue",
+				Description: "Get venue details: address, capacity, images, and related metadata",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["venue_id"],
+					"properties": {
+						"venue_id": {"type": "string", "description": "Ticketmaster venue ID"},
+						"locale": {"type": "string"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.search_attractions",
+				Name:        "Search attractions",
+				Description: "Search artists, teams, shows, and other attractions; filter by genre IDs from classifications",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"keyword": {"type": "string"},
+						"classification_id": {"type": "string"},
+						"segment_id": {"type": "string"},
+						"genre_id": {"type": "string"},
+						"sub_genre_id": {"type": "string"},
+						"source": {"type": "string"},
+						"sort": {"type": "string"},
+						"size": {"type": "integer"},
+						"page": {"type": "integer"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.get_attraction",
+				Name:        "Get attraction",
+				Description: "Get attraction (performer) details and metadata",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["attraction_id"],
+					"properties": {
+						"attraction_id": {"type": "string"},
+						"locale": {"type": "string"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.list_classifications",
+				Name:        "List classifications",
+				Description: "Browse genre hierarchy (segments, genres, sub-genres). Omit classification_id for the full tree, or pass classification_id for one branch",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {
+						"classification_id": {"type": "string", "description": "Optional segment or genre ID to fetch that subtree"},
+						"locale": {"type": "string"},
+						"source": {"type": "string"}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "ticketmaster.suggest",
+				Name:        "Suggest",
+				Description: "Autocomplete suggestions for events, venues, and attractions (Discovery suggest API)",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["keyword"],
+					"properties": {
+						"keyword": {"type": "string", "description": "Partial search text"},
+						"source": {"type": "string", "description": "Restrict suggestion sources"},
+						"locale": {"type": "string"}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{Service: "ticketmaster", AuthType: "api_key", InstructionsURL: "https://developer.ticketmaster.com/products-and-docs/apis/getting-started/"},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_ticketmaster_search_events_read",
+				ActionType:  "ticketmaster.search_events",
+				Name:        "Search events (read-only)",
+				Description: "Search Ticketmaster events by keyword and city or coordinates. No purchases.",
+				Parameters:  json.RawMessage(`{"keyword":"*","city":"*","start_date_time":"*","end_date_time":"*","size":"*"}`),
+			},
+			{
+				ID:          "tpl_ticketmaster_get_event",
+				ActionType:  "ticketmaster.get_event",
+				Name:        "Look up one event",
+				Description: "Fetch a single event by ID (pricing, venue, purchase link).",
+				Parameters:  json.RawMessage(`{"event_id":"*"}`),
+			},
+			{
+				ID:          "tpl_ticketmaster_suggest",
+				ActionType:  "ticketmaster.suggest",
+				Name:        "Autocomplete",
+				Description: "Suggest completions for a user-typed query.",
+				Parameters:  json.RawMessage(`{"keyword":"*"}`),
+			},
+		},
+	}
+}

--- a/connectors/ticketmaster/register.go
+++ b/connectors/ticketmaster/register.go
@@ -1,0 +1,7 @@
+package ticketmaster
+
+import "github.com/supersuit-tech/permission-slip-web/connectors"
+
+func init() {
+	connectors.RegisterBuiltIn(New())
+}

--- a/connectors/ticketmaster/response.go
+++ b/connectors/ticketmaster/response.go
@@ -1,0 +1,63 @@
+package ticketmaster
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// checkResponse maps Discovery API HTTP status codes to typed connector errors.
+func checkResponse(statusCode int, header http.Header, body []byte) error {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+
+	msg := extractErrorMessage(body)
+
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		retryAfter := connectors.ParseRetryAfter(header.Get("Retry-After"), time.Second)
+		return &connectors.RateLimitError{
+			Message:    fmt.Sprintf("Ticketmaster Discovery API rate limit exceeded: %s", msg),
+			RetryAfter: retryAfter,
+		}
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
+		return &connectors.AuthError{Message: fmt.Sprintf("Ticketmaster Discovery API auth error (%d): %s", statusCode, msg)}
+	case statusCode == http.StatusBadRequest:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Ticketmaster Discovery API validation error: %s", msg)}
+	case statusCode == http.StatusNotFound:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Ticketmaster Discovery API resource not found: %s", msg)}
+	default:
+		return &connectors.ExternalError{
+			StatusCode: statusCode,
+			Message:    fmt.Sprintf("Ticketmaster Discovery API error: %s", msg),
+		}
+	}
+}
+
+func extractErrorMessage(body []byte) string {
+	var env struct {
+		Fault struct {
+			FaultString string `json:"faultstring"`
+		} `json:"fault"`
+		Errors []struct {
+			Detail string `json:"detail"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal(body, &env) == nil {
+		if env.Fault.FaultString != "" {
+			return env.Fault.FaultString
+		}
+		if len(env.Errors) > 0 && env.Errors[0].Detail != "" {
+			return env.Errors[0].Detail
+		}
+	}
+	s := string(body)
+	if len(s) > 500 {
+		s = s[:500] + "... (truncated)"
+	}
+	return s
+}

--- a/connectors/ticketmaster/response_test.go
+++ b/connectors/ticketmaster/response_test.go
@@ -1,0 +1,59 @@
+package ticketmaster
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestCheckResponse_Success(t *testing.T) {
+	t.Parallel()
+	if err := checkResponse(200, nil, nil); err != nil {
+		t.Errorf("checkResponse(200) = %v, want nil", err)
+	}
+}
+
+func TestCheckResponse_RateLimit(t *testing.T) {
+	t.Parallel()
+	h := http.Header{"Retry-After": []string{"5"}}
+	err := checkResponse(429, h, []byte(`{"fault":{"faultstring":"limit"}}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Fatalf("got %T, want RateLimitError", err)
+	}
+}
+
+func TestCheckResponse_Auth(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(401, nil, []byte(`{"fault":{"faultstring":"bad key"}}`))
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("got %T, want AuthError", err)
+	}
+}
+
+func TestCheckResponse_Validation(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(400, nil, []byte(`{}`))
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("got %T, want ValidationError", err)
+	}
+}
+
+func TestCheckResponse_NotFound(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(404, nil, []byte(`{}`))
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("got %T, want ValidationError", err)
+	}
+}
+
+func TestCheckResponse_External(t *testing.T) {
+	t.Parallel()
+	err := checkResponse(500, nil, []byte(`err`))
+	if !connectors.IsExternalError(err) {
+		t.Fatalf("got %T, want ExternalError", err)
+	}
+}

--- a/connectors/ticketmaster/search_attractions.go
+++ b/connectors/ticketmaster/search_attractions.go
@@ -1,0 +1,72 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// searchAttractionsAction implements connectors.Action for ticketmaster.search_attractions.
+type searchAttractionsAction struct {
+	conn *TicketmasterConnector
+}
+
+type searchAttractionsParams struct {
+	Keyword          string `json:"keyword"`
+	ClassificationID string `json:"classification_id"`
+	SegmentID        string `json:"segment_id"`
+	GenreID          string `json:"genre_id"`
+	SubGenreID       string `json:"sub_genre_id"`
+	Source           string `json:"source"`
+	Sort             string `json:"sort"`
+	Size             int    `json:"size"`
+	Page             int    `json:"page"`
+}
+
+func (p *searchAttractionsParams) validate() error {
+	if trimString(p.Keyword) == "" && trimString(p.ClassificationID) == "" &&
+		trimString(p.SegmentID) == "" && trimString(p.GenreID) == "" && trimString(p.SubGenreID) == "" {
+		return &connectors.ValidationError{Message: "provide at least one of: keyword, classification_id, segment_id, genre_id, or sub_genre_id"}
+	}
+	if p.Size < 0 || p.Size > 200 {
+		return &connectors.ValidationError{Message: "size must be between 0 and 200 (0 uses API default)"}
+	}
+	if p.Page < 0 {
+		return &connectors.ValidationError{Message: "page must be zero or positive"}
+	}
+	return nil
+}
+
+func (a *searchAttractionsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params searchAttractionsParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "keyword", trimString(params.Keyword))
+	appendNonEmpty(q, "classificationId", trimString(params.ClassificationID))
+	appendNonEmpty(q, "segmentId", trimString(params.SegmentID))
+	appendNonEmpty(q, "genreId", trimString(params.GenreID))
+	appendNonEmpty(q, "subGenreId", trimString(params.SubGenreID))
+	appendNonEmpty(q, "source", trimString(params.Source))
+	appendNonEmpty(q, "sort", trimString(params.Sort))
+	if params.Size > 0 {
+		q.Set("size", strconv.Itoa(params.Size))
+	}
+	if params.Page > 0 {
+		q.Set("page", strconv.Itoa(params.Page))
+	}
+
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, "attractions.json", q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/search_events.go
+++ b/connectors/ticketmaster/search_events.go
@@ -1,0 +1,100 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// searchEventsAction implements connectors.Action for ticketmaster.search_events.
+type searchEventsAction struct {
+	conn *TicketmasterConnector
+}
+
+type searchEventsParams struct {
+	Keyword            string `json:"keyword"`
+	LatLong            string `json:"latlong"`
+	Radius             string `json:"radius"`
+	Unit               string `json:"unit"`
+	City               string `json:"city"`
+	StateCode          string `json:"state_code"`
+	CountryCode        string `json:"country_code"`
+	PostalCode         string `json:"postal_code"`
+	DMAID              string `json:"dma_id"`
+	StartDateTime      string `json:"start_date_time"`
+	EndDateTime        string `json:"end_date_time"`
+	ClassificationName string `json:"classification_name"`
+	ClassificationID   string `json:"classification_id"`
+	SegmentID          string `json:"segment_id"`
+	GenreID            string `json:"genre_id"`
+	SubGenreID         string `json:"sub_genre_id"`
+	Source             string `json:"source"`
+	Sort               string `json:"sort"`
+	Size               int    `json:"size"`
+	Page               int    `json:"page"`
+}
+
+func (p *searchEventsParams) validate() error {
+	if trimString(p.Keyword) == "" &&
+		trimString(p.City) == "" &&
+		trimString(p.PostalCode) == "" &&
+		trimString(p.DMAID) == "" &&
+		trimString(p.LatLong) == "" {
+		return &connectors.ValidationError{Message: "provide at least one of: keyword, city, postal_code, dma_id, or latlong"}
+	}
+	if p.Size < 0 || p.Size > 200 {
+		return &connectors.ValidationError{Message: "size must be between 0 and 200 (0 uses API default)"}
+	}
+	if p.Page < 0 {
+		return &connectors.ValidationError{Message: "page must be zero or positive"}
+	}
+	if p.Unit != "" && p.Unit != "miles" && p.Unit != "km" {
+		return &connectors.ValidationError{Message: "unit must be \"miles\" or \"km\" when set"}
+	}
+	return nil
+}
+
+func (a *searchEventsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params searchEventsParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "keyword", trimString(params.Keyword))
+	appendNonEmpty(q, "latlong", trimString(params.LatLong))
+	appendNonEmpty(q, "radius", trimString(params.Radius))
+	appendNonEmpty(q, "unit", trimString(params.Unit))
+	appendNonEmpty(q, "city", trimString(params.City))
+	appendNonEmpty(q, "stateCode", trimString(params.StateCode))
+	appendNonEmpty(q, "countryCode", trimString(params.CountryCode))
+	appendNonEmpty(q, "postalCode", trimString(params.PostalCode))
+	appendNonEmpty(q, "dmaId", trimString(params.DMAID))
+	appendNonEmpty(q, "startDateTime", trimString(params.StartDateTime))
+	appendNonEmpty(q, "endDateTime", trimString(params.EndDateTime))
+	appendNonEmpty(q, "classificationName", trimString(params.ClassificationName))
+	appendNonEmpty(q, "classificationId", trimString(params.ClassificationID))
+	appendNonEmpty(q, "segmentId", trimString(params.SegmentID))
+	appendNonEmpty(q, "genreId", trimString(params.GenreID))
+	appendNonEmpty(q, "subGenreId", trimString(params.SubGenreID))
+	appendNonEmpty(q, "source", trimString(params.Source))
+	appendNonEmpty(q, "sort", trimString(params.Sort))
+	if params.Size > 0 {
+		q.Set("size", strconv.Itoa(params.Size))
+	}
+	if params.Page > 0 {
+		q.Set("page", strconv.Itoa(params.Page))
+	}
+
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, "events.json", q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/search_venues.go
+++ b/connectors/ticketmaster/search_venues.go
@@ -1,0 +1,83 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// searchVenuesAction implements connectors.Action for ticketmaster.search_venues.
+type searchVenuesAction struct {
+	conn *TicketmasterConnector
+}
+
+type searchVenuesParams struct {
+	Keyword     string `json:"keyword"`
+	LatLong     string `json:"latlong"`
+	Radius      string `json:"radius"`
+	Unit        string `json:"unit"`
+	CountryCode string `json:"country_code"`
+	StateCode   string `json:"state_code"`
+	City        string `json:"city"`
+	PostalCode  string `json:"postal_code"`
+	Source      string `json:"source"`
+	Sort        string `json:"sort"`
+	Size        int    `json:"size"`
+	Page        int    `json:"page"`
+}
+
+func (p *searchVenuesParams) validate() error {
+	if trimString(p.Keyword) == "" &&
+		trimString(p.City) == "" &&
+		trimString(p.PostalCode) == "" &&
+		trimString(p.LatLong) == "" {
+		return &connectors.ValidationError{Message: "provide at least one of: keyword, city, postal_code, or latlong"}
+	}
+	if p.Size < 0 || p.Size > 200 {
+		return &connectors.ValidationError{Message: "size must be between 0 and 200 (0 uses API default)"}
+	}
+	if p.Page < 0 {
+		return &connectors.ValidationError{Message: "page must be zero or positive"}
+	}
+	if p.Unit != "" && p.Unit != "miles" && p.Unit != "km" {
+		return &connectors.ValidationError{Message: "unit must be \"miles\" or \"km\" when set"}
+	}
+	return nil
+}
+
+func (a *searchVenuesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params searchVenuesParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	appendNonEmpty(q, "keyword", trimString(params.Keyword))
+	appendNonEmpty(q, "latlong", trimString(params.LatLong))
+	appendNonEmpty(q, "radius", trimString(params.Radius))
+	appendNonEmpty(q, "unit", trimString(params.Unit))
+	appendNonEmpty(q, "countryCode", trimString(params.CountryCode))
+	appendNonEmpty(q, "stateCode", trimString(params.StateCode))
+	appendNonEmpty(q, "city", trimString(params.City))
+	appendNonEmpty(q, "postalCode", trimString(params.PostalCode))
+	appendNonEmpty(q, "source", trimString(params.Source))
+	appendNonEmpty(q, "sort", trimString(params.Sort))
+	if params.Size > 0 {
+		q.Set("size", strconv.Itoa(params.Size))
+	}
+	if params.Page > 0 {
+		q.Set("page", strconv.Itoa(params.Page))
+	}
+
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, "venues.json", q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/suggest.go
+++ b/connectors/ticketmaster/suggest.go
@@ -1,0 +1,48 @@
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+// suggestAction implements connectors.Action for ticketmaster.suggest.
+type suggestAction struct {
+	conn *TicketmasterConnector
+}
+
+type suggestParams struct {
+	Keyword string `json:"keyword"`
+	Source  string `json:"source"`
+	Locale  string `json:"locale"`
+}
+
+func (p *suggestParams) validate() error {
+	if trimString(p.Keyword) == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: keyword"}
+	}
+	return nil
+}
+
+func (a *suggestAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params suggestParams
+	if err := parseParams(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("keyword", trimString(params.Keyword))
+	appendNonEmpty(q, "source", trimString(params.Source))
+	appendNonEmpty(q, "locale", trimString(params.Locale))
+
+	var out json.RawMessage
+	if err := a.conn.doGET(ctx, req.Credentials, "suggest.json", q, &out); err != nil {
+		return nil, err
+	}
+	return &connectors.ActionResult{Data: out}, nil
+}

--- a/connectors/ticketmaster/ticketmaster.go
+++ b/connectors/ticketmaster/ticketmaster.go
@@ -1,0 +1,254 @@
+// Package ticketmaster implements the Ticketmaster Discovery API connector for
+// the Permission Slip connector execution layer. It uses plain net/http with
+// API key query-parameter authentication (no OAuth for read-only Discovery).
+//
+// Docs: https://developer.ticketmaster.com/products-and-docs/apis/discovery-api/v2/
+package ticketmaster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+const (
+	defaultBaseURL = "https://app.ticketmaster.com/discovery/v2"
+	defaultTimeout = 30 * time.Second
+
+	// maxResponseBytes caps Discovery API response size (10 MB).
+	maxResponseBytes = 10 * 1024 * 1024
+
+	// minInterval is the minimum spacing between requests per API key to stay
+	// under Ticketmaster's documented 5 requests/second limit.
+	minInterval = 210 * time.Millisecond
+
+	// maxDailyRequests is Ticketmaster's documented free-tier daily cap.
+	maxDailyRequests = 5000
+)
+
+// TicketmasterConnector owns the shared HTTP client and per-key rate limits.
+type TicketmasterConnector struct {
+	client  *http.Client
+	baseURL string
+
+	dayMu   sync.Mutex
+	dayKey  string // UTC date YYYYMMDD for daily counter reset
+	dayUsed map[string]int
+
+	secondMu sync.Mutex
+	// lastSecondCall maps api_key -> last request time (process-local).
+	lastSecondCall map[string]time.Time
+}
+
+// New creates a TicketmasterConnector with production defaults.
+func New() *TicketmasterConnector {
+	return &TicketmasterConnector{
+		client:         &http.Client{Timeout: defaultTimeout},
+		baseURL:        defaultBaseURL,
+		dayUsed:        make(map[string]int),
+		lastSecondCall: make(map[string]time.Time),
+	}
+}
+
+func newForTest(client *http.Client, baseURL string) *TicketmasterConnector {
+	return &TicketmasterConnector{
+		client:         client,
+		baseURL:        baseURL,
+		dayUsed:        make(map[string]int),
+		lastSecondCall: make(map[string]time.Time),
+	}
+}
+
+// ID returns "ticketmaster", matching connectors.id in the database.
+func (c *TicketmasterConnector) ID() string { return "ticketmaster" }
+
+// Actions returns registered action handlers keyed by action_type.
+func (c *TicketmasterConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"ticketmaster.search_events":        &searchEventsAction{conn: c},
+		"ticketmaster.get_event":            &getEventAction{conn: c},
+		"ticketmaster.search_venues":        &searchVenuesAction{conn: c},
+		"ticketmaster.get_venue":            &getVenueAction{conn: c},
+		"ticketmaster.search_attractions":   &searchAttractionsAction{conn: c},
+		"ticketmaster.get_attraction":       &getAttractionAction{conn: c},
+		"ticketmaster.list_classifications": &listClassificationsAction{conn: c},
+		"ticketmaster.suggest":              &suggestAction{conn: c},
+	}
+}
+
+// ValidateCredentials ensures a non-empty API key is present.
+func (c *TicketmasterConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
+	key, ok := creds.Get("api_key")
+	if !ok || key == "" {
+		return &connectors.ValidationError{Message: "missing required credential: api_key"}
+	}
+	return nil
+}
+
+func (c *TicketmasterConnector) apiKey(creds connectors.Credentials) (string, error) {
+	key, _ := creds.Get("api_key")
+	if key == "" {
+		return "", &connectors.ValidationError{Message: "missing required credential: api_key"}
+	}
+	return key, nil
+}
+
+// throttlePerSecond waits until at least minInterval has passed since the last
+// request for this API key (process-local best-effort enforcement).
+func (c *TicketmasterConnector) throttlePerSecond(ctx context.Context, apiKey string) error {
+	c.secondMu.Lock()
+	defer c.secondMu.Unlock()
+
+	last := c.lastSecondCall[apiKey]
+	wait := time.Until(last.Add(minInterval))
+	if wait > 0 {
+		select {
+		case <-ctx.Done():
+			return &connectors.TimeoutError{Message: "Ticketmaster API request canceled"}
+		case <-time.After(wait):
+		}
+	}
+	c.lastSecondCall[apiKey] = time.Now()
+	return nil
+}
+
+// checkDailyQuota returns RateLimitError when the process-local daily counter
+// for this key reaches maxDailyRequests (resets at UTC midnight).
+func (c *TicketmasterConnector) checkDailyQuota(apiKey string) error {
+	today := time.Now().UTC().Format("20060102")
+
+	c.dayMu.Lock()
+	defer c.dayMu.Unlock()
+
+	if c.dayKey != today {
+		c.dayKey = today
+		c.dayUsed = make(map[string]int)
+	}
+
+	if c.dayUsed[apiKey] >= maxDailyRequests {
+		return &connectors.RateLimitError{
+			Message:    fmt.Sprintf("Ticketmaster Discovery API daily quota exceeded (%d requests/day per key; counter resets at UTC midnight on this server)", maxDailyRequests),
+			RetryAfter: time.Until(nextUTCMidnight()),
+		}
+	}
+	c.dayUsed[apiKey]++
+	return nil
+}
+
+func nextUTCMidnight() time.Time {
+	now := time.Now().UTC()
+	y, m, d := now.Date()
+	return time.Date(y, m, d+1, 0, 0, 0, 0, time.UTC)
+}
+
+// doGET performs a throttled GET to the Discovery API, appends apikey, and
+// unmarshals JSON into respBody when non-nil.
+func (c *TicketmasterConnector) doGET(ctx context.Context, creds connectors.Credentials, path string, query url.Values, respBody interface{}) error {
+	apiKey, err := c.apiKey(creds)
+	if err != nil {
+		return err
+	}
+
+	if err := c.checkDailyQuota(apiKey); err != nil {
+		return err
+	}
+	if err := c.throttlePerSecond(ctx, apiKey); err != nil {
+		return err
+	}
+
+	if query == nil {
+		query = url.Values{}
+	}
+	query.Set("apikey", apiKey)
+
+	base := strings.TrimSuffix(c.baseURL, "/")
+	rel := strings.TrimPrefix(path, "/")
+	full := base + "/" + rel
+	if strings.Contains(full, "\x00") {
+		return &connectors.ValidationError{Message: "invalid request path"}
+	}
+	u, err := url.Parse(full)
+	if err != nil {
+		return fmt.Errorf("parsing request URL: %w", err)
+	}
+	u.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return &connectors.TimeoutError{Message: fmt.Sprintf("Ticketmaster API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.TimeoutError{Message: "Ticketmaster API request canceled"}
+		}
+		return &connectors.ExternalError{Message: fmt.Sprintf("Ticketmaster API request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, resp.Header, body); err != nil {
+		return err
+	}
+
+	if respBody != nil {
+		if err := json.Unmarshal(body, respBody); err != nil {
+			return &connectors.ExternalError{Message: fmt.Sprintf("parsing Ticketmaster response: %v", err)}
+		}
+	}
+	return nil
+}
+
+func parseParams(data json.RawMessage, dest interface{}) error {
+	if err := json.Unmarshal(data, dest); err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	return nil
+}
+
+// validateTicketmasterID ensures path segments are safe (alphanumeric + TM ids).
+func validateTicketmasterID(id, field string) error {
+	if id == "" {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
+	}
+	if len(id) > 128 {
+		return &connectors.ValidationError{Message: fmt.Sprintf("%s exceeds maximum length of 128 characters", field)}
+	}
+	for _, ch := range id {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+		case ch >= 'A' && ch <= 'Z':
+		case ch >= '0' && ch <= '9':
+		case ch == '_', ch == '-', ch == '.':
+		default:
+			return &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: only letters, digits, hyphen, underscore, and period are allowed", field)}
+		}
+	}
+	return nil
+}
+
+func appendNonEmpty(q url.Values, apiName, val string) {
+	if val != "" {
+		q.Set(apiName, val)
+	}
+}
+
+func trimString(s string) string { return strings.TrimSpace(s) }

--- a/connectors/ticketmaster/ticketmaster_test.go
+++ b/connectors/ticketmaster/ticketmaster_test.go
@@ -1,0 +1,196 @@
+package ticketmaster
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{"api_key": "test_key"})
+}
+
+func TestTicketmasterConnector_ID(t *testing.T) {
+	t.Parallel()
+	if got := New().ID(); got != "ticketmaster" {
+		t.Errorf("ID() = %q, want ticketmaster", got)
+	}
+}
+
+func TestTicketmasterConnector_Actions(t *testing.T) {
+	t.Parallel()
+	n := len(New().Actions())
+	if n != 8 {
+		t.Errorf("len(Actions()) = %d, want 8", n)
+	}
+}
+
+func TestTicketmasterConnector_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+	c := New()
+	err := c.ValidateCredentials(t.Context(), connectors.NewCredentials(map[string]string{"api_key": "x"}))
+	if err != nil {
+		t.Errorf("ValidateCredentials valid: %v", err)
+	}
+	err = c.ValidateCredentials(t.Context(), connectors.NewCredentials(map[string]string{}))
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Errorf("ValidateCredentials empty: %v", err)
+	}
+}
+
+func TestTicketmasterConnector_Manifest(t *testing.T) {
+	t.Parallel()
+	m := New().Manifest()
+	if m.ID != "ticketmaster" {
+		t.Errorf("Manifest ID = %q", m.ID)
+	}
+	if len(m.Actions) != 8 {
+		t.Fatalf("want 8 actions, got %d", len(m.Actions))
+	}
+	if err := m.Validate(); err != nil {
+		t.Errorf("Manifest.Validate: %v", err)
+	}
+}
+
+func TestTicketmasterConnector_ActionsMatchManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+	manifest := c.Manifest()
+	got := make(map[string]bool, len(actions))
+	for k := range actions {
+		got[k] = true
+	}
+	for _, a := range manifest.Actions {
+		if !got[a.ActionType] {
+			t.Errorf("manifest action %q missing from Actions()", a.ActionType)
+		}
+	}
+	for k := range actions {
+		found := false
+		for _, a := range manifest.Actions {
+			if a.ActionType == k {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Actions() has %q not in manifest", k)
+		}
+	}
+}
+
+func TestTicketmasterConnector_DoGET_AppendsAPIKey(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("apikey") != "test_key" {
+			http.Error(w, "no key", 400)
+			return
+		}
+		if r.URL.Path != "/discovery/v2/events.json" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"page":{}}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL+"/discovery/v2")
+	var raw json.RawMessage
+	err := conn.doGET(t.Context(), validCreds(), "events.json", nil, &raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTicketmasterConnector_ThrottlesPerSecond(t *testing.T) {
+	t.Parallel()
+	var first atomic.Int64
+	var second atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		now := time.Now().UnixNano()
+		if first.Load() == 0 {
+			first.Store(now)
+		} else if second.Load() == 0 {
+			second.Store(now)
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL+"/discovery/v2")
+	ctx := t.Context()
+	var out json.RawMessage
+	if err := conn.doGET(ctx, validCreds(), "events.json", nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.doGET(ctx, validCreds(), "events.json", nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	delta := time.Duration(second.Load() - first.Load())
+	if delta < minInterval-20*time.Millisecond {
+		t.Fatalf("expected ~%v between requests, got %v", minInterval, delta)
+	}
+}
+
+func TestSearchEventsAction_Execute(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("keyword") != "jazz" {
+			t.Errorf("keyword = %q", r.URL.Query().Get("keyword"))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"_embedded":{"events":[]}}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL+"/discovery/v2")
+	action := conn.Actions()["ticketmaster.search_events"]
+	params, _ := json.Marshal(map[string]string{"keyword": "jazz"})
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "ticketmaster.search_events",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Data) == 0 {
+		t.Fatal("empty data")
+	}
+}
+
+func TestGetEventAction_InvalidID(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := conn.Actions()["ticketmaster.get_event"]
+	params, _ := json.Marshal(map[string]string{"event_id": "../x"})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "ticketmaster.get_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestSuggestAction_MissingKeyword(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	action := conn.Actions()["ticketmaster.suggest"]
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "ticketmaster.suggest",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("got %v", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a built-in **Ticketmaster** connector (`ticketmaster`) for the [Discovery API](https://developer.ticketmaster.com/) (read-only): API key auth via `apikey` query parameter, eight actions covering event/venue/attraction search and detail, classifications, and suggest. Includes per-process rate helpers: minimum ~210ms between requests per key (5 req/s) and a 5,000 requests/day counter per key (UTC midnight reset) aligned with documented free-tier limits.

Closes #106

### Developer

- [x] Connector package under `connectors/ticketmaster/` with manifest + `register.go`
- [x] Blank import in `connectors/all/all.go`
- [x] Updated built-in connector count in `connectors/testsetup_test.go`
- [x] Unit tests for HTTP/error mapping and a sample action
- [x] `gofmt`; `go test ./connectors/...`; `make build` (after frontend/mobile `npm install` in this environment)

### Manual Testing

- [ ] Enable connector in app UI with a real Ticketmaster API key and run search + get event against production API
- [ ] Confirm rate-limit behavior under burst (optional; server-side limits may differ from process-local guards)

## Test plan

- `GOTOOLCHAIN=auto go test ./connectors/...`
- `GOTOOLCHAIN=auto make build` (requires `frontend` and `mobile` `npm install` if tools are missing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53f58800-b22f-4ca7-9a9d-5d8b32fb782d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53f58800-b22f-4ca7-9a9d-5d8b32fb782d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

