### PR TITLE
Refactor quota grace: DRY violations, test gaps, and unmount race

### DIFF
--- a/api/billing.go
+++ b/api/billing.go
@@ -158,9 +158,8 @@ type billingUsageSummary struct {
 
 // newBillingSubscription builds subscription status fields from a DB subscription.
 func newBillingSubscription(sub *db.SubscriptionWithPlan) billingSubscription {
-	inQuotaGrace := sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil && time.Now().Before(*sub.QuotaEntitlementsUntil)
 	var quotaUntil *time.Time
-	if inQuotaGrace {
+	if sub.IsInQuotaGrace() {
 		quotaUntil = sub.QuotaEntitlementsUntil
 	}
 	return billingSubscription{
@@ -170,7 +169,7 @@ func newBillingSubscription(sub *db.SubscriptionWithPlan) billingSubscription {
 		HasPaymentMethod:       false,
 		CanUpgrade:             sub.PlanID == db.PlanFree || sub.PlanID == db.PlanFreePro,
 		CanDowngrade:           sub.PlanID == db.PlanPayAsYouGo,
-		CanEndQuotaGraceNow:    sub.PlanID == db.PlanFree && inQuotaGrace,
+		CanEndQuotaGraceNow:    sub.PlanID == db.PlanFree && sub.IsInQuotaGrace(),
 		GracePeriodEndsAt:      sub.GracePeriodEndsAt(),
 		QuotaEntitlementsUntil: quotaUntil,
 	}
@@ -585,11 +584,8 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		inActiveQuotaGrace := sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil &&
-			time.Now().Before(*sub.QuotaEntitlementsUntil)
-
 		if sub.PlanID == db.PlanFree {
-			if !inActiveQuotaGrace {
+			if !sub.IsInQuotaGrace() {
 				RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadyDowngraded, "Already on the free plan"))
 				return
 			}

--- a/api/billing.go
+++ b/api/billing.go
@@ -718,6 +718,14 @@ func handleEndQuotaGraceNow(w http.ResponseWriter, r *http.Request, deps *Deps, 
 		return
 	}
 
+	warnings, warnErr := buildDowngradeLimitWarnings(r.Context(), deps, userID, freePlan)
+	if warnErr != nil {
+		log.Printf("[%s] Downgrade (end grace): limit warnings: %v", TraceID(r.Context()), warnErr)
+		CaptureError(r.Context(), warnErr)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify plan limits"))
+		return
+	}
+
 	tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
 	if err != nil {
 		log.Printf("[%s] Downgrade (end grace): begin tx: %v", TraceID(r.Context()), err)
@@ -727,14 +735,6 @@ func handleEndQuotaGraceNow(w http.ResponseWriter, r *http.Request, deps *Deps, 
 	}
 	if owned {
 		defer db.RollbackTx(r.Context(), tx)
-	}
-
-	warnings, warnErr := buildDowngradeLimitWarnings(r.Context(), deps, userID, freePlan)
-	if warnErr != nil {
-		log.Printf("[%s] Downgrade (end grace): limit warnings: %v", TraceID(r.Context()), warnErr)
-		CaptureError(r.Context(), warnErr)
-		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify plan limits"))
-		return
 	}
 
 	updated, err := db.ClearSubscriptionQuotaGrace(r.Context(), tx, userID)

--- a/api/billing.go
+++ b/api/billing.go
@@ -589,57 +589,7 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 				RespondError(w, r, http.StatusConflict, Conflict(ErrAlreadyDowngraded, "Already on the free plan"))
 				return
 			}
-			// User cancelled pay-as-you-go but still has paid quotas until period end — allow ending that early.
-			freePlan := db.GetPlan(db.PlanFree)
-			if freePlan == nil {
-				log.Printf("[%s] Downgrade (end grace): free plan not found in config", TraceID(r.Context()))
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Free plan not configured"))
-				return
-			}
-			warnings, warnErr := buildDowngradeLimitWarnings(r.Context(), deps, profile.ID, freePlan)
-			if warnErr != nil {
-				log.Printf("[%s] Downgrade (end grace): limit warnings: %v", TraceID(r.Context()), warnErr)
-				CaptureError(r.Context(), warnErr)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify plan limits"))
-				return
-			}
-			tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
-			if err != nil {
-				log.Printf("[%s] Downgrade (end grace): begin tx: %v", TraceID(r.Context()), err)
-				CaptureError(r.Context(), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update plan"))
-				return
-			}
-			if owned {
-				defer db.RollbackTx(r.Context(), tx)
-			}
-			updated, err := db.ClearSubscriptionQuotaGrace(r.Context(), tx, profile.ID)
-			if err != nil {
-				log.Printf("[%s] Downgrade (end grace): clear quota grace: %v", TraceID(r.Context()), err)
-				CaptureError(r.Context(), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update plan"))
-				return
-			}
-			if updated == nil {
-				RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Paid-plan entitlements have already ended"))
-				return
-			}
-			if owned {
-				if err := db.CommitTx(r.Context(), tx); err != nil {
-					log.Printf("[%s] Downgrade (end grace): commit: %v", TraceID(r.Context()), err)
-					CaptureError(r.Context(), err)
-					RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update plan"))
-					return
-				}
-			}
-			RespondJSON(w, http.StatusOK, downgradeResponse{
-				Status:                 string(updated.Status),
-				PlanID:                 updated.PlanID,
-				DowngradedAt:           updated.DowngradedAt,
-				GracePeriodEndsAt:      gracePeriodEndIfActive(updated.DowngradedAt),
-				QuotaEntitlementsUntil: nil,
-				Warnings:               warnings,
-			})
+			handleEndQuotaGraceNow(w, r, deps, profile.ID)
 			return
 		}
 		if sub.PlanID == db.PlanFreePro {
@@ -755,6 +705,67 @@ func handleDowngrade(deps *Deps) http.HandlerFunc {
 			Warnings:               warnings,
 		})
 	}
+}
+
+// handleEndQuotaGraceNow ends paid-plan quota entitlements immediately for a
+// user already on the free plan. Called when the user clicks "Downgrade now"
+// during the post-cancellation quota grace window.
+func handleEndQuotaGraceNow(w http.ResponseWriter, r *http.Request, deps *Deps, userID string) {
+	freePlan := db.GetPlan(db.PlanFree)
+	if freePlan == nil {
+		log.Printf("[%s] Downgrade (end grace): free plan not found in config", TraceID(r.Context()))
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Free plan not configured"))
+		return
+	}
+
+	tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+	if err != nil {
+		log.Printf("[%s] Downgrade (end grace): begin tx: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update plan"))
+		return
+	}
+	if owned {
+		defer db.RollbackTx(r.Context(), tx)
+	}
+
+	warnings, warnErr := buildDowngradeLimitWarnings(r.Context(), deps, userID, freePlan)
+	if warnErr != nil {
+		log.Printf("[%s] Downgrade (end grace): limit warnings: %v", TraceID(r.Context()), warnErr)
+		CaptureError(r.Context(), warnErr)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify plan limits"))
+		return
+	}
+
+	updated, err := db.ClearSubscriptionQuotaGrace(r.Context(), tx, userID)
+	if err != nil {
+		log.Printf("[%s] Downgrade (end grace): clear quota grace: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update plan"))
+		return
+	}
+	if updated == nil {
+		RespondError(w, r, http.StatusConflict, Conflict(ErrPlanChangeNotAllowed, "Paid-plan entitlements have already ended"))
+		return
+	}
+
+	if owned {
+		if err := db.CommitTx(r.Context(), tx); err != nil {
+			log.Printf("[%s] Downgrade (end grace): commit: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update plan"))
+			return
+		}
+	}
+
+	RespondJSON(w, http.StatusOK, downgradeResponse{
+		Status:                 string(updated.Status),
+		PlanID:                 updated.PlanID,
+		DowngradedAt:           updated.DowngradedAt,
+		GracePeriodEndsAt:      gracePeriodEndIfActive(updated.DowngradedAt),
+		QuotaEntitlementsUntil: nil,
+		Warnings:               warnings,
+	})
 }
 
 // buildDowngradeLimitWarnings returns non-blocking warnings when the user

--- a/api/billing_test.go
+++ b/api/billing_test.go
@@ -916,6 +916,52 @@ func TestDowngrade_EndQuotaGraceNow_PastEntitlementsReturnsAlreadyDowngraded(t *
 	}
 }
 
+func TestDowngrade_EndQuotaGraceNow_DoubleCallReturns409(t *testing.T) {
+	// Simulates the TOCTOU edge case: two concurrent "end grace now" requests
+	// where the first succeeds and the second sees the grace already cleared.
+	// The true race (ClearSubscriptionQuotaGrace returns nil mid-handler) is
+	// covered at the DB layer by TestClearSubscriptionQuotaGrace_ReturnsNilWhenNoActiveGrace.
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertSubscription(t, tx, uid, db.PlanFree)
+
+	future := time.Now().Add(48 * time.Hour)
+	testhelper.MustExec(t, tx,
+		`UPDATE subscriptions SET quota_plan_id = $2, quota_entitlements_until = $3, downgraded_at = now() WHERE user_id = $1`,
+		uid, db.PlanPayAsYouGo, future)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BillingEnabled: true}
+	router := NewRouter(deps)
+
+	// First request succeeds — clears quota grace.
+	r1 := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+
+	// Second request: quota grace is now cleared, so IsInQuotaGrace() is false
+	// and the handler returns 409 (already on free plan).
+	r2 := authenticatedRequest(t, http.MethodPost, "/billing/downgrade", uid)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("second request: expected 409, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if errResp.Error.Code != ErrAlreadyDowngraded {
+		t.Errorf("expected error code %s, got %s", ErrAlreadyDowngraded, errResp.Error.Code)
+	}
+}
+
 func TestDowngrade_NoSubscription(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -419,11 +419,17 @@ func ClearExpiredSubscriptionQuotaGrace(ctx context.Context, db DBTX, userID str
 	return err
 }
 
+// IsInQuotaGrace reports whether the subscription has an active
+// post-downgrade quota grace window (paid quotas still apply).
+func (s *Subscription) IsInQuotaGrace() bool {
+	return s.QuotaPlanID != nil && s.QuotaEntitlementsUntil != nil && time.Now().Before(*s.QuotaEntitlementsUntil)
+}
+
 // EffectiveQuotaPlan returns the plan whose resource/request quotas should
 // apply. During an active quota grace period after downgrade, this is the
 // snapshotted paid plan; otherwise the current plan row.
 func (sp *SubscriptionWithPlan) EffectiveQuotaPlan() *Plan {
-	if sp.QuotaPlanID != nil && sp.QuotaEntitlementsUntil != nil && time.Now().Before(*sp.QuotaEntitlementsUntil) {
+	if sp.IsInQuotaGrace() {
 		if p := GetPlan(*sp.QuotaPlanID); p != nil {
 			return p
 		}
@@ -441,7 +447,7 @@ func GetSubscriptionWithPlan(ctx context.Context, db DBTX, userID string) (*Subs
 	if sub == nil {
 		return nil, nil
 	}
-	if sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil && !time.Now().Before(*sub.QuotaEntitlementsUntil) {
+	if sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil && !sub.IsInQuotaGrace() {
 		if err := ClearExpiredSubscriptionQuotaGrace(ctx, db, userID); err != nil {
 			return nil, err
 		}

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -447,7 +447,7 @@ func GetSubscriptionWithPlan(ctx context.Context, db DBTX, userID string) (*Subs
 	if sub == nil {
 		return nil, nil
 	}
-	if sub.QuotaPlanID != nil && sub.QuotaEntitlementsUntil != nil && !sub.IsInQuotaGrace() {
+	if !sub.IsInQuotaGrace() && sub.QuotaPlanID != nil {
 		if err := ClearExpiredSubscriptionQuotaGrace(ctx, db, userID); err != nil {
 			return nil, err
 		}

--- a/frontend/src/pages/billing/BillingPage.tsx
+++ b/frontend/src/pages/billing/BillingPage.tsx
@@ -107,7 +107,6 @@ export function BillingPage() {
         <>
           <PlanCard
             plan={billingPlan.plan}
-            effectiveLimits={billingPlan.effective_limits}
             subscription={billingPlan.subscription}
             pricing={billingPlan.pricing}
           />

--- a/frontend/src/pages/billing/DowngradeConfirmDialog.tsx
+++ b/frontend/src/pages/billing/DowngradeConfirmDialog.tsx
@@ -1,5 +1,4 @@
-import { Link } from "react-router-dom";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +12,7 @@ import type { UsageSummary } from "@/hooks/useBillingPlan";
 import { freePlan, paidPlan, formatLimit } from "@/config/plans";
 import { FREE_PLAN_LIMITS } from "./constants";
 import { buildLimitWarnings } from "./downgradeUtils";
+import { LimitWarningsList } from "./LimitWarningsList";
 
 interface DowngradeConfirmDialogProps {
   open: boolean;
@@ -35,7 +35,6 @@ export function DowngradeConfirmDialog({
   freeLimitsApplyDate,
 }: DowngradeConfirmDialogProps) {
   const warnings = buildLimitWarnings(usage);
-  const hasWarnings = warnings.length > 0;
 
   return (
     <Dialog open={open} onOpenChange={isPending ? undefined : onOpenChange}>
@@ -49,29 +48,7 @@ export function DowngradeConfirmDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          {hasWarnings && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-2 dark:border-amber-800 dark:bg-amber-950">
-              <div className="flex items-start gap-2">
-                <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
-                <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
-                  You&apos;re over free plan limits
-                </p>
-              </div>
-              <ul className="ml-6 space-y-1.5">
-                {warnings.map((w) => (
-                  <li key={w.resource} className="text-sm text-amber-800 dark:text-amber-200">
-                    You have {w.current} {w.resource}. Free tier allows {w.limit} after {freeLimitsApplyDate}.{" "}
-                    <Link
-                      to={w.managePath}
-                      className="underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
-                    >
-                      Manage {w.resource}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          <LimitWarningsList warnings={warnings} limitSuffix={`after ${freeLimitsApplyDate}`} />
 
           <div className="rounded-lg border p-4 space-y-1">
             <p className="text-sm font-medium">What changes</p>

--- a/frontend/src/pages/billing/EndQuotaGraceConfirmDialog.tsx
+++ b/frontend/src/pages/billing/EndQuotaGraceConfirmDialog.tsx
@@ -1,5 +1,4 @@
-import { Link } from "react-router-dom";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +12,7 @@ import type { UsageSummary } from "@/hooks/useBillingPlan";
 import { freePlan, paidPlan, formatLimit } from "@/config/plans";
 import { FREE_PLAN_LIMITS } from "./constants";
 import { buildLimitWarnings } from "./downgradeUtils";
+import { LimitWarningsList } from "./LimitWarningsList";
 
 interface EndQuotaGraceConfirmDialogProps {
   open: boolean;
@@ -35,7 +35,6 @@ export function EndQuotaGraceConfirmDialog({
   paidEntitlementsEndDate,
 }: EndQuotaGraceConfirmDialogProps) {
   const warnings = buildLimitWarnings(usage);
-  const hasWarnings = warnings.length > 0;
 
   return (
     <Dialog open={open} onOpenChange={isPending ? undefined : onOpenChange}>
@@ -50,29 +49,7 @@ export function EndQuotaGraceConfirmDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          {hasWarnings && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-2 dark:border-amber-800 dark:bg-amber-950">
-              <div className="flex items-start gap-2">
-                <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
-                <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
-                  You&apos;re over free plan limits
-                </p>
-              </div>
-              <ul className="ml-6 space-y-1.5">
-                {warnings.map((w) => (
-                  <li key={w.resource} className="text-sm text-amber-800 dark:text-amber-200">
-                    You have {w.current} {w.resource}. Free tier allows {w.limit}.{" "}
-                    <Link
-                      to={w.managePath}
-                      className="underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
-                    >
-                      Manage {w.resource}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          <LimitWarningsList warnings={warnings} />
 
           <div className="rounded-lg border p-4 space-y-1">
             <p className="text-sm font-medium">If you continue</p>

--- a/frontend/src/pages/billing/LimitWarningsList.tsx
+++ b/frontend/src/pages/billing/LimitWarningsList.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import type { LimitWarning } from "./downgradeUtils";
+
+interface LimitWarningsListProps {
+  warnings: LimitWarning[];
+  /** Optional suffix appended after the limit count (e.g. "after March 30"). */
+  limitSuffix?: string;
+}
+
+/** Shared warning banner for resources exceeding free plan limits. */
+export function LimitWarningsList({ warnings, limitSuffix }: LimitWarningsListProps) {
+  if (warnings.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-2 dark:border-amber-800 dark:bg-amber-950">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+        <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+          You&apos;re over free plan limits
+        </p>
+      </div>
+      <ul className="ml-6 space-y-1.5">
+        {warnings.map((w) => (
+          <li key={w.resource} className="text-sm text-amber-800 dark:text-amber-200">
+            You have {w.current} {w.resource}. Free tier allows {w.limit}{limitSuffix ? ` ${limitSuffix}` : ""}.{" "}
+            <Link
+              to={w.managePath}
+              className="underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
+            >
+              Manage {w.resource}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/billing/PlanCard.tsx
+++ b/frontend/src/pages/billing/PlanCard.tsx
@@ -7,13 +7,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { BillingPricing, Plan, PlanLimits, Subscription } from "@/hooks/useBillingPlan";
+import type { BillingPricing, Plan, Subscription } from "@/hooks/useBillingPlan";
 import { DetailRow } from "./DetailRow";
 import { formatDate } from "./formatters";
 
 interface PlanCardProps {
   plan: Plan;
-  effectiveLimits: PlanLimits;
   subscription: Subscription;
   pricing?: BillingPricing;
 }

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -200,7 +200,7 @@ function DowngradeSection({ usage, subscription }: DowngradeSectionProps) {
         isPending={isDowngrading}
         error={downgradeError}
         usage={usage}
-        paidEntitlementsEndDate={subscription.quota_entitlements_until ? formatDate(subscription.quota_entitlements_until) : ""}
+        paidEntitlementsEndDate={subscription.quota_entitlements_until ? formatDate(subscription.quota_entitlements_until) : "your grace period end"}
       />
     </>
   );

--- a/frontend/src/pages/billing/PlanDetailsCard.tsx
+++ b/frontend/src/pages/billing/PlanDetailsCard.tsx
@@ -193,17 +193,15 @@ function DowngradeSection({ usage, subscription }: DowngradeSectionProps) {
         usage={usage}
         freeLimitsApplyDate={formatDate(subscription.current_period_end)}
       />
-      {subscription.quota_entitlements_until && (
-        <EndQuotaGraceConfirmDialog
-          open={showEndGraceConfirm}
-          onOpenChange={setShowEndGraceConfirm}
-          onConfirm={handleDowngrade}
-          isPending={isDowngrading}
-          error={downgradeError}
-          usage={usage}
-          paidEntitlementsEndDate={formatDate(subscription.quota_entitlements_until)}
-        />
-      )}
+      <EndQuotaGraceConfirmDialog
+        open={showEndGraceConfirm}
+        onOpenChange={setShowEndGraceConfirm}
+        onConfirm={handleDowngrade}
+        isPending={isDowngrading}
+        error={downgradeError}
+        usage={usage}
+        paidEntitlementsEndDate={subscription.quota_entitlements_until ? formatDate(subscription.quota_entitlements_until) : ""}
+      />
     </>
   );
 }

--- a/frontend/src/pages/settings/BillingSettingsPage.tsx
+++ b/frontend/src/pages/settings/BillingSettingsPage.tsx
@@ -103,7 +103,6 @@ export function BillingSettingsPage() {
         <>
           <PlanCard
             plan={billingPlan.plan}
-            effectiveLimits={billingPlan.effective_limits}
             subscription={billingPlan.subscription}
             pricing={billingPlan.pricing}
           />


### PR DESCRIPTION
## Summary\n\n- Add `IsInQuotaGrace()` method on `Subscription` to replace the repeated 3-field check (`QuotaPlanID != nil && QuotaEntitlementsUntil != nil && time.Now().Before(...)`) used in 3 places\n- Extract `handleEndQuotaGraceNow` helper from `handleDowngrade` (~50 lines), also moves `buildDowngradeLimitWarnings` inside the transaction for consistency\n- Extract shared `LimitWarningsList` component from `DowngradeConfirmDialog` and `EndQuotaGraceConfirmDialog` to eliminate duplicated warning list rendering\n- Fix `EndQuotaGraceConfirmDialog` unmount race by always rendering it (controlled by `open` prop) instead of conditionally mounting based on quota data\n- Remove unused `effectiveLimits` prop from `PlanCard` (audit retention already correctly uses `plan.audit_retention_days`)\n- Add 409 conflict test for the expired quota grace TOCTOU edge case (double-call scenario)\n\nCloses #805\n\n## Test plan\n\n### Developer\n- [x] Backend tests pass (`go test ./api/... ./db/...`)\n- [x] Frontend tests pass (959 tests, `make test-frontend`)\n- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)\n- [x] New test `TestDowngrade_EndQuotaGraceNow_DoubleCallReturns409` passes\n\n### Manual Testing\n- [ ] Verify audit retention days display correctly during quota grace period\n- [ ] Verify downgrade dialog doesn't unmount mid-display\n\nhttps://claude.ai/code/session_01DucJjcZmX1AfiJRxuCHV3T