### PR TITLE
Fix orphaned vault secrets, mixed-auth stuck state, and multi-CRC test gap

### DIFF
--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -279,10 +279,12 @@ func TestExecuteConnectorAction_OAuthPath_NoConnection_NoBinding(t *testing.T) {
 	}
 }
 
-// TestExecuteConnectorAction_DualAuth_NoBinding_ReturnsError verifies that when a
-// connector supports both OAuth and API key, but no credential binding exists,
-// execution fails with a clear error instead of auto-resolving.
-func TestExecuteConnectorAction_DualAuth_NoBinding_ReturnsError(t *testing.T) {
+// TestExecuteConnectorAction_OAuth_NoBinding_ReturnsError verifies that when a
+// connector requires OAuth but no credential binding exists, execution fails
+// with a clear error instead of auto-resolving.
+// (Previously tested with dual oauth2+api_key auth, but mixed auth types are
+// now prevented at the schema level per issue #803.)
+func TestExecuteConnectorAction_OAuth_NoBinding_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{
@@ -292,16 +294,7 @@ func TestExecuteConnectorAction_DualAuth_NoBinding_ReturnsError(t *testing.T) {
 		// No OAuth connection — no binding will be created.
 	})
 
-	// Add a static api_key credential alongside the OAuth one.
-	testhelper.InsertConnectorRequiredCredential(t, f.TX, "testnotion", "testnotion", "api_key")
-	vaultID, vaultErr := f.Vault.CreateSecret(t.Context(), nil, "testnotion-cred", []byte(`{"api_key":"ntn_test_key_123"}`))
-	if vaultErr != nil {
-		t.Fatalf("create vault secret: %v", vaultErr)
-	}
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, f.TX, credID, f.UserID, "testnotion", vaultID)
-
-	// Without a binding, execution should fail even though credentials exist.
+	// Without a binding, execution should fail even though the connector exists.
 	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
 	if err == nil {
 		t.Fatal("expected error when no credential binding exists")
@@ -311,11 +304,12 @@ func TestExecuteConnectorAction_DualAuth_NoBinding_ReturnsError(t *testing.T) {
 	}
 }
 
-// TestExecuteConnectorAction_DualAuth_NeedsReauth_NoFallback verifies that when
-// a connector supports both OAuth and API key, but the OAuth connection exists
-// with status needs_reauth, we do NOT silently fall back to API key — the user
-// must re-authorize OAuth.
-func TestExecuteConnectorAction_DualAuth_NeedsReauth_NoFallback(t *testing.T) {
+// TestExecuteConnectorAction_OAuth_NeedsReauth verifies that when a connector
+// requires OAuth and the connection has status needs_reauth, execution returns
+// an OAuthRefreshError instead of proceeding.
+// (Previously tested with dual oauth2+api_key auth to verify no fallback, but
+// mixed auth types are now prevented at the schema level per issue #803.)
+func TestExecuteConnectorAction_OAuth_NeedsReauth(t *testing.T) {
 	t.Parallel()
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{
@@ -325,18 +319,9 @@ func TestExecuteConnectorAction_DualAuth_NeedsReauth_NoFallback(t *testing.T) {
 		Connection:  &testhelper.OAuthConnectionOpts{Status: "needs_reauth"},
 	})
 
-	// Add a static api_key credential alongside the OAuth one.
-	testhelper.InsertConnectorRequiredCredential(t, f.TX, "testnotion", "testnotion", "api_key")
-	vaultID, vaultErr := f.Vault.CreateSecret(t.Context(), nil, "testnotion-cred", []byte(`{"api_key":"ntn_test_key_123"}`))
-	if vaultErr != nil {
-		t.Fatalf("create vault secret: %v", vaultErr)
-	}
-	credID := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, f.TX, credID, f.UserID, "testnotion", vaultID)
-
 	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
 	if err == nil {
-		t.Fatal("expected error for needs_reauth — should NOT fall back to API key")
+		t.Fatal("expected error for needs_reauth status")
 	}
 	if !connectors.IsOAuthRefreshError(err) {
 		t.Errorf("expected OAuthRefreshError, got %T: %v", err, err)

--- a/db/capabilities_test.go
+++ b/db/capabilities_test.go
@@ -605,3 +605,86 @@ func TestGetAgentCapabilities_StandingApprovalOnlyForCorrectAgent(t *testing.T) 
 		t.Errorf("expected 0 standing approvals for agent2, got %d", len(caps.StandingApprovals))
 	}
 }
+
+func TestGetAgentCapabilities_CredentialsReady_MultiCRCAllSatisfiedViaConnectorID(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	// Connector with two required credential rows (different services, same auth type).
+	// A single bound credential whose service = connector ID should satisfy both,
+	// because the query matches on (cr.service = crc.service OR cr.service = c.id).
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_alpha", "api_key")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_beta", "api_key")
+
+	// Credential with service = connector ID (covers all CRC rows via the OR fallback).
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredential(t, tx, credID, uid, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, credID)
+
+	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("GetAgentCapabilities: %v", err)
+	}
+	if len(caps.Connectors) != 1 {
+		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
+	}
+	if !caps.Connectors[0].CredentialsReady {
+		t.Error("expected credentials_ready=true when a single credential (service=connector_id) satisfies multiple CRC rows")
+	}
+}
+
+func TestGetAgentCapabilities_CredentialsReady_MultiCRCPartiallyUnsatisfied(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	// Connector with two required credential rows for different services.
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_alpha", "api_key")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_beta", "api_key")
+
+	// Credential that matches only svc_alpha (not using connector ID fallback).
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredential(t, tx, credID, uid, "svc_alpha")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, credID)
+
+	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("GetAgentCapabilities: %v", err)
+	}
+	if len(caps.Connectors) != 1 {
+		t.Fatalf("expected 1 connector, got %d", len(caps.Connectors))
+	}
+	if caps.Connectors[0].CredentialsReady {
+		t.Error("expected credentials_ready=false when bound credential only matches one of two CRC rows")
+	}
+}
+
+func TestConnectorRequiredCredentials_MixedAuthTypeRejected(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	// Create a connector with a non-oauth2 CRC row.
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_a", "api_key")
+
+	// Attempting to insert an oauth2 CRC row for the same connector should fail.
+	_, err := tx.Exec(t.Context(),
+		`INSERT INTO connector_required_credentials (connector_id, service, auth_type, oauth_provider, oauth_scopes)
+		 VALUES ($1, 'svc_b', 'oauth2', 'google', '{}')`,
+		connID)
+	if err == nil {
+		t.Fatal("expected error when inserting mixed auth types for the same connector, got nil")
+	}
+}

--- a/db/capabilities_test.go
+++ b/db/capabilities_test.go
@@ -688,3 +688,25 @@ func TestConnectorRequiredCredentials_MixedAuthTypeRejected(t *testing.T) {
 		t.Fatal("expected error when inserting mixed auth types for the same connector, got nil")
 	}
 }
+
+func TestConnectorRequiredCredentials_MixedAuthTypeRejectedOnUpdate(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	// Create a connector with two non-oauth2 CRC rows (different services).
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_a", "api_key")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "svc_b", "basic")
+
+	// Updating one row's auth_type to oauth2 should be rejected because the
+	// other row is still non-oauth2, creating a mixed-auth situation.
+	_, err := tx.Exec(t.Context(),
+		`UPDATE connector_required_credentials
+		 SET auth_type = 'oauth2', oauth_provider = 'google', oauth_scopes = '{}'
+		 WHERE connector_id = $1 AND service = 'svc_a' AND auth_type = 'api_key'`,
+		connID)
+	if err == nil {
+		t.Fatal("expected error when updating auth_type to create mixed auth types, got nil")
+	}
+}

--- a/db/migrations/20260324120708_purge_orphaned_byoa_vault_secrets.sql
+++ b/db/migrations/20260324120708_purge_orphaned_byoa_vault_secrets.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+
+-- Purge orphaned vault secrets left behind when oauth_provider_configs was
+-- dropped (migration 20260323235640). The table stored client_id_vault_id and
+-- client_secret_vault_id references into vault.secrets, but the DROP TABLE did
+-- not clean them up.
+--
+-- Strategy: delete vault secrets whose IDs are not referenced by any current
+-- table (credentials.vault_secret_id, oauth_connections.access_token_vault_id,
+-- oauth_connections.refresh_token_vault_id).
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- Only run if vault extension is installed (not present in plain Postgres / CI).
+    IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'vault') THEN
+        DELETE FROM vault.secrets
+        WHERE id NOT IN (
+            SELECT vault_secret_id FROM credentials
+            UNION ALL
+            SELECT access_token_vault_id FROM oauth_connections
+            UNION ALL
+            SELECT refresh_token_vault_id FROM oauth_connections
+                WHERE refresh_token_vault_id IS NOT NULL
+        );
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Cannot restore deleted secrets; this is a one-way cleanup.

--- a/db/migrations/20260324120708_purge_orphaned_byoa_vault_secrets.sql
+++ b/db/migrations/20260324120708_purge_orphaned_byoa_vault_secrets.sql
@@ -17,9 +17,9 @@ BEGIN
         DELETE FROM vault.secrets
         WHERE id NOT IN (
             SELECT vault_secret_id FROM credentials
-            UNION ALL
+            UNION
             SELECT access_token_vault_id FROM oauth_connections
-            UNION ALL
+            UNION
             SELECT refresh_token_vault_id FROM oauth_connections
                 WHERE refresh_token_vault_id IS NOT NULL
         );

--- a/db/migrations/20260324120723_prevent_mixed_auth_type_connectors.sql
+++ b/db/migrations/20260324120723_prevent_mixed_auth_type_connectors.sql
@@ -23,10 +23,12 @@ BEGIN
         WHERE connector_id = NEW.connector_id
           AND (auth_type = 'oauth2') <> new_is_oauth
           -- Exclude the row being updated (if this is an UPDATE).
+          -- Use OLD.auth_type so the exclusion matches the pre-update row.
           AND NOT (
               connector_id = NEW.connector_id
               AND service = NEW.service
-              AND auth_type = NEW.auth_type
+              AND auth_type = CASE WHEN TG_OP = 'UPDATE' THEN OLD.auth_type
+                                   ELSE NEW.auth_type END
           )
     ) INTO has_conflict;
 

--- a/db/migrations/20260324120723_prevent_mixed_auth_type_connectors.sql
+++ b/db/migrations/20260324120723_prevent_mixed_auth_type_connectors.sql
@@ -1,0 +1,82 @@
+-- +goose Up
+
+-- Prevent a connector from having both oauth2 and non-oauth2 required
+-- credentials. The agent_connector_credentials table enforces one binding per
+-- agent+connector (via unique index), so mixed auth types can never be
+-- satisfied simultaneously — one side is always missing.
+--
+-- We enforce this at the schema level with a trigger that rejects inserts or
+-- updates that would create a mixed-auth situation for a connector.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION check_no_mixed_auth_types()
+RETURNS trigger AS $$
+DECLARE
+    new_is_oauth boolean;
+    has_conflict boolean;
+BEGIN
+    new_is_oauth := (NEW.auth_type = 'oauth2');
+
+    -- Check if any existing row for this connector has the opposite auth category.
+    SELECT EXISTS (
+        SELECT 1 FROM connector_required_credentials
+        WHERE connector_id = NEW.connector_id
+          AND (auth_type = 'oauth2') <> new_is_oauth
+          -- Exclude the row being updated (if this is an UPDATE).
+          AND NOT (
+              connector_id = NEW.connector_id
+              AND service = NEW.service
+              AND auth_type = NEW.auth_type
+          )
+    ) INTO has_conflict;
+
+    IF has_conflict THEN
+        RAISE EXCEPTION
+            'connector % cannot mix oauth2 and non-oauth2 auth types',
+            NEW.connector_id
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_no_mixed_auth_types
+    BEFORE INSERT OR UPDATE ON connector_required_credentials
+    FOR EACH ROW
+    EXECUTE FUNCTION check_no_mixed_auth_types();
+
+-- Clean up any existing mixed-auth connectors by keeping only the majority
+-- auth category. In practice this is a no-op since no mixed-auth connectors
+-- have been created, but guards against edge cases.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    -- Find connectors that have both oauth2 and non-oauth2 rows.
+    FOR r IN
+        SELECT connector_id,
+               COUNT(*) FILTER (WHERE auth_type = 'oauth2') AS oauth_count,
+               COUNT(*) FILTER (WHERE auth_type <> 'oauth2') AS non_oauth_count
+        FROM connector_required_credentials
+        GROUP BY connector_id
+        HAVING COUNT(*) FILTER (WHERE auth_type = 'oauth2') > 0
+           AND COUNT(*) FILTER (WHERE auth_type <> 'oauth2') > 0
+    LOOP
+        -- Keep the majority; on tie, keep non-oauth2 (static creds are simpler).
+        IF r.oauth_count > r.non_oauth_count THEN
+            DELETE FROM connector_required_credentials
+            WHERE connector_id = r.connector_id AND auth_type <> 'oauth2';
+        ELSE
+            DELETE FROM connector_required_credentials
+            WHERE connector_id = r.connector_id AND auth_type = 'oauth2';
+        END IF;
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TRIGGER IF EXISTS trg_no_mixed_auth_types ON connector_required_credentials;
+DROP FUNCTION IF EXISTS check_no_mixed_auth_types();

--- a/db/oauth_connections_refresh_test.go
+++ b/db/oauth_connections_refresh_test.go
@@ -140,9 +140,10 @@ func TestGetRequiredCredentialsByActionType_MultipleAuthMethods(t *testing.T) {
 
 	testhelper.InsertConnector(t, tx, "trello")
 	testhelper.InsertConnectorAction(t, tx, "trello", "trello.create_card", "Create Card")
-	// Insert both OAuth and API key credentials for the same connector.
-	testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, "trello", "trello_oauth", "trello", []string{"read:me:trello"})
-	testhelper.InsertConnectorRequiredCredential(t, tx, "trello", "trello", "api_key")
+	// Insert two non-oauth2 credentials for the same connector (different services).
+	// Mixed oauth2/non-oauth2 types are now prevented at the schema level.
+	testhelper.InsertConnectorRequiredCredential(t, tx, "trello", "trello_api", "api_key")
+	testhelper.InsertConnectorRequiredCredential(t, tx, "trello", "trello_token", "basic")
 
 	creds, err := db.GetRequiredCredentialsByActionType(context.Background(), tx, "trello.create_card")
 	if err != nil {
@@ -151,18 +152,18 @@ func TestGetRequiredCredentialsByActionType_MultipleAuthMethods(t *testing.T) {
 	if len(creds) != 2 {
 		t.Fatalf("expected 2 credentials, got %d", len(creds))
 	}
-	// OAuth should be first (ordering guarantee).
-	if creds[0].AuthType != "oauth2" {
-		t.Errorf("expected first credential to be oauth2, got %q", creds[0].AuthType)
+	// Both are non-oauth2, ordered by service name.
+	if creds[0].AuthType != "api_key" {
+		t.Errorf("expected first credential to be api_key, got %q", creds[0].AuthType)
 	}
-	if creds[0].Service != "trello_oauth" {
-		t.Errorf("expected first credential service 'trello_oauth', got %q", creds[0].Service)
+	if creds[0].Service != "trello_api" {
+		t.Errorf("expected first credential service 'trello_api', got %q", creds[0].Service)
 	}
-	if creds[1].AuthType != "api_key" {
-		t.Errorf("expected second credential to be api_key, got %q", creds[1].AuthType)
+	if creds[1].AuthType != "basic" {
+		t.Errorf("expected second credential to be basic, got %q", creds[1].AuthType)
 	}
-	if creds[1].Service != "trello" {
-		t.Errorf("expected second credential service 'trello', got %q", creds[1].Service)
+	if creds[1].Service != "trello_token" {
+		t.Errorf("expected second credential service 'trello_token', got %q", creds[1].Service)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add migration to purge orphaned vault secrets left behind when `oauth_provider_configs` was dropped — deletes any vault secrets not referenced by `credentials`, `oauth_connections.access_token_vault_id`, or `oauth_connections.refresh_token_vault_id`
- Add trigger on `connector_required_credentials` to prevent mixing oauth2 and non-oauth2 auth types for the same connector, which caused a permanently stuck `credentials_ready=false` state (the unique index on `agent_connector_credentials(agent_id, connector_id)` only allows one binding)
- Add tests for multi-CRC row "all satisfied via connector ID" scenario and partial satisfaction, plus a test verifying the mixed-auth trigger rejects conflicting rows

Closes #803

## Test plan

### Claude Code
- [x] All db tests pass (`go test ./db/...`)
- [x] New multi-CRC tests verify credential resolution with multiple required credential rows
- [x] Mixed-auth trigger test verifies schema-level rejection of conflicting auth types
- [x] Existing mixed-auth test updated to use same-category auth types

### Manual Testing
- [ ] Verify no orphaned secrets remain in vault after migration runs on staging/production
- [ ] Verify connectors with multiple credential requirement rows resolve correctly in the UI

https://claude.ai/code/session_01UgjJpLw9b5cYuLaw99DVw9