### PR TITLE
Always include runtimeVersion for EAS Update support

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -5,10 +5,7 @@ export default (_config: ConfigContext): ExpoConfig => ({
   slug: "permission-slip",
   owner: "supersuit-tech",
   version: "1.0.0",
-  // Only include runtimeVersion during EAS builds — Expo Go doesn't support it
-  ...(process.env.EAS_BUILD
-    ? { runtimeVersion: { policy: "appVersion" as const } }
-    : {}),
+  runtimeVersion: { policy: "appVersion" as const },
   scheme: "permissionslip",
   orientation: "portrait",
   icon: "./assets/icon.png",


### PR DESCRIPTION
## Summary

- Remove conditional `EAS_BUILD` gate on `runtimeVersion` in `app.config.ts`
- `eas update` requires `runtimeVersion` to be present, but it runs outside of EAS Build so the env var isn't set
- The conditional was originally added for Expo Go compatibility, which is no longer needed since we're building for physical devices

## Test plan

### Developer
- [ ] `npx eas-cli@latest update --channel production --message "test" --auto` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)