### PR TITLE
Change Cloudflare connector status to untested

### DIFF
--- a/connectors/cloudflare/manifest.go
+++ b/connectors/cloudflare/manifest.go
@@ -15,7 +15,7 @@ func (c *CloudflareConnector) Manifest() *connectors.ConnectorManifest {
 		ID:          "cloudflare",
 		Name:        "Cloudflare",
 		Description: "Cloudflare integration for DNS management, domain settings, tunnels, and cache purging",
-		Status:      "early_preview",
+		Status:      "untested",
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{


### PR DESCRIPTION
## Summary
- Changes the Cloudflare connector status from `early_preview` to `untested` in `connectors/cloudflare/manifest.go`

## Test plan
### Developer
- [ ] CI passes

### Manual Testing
- [ ] Verify Cloudflare appears under the "Untested" category on the agent connectors page

https://claude.ai/code/session_01QgMkdEdw1SExQsYCpg6xBP