### PR TITLE
Fix mobile OTP input length and resend cooldown

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/src/auth/OtpStep.tsx
+++ b/mobile/src/auth/OtpStep.tsx
@@ -22,7 +22,7 @@ interface OtpStepProps {
   onBack: () => void;
 }
 
-const RESEND_COOLDOWN_SECONDS = 30;
+const RESEND_COOLDOWN_SECONDS = 60;
 
 type ResendStatus = "idle" | "sent" | "failed";
 
@@ -116,7 +116,7 @@ export default function OtpStep({
             placeholderTextColor={colors.gray400}
             keyboardType="number-pad"
             autoComplete="one-time-code"
-            maxLength={6}
+            maxLength={32}
             editable={!isSubmitting}
             onSubmitEditing={submit}
             returnKeyType="go"
@@ -138,11 +138,11 @@ export default function OtpStep({
               authStyles.button,
               authStyles.primaryButton,
               localStyles.flexButton,
-              (isSubmitting || otpCode.length < 6) &&
+              (isSubmitting || otpCode.length < 6 || otpCode.length > 32) &&
                 authStyles.buttonDisabled,
             ]}
             onPress={submit}
-            disabled={isSubmitting || otpCode.length < 6}
+            disabled={isSubmitting || otpCode.length < 6 || otpCode.length > 32}
           >
             <Text style={authStyles.primaryButtonText}>
               {isSubmitting ? "Verifying..." : "Verify"}
@@ -206,9 +206,9 @@ const localStyles = StyleSheet.create({
     color: colors.gray900,
   },
   otpInput: {
-    fontSize: 24,
+    fontSize: 18,
     fontWeight: "600",
-    letterSpacing: 8,
+    letterSpacing: 4,
     textAlign: "center",
   },
   buttonRow: {


### PR DESCRIPTION
## Summary
- **OTP input accepts up to 32 characters** — production codes can be longer than 6 digits (e.g. 8), and the input was truncating them, causing verification to always fail
- **Resend cooldown bumped from 30s to 60s** — Supabase's production `max_frequency` is 60s, so resending after 30s hit a rate limit and showed "Failed to resend"
- **Reduced font size/letter spacing** on OTP input to accommodate longer codes without overflow

## Test plan

### Developer
- [x] `make mobile-test` passes (195/195)

### Manual Testing
- [ ] Enter an 8-digit OTP code on mobile — verify it's not truncated and submission works
- [ ] Tap "Resend code" after cooldown expires — verify it succeeds without "Failed to resend"
- [ ] Verify 6-digit codes still work correctly

https://claude.ai/code/session_01UnWdcpfUgwNuhdRYtfiRsQ