### PR TITLE
Reposition as the approval layer for Openclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 [![CI](https://github.com/supersuit-tech/permission-slip/actions/workflows/ci.yml/badge.svg)](https://github.com/supersuit-tech/permission-slip/actions/workflows/ci.yml)
 [![Deploy](https://github.com/supersuit-tech/permission-slip/actions/workflows/deploy.yml/badge.svg)](https://github.com/supersuit-tech/permission-slip/actions/workflows/deploy.yml)
 
-**The authorization layer between your AI and everything it touches.**
+**Approve what [Openclaw](https://openclaw.org) does before it does it.**
 
-Give your agents the power to act — without giving them the keys to the kingdom. Permission Slip is an open-source secure proxy that sits between your AI agents and the outside world, routing every action through human-in-the-loop approval.
+Permission Slip is an open-source approval layer for [Openclaw](https://openclaw.org). Every action Openclaw wants to take — sending emails, merging PRs, booking flights — goes through you first. Nothing happens without your say-so.
 
 ```
-┌─────────┐         ┌─────────────────┐         ┌──────────────┐
-│ Your AI │ ──────→ │ Permission Slip │ ──────→ │   Gmail,     │
-│  Agent  │ ←────── │   (middle-man)  │ ←────── │   Stripe,    │
-└─────────┘         └─────────────────┘         │   Notion,    │
-                                                │   Expedia…   │
-                           │                    └──────────────┘
+┌──────────┐         ┌─────────────────┐         ┌──────────────┐
+│ Openclaw │ ──────→ │ Permission Slip │ ──────→ │   Gmail,     │
+│          │ ←────── │   (approval     │ ←────── │   Stripe,    │
+└──────────┘         │    layer)       │         │   GitHub,    │
+                     └─────────────────┘         │   Slack…     │
+                           │                     └──────────────┘
                            │ push notification
                            ▼
                      ┌───────────┐
@@ -33,23 +33,23 @@ Or **[self-host it](docs/deployment-self-hosted.md)** on Docker, Fly.io, or bare
 
 ## ✨ Why Permission Slip?
 
-You want your agent to book flights, send emails, and order food. But you can't trust it with full access to your accounts. Your options today:
+You want Openclaw to book flights, send emails, and merge PRs. But you can't trust it with full access to your accounts. Your options today:
 
-- 😬 **Give the agent your passwords** — it can do anything, anytime, with no oversight
-- 😩 **Do everything manually** — defeats the purpose of having an agent
-- 🤞 **Hope the agent asks nicely** — it could lie, hallucinate, or get compromised
+- 😬 **Give Openclaw your passwords** — it can do anything, anytime, with no oversight
+- 😩 **Do everything manually** — defeats the purpose of having Openclaw
+- 🤞 **Hope it asks nicely** — it could hallucinate, misunderstand, or get compromised
 
-Permission Slip solves this with a **secure proxy + human-in-the-loop approval** model. Agents submit structured, schema-validated actions — never arbitrary API calls. Nothing executes without your explicit sign-off.
+Permission Slip solves this with a **secure proxy + human-in-the-loop approval** model. Openclaw submits structured, schema-validated actions — never arbitrary API calls. Nothing executes without your explicit sign-off.
 
 ---
 
 ## 🔑 Key Features
 
-- 🛡️ **Action-based security** — agents submit structured actions, not raw API calls
+- 🛡️ **Action-based security** — Openclaw submits structured actions, not raw API calls
 - 🔔 **Per-request approval** — push notifications with human-readable summaries
 - ✅ **Standing approvals** — pre-authorize trusted, repetitive actions with constraints
-- 🔐 **Cryptographic agent identity** — Ed25519 key pairs for tamper-proof request signing
-- 🙈 **Zero credential exposure** — agents never see your API keys or passwords
+- 🔐 **Cryptographic identity** — Ed25519 key pairs for tamper-proof request signing
+- 🙈 **Zero credential exposure** — Openclaw never sees your API keys or passwords
 - 📋 **Full audit trail** — every request, approval, and execution logged
 - 🔌 **OAuth 2.0 connections** — Google, Microsoft, Dropbox, and custom providers; PKCE where required; tokens encrypted at rest with automatic refresh
 - 🏠 **Self-hostable** — your data, your infrastructure
@@ -117,50 +117,13 @@ Have you tested a connector? [Open an issue](https://github.com/supersuit-tech/p
 
 ---
 
-## 🤖 Agent Compatibility
+## 🤖 Built for Openclaw
 
-Permission Slip needs agents that can **(1) make HTTP requests to arbitrary URLs** and **(2) generate Ed25519 key pairs**. If it runs locally with a real shell, it will work. Cloud-hosted agents need case-by-case verification.
-
-### ✅ Supported
-
-| Agent | Notes |
-|---|---|
-| [OpenClaw](https://openclaw.org) | Full local shell + unrestricted network |
-| [Manis](https://manis.dev) | Full local shell + unrestricted network |
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (Desktop) | Local CLI with full shell access |
-| [Claude Cowork](https://docs.anthropic.com/en/docs/claude-code/overview) (Desktop) | Local IDE integration with full shell access |
-| [Cursor](https://cursor.com) | Local IDE with terminal access |
-| [Windsurf](https://windsurf.com) | Local IDE with terminal access |
-| [Cline](https://github.com/cline/cline) | VS Code extension, runs commands locally |
-| [Aider](https://aider.chat) | Local CLI with full shell access |
-| [Continue](https://continue.dev) | Local IDE extension with terminal access |
-| [Codex CLI](https://github.com/openai/codex) (OpenAI) | Local CLI with full shell access |
-| [Devin](https://devin.ai) | Cloud VM with unrestricted network |
-| [GitHub Copilot Coding Agent](https://github.com/features/copilot) | GitHub Actions VMs with network access |
-
-### ❌ Not Supported
-
-| Agent | Reason |
-|---|---|
-| Claude Code (Mobile) | Egress proxy restricts outbound URLs to an allowlist |
-| ChatGPT / Code Interpreter | Sandboxed environment with restricted network |
-| Claude.ai (web chat) | No shell access |
-| Gemini (web) | No shell access |
-| GitHub Copilot Chat (inline) | Code suggestions only — no shell execution |
-| [v0](https://v0.dev) (Vercel) | Sandboxed, focused on UI generation |
-| [Bolt](https://bolt.new) | Sandboxed WebContainer with limited network |
+Permission Slip is purpose-built for [Openclaw](https://openclaw.org). Openclaw has full local shell access and unrestricted networking — everything it needs to register, sign requests, and submit actions through Permission Slip.
 
 ### Claude Code skills
 
 This repo includes [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) skills under [`.claude/skills/`](.claude/skills/). For example, **`/fix-ci`** (see [`fix-ci/SKILL.md`](.claude/skills/fix-ci/SKILL.md)) triggers **CI + audit** on the current branch, pulls failure logs, and loops on fix → push → re-run until green (with a round cap).
-
-### ❓ Uncertain (needs testing)
-
-| Agent | Concern |
-|---|---|
-| [Replit Agent](https://replit.com) | Cloud-hosted — may have network restrictions |
-| [Google Jules](https://jules.google) | Cloud dev agent — network policy unclear |
-| [Amazon Q Developer](https://aws.amazon.com/q/developer/) | Terminal access varies by context |
 
 ---
 
@@ -197,7 +160,7 @@ For the full walkthrough including PostgreSQL setup and test database configurat
 
 ## 📱 Mobile App
 
-The approval app lives in `mobile/` (React Native / Expo). Approve or deny requests from your phone with push notifications, biometric lock, and deep linking.
+The approval app lives in `mobile/` (React Native / Expo). Approve or deny Openclaw's requests from your phone with push notifications, biometric lock, and deep linking.
 
 ```bash
 make mobile-install  # install dependencies
@@ -273,7 +236,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full testing strategy and develop
 - [SPEC.md](SPEC.md) — protocol design, security model, and full spec
 
 ### 🔌 Integrations & Connectors
-- [Agent Integration Guide](docs/agents.md) — how to wire up an autonomous agent
+- [Openclaw Integration Guide](docs/agents.md) — how Openclaw connects to Permission Slip
 - [Creating Connectors](docs/creating-connectors.md) — build new built-in connectors
 - [Custom Connectors](docs/custom-connectors.md) — add connectors from external Git repos
 - [Community Connectors](docs/community-connectors.md) — third-party connector directory

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,21 +1,21 @@
 # Permission Slip — Protocol Overview
 
-**A protocol for human-approved AI agent actions, mediated by a centralized service. Actions are the core primitive.**
+**The approval layer for [Openclaw](https://openclaw.org). Every action Openclaw takes goes through human approval first. Actions are the core primitive.**
 
 ---
 
 ## The Problem
 
-AI agents need to perform actions on behalf of users — making purchases, accessing accounts, sending emails — but current options are broken:
+Openclaw needs to perform actions on behalf of users — making purchases, accessing accounts, sending emails — but current options are broken:
 
-- **Give the agent full access** to your credentials → security nightmare
-- **Do everything manually** → defeats the purpose of having an agent
-- **No standard approval flow** → every agent invents its own (or skips it entirely)
-- **No structured request format** → agents make arbitrary API calls or describe intentions in free text
+- **Give Openclaw full access** to your credentials → security nightmare
+- **Do everything manually** → defeats the purpose of having Openclaw
+- **No standard approval flow** → no structured way to review what Openclaw wants to do before it does it
+- **No structured request format** → arbitrary API calls or free-text intentions with no validation
 
 ## The Solution
 
-Permission Slip is a middle-man service that mediates between AI agents and external APIs. Agents submit **structured, pre-defined actions** — they never touch user credentials or make arbitrary API calls. Actions require explicit human approval before execution — either **per-request** (one-off approval with push notification and confirmation code) or **pre-approved** via a standing approval that the user creates in advance for repetitive, trusted actions.
+Permission Slip is an approval layer that sits between Openclaw and external APIs. Openclaw submits **structured, pre-defined actions** — it never touches user credentials or makes arbitrary API calls. Actions require explicit human approval before execution — either **per-request** (one-off approval with push notification and confirmation code) or **pre-approved** via a standing approval that the user creates in advance for repetitive, trusted actions.
 
 Think of it as a **secure proxy with human-in-the-loop approval, where "actions" are the core primitive**.
 
@@ -33,13 +33,13 @@ Agents can *only* request pre-defined actions, never arbitrary API calls. This i
 ## Architecture
 
 ```
-Agent ──→ Permission Slip ──→ External Service (Gmail, Stripe, etc.)
-               │
-               ▼
-          User (approve/deny)
+Openclaw ──→ Permission Slip ──→ External Service (Gmail, Stripe, etc.)
+                    │
+                    ▼
+               User (approve/deny)
 ```
 
-**Key insight:** Permission Slip is the only party that holds user credentials. The agent never sees them. The external service never knows an agent is involved — it just sees a normal API call from Permission Slip on the user's behalf.
+**Key insight:** Permission Slip is the only party that holds user credentials. Openclaw never sees them. The external service never knows Openclaw is involved — it just sees a normal API call from Permission Slip on the user's behalf.
 
 ### Why a Middle-Man (Not a Protocol for Services)
 
@@ -116,17 +116,17 @@ The middle-man architecture eliminates all of that:
 
 | Principle | Description |
 |---|---|
-| **Actions as the core primitive** | Agents submit structured, pre-defined actions — never arbitrary API calls |
+| **Actions as the core primitive** | Openclaw submits structured, pre-defined actions — never arbitrary API calls |
 | **Middle-man, not a protocol** | Permission Slip is the service — no adoption required from external APIs |
 | **Cryptographic trust** | Agents prove identity with public/private keys |
-| **Agent-agnostic** | Any AI agent can integrate (one API to learn) |
-| **Zero credentials exposure** | Agents never see user credentials |
+| **Built for Openclaw** | Purpose-built approval layer for Openclaw |
+| **Zero credentials exposure** | Openclaw never sees user credentials |
 | **User always in control** | Every action requires approval — per-request or pre-approved via standing approvals |
 | **Self-hostable** | Run your own instance for full control |
 
-## Agent Integration
+## Openclaw Integration
 
-The agent SDK provides a simple interface for submitting actions:
+The SDK provides a simple interface for submitting actions:
 
 ```javascript
 import { PermissionSlip } from '@permissionslip/sdk';

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
-# Permission Slip Agent Guide
+# Permission Slip — Openclaw Integration Guide
 
-How to integrate your autonomous agent with Permission Slip.
+How Openclaw connects to Permission Slip.
 
 **Base URL**: `https://app.permissionslip.dev/api/v1`
 
@@ -10,13 +10,13 @@ How to integrate your autonomous agent with Permission Slip.
 
 ## Overview
 
-Permission Slip sits between your agent and external services (Gmail, Stripe, GitHub, etc.). Your agent submits structured **actions** for human approval, and Permission Slip executes them using the user's stored credentials. Your agent never sees credentials and can never make arbitrary API calls.
+Permission Slip sits between Openclaw and external services (Gmail, Stripe, GitHub, etc.). Openclaw submits structured **actions** for human approval, and Permission Slip executes them using the user's stored credentials. Openclaw never sees credentials and can never make arbitrary API calls.
 
 ```
-Agent ──→ Permission Slip ──→ External Service
-               │
-               ▼
-          User (approve/deny)
+Openclaw ──→ Permission Slip ──→ External Service
+                    │
+                    ▼
+               User (approve/deny)
 ```
 
 ## Quick Start (CLI — recommended)

--- a/frontend/src/pages/dashboard/AgentConfigHero.tsx
+++ b/frontend/src/pages/dashboard/AgentConfigHero.tsx
@@ -71,7 +71,7 @@ export function AgentConfigHero({ agentId, agentName }: AgentConfigHeroProps) {
           {displayName} is ready &mdash; now give it superpowers
         </h1>
         <p className="text-muted-foreground mb-12 max-w-md text-sm">
-          Connect services like GitHub, Gmail, or Slack so your agent can take
+          Connect services like GitHub, Gmail, or Slack so Openclaw can take
           actions on your behalf. You&rsquo;ll approve every action before it
           happens.
         </p>
@@ -89,7 +89,7 @@ export function AgentConfigHero({ agentId, agentName }: AgentConfigHeroProps) {
             step={2}
             icon={<Plug className="size-6" />}
             title="Add a connector"
-            description="Choose which services your agent can interact with"
+            description="Choose which services Openclaw can interact with"
           />
           <StepConnector />
           <ConfigStep

--- a/frontend/src/pages/dashboard/AgentOnboardingHero.tsx
+++ b/frontend/src/pages/dashboard/AgentOnboardingHero.tsx
@@ -37,19 +37,19 @@ export function AgentOnboardingHero({ onRegisterAgent }: AgentOnboardingHeroProp
         </div>
 
         <h1 className="mb-3 text-2xl font-bold tracking-tight">
-          Control what your AI agents can do
+          Control what Openclaw can do
         </h1>
         <p className="text-muted-foreground mb-12 max-w-md text-sm">
           Permission Slip lets you approve, deny, and set standing rules for the
-          actions your AI agents take. Register your first agent to get started.
+          actions Openclaw takes. Connect Openclaw to get started.
         </p>
 
         <div className="mb-12 grid w-full max-w-2xl grid-cols-1 gap-8 md:grid-cols-3">
           <OnboardingStep
             step={1}
             icon={<Bot className="size-6" />}
-            title="Register an agent"
-            description="Connect your AI agent with a simple invite code"
+            title="Connect Openclaw"
+            description="Link Openclaw with a simple invite code"
           />
           <OnboardingStep
             step={2}
@@ -61,12 +61,12 @@ export function AgentOnboardingHero({ onRegisterAgent }: AgentOnboardingHeroProp
             step={3}
             icon={<Activity className="size-6" />}
             title="Monitor activity"
-            description="Track every action your agents take in real time"
+            description="Track every action Openclaw takes in real time"
           />
         </div>
 
         <Button size="lg" onClick={onRegisterAgent}>
-          Register Your First Agent
+          Connect Openclaw
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/pages/dashboard/InviteCodeDialog.tsx
+++ b/frontend/src/pages/dashboard/InviteCodeDialog.tsx
@@ -46,11 +46,11 @@ export function InviteCodeDialog({
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add an Agent</DialogTitle>
+          <DialogTitle>Connect Openclaw</DialogTitle>
           <DialogDescription>
             {invite
-              ? "Tell your agent to run this command. It handles key generation and registration automatically."
-              : "Generate a one-time invite command to share with your AI agent. Expires in 15 minutes."}
+              ? "Tell Openclaw to run this command. It handles key generation and registration automatically."
+              : "Generate a one-time invite command to share with Openclaw. Expires in 15 minutes."}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
+++ b/frontend/src/pages/dashboard/RegisteredAgentsCard.tsx
@@ -77,14 +77,14 @@ function EmptyState({ onAddAgent }: { onAddAgent: () => void }) {
     <div className="flex flex-col items-center justify-center py-8 text-center">
       <Bot className="text-muted-foreground mb-3 size-10" />
       <p className="text-muted-foreground mb-1 text-sm font-medium">
-        No registered agents yet
+        Openclaw not connected yet
       </p>
       <p className="text-muted-foreground mb-4 max-w-xs text-xs">
-        Register an agent to start controlling what it can do. You&apos;ll get
-        an invite code to share with the agent.
+        Connect Openclaw to start controlling what it can do. You&apos;ll get
+        an invite code to share with Openclaw.
       </p>
       <Button size="sm" onClick={onAddAgent}>
-        Add an Agent
+        Connect Openclaw
       </Button>
     </div>
   );
@@ -235,7 +235,7 @@ export function RegisteredAgentsCard() {
       </CardContent>
       {atLimit ? (
         <CardFooter>
-          <UpgradePrompt feature="Upgrade to add more agents." />
+          <UpgradePrompt feature="Upgrade to connect more Openclaw instances." />
         </CardFooter>
       ) : agents.length > 0 ? (
         <CardFooter>
@@ -243,7 +243,7 @@ export function RegisteredAgentsCard() {
             className="w-full sm:w-auto"
             onClick={() => setInviteDialogOpen(true)}
           >
-            Add an Agent
+            Connect Openclaw
           </Button>
         </CardFooter>
       ) : null}

--- a/frontend/src/pages/dashboard/RegistrationSuccessDialog.tsx
+++ b/frontend/src/pages/dashboard/RegistrationSuccessDialog.tsx
@@ -35,9 +35,9 @@ export function RegistrationSuccessDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Agent Registered Successfully</DialogTitle>
+          <DialogTitle>Openclaw Connected Successfully</DialogTitle>
           <DialogDescription>
-            Your agent is ready. Tell it to run this command to discover what it can do.
+            Openclaw is ready. Tell it to run this command to discover what it can do.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/pages/dashboard/__tests__/AgentOnboardingHero.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/AgentOnboardingHero.test.tsx
@@ -8,17 +8,17 @@ describe("AgentOnboardingHero", () => {
     render(<AgentOnboardingHero onRegisterAgent={vi.fn()} />);
 
     expect(
-      screen.getByText("Control what your AI agents can do"),
+      screen.getByText("Control what Openclaw can do"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Register your first agent to get started/),
+      screen.getByText(/Connect Openclaw to get started/),
     ).toBeInTheDocument();
   });
 
   it("renders three onboarding steps", () => {
     render(<AgentOnboardingHero onRegisterAgent={vi.fn()} />);
 
-    expect(screen.getByText("Register an agent")).toBeInTheDocument();
+    expect(screen.getAllByText("Connect Openclaw").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Set permissions")).toBeInTheDocument();
     expect(screen.getByText("Monitor activity")).toBeInTheDocument();
   });
@@ -29,7 +29,7 @@ describe("AgentOnboardingHero", () => {
     render(<AgentOnboardingHero onRegisterAgent={onRegisterAgent} />);
 
     await user.click(
-      screen.getByRole("button", { name: "Register Your First Agent" }),
+      screen.getByRole("button", { name: "Connect Openclaw" }),
     );
 
     expect(onRegisterAgent).toHaveBeenCalledOnce();

--- a/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -112,11 +112,11 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Control what your AI agents can do"),
+        screen.getByText("Control what Openclaw can do"),
       ).toBeInTheDocument();
     });
     expect(
-      screen.getByRole("button", { name: "Register Your First Agent" }),
+      screen.getByRole("button", { name: "Connect Openclaw" }),
     ).toBeInTheDocument();
 
     // Normal dashboard cards should NOT appear
@@ -138,7 +138,7 @@ describe("Dashboard", () => {
 
     // Onboarding hero should NOT appear
     expect(
-      screen.queryByText("Control what your AI agents can do"),
+      screen.queryByText("Control what Openclaw can do"),
     ).not.toBeInTheDocument();
   });
 
@@ -151,16 +151,18 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Register Your First Agent" }),
+        screen.getByRole("button", { name: "Connect Openclaw" }),
       ).toBeInTheDocument();
     });
 
     await user.click(
-      screen.getByRole("button", { name: "Register Your First Agent" }),
+      screen.getByRole("button", { name: "Connect Openclaw" }),
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Add an Agent")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Generate a one-time invite command/),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/RegisteredAgentsCard.test.tsx
@@ -146,14 +146,14 @@ describe("RegisteredAgentsCard", () => {
     expect(screen.queryByText("Agent 2")).not.toBeInTheDocument();
   });
 
-  it("renders Add an Agent button when agents exist", async () => {
+  it("renders Connect Openclaw button when agents exist", async () => {
     mockAgentsFetch();
 
     render(<RegisteredAgentsCard />, { wrapper });
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Add an Agent" })
+        screen.getByRole("button", { name: "Connect Openclaw" })
       ).toBeInTheDocument();
     });
   });
@@ -164,13 +164,13 @@ describe("RegisteredAgentsCard", () => {
     render(<RegisteredAgentsCard />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText("No registered agents yet")).toBeInTheDocument();
+      expect(screen.getByText("Openclaw not connected yet")).toBeInTheDocument();
     });
     expect(
-      screen.getByText(/Register an agent to start controlling what it can do/)
+      screen.getByText(/Connect Openclaw to start controlling what it can do/)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Add an Agent" })
+      screen.getByRole("button", { name: "Connect Openclaw" })
     ).toBeInTheDocument();
   });
 
@@ -273,7 +273,7 @@ describe("RegisteredAgentsCard", () => {
     expect(screen.getByText("Agent 1")).toBeInTheDocument();
   });
 
-  it("opens invite dialog when Add an Agent is clicked", async () => {
+  it("opens invite dialog when Connect Openclaw is clicked", async () => {
     mockAgentsFetch();
 
     const user = userEvent.setup();
@@ -281,11 +281,11 @@ describe("RegisteredAgentsCard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Add an Agent" })
+        screen.getByRole("button", { name: "Connect Openclaw" })
       ).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Add an Agent" }));
+    await user.click(screen.getByRole("button", { name: "Connect Openclaw" }));
 
     await waitFor(() => {
       expect(
@@ -414,12 +414,12 @@ describe("RegisteredAgentsCard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/Upgrade to add more agents/),
+        screen.getByText(/Upgrade to connect more Openclaw instances/),
       ).toBeInTheDocument();
     });
-    // "Add an Agent" button should not be present when at limit
+    // "Connect Openclaw" button should not be present when at limit
     expect(
-      screen.queryByRole("button", { name: "Add an Agent" }),
+      screen.queryByRole("button", { name: "Connect Openclaw" }),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/policy/TermsOfServicePage.tsx
+++ b/frontend/src/pages/policy/TermsOfServicePage.tsx
@@ -39,10 +39,10 @@ export function TermsOfServicePage() {
       {/* ------------------------------------------------------------------ */}
       <h2>3. Service Description</h2>
       <p>
-        Permission Slip is an AI agent authorization platform. It acts as an
-        approval proxy between your AI agents and external third-party services,
+        Permission Slip is the approval layer for Openclaw. It acts as an
+        approval proxy between Openclaw and external third-party services,
         allowing you to review, approve, deny, or pre-authorize actions that
-        agents request on your behalf.
+        Openclaw requests on your behalf.
       </p>
 
       {/* ------------------------------------------------------------------ */}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -273,7 +273,7 @@ function EmptyState({ tab }: { tab: StatusTab }) {
   const messages: Record<StatusTab, { title: string; body: string }> = {
     pending: {
       title: "No pending requests",
-      body: "New approval requests from your agents will appear here.",
+      body: "New approval requests from Openclaw will appear here.",
     },
     approved: {
       title: "No approved requests",

--- a/spec/openapi/README.md
+++ b/spec/openapi/README.md
@@ -4,9 +4,9 @@ This directory contains the complete OpenAPI 3.0 specification for the Permissio
 
 ## Overview
 
-Permission Slip is a centralized middle-man service that sits between AI agents and external APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes them using the user's stored credentials. Actions are the core primitive — structured templates (like `email.send`, `flight.book`, `payment.charge`) that define what an agent can request, with validated parameters and human-readable display formats.
+Permission Slip is the approval layer for [Openclaw](https://openclaw.org). Openclaw submits pre-defined **actions** for human approval, and Permission Slip executes them using the user's stored credentials. Actions are the core primitive — structured templates (like `email.send`, `flight.book`, `payment.charge`) that define what Openclaw can request, with validated parameters and human-readable display formats.
 
-This specification defines the HTTP API that agents use to interact with Permission Slip at `https://app.permissionslip.dev`. Agents integrate with this single endpoint for everything — action discovery, registration, approval, and execution.
+This specification defines the HTTP API that Openclaw uses to interact with Permission Slip at `https://app.permissionslip.dev`. Openclaw integrates with this single endpoint for everything — action discovery, registration, approval, and execution.
 
 ## Structure
 

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -3,10 +3,9 @@ info:
   title: Permission Slip API
   version: 0.1.0
   description: |
-    Permission Slip is a centralized middle-man service that sits between AI agents and external 
-    APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 
-    them using the user's stored credentials. Agents never see user credentials and can never 
-    make arbitrary API calls.
+    Permission Slip is the approval layer for Openclaw. Openclaw submits pre-defined **actions**
+    for human approval, and Permission Slip executes them using the user's stored credentials.
+    Openclaw never sees user credentials and can never make arbitrary API calls.
 
     **Base URL**: `https://app.permissionslip.dev`
 

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -3,10 +3,9 @@ info:
   title: Permission Slip API
   version: 0.1.0
   description: |
-    Permission Slip is a centralized middle-man service that sits between AI agents and external 
-    APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 
-    them using the user's stored credentials. Agents never see user credentials and can never 
-    make arbitrary API calls.
+    Permission Slip is the approval layer for Openclaw. Openclaw submits pre-defined **actions**
+    for human approval, and Permission Slip executes them using the user's stored credentials.
+    Openclaw never sees user credentials and can never make arbitrary API calls.
     
     **Base URL**: `https://app.permissionslip.dev`
     


### PR DESCRIPTION
## Summary

- Niche down from generic agent-agnostic platform to purpose-built Openclaw approval tool
- Copy/branding only — no backend, protocol, or architectural changes
- Updated 16 files across README, SPEC, frontend, mobile, docs, OpenAPI spec, Terms of Service, and tests

### What changed
- **README**: New headline ("Approve what Openclaw does before it does it"), removed the 20+ agent compatibility table, Openclaw-specific framing throughout
- **SPEC**: Replaced "Agent-agnostic" design principle with "Built for Openclaw"
- **Frontend UI**: Onboarding hero, config hero, invite dialog, registration success, and registered agents card all say "Openclaw" instead of generic "your AI agents"
- **Mobile**: Updated empty state copy
- **Terms of Service**: Updated service description
- **docs/agents.md**: Reframed as "Openclaw Integration Guide"
- **OpenAPI spec**: Updated descriptions in both source and bundled YAML

## Test plan

### Developer
- [x] Frontend tests pass (965/965)
- [x] Mobile tests pass (184/184)
- [x] Frontend build succeeds

### Manual Testing
- [ ] Verify onboarding flow shows "Connect Openclaw" copy on empty dashboard
- [ ] Verify invite dialog says "Connect Openclaw" 
- [ ] Verify registration success dialog says "Openclaw Connected Successfully"
- [ ] Verify mobile approval list empty state mentions Openclaw
- [ ] Review README rendering on GitHub

https://claude.ai/code/session_01TvjV3bfkGoZYKcFhwJYB5e