### PR TITLE
Fix OTP code input to allow up to 32 characters

### DIFF
--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -49,6 +49,7 @@ export default function OtpStep({
           label="Code"
           value={otpCode}
           onChange={setOtpCode}
+          maxLength={32}
           required
         />
         <FormError error={error} prefix />

--- a/frontend/src/components/OtpCodeInput.tsx
+++ b/frontend/src/components/OtpCodeInput.tsx
@@ -16,6 +16,8 @@ interface OtpCodeInputProps {
   required?: boolean;
   /** When true, restricts input to digits only and shows a numeric keyboard. */
   numericOnly?: boolean;
+  /** Maximum number of characters allowed. Defaults to validation.confirmationCode.length (6). */
+  maxLength?: number;
 }
 
 /**
@@ -31,6 +33,7 @@ export function OtpCodeInput({
   disabled,
   required,
   numericOnly,
+  maxLength = validation.confirmationCode.length,
 }: OtpCodeInputProps) {
   return (
     <div className="space-y-2">
@@ -39,7 +42,7 @@ export function OtpCodeInput({
         id={id}
         type="text"
         inputMode={numericOnly ? "numeric" : undefined}
-        maxLength={validation.confirmationCode.length}
+        maxLength={maxLength}
         value={value}
         onChange={(e) =>
           onChange(


### PR DESCRIPTION
## Summary
- The `OtpCodeInput` component was hardcoded to `maxLength=6` (from `validation.confirmationCode.length`), which is correct for TOTP/MFA but too restrictive for email OTP codes on the login screen
- Added an optional `maxLength` prop to `OtpCodeInput` (defaults to 6 for backward compat)
- Set `maxLength={32}` in `OtpStep` to match mobile app behavior

## Test plan
### Developer
- [x] Existing `OtpStep` tests pass
- [x] TypeScript compiles cleanly

### Manual Testing
- [ ] Verify email OTP input on web accepts codes up to 32 characters
- [ ] Verify MFA TOTP input still limits to 6 digits

https://claude.ai/code/session_01RX3er35MJPcvGw1tY5NvQj