### PR TITLE
Deactivate trigger-webhook workflow

### DIFF
--- a/.claude/skills/conflicts/SKILL.md
+++ b/.claude/skills/conflicts/SKILL.md
@@ -90,12 +90,6 @@ Conflicts skill session complete.
 - Clean cycles before exit: 10
 ```
 
-Trigger the webhook to notify the user:
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run trigger-webhook.yml
-```
-
 ## Important Rules
 
 - **Never ask for human input** — decide and resolve conflicts autonomously.

--- a/.claude/skills/fix-ci/SKILL.md
+++ b/.claude/skills/fix-ci/SKILL.md
@@ -147,7 +147,6 @@ If you reach `MAX_ROUNDS` with CI or audit still failing:
 
 - **Default `MAX_ROUNDS`:** 5
 - **No auto-merge** — this skill only fixes CI/audit; it does not merge PRs
-- **No webhook** — do not run `trigger-webhook.yml` unless the user explicitly asked for notification outside this skill
 - **Minimal diffs** — follow merge-conflict minimization rules in `CLAUDE.md`
 
 ## Example invocations

--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -25,8 +25,7 @@ watch-poll.sh          — Deterministic polling loop (no AI needed)
 watch-post.sh          — Post-session tasks (no AI needed)
   ├── Triggers CI and audit workflows
   ├── Waits for completion
-  ├── Auto-merges if enabled and checks pass
-  └── Triggers webhook notification (unless --skip-webhook)
+  └── Auto-merges if enabled and checks pass
 
 watch-append-wrapup-ci.sh — Appends CI/audit remediation bullets to the wrap-up PR comment
 
@@ -376,17 +375,12 @@ When the polling script exits with `IDLE_TIMEOUT`, the wrap-up comment has alrea
 
 **Loop (run until both CI and audit report `success`, or you exhaust retries):**
 
-1. Run post-session. Always pass **`--work-dir "$WORK_DIR"`** (same session directory as `watch-poll.sh`) so CI/audit logs are written under that directory (avoids `/tmp` clashes between concurrent watch sessions) and so the webhook sentinel file is session-scoped. On the **first** iteration of this loop after wrap-up, pass **`--skip-webhook`** so the webhook does not fire until CI is actually green (this creates **`${WORK_DIR}/post-webhook-pending`** on success):
+1. Run post-session. Always pass **`--work-dir "$WORK_DIR"`** (same session directory as `watch-poll.sh`) so CI/audit logs are written under that directory (avoids `/tmp` clashes between concurrent watch sessions):
    ```bash
-   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" --work-dir "$WORK_DIR" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --skip-webhook 2>&1
+   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" --work-dir "$WORK_DIR" $([[ "$AUTO_MERGE" == "false" ]] && echo "--no-automerge") 2>&1
    ```
-   On **subsequent** iterations (after you pushed fixes), omit `--skip-webhook` so each successful pass can notify as usual, **or** keep using `--skip-webhook` until the final successful iteration and then run once with **`--webhook-only`** (see step 2b below).
 
-2. **Exit code 0** — Both workflows concluded `success`. If the webhook was sent this run (no `--skip-webhook`), **`post-webhook-pending`** is removed automatically. If you used **`--skip-webhook`** and `NO_NOTIFY` is false, run once with **`--webhook-only`** — this **requires** `--work-dir` and an existing **`post-webhook-pending`** file (otherwise exit **2**); on success the webhook runs and the sentinel is removed:
-   ```bash
-   bash "${SKILL_DIR}/watch-post.sh" "${PR_URL}" --work-dir "$WORK_DIR" $([[ "$NO_NOTIFY" == "true" ]] && echo "--no-notify") --webhook-only 2>&1
-   ```
-   Read merge result from stdout (`PR merged successfully`, etc.).
+2. **Exit code 0** — Both workflows concluded `success`. Read merge result from stdout (`PR merged successfully`, etc.).
 
 3. **Exit code 101 (CI)** or **102 (audit)** — This is expected while fixing. **Automatically:**
    - Read logs from `CI_LOGS_FILE` or `AUDIT_LOGS_FILE` in the script output.

--- a/.claude/skills/watch/watch-post.sh
+++ b/.claude/skills/watch/watch-post.sh
@@ -77,13 +77,8 @@ if [[ "$WEBHOOK_ONLY" == "true" ]]; then
     echo "[post] ERROR: --webhook-only requires --work-dir and a prior successful watch-post run with --skip-webhook (missing ${pending_file})." >&2
     exit 2
   fi
-  echo "[post] Triggering webhook notification only..."
-  if gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null; then
-    rm -f "$pending_file"
-  else
-    echo "[post] WARNING: Failed to trigger webhook (sentinel kept for retry)." >&2
-    exit 1
-  fi
+  echo "[post] Webhook notifications disabled — skipping."
+  rm -f "$pending_file"
   echo "POST_WEBHOOK_ONLY=true"
   exit 0
 fi
@@ -225,20 +220,11 @@ fi
 # ---------------------------------------------------------------------------
 # Trigger webhook notification (skipped with --no-notify or --skip-webhook)
 # ---------------------------------------------------------------------------
-if [[ "$NO_NOTIFY" == "true" || "$SKIP_WEBHOOK" == "true" ]]; then
-  echo "[post] Skipping webhook notification (--no-notify or --skip-webhook)."
-else
-  echo "[post] Triggering webhook notification..."
-  gh_cmd workflow run trigger-webhook.yml -f pr_url="${PR_URL}" 2>/dev/null || echo "[post] WARNING: Failed to trigger webhook"
-  if [[ -n "$WORK_DIR" && -f "${WORK_DIR}/post-webhook-pending" ]]; then
-    rm -f "${WORK_DIR}/post-webhook-pending"
-  fi
-fi
+# Webhook notifications disabled — trigger-webhook.yml is no longer in use.
+# The flags (--no-notify, --skip-webhook) are kept for backwards compatibility.
+echo "[post] Webhook notifications disabled — skipping."
 
-if [[ -n "$WORK_DIR" && "$SKIP_WEBHOOK" == "true" && "$NO_NOTIFY" == "false" ]]; then
-  touch "${WORK_DIR}/post-webhook-pending"
-  echo "[post] Wrote ${WORK_DIR}/post-webhook-pending (use --webhook-only after final green run to notify)."
-fi
+# post-webhook-pending sentinel no longer needed (webhook disabled)
 
 echo ""
 echo "POST_COMPLETE"

--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -213,4 +213,3 @@ Use the `Skill` tool to invoke the watch skill, passing `--no-notify` as the arg
 - **Include the original prompt in the PR body** (prompt mode) — so reviewers have context on what was requested.
 - **Follow all CLAUDE.md guidelines** — especially around migrations, API types, component architecture, and merge conflict minimization.
 - **Post-task review** — before opening the PR, run all five review passes from CLAUDE.md (self-review, senior engineer lens, maintainability, code quality, documentation).
-- **Do NOT trigger the webhook notification** — the `/yolo` skill is fully autonomous end-to-end. Do not call the `trigger-webhook.yml` workflow at any point during this skill. The `--no-notify` flag on `/watch` handles suppressing the notification from the watch post-session as well.

--- a/.github/workflows/trigger-webhook.yml
+++ b/.github/workflows/trigger-webhook.yml
@@ -1,4 +1,4 @@
-name: Trigger Webhook
+name: Trigger Webhook (disabled)
 on:
   workflow_dispatch:
     inputs:
@@ -17,6 +17,7 @@ on:
 
 jobs:
   notify:
+    if: false  # Webhook notifications disabled — no longer in use
     runs-on: ubuntu-latest
     steps:
       - name: Send Webhook

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,16 +29,6 @@
 - If a file is getting large enough that splitting it would improve maintainability, just go ahead and split it — don't ask first.
 - When you need to ask questions, just ask them in regular chat text. Do NOT use the AskUserQuestion tool — it doesn't work reliably.
 
-## Webhook Notification
-
-Whenever you finish a task or need user input and the user hasn't responded within 2 minutes, trigger the webhook to notify them. This uses the same workflow as the `/watch` command but without a PR URL:
-
-```bash
-GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh workflow run trigger-webhook.yml
-```
-
-Do not include `-f pr_url=...` — this is a general "attention needed" ping, not a PR-specific notification.
-
 ## Post-Task Review (before marking complete)
 
 Before presenting work as done, always perform these review passes:


### PR DESCRIPTION
## Summary

- Disabled the `trigger-webhook.yml` workflow by adding `if: false` to the job (code left in place, just won't run)
- Removed the "Webhook Notification" section from CLAUDE.md that instructed agents to ping the webhook
- Updated `watch-post.sh` to skip webhook calls (flags like `--skip-webhook` and `--no-notify` kept for backwards compatibility)
- Cleaned up webhook references from skill files (conflicts, watch, yolo, fix-ci)

## Test plan

### Developer
- [x] Verify `trigger-webhook.yml` has `if: false` on the job
- [x] Verify CLAUDE.md no longer mentions webhook notification
- [x] Verify `watch-post.sh` no longer calls the webhook workflow
- [x] Verify skill files no longer instruct agents to trigger the webhook

### Manual Testing
- [ ] Confirm no agent sessions attempt to trigger the webhook after merge

https://claude.ai/code/session_015BGjJF9tsNEMgeGPf1rQLd