### PR TITLE
Fix EAS Update by converting app.config.ts to static export

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,6 +1,6 @@
-import { ExpoConfig, ConfigContext } from "expo/config";
+import { ExpoConfig } from "expo/config";
 
-export default (_config: ConfigContext): ExpoConfig => ({
+const config: ExpoConfig = {
   name: "Permission Slip",
   slug: "permission-slip",
   owner: "supersuit-tech",
@@ -65,7 +65,7 @@ export default (_config: ConfigContext): ExpoConfig => ({
     favicon: "./assets/favicon.png",
   },
   updates: {
-    url: `https://u.expo.dev/${process.env.EXPO_PROJECT_ID}`,
+    url: "https://u.expo.dev/6bbabfc7-f70d-45f7-bdc2-4f8387d14006",
     enabled: true,
     fallbackToCacheTimeout: 0,
   },
@@ -74,4 +74,6 @@ export default (_config: ConfigContext): ExpoConfig => ({
       projectId: "6bbabfc7-f70d-45f7-bdc2-4f8387d14006",
     },
   },
-});
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- Convert `app.config.ts` from a dynamic config (function export) to a static object export
- EAS CLI cannot introspect dynamic configs for the `updates.url` pre-flight check, causing `eas update --channel production` to fail even when the value is present
- The config parameter (`_config: ConfigContext`) was unused, so the conversion is a no-op in terms of output
- Hardcode the EAS project ID in the updates URL instead of using `process.env.EXPO_PROJECT_ID`

## Test plan
- [ ] Run `npx eas-cli@latest update --channel production` and confirm it no longer errors on config validation
- [ ] Run `npx expo config --type public` and verify resolved config is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)