### PR TITLE
Fix connector disabled mechanism remaining review items

### DIFF
--- a/connectors/disabled_built_in.go
+++ b/connectors/disabled_built_in.go
@@ -12,6 +12,12 @@ import (
 // seed the database, or appear in connector/OAuth listings. Add an empty file
 // at connectors/<connector_id>/disabled (this path is next to this .go file).
 //
+// NOTE: This embed directive requires at least one connectors/<id>/disabled
+// file to exist. If all connectors are re-enabled (every disabled file
+// removed), the build will fail with "no matching files found". In that case,
+// replace this with an explicit empty embed and update init() to skip the FS
+// scan, or keep a single disabled file as a placeholder.
+//
 //go:embed */disabled
 var disabledBuiltInMarkerFS embed.FS
 

--- a/main.go
+++ b/main.go
@@ -361,9 +361,8 @@ func main() {
 		}
 	}
 
-	for _, id := range connectors.DisabledBuiltInConnectorIDs() {
-		_ = oauthRegistry.Remove(id)
-	}
+	// Disabled connectors' OAuth providers never register (their init()
+	// guards return early), so the oauth registry is already clean.
 
 	// Start all registered background jobs.
 	for _, job := range backgroundJobs {

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -24,6 +24,9 @@ func TestBuiltInProviders_OmitsDisabledConnectors(t *testing.T) {
 	for _, id := range connectors.DisabledBuiltInConnectorIDs() {
 		disabled[id] = true
 	}
+	if len(disabled) == 0 {
+		t.Skip("no connectors currently disabled; nothing to verify")
+	}
 	for _, p := range oauth.BuiltInProviders() {
 		if disabled[p.ID] {
 			t.Errorf("%q should not appear in BuiltInProviders when connector is disabled", p.ID)

--- a/oauth/disabled_built_in_test.go
+++ b/oauth/disabled_built_in_test.go
@@ -3,6 +3,7 @@ package oauth_test
 import (
 	"testing"
 
+	"github.com/supersuit-tech/permission-slip-web/connectors"
 	"github.com/supersuit-tech/permission-slip-web/oauth"
 	_ "github.com/supersuit-tech/permission-slip-web/oauth/providers"
 )
@@ -19,7 +20,10 @@ func TestBuiltInOAuthDisabledForKrogerNotQuickBooks(t *testing.T) {
 
 func TestBuiltInProviders_OmitsDisabledConnectors(t *testing.T) {
 	t.Parallel()
-	disabled := map[string]bool{"kroger": true}
+	disabled := make(map[string]bool)
+	for _, id := range connectors.DisabledBuiltInConnectorIDs() {
+		disabled[id] = true
+	}
 	for _, p := range oauth.BuiltInProviders() {
 		if disabled[p.ID] {
 			t.Errorf("%q should not appear in BuiltInProviders when connector is disabled", p.ID)


### PR DESCRIPTION
## Summary

- **Derive disabled IDs dynamically in test** — `TestBuiltInProviders_OmitsDisabledConnectors` now uses `connectors.DisabledBuiltInConnectorIDs()` instead of hardcoding `{"kroger": true}`, so the test auto-adapts when connectors are disabled or re-enabled.
- **Document `//go:embed */disabled` constraint** — Added a NOTE comment explaining that at least one `disabled` marker file must exist or the build fails with "no matching files found", with guidance on how to handle the all-enabled case.
- **Remove dead-code `oauthRegistry.Remove` loop** — Disabled connectors' OAuth providers never register (their `init()` guards return early), so the `oauthRegistry.Remove()` loop in `main.go` was always a no-op. Replaced with a clarifying comment.

Also verified that all 8 PR #771 review items were already addressed in PR #774 — those threads should be resolved.

Closes #802

## Test plan

### Claude Code
- [x] `TestBuiltInProviders_OmitsDisabledConnectors` passes with dynamic disabled ID derivation
- [x] `TestBuiltInOAuthDisabledForKrogerNotQuickBooks` still passes
- [x] `go vet ./oauth/...` clean
- [x] `go build ./connectors/` clean

### Manual Testing
- [ ] Verify disabled connectors don't appear in the UI or API responses
- [ ] Verify build succeeds with and without disabled connectors

https://claude.ai/code/session_01UWfv7jnWBLBQNPMu8a6LRh