### PR TITLE
Allow 8-digit email login OTP; keep TOTP and agent codes at 6

### DIFF
--- a/frontend/src/auth/MfaChallengePage.tsx
+++ b/frontend/src/auth/MfaChallengePage.tsx
@@ -26,6 +26,7 @@ export default function MfaChallengePage() {
         <OtpCodeInput
           id="mfa-code"
           label="Authenticator Code"
+          variant="totp"
           value={code}
           onChange={setCode}
           autoFocus

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -8,6 +8,7 @@ import DevOnly from "../components/DevOnly";
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/FormError";
 import { OtpCodeInput } from "@/components/OtpCodeInput";
+import validation from "@/lib/validation";
 
 interface OtpStepProps {
   email: string;
@@ -25,6 +26,7 @@ export default function OtpStep({
   const [otpCode, setOtpCode] = useState("");
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
   const resend = useResend({ onResend });
+  const emailOtpLen = validation.emailOtpCode.length;
 
   const handleAutoFill = async () => {
     // Dynamic import keeps dev-only Mailpit code out of the production bundle
@@ -54,7 +56,11 @@ export default function OtpStep({
         />
         <FormError error={error} prefix />
         <div className="flex gap-2">
-          <Button type="submit" className="flex-1" disabled={isSubmitting}>
+          <Button
+            type="submit"
+            className="flex-1"
+            disabled={isSubmitting || otpCode.length < emailOtpLen}
+          >
             Verify
           </Button>
           <Button

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -47,6 +47,7 @@ export default function OtpStep({
         <OtpCodeInput
           id="otp-code"
           label="Code"
+          variant="email"
           value={otpCode}
           onChange={setOtpCode}
           required

--- a/frontend/src/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/auth/__tests__/LoginPage.test.tsx
@@ -98,12 +98,12 @@ describe("LoginPage", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Code")).toBeInTheDocument();
     });
-    await userEvent.type(screen.getByLabelText("Code"), "123456");
+    await userEvent.type(screen.getByLabelText("Code"), "12345678");
     await userEvent.click(screen.getByText("Verify"));
 
     expect(mockAuth.verifyOtp).toHaveBeenCalledWith({
       email: "test@example.com",
-      token: "123456",
+      token: "12345678",
       type: "email",
     });
   });

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -36,14 +36,26 @@ describe("OtpStep", () => {
     expect(screen.getByText("Back")).toBeInTheDocument();
   });
 
+  it("disables verify until full email OTP length is entered", async () => {
+    renderOtpStep();
+    const verify = screen.getByRole("button", { name: "Verify" });
+    expect(verify).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText("Code"), "1234567");
+    expect(verify).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText("Code"), "8");
+    expect(verify).not.toBeDisabled();
+  });
+
   it("calls onVerify with entered code", async () => {
     const onVerify = vi.fn().mockResolvedValue({ error: null });
     renderOtpStep({ ...defaultProps, onVerify });
 
-    await userEvent.type(screen.getByLabelText("Code"), "123456");
+    await userEvent.type(screen.getByLabelText("Code"), "12345678");
     await userEvent.click(screen.getByText("Verify"));
 
-    expect(onVerify).toHaveBeenCalledWith("123456");
+    expect(onVerify).toHaveBeenCalledWith("12345678");
   });
 
   it("shows error on verification failure", async () => {
@@ -52,7 +64,7 @@ describe("OtpStep", () => {
     });
     renderOtpStep({ ...defaultProps, onVerify });
 
-    await userEvent.type(screen.getByLabelText("Code"), "000000");
+    await userEvent.type(screen.getByLabelText("Code"), "00000000");
     await userEvent.click(screen.getByText("Verify"));
 
     await waitFor(() => {

--- a/frontend/src/components/OtpCodeInput.tsx
+++ b/frontend/src/components/OtpCodeInput.tsx
@@ -7,6 +7,8 @@ interface OtpCodeInputProps {
   id: string;
   /** Visible label text above the input. */
   label: string;
+  /** Email magic-link OTP vs authenticator TOTP — controls max digit length. */
+  variant: "email" | "totp";
   /** Current input value (digits only). */
   value: string;
   /** Called with the new value after non-digit characters are stripped. */
@@ -17,8 +19,9 @@ interface OtpCodeInputProps {
 }
 
 /**
- * A 6-digit one-time-code input with numeric keyboard, digit-only filtering,
- * and browser autofill support. Used for both email OTP and TOTP MFA flows.
+ * One-time-code input with numeric keyboard, digit-only filtering, and browser
+ * autofill support. Email OTP and TOTP use different digit lengths from
+ * shared/validation.json.
  *
  * Digit filtering happens on every keystroke via `.replace(/\D/g, "")` so
  * non-numeric characters can never appear in the value — even on paste.
@@ -26,12 +29,17 @@ interface OtpCodeInputProps {
 export function OtpCodeInput({
   id,
   label,
+  variant,
   value,
   onChange,
   autoFocus,
   disabled,
   required,
 }: OtpCodeInputProps) {
+  const maxLength =
+    variant === "email"
+      ? validation.emailOtpCode.length
+      : validation.totpCode.length;
   return (
     <div className="space-y-2">
       <Label htmlFor={id}>{label}</Label>
@@ -39,7 +47,7 @@ export function OtpCodeInput({
         id={id}
         type="text"
         inputMode="numeric"
-        maxLength={validation.confirmationCode.length}
+        maxLength={maxLength}
         value={value}
         onChange={(e) => onChange(e.target.value.replace(/\D/g, ""))}
         autoComplete="one-time-code"

--- a/frontend/src/pages/security/MfaEnrollmentFlow.tsx
+++ b/frontend/src/pages/security/MfaEnrollmentFlow.tsx
@@ -174,6 +174,7 @@ export function MfaEnrollmentFlow({ onEnrolled }: MfaEnrollmentFlowProps) {
         <OtpCodeInput
           id="mfa-enroll-code"
           label="Verification Code"
+          variant="totp"
           value={code}
           onChange={setCode}
           autoFocus

--- a/mobile/src/auth/MfaChallengeScreen.tsx
+++ b/mobile/src/auth/MfaChallengeScreen.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "./AuthContext";
 import { useFormSubmit } from "./useFormSubmit";
 import { authStyles } from "./styles";
 import { colors } from "../theme/colors";
+import validation from "../lib/validation";
 
 /**
  * Full-screen MFA challenge presented when authStatus is "mfa_required".
@@ -39,6 +40,7 @@ export default function MfaChallengeScreen() {
   };
 
   const submit = () => handleSubmit(() => verifyMfa(code));
+  const totpLen = validation.totpCode.length;
 
   return (
     <KeyboardAvoidingView
@@ -64,7 +66,7 @@ export default function MfaChallengeScreen() {
             placeholderTextColor={colors.gray400}
             keyboardType="number-pad"
             autoComplete="one-time-code"
-            maxLength={6}
+            maxLength={totpLen}
             editable={!isSubmitting}
             onSubmitEditing={submit}
             returnKeyType="go"
@@ -86,10 +88,10 @@ export default function MfaChallengeScreen() {
               authStyles.button,
               authStyles.primaryButton,
               localStyles.flexButton,
-              (isSubmitting || code.length < 6) && authStyles.buttonDisabled,
+              (isSubmitting || code.length < totpLen) && authStyles.buttonDisabled,
             ]}
             onPress={submit}
-            disabled={isSubmitting || code.length < 6}
+            disabled={isSubmitting || code.length < totpLen}
           >
             <Text style={authStyles.primaryButtonText}>
               {isSubmitting ? "Verifying..." : "Verify"}

--- a/mobile/src/auth/OtpStep.tsx
+++ b/mobile/src/auth/OtpStep.tsx
@@ -14,6 +14,7 @@ import type { AuthError } from "@supabase/supabase-js";
 import { useFormSubmit } from "./useFormSubmit";
 import { authStyles } from "./styles";
 import { colors } from "../theme/colors";
+import validation from "../lib/validation";
 
 interface OtpStepProps {
   email: string;
@@ -49,6 +50,8 @@ export default function OtpStep({
       if (resendTimerRef.current) clearTimeout(resendTimerRef.current);
     };
   }, []);
+
+  const emailOtpLen = validation.emailOtpCode.length;
 
   const submit = () => handleSubmit(() => onVerify(otpCode));
 
@@ -97,11 +100,11 @@ export default function OtpStep({
             style={[authStyles.input, localStyles.otpInput]}
             value={otpCode}
             onChangeText={setOtpCode}
-            placeholder="000000"
+            placeholder="00000000"
             placeholderTextColor={colors.gray400}
             keyboardType="number-pad"
             autoComplete="one-time-code"
-            maxLength={6}
+            maxLength={emailOtpLen}
             editable={!isSubmitting}
             onSubmitEditing={submit}
             returnKeyType="go"
@@ -123,11 +126,11 @@ export default function OtpStep({
               authStyles.button,
               authStyles.primaryButton,
               localStyles.flexButton,
-              (isSubmitting || otpCode.length < 6) &&
+              (isSubmitting || otpCode.length < emailOtpLen) &&
                 authStyles.buttonDisabled,
             ]}
             onPress={submit}
-            disabled={isSubmitting || otpCode.length < 6}
+            disabled={isSubmitting || otpCode.length < emailOtpLen}
           >
             <Text style={authStyles.primaryButtonText}>
               {isSubmitting ? "Verifying..." : "Verify"}

--- a/mobile/src/lib/validation.ts
+++ b/mobile/src/lib/validation.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared validation constants from repo root `shared/validation.json`
+ * (same source as the web app and Go backend).
+ */
+import config from "../../../shared/validation.json";
+
+export default config;

--- a/shared/validation.go
+++ b/shared/validation.go
@@ -30,6 +30,8 @@ type validationConfig struct {
 	ActionType               fieldLimits `json:"actionType"`
 	ActionVersion            fieldLimits `json:"actionVersion"`
 	ConfirmationCode         fieldLimits `json:"confirmationCode"`
+	EmailOtpCode             fieldLimits `json:"emailOtpCode"`
+	TotpCode                 fieldLimits `json:"totpCode"`
 	ConstraintsBytes         fieldLimits `json:"constraintsBytes"`
 	ParametersBytes          fieldLimits `json:"parametersBytes"`
 }
@@ -48,6 +50,8 @@ var (
 	ActionTypeMaxLength         int
 	ActionVersionMaxLength      int
 	ConfirmationCodeLength      int
+	EmailOtpCodeLength          int
+	TotpCodeLength              int
 	MaxConstraintsBytes         int
 	MaxParametersBytes          int
 )
@@ -78,6 +82,8 @@ func init() {
 	ActionTypeMaxLength = mustInt("actionType.maxLength", cfg.ActionType.MaxLength)
 	ActionVersionMaxLength = mustInt("actionVersion.maxLength", cfg.ActionVersion.MaxLength)
 	ConfirmationCodeLength = mustInt("confirmationCode.length", cfg.ConfirmationCode.Length)
+	EmailOtpCodeLength = mustInt("emailOtpCode.length", cfg.EmailOtpCode.Length)
+	TotpCodeLength = mustInt("totpCode.length", cfg.TotpCode.Length)
 	MaxConstraintsBytes = mustInt("constraintsBytes.max", cfg.ConstraintsBytes.Max)
 	MaxParametersBytes = mustInt("parametersBytes.max", cfg.ParametersBytes.Max)
 }

--- a/shared/validation.json
+++ b/shared/validation.json
@@ -9,6 +9,8 @@
   "actionType": { "maxLength": 128 },
   "actionVersion": { "maxLength": 10 },
   "confirmationCode": { "length": 6 },
+  "emailOtpCode": { "length": 8 },
+  "totpCode": { "length": 6 },
   "constraintsBytes": { "max": 16384 },
   "parametersBytes": { "max": 16384 }
 }

--- a/shared/validation_test.go
+++ b/shared/validation_test.go
@@ -20,6 +20,8 @@ func TestValidationConfigLoads(t *testing.T) {
 		{"ActionTypeMaxLength", ActionTypeMaxLength, 128},
 		{"ActionVersionMaxLength", ActionVersionMaxLength, 10},
 		{"ConfirmationCodeLength", ConfirmationCodeLength, 6},
+		{"EmailOtpCodeLength", EmailOtpCodeLength, 8},
+		{"TotpCodeLength", TotpCodeLength, 6},
 		{"MaxConstraintsBytes", MaxConstraintsBytes, 16384},
 		{"MaxParametersBytes", MaxParametersBytes, 16384},
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The login email OTP field was capped at 6 characters via `shared/validation.json` `confirmationCode`, which is also used for **agent registration** confirmation codes (XXX-XXX) and would break MFA if raised globally.

This change adds separate limits: **`emailOtpCode` (8 digits)** for magic-link / email OTP, and **`totpCode` (6 digits)** for authenticator flows. `OtpCodeInput` now takes a `variant: "email" | "totp"` to pick the right max length. Mobile email OTP uses the same shared JSON via `mobile/src/lib/validation.ts`.

## Test plan

### Developer
- [x] `go test ./shared/...`
- [x] `npx vitest run` (frontend)
- [x] `npx jest --ci` (mobile)

### Manual Testing
- [ ] Web: enter an 8-digit email OTP from your provider without the field truncating
- [ ] Web: MFA / TOTP still accepts exactly 6 digits
- [ ] Mobile: same email OTP length behavior as web
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43f99cfe-3b7a-48e9-bda3-b717f94f35da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43f99cfe-3b7a-48e9-bda3-b717f94f35da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

