### PR TITLE
Hide opaque Slack fields, add user remote-select picker

### DIFF
--- a/api/agent_connector_users.go
+++ b/api/agent_connector_users.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+	"github.com/supersuit-tech/permission-slip-web/db"
+)
+
+type userListResponse struct {
+	Data []connectors.UserListItem `json:"data"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentConnectorUserRoutes)
+}
+
+// RegisterAgentConnectorUserRoutes registers session-authenticated endpoints
+// that proxy user metadata for action configuration UIs (e.g. Slack user picker).
+func RegisterAgentConnectorUserRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /agents/{agent_id}/connectors/{connector_id}/users", requireProfile(handleListAgentConnectorUsers(deps)))
+}
+
+func handleListAgentConnectorUsers(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		lister, ok := conn.(connectors.UserLister)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "This connector does not support user listing"))
+			return
+		}
+
+		listAction := lister.UserListCredentialActionType()
+		connErrCtx := ConnectorContext{
+			ConnectorID: connectorID,
+			ActionType:  listAction,
+			AgentID:     agentID,
+		}
+		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorUsers required creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to look up connector credentials"))
+			return
+		}
+
+		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorUsers resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorUsers validate creds: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
+
+		items, err := lister.ListUsers(r.Context(), creds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListUsers: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list users"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, userListResponse{Data: items})
+	}
+}

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -150,3 +150,23 @@ type ChannelLister interface {
 	ChannelListCredentialActionType() string
 }
 
+// UserListItem is one user row for dashboard pickers (e.g. Slack user select).
+type UserListItem struct {
+	ID           string `json:"id"`
+	Name         string `json:"name,omitempty"`
+	RealName     string `json:"real_name,omitempty"`
+	DisplayName  string `json:"display_name,omitempty"`
+	Email        string `json:"email,omitempty"`
+	IsBot        bool   `json:"is_bot,omitempty"`
+	DisplayLabel string `json:"display_label"`
+}
+
+// UserLister is optionally implemented by connectors that can list users
+// for UI configuration (session-authenticated proxy endpoints).
+type UserLister interface {
+	ListUsers(ctx context.Context, creds Credentials) ([]UserListItem, error)
+	// UserListCredentialActionType is the connector_actions.action_type used
+	// to look up required credentials for this list call (must exist in the DB).
+	UserListCredentialActionType() string
+}
+

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -165,7 +165,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["channel", "thread_ts"],
+					"required": ["channel"],
 					"properties": {
 						"channel": {
 							"type": "string",
@@ -182,7 +182,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"thread_ts": {
 							"type": "string",
 							"description": "Timestamp of the parent message (e.g. 1234567890.123456)",
-							"x-ui": {"label": "Thread ID", "placeholder": "1234567890.123456", "help_text": "The unique timestamp ID of the parent message that started the thread"}
+							"x-ui": {"hidden": true}
 						},
 						"limit": {
 							"type": "integer",
@@ -286,7 +286,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"users": {
 							"type": "string",
 							"description": "Comma-separated list of user IDs to invite (e.g. U01234567,U09876543)",
-							"x-ui": {"label": "User IDs", "placeholder": "U01234567,U09876543", "help_text": "Comma-separated Slack user IDs to invite"}
+							"x-ui": {
+								"widget": "remote-select",
+								"label": "User",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/users",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "User ID (e.g. U01234567)",
+								"help_text": "Choose a user or enter a user ID."
+							}
 						}
 					}
 				}`)),
@@ -337,7 +345,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["channel", "timestamp", "name"],
+					"required": ["channel", "name"],
 					"properties": {
 						"channel": {
 							"type": "string",
@@ -354,7 +362,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"timestamp": {
 							"type": "string",
 							"description": "Timestamp of the message to react to (e.g. 1234567890.123456)",
-							"x-ui": {"label": "Message ID", "placeholder": "1234567890.123456", "help_text": "The unique timestamp ID of the message to react to"}
+							"x-ui": {"hidden": true}
 						},
 						"name": {
 							"type": "string",
@@ -376,7 +384,15 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"user_id": {
 							"type": "string",
 							"description": "User ID to send the DM to (e.g. U01234567)",
-							"x-ui": {"label": "Recipient", "placeholder": "U01234567", "help_text": "The Slack user ID to send the direct message to"}
+							"x-ui": {
+								"widget": "remote-select",
+								"label": "Recipient",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/users",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "User ID (e.g. U01234567)",
+								"help_text": "Choose a user or enter a user ID."
+							}
 						},
 						"message": {
 							"type": "string",
@@ -393,7 +409,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["channel", "ts", "message"],
+					"required": ["channel", "message"],
 					"properties": {
 						"channel": {
 							"type": "string",
@@ -410,7 +426,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"ts": {
 							"type": "string",
 							"description": "Timestamp of the message to update (e.g. 1234567890.123456)",
-							"x-ui": {"label": "Message ID", "placeholder": "1234567890.123456", "help_text": "The unique timestamp ID of the message to update"}
+							"x-ui": {"hidden": true}
 						},
 						"message": {
 							"type": "string",
@@ -427,7 +443,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				RiskLevel:   "high",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
-					"required": ["channel", "ts"],
+					"required": ["channel"],
 					"properties": {
 						"channel": {
 							"type": "string",
@@ -444,7 +460,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 						"ts": {
 							"type": "string",
 							"description": "Timestamp of the message to delete (e.g. 1234567890.123456)",
-							"x-ui": {"label": "Message ID", "placeholder": "1234567890.123456", "help_text": "The unique timestamp ID of the message to delete"}
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),

--- a/connectors/slack/user_lister.go
+++ b/connectors/slack/user_lister.go
@@ -1,0 +1,97 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip-web/connectors"
+)
+
+var _ connectors.UserLister = (*SlackConnector)(nil)
+
+const slackUserListMaxPages = 50
+
+// UserListCredentialActionType returns the action type used for credential
+// resolution on the agent connector users API.
+func (c *SlackConnector) UserListCredentialActionType() string {
+	return "slack.list_users"
+}
+
+// ListUsers returns workspace users for dashboard pickers, paginating until
+// Slack returns no next_cursor or a safety cap is hit.
+func (c *SlackConnector) ListUsers(ctx context.Context, creds connectors.Credentials) ([]connectors.UserListItem, error) {
+	var all []listUserSummary
+	seen := make(map[string]bool)
+	cursor := ""
+	for page := 0; page < slackUserListMaxPages; page++ {
+		body := listUsersRequest{
+			Limit:  200,
+			Cursor: cursor,
+		}
+
+		var resp listUsersResponse
+		if err := c.doPost(ctx, "users.list", creds, body, &resp); err != nil {
+			return nil, err
+		}
+		if !resp.OK {
+			return nil, resp.asError()
+		}
+
+		for _, u := range resp.Members {
+			if seen[u.ID] {
+				continue
+			}
+			// Skip deleted users and bots from picker.
+			if u.Deleted || u.IsBot {
+				continue
+			}
+			seen[u.ID] = true
+			all = append(all, listUserSummary{
+				ID:          u.ID,
+				Name:        u.Name,
+				RealName:    u.RealName,
+				DisplayName: u.Profile.DisplayName,
+				Email:       u.Profile.Email,
+				IsBot:       u.IsBot,
+				IsAdmin:     u.IsAdmin,
+				Deleted:     u.Deleted,
+			})
+		}
+
+		if resp.Meta == nil || resp.Meta.NextCursor == "" {
+			break
+		}
+		cursor = resp.Meta.NextCursor
+	}
+
+	out := make([]connectors.UserListItem, 0, len(all))
+	for _, u := range all {
+		out = append(out, connectors.UserListItem{
+			ID:           u.ID,
+			Name:         u.Name,
+			RealName:     u.RealName,
+			DisplayName:  u.DisplayName,
+			Email:        u.Email,
+			IsBot:        u.IsBot,
+			DisplayLabel: slackUserPickerLabel(u),
+		})
+	}
+	return out, nil
+}
+
+// slackUserPickerLabel builds a human-readable label for the user picker.
+func slackUserPickerLabel(u listUserSummary) string {
+	name := u.RealName
+	if name == "" {
+		name = u.DisplayName
+	}
+	if name == "" {
+		name = u.Name
+	}
+	if name == "" {
+		return u.ID
+	}
+	if u.Email != "" {
+		return name + " (" + u.Email + ")"
+	}
+	return name
+}

--- a/frontend/src/hooks/useAgentConnectorUsers.ts
+++ b/frontend/src/hooks/useAgentConnectorUsers.ts
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import { useAgentConnectorCredential } from "./useAgentConnectorCredential";
+
+export type RemoteUserRow = Record<string, unknown>;
+
+/** Resolve the API base (mirrors api/client.ts normalizeBase). */
+function apiBase(): string {
+  const envUrl = import.meta.env.VITE_API_BASE_URL;
+  if (!envUrl) return "/api";
+  return (envUrl as string).replace(/\/v1\/?$/, "").replace(/\/$/, "");
+}
+
+export function useAgentConnectorUsers(agentId: number, connectorId: string) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const { binding, isCredentialBindingPending } =
+    useAgentConnectorCredential(agentId, connectorId);
+
+  const hasCredential = !!(
+    binding?.oauth_connection_id ?? binding?.credential_id
+  );
+
+  const query = useQuery({
+    queryKey: ["agent-connector-users", agentId, connectorId],
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Missing access token");
+      const base = apiBase();
+      const res = await fetch(
+        `${base}/v1/agents/${agentId}/connectors/${connectorId}/users`,
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+      if (!res.ok) throw new Error("Failed to load users");
+      const json = (await res.json()) as { data?: unknown[] };
+      const rows = json?.data;
+      if (!Array.isArray(rows)) return [] as RemoteUserRow[];
+      return rows as RemoteUserRow[];
+    },
+    enabled: !!accessToken && agentId > 0 && !!connectorId && hasCredential,
+  });
+
+  return {
+    users: query.data ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.isError ? query.error : null,
+    hasCredential,
+    isCredentialBindingPending,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -199,13 +199,18 @@ export function ActionSelect({
  * Returns the names of required parameters that have empty (non-wildcard) values.
  * Used to prevent submitting a form with required params accidentally omitted
  * (e.g. after toggling from wildcard to fixed without entering a value).
+ *
+ * Hidden fields (x-ui.hidden) are excluded — they are auto-wildcarded at
+ * submission time and should never block the user.
  */
 export function getEmptyRequiredParams(
   paramValues: Record<string, string>,
   requiredFields?: string[],
+  schemaProperties?: Record<string, { "x-ui"?: { hidden?: boolean } }>,
 ): string[] {
   if (!requiredFields?.length) return [];
   return requiredFields.filter((key) => {
+    if (schemaProperties?.[key]?.["x-ui"]?.hidden) return false;
     const value = paramValues[key];
     return value === undefined || value === "";
   });
@@ -222,13 +227,26 @@ export type ParamMode = "fixed" | "pattern" | "wildcard";
  * Wildcard parameters (mode === "wildcard") are stored as "*".
  * Values containing "*" are auto-detected as patterns and wrapped as
  * {"$pattern": "<glob>"} for backend pattern matching.
+ *
+ * Hidden fields (x-ui.hidden) are automatically included as wildcards so the
+ * backend config allows the agent to pass any value for those parameters.
  */
 export function buildParametersFromForm(
   paramValues: Record<string, string>,
-  schemaProperties?: Record<string, { type?: string }>,
+  schemaProperties?: Record<string, { type?: string; "x-ui"?: { hidden?: boolean } }>,
   paramModes?: Record<string, ParamMode>,
 ): Record<string, unknown> {
   const parameters: Record<string, unknown> = {};
+
+  // Auto-wildcard hidden fields not already in paramValues.
+  if (schemaProperties) {
+    for (const [key, prop] of Object.entries(schemaProperties)) {
+      if (prop["x-ui"]?.hidden && !(key in paramValues)) {
+        parameters[key] = "*";
+      }
+    }
+  }
+
   for (const [key, value] of Object.entries(paramValues)) {
     if (value === "") continue;
 

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -140,7 +140,7 @@ export function AddActionConfigDialog({
       return;
     }
 
-    const emptyRequired = getEmptyRequiredParams(paramValues, schema?.required);
+    const emptyRequired = getEmptyRequiredParams(paramValues, schema?.required, schema?.properties);
     if (emptyRequired.length > 0) {
       toast.error(`Required parameters need a value or wildcard: ${emptyRequired.join(", ")}`);
       return;

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -92,7 +92,7 @@ export function EditActionConfigDialog({
       return;
     }
 
-    const emptyRequired = getEmptyRequiredParams(paramValues, schema?.required);
+    const emptyRequired = getEmptyRequiredParams(paramValues, schema?.required, schema?.properties);
     if (emptyRequired.length > 0) {
       toast.error(`Required parameters need a value or wildcard: ${emptyRequired.join(", ")}`);
       return;

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -8,6 +8,7 @@ import { inferWidgetFromProperty } from "@/lib/parameterSchema";
 import { isConcreteDatetimeString } from "@/lib/datetime";
 import { CalendarRemoteSelectWidget } from "./CalendarRemoteSelectWidget";
 import { SlackChannelRemoteSelectWidget } from "./SlackChannelRemoteSelectWidget";
+import { SlackUserRemoteSelectWidget } from "./SlackUserRemoteSelectWidget";
 
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
@@ -147,6 +148,21 @@ function RemoteSelectField({
   if (connectorId === "slack" && path.endsWith("/channels")) {
     return (
       <SlackChannelRemoteSelectWidget
+        inputId={inputId}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className}
+        agentId={agentId}
+        connectorId={connectorId}
+        ui={propertyUI}
+      />
+    );
+  }
+  if (connectorId === "slack" && path.endsWith("/users")) {
+    return (
+      <SlackUserRemoteSelectWidget
         inputId={inputId}
         value={value}
         onChange={onChange}

--- a/frontend/src/pages/agents/connectors/SlackUserRemoteSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/SlackUserRemoteSelectWidget.tsx
@@ -1,0 +1,228 @@
+import { useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { SchemaPropertyUI } from "@/lib/parameterSchema";
+import { useAgentConnectorUsers } from "@/hooks/useAgentConnectorUsers";
+
+export interface SlackUserRemoteSelectWidgetProps {
+  inputId: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  agentId: number;
+  connectorId: string;
+  ui: Pick<
+    SchemaPropertyUI,
+    | "help_text"
+    | "remote_select_options_path"
+    | "remote_select_id_key"
+    | "remote_select_label_key"
+    | "remote_select_fallback_placeholder"
+  >;
+}
+
+const DEFAULT_NO_CREDENTIAL =
+  "Connect a Slack credential to select a user.";
+
+function readLabel(row: Record<string, unknown>, labelKey: string): string {
+  const direct = row[labelKey];
+  if (typeof direct === "string" && direct.length > 0) return direct;
+  const displayLabel = row.display_label;
+  if (typeof displayLabel === "string" && displayLabel.length > 0)
+    return displayLabel;
+  const id = row.id;
+  return typeof id === "string" ? id : "";
+}
+
+export function SlackUserRemoteSelectWidget({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  agentId,
+  connectorId,
+  ui,
+}: SlackUserRemoteSelectWidgetProps) {
+  const [manual, setManual] = useState(false);
+  const {
+    users,
+    isLoading,
+    isFetching,
+    error,
+    hasCredential,
+    isCredentialBindingPending,
+    refetch,
+  } = useAgentConnectorUsers(agentId, connectorId);
+
+  const labelKey = ui.remote_select_label_key ?? "display_label";
+
+  const options = useMemo(() => {
+    const rows = users.map((row) => {
+      const idRaw = row[ui.remote_select_id_key ?? "id"];
+      const id = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
+      const label = readLabel(row, labelKey);
+      return { id, label: label || id };
+    });
+    if (value && !rows.some((r) => r.id === value)) {
+      return [{ id: value, label: value }, ...rows];
+    }
+    return rows;
+  }, [users, ui.remote_select_id_key, labelKey, value]);
+
+  const noCredentialText = ui.help_text?.trim() || DEFAULT_NO_CREDENTIAL;
+  const selectDisabled = disabled || isLoading || isFetching;
+  const usersReady = hasCredential && !isLoading && !isFetching && !error;
+
+  if (manual) {
+    return (
+      <div className="space-y-2">
+        <Input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={
+            ui.remote_select_fallback_placeholder ??
+            placeholder ??
+            "User ID (e.g. U01234567)"
+          }
+          className={className}
+          data-testid={`slack-user-remote-select-manual-${inputId}`}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(false)}
+        >
+          Use list
+        </Button>
+      </div>
+    );
+  }
+
+  if (isCredentialBindingPending) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          aria-busy="true"
+          className={`border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+          data-testid={`slack-user-remote-select-binding-pending-${inputId}`}
+        >
+          <option value="">Checking credentials…</option>
+        </select>
+      </div>
+    );
+  }
+
+  if (!hasCredential) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          className={`border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+          data-testid={`slack-user-remote-select-disabled-${inputId}`}
+        >
+          <option value="">{noCredentialText}</option>
+        </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(true)}
+        >
+          Enter user ID manually
+        </Button>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">
+          Could not load users.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => void refetch()}
+          >
+            Retry
+          </button>
+          {" · "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter manually
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <select
+        id={inputId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={selectDisabled}
+        aria-busy={isLoading || isFetching ? "true" : undefined}
+        className={`border-input bg-background ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50${className ? ` ${className}` : ""}`}
+        data-testid={`slack-user-remote-select-${inputId}`}
+      >
+        <option value="">
+          {isLoading || isFetching ? "Loading…" : placeholder ?? "Select user…"}
+        </option>
+        {options.map((opt) => (
+          <option key={opt.id} value={opt.id}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      {usersReady && options.length === 0 && (
+        <p className="text-muted-foreground text-xs">
+          No users returned.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter a user ID manually
+          </button>
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-auto px-0 text-xs"
+        disabled={disabled}
+        onClick={() => setManual(true)}
+      >
+        Enter manually
+      </Button>
+    </div>
+  );
+}

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -408,6 +408,56 @@ agentConnectorCalendars:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+agentConnectorUsers:
+  get:
+    operationId: listAgentConnectorUsers
+    summary: List users for agent connector
+    description: |
+      Returns workspace users visible to the OAuth credential assigned to this agent–connector pair.
+      Used by the dashboard to populate user pickers for Slack actions.
+
+      Requires session authentication (Supabase JWT). The agent must belong to the current user.
+
+    tags:
+      - Agents
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+
+    responses:
+      '200':
+        description: Users listed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorUserListResponse'
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Agent, connector, or user listing not supported
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
 agentConnectorChannels:
   get:
     operationId: listAgentConnectorChannels

--- a/spec/openapi/components/schemas/agent_connectors.yaml
+++ b/spec/openapi/components/schemas/agent_connectors.yaml
@@ -211,6 +211,44 @@ AgentConnectorChannelListResponse:
       items:
         $ref: '../schemas/agent_connectors.yaml#/ChannelListItem'
 
+UserListItem:
+  type: object
+  required:
+    - id
+    - display_label
+  properties:
+    id:
+      type: string
+      description: Slack user ID (U…).
+    name:
+      type: string
+      description: Slack username.
+    real_name:
+      type: string
+      description: User's real name.
+    display_name:
+      type: string
+      description: User's display name.
+    email:
+      type: string
+      description: User's email address when available.
+    is_bot:
+      type: boolean
+      description: True for bot users.
+    display_label:
+      type: string
+      description: Human-readable label for pickers (real name with email).
+
+AgentConnectorUserListResponse:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: '../schemas/agent_connectors.yaml#/UserListItem'
+
 AgentConnectorCredentialResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1727,6 +1727,45 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/users:
+    get:
+      operationId: listAgentConnectorUsers
+      summary: List users for agent connector
+      description: |
+        Returns workspace users visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate user pickers for Slack actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Users listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorUserListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or user listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/registration-invites:
     post:
       operationId: createRegistrationInvite
@@ -11472,6 +11511,42 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChannelListItem'
+    UserListItem:
+      type: object
+      required:
+        - id
+        - display_label
+      properties:
+        id:
+          type: string
+          description: Slack user ID (U…).
+        name:
+          type: string
+          description: Slack username.
+        real_name:
+          type: string
+          description: User's real name.
+        display_name:
+          type: string
+          description: User's display name.
+        email:
+          type: string
+          description: User's email address when available.
+        is_bot:
+          type: boolean
+          description: True for bot users.
+        display_label:
+          type: string
+          description: Human-readable label for pickers (real name with email).
+    AgentConnectorUserListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserListItem'
     RetentionMeta:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -162,6 +162,9 @@ paths:
   /v1/agents/{agent_id}/connectors/{connector_id}/channels:
     $ref: './components/paths/agent_connectors.yaml#/agentConnectorChannels'
 
+  /v1/agents/{agent_id}/connectors/{connector_id}/users:
+    $ref: './components/paths/agent_connectors.yaml#/agentConnectorUsers'
+
   /v1/registration-invites:
     $ref: './components/paths/registration_invites.yaml#/createRegistrationInvite'
 


### PR DESCRIPTION
## Summary

- **Hide opaque timestamp fields** (`thread_ts`, `ts`, `timestamp`) from the action config form across 4 Slack actions (Read Thread, Add Reaction, Update Message, Delete Message). These are internal Slack message timestamps that no admin would ever meaningfully constrain — they're auto-wildcarded on form submission so the agent can provide them at runtime.
- **Add user remote-select picker** for `user_id` (Send DM) and `users` (Invite to Channel) fields. Adds a new `/v1/agents/{agent_id}/connectors/{connector_id}/users` endpoint backed by `UserLister` interface, so admins pick users from a dropdown instead of entering opaque `U01234567` IDs.

### Changes

- `connectors/slack/manifest.go` — Mark timestamp fields as `hidden: true`, remove from `required`; change user ID fields to `remote-select` widget
- `connectors/connector.go` — New `UserListItem` struct and `UserLister` interface
- `connectors/slack/user_lister.go` — Slack `UserLister` implementation (paginated, filters bots/deleted)
- `api/agent_connector_users.go` — New API endpoint mirroring the channels endpoint pattern
- `frontend/.../SlackUserRemoteSelectWidget.tsx` — New user picker component (matches channel picker UX)
- `frontend/.../useAgentConnectorUsers.ts` — React Query hook for the users endpoint
- `frontend/.../ActionConfigFormFields.tsx` — `buildParametersFromForm` auto-wildcards hidden fields; `getEmptyRequiredParams` skips hidden fields
- `frontend/.../ParameterFieldWidget.tsx` — Routes `remote-select` with `/users` path to the new widget
- OpenAPI spec updated with users endpoint schema

## Test plan

### Developer
- [x] All 959 frontend tests pass
- [x] TypeScript compiles cleanly
- [x] Go packages vet cleanly

### Manual Testing
- [ ] Create a Slack "Read Thread" config — verify Thread ID field is no longer shown
- [ ] Create a Slack "Add Reaction" config — verify Message ID field is hidden
- [ ] Create a Slack "Update/Delete Message" config — verify Message ID field is hidden
- [ ] Create a Slack "Send DM" config — verify Recipient shows a user dropdown
- [ ] Create a Slack "Invite to Channel" config — verify User shows a user dropdown
- [ ] Verify user dropdown falls back to manual entry when no credential is connected
- [ ] Verify existing configs with timestamp wildcards still work (backwards compat)

https://claude.ai/code/session_01AuJqtdGdqF9x7kLYH5gjcR