### PR TITLE
Fix approval direct links: service worker URL + mobile deep linking

### DIFF
--- a/api/approvals_test.go
+++ b/api/approvals_test.go
@@ -498,6 +498,102 @@ func TestListApprovals_Pagination(t *testing.T) {
 	})
 }
 
+// ── GET /approvals/{approval_id} ──────────────────────────────────────────────
+
+func TestGetApproval_Success(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	apprID := testhelper.GenerateID(t, "appr_")
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertApproval(t, tx, apprID, agentID, uid)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/approvals/"+apprID, uid)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp approvalDetailResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.ApprovalID != apprID {
+		t.Errorf("expected approval_id %q, got %q", apprID, resp.ApprovalID)
+	}
+	if resp.Status != "pending" {
+		t.Errorf("expected status 'pending', got %q", resp.Status)
+	}
+}
+
+func TestGetApproval_NotFound(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/approvals/appr_nonexistent", uid)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetApproval_OtherUsersApproval(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	// Create an approval owned by user1
+	uid1 := testhelper.GenerateUID(t)
+	apprID := testhelper.GenerateID(t, "appr_")
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid1, "u_"+uid1[:8])
+	testhelper.InsertApproval(t, tx, apprID, agentID, uid1)
+
+	// Authenticate as user2
+	uid2 := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid2, "u_"+uid2[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/approvals/"+apprID, uid2)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for other user's approval, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetApproval_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := httptest.NewRequest(http.MethodGet, "/approvals/appr_test123", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // ── POST /approvals/{approval_id}/approve ────────────────────────────────────
 
 func TestApproveApproval_Success(t *testing.T) {

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -33,9 +33,22 @@ self.addEventListener("notificationclick", (event) => {
   event.notification.close();
 
   // Only navigate to same-origin paths to prevent open-redirect via crafted payloads.
-  // Reject "//" (protocol-relative URLs treated as absolute by browsers).
   const rawUrl = event.notification.data?.url || "/";
-  const url = rawUrl.startsWith("/") && !rawUrl.startsWith("//") ? rawUrl : "/";
+  let url = "/";
+  if (rawUrl.startsWith("/") && !rawUrl.startsWith("//")) {
+    // Relative path — safe to use directly.
+    url = rawUrl;
+  } else {
+    // Absolute URL — verify it's same-origin before using the path.
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.origin === self.location.origin) {
+        url = parsed.pathname + parsed.search + parsed.hash;
+      }
+    } catch {
+      // Malformed URL — fall back to dashboard.
+    }
+  }
 
   event.waitUntil(
     clients.matchAll({ type: "window", includeUncontrolled: true }).then((windowClients) => {

--- a/frontend/src/hooks/__tests__/useApprovalDetail.test.tsx
+++ b/frontend/src/hooks/__tests__/useApprovalDetail.test.tsx
@@ -78,7 +78,10 @@ describe("useApprovalDetail", () => {
 
   it("returns error state on API failure", async () => {
     setupAuthMocks({ authenticated: true });
-    mockGet.mockResolvedValue({ error: { message: "Not found" } });
+    mockGet.mockResolvedValue({
+      error: { message: "Not found" },
+      response: { status: 404 },
+    });
 
     const { result } = renderHook(() => useApprovalDetail("apr_bad"), {
       wrapper,

--- a/frontend/src/hooks/useApprovalDetail.ts
+++ b/frontend/src/hooks/useApprovalDetail.ts
@@ -6,6 +6,16 @@ import type { components } from "@/api/schema";
 
 export type ApprovalDetail = components["schemas"]["ApprovalSummary"];
 
+/** Error with an HTTP status code attached for downstream handling. */
+class ApprovalFetchError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+  }
+}
+
 /**
  * Fetches a single approval by ID for the activity feed detail panel.
  * Only fetches when approvalId is non-null (lazy loading).
@@ -23,27 +33,40 @@ export function useApprovalDetail(approvalId: string | null) {
     queryKey: ["approval-detail", approvalId],
     queryFn: async () => {
       const token = tokenRef.current;
-      if (!token) throw new Error("Missing access token");
-      if (!approvalId) throw new Error("Missing approval ID");
-      const { data, error } = await client.GET(
+      if (!token) throw new ApprovalFetchError("Missing access token", 401);
+      if (!approvalId) throw new ApprovalFetchError("Missing approval ID", 400);
+      const { data, error, response } = await client.GET(
         "/v1/approvals/{approval_id}",
         {
           headers: { Authorization: `Bearer ${token}` },
           params: { path: { approval_id: approvalId } },
         },
       );
-      if (error) throw new Error("Failed to load approval details");
+      if (error) {
+        throw new ApprovalFetchError(
+          "Failed to load approval details",
+          response?.status ?? 500,
+        );
+      }
       return data;
     },
     enabled: !!accessToken && !!approvalId,
     staleTime: Infinity,
+    // Don't retry auth or not-found errors — only retry server errors.
+    retry: (failureCount, err) => {
+      if (err instanceof ApprovalFetchError && err.status < 500) return false;
+      return failureCount < 2;
+    },
   });
+
+  const errorStatus =
+    query.error instanceof ApprovalFetchError ? query.error.status : null;
 
   return {
     approval: query.data ?? null,
     isLoading: query.isLoading,
-    error: query.isError
-      ? "Unable to load approval details."
-      : null,
+    error: query.isError ? "Unable to load approval details." : null,
+    /** HTTP status from the failed request (null when no error). */
+    errorStatus,
   };
 }

--- a/frontend/src/pages/approve/ApproveRedirectPage.tsx
+++ b/frontend/src/pages/approve/ApproveRedirectPage.tsx
@@ -14,7 +14,9 @@ import { ReviewApprovalDialog } from "@/pages/dashboard/ReviewApprovalDialog";
 export function ApproveRedirectPage() {
   const { approvalId } = useParams<{ approvalId: string }>();
   const navigate = useNavigate();
-  const { approval, isLoading, error } = useApprovalDetail(approvalId ?? null);
+  const { approval, isLoading, error, errorStatus } = useApprovalDetail(
+    approvalId ?? null,
+  );
   const { agents } = useAgents();
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -40,11 +42,16 @@ export function ApproveRedirectPage() {
   }
 
   if (error) {
+    const isNotFound = errorStatus === 404;
     return (
       <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-        <p className="text-lg font-semibold">Approval not found</p>
+        <p className="text-lg font-semibold">
+          {isNotFound ? "Approval not found" : "Unable to load approval"}
+        </p>
         <p className="text-muted-foreground text-sm">
-          This approval may have expired or already been handled.
+          {isNotFound
+            ? "This approval may have expired or already been handled."
+            : "Something went wrong loading this approval. Please try again."}
         </p>
         <button
           type="button"

--- a/frontend/src/pages/approve/__tests__/ApproveRedirectPage.test.tsx
+++ b/frontend/src/pages/approve/__tests__/ApproveRedirectPage.test.tsx
@@ -77,7 +77,10 @@ describe("ApproveRedirectPage", () => {
   it("shows error state when approval fetch fails", async () => {
     mockGet.mockImplementation((url: string) => {
       if (url === "/v1/approvals/{approval_id}") {
-        return Promise.resolve({ error: { message: "Not found" } });
+        return Promise.resolve({
+          error: { message: "Not found" },
+          response: { status: 404 },
+        });
       }
       if (url === "/v1/agents") {
         return Promise.resolve({ data: { data: mockAgents } });
@@ -96,7 +99,10 @@ describe("ApproveRedirectPage", () => {
     const user = userEvent.setup();
     mockGet.mockImplementation((url: string) => {
       if (url === "/v1/approvals/{approval_id}") {
-        return Promise.resolve({ error: { message: "Not found" } });
+        return Promise.resolve({
+          error: { message: "Not found" },
+          response: { status: 404 },
+        });
       }
       if (url === "/v1/agents") {
         return Promise.resolve({ data: { data: mockAgents } });

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/src/navigation/__tests__/linking.test.ts
+++ b/mobile/src/navigation/__tests__/linking.test.ts
@@ -12,7 +12,7 @@ describe("linking config", () => {
 
   it("maps approval deep link to DeepLinkDetail screen", () => {
     expect(linking.config?.screens?.DeepLinkDetail).toBe(
-      "permission-slip/approve/:approvalId",
+      "approve/:approvalId",
     );
   });
 

--- a/mobile/src/navigation/linking.ts
+++ b/mobile/src/navigation/linking.ts
@@ -2,8 +2,8 @@
  * Deep linking configuration for React Navigation.
  *
  * Handles two URL patterns:
- * 1. Custom scheme: permissionslip://permission-slip/approve/{approvalId}
- * 2. Universal links: https://app.permissionslip.dev/permission-slip/approve/{approvalId}
+ * 1. Custom scheme: permissionslip://approve/{approvalId}
+ * 2. Universal links: https://app.permissionslip.dev/approve/{approvalId}
  *
  * Deep links navigate to the DeepLinkDetail screen which fetches the full
  * approval data by ID (since deep links only carry the approval ID, not the
@@ -19,7 +19,7 @@ export const linking: LinkingOptions<RootStackParamList> = {
   prefixes: [prefix, "permissionslip://", "https://app.permissionslip.dev"],
   config: {
     screens: {
-      DeepLinkDetail: "permission-slip/approve/:approvalId",
+      DeepLinkDetail: "approve/:approvalId",
       ApprovalList: "",
     },
   },


### PR DESCRIPTION
## Summary

- **Fix service worker push notification clicks** — The `notificationclick` handler only accepted relative paths (`/approve/...`) but the backend sends absolute URLs (`https://app.permissionslip.dev/approve/...`). This caused push notification taps to silently redirect to `/` (dashboard) instead of the approval page. Now parses absolute same-origin URLs and extracts the path.
- **Fix mobile deep linking path mismatch** — The React Navigation config expected `permission-slip/approve/:approvalId` but the backend generates URLs with just `approve/:approvalId`. Updated to match.
- **Improve error handling in useApprovalDetail** — Distinguishes between 404 (shows "Approval not found") and other errors like 401/500 (shows "Unable to load approval"). Also skips retries for client errors (4xx) to fail fast.

## Test plan

### Developer
- [x] Frontend tests pass (964/964)
- [x] Mobile navigation tests pass (3/3)
- [x] ApproveRedirectPage tests updated for new error differentiation

### Manual Testing
- [ ] Trigger a push notification, tap it — should navigate to the approval page (not dashboard)
- [ ] Open an approval direct link in mobile browser — should show the approval dialog
- [ ] Open an invalid approval link — should show "Approval not found"
- [ ] Open a link when logged out, log in — verify you reach the approval page
- [ ] Test deep linking from mobile app notification

Closes #862

https://claude.ai/code/session_01HXN4PAtUyPVU5QcuiDL3RL