### PR TITLE
Add password sign-in link on OTP verification step

### DIFF
--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -37,6 +37,7 @@ export default function LoginPage() {
         onVerify={(code) => verifyOtp(email, code)}
         onBack={() => setStep("email")}
         onResend={handleResend}
+        onUsePassword={() => setStep("password")}
       />
     );
   }

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -14,6 +14,8 @@ interface OtpStepProps {
   onVerify: (code: string) => Promise<{ error: AuthError | null }>;
   onBack: () => void;
   onResend: () => Promise<{ error: AuthError | null }>;
+  /** Shown below resend — for users who cannot access their email for the code. */
+  onUsePassword?: () => void;
 }
 
 export default function OtpStep({
@@ -21,6 +23,7 @@ export default function OtpStep({
   onVerify,
   onBack,
   onResend,
+  onUsePassword,
 }: OtpStepProps) {
   const [otpCode, setOtpCode] = useState("");
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
@@ -74,6 +77,15 @@ export default function OtpStep({
         label="Resend code"
         successMessage="Code resent."
       />
+      {onUsePassword ? (
+        <button
+          type="button"
+          className="text-sm text-muted-foreground underline hover:text-foreground"
+          onClick={onUsePassword}
+        >
+          or sign in with password
+        </button>
+      ) : null}
       <DevOnly>
         <Button
           type="button"

--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -80,8 +80,9 @@ export default function OtpStep({
       {onUsePassword ? (
         <button
           type="button"
-          className="text-sm text-muted-foreground underline hover:text-foreground"
+          className="text-sm text-muted-foreground underline hover:text-foreground disabled:opacity-40"
           onClick={onUsePassword}
+          disabled={isSubmitting}
         >
           or sign in with password
         </button>

--- a/frontend/src/auth/__tests__/OtpStep.test.tsx
+++ b/frontend/src/auth/__tests__/OtpStep.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
@@ -10,18 +11,21 @@ vi.mock("../dev", () => ({
   fetchOtpFromMailpit: vi.fn().mockResolvedValue(null),
 }));
 
-const defaultProps = {
+const defaultProps: Pick<
+  ComponentProps<typeof OtpStep>,
+  "email" | "onVerify" | "onBack" | "onResend"
+> = {
   email: "test@example.com",
   onVerify: vi.fn().mockResolvedValue({ error: null }),
   onBack: vi.fn(),
   onResend: vi.fn().mockResolvedValue({ error: null }),
 };
 
-function renderOtpStep(props = defaultProps) {
+function renderOtpStep(overrides: Partial<ComponentProps<typeof OtpStep>> = {}) {
   return render(
     <MemoryRouter>
       <CookieConsentProvider>
-        <OtpStep {...props} />
+        <OtpStep {...defaultProps} {...overrides} />
       </CookieConsentProvider>
     </MemoryRouter>,
   );
@@ -38,7 +42,7 @@ describe("OtpStep", () => {
 
   it("calls onVerify with entered code", async () => {
     const onVerify = vi.fn().mockResolvedValue({ error: null });
-    renderOtpStep({ ...defaultProps, onVerify });
+    renderOtpStep({ onVerify });
 
     await userEvent.type(screen.getByLabelText("Code"), "123456");
     await userEvent.click(screen.getByText("Verify"));
@@ -50,7 +54,7 @@ describe("OtpStep", () => {
     const onVerify = vi.fn().mockResolvedValue({
       error: new AuthError("Token expired", 401, "otp_expired"),
     });
-    renderOtpStep({ ...defaultProps, onVerify });
+    renderOtpStep({ onVerify });
 
     await userEvent.type(screen.getByLabelText("Code"), "000000");
     await userEvent.click(screen.getByText("Verify"));
@@ -67,7 +71,7 @@ describe("OtpStep", () => {
 
   it("calls onBack when back button is clicked", async () => {
     const onBack = vi.fn();
-    renderOtpStep({ ...defaultProps, onBack });
+    renderOtpStep({ onBack });
 
     await userEvent.click(screen.getByText("Back"));
 
@@ -81,9 +85,27 @@ describe("OtpStep", () => {
     expect(btn).not.toBeDisabled();
   });
 
+  it("does not show password link when onUsePassword is omitted", () => {
+    renderOtpStep();
+    expect(
+      screen.queryByRole("button", { name: "or sign in with password" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onUsePassword when password link is clicked", async () => {
+    const onUsePassword = vi.fn();
+    renderOtpStep({ onUsePassword });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "or sign in with password" }),
+    );
+
+    expect(onUsePassword).toHaveBeenCalled();
+  });
+
   it("calls onResend when resend button is clicked", async () => {
     const onResend = vi.fn().mockResolvedValue({ error: null });
-    renderOtpStep({ ...defaultProps, onResend });
+    renderOtpStep({ onResend });
 
     await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 
@@ -92,7 +114,7 @@ describe("OtpStep", () => {
 
   it("shows success message after resend", async () => {
     const onResend = vi.fn().mockResolvedValue({ error: null });
-    renderOtpStep({ ...defaultProps, onResend });
+    renderOtpStep({ onResend });
 
     await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 
@@ -105,7 +127,7 @@ describe("OtpStep", () => {
     const onResend = vi.fn().mockResolvedValue({
       error: new AuthError("Rate limit", 429, "over_email_send_rate_limit"),
     });
-    renderOtpStep({ ...defaultProps, onResend });
+    renderOtpStep({ onResend });
 
     await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 
@@ -119,7 +141,7 @@ describe("OtpStep", () => {
     const onResend = vi.fn().mockResolvedValue({
       error: new AuthError("Server error", 500, "unexpected_failure"),
     });
-    renderOtpStep({ ...defaultProps, onResend });
+    renderOtpStep({ onResend });
 
     await userEvent.click(screen.getByRole("button", { name: "Resend code" }));
 

--- a/mobile/src/auth/OtpStep.tsx
+++ b/mobile/src/auth/OtpStep.tsx
@@ -20,6 +20,8 @@ interface OtpStepProps {
   onVerify: (code: string) => Promise<{ error: AuthError | null }>;
   onResend: () => Promise<{ error: AuthError | null }>;
   onBack: () => void;
+  /** Shown below resend — for users who cannot access their email for the code. */
+  onUsePassword?: () => void;
 }
 
 type ResendStatus = "idle" | "sent" | "failed";
@@ -29,6 +31,7 @@ export default function OtpStep({
   onVerify,
   onResend,
   onBack,
+  onUsePassword,
 }: OtpStepProps) {
   const [otpCode, setOtpCode] = useState("");
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
@@ -178,6 +181,26 @@ export default function OtpStep({
             </Text>
           ) : null}
         </View>
+
+        {onUsePassword ? (
+          <TouchableOpacity
+            testID="otp-use-password"
+            accessibilityLabel="Or sign in with password"
+            accessibilityRole="button"
+            onPress={onUsePassword}
+            disabled={isSubmitting}
+            style={localStyles.passwordLink}
+          >
+            <Text
+              style={[
+                localStyles.passwordLinkText,
+                isSubmitting && localStyles.passwordLinkDisabled,
+              ]}
+            >
+              or sign in with password
+            </Text>
+          </TouchableOpacity>
+        ) : null}
       </Pressable>
     </KeyboardAvoidingView>
   );
@@ -233,5 +256,18 @@ const localStyles = StyleSheet.create({
   },
   resendSuccess: {
     color: colors.success,
+  },
+  passwordLink: {
+    marginTop: 20,
+    alignItems: "center",
+  },
+  passwordLinkText: {
+    color: colors.gray500,
+    fontSize: 14,
+    fontWeight: "500",
+    textDecorationLine: "underline",
+  },
+  passwordLinkDisabled: {
+    opacity: 0.4,
   },
 });

--- a/mobile/src/auth/__tests__/OtpStep.test.tsx
+++ b/mobile/src/auth/__tests__/OtpStep.test.tsx
@@ -52,6 +52,25 @@ describe("OtpStep", () => {
     expect(resendBtn.props.disabled).toBe(false);
   });
 
+  it("shows password fallback when onUsePassword is provided", async () => {
+    const onUsePassword = jest.fn();
+    const props = makeProps({ onUsePassword });
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(OtpStep, props));
+    });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const link = findByTestId(renderer!, "otp-use-password");
+    expect(link).toBeTruthy();
+    await act(async () => {
+      await link.props.onPress();
+    });
+    expect(onUsePassword).toHaveBeenCalled();
+  });
+
   it("shows success message after successful resend", async () => {
     const props = makeProps();
     let renderer: ReactTestRenderer;

--- a/mobile/src/auth/__tests__/OtpStep.test.tsx
+++ b/mobile/src/auth/__tests__/OtpStep.test.tsx
@@ -52,6 +52,20 @@ describe("OtpStep", () => {
     expect(resendBtn.props.disabled).toBe(false);
   });
 
+  it("does not show password link when onUsePassword is omitted", async () => {
+    const props = makeProps();
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(OtpStep, props));
+    });
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const link = findByTestIdOptional(renderer!, "otp-use-password");
+    expect(link).toBeNull();
+  });
+
   it("shows password fallback when onUsePassword is provided", async () => {
     const onUsePassword = jest.fn();
     const props = makeProps({ onUsePassword });

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -28,6 +28,7 @@ export default function LoginScreen() {
         onVerify={(code) => verifyOtp(email, code)}
         onResend={() => sendOtp(email)}
         onBack={() => setStep("email")}
+        onUsePassword={() => setStep("password")}
       />
     );
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **"or sign in with password"** control below **Resend code** on the email OTP screen so users who cannot reach their inbox can still complete sign-in with the existing password flow. Wired for both the web app (`LoginPage` → `OtpStep`) and the mobile app (`LoginScreen` → `OtpStep`).

## Test plan

### Developer
- [x] `make test-frontend` (includes `OtpStep` tests)

### Manual Testing
- [ ] Web: request a code, confirm the new link appears under Resend, tap it, and complete password sign-in for an account that has a password set.
- [ ] Mobile: same flow in the native login screen.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f39b2d0-763f-48a7-8b4e-c91af31f64bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f39b2d0-763f-48a7-8b4e-c91af31f64bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

