### PR TITLE
Fix graphNextRelativePath path boundary and OAuthProviders nil check

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -354,9 +354,6 @@ func resolveOAuthCredentialsFromConnection(ctx context.Context, deps *Deps, conn
 	if deps.Vault == nil {
 		return zero, fmt.Errorf("credential vault is not configured but connector requires OAuth credentials")
 	}
-	if deps.OAuthProviders == nil {
-		return zero, fmt.Errorf("OAuth provider registry is not configured")
-	}
 
 	return credentialsFromOAuthConnection(ctx, deps, conn)
 }
@@ -380,6 +377,9 @@ func credentialsFromOAuthConnection(ctx context.Context, deps *Deps, conn *db.OA
 
 	// Refresh the token if expired or within pre-emptive buffer.
 	if conn.TokenExpiry != nil && time.Now().After(conn.TokenExpiry.Add(-oauth.TokenExpiryBuffer)) {
+		if deps.OAuthProviders == nil {
+			return zero, fmt.Errorf("OAuth provider registry is not configured")
+		}
 		if err := refreshOAuthConnection(ctx, deps, conn, conn.Provider); err != nil {
 			return zero, err
 		}

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -489,6 +489,38 @@ func TestExecuteConnectorAction_OAuthPath_NilTokenExpirySkipsRefresh(t *testing.
 	}
 }
 
+// TestExecuteConnectorAction_OAuthPath_NilExpiryNilOAuthRegistrySucceeds verifies
+// that tokens with no expiry work even when deps.OAuthProviders is nil.
+// This is the regression test for the OAuthProviders nil-check relocation.
+func TestExecuteConnectorAction_OAuthPath_NilExpiryNilOAuthRegistrySucceeds(t *testing.T) {
+	t.Parallel()
+
+	var capturedCreds connectors.Credentials
+	f := setupOAuthExecutionTest(t, oauthExecOpts{
+		OnExec:          func(creds connectors.Credentials) { capturedCreds = creds },
+		Connection:      &testhelper.OAuthConnectionOpts{Status: "active"},
+		NoOAuthRegistry: true,
+	})
+
+	// Store a token with no expiry — refresh should never be attempted.
+	accessVaultID, _ := f.Vault.CreateSecret(t.Context(), f.TX, "access", []byte("no-expiry-token"))
+	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
+	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, nil)
+
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error with nil OAuthProviders and nil expiry: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	tok, _ := capturedCreds.Get("access_token")
+	if tok != "no-expiry-token" {
+		t.Errorf("expected access_token %q, got %q", "no-expiry-token", tok)
+	}
+}
+
 // TestExecuteConnectorAction_OAuthPath_RefreshesExpiredToken is the hardest
 // integration test: it wires up a real mock OAuth token server, stores an expired
 // access token with a valid refresh token, and verifies the full refresh pipeline:

--- a/connectors/microsoft/list_calendars.go
+++ b/connectors/microsoft/list_calendars.go
@@ -63,12 +63,15 @@ func graphNextRelativePath(baseURL, nextLink string) string {
 	}
 	base := strings.TrimSuffix(baseURL, "/")
 	full := strings.TrimSuffix(u.String(), "/")
-	if !strings.HasPrefix(full, base) {
+	if !strings.HasPrefix(full, base+"/") && !strings.HasPrefix(full, base+"?") {
 		return ""
 	}
-	rel := strings.TrimPrefix(full[len(base):], "/")
-	if rel == "" {
+	rel := full[len(base):]
+	if rel == "" || rel == "/" {
 		return ""
+	}
+	if rel[0] == '/' || rel[0] == '?' {
+		return rel
 	}
 	return "/" + rel
 }

--- a/connectors/microsoft/list_calendars.go
+++ b/connectors/microsoft/list_calendars.go
@@ -66,9 +66,5 @@ func graphNextRelativePath(baseURL, nextLink string) string {
 	if !strings.HasPrefix(full, base+"/") && !strings.HasPrefix(full, base+"?") {
 		return ""
 	}
-	rel := full[len(base):]
-	if rel == "" {
-		return ""
-	}
-	return rel // always starts with '/' or '?' per prefix check above
+	return full[len(base):] // always non-empty, starts with '/' or '?' per prefix check above
 }

--- a/connectors/microsoft/list_calendars.go
+++ b/connectors/microsoft/list_calendars.go
@@ -67,11 +67,8 @@ func graphNextRelativePath(baseURL, nextLink string) string {
 		return ""
 	}
 	rel := full[len(base):]
-	if rel == "" || rel == "/" {
+	if rel == "" {
 		return ""
 	}
-	if rel[0] == '/' || rel[0] == '?' {
-		return rel
-	}
-	return "/" + rel
+	return rel // always starts with '/' or '?' per prefix check above
 }

--- a/connectors/microsoft/list_calendars_test.go
+++ b/connectors/microsoft/list_calendars_test.go
@@ -10,10 +10,25 @@ import (
 func TestGraphNextRelativePath(t *testing.T) {
 	t.Parallel()
 	base := "https://graph.microsoft.com/v1.0"
-	next := "https://graph.microsoft.com/v1.0/me/calendars?$skiptoken=abc"
-	got := graphNextRelativePath(base, next)
-	if got != "/me/calendars?$skiptoken=abc" {
-		t.Errorf("got %q", got)
+
+	tests := []struct {
+		name string
+		next string
+		want string
+	}{
+		{"valid path", "https://graph.microsoft.com/v1.0/me/calendars?$skiptoken=abc", "/me/calendars?$skiptoken=abc"},
+		{"empty next", "", ""},
+		{"different host", "https://evil.com/v1.0/me/calendars", ""},
+		{"prefix collision without path boundary", "https://graph.microsoft.com/v1.0.evil.com/steal", ""},
+		{"query string after base", "https://graph.microsoft.com/v1.0?unexpected=true", "?unexpected=true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := graphNextRelativePath(base, tt.next)
+			if got != tt.want {
+				t.Errorf("graphNextRelativePath(%q, %q) = %q, want %q", base, tt.next, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `graphNextRelativePath` to require a `/` or `?` path boundary after the base URL prefix, preventing prefix collisions (e.g., `v1.0.evil.com` matching `v1.0`)
- Move `OAuthProviders` nil check from `resolveOAuthCredentialsFromConnection` into the token-expiry guard in `credentialsFromOAuthConnection`, so non-expiring tokens work without a registry configured

Closes #801

## Test plan

### Claude Code
- [x] `graphNextRelativePath` tests pass with new boundary check cases (prefix collision, query string)
- [x] All 11 `TestExecuteConnectorAction_OAuthPath_*` tests pass
- [x] Full `./api/...` and `./connectors/...` test suites pass
- [x] Go build succeeds (`go build ./...`)

### Manual Testing
- [ ] Verify calendar list loads for Google and Microsoft
- [ ] Verify calendar selection persists correctly

https://claude.ai/code/session_011BT2Qtx8vCkFJ3nSh8tpAn