### PR TITLE
Add support page with email and GitHub options

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { AppLayout } from "./components/AppLayout";
 import { PrivacyPolicyPage } from "./pages/policy/PrivacyPolicyPage";
 import { TermsOfServicePage } from "./pages/policy/TermsOfServicePage";
 import { CookiePolicyPage } from "./pages/policy/CookiePolicyPage";
+import { SupportPage } from "./pages/support/SupportPage";
 import { useProfile } from "./hooks/useProfile";
 import { appRoutes } from "./routes";
 
@@ -61,13 +62,14 @@ function App() {
     }
   }, [authStatus, user]);
 
-  // Policy pages are public — render without auth.
-  if (pathname.startsWith("/policy/")) {
+  // Policy and support pages are public — render without auth.
+  if (pathname.startsWith("/policy/") || pathname === "/support") {
     return (
       <SentryRoutes>
         <Route path="/policy/privacy" element={<PrivacyPolicyPage />} />
         <Route path="/policy/terms" element={<TermsOfServicePage />} />
         <Route path="/policy/cookies" element={<CookiePolicyPage />} />
+        <Route path="/support" element={<SupportPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </SentryRoutes>
     );

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -22,7 +22,7 @@ export function Footer({ className }: FooterProps) {
         <Link to="/policy/privacy" className={linkClass}>Privacy Policy</Link>
         <Link to="/policy/terms" className={linkClass}>Terms of Service</Link>
         <Link to="/policy/cookies" className={linkClass}>Cookie Policy</Link>
-        <a href="mailto:support@supersuit.tech" className={linkClass}>Support</a>
+        <Link to="/support" className={linkClass}>Support</Link>
         <button type="button" onClick={resetConsent} className={linkClass}>Manage Cookies</button>
       </div>
     </footer>

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -71,11 +71,9 @@ export function UserMenu() {
             </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
-          <DropdownMenuItem asChild>
-            <a href="mailto:support@supersuit.tech">
-              <LifeBuoy />
-              <span>Support</span>
-            </a>
+          <DropdownMenuItem onSelect={() => navigate("/support")}>
+            <LifeBuoy />
+            <span>Support</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuCheckboxItem

--- a/frontend/src/pages/support/SupportPage.tsx
+++ b/frontend/src/pages/support/SupportPage.tsx
@@ -1,0 +1,39 @@
+import { Mail, Github } from "lucide-react";
+import { PolicyLayout } from "../policy/PolicyLayout";
+
+export function SupportPage() {
+  return (
+    <PolicyLayout title="Support">
+      <p>
+        Need help with Permission Slip? We&apos;re here for you. Choose the
+        option that works best and we&apos;ll get back to you as soon as we can.
+      </p>
+
+      <div className="not-prose mt-8 grid gap-4 sm:grid-cols-2">
+        <a
+          href="mailto:support@supersuit.tech"
+          className="flex flex-col items-center gap-3 rounded-lg border bg-card p-6 text-center transition-colors hover:bg-accent"
+        >
+          <Mail className="size-8 text-primary" />
+          <span className="text-lg font-semibold">Email Support</span>
+          <span className="text-sm text-muted-foreground">
+            Send us an email at support@supersuit.tech
+          </span>
+        </a>
+
+        <a
+          href="https://github.com/supersuit-tech/permission-slip"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex flex-col items-center gap-3 rounded-lg border bg-card p-6 text-center transition-colors hover:bg-accent"
+        >
+          <Github className="size-8 text-primary" />
+          <span className="text-lg font-semibold">GitHub</span>
+          <span className="text-sm text-muted-foreground">
+            Open an issue or browse discussions on GitHub
+          </span>
+        </a>
+      </div>
+    </PolicyLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a public `/support` page with introductory text and two contact options: email support (support@supersuit.tech) and GitHub issues (supersuit-tech/permission-slip)
- Updates the Footer and UserMenu support links to navigate to `/support` instead of opening a raw mailto link
- Support page is public (no auth required), consistent with policy pages

## Test plan

### Developer
- [x] TypeScript compiles with no errors
- [x] All 959 frontend tests pass

### Manual Testing
- [ ] Visit `/support` while logged out — page renders with both contact buttons
- [ ] Visit `/support` while logged in — page renders correctly
- [ ] Click "Email Support" button — opens email client with support@supersuit.tech
- [ ] Click "GitHub" button — opens GitHub repo in new tab
- [ ] Click "Support" in the footer — navigates to `/support`
- [ ] Click "Support" in the user menu dropdown — navigates to `/support`

https://claude.ai/code/session_01938nQEt1HdcqeDhgTZuchN