### PR TITLE
Firestore connector: fix post-merge Greptile findings (#846)

### DIFF
--- a/connectors/firestore/client_impl.go
+++ b/connectors/firestore/client_impl.go
@@ -9,7 +9,9 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
@@ -70,6 +72,9 @@ func (r *realRunner) close() error {
 func (r *realRunner) getDocument(ctx context.Context, path string) (map[string]interface{}, error) {
 	snap, err := r.client.Doc(path).Get(ctx)
 	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			return nil, nil
+		}
 		return nil, mapFirestoreError(err)
 	}
 	if !snap.Exists() {

--- a/connectors/firestore/firestore.go
+++ b/connectors/firestore/firestore.go
@@ -13,7 +13,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -301,7 +300,7 @@ func (c *FirestoreConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "firestore.query",
 				Name:        "Query posts subcollection",
 				Description: "Agent may list posts under a user with a limit.",
-				Parameters:  json.RawMessage(`{"collection_path":"users/USER_ID/posts","allowed_paths":["users/USER_ID/posts"],"limit":"*","order_by":[{"field":"createdAt","direction":"desc"}]}`),
+				Parameters:  json.RawMessage(`{"collection_path":"users/USER_ID/posts","allowed_paths":["users/USER_ID/posts"],"limit":50,"order_by":[{"field":"createdAt","direction":"desc"}]}`),
 			},
 		},
 	}
@@ -374,9 +373,6 @@ func (c *FirestoreConnector) buildRunner(ctx context.Context, projectID string, 
 		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid service account credentials: %v", err)}
 	}
 	emulatorHost = strings.TrimSpace(emulatorHost)
-	if emulatorHost == "" {
-		emulatorHost = strings.TrimSpace(os.Getenv("FIRESTORE_EMULATOR_HOST"))
-	}
 	if emulatorHost != "" {
 		if err := validateEmulatorHost(emulatorHost); err != nil {
 			return nil, err

--- a/connectors/firestore/firestore_test.go
+++ b/connectors/firestore/firestore_test.go
@@ -1,6 +1,7 @@
 package firestore
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip-web/connectors"
@@ -116,6 +117,30 @@ func TestFirestoreConnector_ValidateCredentials(t *testing.T) {
 				t.Errorf("got %T, want validation error", err)
 			}
 		})
+	}
+}
+
+func TestFirestoreConnector_ManifestTemplate_QueryPostsLimitIsInteger(t *testing.T) {
+	t.Parallel()
+	m := New().Manifest()
+	var tpl *connectors.ManifestTemplate
+	for i := range m.Templates {
+		if m.Templates[i].ID == "tpl_firestore_query_posts" {
+			tpl = &m.Templates[i]
+			break
+		}
+	}
+	if tpl == nil {
+		t.Fatal("missing tpl_firestore_query_posts")
+	}
+	var params struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.Unmarshal(tpl.Parameters, &params); err != nil {
+		t.Fatalf("template parameters must unmarshal: %v", err)
+	}
+	if params.Limit != defaultQueryLimit {
+		t.Fatalf("template limit = %d, want default %d", params.Limit, defaultQueryLimit)
 	}
 }
 

--- a/connectors/firestore/get_test.go
+++ b/connectors/firestore/get_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
@@ -39,6 +42,36 @@ func TestGet_FoundAndFiltered(t *testing.T) {
 	}
 	if data["name"] != "Alice" {
 		t.Fatalf("name missing: %#v", data)
+	}
+}
+
+func TestGet_NotFoundGRPCReturnsFoundFalse(t *testing.T) {
+	t.Parallel()
+	mock := newMockRunner()
+	mock.getErr = status.Error(codes.NotFound, "no document")
+	conn := newForTest(mock)
+	action := conn.Actions()["firestore.get"]
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "firestore.get",
+		Parameters: json.RawMessage(`{
+			"path":"users/missing",
+			"allowed_paths":["users/missing"]
+		}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("NotFound should be success with found:false, got err %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(res.Data, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["found"].(bool) {
+		t.Fatal("expected found false")
+	}
+	if payload["data"] != nil {
+		t.Fatalf("expected data null, got %#v", payload["data"])
 	}
 }
 

--- a/connectors/firestore/mock_test.go
+++ b/connectors/firestore/mock_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"sync"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
@@ -31,6 +34,9 @@ func (m *mockRunner) getDocument(ctx context.Context, path string) (map[string]i
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.getErr != nil {
+		if st, ok := status.FromError(m.getErr); ok && st.Code() == codes.NotFound {
+			return nil, nil
+		}
 		return nil, m.getErr
 	}
 	d, ok := m.getData[path]

--- a/connectors/firestore/mock_test.go
+++ b/connectors/firestore/mock_test.go
@@ -103,7 +103,7 @@ func (m *mockRunner) queryCollection(ctx context.Context, collectionPath string,
 		return nil, m.queryErr
 	}
 	if len(m.queryDocs) == 0 {
-		return nil, nil
+		return []map[string]interface{}{}, nil
 	}
 	batch := m.queryDocs[0]
 	m.queryDocs = m.queryDocs[1:]

--- a/connectors/firestore/query.go
+++ b/connectors/firestore/query.go
@@ -125,6 +125,9 @@ func (a *queryAction) Execute(ctx context.Context, req connectors.ActionRequest)
 	if err != nil {
 		return nil, err
 	}
+	if docs == nil {
+		docs = []map[string]interface{}{}
+	}
 	allowed := buildFieldSet(params.AllowedReadFields)
 	if allowed != nil {
 		for i := range docs {

--- a/connectors/firestore/query_test.go
+++ b/connectors/firestore/query_test.go
@@ -1,0 +1,51 @@
+package firestore
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+func TestQuery_EmptyDocumentsIsJSONArray(t *testing.T) {
+	t.Parallel()
+	mock := newMockRunner()
+	mock.pushQueryBatch([]map[string]interface{}{})
+	conn := newForTest(mock)
+	action := conn.Actions()["firestore.query"]
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "firestore.query",
+		Parameters: json.RawMessage(`{
+			"collection_path":"posts",
+			"allowed_paths":["posts"]
+		}`),
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := string(res.Data)
+	if raw == "" {
+		t.Fatal("empty result JSON")
+	}
+	if !json.Valid(res.Data) {
+		t.Fatalf("invalid JSON: %s", raw)
+	}
+	var payload struct {
+		Documents []any `json:"documents"`
+		Count     int   `json:"count"`
+	}
+	if err := json.Unmarshal(res.Data, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Documents == nil {
+		t.Fatalf("documents must be non-nil empty slice, got null in JSON: %s", raw)
+	}
+	if len(payload.Documents) != 0 {
+		t.Fatalf("want 0 documents, got %d", len(payload.Documents))
+	}
+	if payload.Count != 0 {
+		t.Fatalf("count = %d, want 0", payload.Count)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the four follow-ups from [PR #823](https://github.com/supersuit-tech/permission-slip/pull/823) that were captured in [#846](https://github.com/supersuit-tech/permission-slip/issues/846) (Greptile review comment IDs: 2981670591, 2981761752, 2981761875, 2981762074).

- **`firestore.get` missing documents:** `DocumentRef.Get` errors with `codes.NotFound` are treated like a missing snapshot: success with `found: false` and `data: null`, not a validation error.
- **Template `limit`:** `tpl_firestore_query_posts` now uses integer `50` instead of `"*"` so parameters unmarshal into `queryParams.Limit`.
- **Emulator host:** `buildRunner` no longer falls back to process `FIRESTORE_EMULATOR_HOST` when credentials omit `emulator_host`, avoiding cross-tenant emulator leakage in production.
- **Query empty results:** Zero hits use a non-nil empty slice so JSON encodes `"documents":[]` instead of `null`.

Closes #846

### Developer

- [x] Unit tests for NotFound → `found: false`, template limit JSON, and empty query `documents` array

### Manual testing

- [ ] `firestore.get` on a non-existent path → JSON `found: false` (no error)
- [ ] Instantiate action config from `tpl_firestore_query_posts` without editing `limit` → `firestore.query` runs
- [ ] Query with zero matches → `documents: []` in result JSON

## Test plan

- `make test-backend` (or `go test ./connectors/firestore/...`) — **not run in this agent environment** (local Go 1.22.2 vs `go.mod` 1.25.8); CI should run the full suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cb0c6c2-d046-46ec-bb07-a03206c43d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cb0c6c2-d046-46ec-bb07-a03206c43d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

