### PR TITLE
Add iOS encryption compliance flag for EAS Build

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -26,6 +26,7 @@ export default (_config: ConfigContext): ExpoConfig => ({
       UIBackgroundModes: ["remote-notification"],
       NSFaceIDUsageDescription:
         "Authenticate with Face ID to access Permission Slip",
+      ITSAppUsesNonExemptEncryption: false,
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

- Add `ITSAppUsesNonExemptEncryption: false` to `ios.infoPlist` in `app.config.ts`
- Required by EAS Build for App Store submission — declares the app only uses standard HTTPS/TLS (exempt encryption), so no export compliance documentation is needed

## Test plan

### Developer
- [ ] `npx eas-cli@latest build --platform ios --profile production` proceeds without the encryption prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)