### PR TITLE
Fix syntax error in jsonSafeMiddleware breaking iOS builds

### DIFF
--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -40,10 +40,9 @@ const useMockApi = __DEV__ && process.env.EXPO_PUBLIC_MOCK_AUTH === "true";
 export const jsonSafeMiddleware: Middleware = {
   async onResponse({ response }) {
     // Let bodyless responses through (204 No Content, 304 Not Modified, etc.)
-    // Cancel the original body stream to release the connection before
-    // returning the replacement response.
-    void response.body?.cancel();
-    return new Response(errorBody, {
+    if (!response.body) {
+      return response;
+    }
 
     const contentType = response.headers.get("content-type") ?? "";
     if (contentType.includes("application/json")) {
@@ -52,6 +51,9 @@ export const jsonSafeMiddleware: Middleware = {
 
     // Non-JSON body (HTML from SPA handler, proxy error page, plain text, etc.)
     // Convert to a structured JSON error so hook-level `if (error)` handling works.
+    // Cancel the original body stream to release the connection before
+    // returning the replacement response.
+    void response.body?.cancel();
     const status = response.status >= 400 ? response.status : 502;
     const errorBody = JSON.stringify({
       error: {


### PR DESCRIPTION
## Summary

- Fixes a mangled bodyless-response guard in `mobile/src/api/client.ts` that caused a `SyntaxError` at Metro bundle time, preventing iOS builds from completing
- The middleware had a dangling `return new Response(errorBody, {` and a `void response.body?.cancel()` referencing `errorBody` before it was defined
- Restructured to correctly: (1) pass bodyless responses through, (2) pass JSON responses through, (3) cancel body stream and convert non-JSON responses to structured errors

## Test plan

- [x] All 7 `jsonSafeMiddleware` unit tests pass
- [ ] `npx expo run:ios --device --configuration Release` bundles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)