### PR TITLE
Add owner field to app.config.ts for EAS

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -3,6 +3,7 @@ import { ExpoConfig, ConfigContext } from "expo/config";
 export default (_config: ConfigContext): ExpoConfig => ({
   name: "Permission Slip",
   slug: "permission-slip",
+  owner: "supersuit-tech",
   version: "1.0.0",
   // Only include runtimeVersion during EAS builds — Expo Go doesn't support it
   ...(process.env.EAS_BUILD


### PR DESCRIPTION
## Summary

- Add `owner: "supersuit-tech"` to `app.config.ts` to complete EAS project linking
- Required because `eas init` cannot auto-write to dynamic config files (`.ts`)

## Test plan

### Developer
- [ ] Run `npx eas-cli@latest init --id 6bbabfc7-f70d-45f7-bdc2-4f8387d14006` and verify it succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)