### PR TITLE
Harden Dropbox PKCE: explicit error, dead code cleanup, fix param placement

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -258,9 +258,6 @@ func verifyOAuthState(deps *Deps, stateStr string) (*oauthState, error) {
 			return nil, fmt.Errorf("invalid state token pkce: %w", err)
 		}
 		pkceVerifier = v
-	} else if legacy, ok := claims["pkce_verifier"].(string); ok && legacy != "" {
-		// In-flight tokens from before pkce_sealed (plaintext in JWT payload).
-		pkceVerifier = legacy
 	}
 	return &oauthState{UserID: sub, Provider: prov, Scopes: scopes, Shop: shop, ReturnTo: returnTo, ReplaceID: replaceID, PKCEVerifier: pkceVerifier}, nil
 }
@@ -623,6 +620,16 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 		provider, ok := deps.OAuthProviders.Get(providerID)
 		if !ok {
 			redirectToFrontend(w, r, deps, providerID, "error", "Provider not found", state.ReturnTo, "")
+			return
+		}
+
+		// PKCE-required providers must have a verifier in the state token.
+		// If the verifier is missing, the token exchange will fail with an
+		// opaque provider error — surface a clear message instead.
+		if provider.PKCE && state.PKCEVerifier == "" {
+			log.Printf("[%s] OAuthCallback: PKCE verifier missing for provider %s", TraceID(r.Context()), providerID)
+			CaptureError(r.Context(), fmt.Errorf("OAuthCallback: PKCE verifier missing for PKCE-required provider %s", providerID))
+			redirectToFrontend(w, r, deps, providerID, "error", "PKCE verifier missing from state token", state.ReturnTo, "")
 			return
 		}
 

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -293,7 +293,7 @@ func TestCreateAndVerifyOAuthState_WithPKCEVerifier(t *testing.T) {
 	}
 }
 
-func TestVerifyOAuthState_LegacyPlaintextPKCEClaim(t *testing.T) {
+func TestVerifyOAuthState_PlaintextPKCEClaimIgnored(t *testing.T) {
 	t.Parallel()
 	deps := &Deps{OAuthStateSecret: testOAuthStateSecret}
 	verifier := "legacy-plaintext-verifier-43charsxxxxxxxxxxxxxxxxxxxxx"
@@ -315,8 +315,8 @@ func TestVerifyOAuthState_LegacyPlaintextPKCEClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verifyOAuthState: %v", err)
 	}
-	if verified.PKCEVerifier != verifier {
-		t.Errorf("legacy PKCE: got %q, want %q", verified.PKCEVerifier, verifier)
+	if verified.PKCEVerifier != "" {
+		t.Errorf("plaintext pkce_verifier claim should be ignored, got %q", verified.PKCEVerifier)
 	}
 }
 
@@ -2030,5 +2030,113 @@ func TestStoreOAuthTokens_WithZendeskSubdomain(t *testing.T) {
 	}
 	if extra["subdomain"] != "mycompany" {
 		t.Errorf("expected subdomain=mycompany, got %q", extra["subdomain"])
+	}
+}
+
+// ── PKCE callback tests ──────────────────────────────────────────────────────
+
+func TestOAuthCallback_PKCEVerifierPropagated(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	// Fake token endpoint that captures the code_verifier form param.
+	var capturedVerifier string
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedVerifier = r.FormValue("code_verifier")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600,"refresh_token":"ref"}`))
+	}))
+	defer tokenSrv.Close()
+
+	reg := oauth.NewRegistry()
+	_ = reg.Register(oauth.Provider{
+		ID:           "dropbox",
+		AuthorizeURL: "https://www.dropbox.com/oauth2/authorize",
+		TokenURL:     tokenSrv.URL,
+		Scopes:       []string{"files.content.read"},
+		PKCE:         true,
+		ClientID:     "test-dropbox-client-id",
+		ClientSecret: "test-dropbox-client-secret",
+		Source:       oauth.SourceBuiltIn,
+	})
+	v := vault.NewMockVaultStore()
+	deps := &Deps{
+		DB:               tx,
+		Vault:            v,
+		OAuthProviders:   reg,
+		OAuthStateSecret: testOAuthStateSecret,
+		BaseURL:          "http://localhost:3000",
+	}
+
+	// Create a state token with a PKCE verifier embedded.
+	verifier := oauth2.GenerateVerifier()
+	state, err := createOAuthState(deps, uid, "dropbox", []string{"files.content.read"}, "", "", "", verifier)
+	if err != nil {
+		t.Fatalf("create state: %v", err)
+	}
+
+	router := NewRouter(deps)
+	r := httptest.NewRequest(http.MethodGet,
+		"/oauth/dropbox/callback?code=test-code&state="+url.QueryEscape(state), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	// The callback should have forwarded the verifier to the token endpoint.
+	if capturedVerifier == "" {
+		t.Fatal("expected code_verifier to be sent to token endpoint, got empty")
+	}
+	if capturedVerifier != verifier {
+		t.Errorf("code_verifier mismatch: got %q, want %q", capturedVerifier, verifier)
+	}
+}
+
+func TestOAuthCallback_PKCEVerifierMissing(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	reg := oauth.NewRegistry()
+	_ = reg.Register(oauth.Provider{
+		ID:           "dropbox",
+		AuthorizeURL: "https://www.dropbox.com/oauth2/authorize",
+		TokenURL:     "https://api.dropboxapi.com/oauth2/token",
+		Scopes:       []string{"files.content.read"},
+		PKCE:         true,
+		ClientID:     "test-dropbox-client-id",
+		ClientSecret: "test-dropbox-client-secret",
+		Source:       oauth.SourceBuiltIn,
+	})
+	deps := &Deps{
+		DB:               tx,
+		Vault:            vault.NewMockVaultStore(),
+		OAuthProviders:   reg,
+		OAuthStateSecret: testOAuthStateSecret,
+		BaseURL:          "http://localhost:3000",
+	}
+
+	// Create state WITHOUT a PKCE verifier (simulates a corrupt/tampered state).
+	state, err := createOAuthState(deps, uid, "dropbox", []string{"files.content.read"}, "", "", "", "")
+	if err != nil {
+		t.Fatalf("create state: %v", err)
+	}
+
+	router := NewRouter(deps)
+	r := httptest.NewRequest(http.MethodGet,
+		"/oauth/dropbox/callback?code=test-code&state="+url.QueryEscape(state), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
+	}
+	location := w.Header().Get("Location")
+	if !strings.Contains(location, "oauth_status=error") {
+		t.Errorf("expected error status in redirect, got: %s", location)
+	}
+	if !strings.Contains(location, "PKCE+verifier+missing") && !strings.Contains(location, "PKCE%20verifier%20missing") {
+		t.Errorf("expected PKCE verifier missing message in redirect, got: %s", location)
 	}
 }

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -142,16 +142,22 @@ var validAuthTypes = map[string]bool{
 // manifest override security-critical values (redirect_uri, state, client_id)
 // that the platform manages.
 var ReservedAuthorizeParams = map[string]bool{
-	"redirect_uri":            true,
-	"state":                   true,
-	"client_id":               true,
-	"client_secret":           true,
-	"response_type":           true,
-	"code":                    true,
-	"grant_type":              true,
-	"code_challenge":          true,
-	"code_challenge_method":   true,
-	"code_verifier":           true,
+	"redirect_uri":          true,
+	"state":                 true,
+	"client_id":             true,
+	"client_secret":         true,
+	"response_type":         true,
+	"code":                  true,
+	"grant_type":            true,
+	"code_challenge":        true,
+	"code_challenge_method": true,
+}
+
+// ReservedTokenParams lists OAuth 2.0 parameters that belong to the token
+// exchange request and must not be set by connectors. code_verifier is a
+// token exchange parameter (RFC 7636 §4.5), not an authorization parameter.
+var ReservedTokenParams = map[string]bool{
+	"code_verifier": true,
 }
 
 // validateURL parses a URL and checks scheme and host. allowedSchemes specifies

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -548,7 +548,7 @@ func TestManifestValidation_ReservedAuthorizeParams(t *testing.T) {
 
 	for _, reserved := range []string{
 		"redirect_uri", "state", "client_id", "client_secret", "response_type", "code", "grant_type",
-		"code_challenge", "code_challenge_method", "code_verifier",
+		"code_challenge", "code_challenge_method",
 	} {
 		t.Run("rejects_"+reserved, func(t *testing.T) {
 			input := fmt.Sprintf(base, fmt.Sprintf(`"%s": "evil-value"`, reserved))


### PR DESCRIPTION
## Summary

- Return explicit error when `provider.PKCE == true && state.PKCEVerifier == ""` instead of letting the token exchange fail with an opaque Dropbox error
- Remove legacy plaintext PKCE fallback (`pkce_verifier` JWT claim) — dead code since this is the first PKCE implementation, and it weakens the security model by accepting unencrypted verifiers
- Move `code_verifier` from `ReservedAuthorizeParams` to new `ReservedTokenParams`, since it's a token exchange parameter (RFC 7636 §4.5), not an authorize parameter
- Add callback integration tests verifying PKCE verifier propagation to the token endpoint and the explicit error for missing verifiers

Closes #799

## Test plan

### Claude Code
- [x] All existing api tests pass
- [x] All connectors tests pass
- [x] New `TestOAuthCallback_PKCEVerifierPropagated` verifies verifier reaches token endpoint
- [x] New `TestOAuthCallback_PKCEVerifierMissing` verifies explicit error redirect
- [x] `TestVerifyOAuthState_PlaintextPKCEClaimIgnored` verifies legacy fallback is removed

### Manual Testing
- [ ] Verify Dropbox OAuth PKCE flow works end-to-end
- [ ] Verify clear error when PKCE verifier is missing

https://claude.ai/code/session_0176Sh1qopn3rY6THpMNU2eF