### PR TITLE
Align mobile styling with web brand identity

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,6 +3575,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/src/auth/EmailStep.tsx
+++ b/mobile/src/auth/EmailStep.tsx
@@ -14,6 +14,7 @@ import type { AuthError } from "@supabase/supabase-js";
 import { useFormSubmit } from "./useFormSubmit";
 import { authStyles } from "./styles";
 import { colors } from "../theme/colors";
+import { BrandBadge } from "../components/BrandBadge";
 
 interface EmailStepProps {
   onSubmit: (email: string) => Promise<{ error: AuthError | null }>;
@@ -43,13 +44,10 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <Pressable style={authStyles.content} onPress={Keyboard.dismiss}>
-          <View
-            style={brandBadgeStyles.badge}
-            accessibilityElementsHidden={true}
-            importantForAccessibility="no-hide-descendants"
-          >
-            <Text style={brandBadgeStyles.badgeText}>P</Text>
-          </View>
+        <View style={styles.brandRow}>
+          <BrandBadge size={32} />
+          <Text style={[authStyles.title, { marginBottom: 0 }]}>Permission Slip</Text>
+        </View>
         <Text style={authStyles.subtitle}>
           Enter your email to sign in or create an account.
         </Text>
@@ -102,24 +100,11 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
   );
 }
 
-const brandBadgeStyles = StyleSheet.create({
-  row: {
+const styles = StyleSheet.create({
+  brandRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
     marginBottom: 8,
-  },
-  badge: {
-    width: 32,
-    height: 32,
-    borderRadius: 8,
-    backgroundColor: colors.primary,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  badgeText: {
-    color: colors.white,
-    fontSize: 16,
-    fontWeight: "700",
   },
 });

--- a/mobile/src/auth/EmailStep.tsx
+++ b/mobile/src/auth/EmailStep.tsx
@@ -43,12 +43,13 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <Pressable style={authStyles.content} onPress={Keyboard.dismiss}>
-        <View style={brandBadgeStyles.row}>
-          <View style={brandBadgeStyles.badge}>
+          <View
+            style={brandBadgeStyles.badge}
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+          >
             <Text style={brandBadgeStyles.badgeText}>P</Text>
           </View>
-          <Text style={[authStyles.title, { marginBottom: 0 }]}>Permission Slip</Text>
-        </View>
         <Text style={authStyles.subtitle}>
           Enter your email to sign in or create an account.
         </Text>

--- a/mobile/src/auth/EmailStep.tsx
+++ b/mobile/src/auth/EmailStep.tsx
@@ -4,6 +4,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
+  StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
@@ -42,7 +43,12 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <Pressable style={authStyles.content} onPress={Keyboard.dismiss}>
-        <Text style={authStyles.title}>Permission Slip</Text>
+        <View style={brandBadgeStyles.row}>
+          <View style={brandBadgeStyles.badge}>
+            <Text style={brandBadgeStyles.badgeText}>P</Text>
+          </View>
+          <Text style={[authStyles.title, { marginBottom: 0 }]}>Permission Slip</Text>
+        </View>
         <Text style={authStyles.subtitle}>
           Enter your email to sign in or create an account.
         </Text>
@@ -94,3 +100,25 @@ export default function EmailStep({ onSubmit }: EmailStepProps) {
     </KeyboardAvoidingView>
   );
 }
+
+const brandBadgeStyles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 8,
+  },
+  badge: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  badgeText: {
+    color: colors.white,
+    fontSize: 16,
+    fontWeight: "700",
+  },
+});

--- a/mobile/src/auth/styles.ts
+++ b/mobile/src/auth/styles.ts
@@ -53,7 +53,7 @@ export const authStyles = StyleSheet.create({
     alignItems: "center" as const,
   },
   primaryButton: {
-    backgroundColor: colors.gray900,
+    backgroundColor: colors.primary,
   },
   primaryButtonText: {
     color: colors.white,

--- a/mobile/src/components/BrandBadge.tsx
+++ b/mobile/src/components/BrandBadge.tsx
@@ -1,0 +1,31 @@
+import { Text, View } from "react-native";
+import { colors } from "../theme/colors";
+
+interface BrandBadgeProps {
+  size?: number;
+}
+
+/** Purple rounded-square "P" brand mark matching the web's nav header badge. */
+export function BrandBadge({ size = 32 }: BrandBadgeProps) {
+  const radius = Math.round(size * 0.25);
+  const fontSize = Math.round(size * 0.5);
+
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: radius,
+        backgroundColor: colors.primary,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      accessibilityElementsHidden={true}
+      importantForAccessibility="no-hide-descendants"
+    >
+      <Text style={{ color: colors.white, fontSize, fontWeight: "700" }}>
+        P
+      </Text>
+    </View>
+  );
+}

--- a/mobile/src/components/ErrorBoundary.tsx
+++ b/mobile/src/components/ErrorBoundary.tsx
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
     lineHeight: 22,
   },
   button: {
-    backgroundColor: colors.gray900,
+    backgroundColor: colors.primary,
     borderRadius: 8,
     paddingVertical: 12,
     paddingHorizontal: 32,

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -38,7 +38,7 @@ export default function RootNavigator() {
       linking={linking}
       fallback={
         <View style={styles.fallback}>
-          <ActivityIndicator size="large" color={colors.gray900} />
+          <ActivityIndicator size="large" color={colors.primary} />
           <Text style={styles.fallbackText}>Loading...</Text>
         </View>
       }

--- a/mobile/src/screens/BiometricLockScreen.tsx
+++ b/mobile/src/screens/BiometricLockScreen.tsx
@@ -35,7 +35,7 @@ export function BiometricLockScreen({ onUnlock }: BiometricLockScreenProps) {
   return (
     <View style={styles.container}>
       <View style={styles.lockIcon}>
-        <Text style={styles.lockIconText}>PS</Text>
+        <Text style={styles.lockIconText}>P</Text>
       </View>
       <Text style={styles.title}>Permission Slip</Text>
       <Text style={styles.subtitle}>
@@ -65,16 +65,16 @@ const styles = StyleSheet.create({
   lockIcon: {
     width: 72,
     height: 72,
-    borderRadius: 36,
-    backgroundColor: colors.gray100,
+    borderRadius: 16,
+    backgroundColor: colors.primary,
     alignItems: "center",
     justifyContent: "center",
     marginBottom: 16,
   },
   lockIconText: {
-    fontSize: 24,
+    fontSize: 28,
     fontWeight: "700",
-    color: colors.gray900,
+    color: colors.white,
   },
   title: {
     fontSize: 22,
@@ -89,7 +89,7 @@ const styles = StyleSheet.create({
     marginBottom: 32,
   },
   button: {
-    backgroundColor: colors.gray900,
+    backgroundColor: colors.primary,
     borderRadius: 12,
     paddingVertical: 14,
     paddingHorizontal: 48,

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -321,7 +321,7 @@ const RISK_DESCRIPTIONS: Record<string, string> = {
 const styles = StyleSheet.create({
   outerContainer: {
     flex: 1,
-    backgroundColor: colors.gray50,
+    backgroundColor: colors.primaryBg,
   },
   container: {
     flex: 1,
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
   // --- Done button ---
   doneButton: {
     marginTop: 16,
-    backgroundColor: colors.gray900,
+    backgroundColor: colors.primary,
     borderRadius: 12,
     paddingVertical: 14,
     alignItems: "center",

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -104,7 +104,12 @@ export default function ApprovalListScreen({ navigation }: Props) {
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
       <View style={styles.header}>
-        <Text style={styles.title}>Approvals</Text>
+        <View style={styles.headerLeft}>
+          <View style={styles.brandBadge}>
+            <Text style={styles.brandBadgeText}>P</Text>
+          </View>
+          <Text style={styles.title}>Approvals</Text>
+        </View>
         <TouchableOpacity
           testID="settings-button"
           accessibilityLabel="Settings"
@@ -164,7 +169,7 @@ export default function ApprovalListScreen({ navigation }: Props) {
         <View style={styles.center}>
           <ActivityIndicator
             size="large"
-            color={colors.gray900}
+            color={colors.primary}
             testID="loading-indicator"
           />
         </View>
@@ -306,6 +311,24 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 12,
   },
+  headerLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  brandBadge: {
+    width: 28,
+    height: 28,
+    borderRadius: 8,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  brandBadgeText: {
+    color: colors.white,
+    fontSize: 14,
+    fontWeight: "700",
+  },
   title: {
     fontSize: 28,
     fontWeight: "700",
@@ -334,7 +357,7 @@ const styles = StyleSheet.create({
     borderBottomColor: "transparent",
   },
   tabActive: {
-    borderBottomColor: colors.gray900,
+    borderBottomColor: colors.secondary,
   },
   tabText: {
     fontSize: 14,
@@ -350,7 +373,7 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   tabBadge: {
-    backgroundColor: colors.gray900,
+    backgroundColor: colors.primary,
     borderRadius: 10,
     minWidth: 20,
     height: 20,

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -24,6 +24,7 @@ import { colors } from "../../theme/colors";
 import { buildActionSummary, humanizeActionType, safeParams, isExpired as checkExpired, formatRelativeTime, formatLastUpdated } from "./approvalUtils";
 import { RiskBadge } from "./RiskBadge";
 import { CountdownBadge } from "./CountdownBadge";
+import { BrandBadge } from "../../components/BrandBadge";
 
 type StatusTab = "pending" | "approved" | "denied";
 
@@ -105,9 +106,7 @@ export default function ApprovalListScreen({ navigation }: Props) {
     <View style={[styles.container, { paddingTop: insets.top }]}>
       <View style={styles.header}>
         <View style={styles.headerLeft}>
-          <View style={styles.brandBadge}>
-            <Text style={styles.brandBadgeText}>P</Text>
-          </View>
+          <BrandBadge size={28} />
           <Text style={styles.title}>Approvals</Text>
         </View>
         <TouchableOpacity
@@ -315,19 +314,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
-  },
-  brandBadge: {
-    width: 28,
-    height: 28,
-    borderRadius: 8,
-    backgroundColor: colors.primary,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  brandBadgeText: {
-    color: colors.white,
-    fontSize: 14,
-    fontWeight: "700",
   },
   title: {
     fontSize: 28,

--- a/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
+++ b/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     padding: 20,
     alignItems: "center",
     borderWidth: 1,
-    borderColor: "#DDD5E5",
+    borderColor: colors.primaryBorder,
   },
   label: {
     fontSize: 12,

--- a/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
+++ b/mobile/src/screens/approvals/ConfirmationCodeCard.tsx
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     padding: 20,
     alignItems: "center",
     borderWidth: 1,
-    borderColor: "#BFDBFE",
+    borderColor: "#DDD5E5",
   },
   label: {
     fontSize: 12,

--- a/mobile/src/screens/approvals/DeepLinkDetailScreen.tsx
+++ b/mobile/src/screens/approvals/DeepLinkDetailScreen.tsx
@@ -40,7 +40,7 @@ export default function DeepLinkDetailScreen({ route, navigation }: Props) {
   if (isLoading || approval) {
     return (
       <View style={styles.container}>
-        <ActivityIndicator size="large" color={colors.gray900} />
+        <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.text}>Loading approval...</Text>
       </View>
     );
@@ -107,18 +107,18 @@ const styles = StyleSheet.create({
   },
   retryButton: {
     borderWidth: 1,
-    borderColor: colors.gray900,
+    borderColor: colors.primary,
     borderRadius: 8,
     paddingVertical: 12,
     paddingHorizontal: 24,
   },
   retryButtonText: {
-    color: colors.gray900,
+    color: colors.primary,
     fontSize: 16,
     fontWeight: "600",
   },
   button: {
-    backgroundColor: colors.gray900,
+    backgroundColor: colors.primary,
     borderRadius: 8,
     paddingVertical: 12,
     paddingHorizontal: 24,

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -151,7 +151,7 @@ export default function SettingsScreen(_props: Props) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.gray50,
+    backgroundColor: colors.primaryBg,
   },
   section: {
     paddingHorizontal: 20,

--- a/mobile/src/theme/colors.ts
+++ b/mobile/src/theme/colors.ts
@@ -35,8 +35,8 @@ export const colors = {
   // Primary / accent
   primary: "#6A2C91",
   primaryBg: "#F5F0FA",
+  primaryBorder: "#DDD5E5",
   secondary: "#D4A843",
-  secondaryBg: "#FBF6EB",
 
   // Cancelled / expired status
   cancelledBg: "#F3F4F6",

--- a/mobile/src/theme/colors.ts
+++ b/mobile/src/theme/colors.ts
@@ -33,8 +33,10 @@ export const colors = {
   deniedText: "#991B1B",
 
   // Primary / accent
-  primary: "#2563EB",
-  primaryBg: "#EFF6FF",
+  primary: "#6A2C91",
+  primaryBg: "#F5F0FA",
+  secondary: "#D4A843",
+  secondaryBg: "#FBF6EB",
 
   // Cancelled / expired status
   cancelledBg: "#F3F4F6",


### PR DESCRIPTION
## Summary
- Update mobile color palette from generic blue to branded purple/gold matching the web's design system (Royal Purple `#6A2C91`, Rich Gold `#D4A843`, Light Lavender `#F5F0FA`)
- Add "P" brand badge to login screen and approval list header, matching the web's nav header pattern
- Update biometric lock screen icon from gray circle "PS" to purple rounded-square "P"
- Replace all accent-colored buttons, tab indicators, loading spinners, and screen backgrounds with brand colors

## Test plan

### Developer
- [x] All 203 mobile tests pass (`make mobile-test`)
- [x] No changes to semantic colors (success/error/warning) or text foreground colors

### Manual Testing
- [ ] Verify login screen shows purple "P" badge next to title and purple "Continue" button
- [ ] Verify approval list header shows purple "P" badge and gold active tab underline
- [ ] Verify approval detail screen has lavender background and purple "Done" button
- [ ] Verify settings screen has lavender background and purple switch track
- [ ] Verify biometric lock screen shows purple rounded-square "P" icon and purple "Unlock" button
- [ ] Verify confirmation code card has purple-tinted border and purple "Copy Code" button
- [ ] Verify deep link loading/error screens use purple for spinners and buttons
- [ ] Check text contrast remains readable on lavender backgrounds

https://claude.ai/code/session_01BdfppGJBy489v1zt7799s4