### PR TITLE
Fix OTP error copy and add web app-review login fallback

### DIFF
--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import type { Factor, Session, User } from "@supabase/supabase-js";
 import { supabase } from "../lib/supabaseClient";
+import { tryAppReviewLogin } from "./appReviewAuth";
 import { createAuthError } from "./errors";
 import type { AuthStatus, AuthState } from "./types";
 
@@ -192,7 +193,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       token,
       type: "email",
     });
-    return { error: error ?? null };
+    if (!error) return { error: null };
+
+    // If Supabase OTP verification failed, try the backend's app-review-login
+    // endpoint as a fallback. This allows App Store reviewers to sign in with
+    // a pre-configured static OTP code.
+    const reviewResult = await tryAppReviewLogin(email, token);
+    if (!reviewResult.error) return { error: null };
+
+    // Return the original Supabase error, not the review fallback error,
+    // since most users won't have review credentials configured.
+    return { error };
   }, []);
 
   const updateEmail = useCallback(async (newEmail: string) => {

--- a/frontend/src/auth/__tests__/AuthContext.test.tsx
+++ b/frontend/src/auth/__tests__/AuthContext.test.tsx
@@ -11,9 +11,13 @@ import {
   verifiedFactor,
 } from "./fixtures";
 import { AuthProvider, useAuth } from "../AuthContext";
+import { tryAppReviewLogin } from "../appReviewAuth";
 import type { AuthState } from "../types";
 
 vi.mock("../../lib/supabaseClient");
+vi.mock("../appReviewAuth");
+
+const mockTryAppReviewLogin = vi.mocked(tryAppReviewLogin);
 
 /**
  * Waits for the auth provider to finish its async initialization (AAL check).
@@ -168,6 +172,62 @@ describe("AuthContext", () => {
         type: "email",
       });
       expect(response).toEqual({ error: null });
+      expect(mockTryAppReviewLogin).not.toHaveBeenCalled();
+    });
+
+    it("falls back to tryAppReviewLogin when verifyOtp fails and review login succeeds", async () => {
+      const supabaseError = new AuthError("Invalid", 401, "otp_expired");
+      mockAuth.verifyOtp.mockResolvedValue({
+        data: { session: null, user: null },
+        error: supabaseError,
+      });
+      mockTryAppReviewLogin.mockResolvedValue({ error: null });
+
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: AuthProvider,
+      });
+
+      const response = await result.current.verifyOtp(
+        "review@example.com",
+        "static-otp"
+      );
+
+      expect(mockTryAppReviewLogin).toHaveBeenCalledWith(
+        "review@example.com",
+        "static-otp"
+      );
+      expect(response).toEqual({ error: null });
+    });
+
+    it("returns the original Supabase error when app review fallback also fails", async () => {
+      const supabaseError = new AuthError("Invalid", 401, "otp_expired");
+      mockAuth.verifyOtp.mockResolvedValue({
+        data: { session: null, user: null },
+        error: supabaseError,
+      });
+      mockTryAppReviewLogin.mockResolvedValue({
+        error: {
+          message: "Invalid credentials",
+          name: "AuthApiError",
+          status: 401,
+          code: "invalid_credentials",
+        } as AuthError,
+      });
+
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: AuthProvider,
+      });
+
+      const response = await result.current.verifyOtp(
+        "user@example.com",
+        "wrong"
+      );
+
+      expect(mockTryAppReviewLogin).toHaveBeenCalledWith(
+        "user@example.com",
+        "wrong"
+      );
+      expect(response.error).toBe(supabaseError);
     });
   });
 

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -58,7 +58,7 @@ describe("OtpStep", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "Your code has expired. Please request a new one.",
+          "Invalid or expired code. Please check your code or request a new one.",
           { exact: false }
         )
       ).toBeInTheDocument();

--- a/frontend/src/auth/__tests__/appReviewAuth.test.ts
+++ b/frontend/src/auth/__tests__/appReviewAuth.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { tryAppReviewLogin } from "../appReviewAuth";
+import { supabase } from "../../lib/supabaseClient";
+
+vi.mock("../../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      setSession: vi.fn(),
+    },
+  },
+}));
+
+const mockSetSession = vi.mocked(supabase.auth.setSession);
+
+describe("tryAppReviewLogin", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_API_BASE_URL", "/api");
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn() as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("POSTs to app-review-login and sets Supabase session on success", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: "at",
+        refresh_token: "rt",
+      }),
+    } as Response);
+    mockSetSession.mockResolvedValue({
+      data: { session: null, user: null },
+      error: null,
+    });
+
+    const result = await tryAppReviewLogin("review@example.com", "static-code");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost/api/v1/auth/app-review-login",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "review@example.com",
+          otp: "static-code",
+        }),
+      })
+    );
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: "at",
+      refresh_token: "rt",
+    });
+    expect(result.error).toBeNull();
+  });
+
+  it("returns invalid_credentials-shaped error when response is not ok", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+    } as Response);
+
+    const result = await tryAppReviewLogin("a@b.com", "wrong");
+
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(result.error?.code).toBe("invalid_credentials");
+    expect(result.error?.status).toBe(401);
+  });
+
+  it("returns network_error when fetch throws", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error("offline"));
+
+    const result = await tryAppReviewLogin("a@b.com", "x");
+
+    expect(result.error?.code).toBe("network_error");
+  });
+});

--- a/frontend/src/auth/__tests__/errors.test.ts
+++ b/frontend/src/auth/__tests__/errors.test.ts
@@ -6,7 +6,7 @@ describe("safeErrorMessage", () => {
   it("maps otp_expired code", () => {
     const error = new AuthError("Token expired", 401, "otp_expired");
     expect(safeErrorMessage(error)).toBe(
-      "Your code has expired. Please request a new one."
+      "Invalid or expired code. Please check your code or request a new one."
     );
   });
 

--- a/frontend/src/auth/appReviewAuth.ts
+++ b/frontend/src/auth/appReviewAuth.ts
@@ -1,0 +1,72 @@
+import { supabase } from "../lib/supabaseClient";
+import type { AuthError } from "@supabase/supabase-js";
+
+/**
+ * Resolves the backend API base URL from the same env var the API client uses.
+ * Falls back to production if not set (mirrors mobile app-review behavior).
+ */
+function getApiBaseUrl(): string {
+  const envUrl = import.meta.env.VITE_API_BASE_URL;
+  if (!envUrl) {
+    return "https://app.permissionslip.dev/api";
+  }
+  const base = envUrl.replace(/\/v1\/?$/, "").replace(/\/$/, "");
+  if (base.startsWith("/") && typeof globalThis.location !== "undefined") {
+    return `${globalThis.location.origin}${base}`;
+  }
+  return base;
+}
+
+/**
+ * Attempts to authenticate via the backend's app-review-login endpoint.
+ *
+ * This is used as a fallback when Supabase OTP verification fails — the
+ * backend validates the email/OTP against pre-configured App Store review
+ * credentials and returns a valid Supabase session.
+ *
+ * Returns { error: null } on success, or { error: AuthError } on failure.
+ */
+export async function tryAppReviewLogin(
+  email: string,
+  otp: string
+): Promise<{ error: AuthError | null }> {
+  try {
+    const baseUrl = getApiBaseUrl();
+    const response = await fetch(`${baseUrl}/v1/auth/app-review-login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, otp }),
+    });
+
+    if (!response.ok) {
+      return {
+        error: {
+          message: "Invalid credentials",
+          name: "AuthApiError",
+          status: response.status,
+          code: "invalid_credentials",
+        } as AuthError,
+      };
+    }
+
+    const session = await response.json();
+
+    // Set the session in the Supabase client so onAuthStateChange fires
+    // and the rest of the app picks up the authenticated state.
+    const { error } = await supabase.auth.setSession({
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    });
+
+    return { error: error ?? null };
+  } catch {
+    return {
+      error: {
+        message: "Network error",
+        name: "AuthApiError",
+        status: 0,
+        code: "network_error",
+      } as AuthError,
+    };
+  }
+}

--- a/frontend/src/auth/errors.ts
+++ b/frontend/src/auth/errors.ts
@@ -5,7 +5,8 @@ import type { AuthError } from "@supabase/supabase-js";
 // we only surface messages from this allowlist and fall back to a generic
 // message for anything unexpected.
 const SAFE_ERROR_MESSAGES: Record<string, string> = {
-  otp_expired: "Your code has expired. Please request a new one.",
+  otp_expired:
+    "Invalid or expired code. Please check your code or request a new one.",
   otp_disabled: "Something went wrong. Please try again.",
   over_request_rate_limit:
     "Too many attempts. Please wait a moment and try again.",

--- a/frontend/src/lib/__mocks__/supabaseClient.ts
+++ b/frontend/src/lib/__mocks__/supabaseClient.ts
@@ -27,6 +27,7 @@ export const supabase = {
       .mockResolvedValue({ data: { session: null }, error: null }),
     signInWithOtp: vi.fn(),
     verifyOtp: vi.fn(),
+    setSession: vi.fn(),
     updateUser: vi.fn(),
     signOut: vi.fn(),
     onAuthStateChange: vi.fn(() => ({

--- a/mobile/src/auth/__tests__/errors.test.ts
+++ b/mobile/src/auth/__tests__/errors.test.ts
@@ -13,7 +13,7 @@ function mockAuthError(code: string): AuthError {
 describe("safeErrorMessage", () => {
   it("returns a safe message for known error codes", () => {
     expect(safeErrorMessage(mockAuthError("otp_expired"))).toBe(
-      "Your code has expired. Please request a new one."
+      "Invalid or expired code. Please check your code or request a new one."
     );
     expect(safeErrorMessage(mockAuthError("over_request_rate_limit"))).toBe(
       "Too many attempts. Please wait a moment and try again."

--- a/mobile/src/auth/errors.ts
+++ b/mobile/src/auth/errors.ts
@@ -5,7 +5,8 @@ import type { AuthError } from "@supabase/supabase-js";
 // we only surface messages from this allowlist and fall back to a generic
 // message for anything unexpected.
 const SAFE_ERROR_MESSAGES: Record<string, string> = {
-  otp_expired: "Your code has expired. Please request a new one.",
+  otp_expired:
+    "Invalid or expired code. Please check your code or request a new one.",
   otp_disabled: "Something went wrong. Please try again.",
   over_request_rate_limit:
     "Too many attempts. Please wait a moment and try again.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Web app review login:** Added `frontend/src/auth/appReviewAuth.ts` (mirrors mobile) using `VITE_API_BASE_URL`, including resolving relative `/api` against the page origin like the OpenAPI client. `verifyOtp` in `AuthContext` now calls `POST /v1/auth/app-review-login` when Supabase `verifyOtp` fails, then `setSession` on success; on failure it still returns the original Supabase error.
- **OTP messaging:** Updated the `otp_expired` safe message on web and mobile to reflect that Supabase uses that code for both wrong and expired codes.

Closes #897

## Test plan

### Developer
- [x] `npm test -- --run` in `frontend/` (Vitest)
- [x] `npm test -- --ci` in `mobile/` (Jest)
- [ ] `make build` — frontend `tsc` + `vite build` succeeded locally; full `make build` failed in this environment: Go 1.22.2 vs `cloud.google.com/go/bigquery` requiring Go ≥ 1.25 (pre-existing toolchain mismatch)

### Manual Testing
- [ ] **Web:** Wrong OTP → error shows “Invalid or expired code…”
- [ ] **Web:** App review static OTP (when `APP_REVIEW_*` configured) → login via fallback
- [ ] **Mobile:** Wrong OTP → same message
- [ ] **Mobile:** App review static OTP still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f4084f8-060d-42c4-bcd6-970727fea137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f4084f8-060d-42c4-bcd6-970727fea137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

