### PR TITLE
Change mobile header from "Approvals" to "Permission Slip"

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3575,36 +3575,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -107,7 +107,7 @@ export default function ApprovalListScreen({ navigation }: Props) {
       <View style={styles.header}>
         <View style={styles.headerLeft}>
           <BrandBadge size={28} />
-          <Text style={styles.title}>Approvals</Text>
+          <Text style={styles.title}>Permission Slip</Text>
         </View>
         <TouchableOpacity
           testID="settings-button"

--- a/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
@@ -153,7 +153,7 @@ describe("ApprovalListScreen", () => {
       renderer = renderList();
     });
     const allText = getAllText(renderer);
-    expect(allText).toContain("Approvals");
+    expect(allText).toContain("Permission Slip");
   });
 
   it("shows loading indicator when loading", async () => {


### PR DESCRIPTION
## Summary
- Renames the mobile app header from "Approvals" to "Permission Slip" to match the web app branding
- Updates the corresponding test assertion

## Test plan

### Developer
- [x] Mobile tests pass (`make mobile-test`)

### Manual Testing
- [ ] Open the mobile app and verify the header reads "Permission Slip" instead of "Approvals"

https://claude.ai/code/session_01WS4kXGnZgKYqLiVEVLsUmS