### PR TITLE
Add EAS project ID to dynamic app config

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -70,4 +70,9 @@ export default (_config: ConfigContext): ExpoConfig => ({
     enabled: true,
     fallbackToCacheTimeout: 0,
   },
+  extra: {
+    eas: {
+      projectId: "6bbabfc7-f70d-45f7-bdc2-4f8387d14006",
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- Add `extra.eas.projectId` to `app.config.ts` so `eas-cli` can identify the project
- Required because `eas init` cannot auto-write to dynamic config files (`.ts`)

## Test plan

### Developer
- [ ] Run `npx eas-cli@latest init --id 6bbabfc7-f70d-45f7-bdc2-4f8387d14006` and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)