### PR TITLE
Fix PayPal idempotency key length + deprecated API usage

### DIFF
--- a/connectors/paypal/manifest_actions.go
+++ b/connectors/paypal/manifest_actions.go
@@ -72,7 +72,7 @@ func paypalActions() []connectors.ManifestAction {
 				"properties": {
 					"order": {
 						"type": "object",
-						"description": "Order create payload (intent, purchase_units, optional payment_source.paypal for wallet checkout, application_context with https return_url/cancel_url). Docs: https://developer.paypal.com/docs/api/orders/v2/",
+						"description": "Order create payload (intent, purchase_units, optional payment_source.paypal.experience_context with https return_url/cancel_url). Docs: https://developer.paypal.com/docs/api/orders/v2/",
 						"additionalProperties": true
 					}
 				}

--- a/connectors/paypal/manifest_templates.go
+++ b/connectors/paypal/manifest_templates.go
@@ -45,9 +45,13 @@ func paypalTemplates() []connectors.ManifestTemplate {
 							}
 						}
 					],
-					"application_context": {
-						"return_url": "https://example.com/paypal/return",
-						"cancel_url": "https://example.com/paypal/cancel"
+					"payment_source": {
+						"paypal": {
+							"experience_context": {
+								"return_url": "https://example.com/paypal/return",
+								"cancel_url": "https://example.com/paypal/cancel"
+							}
+						}
 					}
 				}
 			}`)),

--- a/connectors/paypal/paypal.go
+++ b/connectors/paypal/paypal.go
@@ -124,12 +124,19 @@ func (c *PayPalConnector) resolveAPIBase(creds connectors.Credentials) string {
 	return apiBaseURLForCreds(creds)
 }
 
+// maxRequestIDLen is PayPal's maximum length for the PayPal-Request-Id header.
+const maxRequestIDLen = 38
+
 func deriveRequestID(actionType string, rawParams json.RawMessage) string {
 	h := sha256.New()
 	h.Write([]byte(actionType))
 	h.Write([]byte{0})
 	h.Write(rawParams)
-	return hex.EncodeToString(h.Sum(nil))
+	full := hex.EncodeToString(h.Sum(nil))
+	if len(full) > maxRequestIDLen {
+		return full[:maxRequestIDLen]
+	}
+	return full
 }
 
 func readJSONBody(raw json.RawMessage, fieldName string) (map[string]any, error) {

--- a/connectors/paypal/paypal.go
+++ b/connectors/paypal/paypal.go
@@ -125,6 +125,8 @@ func (c *PayPalConnector) resolveAPIBase(creds connectors.Credentials) string {
 }
 
 // maxRequestIDLen is PayPal's maximum length for the PayPal-Request-Id header.
+// See https://developer.paypal.com/api/rest/reference/idempotency/ — PayPal
+// recommends UUID format (36 chars) because it fits the 38-character limit.
 const maxRequestIDLen = 38
 
 func deriveRequestID(actionType string, rawParams json.RawMessage) string {

--- a/connectors/paypal/paypal_http_test.go
+++ b/connectors/paypal/paypal_http_test.go
@@ -89,6 +89,13 @@ func TestCreateOrderAction_HTTPServer(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer tok" {
 			t.Errorf("auth %q", r.Header.Get("Authorization"))
 		}
+		rid := r.Header.Get("PayPal-Request-Id")
+		if rid == "" {
+			t.Error("missing PayPal-Request-Id header")
+		}
+		if len(rid) > maxRequestIDLen {
+			t.Errorf("PayPal-Request-Id length = %d, want <= %d", len(rid), maxRequestIDLen)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"ORD-1","status":"CREATED"}`))
 	}))

--- a/connectors/paypal/paypal_http_test.go
+++ b/connectors/paypal/paypal_http_test.go
@@ -201,6 +201,29 @@ func TestValidateCredentials(t *testing.T) {
 	}
 }
 
+func TestDeriveRequestID_FitsPayPalLimit(t *testing.T) {
+	t.Parallel()
+	// Use a realistic action type and large params to ensure SHA256 output is truncated.
+	params := json.RawMessage(`{"order":{"intent":"CAPTURE","purchase_units":[{"amount":{"currency_code":"USD","value":"99.99"}}]}}`)
+	id := deriveRequestID("paypal.create_order", params)
+	if len(id) > maxRequestIDLen {
+		t.Errorf("deriveRequestID length = %d, want <= %d; value = %q", len(id), maxRequestIDLen, id)
+	}
+	if len(id) == 0 {
+		t.Error("deriveRequestID returned empty string")
+	}
+	// Same inputs must produce same output (deterministic).
+	id2 := deriveRequestID("paypal.create_order", params)
+	if id != id2 {
+		t.Errorf("deriveRequestID not deterministic: %q != %q", id, id2)
+	}
+	// Different inputs must produce different output.
+	id3 := deriveRequestID("paypal.capture_order", params)
+	if id == id3 {
+		t.Error("different action types produced same request ID")
+	}
+}
+
 func TestAPIBaseURLForCreds_SandboxTrimmed(t *testing.T) {
 	t.Parallel()
 	c := connectors.NewCredentials(map[string]string{


### PR DESCRIPTION
## Summary

- Truncate `deriveRequestID` output to 38 chars to fit PayPal's `PayPal-Request-Id` header limit (was producing 64-char SHA256 hex, breaking idempotency for all POST actions)
- Replace deprecated `application_context` with `payment_source.paypal.experience_context` in the create order starter template and action schema description
- Add test asserting idempotency key length ≤ 38 chars, determinism, and uniqueness across action types

Closes #798

## Test plan

### Developer
- [x] All 15 PayPal connector tests pass (`go test ./connectors/paypal/...`)
- [x] New `TestDeriveRequestID_FitsPayPalLimit` validates length, determinism, and uniqueness
- [ ] CI passes

### Manual Testing
- [ ] Verify PayPal POST actions work with the new truncated key length
- [ ] Verify order creation starter template works with `payment_source.paypal.experience_context`

https://claude.ai/code/session_01FTv94k9EBKJAaApT6v6KAM