### PR TITLE
Fix SQL validation bugs from PR #845 review

### DIFF
--- a/connectors/bigquery/sql_scan.go
+++ b/connectors/bigquery/sql_scan.go
@@ -39,7 +39,8 @@ func findBarePlaceholders(sql string) []int {
 					i += 3
 					break
 				}
-				i++
+				_, w := utf8.DecodeRuneInString(sql[i:])
+				i += w
 			}
 		case c == '\'':
 			i++

--- a/connectors/bigquery/sql_scan.go
+++ b/connectors/bigquery/sql_scan.go
@@ -8,9 +8,97 @@ import (
 	"github.com/supersuit-tech/permission-slip-web/connectors"
 )
 
+// findBarePlaceholders returns byte offsets of all ? characters outside
+// string literals (including triple-quoted), quoted identifiers, and comments.
+func findBarePlaceholders(sql string) []int {
+	var positions []int
+	i := 0
+	for i < len(sql) {
+		c := sql[i]
+		switch {
+		case c == '-' && i+1 < len(sql) && sql[i+1] == '-':
+			i += 2
+			for i < len(sql) && sql[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			i += 2
+			for i < len(sql) {
+				if i+1 < len(sql) && sql[i] == '*' && sql[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+		case (c == '\'' || c == '"') && i+2 < len(sql) && sql[i+1] == c && sql[i+2] == c:
+			// Triple-quoted string ("""...""" or '''...''')
+			q := c
+			i += 3
+			for i < len(sql) {
+				if i+2 < len(sql) && sql[i] == q && sql[i+1] == q && sql[i+2] == q {
+					i += 3
+					break
+				}
+				i++
+			}
+		case c == '\'':
+			i++
+			for i < len(sql) {
+				if sql[i] == '\'' {
+					if i+1 < len(sql) && sql[i+1] == '\'' {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				if sql[i] == '\\' && i+1 < len(sql) {
+					i += 2
+					continue
+				}
+				_, w := utf8.DecodeRuneInString(sql[i:])
+				i += w
+			}
+		case c == '"':
+			i++
+			for i < len(sql) {
+				if sql[i] == '"' {
+					if i+1 < len(sql) && sql[i+1] == '"' {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				if sql[i] == '\\' && i+1 < len(sql) {
+					i += 2
+					continue
+				}
+				_, w := utf8.DecodeRuneInString(sql[i:])
+				i += w
+			}
+		case c == '`':
+			i++
+			for i < len(sql) && sql[i] != '`' {
+				i++
+			}
+			if i < len(sql) {
+				i++
+			}
+		case c == '?':
+			positions = append(positions, i)
+			i++
+		default:
+			i++
+		}
+	}
+	return positions
+}
+
 // translatePlaceholders maps each ? outside strings/comments to @p0, @p1, ...
 func translatePlaceholders(sql string, paramCount int) (string, error) {
-	n := countParamPlaceholders(sql)
+	positions := findBarePlaceholders(sql)
+	n := len(positions)
 	if n == 0 {
 		if paramCount > 0 {
 			return "", &connectors.ValidationError{Message: "sql must use ? placeholders when params is non-empty"}
@@ -22,159 +110,16 @@ func translatePlaceholders(sql string, paramCount int) (string, error) {
 	}
 	var b strings.Builder
 	b.Grow(len(sql) + paramCount*4)
-	i := 0
-	idx := 0
-	for i < len(sql) {
-		c := sql[i]
-		switch {
-		case c == '-' && i+1 < len(sql) && sql[i+1] == '-':
-			b.WriteString(sql[i : i+2])
-			i += 2
-			for i < len(sql) && sql[i] != '\n' {
-				b.WriteByte(sql[i])
-				i++
-			}
-		case c == '/' && i+1 < len(sql) && sql[i+1] == '*':
-			end := strings.Index(sql[i+2:], "*/")
-			if end < 0 {
-				b.WriteString(sql[i:])
-				return b.String(), nil
-			}
-			end += i + 2
-			b.WriteString(sql[i : end+2])
-			i = end + 2
-		case c == '\'':
-			start := i
-			i++
-			for i < len(sql) {
-				if sql[i] == '\'' {
-					if i+1 < len(sql) && sql[i+1] == '\'' {
-						i += 2
-						continue
-					}
-					i++
-					break
-				}
-				if sql[i] == '\\' && i+1 < len(sql) {
-					i += 2
-					continue
-				}
-				_, w := utf8.DecodeRuneInString(sql[i:])
-				i += w
-			}
-			b.WriteString(sql[start:i])
-		case c == '"':
-			start := i
-			i++
-			for i < len(sql) {
-				if sql[i] == '"' {
-					if i+1 < len(sql) && sql[i+1] == '"' {
-						i += 2
-						continue
-					}
-					i++
-					break
-				}
-				if sql[i] == '\\' && i+1 < len(sql) {
-					i += 2
-					continue
-				}
-				_, w := utf8.DecodeRuneInString(sql[i:])
-				i += w
-			}
-			b.WriteString(sql[start:i])
-		case c == '`':
-			start := i
-			i++
-			for i < len(sql) && sql[i] != '`' {
-				i++
-			}
-			if i < len(sql) {
-				i++
-			}
-			b.WriteString(sql[start:i])
-		case c == '?':
-			fmt.Fprintf(&b, "@p%d", idx)
-			idx++
-			i++
-		default:
-			b.WriteByte(c)
-			i++
-		}
+	prev := 0
+	for idx, pos := range positions {
+		b.WriteString(sql[prev:pos])
+		fmt.Fprintf(&b, "@p%d", idx)
+		prev = pos + 1
 	}
+	b.WriteString(sql[prev:])
 	return b.String(), nil
 }
 
 func countParamPlaceholders(sql string) int {
-	n := 0
-	i := 0
-	for i < len(sql) {
-		c := sql[i]
-		switch {
-		case c == '-' && i+1 < len(sql) && sql[i+1] == '-':
-			i += 2
-			for i < len(sql) && sql[i] != '\n' {
-				i++
-			}
-		case c == '/' && i+1 < len(sql) && sql[i+1] == '*':
-			i += 2
-			for i+1 < len(sql) {
-				if sql[i] == '*' && sql[i+1] == '/' {
-					i += 2
-					break
-				}
-				i++
-			}
-		case c == '\'':
-			i++
-			for i < len(sql) {
-				if sql[i] == '\'' {
-					if i+1 < len(sql) && sql[i+1] == '\'' {
-						i += 2
-						continue
-					}
-					i++
-					break
-				}
-				if sql[i] == '\\' && i+1 < len(sql) {
-					i += 2
-					continue
-				}
-				_, w := utf8.DecodeRuneInString(sql[i:])
-				i += w
-			}
-		case c == '"':
-			i++
-			for i < len(sql) {
-				if sql[i] == '"' {
-					if i+1 < len(sql) && sql[i+1] == '"' {
-						i += 2
-						continue
-					}
-					i++
-					break
-				}
-				if sql[i] == '\\' && i+1 < len(sql) {
-					i += 2
-					continue
-				}
-				_, w := utf8.DecodeRuneInString(sql[i:])
-				i += w
-			}
-		case c == '`':
-			i++
-			for i < len(sql) && sql[i] != '`' {
-				i++
-			}
-			if i < len(sql) {
-				i++
-			}
-		case c == '?':
-			n++
-			i++
-		default:
-			i++
-		}
-	}
-	return n
+	return len(findBarePlaceholders(sql))
 }

--- a/connectors/bigquery/sql_scan_test.go
+++ b/connectors/bigquery/sql_scan_test.go
@@ -29,6 +29,43 @@ func TestTranslatePlaceholders_skipsComment(t *testing.T) {
 	}
 }
 
+func TestTranslatePlaceholders_tripleQuotedSingle(t *testing.T) {
+	t.Parallel()
+	sql := "SELECT * FROM t WHERE x = '''Did you mean ?'''"
+	out, err := translatePlaceholders(sql, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != sql {
+		t.Fatalf("got %q want unchanged", out)
+	}
+}
+
+func TestTranslatePlaceholders_tripleQuotedDouble(t *testing.T) {
+	t.Parallel()
+	sql := `SELECT * FROM t WHERE x = """Did you mean ?"""`
+	out, err := translatePlaceholders(sql, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != sql {
+		t.Fatalf("got %q want unchanged", out)
+	}
+}
+
+func TestTranslatePlaceholders_tripleQuotedWithBarePlaceholder(t *testing.T) {
+	t.Parallel()
+	sql := `SELECT * FROM t WHERE x = """hello?""" AND y = ?`
+	out, err := translatePlaceholders(sql, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `SELECT * FROM t WHERE x = """hello?""" AND y = @p0`
+	if out != want {
+		t.Fatalf("got %q want %q", out, want)
+	}
+}
+
 func TestCoerceParamValue_delegates(t *testing.T) {
 	t.Parallel()
 	v := coerceParamValue(float64(7))

--- a/pkg/sqldb/json_params.go
+++ b/pkg/sqldb/json_params.go
@@ -10,8 +10,10 @@ import (
 func CoerceJSONParamValue(v interface{}) interface{} {
 	switch x := v.(type) {
 	case float64:
+		// float64(math.MaxInt64) rounds up to 9223372036854775808.0 (= 2^63),
+		// so strict less-than already excludes the overflow value.
 		if !math.IsNaN(x) && !math.IsInf(x, 0) && x == math.Trunc(x) &&
-			x >= float64(math.MinInt64) && x < float64(math.MaxInt64)+1 {
+			x >= float64(math.MinInt64) && x < float64(math.MaxInt64) {
 			return int64(x)
 		}
 		return x

--- a/pkg/sqldb/json_params.go
+++ b/pkg/sqldb/json_params.go
@@ -10,7 +10,8 @@ import (
 func CoerceJSONParamValue(v interface{}) interface{} {
 	switch x := v.(type) {
 	case float64:
-		if !math.IsNaN(x) && !math.IsInf(x, 0) && x == math.Trunc(x) && x >= math.MinInt64 && x <= math.MaxInt64 {
+		if !math.IsNaN(x) && !math.IsInf(x, 0) && x == math.Trunc(x) &&
+			x >= float64(math.MinInt64) && x < float64(math.MaxInt64)+1 {
 			return int64(x)
 		}
 		return x

--- a/pkg/sqldb/readonly_sql.go
+++ b/pkg/sqldb/readonly_sql.go
@@ -148,16 +148,17 @@ func scrubSQLMasking(sql string) string {
 				i += w
 			}
 		case c == '`':
-			// Preserve backtick-quoted identifiers as underscores so they
-			// remain valid identifier tokens for CTE name parsing.
-			b.WriteByte('_')
+			// Emit a space for the opening backtick so the identifier does not
+			// merge with any preceding keyword, then replace interior bytes
+			// with underscores so the result is a valid identifier token.
+			b.WriteByte(' ')
 			i++
 			for i < len(sql) && sql[i] != '`' {
 				b.WriteByte('_')
 				i++
 			}
 			if i < len(sql) {
-				b.WriteByte('_')
+				b.WriteByte(' ') // closing backtick → space (boundary)
 				i++
 			}
 		default:

--- a/pkg/sqldb/readonly_sql.go
+++ b/pkg/sqldb/readonly_sql.go
@@ -63,8 +63,8 @@ func scrubSQLMasking(sql string) string {
 			b.WriteByte(' ')
 			b.WriteByte(' ')
 			i += 2
-			for i+1 < len(sql) {
-				if sql[i] == '*' && sql[i+1] == '/' {
+			for i < len(sql) {
+				if i+1 < len(sql) && sql[i] == '*' && sql[i+1] == '/' {
 					b.WriteByte(' ')
 					b.WriteByte(' ')
 					i += 2
@@ -72,6 +72,26 @@ func scrubSQLMasking(sql string) string {
 				}
 				b.WriteByte(' ')
 				i++
+			}
+		case (c == '\'' || c == '"') && i+2 < len(sql) && sql[i+1] == c && sql[i+2] == c:
+			// Triple-quoted string (BigQuery """...""" or '''...''')
+			b.WriteByte(' ')
+			b.WriteByte(' ')
+			b.WriteByte(' ')
+			i += 3
+			for i < len(sql) {
+				if i+2 < len(sql) && sql[i] == c && sql[i+1] == c && sql[i+2] == c {
+					b.WriteByte(' ')
+					b.WriteByte(' ')
+					b.WriteByte(' ')
+					i += 3
+					break
+				}
+				_, w := utf8.DecodeRuneInString(sql[i:])
+				for k := 0; k < w; k++ {
+					b.WriteByte(' ')
+				}
+				i += w
 			}
 		case c == '\'':
 			b.WriteByte(' ')
@@ -128,14 +148,16 @@ func scrubSQLMasking(sql string) string {
 				i += w
 			}
 		case c == '`':
-			b.WriteByte(' ')
+			// Preserve backtick-quoted identifiers as underscores so they
+			// remain valid identifier tokens for CTE name parsing.
+			b.WriteByte('_')
 			i++
 			for i < len(sql) && sql[i] != '`' {
-				b.WriteByte(' ')
+				b.WriteByte('_')
 				i++
 			}
 			if i < len(sql) {
-				b.WriteByte(' ')
+				b.WriteByte('_')
 				i++
 			}
 		default:

--- a/pkg/sqldb/readonly_sql_test.go
+++ b/pkg/sqldb/readonly_sql_test.go
@@ -56,6 +56,14 @@ func TestValidateReadOnlyWarehouseSQL_backtickCTEName(t *testing.T) {
 	}
 }
 
+func TestValidateReadOnlyWarehouseSQL_backtickCTENameNoWhitespace(t *testing.T) {
+	t.Parallel()
+	// Backtick identifier directly adjacent to keywords (no whitespace) must still be accepted.
+	if err := ValidateReadOnlyWarehouseSQL("WITH`my-cte`AS(SELECT 1) SELECT * FROM t"); err != nil {
+		t.Fatalf("backtick CTE name without whitespace should be accepted: %v", err)
+	}
+}
+
 func TestValidateReadOnlyWarehouseSQL_tripleQuotedString(t *testing.T) {
 	t.Parallel()
 	// Triple-quoted string containing DELETE should not trigger keyword rejection

--- a/pkg/sqldb/readonly_sql_test.go
+++ b/pkg/sqldb/readonly_sql_test.go
@@ -49,10 +49,45 @@ func TestValidateReadOnlyWarehouseSQL_notWITHIN(t *testing.T) {
 	}
 }
 
+func TestValidateReadOnlyWarehouseSQL_backtickCTEName(t *testing.T) {
+	t.Parallel()
+	if err := ValidateReadOnlyWarehouseSQL("WITH `my-dataset` AS (SELECT 1) SELECT * FROM `my-dataset`"); err != nil {
+		t.Fatalf("backtick CTE name should be accepted: %v", err)
+	}
+}
+
+func TestValidateReadOnlyWarehouseSQL_tripleQuotedString(t *testing.T) {
+	t.Parallel()
+	// Triple-quoted string containing DELETE should not trigger keyword rejection
+	if err := ValidateReadOnlyWarehouseSQL(`SELECT * FROM t WHERE x = """DELETE"""`); err != nil {
+		t.Fatalf("triple-quoted string should be masked: %v", err)
+	}
+}
+
+func TestScrubSQLMasking_unterminatedBlockComment(t *testing.T) {
+	t.Parallel()
+	sql := "SELECT 1 /* note: DELET"
+	scrubbed := scrubSQLMasking(sql)
+	// The final byte of the unterminated comment must be masked
+	if strings.ContainsAny(scrubbed[len("SELECT 1 "):], "DELET/*") {
+		t.Fatalf("unterminated block comment leaked bytes: %q", scrubbed)
+	}
+}
+
 func TestCoerceJSONParamValue_floatWhole(t *testing.T) {
 	t.Parallel()
 	v := CoerceJSONParamValue(float64(42))
 	if i, ok := v.(int64); !ok || i != 42 {
 		t.Fatalf("got %T %v", v, v)
+	}
+}
+
+func TestCoerceJSONParamValue_maxInt64Boundary(t *testing.T) {
+	t.Parallel()
+	// float64(math.MaxInt64) rounds up to 9223372036854775808.0 which overflows int64.
+	// It must remain a float64 and NOT be converted to int64.
+	v := CoerceJSONParamValue(float64(9.223372036854776e18))
+	if _, ok := v.(float64); !ok {
+		t.Fatalf("value near MaxInt64 boundary should stay float64, got %T %v", v, v)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `int64` overflow at `MaxInt64` boundary in `CoerceJSONParamValue` — use strict upper-bound `x < float64(MaxInt64)+1` to prevent silent wraparound
- Fix unterminated `/* */` block comment leaking its final byte through `scrubSQLMasking`
- Fix backtick-quoted CTE names (e.g. `` WITH `my-dataset` AS (...) ``) rejected by `mainKeywordAfterCTEs` — replace backtick content with underscores instead of spaces so it parses as a valid identifier
- Add triple-quoted string support (`"""..."""` and `'''...'''`) to both `scrubSQLMasking` and the BigQuery placeholder scanner
- Deduplicate SQL scanning: extract shared `findBarePlaceholders()` used by both `countParamPlaceholders` and `translatePlaceholders`, eliminating ~70 lines of duplicated state machine code

Closes #205

## Test plan

### Developer
- [x] `go test ./pkg/sqldb/...` — all 17 tests pass including new tests for backtick CTE names, triple-quoted strings, unterminated block comments, and MaxInt64 boundary
- [x] BigQuery `sql_scan.go` logic verified via standalone test (BigQuery SDK requires Go 1.25+ unavailable in sandbox)

### Manual Testing
- [ ] Verify BigQuery queries with triple-quoted strings containing `?` don't produce placeholder errors
- [ ] Verify `WITH \`hyphenated-name\` AS (...)` queries pass validation

https://claude.ai/code/session_01AaRFTUVHq8v81ejNgtUx2J