### PR TITLE
Fix accumulated Slack connector review feedback

### DIFF
--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -87,6 +87,8 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 			if handleConnectorError(w, r, err, connErrCtx) {
 				return
 			}
+			log.Printf("[%s] ListAgentConnectorCalendars validate creds: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
 			return
 		}

--- a/api/agent_connector_channels.go
+++ b/api/agent_connector_channels.go
@@ -89,6 +89,7 @@ func handleListAgentConnectorChannels(deps *Deps) http.HandlerFunc {
 				return
 			}
 			log.Printf("[%s] ListAgentConnectorChannels validate creds: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
 			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
 			return
 		}

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -657,14 +657,17 @@ func handleOAuthCallback(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Slack user-token-only OAuth: the v2_user token endpoint returns
-		// the user token (xoxp-) at the top level, so no authed_user
-		// extraction is needed. Verify we got a user token (not empty).
-		if providerID == "slack" && token.AccessToken == "" {
-			redirectToFrontend(w, r, deps, providerID, "error",
-				"Slack did not return a user OAuth token. Check your Slack app User Token Scopes configuration, then try again.",
-				state.ReturnTo, "")
-			return
+		// Slack user-token-only OAuth: the standard oauth.v2.access endpoint
+		// nests the user token inside authed_user when only user scopes are
+		// requested. Normalize the token so AccessToken is the user token.
+		if providerID == "slack" {
+			token = oauth.NormalizeSlackUserOAuthToken(token)
+			if token.AccessToken == "" {
+				redirectToFrontend(w, r, deps, providerID, "error",
+					"Slack did not return a user OAuth token. Check your Slack app User Token Scopes configuration, then try again.",
+					state.ReturnTo, "")
+				return
+			}
 		}
 
 		// Store tokens in vault within a transaction. Use scopes from the

--- a/connectors/intercom/search_tickets.go
+++ b/connectors/intercom/search_tickets.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -72,14 +71,10 @@ func (a *searchTicketsAction) Execute(ctx context.Context, req connectors.Action
 		if err != nil {
 			return err
 		}
-		v := strconv.FormatInt(sec, 10)
-		if err != nil {
-			return err
-		}
 		predicates = append(predicates, map[string]any{
 			"field":    field,
 			"operator": op,
-			"value":    v,
+			"value":    sec,
 		})
 		return nil
 	}

--- a/connectors/intercom/search_tickets_test.go
+++ b/connectors/intercom/search_tickets_test.go
@@ -89,7 +89,8 @@ func TestSearchTickets_WithCreatedAtBounds_ANDQuery(t *testing.T) {
 			t.Errorf("unexpected first predicate: %#v", p0)
 		}
 		p1 := vals[1].(map[string]any)
-		if p1["field"] != "created_at" || p1["operator"] != ">" || p1["value"] != "1709251200" {
+		// value is serialized as a JSON number (int64 → float64 after round-trip).
+		if p1["field"] != "created_at" || p1["operator"] != ">" || p1["value"] != float64(1709251200) {
 			t.Errorf("unexpected second predicate: %#v", p1)
 		}
 

--- a/connectors/slack/add_reaction.go
+++ b/connectors/slack/add_reaction.go
@@ -65,7 +65,7 @@ func (a *addReactionAction) Execute(ctx context.Context, req connectors.ActionRe
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/slack/channel_lister.go
+++ b/connectors/slack/channel_lister.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -22,6 +21,7 @@ func (c *SlackConnector) ChannelListCredentialActionType() string {
 // or a safety cap is hit.
 func (c *SlackConnector) ListChannels(ctx context.Context, creds connectors.Credentials, userEmail string) ([]connectors.ChannelListItem, error) {
 	var all []listChannelSummary
+	seen := make(map[string]bool)
 	cursor := ""
 	for page := 0; page < slackChannelListMaxPages; page++ {
 		params := listChannelsParams{
@@ -33,15 +33,20 @@ func (c *SlackConnector) ListChannels(ctx context.Context, creds connectors.Cred
 		if err != nil {
 			return nil, err
 		}
-		all = append(all, batch.Channels...)
+		for _, ch := range batch.Channels {
+			if seen[ch.ID] {
+				continue
+			}
+			seen[ch.ID] = true
+			all = append(all, ch)
+		}
 		if batch.NextCursor == "" {
 			break
 		}
 		cursor = batch.NextCursor
 	}
-	if cursor != "" {
-		return nil, fmt.Errorf("slack channel list exceeded max pages (%d)", slackChannelListMaxPages)
-	}
+	// Return partial results when the page cap is reached rather than
+	// erroring, so callers still get a usable (large) channel list.
 	out := make([]connectors.ChannelListItem, 0, len(all))
 	for _, ch := range all {
 		out = append(out, connectors.ChannelListItem{

--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -41,7 +41,7 @@ func (c *SlackConnector) lookupSlackUserByEmail(ctx context.Context, creds conne
 		if resp.Error == "users_not_found" {
 			return "", nil
 		}
-		return "", mapSlackError(resp.Error)
+		return "", resp.asError()
 	}
 
 	return resp.User.ID, nil
@@ -82,7 +82,7 @@ func (c *SlackConnector) isUserInChannel(ctx context.Context, creds connectors.C
 			return false, err
 		}
 		if !resp.OK {
-			return false, mapSlackError(resp.Error)
+			return false, resp.asError()
 		}
 
 		for _, member := range resp.Members {
@@ -207,7 +207,7 @@ func (c *SlackConnector) isChannelPrivate(ctx context.Context, creds connectors.
 		return false, err
 	}
 	if !resp.OK {
-		return false, mapSlackError(resp.Error)
+		return false, resp.asError()
 	}
 
 	return resp.Channel.IsPrivate, nil
@@ -249,7 +249,10 @@ type usersConversationsResponse struct {
 const maxUserConversationPages = 50
 
 // getUserPrivateConversations returns conversation objects for the given Slack user
-// and types via users.conversations.
+// and types via users.conversations. This uses the user token (xoxp-), which only
+// returns conversations the token owner belongs to. A bot token with the `user`
+// parameter would require admin.conversations:read scope — we intentionally
+// use the user token to avoid that requirement.
 func (c *SlackConnector) getUserPrivateConversations(ctx context.Context, creds connectors.Credentials, slackUserID, types string) ([]listChannelEntry, error) {
 	var out []listChannelEntry
 	cursor := ""
@@ -266,7 +269,7 @@ func (c *SlackConnector) getUserPrivateConversations(ctx context.Context, creds 
 			return nil, err
 		}
 		if !resp.OK {
-			return nil, mapSlackError(resp.Error)
+			return nil, resp.asError()
 		}
 
 		out = append(out, resp.Channels...)

--- a/connectors/slack/create_channel.go
+++ b/connectors/slack/create_channel.go
@@ -49,7 +49,7 @@ func (a *createChannelAction) Execute(ctx context.Context, req connectors.Action
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	if resp.Channel == nil {

--- a/connectors/slack/delete_message.go
+++ b/connectors/slack/delete_message.go
@@ -58,7 +58,7 @@ func (a *deleteMessageAction) Execute(ctx context.Context, req connectors.Action
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/slack/invite_to_channel.go
+++ b/connectors/slack/invite_to_channel.go
@@ -66,7 +66,7 @@ func (a *inviteToChannelAction) Execute(ctx context.Context, req connectors.Acti
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	result := map[string]string{

--- a/connectors/slack/list_channel_entry_matches_test.go
+++ b/connectors/slack/list_channel_entry_matches_test.go
@@ -42,6 +42,12 @@ func TestListChannelEntryMatchesTypes(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "mpim G prefix heuristic excludes private channels",
+			types: "mpim",
+			ch:    listChannelEntry{ID: "G0123", IsPrivate: true},
+			want:  false,
+		},
+		{
 			name:  "mpim C channel",
 			types: "mpim",
 			ch:    listChannelEntry{ID: "C0123", IsPrivate: true},

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -117,9 +117,10 @@ func listChannelEntryMatchesTypes(types string, ch listChannelEntry) bool {
 			if ch.IsMPIM {
 				return true
 			}
-			// Fallback if API omits is_mpim: treat G-prefix non-DM as mpim (Slack encodes
-			// group DMs as G; legacy G-prefix private channels are rare and usually include is_mpim=false).
-			if len(ch.ID) > 0 && ch.ID[0] == 'G' && !ch.IsIM {
+			// Fallback if API omits is_mpim: treat G-prefix non-DM, non-private-channel
+			// as mpim. Pre-2020 workspaces used G-prefix for private channels too, so
+			// we exclude those by checking !ch.IsPrivate (real MPIMs aren't marked private).
+			if len(ch.ID) > 0 && ch.ID[0] == 'G' && !ch.IsIM && !ch.IsPrivate {
 				return true
 			}
 		case "private_channel":

--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -71,7 +71,7 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	seen := make(map[string]bool)

--- a/connectors/slack/list_users.go
+++ b/connectors/slack/list_users.go
@@ -87,7 +87,7 @@ func (a *listUsersAction) Execute(ctx context.Context, req connectors.ActionRequ
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	result := listUsersResult{

--- a/connectors/slack/read_channel_messages.go
+++ b/connectors/slack/read_channel_messages.go
@@ -85,7 +85,7 @@ func (a *readChannelMessagesAction) Execute(ctx context.Context, req connectors.
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(toMessagesResult(&resp))
@@ -104,8 +104,8 @@ func toSlackTimestamp(value string) (string, error) {
 	if _, err := strconv.ParseFloat(value, 64); err == nil {
 		return value, nil
 	}
-	// Try parsing as RFC 3339.
-	t, err := time.Parse(time.RFC3339, value)
+	// Try parsing as RFC 3339 (with optional fractional seconds).
+	t, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
 		return "", fmt.Errorf("expected a date/time or Unix timestamp, got %q", value)
 	}

--- a/connectors/slack/read_thread.go
+++ b/connectors/slack/read_thread.go
@@ -71,7 +71,7 @@ func (a *readThreadAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(toMessagesResult(&resp))

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -153,7 +153,7 @@ func (a *scheduleMessageAction) Execute(ctx context.Context, req connectors.Acti
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(map[string]any{

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -138,7 +138,7 @@ func (a *searchMessagesAction) Execute(ctx context.Context, req connectors.Actio
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	// Filter search results to only include matches from channels the user

--- a/connectors/slack/send_dm.go
+++ b/connectors/slack/send_dm.go
@@ -56,7 +56,7 @@ func (a *sendDMAction) Execute(ctx context.Context, req connectors.ActionRequest
 		return nil, err
 	}
 	if !openResp.OK {
-		return nil, mapSlackError(openResp.Error)
+		return nil, openResp.asError()
 	}
 
 	dmChannelID := openResp.Channel.ID
@@ -71,7 +71,7 @@ func (a *sendDMAction) Execute(ctx context.Context, req connectors.ActionRequest
 		return nil, err
 	}
 	if !msgResp.OK {
-		return nil, mapSlackError(msgResp.Error)
+		return nil, msgResp.asError()
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/slack/send_message.go
+++ b/connectors/slack/send_message.go
@@ -59,7 +59,7 @@ func (a *sendMessageAction) Execute(ctx context.Context, req connectors.ActionRe
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/slack/set_topic.go
+++ b/connectors/slack/set_topic.go
@@ -73,7 +73,7 @@ func (a *setTopicAction) Execute(ctx context.Context, req connectors.ActionReque
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	topic := ""

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -123,8 +123,21 @@ func (c *SlackConnector) ValidateCredentials(_ context.Context, creds connectors
 // slackResponse is the common envelope for Slack Web API responses.
 // Every endpoint returns {"ok": true/false, ...}.
 type slackResponse struct {
-	OK    bool   `json:"ok"`
-	Error string `json:"error,omitempty"`
+	OK     bool   `json:"ok"`
+	Error  string `json:"error,omitempty"`
+	Needed string `json:"needed,omitempty"` // populated on missing_scope errors
+}
+
+// asError converts a failed slackResponse to a typed connector error.
+// Prefer this over mapSlackError when the full response is available,
+// because it can include the missing scope name for missing_scope errors.
+func (r slackResponse) asError() error {
+	if r.Error == "missing_scope" && r.Needed != "" {
+		return &connectors.AuthError{
+			Message: fmt.Sprintf("Slack token is missing the %q OAuth scope — re-authorize the Slack connection to add it", r.Needed),
+		}
+	}
+	return mapSlackError(r.Error)
 }
 
 // validatable is implemented by action param structs to validate their fields.

--- a/connectors/slack/to_slack_timestamp_test.go
+++ b/connectors/slack/to_slack_timestamp_test.go
@@ -1,0 +1,52 @@
+package slack
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToSlackTimestamp(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "numeric passthrough", in: "1678800000.000000", want: "1678800000.000000"},
+		{name: "integer passthrough", in: "1678800000", want: "1678800000"},
+		{name: "rfc3339", in: "2023-03-14T12:00:00Z", want: "1678795200.000000"},
+		{name: "rfc3339 with fractional seconds", in: "2023-03-14T12:00:00.500Z", want: "1678795200.500000"},
+		{name: "rfc3339 with offset", in: "2023-03-14T08:00:00-04:00", want: "1678795200.000000"},
+		{name: "invalid", in: "not-a-time", wantErr: true},
+		{name: "date only", in: "2023-03-14", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := toSlackTimestamp(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("toSlackTimestamp(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("toSlackTimestamp(%q) error: %v", tc.in, err)
+				return
+			}
+			if tc.want != "" && got != tc.want {
+				t.Errorf("toSlackTimestamp(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			// For RFC 3339 inputs, verify output is "seconds.microseconds" format.
+			if strings.Contains(tc.in, "T") && !tc.wantErr && got != "" {
+				if !strings.Contains(got, ".") {
+					t.Errorf("toSlackTimestamp(%q) = %q, expected dot-separated format", tc.in, got)
+				}
+			}
+		})
+	}
+}

--- a/connectors/slack/update_message.go
+++ b/connectors/slack/update_message.go
@@ -64,7 +64,7 @@ func (a *updateMessageAction) Execute(ctx context.Context, req connectors.Action
 	}
 
 	if !resp.OK {
-		return nil, mapSlackError(resp.Error)
+		return nil, resp.asError()
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/slack/upload_file.go
+++ b/connectors/slack/upload_file.go
@@ -108,7 +108,7 @@ func (a *uploadFileAction) Execute(ctx context.Context, req connectors.ActionReq
 		return nil, err
 	}
 	if !getURLResp.OK {
-		return nil, mapSlackError(getURLResp.Error)
+		return nil, getURLResp.asError()
 	}
 
 	// Step 2: Upload file content to the upload URL (multipart/form-data, no auth).
@@ -141,7 +141,7 @@ func (a *uploadFileAction) Execute(ctx context.Context, req connectors.ActionReq
 		return nil, err
 	}
 	if !completeResp.OK {
-		return nil, mapSlackError(completeResp.Error)
+		return nil, completeResp.asError()
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/timestamp.go
+++ b/connectors/timestamp.go
@@ -20,7 +20,7 @@ func ParseUnixTimestampOrRFC3339(s string) (int64, error) {
 	if f, err := strconv.ParseFloat(s, 64); err == nil {
 		return unixSecondsFromNumeric(f), nil
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
 		return 0, fmt.Errorf("expected Unix timestamp or RFC 3339 datetime, got %q", s)
 	}
@@ -42,7 +42,7 @@ func NormalizeHubSpotAnalyticsTimeParam(s string) (string, error) {
 		t := time.Unix(sec, 0).UTC()
 		return t.Format("2006-01-02"), nil
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
 		return "", fmt.Errorf("expected YYYY-MM-DD, RFC 3339, or Unix timestamp, got %q", s)
 	}
@@ -63,7 +63,7 @@ func NormalizePlaidDateParam(s string) (string, error) {
 		t := time.Unix(sec, 0).UTC()
 		return t.Format("2006-01-02"), nil
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
 		return "", fmt.Errorf("expected YYYY-MM-DD, RFC 3339, or Unix timestamp, got %q", s)
 	}

--- a/connectors/timestamp_test.go
+++ b/connectors/timestamp_test.go
@@ -17,14 +17,31 @@ func TestParseUnixTimestampOrRFC3339(t *testing.T) {
 		{"1709251200", 1709251200},
 		{"1709251200000", 1709251200},
 		{"2024-03-01T00:00:00Z", mar1},
+		{"2024-03-01T00:00:00.123456789Z", mar1}, // fractional seconds
 	}
 	for _, tc := range cases {
 		got, err := ParseUnixTimestampOrRFC3339(tc.in)
 		if err != nil {
-			t.Fatalf("ParseUnixTimestampOrRFC3339(%q): %v", tc.in, err)
+			t.Errorf("ParseUnixTimestampOrRFC3339(%q): %v", tc.in, err)
+			continue
 		}
 		if got != tc.want {
 			t.Errorf("ParseUnixTimestampOrRFC3339(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseUnixTimestampOrRFC3339_Errors(t *testing.T) {
+	t.Parallel()
+	badInputs := []string{
+		"not-a-date",
+		"2024-13-01",
+		"yesterday",
+	}
+	for _, in := range badInputs {
+		_, err := ParseUnixTimestampOrRFC3339(in)
+		if err == nil {
+			t.Errorf("ParseUnixTimestampOrRFC3339(%q) expected error, got nil", in)
 		}
 	}
 }
@@ -33,16 +50,27 @@ func TestNormalizeHubSpotAnalyticsTimeParam(t *testing.T) {
 	t.Parallel()
 	got, err := NormalizeHubSpotAnalyticsTimeParam("2026-01-01")
 	if err != nil || got != "2026-01-01" {
-		t.Fatalf("date-only: got %q err %v", got, err)
+		t.Errorf("date-only: got %q err %v", got, err)
 	}
 	got, err = NormalizeHubSpotAnalyticsTimeParam("2026-01-01T12:00:00Z")
 	if err != nil || got != "2026-01-01" {
-		t.Fatalf("rfc3339: got %q err %v", got, err)
+		t.Errorf("rfc3339: got %q err %v", got, err)
 	}
 	ms := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
 	got, err = NormalizeHubSpotAnalyticsTimeParam(strconv.FormatInt(ms, 10))
 	if err != nil || got != "2025-02-01" {
-		t.Fatalf("epoch ms: got %q err %v", got, err)
+		t.Errorf("epoch ms: got %q err %v", got, err)
+	}
+}
+
+func TestNormalizeHubSpotAnalyticsTimeParam_Errors(t *testing.T) {
+	t.Parallel()
+	badInputs := []string{"not-a-date", "yesterday"}
+	for _, in := range badInputs {
+		_, err := NormalizeHubSpotAnalyticsTimeParam(in)
+		if err == nil {
+			t.Errorf("NormalizeHubSpotAnalyticsTimeParam(%q) expected error, got nil", in)
+		}
 	}
 }
 
@@ -50,10 +78,21 @@ func TestNormalizePlaidDateParam(t *testing.T) {
 	t.Parallel()
 	got, err := NormalizePlaidDateParam("2025-06-15")
 	if err != nil || got != "2025-06-15" {
-		t.Fatalf("date: got %q err %v", got, err)
+		t.Errorf("date: got %q err %v", got, err)
 	}
 	got, err = NormalizePlaidDateParam("2025-06-15T23:59:59Z")
 	if err != nil || got != "2025-06-15" {
-		t.Fatalf("rfc3339: got %q err %v", got, err)
+		t.Errorf("rfc3339: got %q err %v", got, err)
+	}
+}
+
+func TestNormalizePlaidDateParam_Errors(t *testing.T) {
+	t.Parallel()
+	badInputs := []string{"", "not-a-date", "yesterday"}
+	for _, in := range badInputs {
+		_, err := NormalizePlaidDateParam(in)
+		if err == nil {
+			t.Errorf("NormalizePlaidDateParam(%q) expected error, got nil", in)
+		}
 	}
 }

--- a/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigParameterFields.tsx
@@ -133,7 +133,7 @@ export function ActionConfigParameterFields({
           if (visibleGroupKeys.length === 0) return null;
           return (
             <CollapsibleFieldGroup key={group.id} group={group}>
-              {groupKeys.map(renderField)}
+              {visibleGroupKeys.map(renderField)}
             </CollapsibleFieldGroup>
           );
         })}

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -143,7 +143,7 @@ function RemoteSelectField({
     );
   }
   const path = propertyUI.remote_select_options_path ?? "";
-  if (path.includes("/channels")) {
+  if (connectorId === "slack" && path.endsWith("/channels")) {
     return (
       <SlackChannelRemoteSelectWidget
         inputId={inputId}

--- a/oauth/providers/slack.go
+++ b/oauth/providers/slack.go
@@ -14,19 +14,21 @@ func init() {
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
 			ID: "slack",
-			// User-token-only OAuth: use the v2_user authorize and token
-			// endpoints so Slack returns the user token (xoxp-) at the top
-			// level of the response. The standard v2 endpoints nest user
-			// tokens inside authed_user and omit the top-level access_token
-			// when no bot scopes are requested, which breaks Go's oauth2
-			// library ("server response missing access_token").
-			AuthorizeURL: "https://slack.com/oauth/v2_user/authorize",
-			TokenURL:     "https://slack.com/api/oauth.v2.user.access",
+			// Standard Slack OAuth v2 endpoints. The authorize URL uses the
+			// standard /oauth/v2/authorize path with user_scope (not scope)
+			// to request user-level permissions. The token URL is the standard
+			// oauth.v2.access endpoint. When only user scopes are requested
+			// (no bot scopes), Slack nests the user token inside authed_user
+			// rather than at the top level — the OAuth callback handles this
+			// via NormalizeSlackUserOAuthToken.
+			AuthorizeURL: "https://slack.com/oauth/v2/authorize",
+			TokenURL:     "https://slack.com/api/oauth.v2.access",
 			Scopes:       slackconnector.OAuthScopes,
-			// Slack requires comma-separated scopes; the oauth2 library sends
-			// space-separated. Override via AuthorizeParams so the URL is correct.
+			// Slack requires user_scope (not scope) for user-level OAuth
+			// permissions, and scopes must be comma-separated (the oauth2
+			// library sends space-separated). Override via AuthorizeParams.
 			AuthorizeParams: map[string]string{
-				"scope": strings.Join(slackconnector.OAuthScopes, ","),
+				"user_scope": strings.Join(slackconnector.OAuthScopes, ","),
 			},
 			// Slack's token endpoint requires client credentials as POST body
 			// params and returns HTTP 200 for all responses (even errors).


### PR DESCRIPTION
## Summary

- Switches Slack OAuth from undocumented `v2_user` endpoints to standard `v2` endpoints with `NormalizeSlackUserOAuthToken` for user token extraction
- Adds `Needed` field to `slackResponse` so `missing_scope` errors include the actual missing scope name instead of a generic message
- Fixes DM deduplication across paginated `ListChannels` calls by persisting the `seen` map across pages
- Tightens mpim G-prefix fallback to exclude legacy private channels (`!ch.IsPrivate`)
- Returns partial results instead of erroring when the channel page cap (50 pages / ~10K channels) is hit
- Adds `CaptureConnectorError` in `ValidateCredentials` failure fallback paths for Sentry visibility
- Switches `time.RFC3339` → `time.RFC3339Nano` in `toSlackTimestamp` and timestamp helpers to accept fractional-second timestamps
- Removes dead `if err != nil` check after `strconv.FormatInt` in Intercom search
- Fixes Intercom timestamp predicate to serialize as integer (not string) per Intercom API spec
- Gates Slack channel widget on `connectorId === "slack"` and uses `endsWith("/channels")` instead of `includes("/channels")`
- Fixes grouped rendering path to use `visibleGroupKeys` instead of `groupKeys` for consistency
- Documents admin scope guard assumption for `users.conversations` user-token usage
- Adds unit tests for `toSlackTimestamp` RFC 3339 conversion and error paths for timestamp helpers
- Replaces `t.Fatalf` with `t.Errorf` in table-driven timestamp tests

Closes #800

## Test plan

### Claude Code
- [x] Slack connector tests pass (`go test ./connectors/slack/...`)
- [x] Intercom connector tests pass (`go test ./connectors/intercom/...`)
- [x] OAuth tests pass (`go test ./oauth/...`)
- [x] Frontend tests pass (959/959 — `make test-frontend`)
- [x] New `toSlackTimestamp` test covers RFC 3339 with fractional seconds
- [x] New timestamp error-path tests cover invalid inputs
- [x] Updated mpim test verifies G-prefix private channel exclusion

### Manual Testing
- [ ] Verify Slack OAuth flow works end-to-end with standard v2 endpoints
- [ ] Verify channel picker works in large workspaces (>10K channels returns partial)
- [ ] Verify DM list doesn't show duplicates across pages

https://claude.ai/code/session_01Tr4EuLM7JvW5U1qsiDKNaM