### PR TITLE
Ignore .ipa, .apk, and .aab build artifacts

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -17,6 +17,9 @@ expo-env.d.ts
 *.p12
 *.key
 *.mobileprovision
+*.ipa
+*.apk
+*.aab
 
 # Google Play service account keys (used by EAS Submit)
 google-services.json


### PR DESCRIPTION
## Summary

- Add `*.ipa`, `*.apk`, and `*.aab` to mobile `.gitignore` so build artifacts from EAS or local builds are never accidentally committed

## Test plan

- [x] No build artifacts currently tracked in git

🤖 Generated with [Claude Code](https://claude.com/claude-code)