### PR TITLE
Add EAS project ID for push notifications

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -59,6 +59,11 @@
       ],
       "predictiveBackGestureEnabled": false
     },
+    "extra": {
+      "eas": {
+        "projectId": "6bbabfc7-f70d-45f7-bdc2-4f8387d14006"
+      }
+    },
     "web": {
       "favicon": "./assets/favicon.png"
     },


### PR DESCRIPTION
## Summary
- Adds `extra.eas.projectId` to `mobile/app.json` linking the repo to the Expo project (`6bbabfc7-f70d-45f7-bdc2-4f8387d14006`)
- Required for `getExpoPushTokenAsync()` to issue push tokens and for EAS credentials/builds to work

## Test plan

### Claude Code
- [ ] Verify `make mobile-test` passes
- [ ] Verify `make build` passes

### Manual Testing
- [ ] Rebuild the app on device (`npx expo run:ios --device --configuration Release`)
- [ ] Verify push token registration succeeds (check `GET /api/v1/push-subscriptions` returns a token)
- [ ] Trigger an approval and verify iOS push notification is received

https://claude.ai/code/session_01RLa9MrdDTViVQBW88Uexar