### PR TITLE
Fix EAS Build: copy shared validation.json locally for Metro

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -50,3 +50,6 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+
+# Copied from repo root shared/ during postinstall
+src/lib/validation.json

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,7 +8,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "generate:api": "openapi-typescript ../spec/openapi/openapi.bundle.yaml -o src/api/schema.d.ts",
-    "postinstall": "npm run generate:api",
+    "postinstall": "npm run generate:api && cp ../shared/validation.json src/lib/validation.json",
     "test": "jest",
     "eas-build:dev": "npx eas-cli@latest build --profile development --platform all",
     "eas-build:preview": "npx eas-cli@latest build --profile preview --platform all",

--- a/mobile/src/lib/validation.ts
+++ b/mobile/src/lib/validation.ts
@@ -2,6 +2,6 @@
  * Shared validation constants from repo root `shared/validation.json`
  * (same source as the web app and Go backend).
  */
-import config from "../../../shared/validation.json";
+import config from "./validation.json";
 
 export default config;


### PR DESCRIPTION
## Summary

- Metro bundler on EAS Build can't resolve `../../../shared/validation.json` because it only watches the `mobile/` project root
- Copy `shared/validation.json` into `mobile/src/lib/` during `postinstall` so Metro can find it
- Update import in `validation.ts` to use the local copy
- Gitignore the local copy to avoid repo duplication

## Test plan

### Developer
- [x] `PasswordStep` tests pass (uses validation config)
- [ ] `npx eas-cli@latest build --platform ios --profile production` passes the Bundle JavaScript phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)