### PR TITLE
Fix CI/watch skill bugs from review feedback

### DIFF
--- a/.claude/skills/fix-ci/fix-ci-trigger.sh
+++ b/.claude/skills/fix-ci/fix-ci-trigger.sh
@@ -56,80 +56,6 @@ latest_completed_for_sha() {
           else "failed:\(.[0].databaseId):\(.[0].conclusion)" end'
 }
 
-ci_fast=$(latest_completed_for_sha "ci.yml" || true)
-audit_fast=$(latest_completed_for_sha "audit.yml" || true)
-
-if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" ]]; then
-  ci_fid="${ci_fast#success:}"
-  if [[ -n "$audit_fast" && "${audit_fast%%:*}" == "success" ]]; then
-    audit_fid="${audit_fast#success:}"
-    echo "[fix-ci] CI and audit already green for HEAD ${LOCAL_SHA}; skipping trigger."
-    echo ""
-    echo "FIX_CI_COMPLETE"
-    echo "BRANCH=${BRANCH}"
-    echo "LOCAL_HEAD=${LOCAL_SHA}"
-    echo "CI_RUN_URL=$(gh_cmd run view "$ci_fid" --json url --jq -r '.url')"
-    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_fid" --json url --jq -r '.url')"
-    exit 0
-  fi
-fi
-
-if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "failed" ]]; then
-  # rest: failed:id:conclusion
-  rest="${ci_fast#failed:}"
-  ci_run_id="${rest%%:*}"
-  ci_conclusion="${rest##*:}"
-  echo "[fix-ci] Latest CI for HEAD ${LOCAL_SHA} already completed with ${ci_conclusion} (run ${ci_run_id})."
-  echo ""
-  echo "CI_FAILED"
-  echo "CI_RUN_ID=${ci_run_id}"
-  echo "CI_CONCLUSION=${ci_conclusion}"
-  gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
-  gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
-  echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
-  echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq -r '.url')"
-  echo "AGENT_NEEDED"
-  exit 101
-fi
-
-if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" && -n "$audit_fast" && "${audit_fast%%:*}" == "failed" ]]; then
-  rest="${audit_fast#failed:}"
-  audit_run_id="${rest%%:*}"
-  audit_conclusion="${rest##*:}"
-  echo "[fix-ci] Latest audit for HEAD ${LOCAL_SHA} already completed with ${audit_conclusion} (run ${audit_run_id})."
-  echo ""
-  echo "AUDIT_FAILED"
-  echo "AUDIT_RUN_ID=${audit_run_id}"
-  echo "AUDIT_CONCLUSION=${audit_conclusion}"
-  gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
-  gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
-  echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
-  echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq -r '.url')"
-  echo "AGENT_NEEDED"
-  exit 102
-fi
-
-get_latest_run_id() {
-  local workflow="$1"
-  gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 1 --json databaseId 2>/dev/null \
-    | jq -r '.[0].databaseId // "0"'
-}
-
-ci_prev_run_id=$(get_latest_run_id "ci.yml")
-audit_prev_run_id=$(get_latest_run_id "audit.yml")
-
-echo "[fix-ci] Triggering ci.yml on ${BRANCH}..."
-gh_cmd workflow run ci.yml --ref "$BRANCH" 2>/dev/null || {
-  echo "[fix-ci] ERROR: Failed to trigger ci.yml" >&2
-  exit 1
-}
-
-echo "[fix-ci] Triggering audit.yml on ${BRANCH}..."
-gh_cmd workflow run audit.yml --ref "$BRANCH" 2>/dev/null || {
-  echo "[fix-ci] ERROR: Failed to trigger audit.yml" >&2
-  exit 1
-}
-
 wait_for_workflow() {
   local workflow="$1"
   local prev_run_id="$2"
@@ -159,6 +85,131 @@ wait_for_workflow() {
   echo "timeout:unknown"
 }
 
+ci_fast=$(latest_completed_for_sha "ci.yml" || true)
+audit_fast=$(latest_completed_for_sha "audit.yml" || true)
+
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" ]]; then
+  ci_fid="${ci_fast#success:}"
+  if [[ -n "$audit_fast" && "${audit_fast%%:*}" == "success" ]]; then
+    audit_fid="${audit_fast#success:}"
+    echo "[fix-ci] CI and audit already green for HEAD ${LOCAL_SHA}; skipping trigger."
+    echo ""
+    echo "FIX_CI_COMPLETE"
+    echo "BRANCH=${BRANCH}"
+    echo "LOCAL_HEAD=${LOCAL_SHA}"
+    echo "CI_RUN_URL=$(gh_cmd run view "$ci_fid" --json url --jq '.url')"
+    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_fid" --json url --jq '.url')"
+    exit 0
+  fi
+fi
+
+# Fast path: CI already passed but audit hasn't run yet — only trigger audit.yml
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" && -z "$audit_fast" ]]; then
+  ci_fid="${ci_fast#success:}"
+  echo "[fix-ci] CI already green for HEAD ${LOCAL_SHA}; only audit missing — triggering audit.yml only."
+  echo "CI_RUN_URL=$(gh_cmd run view "$ci_fid" --json url --jq '.url')"
+
+  audit_prev_run_id=$(gh_cmd run list --workflow="audit.yml" --branch "$BRANCH" --limit 1 --json databaseId 2>/dev/null \
+    | jq -r '.[0].databaseId // "0"')
+
+  gh_cmd workflow run audit.yml --ref "$BRANCH" 2>/dev/null || {
+    echo "[fix-ci] ERROR: Failed to trigger audit.yml" >&2
+    exit 1
+  }
+
+  echo "[fix-ci] Waiting for audit..."
+  audit_result=$(wait_for_workflow "audit.yml" "$audit_prev_run_id")
+  audit_conclusion="${audit_result%%:*}"
+  audit_run_id="${audit_result##*:}"
+  echo "[fix-ci] Audit result: ${audit_conclusion} (run ${audit_run_id})"
+
+  if [[ "$audit_conclusion" == "success" ]]; then
+    echo ""
+    echo "FIX_CI_COMPLETE"
+    echo "BRANCH=${BRANCH}"
+    echo "LOCAL_HEAD=${LOCAL_SHA}"
+    echo "CI_RUN_URL=$(gh_cmd run view "$ci_fid" --json url --jq '.url')"
+    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq '.url')"
+    exit 0
+  fi
+
+  echo ""
+  echo "AUDIT_FAILED"
+  echo "AUDIT_RUN_ID=${audit_run_id}"
+  echo "AUDIT_CONCLUSION=${audit_conclusion}"
+  echo "[fix-ci] Fetching audit logs..."
+  if [[ "$audit_run_id" != "unknown" ]]; then
+    gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
+    if [[ "$audit_conclusion" == "failure" ]]; then
+      gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+    fi
+  else
+    echo "[fix-ci] Audit timed out waiting for completion. The workflow may still be running on GitHub." > "$AUDIT_LOGS_FILE"
+  fi
+  echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
+  if [[ -n "$audit_run_id" && "$audit_run_id" != "unknown" ]]; then
+    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq '.url')"
+  fi
+  echo "AGENT_NEEDED"
+  exit 102
+fi
+
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "failed" ]]; then
+  # rest: failed:id:conclusion
+  rest="${ci_fast#failed:}"
+  ci_run_id="${rest%%:*}"
+  ci_conclusion="${rest##*:}"
+  echo "[fix-ci] Latest CI for HEAD ${LOCAL_SHA} already completed with ${ci_conclusion} (run ${ci_run_id})."
+  echo ""
+  echo "CI_FAILED"
+  echo "CI_RUN_ID=${ci_run_id}"
+  echo "CI_CONCLUSION=${ci_conclusion}"
+  gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
+  gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+  echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
+  echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq '.url')"
+  echo "AGENT_NEEDED"
+  exit 101
+fi
+
+if [[ -n "$ci_fast" && "${ci_fast%%:*}" == "success" && -n "$audit_fast" && "${audit_fast%%:*}" == "failed" ]]; then
+  rest="${audit_fast#failed:}"
+  audit_run_id="${rest%%:*}"
+  audit_conclusion="${rest##*:}"
+  echo "[fix-ci] Latest audit for HEAD ${LOCAL_SHA} already completed with ${audit_conclusion} (run ${audit_run_id})."
+  echo ""
+  echo "AUDIT_FAILED"
+  echo "AUDIT_RUN_ID=${audit_run_id}"
+  echo "AUDIT_CONCLUSION=${audit_conclusion}"
+  gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
+  gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+  echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
+  echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq '.url')"
+  echo "AGENT_NEEDED"
+  exit 102
+fi
+
+get_latest_run_id() {
+  local workflow="$1"
+  gh_cmd run list --workflow="$workflow" --branch "$BRANCH" --limit 1 --json databaseId 2>/dev/null \
+    | jq -r '.[0].databaseId // "0"'
+}
+
+ci_prev_run_id=$(get_latest_run_id "ci.yml")
+audit_prev_run_id=$(get_latest_run_id "audit.yml")
+
+echo "[fix-ci] Triggering ci.yml on ${BRANCH}..."
+gh_cmd workflow run ci.yml --ref "$BRANCH" 2>/dev/null || {
+  echo "[fix-ci] ERROR: Failed to trigger ci.yml" >&2
+  exit 1
+}
+
+echo "[fix-ci] Triggering audit.yml on ${BRANCH}..."
+gh_cmd workflow run audit.yml --ref "$BRANCH" 2>/dev/null || {
+  echo "[fix-ci] ERROR: Failed to trigger audit.yml" >&2
+  exit 1
+}
+
 echo "[fix-ci] Waiting for CI..."
 ci_result=$(wait_for_workflow "ci.yml" "$ci_prev_run_id")
 ci_conclusion="${ci_result%%:*}"
@@ -173,13 +224,15 @@ if [[ "$ci_conclusion" != "success" ]]; then
   echo "[fix-ci] Fetching CI logs..."
   if [[ "$ci_run_id" != "unknown" ]]; then
     gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
-    gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+    if [[ "$ci_conclusion" == "failure" ]]; then
+      gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+    fi
   else
-    : > "$CI_LOGS_FILE"
+    echo "[fix-ci] CI timed out waiting for completion. The workflow may still be running on GitHub." > "$CI_LOGS_FILE"
   fi
   echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
   if [[ -n "$ci_run_id" && "$ci_run_id" != "unknown" ]]; then
-    echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq -r '.url')"
+    echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq '.url')"
   fi
   echo "AGENT_NEEDED"
   exit 101
@@ -199,13 +252,15 @@ if [[ "$audit_conclusion" != "success" ]]; then
   echo "[fix-ci] Fetching audit logs..."
   if [[ "$audit_run_id" != "unknown" ]]; then
     gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
-    gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+    if [[ "$audit_conclusion" == "failure" ]]; then
+      gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+    fi
   else
-    : > "$AUDIT_LOGS_FILE"
+    echo "[fix-ci] Audit timed out waiting for completion. The workflow may still be running on GitHub." > "$AUDIT_LOGS_FILE"
   fi
   echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
   if [[ -n "$audit_run_id" && "$audit_run_id" != "unknown" ]]; then
-    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq -r '.url')"
+    echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq '.url')"
   fi
   echo "AGENT_NEEDED"
   exit 102
@@ -216,8 +271,8 @@ echo "FIX_CI_COMPLETE"
 echo "BRANCH=${BRANCH}"
 echo "LOCAL_HEAD=$(git rev-parse HEAD)"
 if [[ -n "$ci_run_id" && "$ci_run_id" != "unknown" ]]; then
-  echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq -r '.url')"
+  echo "CI_RUN_URL=$(gh_cmd run view "$ci_run_id" --json url --jq '.url')"
 fi
 if [[ -n "$audit_run_id" && "$audit_run_id" != "unknown" ]]; then
-  echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq -r '.url')"
+  echo "AUDIT_RUN_URL=$(gh_cmd run view "$audit_run_id" --json url --jq '.url')"
 fi

--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -16,7 +16,6 @@ This skill uses shell scripts for all mechanical bookkeeping (polling, fetching,
 watch-poll.sh          — Deterministic polling loop (no AI needed)
   ├── Fetches comments from 3 GitHub API endpoints
   ├── Deduplicates by tracking last-seen IDs
-  ├── Filters out bot-authored comments
   ├── Merges from main, detects conflicts
   ├── Parses PR body for unchecked Claude Code checklist items
   ├── Writes work-items.json when there's actionable work
@@ -82,7 +81,6 @@ bash "${SKILL_DIR}/watch-poll.sh" "${PR_URL}" $([[ "$AUTO_MERGE" == "false" ]] &
 The script handles:
 - Fetching comments from all 3 GitHub API endpoints (reviews, review comments, issue comments)
 - Deduplication via last-seen ID tracking per endpoint
-- Filtering out bot-authored comments
 - Merging from main and detecting conflicts
 - Parsing the PR body for unchecked `### Claude Code` checklist items
 - Idle counter tracking (6 consecutive empty cycles = timeout)
@@ -127,7 +125,7 @@ The script communicates via stdout signals and exit codes:
 
 When the script prints **`AGENT_NEEDED`** and exits **0**, it has **not** posted the wrap-up and **has not** emitted `IDLE_TIMEOUT`. The orchestrator **must** run **Step 1 again** with the **same `--work-dir`** (and the **same** `--max-turns` if any) after finishing Step 3 — **unless** the user explicitly asked to stop mid-session.
 
-- **Why:** On an `AGENT_NEEDED` exit, `watch-poll.sh` increments `turns-count` in `WORK_DIR` and exits. The **next** invocation either (a) hits **idle** after empty poll cycles and posts wrap-up + `IDLE_TIMEOUT`, or (b) with **`--max-turns N`**, sees `turns-count >= N` **at the start** of that next run, posts wrap-up, then prints `IDLE_TIMEOUT` **immediately** (no extra agent work). Skipping that second poll is why wrap-up and **`watch-post.sh` never ran.
+- **Why:** On an `AGENT_NEEDED` exit, `watch-poll.sh` increments `turns-count` in `WORK_DIR` and exits. The **next** invocation either (a) hits **idle** after empty poll cycles and posts wrap-up + `IDLE_TIMEOUT`, or (b) with **`--max-turns N`**, sees `turns-count >= N` **at the start** of that next run, posts wrap-up, then prints `IDLE_TIMEOUT` **immediately** (no extra agent work). Skipping that second poll is why wrap-up and **`watch-post.sh`** never ran.
 
 - **`--max-turns 1`:** Expect **two** poll runs in the common case: first run → `AGENT_NEEDED` (do work); second run → `IDLE_TIMEOUT` (wrap-up posted) → **Step 5**.
 

--- a/.claude/skills/watch/watch-append-wrapup-ci.sh
+++ b/.claude/skills/watch/watch-append-wrapup-ci.sh
@@ -98,6 +98,12 @@ fi
 posted=false
 if [[ -z "$COMMENT_ID" ]]; then
   echo "[append-wrapup-ci] No wrap-up comment id; posting remediation as a new PR comment."
+  # When posting as a standalone comment, always include the H2 heading for context
+  if [[ "$stored" -gt 0 ]]; then
+    block="## 🔧 CI / audit remediation
+
+${block}"
+  fi
   if gh_api "/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" -f body="$block" > /dev/null 2>&1; then
     posted=true
   fi

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -72,22 +72,24 @@ export GH_REPO="${GH_REPO:-${OWNER}/${REPO}}"
 BRANCH=$(git branch --show-current)
 
 # ---------------------------------------------------------------------------
-# If the PR is a draft, mark it as ready for review
+# If the PR is a draft, mark it as ready for review (only on first invocation)
 # ---------------------------------------------------------------------------
 PR_META=$(GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh api "/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '{draft: .draft, node_id: .node_id}' 2>/dev/null || echo '{"draft":false}')
 IS_DRAFT=$(echo "$PR_META" | jq -r '.draft')
-if [[ "$IS_DRAFT" == "true" ]]; then
+if [[ "$IS_DRAFT" == "true" && -z "$EXISTING_WORK_DIR" ]]; then
   echo "[setup] PR is a draft — marking as ready for review..."
   PR_NODE_ID=$(echo "$PR_META" | jq -r '.node_id')
   if [[ -n "$PR_NODE_ID" && "$PR_NODE_ID" != "null" ]]; then
-    GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh api graphql -f query="
-      mutation {
-        markPullRequestReadyForReview(input: {pullRequestId: \"${PR_NODE_ID}\"}) {
+    GH_HOST="${GH_HOST}" GH_REPO="${GH_REPO}" gh api graphql \
+      -f id="$PR_NODE_ID" \
+      -f query='
+      mutation($id: ID!) {
+        markPullRequestReadyForReview(input: {pullRequestId: $id}) {
           pullRequest {
             isDraft
           }
         }
-      }" > /dev/null 2>&1 && echo "[setup] PR marked as ready for review." || echo "[setup] WARNING: Failed to mark PR as ready for review." >&2
+      }' > /dev/null 2>&1 && echo "[setup] PR marked as ready for review." || echo "[setup] WARNING: Failed to mark PR as ready for review." >&2
   else
     echo "[setup] WARNING: Could not fetch PR node ID to mark as ready." >&2
   fi

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -169,9 +169,11 @@ if [[ "$ci_conclusion" != "success" ]]; then
   echo "[post] Fetching CI logs (failed jobs if any)..."
   if [[ "$ci_run_id" != "unknown" ]]; then
     gh_cmd run view "$ci_run_id" --log-failed 2>/dev/null > "$CI_LOGS_FILE" || true
-    gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+    if [[ "$ci_conclusion" == "failure" ]]; then
+      gh_cmd run view "$ci_run_id" --log 2>/dev/null >> "$CI_LOGS_FILE" || true
+    fi
   else
-    : > "$CI_LOGS_FILE"
+    echo "[post] CI timed out waiting for completion. The workflow may still be running on GitHub." > "$CI_LOGS_FILE"
   fi
   echo "CI_LOGS_FILE=${CI_LOGS_FILE}"
   echo "AGENT_NEEDED"
@@ -191,9 +193,11 @@ if [[ "$audit_conclusion" != "success" ]]; then
   echo "[post] Fetching audit logs (failed jobs if any)..."
   if [[ "$audit_run_id" != "unknown" ]]; then
     gh_cmd run view "$audit_run_id" --log-failed 2>/dev/null > "$AUDIT_LOGS_FILE" || true
-    gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+    if [[ "$audit_conclusion" == "failure" ]]; then
+      gh_cmd run view "$audit_run_id" --log 2>/dev/null >> "$AUDIT_LOGS_FILE" || true
+    fi
   else
-    : > "$AUDIT_LOGS_FILE"
+    echo "[post] Audit timed out waiting for completion. The workflow may still be running on GitHub." > "$AUDIT_LOGS_FILE"
   fi
   echo "AUDIT_LOGS_FILE=${AUDIT_LOGS_FILE}"
   echo "AGENT_NEEDED"


### PR DESCRIPTION
## Summary

- Fix `--jq -r '.url'` → `--jq '.url'` across all 8 occurrences in fix-ci-trigger.sh (the `-r` was consumed as the jq expression instead of being a raw-output flag)
- Handle `ci=success, audit=empty` fast-path to only trigger `audit.yml` instead of re-triggering both workflows unnecessarily
- Write timeout explanation to log file when `wait_for_workflow` times out (previously left an empty file with no diagnostic info for the agent)
- Restrict full `--log` fetching to `failure` conclusion only in both fix-ci-trigger.sh and watch-post.sh (`cancelled`, `skipped`, `timed_out` logs can be huge with no diagnostic value)
- Prepend `## CI / audit remediation` heading in standalone fallback comments in watch-append-wrapup-ci.sh (fixes orphaned `### Remediation round N` heading)
- Guard draft promotion with `EXISTING_WORK_DIR` check in watch-poll.sh (prevents re-promoting PRs intentionally marked back to draft)
- Use GraphQL variables instead of string interpolation for `PR_NODE_ID` in watch-poll.sh mutation
- Remove stale bot-filtering references from watch SKILL.md (bot filtering was removed but docs still referenced it)
- Fix unclosed bold marker on `watch-post.sh` in SKILL.md that broke markdown rendering

Closes #804

## Test plan

### Claude Code
- [ ] All modified shell scripts pass `bash -n` syntax check
- [ ] No remaining `--jq -r` patterns in skills directory
- [ ] No remaining unclosed bold markers in SKILL.md files

### OpenClaw
- [ ] Verify /fix-ci correctly parses workflow URLs
- [ ] Verify /watch doesn't re-promote intentionally drafted PRs

https://claude.ai/code/session_01XUdn23DyS2uwKeeDiKfD8G