### PR TITLE
Add App Store review login bypass for passwordless auth

### DIFF
--- a/api/app_review_auth.go
+++ b/api/app_review_auth.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func init() {
+	RegisterRouteGroup(registerAppReviewAuthRoutes)
+}
+
+func registerAppReviewAuthRoutes(mux *http.ServeMux, deps *Deps) {
+	mux.HandleFunc("POST /v1/auth/app-review-login", handleAppReviewLogin(deps))
+}
+
+// handleAppReviewLogin authenticates the App Store review account using a
+// pre-shared OTP code. This bypasses the normal Supabase OTP flow because
+// Apple's review team cannot receive real OTP emails.
+//
+// The endpoint validates the email and OTP against the APP_REVIEW_EMAIL and
+// APP_REVIEW_OTP environment variables. If they match, it uses the Supabase
+// Admin API to generate a magic link for the review user, then exchanges the
+// link token for a real session.
+//
+// Security considerations:
+//   - Only enabled when both APP_REVIEW_EMAIL and APP_REVIEW_OTP are set
+//   - The OTP is a static secret — treat it like a password in env config
+//   - Rate limited by the standard API rate limiter (applied upstream)
+//   - Returns generic errors to avoid leaking whether the feature is enabled
+func handleAppReviewLogin(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cfg := loadAppReviewConfig()
+		if !cfg.enabled {
+			RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Invalid credentials"))
+			return
+		}
+
+		var body struct {
+			Email string `json:"email"`
+			OTP   string `json:"otp"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Invalid request body"))
+			return
+		}
+
+		if !strings.EqualFold(body.Email, cfg.email) || body.OTP != cfg.otp {
+			RespondError(w, r, http.StatusUnauthorized, Unauthorized(ErrInvalidToken, "Invalid credentials"))
+			return
+		}
+
+		if deps.SupabaseURL == "" || deps.SupabaseServiceRoleKey == "" {
+			log.Printf("[%s] app-review-login: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set", TraceID(r.Context()))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Authentication service not configured"))
+			return
+		}
+
+		// Step 1: Generate a magic link via the Supabase Admin API.
+		// This creates the user if they don't exist and returns a link
+		// containing a token_hash we can exchange for a session.
+		linkReq := map[string]string{
+			"type":  "magiclink",
+			"email": body.Email,
+		}
+		linkBody, _ := json.Marshal(linkReq)
+
+		generateURL := fmt.Sprintf("%s/auth/v1/admin/generate_link", deps.SupabaseURL)
+		httpReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, generateURL, bytes.NewReader(linkBody))
+		if err != nil {
+			log.Printf("[%s] app-review-login: create generate_link request: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+deps.SupabaseServiceRoleKey)
+		httpReq.Header.Set("apikey", deps.SupabaseServiceRoleKey)
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			log.Printf("[%s] app-review-login: generate_link request failed: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+		defer resp.Body.Close()
+
+		respBody, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			log.Printf("[%s] app-review-login: generate_link returned %d: %s", TraceID(r.Context()), resp.StatusCode, string(respBody))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+
+		var linkResp struct {
+			ActionLink string `json:"action_link"`
+		}
+		if err := json.Unmarshal(respBody, &linkResp); err != nil || linkResp.ActionLink == "" {
+			log.Printf("[%s] app-review-login: failed to parse generate_link response", TraceID(r.Context()))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+
+		// Step 2: Extract the token_hash from the action_link URL.
+		parsed, err := url.Parse(linkResp.ActionLink)
+		if err != nil {
+			log.Printf("[%s] app-review-login: failed to parse action_link: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+
+		// The token might be in the query params or the URL fragment.
+		// Supabase puts it in query: ?token_hash=...&type=magiclink
+		tokenHash := parsed.Query().Get("token_hash")
+		tokenType := parsed.Query().Get("type")
+		if tokenHash == "" {
+			// Some Supabase versions put the token directly
+			tokenHash = parsed.Query().Get("token")
+			tokenType = "magiclink"
+		}
+		if tokenHash == "" {
+			log.Printf("[%s] app-review-login: no token_hash in action_link: %s", TraceID(r.Context()), linkResp.ActionLink)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+		if tokenType == "" {
+			tokenType = "magiclink"
+		}
+
+		// Step 3: Exchange the token for a session via the verify endpoint.
+		verifyReq := map[string]string{
+			"token_hash": tokenHash,
+			"type":       tokenType,
+		}
+		verifyBody, _ := json.Marshal(verifyReq)
+
+		verifyURL := fmt.Sprintf("%s/auth/v1/verify", deps.SupabaseURL)
+		httpReq2, err := http.NewRequestWithContext(r.Context(), http.MethodPost, verifyURL, bytes.NewReader(verifyBody))
+		if err != nil {
+			log.Printf("[%s] app-review-login: create verify request: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+		httpReq2.Header.Set("apikey", deps.SupabaseServiceRoleKey)
+		httpReq2.Header.Set("Content-Type", "application/json")
+
+		resp2, err := client.Do(httpReq2)
+		if err != nil {
+			log.Printf("[%s] app-review-login: verify request failed: %v", TraceID(r.Context()), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+		defer resp2.Body.Close()
+
+		verifyRespBody, _ := io.ReadAll(resp2.Body)
+		if resp2.StatusCode != http.StatusOK {
+			log.Printf("[%s] app-review-login: verify returned %d: %s", TraceID(r.Context()), resp2.StatusCode, string(verifyRespBody))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to authenticate"))
+			return
+		}
+
+		// Step 4: Return the session tokens to the client.
+		// The verify response contains access_token, refresh_token, user, etc.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(verifyRespBody)
+	}
+}

--- a/api/app_review_auth_test.go
+++ b/api/app_review_auth_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleAppReviewLogin_DisabledWhenNotConfigured(t *testing.T) {
+	// Clear env vars to ensure the feature is disabled.
+	t.Setenv("APP_REVIEW_EMAIL", "")
+	t.Setenv("APP_REVIEW_OTP", "")
+
+	deps := &Deps{}
+	handler := handleAppReviewLogin(deps)
+
+	body, _ := json.Marshal(map[string]string{
+		"email": "test@example.com",
+		"otp":   "123456",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/app-review-login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when not configured, got %d", rr.Code)
+	}
+}
+
+func TestHandleAppReviewLogin_RejectsWrongCredentials(t *testing.T) {
+	t.Setenv("APP_REVIEW_EMAIL", "review@example.com")
+	t.Setenv("APP_REVIEW_OTP", "999999")
+
+	deps := &Deps{}
+	handler := handleAppReviewLogin(deps)
+
+	tests := []struct {
+		name  string
+		email string
+		otp   string
+	}{
+		{"wrong email", "wrong@example.com", "999999"},
+		{"wrong otp", "review@example.com", "000000"},
+		{"both wrong", "wrong@example.com", "000000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]string{
+				"email": tt.email,
+				"otp":   tt.otp,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/v1/auth/app-review-login", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("expected 401 for %s, got %d", tt.name, rr.Code)
+			}
+		})
+	}
+}
+
+func TestHandleAppReviewLogin_RejectsInvalidBody(t *testing.T) {
+	t.Setenv("APP_REVIEW_EMAIL", "review@example.com")
+	t.Setenv("APP_REVIEW_OTP", "999999")
+
+	deps := &Deps{}
+	handler := handleAppReviewLogin(deps)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/app-review-login", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid body, got %d", rr.Code)
+	}
+}
+
+func TestHandleAppReviewLogin_EmailCaseInsensitive(t *testing.T) {
+	t.Setenv("APP_REVIEW_EMAIL", "Review@Example.com")
+	t.Setenv("APP_REVIEW_OTP", "999999")
+
+	deps := &Deps{}
+	handler := handleAppReviewLogin(deps)
+
+	// Email matches case-insensitively but Supabase isn't configured,
+	// so it should get past credential validation and fail at the
+	// Supabase step (500) rather than the credential step (401).
+	body, _ := json.Marshal(map[string]string{
+		"email": "review@example.com",
+		"otp":   "999999",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/app-review-login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	// Should fail at the Supabase step (no URL configured), not at credential validation.
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 (Supabase not configured), got %d", rr.Code)
+	}
+}

--- a/api/app_review_config.go
+++ b/api/app_review_config.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"os"
+	"strings"
+)
+
+// appReviewConfig holds the App Store review account configuration.
+type appReviewConfig struct {
+	email   string
+	otp     string
+	enabled bool
+}
+
+// loadAppReviewConfig reads the app review credentials from environment variables.
+// The feature is only enabled when both APP_REVIEW_EMAIL and APP_REVIEW_OTP are set.
+func loadAppReviewConfig() appReviewConfig {
+	email := strings.TrimSpace(os.Getenv("APP_REVIEW_EMAIL"))
+	otp := strings.TrimSpace(os.Getenv("APP_REVIEW_OTP"))
+	return appReviewConfig{
+		email:   email,
+		otp:     otp,
+		enabled: email != "" && otp != "",
+	}
+}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -7901,9 +7901,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7923,9 +7920,6 @@
       "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7947,9 +7941,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7969,9 +7960,6 @@
       "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/mobile/src/auth/AuthContext.tsx
+++ b/mobile/src/auth/AuthContext.tsx
@@ -11,6 +11,7 @@ import type { AuthError, Session, User } from "@supabase/supabase-js";
 import { supabase } from "../lib/supabaseClient";
 import type { AuthStatus, AuthState } from "./types";
 import { AuthContext } from "./authContext";
+import { tryAppReviewLogin } from "./appReviewAuth";
 
 /**
  * Constructs a synthetic AuthError for cases where we need to generate an
@@ -178,7 +179,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       token,
       type: "email",
     });
-    return { error: error ?? null };
+    if (!error) return { error: null };
+
+    // If Supabase OTP verification failed, try the backend's app-review-login
+    // endpoint as a fallback. This allows App Store reviewers to sign in with
+    // a pre-configured static OTP code.
+    const reviewResult = await tryAppReviewLogin(email, token);
+    if (!reviewResult.error) return { error: null };
+
+    // Return the original Supabase error, not the review fallback error,
+    // since most users won't have review credentials configured.
+    return { error };
   }, []);
 
   const signOut = useCallback(async () => {

--- a/mobile/src/auth/appReviewAuth.ts
+++ b/mobile/src/auth/appReviewAuth.ts
@@ -1,0 +1,68 @@
+import { supabase } from "../lib/supabaseClient";
+import type { AuthError } from "@supabase/supabase-js";
+
+/**
+ * Resolves the backend API base URL from the same env var the API client uses.
+ * Falls back to production if not set.
+ */
+function getApiBaseUrl(): string {
+  const envUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
+  if (!envUrl) {
+    return "https://app.permissionslip.dev/api";
+  }
+  return envUrl.replace(/\/v1\/?$/, "").replace(/\/$/, "");
+}
+
+/**
+ * Attempts to authenticate via the backend's app-review-login endpoint.
+ *
+ * This is used as a fallback when Supabase OTP verification fails — the
+ * backend validates the email/OTP against pre-configured App Store review
+ * credentials and returns a valid Supabase session.
+ *
+ * Returns { error: null } on success, or { error: AuthError } on failure.
+ */
+export async function tryAppReviewLogin(
+  email: string,
+  otp: string
+): Promise<{ error: AuthError | null }> {
+  try {
+    const baseUrl = getApiBaseUrl();
+    const response = await fetch(`${baseUrl}/v1/auth/app-review-login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, otp }),
+    });
+
+    if (!response.ok) {
+      return {
+        error: {
+          message: "Invalid credentials",
+          name: "AuthApiError",
+          status: response.status,
+          code: "invalid_credentials",
+        } as AuthError,
+      };
+    }
+
+    const session = await response.json();
+
+    // Set the session in the Supabase client so onAuthStateChange fires
+    // and the rest of the app picks up the authenticated state.
+    const { error } = await supabase.auth.setSession({
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    });
+
+    return { error: error ?? null };
+  } catch {
+    return {
+      error: {
+        message: "Network error",
+        name: "AuthApiError",
+        status: 0,
+        code: "network_error",
+      } as AuthError,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a backend endpoint `POST /v1/auth/app-review-login` that authenticates Apple's App Store review team using pre-configured credentials (`APP_REVIEW_EMAIL` + `APP_REVIEW_OTP` env vars), bypassing the normal email OTP flow they can't complete
- The endpoint uses the Supabase Admin API to generate a magic link and exchange it for a real session, so the reviewer gets a fully valid auth session
- The mobile app's `verifyOtp` falls back to this endpoint when Supabase OTP verification fails, making the flow transparent to reviewers

## How it works

1. Set `APP_REVIEW_EMAIL` and `APP_REVIEW_OTP` env vars in production
2. In App Store Connect review notes, tell Apple: "Enter email `<review-email>`, then enter code `<review-otp>`"
3. The reviewer enters the email → gets the OTP screen → enters the static code
4. Supabase rejects the code (it's not a real OTP) → mobile falls back to the backend endpoint → backend validates against env vars → generates a real Supabase session → reviewer is signed in

## Security

- Only active when both `APP_REVIEW_EMAIL` and `APP_REVIEW_OTP` env vars are set — disabled by default
- Returns generic "Invalid credentials" errors regardless of failure reason (avoids leaking config state)
- Rate limited by the standard `/v1/` API rate limiter
- Email comparison is case-insensitive; OTP comparison is exact
- Supabase service role key stays server-side only

## Test plan

### Developer
- [ ] Verify Go code compiles (`go build ./api/...`)
- [ ] Run backend tests (`make test-backend`)
- [ ] Run mobile tests (`make mobile-test`) — 210 tests pass
- [ ] Verify no new TypeScript errors in mobile

### Manual Testing
- [ ] Deploy with `APP_REVIEW_EMAIL` and `APP_REVIEW_OTP` set
- [ ] Test review login flow: enter review email → enter static OTP → verify session is established
- [ ] Test normal login flow still works (Supabase OTP → success, no fallback triggered)
- [ ] Test with env vars unset: endpoint returns 401, normal flow unaffected
- [ ] Test wrong credentials: returns 401

https://claude.ai/code/session_01T83UzE85gzMLJ2MNPTTB64