### PR TITLE
Fix profile creation and add password to onboarding

### DIFF
--- a/api/onboarding.go
+++ b/api/onboarding.go
@@ -74,7 +74,8 @@ func handleOnboarding(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		profile, err := db.CreateProfile(r.Context(), deps.DB, userID, username, req.MarketingOptIn)
+		email := UserEmail(r.Context())
+		profile, err := db.CreateProfile(r.Context(), deps.DB, userID, username, email, req.MarketingOptIn)
 		if err != nil {
 			var onboardErr *db.OnboardingError
 			if errors.As(err, &onboardErr) {

--- a/api/onboarding.go
+++ b/api/onboarding.go
@@ -84,7 +84,7 @@ func handleOnboarding(deps *Deps) http.HandlerFunc {
 					// Before rejecting, check if the taken username belongs to
 					// the same user under a different Supabase identity (new UUID,
 					// same email). If so, re-link the existing profile.
-					if email := UserEmail(r.Context()); email != "" {
+					if email != "" {
 						owner, lookupErr := db.FindProfileByUsername(r.Context(), deps.DB, username)
 						if lookupErr != nil {
 							log.Printf("[%s] Onboarding: username owner lookup: %v", TraceID(r.Context()), lookupErr)

--- a/db/onboarding.go
+++ b/db/onboarding.go
@@ -29,7 +29,7 @@ const (
 // Returns the created Profile, or an *OnboardingError if the username is
 // already taken (OnboardingErrUsernameTaken) or if a profile already exists
 // for this user due to a concurrent request (OnboardingErrProfileExists).
-func CreateProfile(ctx context.Context, db DBTX, userID, username string, marketingOptIn bool) (*Profile, error) {
+func CreateProfile(ctx context.Context, db DBTX, userID, username, email string, marketingOptIn bool) (*Profile, error) {
 	// Upsert auth.users so the FK from profiles is satisfied.
 	// In production (Supabase), auth.users is managed by Supabase and this
 	// row already exists by the time the user reaches onboarding.
@@ -56,12 +56,23 @@ func CreateProfile(ctx context.Context, db DBTX, userID, username string, market
 		}
 	}
 
+	// Use the email passed from the JWT session context instead of
+	// subquerying auth.users. This avoids requiring SELECT + USAGE
+	// grants on the auth schema — which caused production failures
+	// (Sentry PERMISSION-SLIP-GO-J: "permission denied for schema auth")
+	// when the app_backend role lacked auth schema access during the
+	// INSERT's prepared-statement phase.
+	var emailArg *string
+	if email != "" {
+		emailArg = &email
+	}
+
 	var p Profile
 	err = db.QueryRow(ctx,
 		`INSERT INTO profiles (id, username, email, marketing_opt_in)
-		 VALUES ($1, $2, (SELECT email FROM auth.users WHERE id = $1), $3)
+		 VALUES ($1, $2, $3, $4)
 		 RETURNING id, username, email, phone, marketing_opt_in, created_at`,
-		userID, username, marketingOptIn,
+		userID, username, emailArg, marketingOptIn,
 	).Scan(&p.ID, &p.Username, &p.Email, &p.Phone, &p.MarketingOptIn, &p.CreatedAt)
 
 	if err != nil {

--- a/db/onboarding_test.go
+++ b/db/onboarding_test.go
@@ -13,7 +13,7 @@ func TestCreateProfile_Success(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 
-	profile, err := db.CreateProfile(context.Background(), tx, uid, "newuser", false)
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "newuser", "newuser@example.com", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -29,6 +29,9 @@ func TestCreateProfile_Success(t *testing.T) {
 	if profile.CreatedAt.IsZero() {
 		t.Error("expected non-zero created_at")
 	}
+	if profile.Email == nil || *profile.Email != "newuser@example.com" {
+		t.Errorf("expected email %q, got %v", "newuser@example.com", profile.Email)
+	}
 }
 
 func TestCreateProfile_UsernameTaken(t *testing.T) {
@@ -38,7 +41,7 @@ func TestCreateProfile_UsernameTaken(t *testing.T) {
 	uid2 := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid1, "taken")
 
-	_, err := db.CreateProfile(context.Background(), tx, uid2, "taken", false)
+	_, err := db.CreateProfile(context.Background(), tx, uid2, "taken", "taken@example.com", false)
 	if err == nil {
 		t.Fatal("expected error for duplicate username, got nil")
 	}
@@ -60,7 +63,7 @@ func TestCreateProfile_Idempotent_AuthUsers(t *testing.T) {
 	// Pre-insert the auth.users row (as Supabase would have done)
 	testhelper.MustExec(t, tx, `INSERT INTO auth.users (id) VALUES ($1)`, uid)
 
-	profile, err := db.CreateProfile(context.Background(), tx, uid, "preseeded", false)
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "preseeded", "preseeded@example.com", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -74,7 +77,7 @@ func TestCreateProfile_MarketingOptIn(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 
-	profile, err := db.CreateProfile(context.Background(), tx, uid, "marketer", true)
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "marketer", "marketer@example.com", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,7 +100,7 @@ func TestCreateProfile_SMSDisabledByDefault(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 
-	_, err := db.CreateProfile(context.Background(), tx, uid, "smsuser", false)
+	_, err := db.CreateProfile(context.Background(), tx, uid, "smsuser", "smsuser@example.com", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/db/onboarding_test.go
+++ b/db/onboarding_test.go
@@ -114,6 +114,20 @@ func TestCreateProfile_SMSDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestCreateProfile_EmptyEmail(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+
+	profile, err := db.CreateProfile(context.Background(), tx, uid, "noemailer", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Email != nil {
+		t.Errorf("expected nil email, got %v", profile.Email)
+	}
+}
+
 // isOnboardingErr is a helper to avoid importing errors in test file.
 func isOnboardingErr(err error, target **db.OnboardingError) bool {
 	if e, ok := err.(*db.OnboardingError); ok {

--- a/frontend/src/auth/OnboardingPage.tsx
+++ b/frontend/src/auth/OnboardingPage.tsx
@@ -46,9 +46,14 @@ export default function OnboardingPage() {
         password,
       });
       if (pwError) {
-        // Profile was created but password failed — log the user in
-        // anyway so they aren't stuck. They can set a password later.
+        // Profile was created but password failed — warn the user but
+        // don't block onboarding. They can set a password later in settings.
         console.error("Failed to set password during onboarding:", pwError.message);
+        setError(
+          "Your account was created, but we couldn't set your password. " +
+          "You can set a password later in Settings."
+        );
+        // Still proceed — invalidate profile so user reaches the dashboard.
       }
 
       // Invalidate the profile query so App.tsx re-fetches and routes to dashboard

--- a/frontend/src/auth/OnboardingPage.tsx
+++ b/frontend/src/auth/OnboardingPage.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { FormError } from "@/components/FormError";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { supabase } from "@/lib/supabaseClient";
 import client from "@/api/client";
 import validation from "@/lib/validation";
 
@@ -15,6 +16,7 @@ export default function OnboardingPage() {
   const { session, signOut } = useAuth();
   const queryClient = useQueryClient();
   const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [marketingOptIn, setMarketingOptIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,6 +39,16 @@ export default function OnboardingPage() {
             "Something went wrong. Please try again."
         );
         return;
+      }
+
+      // Set the user's password via Supabase after profile creation.
+      const { error: pwError } = await supabase.auth.updateUser({
+        password,
+      });
+      if (pwError) {
+        // Profile was created but password failed — log the user in
+        // anyway so they aren't stuck. They can set a password later.
+        console.error("Failed to set password during onboarding:", pwError.message);
       }
 
       // Invalidate the profile query so App.tsx re-fetches and routes to dashboard
@@ -69,6 +81,21 @@ export default function OnboardingPage() {
           />
           <p className="text-xs text-muted-foreground">
             3–32 characters. Letters, digits, underscores, and hyphens only.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            minLength={validation.password.minLength}
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            At least {validation.password.minLength} characters.
           </p>
         </div>
         <div className="flex items-start gap-2">
@@ -122,7 +149,7 @@ export default function OnboardingPage() {
           <Button
             type="submit"
             className="flex-1"
-            disabled={isSubmitting || !agreedToTerms}
+            disabled={isSubmitting || !agreedToTerms || password.length < validation.password.minLength}
           >
             {isSubmitting ? "Creating account…" : "Create account"}
           </Button>

--- a/frontend/src/auth/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/auth/__tests__/OnboardingPage.test.tsx
@@ -4,10 +4,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderWithProviders } from "../../test-helpers";
 import { mockAuth, setupAuthMocks } from "./fixtures";
 import { mockPost, resetClientMocks } from "../../api/__mocks__/client";
+import { supabase } from "../../lib/supabaseClient";
 import OnboardingPage from "../OnboardingPage";
 
 vi.mock("../../lib/supabaseClient");
 vi.mock("../../api/client");
+
+const mockUpdateUser = vi.mocked(supabase.auth.updateUser);
 
 describe("OnboardingPage", () => {
   beforeEach(() => {
@@ -15,11 +18,12 @@ describe("OnboardingPage", () => {
     resetClientMocks();
   });
 
-  it("renders username field and both buttons", async () => {
+  it("renders username field, password field, and both buttons", async () => {
     renderWithProviders(<OnboardingPage />);
     await waitFor(() => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
     expect(screen.getByText("Create account")).toBeInTheDocument();
     expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
@@ -39,7 +43,7 @@ describe("OnboardingPage", () => {
     });
   });
 
-  it("disables submit button until terms checkbox is checked", async () => {
+  it("disables submit button until terms checkbox is checked and password meets minimum length", async () => {
     renderWithProviders(<OnboardingPage />);
     await waitFor(() => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
@@ -48,8 +52,13 @@ describe("OnboardingPage", () => {
     const submitButton = screen.getByText("Create account");
     expect(submitButton).toBeDisabled();
 
+    // Check terms — still disabled because password is empty
     const tosCheckbox = screen.getByLabelText(/I agree to the/);
     await userEvent.click(tosCheckbox);
+    expect(submitButton).toBeDisabled();
+
+    // Enter a password that meets the minimum length
+    await userEvent.type(screen.getByLabelText("Password"), "securepass");
     expect(submitButton).toBeEnabled();
   });
 
@@ -65,14 +74,16 @@ describe("OnboardingPage", () => {
     expect(mockAuth.signOut).toHaveBeenCalled();
   });
 
-  it("submits username on form submit", async () => {
+  it("submits username and sets password on form submit", async () => {
     mockPost.mockResolvedValue({ data: { id: "1", username: "alice", created_at: "2024-01-01" }, error: undefined });
+    mockUpdateUser.mockResolvedValue({ data: { user: {} as never }, error: null });
     renderWithProviders(<OnboardingPage />);
 
     await waitFor(() => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "alice");
+    await userEvent.type(screen.getByLabelText("Password"), "securepass");
     await userEvent.click(screen.getByLabelText(/I agree to the/));
     await userEvent.click(screen.getByText("Create account"));
 
@@ -82,16 +93,21 @@ describe("OnboardingPage", () => {
         expect.objectContaining({ body: { username: "alice", marketing_opt_in: false } })
       );
     });
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({ password: "securepass" });
+    });
   });
 
   it("sends marketing_opt_in=true when checkbox is checked", async () => {
     mockPost.mockResolvedValue({ data: { id: "1", username: "bob", created_at: "2024-01-01" }, error: undefined });
+    mockUpdateUser.mockResolvedValue({ data: { user: {} as never }, error: null });
     renderWithProviders(<OnboardingPage />);
 
     await waitFor(() => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "bob");
+    await userEvent.type(screen.getByLabelText("Password"), "securepass");
     await userEvent.click(screen.getByLabelText(/I agree to the/));
     await userEvent.click(screen.getByLabelText(/Keep me in the loop/));
     await userEvent.click(screen.getByText("Create account"));
@@ -115,6 +131,7 @@ describe("OnboardingPage", () => {
       expect(screen.getByLabelText("Username")).toBeInTheDocument();
     });
     await userEvent.type(screen.getByLabelText("Username"), "taken");
+    await userEvent.type(screen.getByLabelText("Password"), "securepass");
     await userEvent.click(screen.getByLabelText(/I agree to the/));
     await userEvent.click(screen.getByText("Create account"));
 

--- a/shared/validation.json
+++ b/shared/validation.json
@@ -1,5 +1,6 @@
 {
   "username": { "minLength": 3, "maxLength": 32 },
+  "password": { "minLength": 8 },
   "agentName": { "maxLength": 256 },
   "actionConfigName": { "maxLength": 255 },
   "actionConfigDescription": { "maxLength": 4096 },


### PR DESCRIPTION
## Summary

- **Fix Sentry PERMISSION-SLIP-GO-J**: The `INSERT INTO profiles` query subqueried `auth.users` for the user's email, which failed with `permission denied for schema auth` when `app_backend` lacked auth schema access during the prepared-statement phase. Now passes the email from the JWT session context directly, eliminating the `auth.users` dependency from the profiles INSERT entirely.
- **Add password field to onboarding**: New users are now required to set a password during account creation. The password is set via Supabase's `updateUser` API after profile creation succeeds. If the password set fails, the user still proceeds (non-blocking) and can set a password later.
- **Add shared password validation**: Minimum 8 characters, defined in `shared/validation.json` for frontend/backend parity.

Closes #901

## Test plan

### Developer
- [x] Backend db tests pass (`go test ./db/...`)
- [x] Frontend tests pass (`npm test -- --run`) — all 953 tests green
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Go packages compile (`go build ./api/... ./db/...`)

### Manual Testing
- [ ] Sign up as a new user — verify password field appears on onboarding page
- [ ] Complete onboarding with username + password — verify profile is created and password is set
- [ ] Sign out and sign back in using email + password — verify it works
- [ ] Verify the "Create account" button stays disabled until terms are checked AND password meets minimum length

https://claude.ai/code/session_0132mMbDF6z93fjxu1afMrTy