### PR TITLE
Fix CI: multi-select widget, manifest validation, connector count

### DIFF
--- a/connectors/all/schema_quality_test.go
+++ b/connectors/all/schema_quality_test.go
@@ -20,11 +20,6 @@ import (
 // instead. This list exists only for pre-existing connectors that predate the
 // lint.
 var knownMissingAnnotations = map[string]bool{
-	// textarea — sendgrid HTML content fields
-	"sendgrid.sendgrid.send_campaign:html_content":            true,
-	"sendgrid.sendgrid.schedule_campaign:html_content":        true,
-	"sendgrid.sendgrid.send_transactional_email:html_content": true,
-
 	// datetime — various connectors with ISO 8601 fields missing format
 	"hubspot.hubspot.create_deal:closedate":           true,
 	"hubspot.hubspot.update_deal_stage:close_date":    true,

--- a/connectors/linear/manifest.go
+++ b/connectors/linear/manifest.go
@@ -54,7 +54,7 @@ func (c *LinearConnector) Manifest() *connectors.ConnectorManifest {
 							"minimum": 0,
 							"maximum": 4,
 							"description": "Priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low",
-							"x-ui": {"label": "Priority", "help_text": "0 = No priority, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low", "widget": "select"}
+							"x-ui": {"label": "Priority", "help_text": "0 = No priority, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low", "widget": "number"}
 						},
 						"state_id": {
 							"type": "string",
@@ -109,7 +109,7 @@ func (c *LinearConnector) Manifest() *connectors.ConnectorManifest {
 							"minimum": 0,
 							"maximum": 4,
 							"description": "Priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low",
-							"x-ui": {"label": "Priority", "help_text": "0 = No priority, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low", "widget": "select"}
+							"x-ui": {"label": "Priority", "help_text": "0 = No priority, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low", "widget": "number"}
 						},
 						"state_id": {
 							"type": "string",

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -118,6 +118,7 @@ var validPreviewLayouts = map[string]bool{
 var validWidgets = map[string]bool{
 	"text":           true,
 	"select":         true,
+	"multi-select":   true,
 	"remote-select":  true,
 	"textarea":       true,
 	"toggle":         true,
@@ -554,14 +555,14 @@ func validateParametersSchemaUI(schema json.RawMessage, actionIdx int) error {
 			continue
 		}
 		if prop.XUI.Widget != "" && !validWidgets[prop.XUI.Widget] {
-			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, remote-select, textarea, toggle, number, date, datetime, list", actionIdx, propName, prop.XUI.Widget)
+			return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q must be one of: text, select, multi-select, remote-select, textarea, toggle, number, date, datetime, list", actionIdx, propName, prop.XUI.Widget)
 		}
-		// A "select" widget needs enum values to populate the dropdown.
-		if prop.XUI.Widget == "select" {
+		// "select" and "multi-select" widgets need enum values to populate options.
+		if prop.XUI.Widget == "select" || prop.XUI.Widget == "multi-select" {
 			var propObj map[string]json.RawMessage
 			if err := json.Unmarshal(propRaw, &propObj); err == nil {
 				if _, hasEnum := propObj["enum"]; !hasEnum {
-					return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget \"select\" requires an \"enum\" array on the property", actionIdx, propName)
+					return fmt.Errorf("manifest validation: actions[%d].parameters_schema.properties.%s x-ui.widget %q requires an \"enum\" array on the property", actionIdx, propName, prop.XUI.Widget)
 				}
 			}
 		}

--- a/connectors/plaid/manifest.go
+++ b/connectors/plaid/manifest.go
@@ -43,7 +43,7 @@ func (c *PlaidConnector) Manifest() *connectors.ConnectorManifest {
 							"description": "Plaid products to enable (e.g. auth, transactions, identity, balance)",
 							"x-ui": {
 								"label": "Products",
-								"widget": "select",
+								"widget": "list",
 								"help_text": "Plaid products to enable — e.g. transactions, auth, identity"
 							}
 						},

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -34,10 +34,10 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 55 active built-in connectors; kroger is disabled via
+	// There are 56 active built-in connectors; kroger is disabled via
 	// connectors/kroger/disabled (embedded in the binary via //go:embed).
 	// Update this number when adding, removing, or re-enabling connectors.
-	const expected = 55
+	const expected = 56
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}


### PR DESCRIPTION
## Summary

Fixes CI failures introduced by PRs #854 (multi-select widgets) and #857 (Cloudflare connector + UI labels) that have been breaking main for the last 3 commits.

- **Add `multi-select` to valid widget types** in manifest validation — PR #854 added `widget: "multi-select"` to Slack and Square connectors but didn't update the `validWidgets` map, causing `Validate()` to reject these manifests
- **Fix invalid widget types in Linear and Plaid manifests** — Linear's `priority` (integer 0-4) had `widget: "select"` without `enum` (changed to `number`); Plaid's `products` (array type) had `widget: "select"` without property-level `enum` (changed to `list`)
- **Remove stale sendgrid entries from schema quality allowlist** — PR #857 added `widget: "textarea"` to sendgrid `html_content` fields, fixing the missing annotation, but the `knownMissingAnnotations` allowlist wasn't updated
- **Update built-in connector count from 55 to 56** — Cloudflare connector was added to `connectors/all/all.go` but `TestBuiltInConnectorsAreRegistered` expected count wasn't bumped

## Test plan

### Developer
- [x] All backend tests pass locally (`go test ./...`)
- [x] CI workflow passes: https://github.com/supersuit-tech/permission-slip/actions/runs/23535439624
- [x] Audit workflow passes: https://github.com/supersuit-tech/permission-slip/actions/runs/23535440301

### Manual Testing
- [ ] Verify Slack connector channel type multi-select renders correctly in the UI
- [ ] Verify Square catalog type multi-select renders correctly in the UI

https://claude.ai/code/session_01EyeuXyCWfVeTtGTLbBNaNf