### PR TITLE
feat(mobile): add account deletion and legal links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7415,9 +7415,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -9511,9 +9511,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1479,15 +1479,15 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.8.tgz",
-      "integrity": "sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==",
+      "version": "55.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.12.tgz",
+      "integrity": "sha512-qVih0IrjupykH/yAUilZqW1RCpqm8TKG8XJabji2VHI1LstGqw0NJAsBjX927yns08u/fFJTwOsB4PYOoq1HiA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~55.0.6",
+        "@expo/config-plugins": "~55.0.7",
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.12",
-        "@expo/require-utils": "^55.0.2",
+        "@expo/json-file": "^10.0.13",
+        "@expo/require-utils": "^55.0.3",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -1498,9 +1498,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "55.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
-      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
+      "version": "55.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.7.tgz",
+      "integrity": "sha512-XZUoDWrsHEkH3yasnDSJABM/UxP5a1ixzRwU/M+BToyn/f0nTrSJJe/Ay/FpxkI4JSNz2n0e06I23b2bleXKVA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^55.0.5",
@@ -1616,9 +1616,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "55.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.2.tgz",
-      "integrity": "sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==",
+      "version": "55.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.3.tgz",
+      "integrity": "sha512-TS1m5tW45q4zoaTlt6DwmdYHxvFTIxoLrTHKOFrIirHIqIXnHCzpceg8wumiBi+ZXSaGY2gobTbfv+WVhJY6Fw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2155,9 +2155,9 @@
       "peer": true
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2489,9 +2489,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2784,9 +2784,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3204,9 +3204,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4861,9 +4861,9 @@
       }
     },
     "node_modules/expect/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5499,9 +5499,9 @@
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6595,9 +6595,9 @@
       "peer": true
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6802,14 +6802,14 @@
       }
     },
     "node_modules/jest-expo": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-55.0.9.tgz",
-      "integrity": "sha512-6wz7JJUeW2e0+APRQP7eOcXKPdI7bdmAIoBiPJbtzSBRlghho8LzPcv4jkoVFoYi8SKb9k3BTKx4GcUlyVMedw==",
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-55.0.13.tgz",
+      "integrity": "sha512-HMI2IDOsnoQnKbUNPPLuM+XDQ8QD+QUVP7ETeQWYeq87SUZWKYV+vMwwtRiZFawGnYEqYx0qj8iL0RzKXlFNWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.8",
-        "@expo/json-file": "^10.0.12",
+        "@expo/config": "~55.0.12",
+        "@expo/json-file": "^10.0.13",
         "@jest/create-cache-key-function": "^29.2.1",
         "@jest/globals": "^29.2.1",
         "babel-jest": "^29.2.1",
@@ -7167,9 +7167,9 @@
       "peer": true
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8035,9 +8035,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8618,9 +8618,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -9103,9 +9103,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9518,9 +9518,9 @@
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9780,9 +9780,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10450,9 +10450,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11082,9 +11082,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/mobile/src/hooks/useDeleteAccount.ts
+++ b/mobile/src/hooks/useDeleteAccount.ts
@@ -1,0 +1,45 @@
+/**
+ * React Query mutation hook for permanently deleting the user's account.
+ * Requires `confirmation: "DELETE"` in the request body as a safety check.
+ * On success, signs the user out locally.
+ */
+import { useRef } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+
+export function useDeleteAccount() {
+  const { session, signOut } = useAuth();
+
+  const tokenRef = useRef(session?.access_token);
+  tokenRef.current = session?.access_token;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const token = tokenRef.current;
+      if (!token) {
+        throw new Error("Not authenticated");
+      }
+      const { data, error } = await client.DELETE("/v1/profile", {
+        headers: { Authorization: `Bearer ${token}` },
+        body: { confirmation: "DELETE" },
+      });
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to delete account. Please try again."),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      signOut();
+    },
+  });
+
+  return {
+    deleteAccount: mutation.mutateAsync,
+    isDeleting: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -169,7 +169,7 @@ export default function SettingsScreen(_props: Props) {
           accessibilityLabel="Sign out of your account"
           onPress={handleSignOut}
         >
-          <Text style={styles.signOutText}>Sign Out</Text>
+          <Text style={styles.destructiveActionText}>Sign Out</Text>
         </TouchableOpacity>
         <TouchableOpacity
           testID="delete-account-button"
@@ -182,7 +182,7 @@ export default function SettingsScreen(_props: Props) {
           {isDeleting ? (
             <ActivityIndicator size="small" color={colors.error} />
           ) : (
-            <Text style={styles.deleteAccountText}>Delete Account</Text>
+            <Text style={styles.destructiveActionText}>Delete Account</Text>
           )}
         </TouchableOpacity>
       </View>
@@ -195,7 +195,11 @@ export default function SettingsScreen(_props: Props) {
             style={styles.linkRow}
             accessibilityRole="link"
             accessibilityLabel="Privacy Policy"
-            onPress={() => Linking.openURL(PRIVACY_POLICY_URL)}
+            onPress={() => {
+              Linking.openURL(PRIVACY_POLICY_URL).catch(() => {
+                Alert.alert("Error", "Could not open Privacy Policy.");
+              });
+            }}
           >
             <Text style={styles.linkText}>Privacy Policy</Text>
             <Text style={styles.linkChevron}>›</Text>
@@ -206,7 +210,11 @@ export default function SettingsScreen(_props: Props) {
             style={styles.linkRow}
             accessibilityRole="link"
             accessibilityLabel="Terms of Service"
-            onPress={() => Linking.openURL(TERMS_OF_SERVICE_URL)}
+            onPress={() => {
+              Linking.openURL(TERMS_OF_SERVICE_URL).catch(() => {
+                Alert.alert("Error", "Could not open Terms of Service.");
+              });
+            }}
           >
             <Text style={styles.linkText}>Terms of Service</Text>
             <Text style={styles.linkChevron}>›</Text>
@@ -322,12 +330,7 @@ const styles = StyleSheet.create({
   actionButtonSpaced: {
     marginTop: 12,
   },
-  signOutText: {
-    color: colors.error,
-    fontSize: 15,
-    fontWeight: "600",
-  },
-  deleteAccountText: {
+  destructiveActionText: {
     color: colors.error,
     fontSize: 15,
     fontWeight: "600",

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import { useCallback, useMemo } from "react";
 import {
   ActivityIndicator,
   Alert,
+  Linking,
   ScrollView,
   StyleSheet,
   Switch,
@@ -20,7 +21,11 @@ import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useAuth } from "../../auth/AuthContext";
 import { useNotificationPreferences } from "../../hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "../../hooks/useUpdateNotificationPreferences";
+import { useDeleteAccount } from "../../hooks/useDeleteAccount";
 import { colors } from "../../theme/colors";
+
+const PRIVACY_POLICY_URL = "https://permissionslip.dev/privacy";
+const TERMS_OF_SERVICE_URL = "https://permissionslip.dev/terms";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Settings">;
 
@@ -31,6 +36,7 @@ export default function SettingsScreen(_props: Props) {
     useNotificationPreferences();
   const { updatePreferences, isUpdating } =
     useUpdateNotificationPreferences();
+  const { deleteAccount, isDeleting } = useDeleteAccount();
 
   const contentContainerStyle = useMemo(
     () => ({ paddingBottom: insets.bottom + 24 }),
@@ -59,6 +65,28 @@ export default function SettingsScreen(_props: Props) {
       { text: "Sign Out", style: "destructive", onPress: () => signOut() },
     ]);
   }, [signOut]);
+
+  const handleDeleteAccount = useCallback(() => {
+    Alert.alert(
+      "Delete Account",
+      "This will permanently delete your account and all associated data including agents, approvals, and credentials. This action cannot be undone.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete Account",
+          style: "destructive",
+          onPress: () => {
+            deleteAccount().catch(() => {
+              Alert.alert(
+                "Error",
+                "Failed to delete account. Please try again.",
+              );
+            });
+          },
+        },
+      ],
+    );
+  }, [deleteAccount]);
 
   return (
     <ScrollView
@@ -136,13 +164,54 @@ export default function SettingsScreen(_props: Props) {
         ) : null}
         <TouchableOpacity
           testID="sign-out-button"
-          style={[styles.signOutButton, user?.email ? styles.signOutButtonSpaced : null]}
+          style={[styles.actionButton, user?.email ? styles.actionButtonSpaced : null]}
           accessibilityRole="button"
           accessibilityLabel="Sign out of your account"
           onPress={handleSignOut}
         >
           <Text style={styles.signOutText}>Sign Out</Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          testID="delete-account-button"
+          style={[styles.actionButton, styles.actionButtonSpaced]}
+          accessibilityRole="button"
+          accessibilityLabel="Permanently delete your account"
+          onPress={handleDeleteAccount}
+          disabled={isDeleting}
+        >
+          {isDeleting ? (
+            <ActivityIndicator size="small" color={colors.error} />
+          ) : (
+            <Text style={styles.deleteAccountText}>Delete Account</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Legal</Text>
+        <View style={styles.card}>
+          <TouchableOpacity
+            testID="privacy-policy-link"
+            style={styles.linkRow}
+            accessibilityRole="link"
+            accessibilityLabel="Privacy Policy"
+            onPress={() => Linking.openURL(PRIVACY_POLICY_URL)}
+          >
+            <Text style={styles.linkText}>Privacy Policy</Text>
+            <Text style={styles.linkChevron}>›</Text>
+          </TouchableOpacity>
+          <View style={styles.linkSeparator} />
+          <TouchableOpacity
+            testID="terms-link"
+            style={styles.linkRow}
+            accessibilityRole="link"
+            accessibilityLabel="Terms of Service"
+            onPress={() => Linking.openURL(TERMS_OF_SERVICE_URL)}
+          >
+            <Text style={styles.linkText}>Terms of Service</Text>
+            <Text style={styles.linkChevron}>›</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </ScrollView>
   );
@@ -242,7 +311,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     marginLeft: 12,
   },
-  signOutButton: {
+  actionButton: {
     backgroundColor: colors.white,
     borderRadius: 12,
     borderWidth: 1,
@@ -250,12 +319,37 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     alignItems: "center",
   },
-  signOutButtonSpaced: {
+  actionButtonSpaced: {
     marginTop: 12,
   },
   signOutText: {
     color: colors.error,
     fontSize: 15,
     fontWeight: "600",
+  },
+  deleteAccountText: {
+    color: colors.error,
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  linkRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  linkSeparator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.gray200,
+    marginLeft: 16,
+  },
+  linkText: {
+    fontSize: 15,
+    color: colors.gray900,
+  },
+  linkChevron: {
+    fontSize: 18,
+    color: colors.gray400,
   },
 });

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -61,6 +61,16 @@ jest.mock("../../../hooks/useUpdateNotificationPreferences", () => ({
   }),
 }));
 
+const mockDeleteAccount = jest.fn().mockResolvedValue({});
+
+jest.mock("../../../hooks/useDeleteAccount", () => ({
+  useDeleteAccount: () => ({
+    deleteAccount: mockDeleteAccount,
+    isDeleting: false,
+    error: null,
+  }),
+}));
+
 // Import after mocks
 import SettingsScreen from "../SettingsScreen";
 
@@ -209,5 +219,29 @@ describe("SettingsScreen", () => {
     });
     const toggle = findByTestId(renderer, "mobile-push-toggle")[0];
     expect(toggle?.props.value).toBe(true);
+  });
+
+  it("renders the delete account button", async () => {
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    expect(findByTestId(renderer, "delete-account-button").length).toBeGreaterThanOrEqual(1);
+    expect(hasText(renderer, "Delete Account")).toBe(true);
+  });
+
+  it("renders the privacy policy link", async () => {
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    expect(findByTestId(renderer, "privacy-policy-link").length).toBeGreaterThanOrEqual(1);
+    expect(hasText(renderer, "Privacy Policy")).toBe(true);
+  });
+
+  it("renders the terms of service link", async () => {
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    expect(findByTestId(renderer, "terms-link").length).toBeGreaterThanOrEqual(1);
+    expect(hasText(renderer, "Terms of Service")).toBe(true);
   });
 });

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -1,4 +1,5 @@
 import React, { createElement } from "react";
+import { Alert, Linking } from "react-native";
 import { create, act, type ReactTestRenderer } from "react-test-renderer";
 import type { NotificationPreference } from "../../../hooks/useNotificationPreferences";
 
@@ -243,5 +244,69 @@ describe("SettingsScreen", () => {
     });
     expect(findByTestId(renderer, "terms-link").length).toBeGreaterThanOrEqual(1);
     expect(hasText(renderer, "Terms of Service")).toBe(true);
+  });
+
+  it("calls deleteAccount after confirming the delete dialog", async () => {
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _msg, buttons) => {
+        const confirm = buttons?.find(
+          (b) => typeof b === "object" && b.style === "destructive",
+        );
+        if (confirm && typeof confirm === "object" && confirm.onPress) {
+          confirm.onPress();
+        }
+      });
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    const btn = renderer.root.findAll(
+      (node) =>
+        node.props.testID === "delete-account-button" &&
+        typeof node.props.onPress === "function",
+    )[0];
+    await act(async () => {
+      btn?.props.onPress();
+    });
+    expect(mockDeleteAccount).toHaveBeenCalledTimes(1);
+    alertSpy.mockRestore();
+  });
+
+  it("opens privacy policy URL when tapped", async () => {
+    const openURLSpy = jest
+      .spyOn(Linking, "openURL")
+      .mockResolvedValue(undefined as never);
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    const link = renderer.root.findAll(
+      (node) =>
+        node.props.testID === "privacy-policy-link" &&
+        typeof node.props.onPress === "function",
+    )[0];
+    await act(async () => {
+      link?.props.onPress();
+    });
+    expect(openURLSpy).toHaveBeenCalledWith("https://permissionslip.dev/privacy");
+    openURLSpy.mockRestore();
+  });
+
+  it("opens terms of service URL when tapped", async () => {
+    const openURLSpy = jest
+      .spyOn(Linking, "openURL")
+      .mockResolvedValue(undefined as never);
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    const link = renderer.root.findAll(
+      (node) =>
+        node.props.testID === "terms-link" &&
+        typeof node.props.onPress === "function",
+    )[0];
+    await act(async () => {
+      link?.props.onPress();
+    });
+    expect(openURLSpy).toHaveBeenCalledWith("https://permissionslip.dev/terms");
+    openURLSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Add in-app account deletion with two-step confirmation dialog (Apple Guideline 5.1.1v requirement), calling `DELETE /v1/profile` with `confirmation: "DELETE"` safety check
- Add Privacy Policy and Terms of Service links in a new Legal section on the Settings screen
- Auto sign-out after successful account deletion

## Test plan

### Developer
- [x] Added `useDeleteAccount` hook with proper auth, error handling, and auto sign-out on success
- [x] Added 3 new tests for delete account button, privacy policy link, and terms of service link
- [x] All 213 mobile tests pass

### Manual Testing
- [ ] Verify delete account confirmation dialog appears with warning text
- [ ] Verify account deletion completes and signs user out
- [ ] Verify Privacy Policy link opens in browser
- [ ] Verify Terms of Service link opens in browser
- [ ] Verify delete button shows spinner while request is in flight

https://claude.ai/code/session_01FfGgGXSNkzMdDjW9gU1VS3