### PR TITLE
fix(mobile): settings Privacy/Terms open app policy URLs

### DIFF
--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -24,8 +24,8 @@ import { useUpdateNotificationPreferences } from "../../hooks/useUpdateNotificat
 import { useDeleteAccount } from "../../hooks/useDeleteAccount";
 import { colors } from "../../theme/colors";
 
-const PRIVACY_POLICY_URL = "https://permissionslip.dev/privacy";
-const TERMS_OF_SERVICE_URL = "https://permissionslip.dev/terms";
+const PRIVACY_POLICY_URL = "https://app.permissionslip.dev/policy/privacy";
+const TERMS_OF_SERVICE_URL = "https://app.permissionslip.dev/policy/terms";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Settings">;
 

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -287,7 +287,7 @@ describe("SettingsScreen", () => {
     await act(async () => {
       link?.props.onPress();
     });
-    expect(openURLSpy).toHaveBeenCalledWith("https://permissionslip.dev/privacy");
+    expect(openURLSpy).toHaveBeenCalledWith("https://app.permissionslip.dev/policy/privacy");
     openURLSpy.mockRestore();
   });
 
@@ -306,7 +306,7 @@ describe("SettingsScreen", () => {
     await act(async () => {
       link?.props.onPress();
     });
-    expect(openURLSpy).toHaveBeenCalledWith("https://permissionslip.dev/terms");
+    expect(openURLSpy).toHaveBeenCalledWith("https://app.permissionslip.dev/policy/terms");
     openURLSpy.mockRestore();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Settings screen legal links so Privacy Policy and Terms of Service open the hosted app policy pages at `app.permissionslip.dev` instead of the marketing-site paths.

## Test plan

- `cd mobile && npm test -- --ci --testPathPattern=SettingsScreen`

### Developer

- [x] Unit tests updated and passing for URL expectations

### Manual Testing

- [ ] Open Settings → tap Privacy Policy and Terms of Service; confirm Safari/browser opens the correct URLs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-070c8131-ad0a-4fda-955f-5b5c65fb0567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-070c8131-ad0a-4fda-955f-5b5c65fb0567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

