### PR TITLE
Add multi-select user picker for invite_to_channel

### DIFF
--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -116,15 +116,17 @@ var validPreviewLayouts = map[string]bool{
 
 // validWidgets are the allowed values for x-ui.widget on schema properties.
 var validWidgets = map[string]bool{
-	"text":           true,
-	"select":         true,
-	"remote-select":  true,
-	"textarea":       true,
-	"toggle":         true,
-	"number":         true,
-	"date":           true,
-	"datetime":       true,
-	"list":           true,
+	"text":                true,
+	"select":              true,
+	"multi-select":        true,
+	"remote-select":       true,
+	"remote-multi-select": true,
+	"textarea":            true,
+	"toggle":              true,
+	"number":              true,
+	"date":                true,
+	"datetime":            true,
+	"list":                true,
 }
 
 // validAuthTypes are the allowed values for credential auth types.

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -288,13 +288,13 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "string",
 							"description": "Comma-separated list of user IDs to invite (e.g. U01234567,U09876543)",
 							"x-ui": {
-								"widget": "remote-select",
-								"label": "User",
+								"widget": "remote-multi-select",
+								"label": "Users",
 								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/users",
 								"remote_select_id_key": "id",
 								"remote_select_label_key": "display_label",
-								"remote_select_fallback_placeholder": "User ID (e.g. U01234567)",
-								"help_text": "Choose a user or enter a user ID."
+								"remote_select_fallback_placeholder": "Comma-separated user IDs (e.g. U01234567,U09876543)",
+								"help_text": "Select one or more users to invite."
 							}
 						}
 					}

--- a/frontend/src/lib/parameterSchema.ts
+++ b/frontend/src/lib/parameterSchema.ts
@@ -20,6 +20,7 @@ export interface SchemaPropertyUI {
     | "select"
     | "multi-select"
     | "remote-select"
+    | "remote-multi-select"
     | "textarea"
     | "toggle"
     | "number"
@@ -147,6 +148,7 @@ export const VALID_WIDGETS = [
   "select",
   "multi-select",
   "remote-select",
+  "remote-multi-select",
   "textarea",
   "toggle",
   "number",

--- a/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
+++ b/frontend/src/pages/agents/connectors/ParameterFieldWidget.tsx
@@ -9,6 +9,7 @@ import { isConcreteDatetimeString } from "@/lib/datetime";
 import { CalendarRemoteSelectWidget } from "./CalendarRemoteSelectWidget";
 import { SlackChannelRemoteSelectWidget } from "./SlackChannelRemoteSelectWidget";
 import { SlackUserRemoteSelectWidget } from "./SlackUserRemoteSelectWidget";
+import { SlackUserRemoteMultiSelectWidget } from "./SlackUserRemoteMultiSelectWidget";
 
 export interface ParameterFieldWidgetProps {
   /** The parameter key (used for id, fallback label). */
@@ -72,7 +73,7 @@ export function ParameterFieldWidget({
         connectorId,
         propertyUI: ui,
       })}
-      <FieldHints ui={ui} omitHelpText={widget === "remote-select"} />
+      <FieldHints ui={ui} omitHelpText={widget === "remote-select" || widget === "remote-multi-select"} />
     </div>
   );
 }
@@ -96,6 +97,8 @@ function renderWidget(widget: WidgetType, props: WidgetRenderProps) {
   switch (widget) {
     case "remote-select":
       return <RemoteSelectField {...props} />;
+    case "remote-multi-select":
+      return <RemoteMultiSelectField {...props} />;
     case "select":
       return <SelectWidget {...props} />;
     case "multi-select":
@@ -188,6 +191,63 @@ function RemoteSelectField({
       agentId={agentId}
       connectorId={connectorId}
       ui={propertyUI}
+    />
+  );
+}
+
+function RemoteMultiSelectField({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  agentId,
+  connectorId,
+  propertyUI,
+}: WidgetRenderProps) {
+  if (
+    !propertyUI ||
+    agentId === undefined ||
+    agentId <= 0 ||
+    !connectorId
+  ) {
+    return (
+      <TextWidget
+        inputId={inputId}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className}
+      />
+    );
+  }
+  const path = propertyUI.remote_select_options_path ?? "";
+  if (connectorId === "slack" && path.endsWith("/users")) {
+    return (
+      <SlackUserRemoteMultiSelectWidget
+        inputId={inputId}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className}
+        agentId={agentId}
+        connectorId={connectorId}
+        ui={propertyUI}
+      />
+    );
+  }
+  // Fallback: plain text for unsupported remote-multi-select paths
+  return (
+    <TextWidget
+      inputId={inputId}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={className}
     />
   );
 }

--- a/frontend/src/pages/agents/connectors/SlackUserRemoteMultiSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/SlackUserRemoteMultiSelectWidget.tsx
@@ -139,6 +139,14 @@ export function SlackUserRemoteMultiSelectWidget({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // Escape should always close the dropdown, even with zero results
+      if (e.key === "Escape" && dropdownOpen) {
+        e.preventDefault();
+        setDropdownOpen(false);
+        setActiveIndex(-1);
+        return;
+      }
+
       if (!dropdownOpen || filteredOptions.length === 0) return;
 
       switch (e.key) {
@@ -160,11 +168,6 @@ export function SlackUserRemoteMultiSelectWidget({
           if (opt) addUser(opt.id);
           break;
         }
-        case "Escape":
-          e.preventDefault();
-          setDropdownOpen(false);
-          setActiveIndex(-1);
-          break;
       }
     },
     [dropdownOpen, filteredOptions, activeIndex, addUser],
@@ -333,7 +336,7 @@ export function SlackUserRemoteMultiSelectWidget({
               : placeholder ?? "Search users\u2026"
           }
           aria-busy={isLoading || isFetching ? "true" : undefined}
-          aria-expanded={dropdownOpen}
+          aria-expanded={dropdownOpen && usersReady}
           aria-controls={listboxId}
           aria-autocomplete="list"
           aria-activedescendant={

--- a/frontend/src/pages/agents/connectors/SlackUserRemoteMultiSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/SlackUserRemoteMultiSelectWidget.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import type { SchemaPropertyUI } from "@/lib/parameterSchema";
+import { useAgentConnectorUsers } from "@/hooks/useAgentConnectorUsers";
+
+export interface SlackUserRemoteMultiSelectWidgetProps {
+  inputId: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  agentId: number;
+  connectorId: string;
+  ui: Pick<
+    SchemaPropertyUI,
+    | "help_text"
+    | "remote_select_options_path"
+    | "remote_select_id_key"
+    | "remote_select_label_key"
+    | "remote_select_fallback_placeholder"
+  >;
+}
+
+const DEFAULT_NO_CREDENTIAL =
+  "Connect a Slack credential to select users.";
+
+function readLabel(row: Record<string, unknown>, labelKey: string): string {
+  const direct = row[labelKey];
+  if (typeof direct === "string" && direct.length > 0) return direct;
+  const displayLabel = row.display_label;
+  if (typeof displayLabel === "string" && displayLabel.length > 0)
+    return displayLabel;
+  const id = row.id;
+  return typeof id === "string" ? id : "";
+}
+
+/** Parse comma-separated IDs into a deduplicated array. */
+function parseSelected(value: string): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function SlackUserRemoteMultiSelectWidget({
+  inputId,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  className,
+  agentId,
+  connectorId,
+  ui,
+}: SlackUserRemoteMultiSelectWidgetProps) {
+  const [manual, setManual] = useState(false);
+  const [search, setSearch] = useState("");
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const {
+    users,
+    isLoading,
+    isFetching,
+    error,
+    hasCredential,
+    isCredentialBindingPending,
+    refetch,
+  } = useAgentConnectorUsers(agentId, connectorId);
+
+  const labelKey = ui.remote_select_label_key ?? "display_label";
+  const idKey = ui.remote_select_id_key ?? "id";
+
+  const selectedIds = useMemo(() => parseSelected(value), [value]);
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const allOptions = useMemo(() => {
+    return users.map((row) => {
+      const idRaw = row[idKey];
+      const id = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
+      const label = readLabel(row, labelKey);
+      return { id, label: label || id };
+    });
+  }, [users, idKey, labelKey]);
+
+  /** Map from ID to label for chip display. */
+  const labelMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const opt of allOptions) {
+      m.set(opt.id, opt.label);
+    }
+    return m;
+  }, [allOptions]);
+
+  /** Options filtered by search, excluding already-selected. */
+  const filteredOptions = useMemo(() => {
+    const available = allOptions.filter((opt) => !selectedSet.has(opt.id));
+    if (!search) return available;
+    const q = search.toLowerCase();
+    return available.filter(
+      (opt) =>
+        opt.label.toLowerCase().includes(q) ||
+        opt.id.toLowerCase().includes(q),
+    );
+  }, [allOptions, selectedSet, search]);
+
+  const serialize = useCallback(
+    (ids: string[]) => onChange(ids.join(",")),
+    [onChange],
+  );
+
+  const addUser = useCallback(
+    (id: string) => {
+      if (selectedSet.has(id)) return;
+      serialize([...selectedIds, id]);
+      setSearch("");
+    },
+    [selectedIds, selectedSet, serialize],
+  );
+
+  const removeUser = useCallback(
+    (id: string) => {
+      serialize(selectedIds.filter((sid) => sid !== id));
+    },
+    [selectedIds, serialize],
+  );
+
+  const handleBlur = useCallback((e: React.FocusEvent) => {
+    // Close dropdown only if focus leaves the entire container
+    if (
+      containerRef.current &&
+      !containerRef.current.contains(e.relatedTarget as Node)
+    ) {
+      setDropdownOpen(false);
+    }
+  }, []);
+
+  const noCredentialText = ui.help_text?.trim() || DEFAULT_NO_CREDENTIAL;
+  const selectDisabled = disabled || isLoading || isFetching;
+  const usersReady = hasCredential && !isLoading && !isFetching && !error;
+
+  const selectClassName = `border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`;
+
+  // Manual entry mode
+  if (manual) {
+    return (
+      <div className="space-y-2">
+        <Input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={
+            ui.remote_select_fallback_placeholder ??
+            placeholder ??
+            "Comma-separated user IDs (e.g. U01234567,U09876543)"
+          }
+          className={className}
+          data-testid={`slack-user-remote-multi-select-manual-${inputId}`}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(false)}
+        >
+          Use list
+        </Button>
+      </div>
+    );
+  }
+
+  // Credential binding pending
+  if (isCredentialBindingPending) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          aria-busy="true"
+          className={selectClassName}
+          data-testid={`slack-user-remote-multi-select-binding-pending-${inputId}`}
+        >
+          <option value="">Checking credentials...</option>
+        </select>
+      </div>
+    );
+  }
+
+  // No credential
+  if (!hasCredential) {
+    return (
+      <div className="space-y-2">
+        <select
+          id={inputId}
+          value=""
+          disabled
+          className={selectClassName}
+          data-testid={`slack-user-remote-multi-select-disabled-${inputId}`}
+        >
+          <option value="">{noCredentialText}</option>
+        </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 text-xs"
+          disabled={disabled}
+          onClick={() => setManual(true)}
+        >
+          Enter user IDs manually
+        </Button>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">
+          Could not load users.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => void refetch()}
+          >
+            Retry
+          </button>
+          {" \u00b7 "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter manually
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  // Main multi-select UI
+  return (
+    <div className="space-y-2" ref={containerRef} onBlur={handleBlur}>
+      {/* Selected user chips */}
+      {selectedIds.length > 0 && (
+        <div
+          className="flex flex-wrap gap-1.5"
+          data-testid={`slack-user-remote-multi-select-chips-${inputId}`}
+        >
+          {selectedIds.map((id) => (
+            <span
+              key={id}
+              className="bg-secondary text-secondary-foreground inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium"
+            >
+              {labelMap.get(id) ?? id}
+              <button
+                type="button"
+                className="hover:text-destructive ml-0.5 rounded-sm outline-none focus-visible:ring-1"
+                onClick={() => removeUser(id)}
+                disabled={disabled}
+                aria-label={`Remove ${labelMap.get(id) ?? id}`}
+              >
+                <X className="size-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Search input + dropdown */}
+      <div className="relative">
+        <Input
+          id={inputId}
+          type="text"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setDropdownOpen(true);
+          }}
+          onFocus={() => setDropdownOpen(true)}
+          disabled={selectDisabled}
+          placeholder={
+            isLoading || isFetching
+              ? "Loading..."
+              : placeholder ?? "Search users..."
+          }
+          aria-busy={isLoading || isFetching ? "true" : undefined}
+          className={className}
+          autoComplete="off"
+          data-testid={`slack-user-remote-multi-select-search-${inputId}`}
+        />
+        {dropdownOpen && usersReady && (
+          <ul
+            className="border-input bg-popover text-popover-foreground absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border shadow-md"
+            role="listbox"
+            data-testid={`slack-user-remote-multi-select-dropdown-${inputId}`}
+          >
+            {filteredOptions.length === 0 ? (
+              <li className="text-muted-foreground px-3 py-2 text-sm">
+                {allOptions.length === 0
+                  ? "No users available"
+                  : "No matching users"}
+              </li>
+            ) : (
+              filteredOptions.map((opt) => (
+                <li
+                  key={opt.id}
+                  role="option"
+                  aria-selected={false}
+                  className="hover:bg-accent hover:text-accent-foreground cursor-pointer px-3 py-1.5 text-sm"
+                  onMouseDown={(e) => {
+                    // Prevent input blur before click registers
+                    e.preventDefault();
+                    addUser(opt.id);
+                  }}
+                >
+                  {opt.label}
+                </li>
+              ))
+            )}
+          </ul>
+        )}
+      </div>
+
+      {usersReady && allOptions.length === 0 && (
+        <p className="text-muted-foreground text-xs">
+          No users returned.{" "}
+          <button
+            type="button"
+            className="text-foreground underline"
+            disabled={disabled}
+            onClick={() => setManual(true)}
+          >
+            Enter user IDs manually
+          </button>
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-auto px-0 text-xs"
+        disabled={disabled}
+        onClick={() => setManual(true)}
+      >
+        Enter manually
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/SlackUserRemoteMultiSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/SlackUserRemoteMultiSelectWidget.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
 import type { SchemaPropertyUI } from "@/lib/parameterSchema";
 import { useAgentConnectorUsers } from "@/hooks/useAgentConnectorUsers";
+import { readLabel } from "./remoteSelectUtils";
 
 export interface SlackUserRemoteMultiSelectWidgetProps {
   inputId: string;
@@ -27,23 +28,18 @@ export interface SlackUserRemoteMultiSelectWidgetProps {
 const DEFAULT_NO_CREDENTIAL =
   "Connect a Slack credential to select users.";
 
-function readLabel(row: Record<string, unknown>, labelKey: string): string {
-  const direct = row[labelKey];
-  if (typeof direct === "string" && direct.length > 0) return direct;
-  const displayLabel = row.display_label;
-  if (typeof displayLabel === "string" && displayLabel.length > 0)
-    return displayLabel;
-  const id = row.id;
-  return typeof id === "string" ? id : "";
-}
-
 /** Parse comma-separated IDs into a deduplicated array. */
 function parseSelected(value: string): string[] {
   if (!value) return [];
+  const seen = new Set<string>();
   return value
     .split(",")
     .map((s) => s.trim())
-    .filter(Boolean);
+    .filter((s) => {
+      if (!s || seen.has(s)) return false;
+      seen.add(s);
+      return true;
+    });
 }
 
 export function SlackUserRemoteMultiSelectWidget({
@@ -60,6 +56,7 @@ export function SlackUserRemoteMultiSelectWidget({
   const [manual, setManual] = useState(false);
   const [search, setSearch] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -118,6 +115,7 @@ export function SlackUserRemoteMultiSelectWidget({
       if (selectedSet.has(id)) return;
       serialize([...selectedIds, id]);
       setSearch("");
+      setActiveIndex(-1);
     },
     [selectedIds, selectedSet, serialize],
   );
@@ -130,18 +128,53 @@ export function SlackUserRemoteMultiSelectWidget({
   );
 
   const handleBlur = useCallback((e: React.FocusEvent) => {
-    // Close dropdown only if focus leaves the entire container
     if (
       containerRef.current &&
       !containerRef.current.contains(e.relatedTarget as Node)
     ) {
       setDropdownOpen(false);
+      setActiveIndex(-1);
     }
   }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!dropdownOpen || filteredOptions.length === 0) return;
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((prev) =>
+            prev < filteredOptions.length - 1 ? prev + 1 : 0,
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((prev) =>
+            prev > 0 ? prev - 1 : filteredOptions.length - 1,
+          );
+          break;
+        case "Enter": {
+          e.preventDefault();
+          const opt = filteredOptions[activeIndex];
+          if (opt) addUser(opt.id);
+          break;
+        }
+        case "Escape":
+          e.preventDefault();
+          setDropdownOpen(false);
+          setActiveIndex(-1);
+          break;
+      }
+    },
+    [dropdownOpen, filteredOptions, activeIndex, addUser],
+  );
 
   const noCredentialText = ui.help_text?.trim() || DEFAULT_NO_CREDENTIAL;
   const selectDisabled = disabled || isLoading || isFetching;
   const usersReady = hasCredential && !isLoading && !isFetching && !error;
+
+  const listboxId = `${inputId}-listbox`;
 
   const selectClassName = `border-input bg-muted ring-ring/50 flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none disabled:opacity-50${className ? ` ${className}` : ""}`;
 
@@ -189,7 +222,7 @@ export function SlackUserRemoteMultiSelectWidget({
           className={selectClassName}
           data-testid={`slack-user-remote-multi-select-binding-pending-${inputId}`}
         >
-          <option value="">Checking credentials...</option>
+          <option value="">Checking credentials\u2026</option>
         </select>
       </div>
     );
@@ -284,27 +317,40 @@ export function SlackUserRemoteMultiSelectWidget({
         <Input
           id={inputId}
           type="text"
+          role="combobox"
           value={search}
           onChange={(e) => {
             setSearch(e.target.value);
             setDropdownOpen(true);
+            setActiveIndex(-1);
           }}
           onFocus={() => setDropdownOpen(true)}
+          onKeyDown={handleKeyDown}
           disabled={selectDisabled}
           placeholder={
             isLoading || isFetching
-              ? "Loading..."
-              : placeholder ?? "Search users..."
+              ? "Loading\u2026"
+              : placeholder ?? "Search users\u2026"
           }
           aria-busy={isLoading || isFetching ? "true" : undefined}
+          aria-expanded={dropdownOpen}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            activeIndex >= 0
+              ? `${listboxId}-option-${activeIndex}`
+              : undefined
+          }
           className={className}
           autoComplete="off"
           data-testid={`slack-user-remote-multi-select-search-${inputId}`}
         />
         {dropdownOpen && usersReady && (
           <ul
+            id={listboxId}
             className="border-input bg-popover text-popover-foreground absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border shadow-md"
             role="listbox"
+            aria-label="User suggestions"
             data-testid={`slack-user-remote-multi-select-dropdown-${inputId}`}
           >
             {filteredOptions.length === 0 ? (
@@ -314,17 +360,22 @@ export function SlackUserRemoteMultiSelectWidget({
                   : "No matching users"}
               </li>
             ) : (
-              filteredOptions.map((opt) => (
+              filteredOptions.map((opt, idx) => (
                 <li
                   key={opt.id}
+                  id={`${listboxId}-option-${idx}`}
                   role="option"
-                  aria-selected={false}
-                  className="hover:bg-accent hover:text-accent-foreground cursor-pointer px-3 py-1.5 text-sm"
+                  aria-selected={idx === activeIndex}
+                  className={`cursor-pointer px-3 py-1.5 text-sm${
+                    idx === activeIndex
+                      ? " bg-accent text-accent-foreground"
+                      : " hover:bg-accent hover:text-accent-foreground"
+                  }`}
                   onMouseDown={(e) => {
-                    // Prevent input blur before click registers
                     e.preventDefault();
                     addUser(opt.id);
                   }}
+                  onMouseEnter={() => setActiveIndex(idx)}
                 >
                   {opt.label}
                 </li>

--- a/frontend/src/pages/agents/connectors/SlackUserRemoteSelectWidget.tsx
+++ b/frontend/src/pages/agents/connectors/SlackUserRemoteSelectWidget.tsx
@@ -3,6 +3,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import type { SchemaPropertyUI } from "@/lib/parameterSchema";
 import { useAgentConnectorUsers } from "@/hooks/useAgentConnectorUsers";
+import { readLabel } from "./remoteSelectUtils";
 
 export interface SlackUserRemoteSelectWidgetProps {
   inputId: string;
@@ -25,16 +26,6 @@ export interface SlackUserRemoteSelectWidgetProps {
 
 const DEFAULT_NO_CREDENTIAL =
   "Connect a Slack credential to select a user.";
-
-function readLabel(row: Record<string, unknown>, labelKey: string): string {
-  const direct = row[labelKey];
-  if (typeof direct === "string" && direct.length > 0) return direct;
-  const displayLabel = row.display_label;
-  if (typeof displayLabel === "string" && displayLabel.length > 0)
-    return displayLabel;
-  const id = row.id;
-  return typeof id === "string" ? id : "";
-}
 
 export function SlackUserRemoteSelectWidget({
   inputId,

--- a/frontend/src/pages/agents/connectors/remoteSelectUtils.ts
+++ b/frontend/src/pages/agents/connectors/remoteSelectUtils.ts
@@ -1,0 +1,10 @@
+/** Resolve a display label from a remote-select option row. */
+export function readLabel(row: Record<string, unknown>, labelKey: string): string {
+  const direct = row[labelKey];
+  if (typeof direct === "string" && direct.length > 0) return direct;
+  const displayLabel = row.display_label;
+  if (typeof displayLabel === "string" && displayLabel.length > 0)
+    return displayLabel;
+  const id = row.id;
+  return typeof id === "string" ? id : "";
+}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",


### PR DESCRIPTION
## Summary

- Adds a new `remote-multi-select` widget type that supports selecting multiple users from a searchable dropdown, displaying them as removable chips/tags
- Updates `slack.invite_to_channel` manifest to use `remote-multi-select` for the `users` field instead of the single-value `remote-select`
- Selected user IDs are serialized as comma-separated values matching the backend's expected format

Closes #858

## Test plan

### Developer
- [x] Frontend TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 959 frontend tests pass (`make test-frontend`)
- [ ] Verify Storybook renders if stories exist for action config forms

### Manual Testing
- [ ] Configure `slack.invite_to_channel` action — verify multi-select dropdown appears for users field
- [ ] Search/filter users in the dropdown
- [ ] Select multiple users — verify chips appear with remove (X) buttons
- [ ] Remove a chip — verify it returns to the dropdown options
- [ ] Switch to "Enter manually" — verify comma-separated input works
- [ ] Switch back to "Use list" — verify previously entered IDs display as chips
- [ ] Verify single-select `remote-select` widgets (e.g. `send_dm` user picker) are unaffected

https://claude.ai/code/session_01Rev57A16T6GGH1TfQGHE95