### PR TITLE
Fix hook bypass, webhook injection, and CLAUDE.md docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -q 'gh.*pr.*create' && echo \"$CMD\" | grep -qE '(^|\\s)--draft(\\s|$)'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Draft PRs are not allowed per CLAUDE.md. Remove --draft to open as ready for review.\"}}'; fi",
+            "command": "INPUT=$(cat); check_draft() { local cmd=\"$1\"; local stripped=$(echo \"$cmd\" | sed \"s/[\\\"']//g\"); if echo \"$stripped\" | grep -q 'gh.*pr.*create' && echo \"$stripped\" | grep -qE '(^|\\s)--draft(\\s|$)'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Draft PRs are not allowed per CLAUDE.md. Remove --draft to open as ready for review.\"}}'; return 0; fi; return 1; }; if ! command -v jq >/dev/null 2>&1; then check_draft \"$INPUT\"; exit 0; fi; CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if [ -z \"$CMD\" ]; then exit 0; fi; check_draft \"$CMD\"",
             "statusMessage": "Checking PR draft policy..."
           }
         ]

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -37,11 +37,11 @@ jobs:
           if [ -n "$MESSAGE_OVERRIDE" ]; then
             MESSAGE="permission-slip: ${MESSAGE_OVERRIDE}"
           elif [ -n "$PR_URL" ] && [ -n "$PR_TITLE" ]; then
-            MESSAGE="permission-slip: ${ACTOR} — ${PR_TITLE} — ${PR_URL}"
+            MESSAGE="permission-slip: ${PR_TITLE} needs your review (from ${ACTOR}) — ${PR_URL}"
           elif [ -n "$PR_URL" ]; then
-            MESSAGE="permission-slip: ${ACTOR} — PR needs attention — ${PR_URL}"
+            MESSAGE="permission-slip: PR needs your review (from ${ACTOR}) — ${PR_URL}"
           else
-            MESSAGE="permission-slip: ${ACTOR} needs your attention"
+            MESSAGE="permission-slip: Your attention needed (triggered by ${ACTOR})"
           fi
 
           PAYLOAD=$(jq -n --arg msg "$MESSAGE" --arg secret "$NOTIFY_WEBHOOK_SECRET" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@
 - **Link PRs to issues.** When a PR addresses a GitHub issue, include `Closes #<issue>` in the PR body so the issue is automatically closed when the PR merges. Don't wait to be asked.
 - **Never open draft PRs.** Always open PRs as ready for review.
 - When suggesting a PR body or GitHub issue that includes a checklist, **split the checklist into two sections** based on who should handle each item:
-  - `### Developer` — items that a developer can address (e.g., add tests, fix lint, update docs, add error handling, run checks). The `/watch` command will pick these up and check them off.
-  - `### Manual Testing` — items that require manual verification, design review, or hands-on testing that a developer can't perform.
+  - `### Developer` — items that can be automated or handled by `/watch` (e.g., add tests, fix lint, update docs, add error handling, run checks).
+  - `### Manual Testing` — items that require manual verification, design review, or hands-on testing that can't be automated.
 - Always include the pull request URL at the end of every message where a PR already exists, formatted exactly as: `Pull request: <url>` — no bold, no markdown link syntax, just the plain text and URL so the link doesn't break.
 - Whenever you bring up a problem, always suggest a recommendation for how to address it.
 - When asked to review for improvements or issues: fix anything you're confident should be fixed (commit & push), then mention any additional findings that are more subjective or optional so the user can decide.
@@ -226,6 +226,7 @@ The OpenAPI spec (`spec/openapi/`) is the single source of truth for all API typ
 - When creating issues, default to using checklists (`- [ ]`) instead of bullet points for work items that can be completed independently. This makes it easy to track progress directly in the issue.
 - When you encounter an issue with a checklist that is out of date (items completed but not checked off, missing items, irrelevant items), update the checklist to reflect the current state.
 - **Never assume issue scope.** If you can't access an issue (e.g., a link doesn't work or returns an error), try fetching it with the `gh` CLI (`GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh issue view <number>`). If you still can't access it, ask the user for the issue details — do not guess or infer what the issue is about.
+- **Organize multi-task issues into phases.** When an issue has multiple tasks, group them into sequential phases where each phase depends on the previous one completing. Within each phase, mark which tasks can run in parallel vs. which must be sequential. Use checklists within each phase for trackability.
 
 ## Go Toolchain Setup
 


### PR DESCRIPTION
## Summary

- **Hook regex bypass**: Strip quotes before matching `--draft` so `gh pr create "--draft"` is correctly blocked
- **Fail-closed fallback**: When `jq` is unavailable, fall back to raw pattern matching on stdin instead of blocking all commands or silently allowing everything
- **Webhook message clarity**: Rephrase `@actor — PR needs attention` (ambiguous about who needs attention) to `PR needs your review (from @actor)`
- **CLAUDE.md fixes**: Update "Developer" and "Manual Testing" checklist descriptions to align with `/watch` automation; restore phase structure guidance for multi-task issues

Closes #808

## Test plan

### Developer
- [x] Verify JSON in `.claude/settings.json` is valid
- [x] Test hook catches `--draft` in various quoting styles
- [x] Test hook allows non-draft `gh pr create` commands

### Manual Testing
- [ ] Verify webhook sends correct message with actor name in a real workflow dispatch
- [ ] Verify non-draft hook catches `"--draft"` when triggered by Claude Code

https://claude.ai/code/session_01YGTMvCqicdCdtrEoMa2UbG