### PR TITLE
Fix OTA update URL interpolation in app.config.ts

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig, ConfigContext } from "expo/config";
 
-export default ({ config }: ConfigContext): ExpoConfig => ({
+export default (_config: ConfigContext): ExpoConfig => ({
   name: "Permission Slip",
   slug: "permission-slip",
   version: "1.0.0",
@@ -66,7 +66,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     favicon: "./assets/favicon.png",
   },
   updates: {
-    url: "https://u.expo.dev/${EXPO_PROJECT_ID}",
+    url: `https://u.expo.dev/${process.env.EXPO_PROJECT_ID}`,
     enabled: true,
     fallbackToCacheTimeout: 0,
   },


### PR DESCRIPTION
## Summary

- Fix P0 bug where OTA update URL used double quotes instead of backticks, preventing `EXPO_PROJECT_ID` from being interpolated — OTA updates would silently fail in production
- Add `process.env.` prefix so the env var is properly accessed at runtime
- Prefix unused `config` parameter with underscore to avoid potential `noUnusedLocals` compilation errors

Closes #807

## Test plan

### Claude Code
- [x] All 184 mobile tests pass

### Manual Testing
- [ ] Verify OTA updates resolve to the correct Expo project URL in a production build

https://claude.ai/code/session_01SbtQor2SRzFjQbGvSzRkga