### PR TITLE
Add MFA challenge screen to mobile app

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/src/auth/AuthContext.tsx
+++ b/mobile/src/auth/AuthContext.tsx
@@ -8,9 +8,45 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import type { Session, User } from "@supabase/supabase-js";
+import type { AuthError, Session, User } from "@supabase/supabase-js";
 import { supabase } from "../lib/supabaseClient";
 import type { AuthStatus, AuthState } from "./types";
+
+/**
+ * Constructs a synthetic AuthError for cases where we need to generate an
+ * error client-side (e.g. missing factors). Uses `as AuthError` because
+ * Supabase doesn't export the AuthApiError class from @supabase/supabase-js.
+ */
+function createAuthError(
+  code: string,
+  message: string,
+  status: number
+): AuthError {
+  return {
+    message,
+    name: "AuthApiError",
+    status,
+    code,
+  } as AuthError;
+}
+
+/**
+ * Races `request` against a timeout. Rejects with an AuthError on timeout.
+ */
+async function withTimeout<T>(request: Promise<T>, ms: number): Promise<T> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timerId = setTimeout(
+      () => reject(new Error("Request timed out")),
+      ms
+    );
+  });
+  try {
+    return await Promise.race([request, timeoutPromise]);
+  } finally {
+    clearTimeout(timerId);
+  }
+}
 
 const AuthContext = createContext<AuthState | undefined>(undefined);
 
@@ -107,6 +143,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
+  /**
+   * Calls challengeAndVerify and promotes authStatus to "authenticated" on
+   * success. We eagerly set "authenticated" rather than waiting for
+   * onAuthStateChange because Supabase may not re-fire the event for an
+   * AAL promotion within the same session.
+   */
+  const challengeAndVerifyTotp = useCallback(
+    async (factorId: string, code: string) => {
+      const { error } = await withTimeout(
+        supabase.auth.mfa.challengeAndVerify({ factorId, code }),
+        10000
+      ).catch((err) => ({
+        error: createAuthError(
+          "unknown",
+          err instanceof Error ? err.message : String(err),
+          500
+        ),
+      }));
+      if (!error) {
+        setAuthStatus("authenticated");
+      }
+      return { error: error ?? null };
+    },
+    []
+  );
+
   const sendOtp = useCallback(async (email: string) => {
     const { error } = await supabase.auth.signInWithOtp({ email });
     return { error: error ?? null };
@@ -128,6 +190,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { error: error ?? null };
   }, []);
 
+  const verifyMfa = useCallback(
+    async (code: string) => {
+      const totpFactor = (user?.factors ?? []).find(
+        (f) => f.factor_type === "totp" && f.status === "verified"
+      );
+      if (!totpFactor) {
+        return {
+          error: createAuthError(
+            "mfa_factor_not_found",
+            "No authenticator found. Please re-enroll.",
+            400
+          ),
+        };
+      }
+      return challengeAndVerifyTotp(totpFactor.id, code);
+    },
+    [challengeAndVerifyTotp, user]
+  );
+
   const value = useMemo<AuthState>(
     () => ({
       session,
@@ -135,9 +216,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       authStatus,
       sendOtp,
       verifyOtp,
+      verifyMfa,
       signOut,
     }),
-    [session, user, authStatus, sendOtp, verifyOtp, signOut]
+    [session, user, authStatus, sendOtp, verifyOtp, verifyMfa, signOut]
   );
 
   return (

--- a/mobile/src/auth/MfaChallengeScreen.tsx
+++ b/mobile/src/auth/MfaChallengeScreen.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useAuth } from "./AuthContext";
+import { useFormSubmit } from "./useFormSubmit";
+import { authStyles } from "./styles";
+import { colors } from "../theme/colors";
+
+/**
+ * Full-screen MFA challenge presented when authStatus is "mfa_required".
+ * The user enters a 6-digit TOTP code from their authenticator app.
+ * On success, authStatus transitions to "authenticated" and the navigator
+ * swaps to the main app screens automatically.
+ */
+export default function MfaChallengeScreen() {
+  const { verifyMfa, signOut } = useAuth();
+  const [code, setCode] = useState("");
+  const { error, isSubmitting, handleSubmit } = useFormSubmit();
+  const inputRef = useRef<TextInput>(null);
+
+  // Auto-focus the code input on mount.
+  useEffect(() => {
+    const timer = setTimeout(() => inputRef.current?.focus(), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Strip non-digit characters (matches web OtpCodeInput behavior).
+  const handleChangeText = (text: string) => {
+    setCode(text.replace(/\D/g, ""));
+  };
+
+  const submit = () => handleSubmit(() => verifyMfa(code));
+
+  return (
+    <KeyboardAvoidingView
+      style={authStyles.container}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+    >
+      <Pressable style={authStyles.content} onPress={Keyboard.dismiss}>
+        <Text style={authStyles.title}>Two-factor authentication</Text>
+        <Text style={authStyles.subtitle}>
+          Enter the 6-digit code from your authenticator app to continue.
+        </Text>
+
+        <View style={authStyles.field}>
+          <Text style={authStyles.label}>Authenticator Code</Text>
+          <TextInput
+            ref={inputRef}
+            testID="mfa-code-input"
+            accessibilityLabel="Authenticator code"
+            style={[authStyles.input, localStyles.codeInput]}
+            value={code}
+            onChangeText={handleChangeText}
+            placeholder="000000"
+            placeholderTextColor={colors.gray400}
+            keyboardType="number-pad"
+            autoComplete="one-time-code"
+            maxLength={6}
+            editable={!isSubmitting}
+            onSubmitEditing={submit}
+            returnKeyType="go"
+          />
+        </View>
+
+        {error ? (
+          <Text testID="mfa-error" style={authStyles.error}>
+            {error}
+          </Text>
+        ) : null}
+
+        <View style={localStyles.buttonRow}>
+          <TouchableOpacity
+            testID="mfa-verify"
+            accessibilityLabel={isSubmitting ? "Verifying code" : "Verify code"}
+            accessibilityRole="button"
+            style={[
+              authStyles.button,
+              authStyles.primaryButton,
+              localStyles.flexButton,
+              (isSubmitting || code.length < 6) && authStyles.buttonDisabled,
+            ]}
+            onPress={submit}
+            disabled={isSubmitting || code.length < 6}
+          >
+            <Text style={authStyles.primaryButtonText}>
+              {isSubmitting ? "Verifying..." : "Verify"}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            testID="mfa-sign-out"
+            accessibilityLabel="Sign out"
+            accessibilityRole="button"
+            style={[authStyles.button, localStyles.outlineButton]}
+            onPress={() => signOut()}
+            disabled={isSubmitting}
+          >
+            <Text style={localStyles.outlineButtonText}>Sign Out</Text>
+          </TouchableOpacity>
+        </View>
+      </Pressable>
+    </KeyboardAvoidingView>
+  );
+}
+
+const localStyles = StyleSheet.create({
+  codeInput: {
+    fontSize: 24,
+    fontWeight: "600",
+    letterSpacing: 8,
+    textAlign: "center",
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 8,
+  },
+  flexButton: {
+    flex: 1,
+  },
+  outlineButton: {
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    paddingHorizontal: 20,
+  },
+  outlineButtonText: {
+    color: colors.gray700,
+    fontSize: 16,
+    fontWeight: "500",
+  },
+});

--- a/mobile/src/auth/__tests__/AuthContext.test.tsx
+++ b/mobile/src/auth/__tests__/AuthContext.test.tsx
@@ -19,6 +19,7 @@ const mocks = {
   signInWithOtp: jest.fn(),
   verifyOtp: jest.fn(),
   signOut: jest.fn(),
+  challengeAndVerify: jest.fn(),
 };
 
 jest.mock("../../lib/supabaseClient", () => ({
@@ -42,6 +43,8 @@ jest.mock("../../lib/supabaseClient", () => ({
           data: { currentLevel: "aal1", nextLevel: "aal1" },
           error: null,
         }),
+        challengeAndVerify: (...args: unknown[]) =>
+          mocks.challengeAndVerify(...args),
       },
     },
   },
@@ -288,5 +291,99 @@ describe("AuthProvider", () => {
     });
 
     expect(mocks.signOut).toHaveBeenCalledWith({ scope: "local" });
+  });
+
+  it("verifyMfa calls challengeAndVerify with the correct factor ID", async () => {
+    mocks.challengeAndVerify.mockResolvedValue({ data: {}, error: null });
+
+    let verifyMfa: ((code: string) => Promise<unknown>) | undefined;
+
+    function CaptureVerifyMfa() {
+      const auth = useAuth();
+      verifyMfa = auth.verifyMfa;
+      return null;
+    }
+
+    await act(async () => {
+      create(
+        createElement(AuthProvider, null, createElement(CaptureVerifyMfa))
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    // Sign in with a session that has a verified TOTP factor.
+    const session = mockSession({
+      user: {
+        id: "user-mfa",
+        email: "mfa@example.com",
+        app_metadata: {},
+        user_metadata: {},
+        aud: "authenticated",
+        created_at: new Date().toISOString(),
+        factors: [
+          {
+            id: "factor-123",
+            friendly_name: "TOTP",
+            factor_type: "totp",
+            status: "verified",
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
+      } as Session["user"],
+    });
+
+    await act(async () => {
+      mocks.authChangeCallback!("SIGNED_IN" as AuthChangeEvent, session);
+    });
+
+    let result: unknown;
+    await act(async () => {
+      result = await verifyMfa!("654321");
+    });
+
+    expect(mocks.challengeAndVerify).toHaveBeenCalledWith({
+      factorId: "factor-123",
+      code: "654321",
+    });
+    expect(result).toEqual({ error: null });
+  });
+
+  it("verifyMfa returns error when no TOTP factor exists", async () => {
+    let verifyMfa: ((code: string) => Promise<unknown>) | undefined;
+
+    function CaptureVerifyMfa() {
+      const auth = useAuth();
+      verifyMfa = auth.verifyMfa;
+      return null;
+    }
+
+    await act(async () => {
+      create(
+        createElement(AuthProvider, null, createElement(CaptureVerifyMfa))
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    // Sign in with no TOTP factors.
+    const session = mockSession();
+    await act(async () => {
+      mocks.authChangeCallback!("SIGNED_IN" as AuthChangeEvent, session);
+    });
+
+    let result: { error: { code: string } | null };
+    await act(async () => {
+      result = (await verifyMfa!("123456")) as typeof result;
+    });
+
+    expect(result!.error).not.toBeNull();
+    expect(result!.error!.code).toBe("mfa_factor_not_found");
+    expect(mocks.challengeAndVerify).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/auth/__tests__/MfaChallengeScreen.test.tsx
+++ b/mobile/src/auth/__tests__/MfaChallengeScreen.test.tsx
@@ -1,0 +1,193 @@
+import { createElement } from "react";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+
+// --- Mocks ---
+
+const mockVerifyMfa = jest.fn();
+const mockSignOut = jest.fn();
+
+jest.mock("../AuthContext", () => ({
+  useAuth: () => ({
+    verifyMfa: mockVerifyMfa,
+    signOut: mockSignOut,
+    session: null,
+    user: null,
+    authStatus: "mfa_required" as const,
+  }),
+}));
+
+jest.mock("../../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: jest.fn().mockReturnValue({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      }),
+    },
+  },
+}));
+
+import MfaChallengeScreen from "../MfaChallengeScreen";
+
+// --- Helpers ---
+
+function findByTestId(
+  renderer: ReactTestRenderer,
+  testID: string
+) {
+  return renderer.root.findByProps({ testID });
+}
+
+function findByTestIdOptional(
+  renderer: ReactTestRenderer,
+  testID: string
+) {
+  const matches = renderer.root.findAllByProps({ testID });
+  return matches.length > 0 ? matches[0] : null;
+}
+
+// --- Tests ---
+
+describe("MfaChallengeScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockVerifyMfa.mockResolvedValue({ error: null });
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders the title and subtitle", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    const texts = renderer!.root
+      .findAllByType("Text" as any)
+      .map((t) => {
+        const children = t.props.children;
+        return typeof children === "string" ? children : null;
+      })
+      .filter(Boolean);
+
+    expect(texts).toContain("Two-factor authentication");
+    expect(texts).toContain(
+      "Enter the 6-digit code from your authenticator app to continue."
+    );
+  });
+
+  it("strips non-digit characters from input", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const input = findByTestId(renderer!, "mfa-code-input");
+    await act(async () => {
+      input.props.onChangeText("12ab34");
+    });
+
+    expect(input.props.value).toBe("1234");
+  });
+
+  it("disables verify button when code is less than 6 digits", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    const verifyButton = findByTestId(renderer!, "mfa-verify");
+    expect(verifyButton.props.disabled).toBe(true);
+
+    // Enter partial code
+    const input = findByTestId(renderer!, "mfa-code-input");
+    await act(async () => {
+      input.props.onChangeText("123");
+    });
+
+    expect(findByTestId(renderer!, "mfa-verify").props.disabled).toBe(true);
+  });
+
+  it("calls verifyMfa on submit with 6-digit code", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    const input = findByTestId(renderer!, "mfa-code-input");
+    await act(async () => {
+      input.props.onChangeText("123456");
+    });
+
+    const verifyButton = findByTestId(renderer!, "mfa-verify");
+    expect(verifyButton.props.disabled).toBe(false);
+
+    await act(async () => {
+      verifyButton.props.onPress();
+    });
+
+    expect(mockVerifyMfa).toHaveBeenCalledWith("123456");
+  });
+
+  it("shows error message when verification fails", async () => {
+    mockVerifyMfa.mockResolvedValue({
+      error: {
+        message: "Invalid code",
+        name: "AuthApiError",
+        status: 400,
+        code: "mfa_verification_failed",
+      },
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    const input = findByTestId(renderer!, "mfa-code-input");
+    await act(async () => {
+      input.props.onChangeText("999999");
+    });
+
+    await act(async () => {
+      findByTestId(renderer!, "mfa-verify").props.onPress();
+    });
+
+    const errorElement = findByTestId(renderer!, "mfa-error");
+    expect(errorElement).toBeTruthy();
+    expect(errorElement.props.children).toBe(
+      "Invalid code. Please check your authenticator app and try again."
+    );
+  });
+
+  it("calls signOut when sign out button is pressed", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    const signOutButton = findByTestId(renderer!, "mfa-sign-out");
+    await act(async () => {
+      signOutButton.props.onPress();
+    });
+
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+
+  it("does not show error message initially", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(MfaChallengeScreen));
+    });
+
+    const errorElement = findByTestIdOptional(renderer!, "mfa-error");
+    expect(errorElement).toBeNull();
+  });
+});

--- a/mobile/src/auth/errors.ts
+++ b/mobile/src/auth/errors.ts
@@ -11,6 +11,10 @@ const SAFE_ERROR_MESSAGES: Record<string, string> = {
     "Too many attempts. Please wait a moment and try again.",
   over_email_send_rate_limit:
     "Too many requests. Please wait a moment and try again.",
+  mfa_factor_not_found: "No authenticator found. Please re-enroll.",
+  mfa_verification_failed:
+    "Invalid code. Please check your authenticator app and try again.",
+  mfa_challenge_expired: "Verification timed out. Please try again.",
 };
 
 /** Returns a user-safe message for a Supabase AuthError by matching its code

--- a/mobile/src/auth/types.ts
+++ b/mobile/src/auth/types.ts
@@ -26,6 +26,8 @@ export interface AuthState {
   sendOtp: (email: string) => Promise<AuthResult>;
   /** Verify an email OTP token to complete sign-in. */
   verifyOtp: (email: string, token: string) => Promise<AuthResult>;
+  /** Verify a TOTP code to complete the MFA challenge. */
+  verifyMfa: (code: string) => Promise<AuthResult>;
   /** Sign the user out of this device only (local scope). */
   signOut: () => Promise<AuthResult>;
 }

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from "react";
-import { ActivityIndicator, Alert, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useAuth } from "../auth/AuthContext";
 import LoginScreen from "../screens/LoginScreen";
+import MfaChallengeScreen from "../auth/MfaChallengeScreen";
 import ApprovalListScreen from "../screens/approvals/ApprovalListScreen";
 import ApprovalDetailScreen from "../screens/approvals/ApprovalDetailScreen";
 import DeepLinkDetailScreen from "../screens/approvals/DeepLinkDetailScreen";
@@ -15,6 +15,7 @@ import { colors } from "../theme/colors";
 
 export type RootStackParamList = {
   Login: undefined;
+  MfaChallenge: undefined;
   ApprovalList: undefined;
   ApprovalDetail: {
     approvalId: string;
@@ -29,20 +30,7 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function RootNavigator() {
-  const { authStatus, signOut } = useAuth();
-
-  // MFA challenge is not yet supported on mobile. If the user's account
-  // requires MFA, sign them out and show a message. A proper MFA challenge
-  // screen will be added in a future phase.
-  useEffect(() => {
-    if (authStatus === "mfa_required") {
-      Alert.alert(
-        "MFA required",
-        "Multi-factor authentication is not yet supported in the mobile app. Please sign in via the web app.",
-        [{ text: "OK", onPress: () => signOut() }]
-      );
-    }
-  }, [authStatus, signOut]);
+  const { authStatus } = useAuth();
 
   return (
     <NavigationContainer
@@ -87,6 +75,8 @@ export default function RootNavigator() {
               }}
             />
           </>
+        ) : authStatus === "mfa_required" ? (
+          <Stack.Screen name="MfaChallenge" component={MfaChallengeScreen} />
         ) : (
           <Stack.Screen
             name="Login"


### PR DESCRIPTION
## Summary

- Add a proper TOTP MFA challenge screen to the mobile app, replacing the placeholder alert that signed users out and told them to use the web app
- Port `verifyMfa` logic from the web frontend's AuthContext (with 10s timeout, error handling, and eager `authStatus` promotion)
- Add MFA-specific error codes (`mfa_factor_not_found`, `mfa_verification_failed`, `mfa_challenge_expired`) to the mobile error mapping

## Test plan

### Developer
- [x] Add unit tests for `MfaChallengeScreen` (rendering, input stripping, verify, sign-out, error display)
- [x] Add unit tests for `verifyMfa` in `AuthContext.test.tsx` (correct factor ID, missing factor error)
- [x] All 193 mobile tests pass

### Manual Testing
- [ ] Sign in with an account that has TOTP MFA enrolled — verify the challenge screen appears
- [ ] Enter a valid 6-digit code — verify it transitions to the authenticated app
- [ ] Enter an invalid code — verify error message is displayed
- [ ] Tap Sign Out — verify it returns to the login screen
- [ ] Verify the code input strips non-digit characters and disables Verify until 6 digits entered
- [ ] Test on both iOS and Android

https://claude.ai/code/session_01Qs2tDi4zqXQzQRFV2MMzxi