### PR TITLE
Fix ADR-002: standing approval creation has no confirmation code

### DIFF
--- a/docs/adr/002-standing-approvals.md
+++ b/docs/adr/002-standing-approvals.md
@@ -94,7 +94,7 @@ Created ──> Active ──> Expired
               └──> Exhausted (max executions reached)
 ```
 
-1. **Created:** User configures and confirms the standing approval (requires confirmation code, same as one-off).
+1. **Created:** User configures the standing approval from the web UI.
 2. **Active:** Agent can execute the action freely within constraints.
 3. **Expired:** Duration elapsed. Agent must request a new standing approval or fall back to one-off.
 4. **Revoked:** User manually cancels at any time. Takes effect immediately.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Standing Approval Lifecycle in ADR-002 so the **Created** state matches the product: standing approvals are configured and created from the web UI without a confirmation code (unlike one-off approvals).

Closes #915.

### Developer

- [x] Corrected the **Created** lifecycle bullet in `docs/adr/002-standing-approvals.md`.
- [x] Reviewed the rest of ADR-002 for other standing-approval + confirmation-code claims; no further edits needed (remaining mentions are ADR-001 context, execution path, or one-off comparison).

### Manual Testing

- [ ] N/A — documentation only.

## Test plan

- Read `docs/adr/002-standing-approvals.md` lifecycle section and confirm it aligns with `handleCreateStandingApproval` (no confirmation step) and the create standing approval UI flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9095b32b-e5cb-4825-96a6-7f7d96a13f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9095b32b-e5cb-4825-96a6-7f7d96a13f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

