### PR TITLE
Fix cross-connector UTF-8 truncation, CanceledError, and error classification

### DIFF
--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -118,6 +118,17 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error, cc 
 		RespondError(w, r, http.StatusGatewayTimeout, newErrorResponse(ErrUpstreamError, msg, true))
 		return true
 
+	case connectors.IsCanceledError(err):
+		msg := "Request was canceled"
+		var ce *connectors.CanceledError
+		if errors.As(err, &ce) && ce.Message != "" {
+			msg = ce.Message
+		}
+		log.Printf("[%s] connector request canceled: %v", traceID, err)
+		// Canceled requests are NOT retryable — the caller intentionally canceled.
+		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, msg, false))
+		return true
+
 	default:
 		return false
 	}

--- a/api/connector_errors.go
+++ b/api/connector_errors.go
@@ -125,6 +125,7 @@ func handleConnectorError(w http.ResponseWriter, r *http.Request, err error, cc 
 			msg = ce.Message
 		}
 		log.Printf("[%s] connector request canceled: %v", traceID, err)
+		CaptureConnectorError(r.Context(), err, cc)
 		// Canceled requests are NOT retryable — the caller intentionally canceled.
 		RespondError(w, r, http.StatusBadGateway, newErrorResponse(ErrUpstreamError, msg, false))
 		return true

--- a/api/sentry.go
+++ b/api/sentry.go
@@ -107,6 +107,8 @@ func classifyConnectorError(err error) string {
 		return "auth"
 	case connectors.IsTimeoutError(err):
 		return "timeout"
+	case connectors.IsCanceledError(err):
+		return "canceled"
 	case errors.Is(err, context.DeadlineExceeded):
 		return "deadline_exceeded"
 	case errors.Is(err, context.Canceled):

--- a/api/sentry_test.go
+++ b/api/sentry_test.go
@@ -263,6 +263,7 @@ func TestClassifyConnectorError(t *testing.T) {
 		{"oauth_refresh", &connectors.OAuthRefreshError{Provider: "google"}, "oauth_refresh"},
 		{"validation", &connectors.ValidationError{Message: "bad param"}, "validation"},
 		{"payment", &connectors.PaymentError{Code: connectors.PaymentErrMissing}, "payment"},
+		{"canceled_error", &connectors.CanceledError{Message: "aborted"}, "canceled"},
 		{"deadline_exceeded", context.DeadlineExceeded, "deadline_exceeded"},
 		{"canceled", context.Canceled, "canceled"},
 		{"unknown", errors.New("something weird"), "unknown"},

--- a/connectors/airtable/airtable.go
+++ b/connectors/airtable/airtable.go
@@ -209,7 +209,7 @@ func (c *AirtableConnector) doRequest(ctx context.Context, method, url string, c
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Airtable API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Airtable API request canceled"}
+			return &connectors.CanceledError{Message: "Airtable API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Airtable API request failed: %v", err)}
 	}
@@ -270,10 +270,7 @@ type airtableErrorDetail struct {
 func mapAirtableError(statusCode int, body []byte) error {
 	var errResp airtableErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil || errResp.Error == nil {
-		snippet := string(body)
-		if len(snippet) > 500 {
-			snippet = snippet[:500] + "...(truncated)"
-		}
+		snippet := connectors.TruncateUTF8(string(body), 500)
 		return &connectors.ExternalError{
 			StatusCode: statusCode,
 			Message:    fmt.Sprintf("Airtable API error (HTTP %d): %s", statusCode, snippet),

--- a/connectors/amadeus/amadeus.go
+++ b/connectors/amadeus/amadeus.go
@@ -162,7 +162,7 @@ func (c *AmadeusConnector) fetchToken(ctx context.Context, creds connectors.Cred
 			return "", &connectors.TimeoutError{Message: fmt.Sprintf("Amadeus token request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return "", &connectors.TimeoutError{Message: "Amadeus token request canceled"}
+			return "", &connectors.CanceledError{Message: "Amadeus token request canceled"}
 		}
 		return "", &connectors.ExternalError{Message: fmt.Sprintf("Amadeus token request failed: %v", err)}
 	}
@@ -297,7 +297,7 @@ func (c *AmadeusConnector) doOnce(ctx context.Context, creds connectors.Credenti
 			return 0, &connectors.TimeoutError{Message: fmt.Sprintf("Amadeus API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return 0, &connectors.TimeoutError{Message: "Amadeus API request canceled"}
+			return 0, &connectors.CanceledError{Message: "Amadeus API request canceled"}
 		}
 		return 0, &connectors.ExternalError{Message: fmt.Sprintf("Amadeus API request failed: %v", err)}
 	}

--- a/connectors/amadeus/response.go
+++ b/connectors/amadeus/response.go
@@ -68,9 +68,5 @@ func extractErrorMessage(body []byte) string {
 	}
 	// Truncate to avoid leaking large upstream responses (e.g., HTML error
 	// pages from a proxy) into error messages.
-	s := string(body)
-	if len(s) > 500 {
-		s = s[:500] + "... (truncated)"
-	}
-	return s
+	return connectors.TruncateUTF8(string(body), 500)
 }

--- a/connectors/asana/asana.go
+++ b/connectors/asana/asana.go
@@ -100,7 +100,7 @@ func (c *AsanaConnector) execRequest(ctx context.Context, creds connectors.Crede
 			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Asana API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, &connectors.TimeoutError{Message: "Asana API request canceled"}
+			return nil, &connectors.CanceledError{Message: "Asana API request canceled"}
 		}
 		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Asana API request failed: %v", err)}
 	}

--- a/connectors/asana/response.go
+++ b/connectors/asana/response.go
@@ -63,8 +63,5 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 // truncateErrorMessage caps error message length to prevent unexpectedly large
 // Asana responses from bloating error payloads.
 func truncateErrorMessage(msg string) string {
-	if len(msg) <= maxErrorMessageLen {
-		return msg
-	}
-	return msg[:maxErrorMessageLen] + "... (truncated)"
+	return connectors.TruncateUTF8(msg, maxErrorMessageLen)
 }

--- a/connectors/aws/aws.go
+++ b/connectors/aws/aws.go
@@ -400,8 +400,11 @@ func (c *AWSConnector) do(ctx context.Context, creds connectors.Credentials, met
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("AWS API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, &connectors.CanceledError{Message: "AWS API request canceled"}
 		}
 		return nil, &connectors.ExternalError{Message: fmt.Sprintf("AWS API request failed: %v", err)}
 	}

--- a/connectors/calendly/calendly.go
+++ b/connectors/calendly/calendly.go
@@ -163,7 +163,7 @@ func (c *CalendlyConnector) doJSON(ctx context.Context, creds connectors.Credent
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Calendly API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Calendly API request canceled"}
+			return &connectors.CanceledError{Message: "Calendly API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Calendly API request failed: %v", err)}
 	}

--- a/connectors/coinbaseagentkit/coinbaseagentkit.go
+++ b/connectors/coinbaseagentkit/coinbaseagentkit.go
@@ -183,10 +183,7 @@ func parseSwapNetwork(s string) (openapi.EvmSwapsNetwork, error) {
 }
 
 func mapCDPError(status int, body []byte) error {
-	msg := strings.TrimSpace(string(body))
-	if len(msg) > 4096 {
-		msg = msg[:4096] + "…"
-	}
+	msg := connectors.TruncateUTF8(strings.TrimSpace(string(body)), 4096)
 	if msg == "" {
 		msg = "(empty response body)"
 	}

--- a/connectors/confluence/confluence.go
+++ b/connectors/confluence/confluence.go
@@ -150,8 +150,11 @@ func (c *ConfluenceConnector) do(ctx context.Context, creds connectors.Credentia
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Confluence API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.CanceledError{Message: "Confluence API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Confluence API request failed: %v", err)}
 	}

--- a/connectors/confluence/confluence_test.go
+++ b/connectors/confluence/confluence_test.go
@@ -172,8 +172,8 @@ func TestConfluenceConnector_Do_ContextCanceled(t *testing.T) {
 	if err == nil {
 		t.Fatal("do() expected error, got nil")
 	}
-	if !connectors.IsTimeoutError(err) {
-		t.Errorf("expected TimeoutError for canceled context, got %T: %v", err, err)
+	if !connectors.IsCanceledError(err) {
+		t.Errorf("expected CanceledError for canceled context, got %T: %v", err, err)
 	}
 }
 

--- a/connectors/confluence/response.go
+++ b/connectors/confluence/response.go
@@ -67,10 +67,7 @@ func extractErrorMessage(body []byte) string {
 	return truncate(string(body), 200)
 }
 
-// truncate shortens s to maxLen characters, appending "..." if truncated.
+// truncate shortens s to maxLen characters, appending an ellipsis if truncated.
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
+	return connectors.TruncateUTF8(s, maxLen)
 }

--- a/connectors/discord/discord.go
+++ b/connectors/discord/discord.go
@@ -637,7 +637,7 @@ func (c *DiscordConnector) doRequest(ctx context.Context, method, path string, c
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Discord API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Discord API request canceled"}
+			return &connectors.CanceledError{Message: "Discord API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Discord API request failed: %v", err)}
 	}

--- a/connectors/docusign/docusign_errors.go
+++ b/connectors/docusign/docusign_errors.go
@@ -12,12 +12,9 @@ import (
 const maxErrorBodyLen = 512
 
 // truncateBody returns the response body as a string, truncated to
-// maxErrorBodyLen bytes to prevent oversized error messages.
+// maxErrorBodyLen characters to prevent oversized error messages.
 func truncateBody(body []byte) string {
-	if len(body) <= maxErrorBodyLen {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyLen]) + "... (truncated)"
+	return connectors.TruncateUTF8(string(body), maxErrorBodyLen)
 }
 
 // docuSignAPIError represents the standard DocuSign API error response.

--- a/connectors/docusign/docusign_http.go
+++ b/connectors/docusign/docusign_http.go
@@ -87,7 +87,7 @@ func (c *DocuSignConnector) doJSON(ctx context.Context, method, path string, cre
 			return &connectors.TimeoutError{Message: fmt.Sprintf("DocuSign API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "DocuSign API request canceled"}
+			return &connectors.CanceledError{Message: "DocuSign API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("DocuSign API request failed: %v", err)}
 	}
@@ -166,7 +166,7 @@ func (c *DocuSignConnector) doRaw(ctx context.Context, method, path string, cred
 			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("DocuSign API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, &connectors.TimeoutError{Message: "DocuSign API request canceled"}
+			return nil, &connectors.CanceledError{Message: "DocuSign API request canceled"}
 		}
 		return nil, &connectors.ExternalError{Message: fmt.Sprintf("DocuSign API request failed: %v", err)}
 	}

--- a/connectors/doordash/doordash.go
+++ b/connectors/doordash/doordash.go
@@ -197,7 +197,7 @@ func (c *DoorDashConnector) do(ctx context.Context, creds connectors.Credentials
 			return &connectors.TimeoutError{Message: fmt.Sprintf("DoorDash API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "DoorDash API request canceled"}
+			return &connectors.CanceledError{Message: "DoorDash API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("DoorDash API request failed: %v", err)}
 	}

--- a/connectors/doordash/response.go
+++ b/connectors/doordash/response.go
@@ -79,8 +79,5 @@ func formatErrorMessage(body []byte) string {
 }
 
 func truncateBody(body []byte) string {
-	if len(body) <= maxErrorBodyLen {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyLen]) + "... (truncated)"
+	return connectors.TruncateUTF8(string(body), maxErrorBodyLen)
 }

--- a/connectors/doordash/response.go
+++ b/connectors/doordash/response.go
@@ -75,7 +75,7 @@ func formatErrorMessage(body []byte) string {
 	if len(parts) == 0 {
 		return truncateBody(body)
 	}
-	return strings.Join(parts, "; ")
+	return connectors.TruncateUTF8(strings.Join(parts, "; "), maxErrorBodyLen)
 }
 
 func truncateBody(body []byte) string {

--- a/connectors/doordash/response_test.go
+++ b/connectors/doordash/response_test.go
@@ -128,7 +128,7 @@ func TestTruncateBody(t *testing.T) {
 	if len(got) > maxErrorBodyLen+20 {
 		t.Errorf("truncateBody(long) length = %d, want <= %d", len(got), maxErrorBodyLen+20)
 	}
-	if !strings.HasSuffix(got, "... (truncated)") {
+	if !strings.HasSuffix(got, "...(truncated)") {
 		t.Errorf("truncateBody(long) should end with truncation marker")
 	}
 }

--- a/connectors/dropbox/dropbox.go
+++ b/connectors/dropbox/dropbox.go
@@ -281,7 +281,7 @@ func (c *DropboxConnector) mapHTTPError(err error) error {
 		return &connectors.TimeoutError{Message: fmt.Sprintf("Dropbox API request timed out: %v", err)}
 	}
 	if errors.Is(err, context.Canceled) {
-		return &connectors.TimeoutError{Message: "Dropbox API request canceled"}
+		return &connectors.CanceledError{Message: "Dropbox API request canceled"}
 	}
 	return &connectors.ExternalError{Message: fmt.Sprintf("Dropbox API request failed: %v", err)}
 }

--- a/connectors/errors.go
+++ b/connectors/errors.go
@@ -48,6 +48,17 @@ func (e *TimeoutError) Error() string {
 	return fmt.Sprintf("external service timeout: %s", e.Message)
 }
 
+// CanceledError indicates the request was intentionally canceled (context.Canceled).
+// Distinct from TimeoutError — canceled requests should NOT be retried.
+// Maps to HTTP 499 (Client Closed Request) or 502.
+type CanceledError struct {
+	Message string // human-readable description
+}
+
+func (e *CanceledError) Error() string {
+	return fmt.Sprintf("request canceled: %s", e.Message)
+}
+
 // ValidationError indicates a parameter or credential validation failure.
 // Maps to HTTP 400 Bad Request.
 type ValidationError struct {
@@ -79,6 +90,12 @@ func IsRateLimitError(err error) bool {
 // IsTimeoutError reports whether err is or wraps a *TimeoutError.
 func IsTimeoutError(err error) bool {
 	var target *TimeoutError
+	return errors.As(err, &target)
+}
+
+// IsCanceledError reports whether err is or wraps a *CanceledError.
+func IsCanceledError(err error) bool {
+	var target *CanceledError
 	return errors.As(err, &target)
 }
 

--- a/connectors/expedia/expedia.go
+++ b/connectors/expedia/expedia.go
@@ -158,7 +158,7 @@ func (c *ExpediaConnector) doWithHeaders(ctx context.Context, creds connectors.C
 			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Expedia Rapid API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, &connectors.TimeoutError{Message: "Expedia Rapid API request canceled"}
+			return nil, &connectors.CanceledError{Message: "Expedia Rapid API request canceled"}
 		}
 		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Expedia Rapid API request failed: %v", err)}
 	}

--- a/connectors/expedia/expedia_test.go
+++ b/connectors/expedia/expedia_test.go
@@ -432,9 +432,9 @@ func TestExpediaConnector_Do_ContextCanceled(t *testing.T) {
 	if err == nil {
 		t.Fatal("do() expected error, got nil")
 	}
-	// Should be a TimeoutError (we map context.Canceled to TimeoutError).
-	if !connectors.IsTimeoutError(err) {
-		t.Errorf("do() error = %T (%v), want *connectors.TimeoutError", err, err)
+	// Should be a CanceledError (context.Canceled is not retryable).
+	if !connectors.IsCanceledError(err) {
+		t.Errorf("do() error = %T (%v), want *connectors.CanceledError", err, err)
 	}
 }
 

--- a/connectors/figma/figma.go
+++ b/connectors/figma/figma.go
@@ -304,7 +304,7 @@ func (c *FigmaConnector) doRequest(req *http.Request, dest any) error {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Figma API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Figma API request canceled"}
+			return &connectors.CanceledError{Message: "Figma API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Figma API request failed: %v", err)}
 	}

--- a/connectors/google/google.go
+++ b/connectors/google/google.go
@@ -276,7 +276,7 @@ func wrapHTTPError(err error) error {
 		return &connectors.TimeoutError{Message: fmt.Sprintf("Google API request timed out: %v", err)}
 	}
 	if errors.Is(err, context.Canceled) {
-		return &connectors.TimeoutError{Message: "Google API request canceled"}
+		return &connectors.CanceledError{Message: "Google API request canceled"}
 	}
 	return &connectors.ExternalError{Message: fmt.Sprintf("Google API request failed: %v", err)}
 }

--- a/connectors/helpers.go
+++ b/connectors/helpers.go
@@ -53,11 +53,14 @@ func JSONResult(v any) (*ActionResult, error) {
 // UTF-8 sequences. Use this for schema-facing validation where maxLength
 // counts Unicode code points, not bytes.
 func TruncateUTF8(s string, maxChars int) string {
-	if utf8.RuneCountInString(s) <= maxChars {
-		return s
+	count := 0
+	for i := range s {
+		if count == maxChars {
+			return s[:i] + "...(truncated)"
+		}
+		count++
 	}
-	runes := []rune(s)
-	return string(runes[:maxChars]) + "...(truncated)"
+	return s
 }
 
 // RuneLen returns the number of Unicode code points in s. Use this instead of

--- a/connectors/helpers.go
+++ b/connectors/helpers.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // IsTimeout reports whether err represents a timeout — either a context
@@ -45,6 +46,25 @@ func JSONResult(v any) (*ActionResult, error) {
 		return nil, fmt.Errorf("marshaling result: %w", err)
 	}
 	return &ActionResult{Data: data}, nil
+}
+
+// TruncateUTF8 truncates s to at most maxChars Unicode code points (runes),
+// appending a suffix if the string was shortened. It never splits multibyte
+// UTF-8 sequences. Use this for schema-facing validation where maxLength
+// counts Unicode code points, not bytes.
+func TruncateUTF8(s string, maxChars int) string {
+	if utf8.RuneCountInString(s) <= maxChars {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxChars]) + "...(truncated)"
+}
+
+// RuneLen returns the number of Unicode code points in s. Use this instead of
+// len() when validating against JSON Schema maxLength, which counts characters
+// not bytes.
+func RuneLen(s string) int {
+	return utf8.RuneCountInString(s)
 }
 
 // TrimIndent removes common leading tab indentation from a multi-line string

--- a/connectors/helpers.go
+++ b/connectors/helpers.go
@@ -53,6 +53,9 @@ func JSONResult(v any) (*ActionResult, error) {
 // UTF-8 sequences. Use this for schema-facing validation where maxLength
 // counts Unicode code points, not bytes.
 func TruncateUTF8(s string, maxChars int) string {
+	if maxChars <= 0 {
+		return "...(truncated)"
+	}
 	count := 0
 	for i := range s {
 		if count == maxChars {

--- a/connectors/helpers_test.go
+++ b/connectors/helpers_test.go
@@ -101,6 +101,72 @@ func TestJSONResult_MarshalError(t *testing.T) {
 	}
 }
 
+func TestTruncateUTF8_Short(t *testing.T) {
+	t.Parallel()
+	got := TruncateUTF8("hello", 10)
+	if got != "hello" {
+		t.Errorf("TruncateUTF8(short) = %q, want %q", got, "hello")
+	}
+}
+
+func TestTruncateUTF8_ExactLength(t *testing.T) {
+	t.Parallel()
+	got := TruncateUTF8("hello", 5)
+	if got != "hello" {
+		t.Errorf("TruncateUTF8(exact) = %q, want %q", got, "hello")
+	}
+}
+
+func TestTruncateUTF8_Truncated(t *testing.T) {
+	t.Parallel()
+	got := TruncateUTF8("hello world", 5)
+	want := "hello...(truncated)"
+	if got != want {
+		t.Errorf("TruncateUTF8(long) = %q, want %q", got, want)
+	}
+}
+
+func TestTruncateUTF8_MultibyteSafe(t *testing.T) {
+	t.Parallel()
+	// "日本語テスト" = 6 runes, each 3 bytes = 18 bytes
+	input := "日本語テスト"
+	got := TruncateUTF8(input, 3)
+	want := "日本語...(truncated)"
+	if got != want {
+		t.Errorf("TruncateUTF8(multibyte) = %q, want %q", got, want)
+	}
+}
+
+func TestTruncateUTF8_Emoji(t *testing.T) {
+	t.Parallel()
+	input := "😀😁😂🤣😃"
+	got := TruncateUTF8(input, 2)
+	want := "😀😁...(truncated)"
+	if got != want {
+		t.Errorf("TruncateUTF8(emoji) = %q, want %q", got, want)
+	}
+}
+
+func TestRuneLen(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"hello", 5},
+		{"日本語", 3},
+		{"😀😁", 2},
+		{"", 0},
+		{"abc日本", 5},
+	}
+	for _, tt := range tests {
+		got := RuneLen(tt.input)
+		if got != tt.want {
+			t.Errorf("RuneLen(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestTrimIndent(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/hubspot/response.go
+++ b/connectors/hubspot/response.go
@@ -30,10 +30,7 @@ func truncateBody(body []byte) string {
 	if len(body) == 0 {
 		return "(empty response)"
 	}
-	if len(body) <= maxErrorBodyPreview {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyPreview]) + "... (truncated)"
+	return connectors.TruncateUTF8(string(body), maxErrorBodyPreview)
 }
 
 // checkResponse inspects the HTTP status code and response body, returning

--- a/connectors/instacart/create_products_link.go
+++ b/connectors/instacart/create_products_link.go
@@ -38,7 +38,7 @@ func (p *createProductsLinkParams) validate() error {
 		if len(strings.TrimSpace(*p.Title)) == 0 {
 			return &connectors.ValidationError{Message: "title cannot be empty or whitespace-only when provided"}
 		}
-		if len(*p.Title) > maxTitleLen {
+		if connectors.RuneLen(*p.Title) > maxTitleLen {
 			return &connectors.ValidationError{Message: fmt.Sprintf("title exceeds maximum length (%d characters)", maxTitleLen)}
 		}
 	}
@@ -46,7 +46,7 @@ func (p *createProductsLinkParams) validate() error {
 		if strings.TrimSpace(*p.ImageURL) == "" {
 			return &connectors.ValidationError{Message: "image_url cannot be empty or whitespace-only when provided"}
 		}
-		if len(*p.ImageURL) > maxImageURLLen {
+		if connectors.RuneLen(*p.ImageURL) > maxImageURLLen {
 			return &connectors.ValidationError{Message: fmt.Sprintf("image_url exceeds maximum length (%d characters)", maxImageURLLen)}
 		}
 	}
@@ -69,7 +69,7 @@ func (p *createProductsLinkParams) validate() error {
 		return &connectors.ValidationError{Message: fmt.Sprintf("instructions exceeds maximum of %d entries", maxInstructions)}
 	}
 	for i, line := range p.Instructions {
-		if len(line) > maxInstructionLen {
+		if connectors.RuneLen(line) > maxInstructionLen {
 			return &connectors.ValidationError{Message: fmt.Sprintf("instructions[%d] exceeds maximum length", i)}
 		}
 	}
@@ -84,8 +84,8 @@ func (p *createProductsLinkParams) validate() error {
 		if item.Name == "" {
 			return &connectors.ValidationError{Message: fmt.Sprintf("line_items[%d]: name is required", i)}
 		}
-		if len(item.Name) > maxLineItemNameBytes {
-			return &connectors.ValidationError{Message: fmt.Sprintf("line_items[%d]: name exceeds maximum length (%d bytes)", i, maxLineItemNameBytes)}
+		if connectors.RuneLen(item.Name) > maxLineItemNameChars {
+			return &connectors.ValidationError{Message: fmt.Sprintf("line_items[%d]: name exceeds maximum length (%d characters)", i, maxLineItemNameChars)}
 		}
 	}
 

--- a/connectors/instacart/create_products_link_test.go
+++ b/connectors/instacart/create_products_link_test.go
@@ -164,7 +164,7 @@ func TestCreateProductsLink_LineItemNameTooLong(t *testing.T) {
 	t.Parallel()
 	conn := New()
 	action := conn.Actions()["instacart.create_products_link"]
-	longName := make([]byte, maxLineItemNameBytes+1)
+	longName := make([]byte, maxLineItemNameChars+1)
 	for i := range longName {
 		longName[i] = 'a'
 	}

--- a/connectors/instacart/instacart.go
+++ b/connectors/instacart/instacart.go
@@ -149,7 +149,7 @@ func (c *InstacartConnector) do(ctx context.Context, creds connectors.Credential
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Instacart API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Instacart API request canceled"}
+			return &connectors.CanceledError{Message: "Instacart API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Instacart API request failed: %v", err)}
 	}

--- a/connectors/instacart/params_parse.go
+++ b/connectors/instacart/params_parse.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	// maxLineItemNameBytes caps each line item's name field so a single
+	// maxLineItemNameChars caps each line item's name field so a single
 	// oversized string cannot dominate request bodies or logs.
-	maxLineItemNameBytes = 2048
+	// Measured in Unicode code points to match JSON Schema maxLength.
+	maxLineItemNameChars = 2048
 )
 
 // parseAndValidateProductsLinkParams unmarshals JSON, expands string

--- a/connectors/instacart/response.go
+++ b/connectors/instacart/response.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -26,37 +25,21 @@ type instacartMultiError struct {
 
 const maxAPIErrorMessageRunes = 512
 
-func truncateForErrorMessage(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return s
-	}
-	runes := []rune(s)
-	if len(runes) <= maxAPIErrorMessageRunes {
-		return s
-	}
-	return string(runes[:maxAPIErrorMessageRunes]) + "...(truncated)"
-}
-
 // checkResponse maps non-success HTTP responses to typed connector errors.
 func checkResponse(statusCode int, header http.Header, body []byte) error {
 	if statusCode >= 200 && statusCode < 300 {
 		return nil
 	}
 
-	const maxErrBody = 512
-	msg := string(body)
-	if len(msg) > maxErrBody {
-		msg = msg[:maxErrBody] + "...(truncated)"
-	}
+	msg := connectors.TruncateUTF8(string(body), maxAPIErrorMessageRunes)
 
 	var single instacartSingleError
 	if json.Unmarshal(body, &single) == nil && single.Error.Message != "" {
-		msg = truncateForErrorMessage(single.Error.Message)
+		msg = connectors.TruncateUTF8(single.Error.Message, maxAPIErrorMessageRunes)
 	} else {
 		var multi instacartMultiError
 		if json.Unmarshal(body, &multi) == nil && len(multi.Errors) > 0 && multi.Errors[0].Message != "" {
-			msg = truncateForErrorMessage(multi.Errors[0].Message)
+			msg = connectors.TruncateUTF8(multi.Errors[0].Message, maxAPIErrorMessageRunes)
 		}
 	}
 
@@ -71,6 +54,8 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 		return &connectors.AuthError{Message: fmt.Sprintf("Instacart API auth error: %s", msg)}
 	case statusCode == http.StatusForbidden:
 		return &connectors.AuthError{Message: fmt.Sprintf("Instacart API permission error: %s", msg)}
+	case statusCode == http.StatusUnprocessableEntity:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Instacart API validation error: %s", msg)}
 	default:
 		return &connectors.ExternalError{StatusCode: statusCode, Message: fmt.Sprintf("Instacart API error: %s", msg)}
 	}

--- a/connectors/instacart/response.go
+++ b/connectors/instacart/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -35,11 +36,11 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 
 	var single instacartSingleError
 	if json.Unmarshal(body, &single) == nil && single.Error.Message != "" {
-		msg = connectors.TruncateUTF8(single.Error.Message, maxAPIErrorMessageRunes)
+		msg = connectors.TruncateUTF8(strings.TrimSpace(single.Error.Message), maxAPIErrorMessageRunes)
 	} else {
 		var multi instacartMultiError
 		if json.Unmarshal(body, &multi) == nil && len(multi.Errors) > 0 && multi.Errors[0].Message != "" {
-			msg = connectors.TruncateUTF8(multi.Errors[0].Message, maxAPIErrorMessageRunes)
+			msg = connectors.TruncateUTF8(strings.TrimSpace(multi.Errors[0].Message), maxAPIErrorMessageRunes)
 		}
 	}
 

--- a/connectors/instacart/response_test.go
+++ b/connectors/instacart/response_test.go
@@ -51,6 +51,15 @@ func TestCheckResponse_TruncateLongMessage(t *testing.T) {
 	}
 }
 
+func TestCheckResponse_UnprocessableEntity(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"error":{"message":"line_items[0].name is required"}}`)
+	err := checkResponse(http.StatusUnprocessableEntity, nil, body)
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("want ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestCheckResponse_RateLimit(t *testing.T) {
 	t.Parallel()
 	h := http.Header{}

--- a/connectors/intercom/intercom.go
+++ b/connectors/intercom/intercom.go
@@ -109,8 +109,11 @@ func (c *IntercomConnector) do(ctx context.Context, creds connectors.Credentials
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Intercom API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.CanceledError{Message: "Intercom API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Intercom API request failed: %v", err)}
 	}

--- a/connectors/intercom/intercom_test.go
+++ b/connectors/intercom/intercom_test.go
@@ -287,7 +287,7 @@ func TestIntercomConnector_Do_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("do() with cancelled context expected error, got nil")
 	}
-	if !connectors.IsTimeoutError(err) {
-		t.Errorf("do() with cancelled context should return TimeoutError, got: %T", err)
+	if !connectors.IsCanceledError(err) {
+		t.Errorf("do() with cancelled context should return CanceledError, got: %T", err)
 	}
 }

--- a/connectors/intercom/response.go
+++ b/connectors/intercom/response.go
@@ -29,10 +29,7 @@ func truncateBody(body []byte) string {
 	if len(body) == 0 {
 		return "(empty response)"
 	}
-	if len(body) <= maxErrorBodyPreview {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyPreview]) + "... (truncated)"
+	return connectors.TruncateUTF8(string(body), maxErrorBodyPreview)
 }
 
 // checkResponse inspects the HTTP status code and response body, returning

--- a/connectors/jira/jira.go
+++ b/connectors/jira/jira.go
@@ -232,8 +232,11 @@ func (c *JiraConnector) doRequest(ctx context.Context, creds connectors.Credenti
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Jira API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.CanceledError{Message: "Jira API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Jira API request failed: %v", err)}
 	}

--- a/connectors/jira/oauth_discovery.go
+++ b/connectors/jira/oauth_discovery.go
@@ -120,8 +120,11 @@ func (c *JiraConnector) fetchCloudID(ctx context.Context, accessToken string) (s
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return "", &connectors.TimeoutError{Message: fmt.Sprintf("accessible-resources request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return "", &connectors.CanceledError{Message: "accessible-resources request canceled"}
 		}
 		return "", &connectors.ExternalError{Message: fmt.Sprintf("accessible-resources request failed: %v", err)}
 	}

--- a/connectors/jira/response.go
+++ b/connectors/jira/response.go
@@ -71,10 +71,7 @@ func extractErrorMessage(body []byte) string {
 	return strings.Join(parts, "; ")
 }
 
-// truncate shortens s to maxLen characters, appending "..." if truncated.
+// truncate shortens s to maxLen characters, appending an ellipsis if truncated.
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
+	return connectors.TruncateUTF8(s, maxLen)
 }

--- a/connectors/kroger/kroger.go
+++ b/connectors/kroger/kroger.go
@@ -107,7 +107,7 @@ func (c *KrogerConnector) do(ctx context.Context, creds connectors.Credentials, 
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Kroger API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Kroger API request canceled"}
+			return &connectors.CanceledError{Message: "Kroger API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Kroger API request failed: %v", err)}
 	}

--- a/connectors/kroger/response.go
+++ b/connectors/kroger/response.go
@@ -27,10 +27,7 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 	// Truncate raw body to prevent leaking large or sensitive payloads in
 	// error messages (the body could be up to maxResponseBytes).
 	const maxErrBody = 512
-	msg := string(body)
-	if len(msg) > maxErrBody {
-		msg = msg[:maxErrBody] + "...(truncated)"
-	}
+	msg := connectors.TruncateUTF8(string(body), maxErrBody)
 
 	// Try to extract a structured Kroger API error message.
 	var kErr krogerErrorResponse

--- a/connectors/linear/linear.go
+++ b/connectors/linear/linear.go
@@ -163,7 +163,7 @@ func (c *LinearConnector) doGraphQL(ctx context.Context, creds connectors.Creden
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Linear API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Linear API request canceled"}
+			return &connectors.CanceledError{Message: "Linear API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Linear API request failed: %v", err)}
 	}

--- a/connectors/linkedin/linkedin.go
+++ b/connectors/linkedin/linkedin.go
@@ -253,7 +253,7 @@ func wrapHTTPError(err error) error {
 		return &connectors.TimeoutError{Message: fmt.Sprintf("LinkedIn API request timed out: %v", err)}
 	}
 	if errors.Is(err, context.Canceled) {
-		return &connectors.TimeoutError{Message: "LinkedIn API request canceled"}
+		return &connectors.CanceledError{Message: "LinkedIn API request canceled"}
 	}
 	return &connectors.ExternalError{Message: fmt.Sprintf("LinkedIn API request failed: %v", err)}
 }

--- a/connectors/make/make.go
+++ b/connectors/make/make.go
@@ -321,7 +321,7 @@ func (c *MakeConnector) doRequest(ctx context.Context, method, path string, cred
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Make API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Make API request canceled"}
+			return &connectors.CanceledError{Message: "Make API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Make API request failed: %v", err)}
 	}
@@ -367,11 +367,7 @@ func (c *MakeConnector) doRequest(ctx context.Context, method, path string, cred
 // payloads through error strings.
 const maxErrorBodyLen = 512
 
-// truncateBody returns the first maxErrorBodyLen bytes of body as a string,
-// appending "..." if truncated.
+// truncateBody returns the body truncated to maxErrorBodyLen runes.
 func truncateBody(body []byte) string {
-	if len(body) <= maxErrorBodyLen {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyLen]) + "..."
+	return connectors.TruncateUTF8(string(body), maxErrorBodyLen)
 }

--- a/connectors/meta/meta.go
+++ b/connectors/meta/meta.go
@@ -172,7 +172,7 @@ func wrapHTTPError(err error) error {
 		return &connectors.TimeoutError{Message: fmt.Sprintf("Meta API request timed out: %v", err)}
 	}
 	if errors.Is(err, context.Canceled) {
-		return &connectors.TimeoutError{Message: "Meta API request canceled"}
+		return &connectors.CanceledError{Message: "Meta API request canceled"}
 	}
 	return &connectors.ExternalError{Message: fmt.Sprintf("Meta API request failed: %v", err)}
 }

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -911,7 +911,7 @@ func (c *MicrosoftConnector) executeRequest(req *http.Request) ([]byte, error) {
 			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Microsoft Graph API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, &connectors.TimeoutError{Message: "Microsoft Graph API request canceled"}
+			return nil, &connectors.CanceledError{Message: "Microsoft Graph API request canceled"}
 		}
 		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Microsoft Graph API request failed: %v", err)}
 	}

--- a/connectors/monday/monday.go
+++ b/connectors/monday/monday.go
@@ -130,7 +130,7 @@ func (c *MondayConnector) query(ctx context.Context, creds connectors.Credential
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Monday.com API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Monday.com API request canceled"}
+			return &connectors.CanceledError{Message: "Monday.com API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Monday.com API request failed: %v", err)}
 	}

--- a/connectors/netlify/netlify.go
+++ b/connectors/netlify/netlify.go
@@ -390,8 +390,11 @@ func (c *NetlifyConnector) do(ctx context.Context, creds connectors.Credentials,
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Netlify API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.CanceledError{Message: "Netlify API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Netlify API request failed: %v", err)}
 	}

--- a/connectors/notion/notion.go
+++ b/connectors/notion/notion.go
@@ -387,7 +387,7 @@ func (c *NotionConnector) do(ctx context.Context, httpMethod, path string, creds
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Notion API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Notion API request canceled"}
+			return &connectors.CanceledError{Message: "Notion API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Notion API request failed: %v", err)}
 	}

--- a/connectors/paypal/paypal.go
+++ b/connectors/paypal/paypal.go
@@ -189,7 +189,7 @@ func (c *PayPalConnector) doJSON(ctx context.Context, creds connectors.Credentia
 			return &connectors.TimeoutError{Message: fmt.Sprintf("PayPal API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "PayPal API request canceled"}
+			return &connectors.CanceledError{Message: "PayPal API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("PayPal API request failed: %v", err)}
 	}

--- a/connectors/paypal/paypal.go
+++ b/connectors/paypal/paypal.go
@@ -34,7 +34,7 @@ const (
 	defaultRetryAfter = 30 * time.Second
 
 	maxResponseBytes     = 4 << 20 // 4 MiB
-	maxErrorMessageBytes = 512
+	maxErrorMessageChars = 512
 	maxJSONBodyBytes     = 256 << 10 // 256 KiB cap for caller-supplied JSON bodies
 )
 

--- a/connectors/paypal/response.go
+++ b/connectors/paypal/response.go
@@ -25,7 +25,7 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 		return nil
 	}
 
-	msg := connectors.TruncateUTF8(string(body), maxErrorMessageBytes)
+	msg := connectors.TruncateUTF8(string(body), maxErrorMessageChars)
 	var pe paypalError
 	if json.Unmarshal(body, &pe) == nil && pe.Message != "" {
 		msg = pe.Message
@@ -39,7 +39,7 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 			msg = fmt.Sprintf("%s — %s", msg, pe.Details[0].Issue)
 		}
 		// Apply truncation after composing the structured message too.
-		msg = connectors.TruncateUTF8(msg, maxErrorMessageBytes)
+		msg = connectors.TruncateUTF8(msg, maxErrorMessageChars)
 	}
 
 	if statusCode == http.StatusTooManyRequests {

--- a/connectors/paypal/response.go
+++ b/connectors/paypal/response.go
@@ -25,21 +25,21 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 		return nil
 	}
 
-	msg := truncate(string(body), maxErrorMessageBytes)
+	msg := connectors.TruncateUTF8(string(body), maxErrorMessageBytes)
 	var pe paypalError
-	if json.Unmarshal(body, &pe) == nil {
-		if pe.Message != "" {
-			msg = pe.Message
-			if pe.Name != "" {
-				msg = fmt.Sprintf("%s: %s", pe.Name, pe.Message)
-			}
-			if pe.DebugID != "" {
-				msg = fmt.Sprintf("%s (debug_id: %s)", msg, pe.DebugID)
-			}
-			if len(pe.Details) > 0 && pe.Details[0].Issue != "" {
-				msg = fmt.Sprintf("%s — %s", msg, pe.Details[0].Issue)
-			}
+	if json.Unmarshal(body, &pe) == nil && pe.Message != "" {
+		msg = pe.Message
+		if pe.Name != "" {
+			msg = fmt.Sprintf("%s: %s", pe.Name, pe.Message)
 		}
+		if pe.DebugID != "" {
+			msg = fmt.Sprintf("%s (debug_id: %s)", msg, pe.DebugID)
+		}
+		if len(pe.Details) > 0 && pe.Details[0].Issue != "" {
+			msg = fmt.Sprintf("%s — %s", msg, pe.Details[0].Issue)
+		}
+		// Apply truncation after composing the structured message too.
+		msg = connectors.TruncateUTF8(msg, maxErrorMessageBytes)
 	}
 
 	if statusCode == http.StatusTooManyRequests {
@@ -54,19 +54,14 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 	switch {
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
 		return &connectors.AuthError{Message: fmt.Sprintf("PayPal auth error (%d): %s", statusCode, msg)}
-	case statusCode == http.StatusBadRequest || statusCode == http.StatusUnprocessableEntity:
+	case statusCode == http.StatusBadRequest:
 		if strings.Contains(lowerName, "validation") || strings.Contains(lowerName, "invalid") {
 			return &connectors.ValidationError{Message: fmt.Sprintf("PayPal validation error: %s", msg)}
 		}
-		return &connectors.ValidationError{Message: fmt.Sprintf("PayPal request error: %s", msg)}
+		return &connectors.ExternalError{StatusCode: statusCode, Message: fmt.Sprintf("PayPal API error: %s", msg)}
+	case statusCode == http.StatusUnprocessableEntity:
+		return &connectors.ValidationError{Message: fmt.Sprintf("PayPal validation error: %s", msg)}
 	default:
 		return &connectors.ExternalError{StatusCode: statusCode, Message: fmt.Sprintf("PayPal API error: %s", msg)}
 	}
-}
-
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
 }

--- a/connectors/plaid/response.go
+++ b/connectors/plaid/response.go
@@ -24,20 +24,14 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 	}
 
 	const maxErrBody = 512
-	msg := string(body)
-	if len(msg) > maxErrBody {
-		msg = msg[:maxErrBody] + "...(truncated)"
-	}
+	msg := connectors.TruncateUTF8(string(body), maxErrBody)
 	if json.Unmarshal(body, &plaidErr) == nil && plaidErr.ErrorMessage != "" {
 		// Put the human-readable message first, then include the error code
 		// for debugging — matches the Stripe connector pattern. Re-apply the
 		// length cap so a very large error_message doesn't produce oversized
 		// error strings.
 		formatted := fmt.Sprintf("%s (code: %s, type: %s)", plaidErr.ErrorMessage, plaidErr.ErrorCode, plaidErr.ErrorType)
-		if len(formatted) > maxErrBody {
-			formatted = formatted[:maxErrBody] + "...(truncated)"
-		}
-		msg = formatted
+		msg = connectors.TruncateUTF8(formatted, maxErrBody)
 	}
 
 	switch {

--- a/connectors/quickbooks/quickbooks.go
+++ b/connectors/quickbooks/quickbooks.go
@@ -145,7 +145,7 @@ func (c *QuickBooksConnector) doJSON(ctx context.Context, creds connectors.Crede
 			return &connectors.TimeoutError{Message: fmt.Sprintf("QuickBooks API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "QuickBooks API request canceled"}
+			return &connectors.CanceledError{Message: "QuickBooks API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("QuickBooks API request failed: %v", err)}
 	}

--- a/connectors/redis/redis.go
+++ b/connectors/redis/redis.go
@@ -287,7 +287,7 @@ func mapRedisError(err error) error {
 		return &connectors.TimeoutError{Message: fmt.Sprintf("Redis operation timed out: %v", err)}
 	}
 	if errors.Is(err, context.Canceled) {
-		return &connectors.TimeoutError{Message: "Redis operation canceled"}
+		return &connectors.CanceledError{Message: "Redis operation canceled"}
 	}
 	errMsg := err.Error()
 	if strings.Contains(errMsg, "NOAUTH") || strings.Contains(errMsg, "WRONGPASS") ||

--- a/connectors/salesforce/salesforce.go
+++ b/connectors/salesforce/salesforce.go
@@ -266,7 +266,7 @@ func wrapHTTPError(err error) error {
 		return &connectors.TimeoutError{Message: fmt.Sprintf("Salesforce API request timed out: %v", err)}
 	}
 	if errors.Is(err, context.Canceled) {
-		return &connectors.TimeoutError{Message: "Salesforce API request canceled"}
+		return &connectors.CanceledError{Message: "Salesforce API request canceled"}
 	}
 	return &connectors.ExternalError{Message: fmt.Sprintf("Salesforce API request failed: %v", err)}
 }

--- a/connectors/sendgrid/response.go
+++ b/connectors/sendgrid/response.go
@@ -51,10 +51,7 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 	}
 
 	const maxErrBody = 512
-	msg := string(body)
-	if len(msg) > maxErrBody {
-		msg = msg[:maxErrBody] + "...(truncated)"
-	}
+	msg := connectors.TruncateUTF8(string(body), maxErrBody)
 
 	if json.Unmarshal(body, &sgErr) == nil && len(sgErr.Errors) > 0 {
 		first := sgErr.Errors[0]

--- a/connectors/sendgrid/sendgrid.go
+++ b/connectors/sendgrid/sendgrid.go
@@ -139,7 +139,7 @@ func (c *SendGridConnector) doRequest(ctx context.Context, creds connectors.Cred
 			return nil, nil, &connectors.TimeoutError{Message: fmt.Sprintf("SendGrid API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, nil, &connectors.TimeoutError{Message: "SendGrid API request canceled"}
+			return nil, nil, &connectors.CanceledError{Message: "SendGrid API request canceled"}
 		}
 		return nil, nil, &connectors.ExternalError{Message: fmt.Sprintf("SendGrid API request failed: %v", err)}
 	}

--- a/connectors/shopify/response.go
+++ b/connectors/shopify/response.go
@@ -90,11 +90,8 @@ func extractErrorMessage(body []byte) string {
 	// Fallback to raw body, truncated to avoid leaking large payloads
 	// (e.g. HTML error pages) into error messages.
 	const maxFallbackLen = 500
-	if len(body) > maxFallbackLen {
-		return string(body[:maxFallbackLen]) + "... (truncated)"
-	}
 	if len(body) > 0 {
-		return string(body)
+		return connectors.TruncateUTF8(string(body), maxFallbackLen)
 	}
 	return "unknown error"
 }

--- a/connectors/shopify/shopify.go
+++ b/connectors/shopify/shopify.go
@@ -216,7 +216,7 @@ func (c *ShopifyConnector) do(ctx context.Context, creds connectors.Credentials,
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Shopify API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Shopify API request canceled"}
+			return &connectors.CanceledError{Message: "Shopify API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Shopify API request failed: %v", err)}
 	}

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -264,7 +264,7 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Slack API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Slack API request canceled"}
+			return &connectors.CanceledError{Message: "Slack API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Slack API request failed: %v", err)}
 	}
@@ -326,7 +326,7 @@ func (c *SlackConnector) doGetURL(ctx context.Context, url, token string, dest a
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Slack API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Slack API request canceled"}
+			return &connectors.CanceledError{Message: "Slack API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Slack API request failed: %v", err)}
 	}

--- a/connectors/slack/upload_file.go
+++ b/connectors/slack/upload_file.go
@@ -199,7 +199,7 @@ func (a *uploadFileAction) uploadContent(ctx context.Context, uploadURL, filenam
 		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("file upload timed out: %v", err)}
 		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.Canceled) {
 			return &connectors.CanceledError{Message: fmt.Sprintf("file upload canceled: %v", err)}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("file upload failed: %v", err)}

--- a/connectors/slack/upload_file.go
+++ b/connectors/slack/upload_file.go
@@ -200,7 +200,7 @@ func (a *uploadFileAction) uploadContent(ctx context.Context, uploadURL, filenam
 			return &connectors.TimeoutError{Message: fmt.Sprintf("file upload timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("file upload canceled: %v", err)}
+			return &connectors.CanceledError{Message: fmt.Sprintf("file upload canceled: %v", err)}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("file upload failed: %v", err)}
 	}

--- a/connectors/square/response.go
+++ b/connectors/square/response.go
@@ -120,8 +120,5 @@ func parsedHasCategory(errs []squareError, category string) bool {
 // This prevents large or unexpected response payloads from leaking into
 // error messages that may surface in logs or API responses.
 func truncateBody(body []byte) string {
-	if len(body) <= maxErrorBodyLen {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyLen]) + "... (truncated)"
+	return connectors.TruncateUTF8(string(body), maxErrorBodyLen)
 }

--- a/connectors/square/square.go
+++ b/connectors/square/square.go
@@ -191,7 +191,7 @@ func (c *SquareConnector) do(ctx context.Context, creds connectors.Credentials, 
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Square API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Square API request canceled"}
+			return &connectors.CanceledError{Message: "Square API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Square API request failed: %v", err)}
 	}

--- a/connectors/stripe/stripe.go
+++ b/connectors/stripe/stripe.go
@@ -266,7 +266,7 @@ func (c *StripeConnector) do(ctx context.Context, creds connectors.Credentials, 
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Stripe API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Stripe API request canceled"}
+			return &connectors.CanceledError{Message: "Stripe API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Stripe API request failed: %v", err)}
 	}

--- a/connectors/supabase/errors.go
+++ b/connectors/supabase/errors.go
@@ -21,10 +21,7 @@ type postgrestErrorResponse struct {
 func mapSupabaseError(statusCode int, body []byte) error {
 	var errResp postgrestErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil {
-		snippet := string(body)
-		if len(snippet) > 500 {
-			snippet = snippet[:500] + "...(truncated)"
-		}
+		snippet := connectors.TruncateUTF8(string(body), 500)
 		return &connectors.ExternalError{
 			StatusCode: statusCode,
 			Message:    fmt.Sprintf("Supabase PostgREST error (HTTP %d): %s", statusCode, snippet),

--- a/connectors/supabase/supabase.go
+++ b/connectors/supabase/supabase.go
@@ -347,7 +347,7 @@ func (c *SupabaseConnector) doRequestWithHeaders(ctx context.Context, method, re
 			return "", &connectors.TimeoutError{Message: fmt.Sprintf("Supabase API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return "", &connectors.TimeoutError{Message: "Supabase API request canceled"}
+			return "", &connectors.CanceledError{Message: "Supabase API request canceled"}
 		}
 		return "", &connectors.ExternalError{Message: fmt.Sprintf("Supabase API request failed: %v", err)}
 	}

--- a/connectors/trello/response.go
+++ b/connectors/trello/response.go
@@ -51,8 +51,5 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 // truncateErrorMessage caps error message length to prevent unexpectedly
 // large Trello responses from bloating error payloads.
 func truncateErrorMessage(msg string) string {
-	if len(msg) <= maxErrorMessageLen {
-		return msg
-	}
-	return msg[:maxErrorMessageLen] + "... (truncated)"
+	return connectors.TruncateUTF8(msg, maxErrorMessageLen)
 }

--- a/connectors/trello/response_test.go
+++ b/connectors/trello/response_test.go
@@ -30,11 +30,11 @@ func TestTruncateErrorMessage_Long(t *testing.T) {
 	t.Parallel()
 	msg := strings.Repeat("x", maxErrorMessageLen+100)
 	result := truncateErrorMessage(msg)
-	if !strings.HasSuffix(result, "... (truncated)") {
+	if !strings.HasSuffix(result, "...(truncated)") {
 		t.Errorf("expected truncated suffix, got %q", result[len(result)-20:])
 	}
-	if len(result) != maxErrorMessageLen+len("... (truncated)") {
-		t.Errorf("expected length %d, got %d", maxErrorMessageLen+len("... (truncated)"), len(result))
+	if len(result) != maxErrorMessageLen+len("...(truncated)") {
+		t.Errorf("expected length %d, got %d", maxErrorMessageLen+len("...(truncated)"), len(result))
 	}
 }
 

--- a/connectors/trello/trello.go
+++ b/connectors/trello/trello.go
@@ -207,7 +207,7 @@ func (c *TrelloConnector) sendAndDecode(req *http.Request, respBody any) error {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Trello API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Trello API request canceled"}
+			return &connectors.CanceledError{Message: "Trello API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Trello API request failed: %v", err)}
 	}

--- a/connectors/twilio/response.go
+++ b/connectors/twilio/response.go
@@ -23,10 +23,7 @@ func checkResponse(statusCode int, header http.Header, body []byte) error {
 	}
 	// Truncate raw body to avoid leaking large/sensitive payloads into error messages.
 	const maxErrBody = 512
-	msg := string(body)
-	if len(msg) > maxErrBody {
-		msg = msg[:maxErrBody] + "...(truncated)"
-	}
+	msg := connectors.TruncateUTF8(string(body), maxErrBody)
 	if json.Unmarshal(body, &twilioErr) == nil && twilioErr.Message != "" {
 		if twilioErr.Code > 0 {
 			msg = fmt.Sprintf("[%d] %s", twilioErr.Code, twilioErr.Message)

--- a/connectors/vercel/vercel.go
+++ b/connectors/vercel/vercel.go
@@ -437,8 +437,11 @@ func (c *VercelConnector) do(ctx context.Context, creds connectors.Credentials, 
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Vercel API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.CanceledError{Message: "Vercel API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Vercel API request failed: %v", err)}
 	}

--- a/connectors/walmart/response.go
+++ b/connectors/walmart/response.go
@@ -76,11 +76,8 @@ func extractErrorMessage(body []byte) string {
 	}
 
 	s := string(body)
-	if len(s) > 500 {
-		s = s[:500] + "... (truncated)"
-	}
 	if len(s) > 0 {
-		return s
+		return connectors.TruncateUTF8(s, 500)
 	}
 	return "unknown error"
 }

--- a/connectors/walmart/response_test.go
+++ b/connectors/walmart/response_test.go
@@ -134,7 +134,7 @@ func TestExtractErrorMessage_Truncation(t *testing.T) {
 	if len(msg) > 520 {
 		t.Errorf("extractErrorMessage should truncate long bodies, got len %d", len(msg))
 	}
-	if !strings.HasSuffix(msg, "... (truncated)") {
+	if !strings.HasSuffix(msg, "...(truncated)") {
 		t.Errorf("expected truncation suffix, got %q", msg[len(msg)-20:])
 	}
 }

--- a/connectors/walmart/walmart.go
+++ b/connectors/walmart/walmart.go
@@ -138,7 +138,7 @@ func (c *WalmartConnector) do(ctx context.Context, creds connectors.Credentials,
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Walmart API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Walmart API request canceled"}
+			return &connectors.CanceledError{Message: "Walmart API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Walmart API request failed: %v", err)}
 	}

--- a/connectors/walmart/walmart_test.go
+++ b/connectors/walmart/walmart_test.go
@@ -175,8 +175,8 @@ func TestDo_ContextCanceled(t *testing.T) {
 	if err == nil {
 		t.Fatal("do() expected error with canceled context, got nil")
 	}
-	if !connectors.IsTimeoutError(err) {
-		t.Errorf("expected TimeoutError, got %T: %v", err, err)
+	if !connectors.IsCanceledError(err) {
+		t.Errorf("expected CanceledError, got %T: %v", err, err)
 	}
 }
 

--- a/connectors/x/README.md
+++ b/connectors/x/README.md
@@ -307,7 +307,7 @@ The connector maps X API error responses to typed connector errors:
 | 429 | `RateLimitError` | Rate limit exceeded (includes retry-after) |
 | Other 4xx/5xx | `ExternalError` | X API error with message |
 | Client timeout | `TimeoutError` | Request timed out (30s default) |
-| Context cancel | `TimeoutError` | Request canceled by caller |
+| Context cancel | `CanceledError` | Request canceled by caller (not retryable) |
 
 Rate limit responses use the `x-rate-limit-reset` header to determine retry timing (defaults to 30s if missing).
 

--- a/connectors/x/upload_media.go
+++ b/connectors/x/upload_media.go
@@ -182,7 +182,7 @@ func (c *XConnector) doUpload(ctx context.Context, creds connectors.Credentials,
 			return &connectors.TimeoutError{Message: fmt.Sprintf("upload request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "upload request canceled"}
+			return &connectors.CanceledError{Message: "upload request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("upload request failed: %v", err)}
 	}

--- a/connectors/x/x.go
+++ b/connectors/x/x.go
@@ -131,7 +131,7 @@ func (c *XConnector) do(ctx context.Context, creds connectors.Credentials, metho
 			return &connectors.TimeoutError{Message: fmt.Sprintf("X API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "X API request canceled"}
+			return &connectors.CanceledError{Message: "X API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("X API request failed: %v", err)}
 	}

--- a/connectors/zapier/zapier.go
+++ b/connectors/zapier/zapier.go
@@ -178,7 +178,7 @@ func (c *ZapierConnector) doPost(ctx context.Context, targetURL string, body any
 			return nil, 0, &connectors.TimeoutError{Message: fmt.Sprintf("Zapier webhook request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, 0, &connectors.TimeoutError{Message: "Zapier webhook request canceled"}
+			return nil, 0, &connectors.CanceledError{Message: "Zapier webhook request canceled"}
 		}
 		return nil, 0, &connectors.ExternalError{Message: fmt.Sprintf("Zapier webhook request failed: %v", err)}
 	}

--- a/connectors/zendesk/response.go
+++ b/connectors/zendesk/response.go
@@ -31,10 +31,7 @@ func truncateBody(body []byte) string {
 	if len(body) == 0 {
 		return "(empty response)"
 	}
-	if len(body) <= maxErrorBodyPreview {
-		return string(body)
-	}
-	return string(body[:maxErrorBodyPreview]) + "... (truncated)"
+	return connectors.TruncateUTF8(string(body), maxErrorBodyPreview)
 }
 
 // checkResponse inspects the HTTP status code and response body, returning

--- a/connectors/zendesk/zendesk.go
+++ b/connectors/zendesk/zendesk.go
@@ -144,8 +144,11 @@ func (c *ZendeskConnector) do(ctx context.Context, creds connectors.Credentials,
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		if connectors.IsTimeout(err) || errors.Is(err, context.Canceled) {
+		if connectors.IsTimeout(err) {
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Zendesk API request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return &connectors.CanceledError{Message: "Zendesk API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Zendesk API request failed: %v", err)}
 	}

--- a/connectors/zendesk/zendesk_test.go
+++ b/connectors/zendesk/zendesk_test.go
@@ -287,7 +287,7 @@ func TestZendeskConnector_Do_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("do() with cancelled context expected error, got nil")
 	}
-	if !connectors.IsTimeoutError(err) {
-		t.Errorf("do() with cancelled context should return TimeoutError, got: %T", err)
+	if !connectors.IsCanceledError(err) {
+		t.Errorf("do() with cancelled context should return CanceledError, got: %T", err)
 	}
 }

--- a/connectors/zoom/zoom.go
+++ b/connectors/zoom/zoom.go
@@ -118,7 +118,7 @@ func (c *ZoomConnector) doJSON(ctx context.Context, creds connectors.Credentials
 			return &connectors.TimeoutError{Message: fmt.Sprintf("Zoom API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.TimeoutError{Message: "Zoom API request canceled"}
+			return &connectors.CanceledError{Message: "Zoom API request canceled"}
 		}
 		return &connectors.ExternalError{Message: fmt.Sprintf("Zoom API request failed: %v", err)}
 	}


### PR DESCRIPTION
## Summary

- Add shared `TruncateUTF8()` helper and `CanceledError` type to the connectors package, replacing per-connector byte-based truncation and the incorrect `context.Canceled → TimeoutError` mapping
- Fix Instacart: 422→ValidationError, `len()`→`RuneLen()` for schema-facing validation (title, image_url, instructions, line_item name)
- Fix PayPal: unreachable ExternalError branch (400 without validation name now returns ExternalError, 422 returns ValidationError), truncation applied to composed JSON error messages
- Update ~45 connectors to use `CanceledError` for canceled requests (non-retryable) and `TruncateUTF8` for error body truncation

Closes #795

## Test plan

### Claude Code
- [x] All connector tests pass (53/55 packages — mysql and square fail due to pre-existing missing modules in sandbox)
- [x] New TruncateUTF8 tests cover exact-length, short, truncated, multibyte (CJK), and emoji strings
- [x] Instacart 422→ValidationError test added
- [x] go vet passes on all connector packages

### Manual Testing
- [ ] Verify multibyte strings (emoji, CJK) are not corrupted in error messages
- [ ] Verify canceled requests are not retried

https://claude.ai/code/session_01CH1xbqTRerFeSsmzb2rC8L