### PR TITLE
Remove web push from notification settings UI and API

### DIFF
--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -55,7 +55,6 @@ const (
 	ErrDowngradeLimitExceeded       ErrorCode = "downgrade_limit_exceeded"
 	ErrBillingNotEnabled            ErrorCode = "billing_not_enabled"
 	ErrSMSRequiresPaidPlan          ErrorCode = "sms_requires_paid_plan"
-	ErrChannelUnavailableBeta       ErrorCode = "channel_unavailable_beta"
 	ErrChannelNotConfigured         ErrorCode = "channel_not_configured"
 	// OAuth
 	ErrOAuthProviderNotFound       ErrorCode = "oauth_provider_not_found"

--- a/api/notification_preferences.go
+++ b/api/notification_preferences.go
@@ -1,14 +1,9 @@
 package api
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"sort"
-	"strings"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 
 	"github.com/supersuit-tech/permission-slip-web/db"
 )
@@ -18,6 +13,7 @@ import (
 // when false, the frontend shows a "coming soon" badge instead of a toggle.
 // Note: SMS is excluded from the response entirely (not just marked unavailable)
 // when the server has no SMS sender configured.
+// Web push is excluded from the response entirely so it is not configurable in the product UI.
 type notificationPreferenceResponse struct {
 	Channel   string `json:"channel"`
 	Enabled   bool   `json:"enabled"`
@@ -57,12 +53,6 @@ var allChannels = func() []string {
 	sort.Strings(channels) // deterministic order: email, mobile-push, sms, web-push
 	return channels
 }()
-
-// betaDisabledChannels lists channels that are disabled during the beta period.
-// These channels are always unavailable regardless of plan.
-var betaDisabledChannels = map[string]bool{
-	"web-push": true,
-}
 
 func handleGetNotificationPreferences(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -110,12 +100,11 @@ func handleUpdateNotificationPreferences(deps *Deps) http.HandlerFunc {
 			seen[p.Channel] = true
 		}
 
-		// Gate beta-disabled channels: reject enabling any channel disabled during beta.
+		// Web push preferences are not exposed in the API (no in-product UI). Reject any
+		// update so stale clients cannot write preference rows.
 		for _, p := range req.Preferences {
-			if p.Enabled && betaDisabledChannels[p.Channel] {
-				label := cases.Title(language.English).String(strings.NewReplacer("-", " ").Replace(p.Channel))
-				msg := fmt.Sprintf("%s notifications are not yet available. They will be enabled after the beta period.", label)
-				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelUnavailableBeta, msg))
+			if p.Channel == "web-push" {
+				RespondError(w, r, http.StatusForbidden, Forbidden(ErrChannelNotConfigured, "Web push notification preferences are not available."))
 				return
 			}
 		}
@@ -170,15 +159,15 @@ func buildPreferencesResponse(prefs []db.NotificationPreference, smsEnabled bool
 		if ch == "sms" && !smsEnabled {
 			continue
 		}
+		// Web push is not user-configurable in the product; omit from the list.
+		if ch == "web-push" {
+			continue
+		}
 		enabled, exists := channelMap[ch]
 		if !exists {
-			if betaDisabledChannels[ch] {
-				enabled = false // beta-disabled channels default to off
-			} else {
-				enabled = true // missing rows default to enabled
-			}
+			enabled = true // missing rows default to enabled
 		}
-		available := !betaDisabledChannels[ch]
+		available := true
 		result = append(result, notificationPreferenceResponse{
 			Channel:   ch,
 			Enabled:   enabled,

--- a/api/notification_preferences_test.go
+++ b/api/notification_preferences_test.go
@@ -187,16 +187,13 @@ func TestGetNotificationPreferences_SMSExcluded_WhenNotConfigured(t *testing.T) 
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	// SMS should be excluded entirely when not configured on the server.
-	// web-push is still present but unavailable (beta-disabled).
+	// SMS and web-push should be excluded entirely when SMS is not configured on the server.
 	for _, p := range resp.Preferences {
 		if p.Channel == "sms" {
 			t.Error("expected SMS to be excluded from response when not configured")
 		}
 		if p.Channel == "web-push" {
-			if p.Available {
-				t.Error("expected web-push unavailable during beta")
-			}
+			t.Error("expected web-push to be excluded from notification preferences API")
 		}
 	}
 }
@@ -302,7 +299,7 @@ func TestGetNotificationPreferences_IncludesMobilePush(t *testing.T) {
 	}
 }
 
-func TestUpdateNotificationPreferences_EnableWebPush_RejectedDuringBeta(t *testing.T) {
+func TestUpdateNotificationPreferences_WebPush_Rejected(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -317,7 +314,7 @@ func TestUpdateNotificationPreferences_EnableWebPush_RejectedDuringBeta(t *testi
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	// web-push is disabled during beta regardless of plan.
+	// web-push is not exposed in the notification preferences API.
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
 	}
@@ -326,7 +323,7 @@ func TestUpdateNotificationPreferences_EnableWebPush_RejectedDuringBeta(t *testi
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal error response: %v", err)
 	}
-	if resp.Error.Code != ErrChannelUnavailableBeta {
-		t.Errorf("expected error code %q, got %q", ErrChannelUnavailableBeta, resp.Error.Code)
+	if resp.Error.Code != ErrChannelNotConfigured {
+		t.Errorf("expected error code %q, got %q", ErrChannelNotConfigured, resp.Error.Code)
 	}
 }

--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -324,10 +324,10 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
-	// SMS is excluded when SMSEnabled=false.
-	expectedChannels := len(allChannels) - 1
+	// SMS and web-push are excluded when SMSEnabled=false (SMS) and web-push is not exposed in the API.
+	expectedChannels := len(allChannels) - 2
 	if len(resp.Preferences) != expectedChannels {
-		t.Fatalf("expected %d preferences (SMS excluded), got %d", expectedChannels, len(resp.Preferences))
+		t.Fatalf("expected %d preferences (SMS and web-push excluded), got %d", expectedChannels, len(resp.Preferences))
 	}
 
 	// Index preferences by channel for explicit assertions.
@@ -336,33 +336,26 @@ func TestGetNotificationPreferences_Defaults(t *testing.T) {
 		prefsByChannel[p.Channel] = p
 	}
 
-	// All non-beta channels default to enabled. web-push is unavailable during beta.
-	// SMS is excluded entirely when SMSEnabled=false.
-	requiredChannels := []string{"email", "web-push", "mobile-push"}
+	// All returned channels default to enabled. SMS and web-push are excluded when SMSEnabled=false.
+	requiredChannels := []string{"email", "mobile-push"}
 	for _, ch := range requiredChannels {
 		p, ok := prefsByChannel[ch]
 		if !ok {
 			t.Errorf("expected preference for channel %q", ch)
 			continue
 		}
-		if ch == "web-push" {
-			if p.Enabled {
-				t.Errorf("expected %q to default to disabled during beta", ch)
-			}
-			if p.Available {
-				t.Errorf("expected %q to be unavailable during beta", ch)
-			}
-		} else if !p.Enabled {
+		if !p.Enabled {
 			t.Errorf("expected channel %q to default to enabled", ch)
 		}
-		if ch != "web-push" {
-			if !p.Available {
-				t.Errorf("expected channel %q to be available", ch)
-			}
+		if !p.Available {
+			t.Errorf("expected channel %q to be available", ch)
 		}
 	}
 	if _, ok := prefsByChannel["sms"]; ok {
 		t.Error("expected SMS to be excluded when SMSEnabled=false")
+	}
+	if _, ok := prefsByChannel["web-push"]; ok {
+		t.Error("expected web-push to be excluded from notification preferences API")
 	}
 }
 
@@ -396,10 +389,6 @@ func TestUpdateNotificationPreferences_Toggle(t *testing.T) {
 		case "email":
 			if p.Enabled {
 				t.Error("expected email to be disabled")
-			}
-		case "web-push":
-			if p.Enabled {
-				t.Errorf("expected %q to default to disabled during beta", p.Channel)
 			}
 		case "sms":
 			if p.Enabled {

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -21,11 +21,6 @@ const CHANNEL_LABELS: Record<string, { name: string; description: string }> = {
     name: "Email",
     description: "Receive notifications via email when actions need approval.",
   },
-  "web-push": {
-    name: "Web Push",
-    description:
-      "Browser push notifications for real-time approval alerts.",
-  },
   sms: {
     name: "SMS",
     description: "Text message notifications for urgent approval requests.",
@@ -105,7 +100,9 @@ export function NotificationSection() {
           <p className="text-destructive text-sm">{error}</p>
         ) : (
           <div className="space-y-4">
-            {preferences.map((pref) => {
+            {preferences
+              .filter((pref) => pref.channel !== "web-push")
+              .map((pref) => {
               const label = CHANNEL_LABELS[pref.channel];
               const warning = missingContact[pref.channel];
               const planGated = pref.available === false;

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -17,7 +17,6 @@ vi.mock("../../../api/client");
 // Default fixture: SMS not configured on server, so excluded from response.
 const allEnabled = [
   { channel: "email", enabled: true, available: true },
-  { channel: "web-push", enabled: true, available: true },
   { channel: "mobile-push", enabled: true, available: true },
 ];
 
@@ -26,7 +25,6 @@ const withSmsEnabled = [
   { channel: "email", enabled: true, available: true },
   { channel: "mobile-push", enabled: true, available: true },
   { channel: "sms", enabled: true, available: true },
-  { channel: "web-push", enabled: true, available: true },
 ];
 
 interface MockProfile {
@@ -97,7 +95,7 @@ describe("NotificationSection", () => {
     await waitFor(() => {
       expect(screen.getByText("Email")).toBeInTheDocument();
     });
-    expect(screen.getByText("Web Push")).toBeInTheDocument();
+    expect(screen.queryByText("Web Push")).not.toBeInTheDocument();
     expect(screen.getByText("Mobile Push")).toBeInTheDocument();
     expect(screen.queryByText("SMS")).not.toBeInTheDocument();
   });
@@ -129,7 +127,6 @@ describe("NotificationSection", () => {
   it("shows enabled/disabled state for each channel", async () => {
     const prefs = [
       { channel: "email", enabled: true, available: true },
-      { channel: "web-push", enabled: false, available: true },
       { channel: "mobile-push", enabled: true, available: true },
     ];
     mockApiFetch(profileWithContact, prefs);
@@ -144,9 +141,9 @@ describe("NotificationSection", () => {
       const unchecked = switches.filter(
         (s) => s.getAttribute("data-state") === "unchecked",
       );
-      // 2 channels enabled (email, mobile-push) + 2 unchecked (web-push, product updates)
+      // email + mobile-push enabled + product updates unchecked
       expect(checked).toHaveLength(2);
-      expect(unchecked).toHaveLength(2);
+      expect(unchecked).toHaveLength(1);
     });
   });
 
@@ -211,7 +208,6 @@ describe("NotificationSection", () => {
   it("does not show warning for disabled channel even if contact is missing", async () => {
     const prefs = [
       { channel: "email", enabled: false, available: true },
-      { channel: "web-push", enabled: true, available: true },
       { channel: "mobile-push", enabled: true, available: true },
     ];
     mockApiFetch(profileNoContact, prefs);
@@ -235,7 +231,6 @@ describe("NotificationSection", () => {
       data: {
         preferences: [
           { channel: "email", enabled: false },
-          { channel: "web-push", enabled: true },
           { channel: "sms", enabled: true },
           { channel: "mobile-push", enabled: true },
         ],

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -35,7 +35,6 @@ function mockApiFetch() {
         data: {
           preferences: [
             { channel: "email", enabled: true },
-            { channel: "web-push", enabled: true },
             { channel: "sms", enabled: false },
           ],
         },

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -37,7 +37,6 @@ jest.mock("react-native-safe-area-context", () => ({
 
 const mockPreferences: NotificationPreference[] = [
   { channel: "email", enabled: true, available: true },
-  { channel: "web-push", enabled: true, available: true },
   { channel: "mobile-push", enabled: true, available: true },
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users no longer see web push in Settings → Notifications. The channel is omitted from `GET /v1/profile/notification-preferences` (same pattern as SMS when not configured). `PUT` requests that include `web-push` are rejected with `channel_not_configured` so stale clients cannot write preference rows.

Frontend: removed the web-push label entry and filter it out if ever present in the response.

Removed the unused `channel_unavailable_beta` error code.

## Test plan

### Developer

- [x] `go build ./...` (with `GOTOOLCHAIN=auto` where needed)
- [x] `npx vitest run --run NotificationSection SettingsPage` in `frontend/`
- [ ] `make test-backend` (requires Postgres for full `api` package tests)

### Manual Testing

- [ ] Open Settings → Notifications: confirm Email, Mobile Push, and SMS (if configured) appear; Web Push does not.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2702c51b-3a2c-430d-9c1e-29814a4a900b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2702c51b-3a2c-430d-9c1e-29814a4a900b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

