### PR TITLE
Allow text input for sign-in OTP code

### DIFF
--- a/frontend/src/auth/MfaChallengePage.tsx
+++ b/frontend/src/auth/MfaChallengePage.tsx
@@ -29,6 +29,7 @@ export default function MfaChallengePage() {
           value={code}
           onChange={setCode}
           autoFocus
+          numericOnly
         />
         <FormError error={error} prefix />
         <div className="flex gap-2">

--- a/frontend/src/components/OtpCodeInput.tsx
+++ b/frontend/src/components/OtpCodeInput.tsx
@@ -7,21 +7,20 @@ interface OtpCodeInputProps {
   id: string;
   /** Visible label text above the input. */
   label: string;
-  /** Current input value (digits only). */
+  /** Current input value. */
   value: string;
-  /** Called with the new value after non-digit characters are stripped. */
+  /** Called with the new value. */
   onChange: (value: string) => void;
   autoFocus?: boolean;
   disabled?: boolean;
   required?: boolean;
+  /** When true, restricts input to digits only and shows a numeric keyboard. */
+  numericOnly?: boolean;
 }
 
 /**
- * A 6-digit one-time-code input with numeric keyboard, digit-only filtering,
- * and browser autofill support. Used for both email OTP and TOTP MFA flows.
- *
- * Digit filtering happens on every keystroke via `.replace(/\D/g, "")` so
- * non-numeric characters can never appear in the value — even on paste.
+ * A one-time-code text input with browser autofill support.
+ * Used for both email OTP and TOTP MFA flows.
  */
 export function OtpCodeInput({
   id,
@@ -31,6 +30,7 @@ export function OtpCodeInput({
   autoFocus,
   disabled,
   required,
+  numericOnly,
 }: OtpCodeInputProps) {
   return (
     <div className="space-y-2">
@@ -38,10 +38,16 @@ export function OtpCodeInput({
       <Input
         id={id}
         type="text"
-        inputMode="numeric"
+        inputMode={numericOnly ? "numeric" : undefined}
         maxLength={validation.confirmationCode.length}
         value={value}
-        onChange={(e) => onChange(e.target.value.replace(/\D/g, ""))}
+        onChange={(e) =>
+          onChange(
+            numericOnly
+              ? e.target.value.replace(/\D/g, "")
+              : e.target.value,
+          )
+        }
         autoComplete="one-time-code"
         autoFocus={autoFocus}
         disabled={disabled}

--- a/mobile/src/auth/OtpStep.tsx
+++ b/mobile/src/auth/OtpStep.tsx
@@ -97,9 +97,9 @@ export default function OtpStep({
             style={[authStyles.input, localStyles.otpInput]}
             value={otpCode}
             onChangeText={setOtpCode}
-            placeholder="000000"
+            placeholder="Enter code"
             placeholderTextColor={colors.gray400}
-            keyboardType="number-pad"
+            keyboardType="default"
             autoComplete="one-time-code"
             maxLength={32}
             editable={!isSubmitting}


### PR DESCRIPTION
## Summary
- Removed numeric-only restriction from the OTP code input used during sign-in (email verification)
- The sign-in code input now accepts any text characters, not just digits
- MFA TOTP authenticator input remains numeric-only (added `numericOnly` prop) since authenticator apps always produce digit codes
- Updated both web (`OtpCodeInput.tsx`) and mobile (`OtpStep.tsx`) components

## Test plan
- [x] Frontend tests pass (945/945)
- [x] Mobile tests pass (210/210)
- [x] TypeScript compilation clean

### Manual Testing
- [ ] Sign in with email, verify the OTP input accepts letters and numbers
- [ ] Verify MFA challenge still restricts to digits only

https://claude.ai/code/session_012kaqaSjkt46Q9LkFkYLjTJ