### PR TITLE
Fix DynamoDB connector security issues and code quality

### DIFF
--- a/connectors/dynamodb/delete_item.go
+++ b/connectors/dynamodb/delete_item.go
@@ -25,6 +25,8 @@ type deleteItemParams struct {
 	ExpressionAttributeNames  map[string]string      `json:"expression_attribute_names"`
 	ExpressionAttributeValues map[string]interface{} `json:"expression_attribute_values"`
 	AllowedTables             []string               `json:"allowed_tables"`
+	AllowedWriteAttributes    []string               `json:"allowed_write_attributes"`
+	AllowedReadAttributes     []string               `json:"allowed_read_attributes"`
 }
 
 func (p *deleteItemParams) validate() error {
@@ -37,7 +39,23 @@ func (p *deleteItemParams) validate() error {
 	if len(p.Key) == 0 {
 		return &connectors.ValidationError{Message: "missing required parameter: key"}
 	}
-	return validateAllowedTables(p.Table, p.AllowedTables)
+	if err := validateAllowedTables(p.Table, p.AllowedTables); err != nil {
+		return err
+	}
+	if len(p.AllowedWriteAttributes) > 0 {
+		if err := validateAttrAllowlist(p.AllowedWriteAttributes); err != nil {
+			return err
+		}
+	}
+	if len(p.AllowedReadAttributes) > 0 {
+		if err := validateAttrAllowlist(p.AllowedReadAttributes); err != nil {
+			return err
+		}
+	}
+	if err := validateExprAttrNames(p.ExpressionAttributeNames, buildAllowedSet(p.AllowedWriteAttributes)); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (a *deleteItemAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
@@ -90,8 +108,12 @@ func (a *deleteItemAction) Execute(ctx context.Context, req connectors.ActionReq
 		resp["previous_item"] = nil
 		return connectors.JSONResult(resp)
 	}
+	attrs := out.Attributes
+	if allowed := buildAllowedSet(params.AllowedReadAttributes); allowed != nil {
+		attrs = filterItemAttrs(attrs, allowed)
+	}
 	var prev map[string]interface{}
-	if err := attributevalue.UnmarshalMap(out.Attributes, &prev); err != nil {
+	if err := attributevalue.UnmarshalMap(attrs, &prev); err != nil {
 		return nil, &connectors.ExternalError{Message: fmt.Sprintf("unmarshaling deleted item: %v", err)}
 	}
 	resp["previous_item"] = prev

--- a/connectors/dynamodb/dynamodb.go
+++ b/connectors/dynamodb/dynamodb.go
@@ -206,6 +206,18 @@ func (c *DynamoDBConnector) Manifest() *connectors.ConnectorManifest {
 							"minItems": 1,
 							"maxItems": 64,
 							"description": "Table allowlist — request is rejected if table is not listed"
+						},
+						"allowed_write_attributes": {
+							"type": "array",
+							"items": {"type": "string"},
+							"maxItems": 100,
+							"description": "When set, condition expression attribute names must reference only these attributes"
+						},
+						"allowed_read_attributes": {
+							"type": "array",
+							"items": {"type": "string"},
+							"maxItems": 100,
+							"description": "When set, previous_item only returns these attributes"
 						}
 					}
 				}`)),

--- a/connectors/dynamodb/get_item.go
+++ b/connectors/dynamodb/get_item.go
@@ -45,7 +45,7 @@ func (p *getItemParams) validate() error {
 			return err
 		}
 	}
-	allowed := allowedReadSet(p.AllowedReadAttributes)
+	allowed := buildAllowedSet(p.AllowedReadAttributes)
 	return validateProjectionSubset(p.Projection, allowed)
 }
 
@@ -97,7 +97,7 @@ func (a *getItemAction) Execute(ctx context.Context, req connectors.ActionReques
 	}
 
 	item := out.Item
-	if allowed := allowedReadSet(params.AllowedReadAttributes); allowed != nil {
+	if allowed := buildAllowedSet(params.AllowedReadAttributes); allowed != nil {
 		item = filterItemAttrs(item, allowed)
 	}
 

--- a/connectors/dynamodb/helpers.go
+++ b/connectors/dynamodb/helpers.go
@@ -2,9 +2,11 @@ package dynamodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -78,20 +80,22 @@ func validateAttrAllowlist(names []string) error {
 	return nil
 }
 
+// isValidAttrName validates DynamoDB attribute names. DynamoDB allows most
+// printable characters including hyphens, dots, spaces, and others. We reject
+// only control characters and empty/overlong names.
 func isValidAttrName(s string) bool {
 	if len(s) == 0 || len(s) > 255 {
 		return false
 	}
 	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			continue
+		if r < 0x20 { // reject control characters
+			return false
 		}
-		return false
 	}
 	return true
 }
 
-func allowedReadSet(allowed []string) map[string]struct{} {
+func buildAllowedSet(allowed []string) map[string]struct{} {
 	if len(allowed) == 0 {
 		return nil
 	}
@@ -143,6 +147,77 @@ func validateItemWriteSubset(item map[string]types.AttributeValue, allowed map[s
 		}
 	}
 	return nil
+}
+
+// validateExprAttrNames checks that every value in expression_attribute_names
+// is present in the allowed set. This prevents condition expressions from
+// referencing restricted attributes as a side-channel.
+func validateExprAttrNames(names map[string]string, allowed map[string]struct{}) error {
+	if allowed == nil || len(names) == 0 {
+		return nil
+	}
+	for placeholder, attr := range names {
+		if _, ok := allowed[attr]; !ok {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf("expression_attribute_names placeholder %q references attribute %q which is not in the allowed attributes", placeholder, attr),
+			}
+		}
+	}
+	return nil
+}
+
+// marshalJSONValue unmarshals a JSON raw message and marshals it to a DynamoDB
+// AttributeValue. label is used in error messages.
+func marshalJSONValue(raw json.RawMessage, label string) (types.AttributeValue, error) {
+	var val interface{}
+	if err := json.Unmarshal(raw, &val); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: %v", label, err)}
+	}
+	av, err := attributevalue.Marshal(val)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid %s: %v", label, err)}
+	}
+	return av, nil
+}
+
+// sortKeyOperators maps condition strings to their DynamoDB expression fragment.
+// Each operator uses the #sk name placeholder and :sk value placeholder.
+var sortKeyOperators = map[string]string{
+	"eq":          " AND #sk = :sk",
+	"lt":          " AND #sk < :sk",
+	"lte":         " AND #sk <= :sk",
+	"gt":          " AND #sk > :sk",
+	"gte":         " AND #sk >= :sk",
+	"begins_with": " AND begins_with(#sk, :sk)",
+}
+
+// buildSortKeyCondition produces the key condition expression fragment and
+// populates exprVals for the sort key. Returns the expression string to append
+// to the key condition.
+func buildSortKeyCondition(condition string, sortKeyValue json.RawMessage, sortKeyBetween []json.RawMessage, exprVals map[string]types.AttributeValue) (string, error) {
+	cond := strings.ToLower(condition)
+	if expr, ok := sortKeyOperators[cond]; ok {
+		av, err := marshalJSONValue(sortKeyValue, "sort_key_value")
+		if err != nil {
+			return "", err
+		}
+		exprVals[":sk"] = av
+		return expr, nil
+	}
+	if cond == "between" {
+		loAv, err := marshalJSONValue(sortKeyBetween[0], "sort_key_between[0]")
+		if err != nil {
+			return "", err
+		}
+		hiAv, err := marshalJSONValue(sortKeyBetween[1], "sort_key_between[1]")
+		if err != nil {
+			return "", err
+		}
+		exprVals[":sklo"] = loAv
+		exprVals[":skhi"] = hiAv
+		return " AND #sk BETWEEN :sklo AND :skhi", nil
+	}
+	return "", &connectors.ValidationError{Message: fmt.Sprintf("unsupported sort_key_condition: %q", condition)}
 }
 
 func cloneStringMap(m map[string]string) map[string]string {

--- a/connectors/dynamodb/put_item.go
+++ b/connectors/dynamodb/put_item.go
@@ -42,7 +42,12 @@ func (p *putItemParams) validate() error {
 		return err
 	}
 	if len(p.AllowedWriteAttributes) > 0 {
-		return validateAttrAllowlist(p.AllowedWriteAttributes)
+		if err := validateAttrAllowlist(p.AllowedWriteAttributes); err != nil {
+			return err
+		}
+	}
+	if err := validateExprAttrNames(p.ExpressionAttributeNames, buildAllowedSet(p.AllowedWriteAttributes)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -60,7 +65,7 @@ func (a *putItemAction) Execute(ctx context.Context, req connectors.ActionReques
 	if err != nil {
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid item attribute values: %v", err)}
 	}
-	if err := validateItemWriteSubset(itemAv, allowedReadSet(params.AllowedWriteAttributes)); err != nil {
+	if err := validateItemWriteSubset(itemAv, buildAllowedSet(params.AllowedWriteAttributes)); err != nil {
 		return nil, err
 	}
 

--- a/connectors/dynamodb/query.go
+++ b/connectors/dynamodb/query.go
@@ -61,7 +61,7 @@ func (p *queryParams) validate() error {
 			return err
 		}
 	}
-	if err := validateProjectionSubset(p.Projection, allowedReadSet(p.AllowedReadAttributes)); err != nil {
+	if err := validateProjectionSubset(p.Projection, buildAllowedSet(p.AllowedReadAttributes)); err != nil {
 		return err
 	}
 
@@ -84,6 +84,9 @@ func (p *queryParams) validate() error {
 		case "eq", "lt", "lte", "gt", "gte", "begins_with":
 			if len(p.SortKeyValue) == 0 {
 				return &connectors.ValidationError{Message: "sort_key_value is required for this sort_key_condition"}
+			}
+			if len(p.SortKeyBetween) > 0 {
+				return &connectors.ValidationError{Message: "sort_key_between must not be provided when sort_key_condition is not \"between\""}
 			}
 		default:
 			return &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_condition: %q", p.SortKeyCondition)}
@@ -134,93 +137,11 @@ func (a *queryAction) Execute(ctx context.Context, req connectors.ActionRequest)
 
 	if params.SortKeyName != "" {
 		exprNames["#sk"] = params.SortKeyName
-		switch strings.ToLower(params.SortKeyCondition) {
-		case "eq":
-			var skVal interface{}
-			if err := json.Unmarshal(params.SortKeyValue, &skVal); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			skAv, err := attributevalue.Marshal(skVal)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			exprVals[":sk"] = skAv
-			keyCond += " AND #sk = :sk"
-		case "lt":
-			var skVal interface{}
-			if err := json.Unmarshal(params.SortKeyValue, &skVal); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			skAv, err := attributevalue.Marshal(skVal)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			exprVals[":sk"] = skAv
-			keyCond += " AND #sk < :sk"
-		case "lte":
-			var skVal interface{}
-			if err := json.Unmarshal(params.SortKeyValue, &skVal); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			skAv, err := attributevalue.Marshal(skVal)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			exprVals[":sk"] = skAv
-			keyCond += " AND #sk <= :sk"
-		case "gt":
-			var skVal interface{}
-			if err := json.Unmarshal(params.SortKeyValue, &skVal); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			skAv, err := attributevalue.Marshal(skVal)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			exprVals[":sk"] = skAv
-			keyCond += " AND #sk > :sk"
-		case "gte":
-			var skVal interface{}
-			if err := json.Unmarshal(params.SortKeyValue, &skVal); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			skAv, err := attributevalue.Marshal(skVal)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			exprVals[":sk"] = skAv
-			keyCond += " AND #sk >= :sk"
-		case "begins_with":
-			var skVal interface{}
-			if err := json.Unmarshal(params.SortKeyValue, &skVal); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			skAv, err := attributevalue.Marshal(skVal)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_value: %v", err)}
-			}
-			exprVals[":sk"] = skAv
-			keyCond += " AND begins_with(#sk, :sk)"
-		case "between":
-			var lo, hi interface{}
-			if err := json.Unmarshal(params.SortKeyBetween[0], &lo); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_between[0]: %v", err)}
-			}
-			if err := json.Unmarshal(params.SortKeyBetween[1], &hi); err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_between[1]: %v", err)}
-			}
-			loAv, err := attributevalue.Marshal(lo)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_between[0]: %v", err)}
-			}
-			hiAv, err := attributevalue.Marshal(hi)
-			if err != nil {
-				return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid sort_key_between[1]: %v", err)}
-			}
-			exprVals[":sklo"] = loAv
-			exprVals[":skhi"] = hiAv
-			keyCond += " AND #sk BETWEEN :sklo AND :skhi"
+		sortExpr, err := buildSortKeyCondition(params.SortKeyCondition, params.SortKeyValue, params.SortKeyBetween, exprVals)
+		if err != nil {
+			return nil, err
 		}
+		keyCond += sortExpr
 	}
 
 	limit := int32(defaultQueryLimit)
@@ -278,7 +199,7 @@ func (a *queryAction) Execute(ctx context.Context, req connectors.ActionRequest)
 		return nil, mapDynamoError(err)
 	}
 
-	allowed := allowedReadSet(params.AllowedReadAttributes)
+	allowed := buildAllowedSet(params.AllowedReadAttributes)
 	items := make([]map[string]interface{}, 0, len(out.Items))
 	for _, it := range out.Items {
 		if allowed != nil {

--- a/connectors/dynamodb/security_test.go
+++ b/connectors/dynamodb/security_test.go
@@ -1,0 +1,185 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestDeleteItem_PreviousItemFiltered(t *testing.T) {
+	t.Parallel()
+	mock := &mockDynamo{
+		deleteItemOut: &dynamodb.DeleteItemOutput{
+			Attributes: map[string]types.AttributeValue{
+				"pk":     &types.AttributeValueMemberS{Value: "k1"},
+				"name":   &types.AttributeValueMemberS{Value: "Ada"},
+				"secret": &types.AttributeValueMemberS{Value: "classified"},
+			},
+		},
+	}
+	conn := newForTest(mock)
+	action := conn.Actions()["dynamodb.delete_item"]
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "dynamodb.delete_item",
+		Parameters: json.RawMessage(`{
+			"region":"us-east-1",
+			"table":"t1",
+			"key":{"pk":"k1"},
+			"allowed_tables":["t1"],
+			"allowed_read_attributes":["pk","name"]
+		}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(res.Data, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload["existed"].(bool) {
+		t.Fatal("want existed true")
+	}
+	prev := payload["previous_item"].(map[string]interface{})
+	if _, has := prev["secret"]; has {
+		t.Fatalf("secret should be filtered from previous_item: %#v", prev)
+	}
+	if prev["pk"] != "k1" || prev["name"] != "Ada" {
+		t.Fatalf("allowed attributes missing: %#v", prev)
+	}
+}
+
+func TestDeleteItem_ExprAttrNamesValidated(t *testing.T) {
+	t.Parallel()
+	mock := &mockDynamo{}
+	conn := newForTest(mock)
+	action := conn.Actions()["dynamodb.delete_item"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "dynamodb.delete_item",
+		Parameters: json.RawMessage(`{
+			"region":"us-east-1",
+			"table":"t1",
+			"key":{"pk":"k1"},
+			"allowed_tables":["t1"],
+			"allowed_write_attributes":["pk","status"],
+			"condition_expression":"#s = :v",
+			"expression_attribute_names":{"#s":"secret_field"},
+			"expression_attribute_values":{":v":"active"}
+		}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("want validation error for disallowed expr attr name, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "secret_field") {
+		t.Fatalf("error should mention the disallowed attribute: %v", err)
+	}
+}
+
+func TestPutItem_ExprAttrNamesValidated(t *testing.T) {
+	t.Parallel()
+	mock := &mockDynamo{}
+	conn := newForTest(mock)
+	action := conn.Actions()["dynamodb.put_item"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "dynamodb.put_item",
+		Parameters: json.RawMessage(`{
+			"region":"us-east-1",
+			"table":"t1",
+			"item":{"pk":"a"},
+			"allowed_tables":["t1"],
+			"allowed_write_attributes":["pk"],
+			"condition_expression":"attribute_not_exists(#r)",
+			"expression_attribute_names":{"#r":"restricted"}
+		}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("want validation error for disallowed expr attr name, got %v", err)
+	}
+}
+
+func TestPutItem_ExprAttrNamesAllowed(t *testing.T) {
+	t.Parallel()
+	mock := &mockDynamo{}
+	conn := newForTest(mock)
+	action := conn.Actions()["dynamodb.put_item"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "dynamodb.put_item",
+		Parameters: json.RawMessage(`{
+			"region":"us-east-1",
+			"table":"t1",
+			"item":{"pk":"a","status":"active"},
+			"allowed_tables":["t1"],
+			"allowed_write_attributes":["pk","status"],
+			"condition_expression":"attribute_not_exists(#s)",
+			"expression_attribute_names":{"#s":"status"}
+		}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestQuery_SortKeyBetweenRejectedForNonBetweenCondition(t *testing.T) {
+	t.Parallel()
+	mock := &mockDynamo{}
+	conn := newForTest(mock)
+	action := conn.Actions()["dynamodb.query"]
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "dynamodb.query",
+		Parameters: json.RawMessage(`{
+			"region":"us-east-1",
+			"table":"t1",
+			"partition_key_name":"pk",
+			"partition_key_value":"a",
+			"sort_key_name":"sk",
+			"sort_key_condition":"eq",
+			"sort_key_value":"x",
+			"sort_key_between":[1,9],
+			"allowed_tables":["t1"]
+		}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("want validation error for sort_key_between with non-between condition, got %v", err)
+	}
+}
+
+func TestIsValidAttrName_AcceptsHyphensAndDots(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"alphanumeric", "myAttr123", true},
+		{"underscore", "my_attr", true},
+		{"hyphen", "my-attr", true},
+		{"dot", "my.attr", true},
+		{"space", "my attr", true},
+		{"empty", "", false},
+		{"control_char", "my\x00attr", false},
+		{"newline", "my\nattr", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isValidAttrName(tc.input)
+			if got != tc.want {
+				t.Fatalf("isValidAttrName(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **[Security]** Filter `previous_item` attributes through `allowed_read_attributes` in `delete_item`, preventing privilege escalation via `ReturnValues: AllOld`
- **[Security]** Validate `expression_attribute_names` values against `allowed_write_attributes` in both `delete_item` and `put_item`, closing the condition expression side-channel for reading restricted attributes
- **[Code quality]** Expand `isValidAttrName` to accept hyphens, dots, spaces, and other valid DynamoDB characters; extract sort key handling into `buildSortKeyCondition` helper (~90 lines DRY fix); rename `allowedReadSet` → `buildAllowedSet`; reject `sort_key_between` when condition is not `"between"`

Closes #797

## Test plan

### Claude Code
- [x] All 21 existing + new DynamoDB connector tests pass
- [x] `go vet` clean
- [ ] CI passes

### OpenClaw
- [ ] Verify `delete_item` does not leak restricted attributes
- [ ] Verify condition expressions cannot read restricted attributes

https://claude.ai/code/session_01GUzCYPDi9wLyvP5XPhnobD