### PR TITLE
feat(mobile): make app config contributor-friendly

### DIFF
--- a/docs/mobile-builds.md
+++ b/docs/mobile-builds.md
@@ -18,19 +18,14 @@ From the `mobile/` directory:
 npx eas-cli init
 ```
 
-This creates a project on Expo's servers and outputs an `EXPO_PROJECT_ID`. Add this to your `.env`:
+This creates a project on Expo's servers and outputs an `EXPO_PROJECT_ID`. Add it (along with your Expo account name) to your `.env`:
 
 ```
 EXPO_PROJECT_ID=your-project-id-here
+EXPO_OWNER=your-expo-username
 ```
 
-Then update the OTA update URL in `app.json` — replace `${EXPO_PROJECT_ID}` with the actual ID:
-
-```json
-"updates": {
-  "url": "https://u.expo.dev/your-project-id-here"
-}
-```
+`app.config.ts` reads these env vars automatically — no manual edits needed.
 
 ### 2. Configure app signing
 

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,16 +1,21 @@
-# Supabase project credentials (same project as web frontend)
+# Expo / EAS Configuration
+# These are used in app.config.ts. Contributors must set their own values.
+# Get EXPO_PROJECT_ID and EXPO_OWNER by running `npx eas-cli init` in this directory.
+EXPO_PROJECT_ID=
+EXPO_OWNER=
+# iOS bundle identifier / Android package name. Must be unique to your developer account.
+APP_BUNDLE_ID=com.yourorg.permissionslip
+
+# Supabase project credentials
+# Use http://127.0.0.1:54321 for local development with `supabase start`
 EXPO_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key-here
-
-# EAS Project ID (required for OTA updates via expo-updates)
-# Get this from: https://expo.dev after running `eas init`
-EXPO_PROJECT_ID=
 
 # Backend API base URL. Must end in /api (spec paths add /v1 automatically).
 # Falls back to https://app.permissionslip.dev/api when unset.
 # EXPO_PUBLIC_API_BASE_URL=https://app.permissionslip.dev/api
 
 # Mock auth mode — bypass Supabase auth and use a fake session.
-# Set to "true" to test the app UI with Expo Go without a running backend.
+# Set to "true" to test the app UI without a running backend.
 # Only works in __DEV__ mode — ignored in production builds.
 # EXPO_PUBLIC_MOCK_AUTH=true

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,108 @@
+# Permission Slip — Mobile App
+
+React Native mobile app built with [Expo](https://expo.dev). Lets users approve or deny permission requests via push notifications, biometric authentication, and deep linking.
+
+## Prerequisites
+
+- Node.js 20+
+- [EAS CLI](https://docs.expo.dev/eas/) (included as a dev dependency — `npx eas-cli` works)
+- An [Expo account](https://expo.dev/signup) (for device builds)
+- Apple Developer account (for iOS device builds)
+- The backend running locally, or `EXPO_PUBLIC_MOCK_AUTH=true` for UI-only development
+
+## Quick Start
+
+### 1. Install dependencies
+
+```bash
+cd mobile
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Fill in your values — see [Environment Variables](#environment-variables) below.
+
+### 3. Start the dev server
+
+```bash
+npm start
+```
+
+> **Note:** Expo Go won't work because the app uses custom native modules (notifications, local authentication). You need a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+
+## Development Builds
+
+Build for iOS simulator:
+
+```bash
+npx eas-cli build --profile development --platform ios
+```
+
+Once the build completes, install it on your simulator and run `npm start` to connect.
+
+For physical device builds, set `ios.simulator` to `false` in the `development` profile in `eas.json` and rebuild.
+
+## Setting Up Your Own Expo Project
+
+Contributors need their own Expo project to run device builds:
+
+1. Create an Expo account at https://expo.dev/signup
+
+2. Initialize your project:
+   ```bash
+   cd mobile
+   npx eas-cli init
+   ```
+
+3. Add the project ID and your account details to `.env`:
+   ```
+   EXPO_PROJECT_ID=your-project-id
+   EXPO_OWNER=your-expo-username
+   APP_BUNDLE_ID=com.yourname.permissionslip
+   ```
+
+4. If using your own Supabase instance, update the env vars in the `eas.json` build profiles.
+
+`app.config.ts` reads all of these from environment variables — no need to edit the config file directly.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EXPO_PUBLIC_SUPABASE_URL` | Yes | — | Supabase project URL (`http://127.0.0.1:54321` for local) |
+| `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Yes | — | Supabase anon/publishable key |
+| `EXPO_PROJECT_ID` | For builds | — | EAS project ID (from `npx eas-cli init`) |
+| `EXPO_OWNER` | For builds | — | Expo account username or org |
+| `APP_BUNDLE_ID` | For builds | — | iOS bundle ID / Android package (must be unique to your account) |
+| `EXPO_PUBLIC_API_BASE_URL` | No | `https://app.permissionslip.dev/api` | Backend API URL |
+| `EXPO_PUBLIC_MOCK_AUTH` | No | `false` | `true` to test UI without a backend (`__DEV__` only) |
+
+## Testing
+
+```bash
+npm test           # run all tests
+npm test -- --ci   # CI mode (used by make mobile-test)
+```
+
+## Project Structure
+
+```
+src/
+├── api/           # API client (generated from OpenAPI spec)
+├── auth/          # Authentication context and screens
+├── components/    # Shared UI components
+├── hooks/         # Custom React hooks
+├── lib/           # Supabase client, secure storage
+├── navigation/    # React Navigation setup and deep linking
+├── screens/       # Screen components (approvals, settings)
+└── theme/         # Colors and design tokens
+```
+
+## Builds & Distribution
+
+For full details on build profiles, OTA updates, code signing, and App Store submission, see [docs/mobile-builds.md](../docs/mobile-builds.md).

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,9 +1,12 @@
 import { ExpoConfig } from "expo/config";
 
+const projectId =
+  process.env.EXPO_PROJECT_ID || "6bbabfc7-f70d-45f7-bdc2-4f8387d14006";
+
 const config: ExpoConfig = {
   name: "Permission Slip",
   slug: "permission-slip",
-  owner: "supersuit-tech",
+  owner: process.env.EXPO_OWNER || "supersuit-tech",
   version: "1.0.0",
   runtimeVersion: { policy: "appVersion" as const },
   scheme: "permissionslip",
@@ -17,7 +20,7 @@ const config: ExpoConfig = {
   },
   ios: {
     supportsTablet: true,
-    bundleIdentifier: "dev.permissionslip.app",
+    bundleIdentifier: process.env.APP_BUNDLE_ID || "dev.permissionslip.app",
     associatedDomains: ["applinks:app.permissionslip.dev"],
     infoPlist: {
       UIBackgroundModes: ["remote-notification"],
@@ -38,7 +41,7 @@ const config: ExpoConfig = {
     "expo-updates",
   ],
   android: {
-    package: "dev.permissionslip.app",
+    package: process.env.APP_BUNDLE_ID || "dev.permissionslip.app",
     adaptiveIcon: {
       backgroundColor: "#6A2C91",
       foregroundImage: "./assets/android-icon-foreground.png",
@@ -65,13 +68,13 @@ const config: ExpoConfig = {
     favicon: "./assets/favicon.png",
   },
   updates: {
-    url: "https://u.expo.dev/6bbabfc7-f70d-45f7-bdc2-4f8387d14006",
+    url: `https://u.expo.dev/${projectId}`,
     enabled: true,
     fallbackToCacheTimeout: 0,
   },
   extra: {
     eas: {
-      projectId: "6bbabfc7-f70d-45f7-bdc2-4f8387d14006",
+      projectId,
     },
   },
 };


### PR DESCRIPTION
## Summary

- Move hardcoded org-specific values in `app.config.ts` to environment variables (`EXPO_OWNER`, `APP_BUNDLE_ID`, `EXPO_PROJECT_ID`) with backward-compatible defaults so existing workflows are unaffected
- Add `mobile/README.md` with contributor onboarding: prerequisites, quick start, env vars table, project structure, and how to set up your own Expo project
- Update `.env.example` with the new variables and clearer comments
- Simplify `docs/mobile-builds.md` first-time setup — no more manual config edits needed since `app.config.ts` reads env vars automatically

## Test plan

### Developer
- [ ] Verify `eas update --channel production` still works (env-var approach for project ID vs previous hardcoded value)
- [ ] Verify `eas build --profile development --platform ios` succeeds with env vars from `.env`

### Manual Testing
- [ ] Follow the `mobile/README.md` instructions from scratch on a clean checkout to confirm the contributor flow works
- [ ] Confirm a contributor can run `eas init` + set env vars + build without editing `app.config.ts`


🤖 Generated with [Claude Code](https://claude.com/claude-code)