### PR TITLE
Serve AASA file for iOS universal links

### DIFF
--- a/main.go
+++ b/main.go
@@ -419,6 +419,14 @@ func main() {
 	// versioned API resource.
 	mux.Handle("/invite/", api.InviteHandler(&deps))
 
+	// Apple App Site Association — required for iOS universal links.
+	// Must be served at /.well-known/apple-app-site-association with
+	// content-type application/json (no file extension).
+	mux.HandleFunc("/.well-known/apple-app-site-association", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"applinks":{"apps":[],"details":[{"appID":"AWUV887E3B.dev.permissionslip.app","paths":["*"]}]}}`))
+	})
+
 	// In production, serve the built React app.
 	// In development, use Vite's dev server (port 5173) instead.
 	if os.Getenv("MODE") != "development" {


### PR DESCRIPTION
## Summary

- Add `/.well-known/apple-app-site-association` route to the Go server
- Returns the AASA JSON with Team ID `AWUV887E3B` and Bundle ID `dev.permissionslip.app`
- Previously the SPA handler was catching this path and returning HTML, which broke iOS universal link verification

## Test plan

### Developer
- [ ] `curl -s https://app.permissionslip.dev/.well-known/apple-app-site-association` returns valid JSON with correct `appID`
- [ ] Response content-type is `application/json`

### Manual Testing
- [ ] iOS universal links work — tapping `https://app.permissionslip.dev/permission-slip/approve/...` opens the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)