### PR TITLE
Fix Instacart connector schema validation and empty URL handling

### DIFF
--- a/connectors/instacart/create_products_link.go
+++ b/connectors/instacart/create_products_link.go
@@ -132,5 +132,9 @@ func (a *createProductsLinkAction) Execute(ctx context.Context, req connectors.A
 		return nil, err
 	}
 
+	if strings.TrimSpace(apiResp.ProductsLinkURL) == "" {
+		return nil, &connectors.ExternalError{Message: "Instacart returned an empty products_link_url"}
+	}
+
 	return connectors.JSONResult(apiResp)
 }

--- a/connectors/instacart/create_products_link_test.go
+++ b/connectors/instacart/create_products_link_test.go
@@ -218,6 +218,72 @@ func TestCreateProductsLink_InvalidLinkType(t *testing.T) {
 	}
 }
 
+func TestCreateProductsLink_ItemsAlias(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody struct {
+			LineItems []map[string]any `json:"line_items"`
+		}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(reqBody.LineItems) != 1 || reqBody.LineItems[0]["name"] != "bread" {
+			t.Fatalf("unexpected payload: %#v", reqBody.LineItems)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"products_link_url":"https://example.test/y"}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["instacart.create_products_link"]
+
+	// Simulate the alias+normalize pipeline the API layer runs before Execute.
+	raw := json.RawMessage(`{"items":["bread"]}`)
+	if aliaser, ok := action.(connectors.ParameterAliaser); ok {
+		raw = connectors.NormalizeParameters(aliaser.ParameterAliases(), raw)
+	}
+	if normalizer, ok := action.(connectors.Normalizer); ok {
+		raw = normalizer.Normalize(raw)
+	}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "instacart.create_products_link",
+		Parameters:  raw,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+}
+
+func TestCreateProductsLink_EmptyProductsLinkURL(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"products_link_url":""}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := conn.Actions()["instacart.create_products_link"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "instacart.create_products_link",
+		Parameters:  json.RawMessage(`{"line_items":[{"name":"milk"}]}`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for empty products_link_url")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Errorf("want ExternalError, got %T: %v", err, err)
+	}
+}
+
 func TestCreateProductsLink_AuthError(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/connectors/instacart/manifest.go
+++ b/connectors/instacart/manifest.go
@@ -10,6 +10,59 @@ import (
 //go:embed logo.svg
 var logoSVG string
 
+// lineItemOneOf is the shared oneOf schema for line item elements, used by both
+// the line_items property and the items alias to keep them consistent.
+const lineItemOneOf = `[
+	{
+		"type": "string",
+		"maxLength": 2048,
+		"description": "Plain product name, expanded to {\"name\": \"...\"} before sending to Instacart"
+	},
+	{
+		"type": "object",
+		"required": ["name"],
+		"additionalProperties": true,
+		"properties": {
+			"name": {
+				"type": "string",
+				"maxLength": 2048,
+				"description": "Product or ingredient text for Instacart to match (e.g. \"2 lb chicken breast\")"
+			},
+			"display_text": {
+				"type": "string",
+				"description": "Display title for the matched item"
+			},
+			"quantity": {
+				"type": "number",
+				"description": "Deprecated by Instacart; prefer line_item_measurements"
+			},
+			"unit": {
+				"type": "string",
+				"description": "Deprecated by Instacart; prefer line_item_measurements"
+			},
+			"line_item_measurements": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"quantity": {"type": "number"},
+						"unit": {"type": "string"}
+					},
+					"additionalProperties": false
+				}
+			},
+			"upcs": {
+				"type": "array",
+				"items": {"type": "string"}
+			},
+			"product_ids": {
+				"type": "array",
+				"items": {"type": "integer"}
+			}
+		}
+	}
+]`
+
 // Manifest returns the connector's metadata manifest. Used by the server to
 // auto-seed DB rows on startup.
 func (c *InstacartConnector) Manifest() *connectors.ConnectorManifest {
@@ -27,7 +80,10 @@ func (c *InstacartConnector) Manifest() *connectors.ConnectorManifest {
 				DisplayTemplate: "Create Instacart link — {{line_items:count}} items",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["line_items"],
+					"anyOf": [
+						{"required": ["line_items"]},
+						{"required": ["items"]}
+					],
 					"properties": {
 						"title": {
 							"type": "string",
@@ -60,64 +116,14 @@ func (c *InstacartConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "array",
 							"minItems": 1,
 							"maxItems": 200,
-							"items": {
-								"oneOf": [
-									{
-										"type": "string",
-										"maxLength": 2048,
-										"description": "Plain product name, expanded to {\"name\": \"...\"} before sending to Instacart"
-									},
-									{
-										"type": "object",
-										"required": ["name"],
-										"additionalProperties": true,
-										"properties": {
-											"name": {
-												"type": "string",
-												"maxLength": 2048,
-												"description": "Product or ingredient text for Instacart to match (e.g. \"2 lb chicken breast\")"
-											},
-											"display_text": {
-												"type": "string",
-												"description": "Display title for the matched item"
-											},
-											"quantity": {
-												"type": "number",
-												"description": "Deprecated by Instacart; prefer line_item_measurements"
-											},
-											"unit": {
-												"type": "string",
-												"description": "Deprecated by Instacart; prefer line_item_measurements"
-											},
-											"line_item_measurements": {
-												"type": "array",
-												"items": {
-													"type": "object",
-													"properties": {
-														"quantity": {"type": "number"},
-														"unit": {"type": "string"}
-													},
-													"additionalProperties": false
-												}
-											},
-											"upcs": {
-												"type": "array",
-												"items": {"type": "string"}
-											},
-											"product_ids": {
-												"type": "array",
-												"items": {"type": "integer"}
-											}
-										}
-									}
-								]
-							},
+							"items": {"oneOf": ` + lineItemOneOf + `},
 							"description": "Items to include. Each element is a LineItem object with at least name, or use line_item_measurements for quantities (see Instacart docs). You may use the parameter name items instead of line_items. For convenience, each element may be a plain string (same as {\"name\": \"...\"})."
 						},
 						"items": {
 							"type": "array",
 							"minItems": 1,
 							"maxItems": 200,
+							"items": {"oneOf": ` + lineItemOneOf + `},
 							"description": "Alias for line_items. Rewritten to line_items before validation."
 						},
 						"landing_page_configuration": {

--- a/connectors/instacart/manifest.go
+++ b/connectors/instacart/manifest.go
@@ -80,7 +80,7 @@ func (c *InstacartConnector) Manifest() *connectors.ConnectorManifest {
 				DisplayTemplate: "Create Instacart link — {{line_items:count}} items",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"anyOf": [
+					"oneOf": [
 						{"required": ["line_items"]},
 						{"required": ["items"]}
 					],

--- a/connectors/instacart/manifest.go
+++ b/connectors/instacart/manifest.go
@@ -61,49 +61,64 @@ func (c *InstacartConnector) Manifest() *connectors.ConnectorManifest {
 							"minItems": 1,
 							"maxItems": 200,
 							"items": {
-								"type": "object",
-								"required": ["name"],
-								"additionalProperties": true,
-								"properties": {
-									"name": {
+								"oneOf": [
+									{
 										"type": "string",
 										"maxLength": 2048,
-										"description": "Product or ingredient text for Instacart to match (e.g. \"2 lb chicken breast\")"
+										"description": "Plain product name, expanded to {\"name\": \"...\"} before sending to Instacart"
 									},
-									"display_text": {
-										"type": "string",
-										"description": "Display title for the matched item"
-									},
-									"quantity": {
-										"type": "number",
-										"description": "Deprecated by Instacart; prefer line_item_measurements"
-									},
-									"unit": {
-										"type": "string",
-										"description": "Deprecated by Instacart; prefer line_item_measurements"
-									},
-									"line_item_measurements": {
-										"type": "array",
-										"items": {
-											"type": "object",
-											"properties": {
-												"quantity": {"type": "number"},
-												"unit": {"type": "string"}
+									{
+										"type": "object",
+										"required": ["name"],
+										"additionalProperties": true,
+										"properties": {
+											"name": {
+												"type": "string",
+												"maxLength": 2048,
+												"description": "Product or ingredient text for Instacart to match (e.g. \"2 lb chicken breast\")"
 											},
-											"additionalProperties": false
+											"display_text": {
+												"type": "string",
+												"description": "Display title for the matched item"
+											},
+											"quantity": {
+												"type": "number",
+												"description": "Deprecated by Instacart; prefer line_item_measurements"
+											},
+											"unit": {
+												"type": "string",
+												"description": "Deprecated by Instacart; prefer line_item_measurements"
+											},
+											"line_item_measurements": {
+												"type": "array",
+												"items": {
+													"type": "object",
+													"properties": {
+														"quantity": {"type": "number"},
+														"unit": {"type": "string"}
+													},
+													"additionalProperties": false
+												}
+											},
+											"upcs": {
+												"type": "array",
+												"items": {"type": "string"}
+											},
+											"product_ids": {
+												"type": "array",
+												"items": {"type": "integer"}
+											}
 										}
-									},
-									"upcs": {
-										"type": "array",
-										"items": {"type": "string"}
-									},
-									"product_ids": {
-										"type": "array",
-										"items": {"type": "integer"}
 									}
-								}
+								]
 							},
 							"description": "Items to include. Each element is a LineItem object with at least name, or use line_item_measurements for quantities (see Instacart docs). You may use the parameter name items instead of line_items. For convenience, each element may be a plain string (same as {\"name\": \"...\"})."
+						},
+						"items": {
+							"type": "array",
+							"minItems": 1,
+							"maxItems": 200,
+							"description": "Alias for line_items. Rewritten to line_items before validation."
 						},
 						"landing_page_configuration": {
 							"type": "object",


### PR DESCRIPTION
## Summary

- Update `line_items` schema to use `oneOf` accepting both string and object items, matching the connector's actual string shorthand support (`["milk", "eggs"]`)
- Add `items` as an accepted property in the schema so `additionalProperties: false` doesn't reject the documented parameter alias
- Validate non-empty `products_link_url` before returning success — previously an empty URL from Instacart would silently propagate as a successful result

Closes #796

## Test plan

### Claude Code
- [x] All 26 existing Instacart connector tests pass
- [x] New test: `TestCreateProductsLink_ItemsAlias` — verifies `{"items": ["bread"]}` works through the full alias+normalize+execute pipeline
- [x] New test: `TestCreateProductsLink_EmptyProductsLinkURL` — verifies empty URL returns `ExternalError`

### Manual Testing
- [ ] Verify `["milk", "eggs"]` shorthand works end-to-end
- [ ] Verify `{"items": [...]}` alias works end-to-end

https://claude.ai/code/session_018iz4g5JYbPuVWDf1DAwNAx