### PR TITLE
Fix approval URL redirect to home page

### DIFF
--- a/frontend/src/pages/approve/ApproveRedirectPage.tsx
+++ b/frontend/src/pages/approve/ApproveRedirectPage.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import { useApprovalDetail } from "@/hooks/useApprovalDetail";
+import { useAgents } from "@/hooks/useAgents";
+import { getAgentDisplayName } from "@/lib/agents";
+import { ReviewApprovalDialog } from "@/pages/dashboard/ReviewApprovalDialog";
+
+/**
+ * Handles `/approve/:approvalId` URLs from email/SMS/push notifications.
+ * Fetches the approval, resolves the agent name, and opens the review dialog.
+ * Redirects to the dashboard when the dialog is closed.
+ */
+export function ApproveRedirectPage() {
+  const { approvalId } = useParams<{ approvalId: string }>();
+  const navigate = useNavigate();
+  const { approval, isLoading, error } = useApprovalDetail(approvalId ?? null);
+  const { agents } = useAgents();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Open the dialog once the approval loads
+  useEffect(() => {
+    if (approval && !dialogOpen) {
+      setDialogOpen(true);
+    }
+  }, [approval, dialogOpen]);
+
+  const agentDisplayName = (() => {
+    if (!approval) return "";
+    const agent = agents.find((a) => a.agent_id === approval.agent_id);
+    if (agent) return getAgentDisplayName(agent);
+    return `Agent ${approval.agent_id}`;
+  })();
+
+  function handleOpenChange(nextOpen: boolean) {
+    setDialogOpen(nextOpen);
+    if (!nextOpen) {
+      navigate("/", { replace: true });
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+        <p className="text-lg font-semibold">Approval not found</p>
+        <p className="text-muted-foreground text-sm">
+          This approval may have expired or already been handled.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/", { replace: true })}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Go to Dashboard
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading || !approval) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+        <p className="text-muted-foreground text-sm">Loading approval…</p>
+      </div>
+    );
+  }
+
+  return (
+    <ReviewApprovalDialog
+      approval={approval}
+      agentDisplayName={agentDisplayName}
+      open={dialogOpen}
+      onOpenChange={handleOpenChange}
+    />
+  );
+}

--- a/frontend/src/pages/approve/__tests__/ApproveRedirectPage.test.tsx
+++ b/frontend/src/pages/approve/__tests__/ApproveRedirectPage.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "@/auth/AuthContext";
+import { CookieConsentProvider } from "@/components/CookieConsentContext";
+import { setupAuthMocks } from "@/auth/__tests__/fixtures";
+import { mockGet, resetClientMocks } from "@/api/__mocks__/client";
+import { ApproveRedirectPage } from "../ApproveRedirectPage";
+
+vi.mock("@/lib/supabaseClient");
+vi.mock("@/api/client");
+
+const futureDate = new Date(Date.now() + 600_000).toISOString();
+
+const mockApproval = {
+  approval_id: "appr_abc123",
+  agent_id: 1,
+  action: {
+    type: "email.send",
+    version: "1",
+    parameters: { recipient: "user@example.com", subject: "Hello" },
+  },
+  context: {
+    description: "Send an email",
+    risk_level: "low",
+  },
+  status: "pending",
+  expires_at: futureDate,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const mockAgents = [
+  {
+    agent_id: 1,
+    status: "registered",
+    metadata: { name: "Test Bot" },
+    confirmation_code: null,
+    expires_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+function renderPage(approvalId = "appr_abc123") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter initialEntries={[`/approve/${approvalId}`]}>
+      <QueryClientProvider client={queryClient}>
+        <CookieConsentProvider>
+          <AuthProvider>
+            <Routes>
+              <Route path="/approve/:approvalId" element={<ApproveRedirectPage />} />
+              <Route path="/" element={<div data-testid="dashboard">Dashboard</div>} />
+            </Routes>
+          </AuthProvider>
+        </CookieConsentProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ApproveRedirectPage", () => {
+  beforeEach(() => {
+    resetClientMocks();
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("shows loading state while fetching approval", () => {
+    mockGet.mockImplementation(() => new Promise(() => {})); // never resolves
+    renderPage();
+    expect(screen.getByText("Loading approval…")).toBeInTheDocument();
+  });
+
+  it("shows error state when approval fetch fails", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/approvals/{approval_id}") {
+        return Promise.resolve({ error: { message: "Not found" } });
+      }
+      if (url === "/v1/agents") {
+        return Promise.resolve({ data: { data: mockAgents } });
+      }
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Approval not found")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to dashboard when clicking Go to Dashboard on error", async () => {
+    const user = userEvent.setup();
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/approvals/{approval_id}") {
+        return Promise.resolve({ error: { message: "Not found" } });
+      }
+      if (url === "/v1/agents") {
+        return Promise.resolve({ data: { data: mockAgents } });
+      }
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Go to Dashboard")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Go to Dashboard"));
+    expect(screen.getByTestId("dashboard")).toBeInTheDocument();
+  });
+
+  it("opens ReviewApprovalDialog when approval loads", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/approvals/{approval_id}") {
+        return Promise.resolve({ data: mockApproval });
+      }
+      if (url === "/v1/agents") {
+        return Promise.resolve({ data: { data: mockAgents } });
+      }
+      if (url === "/v1/standing-approvals") {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      if (url === "/v1/action-configurations") {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    renderPage();
+
+    // The ReviewApprovalDialog should open and show the Approve button
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
+    });
+  });
+
+  it("resolves agent display name from agents list", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/approvals/{approval_id}") {
+        return Promise.resolve({ data: mockApproval });
+      }
+      if (url === "/v1/agents") {
+        return Promise.resolve({ data: { data: mockAgents } });
+      }
+      if (url === "/v1/standing-approvals") {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      if (url === "/v1/action-configurations") {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      return Promise.resolve({ data: { data: [] } });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Bot")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -5,6 +5,7 @@ import { ConnectorConfigPage } from "./pages/agents/connectors/ConnectorConfigPa
 import { ActivityPage } from "./pages/activity/ActivityPage";
 import { SettingsLayout } from "./pages/settings/SettingsLayout";
 import { BillingRedirect } from "./pages/billing/BillingRedirect";
+import { ApproveRedirectPage } from "./pages/approve/ApproveRedirectPage";
 
 export interface RouteConfig {
   path: string;
@@ -25,4 +26,5 @@ export const appRoutes: RouteConfig[] = [
   { path: "/activity", Component: ActivityPage },
   { path: "/settings/*", Component: SettingsLayout },
   { path: "/billing", Component: BillingRedirect },
+  { path: "/approve/:approvalId", Component: ApproveRedirectPage },
 ];


### PR DESCRIPTION
## Summary

- Approval URLs from notifications (email, SMS, push) like `/approve/appr_...` were hitting the catch-all `*` route and redirecting to `/` instead of showing the approval dialog
- Added `/approve/:approvalId` route with an `ApproveRedirectPage` that fetches the approval by ID, resolves the agent name, and opens the existing `ReviewApprovalDialog`
- Handles error states (expired/missing approvals) with a fallback UI and link back to dashboard

## Test plan

### Developer
- [x] Added unit tests for loading, error, navigation, dialog open, and agent name resolution
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 5 new tests pass

### Manual Testing
- [ ] Visit an approval URL while logged in — should show the approval review dialog
- [ ] Visit an approval URL while logged out — should show login, then redirect to the approval after auth
- [ ] Visit an approval URL for an expired/handled approval — should show "Approval not found" with dashboard link
- [ ] Close the dialog — should navigate to the dashboard

https://claude.ai/code/session_01Jt4UgFX1gufqobKA7bbTZx