### PR TITLE
Add Recommended Templates browser on connector config page

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -17,12 +17,15 @@ import {
 } from "@/components/ui/table";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
 import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
+import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
+import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 import { ActionConfigRow } from "./ActionConfigRow";
 import { AddActionConfigDialog } from "./AddActionConfigDialog";
 import { EditActionConfigDialog } from "./EditActionConfigDialog";
 import { DeleteActionConfigDialog } from "./DeleteActionConfigDialog";
+import { RecommendedTemplatesDialog } from "./RecommendedTemplatesDialog";
 
 interface ActionConfigurationsSectionProps {
   agentId: number;
@@ -44,6 +47,9 @@ export function ActionConfigurationsSection({
   error,
 }: ActionConfigurationsSectionProps) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [initialTemplateForAdd, setInitialTemplateForAdd] =
+    useState<ActionConfigTemplate | null>(null);
+  const [recommendedDialogOpen, setRecommendedDialogOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ActionConfiguration | null>(
     null,
   );
@@ -51,6 +57,14 @@ export function ActionConfigurationsSection({
     null,
   );
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const { templates, isLoading: templatesLoading } =
+    useActionConfigTemplates(connectorId);
+
+  const actionTypeSet = new Set(actions.map((a) => a.action_type));
+  const hasRecommendedTemplates =
+    !templatesLoading &&
+    templates.some((t) => actionTypeSet.has(t.action_type));
 
   const hasWildcardConfig = configs.some(
     (c) => c.action_type === WILDCARD_ACTION_TYPE,
@@ -78,6 +92,18 @@ export function ActionConfigurationsSection({
     }
   };
 
+  function openAddDialog(fromTemplate?: ActionConfigTemplate | null) {
+    setInitialTemplateForAdd(fromTemplate ?? null);
+    setAddDialogOpen(true);
+  }
+
+  function handleAddDialogOpenChange(open: boolean) {
+    if (!open) {
+      setInitialTemplateForAdd(null);
+    }
+    setAddDialogOpen(open);
+  }
+
   return (
     <Card>
       <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -104,11 +130,23 @@ export function ActionConfigurationsSection({
                 Enable All Actions
               </Button>
             )}
+            {hasRecommendedTemplates && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => setRecommendedDialogOpen(true)}
+                disabled={actions.length === 0}
+              >
+                Recommended Templates
+              </Button>
+            )}
             <Button
               type="button"
               size="sm"
               className="shrink-0"
-              onClick={() => setAddDialogOpen(true)}
+              onClick={() => openAddDialog()}
               disabled={actions.length === 0}
             >
               <Plus className="size-4" />
@@ -133,7 +171,11 @@ export function ActionConfigurationsSection({
             isEnablingAll={isEnablingAll}
             showAdvanced={showAdvanced}
             onToggleAdvanced={() => setShowAdvanced((v) => !v)}
-            onAddCustom={() => setAddDialogOpen(true)}
+            onAddCustom={() => openAddDialog()}
+            onBrowseRecommendedTemplates={() =>
+              setRecommendedDialogOpen(true)
+            }
+            showRecommendedLink={hasRecommendedTemplates}
             actionsDisabled={actions.length === 0}
           />
         ) : (
@@ -174,10 +216,22 @@ export function ActionConfigurationsSection({
 
       <AddActionConfigDialog
         open={addDialogOpen}
-        onOpenChange={setAddDialogOpen}
+        onOpenChange={handleAddDialogOpenChange}
         agentId={agentId}
         connectorId={connectorId}
         actions={actions}
+        initialTemplate={initialTemplateForAdd}
+      />
+
+      <RecommendedTemplatesDialog
+        open={recommendedDialogOpen}
+        onOpenChange={setRecommendedDialogOpen}
+        agentId={agentId}
+        connectorId={connectorId}
+        actions={actions}
+        onCustomize={(template) => {
+          openAddDialog(template);
+        }}
       />
 
       {editTarget && (
@@ -213,6 +267,8 @@ function EnableAllEmptyState({
   showAdvanced,
   onToggleAdvanced,
   onAddCustom,
+  onBrowseRecommendedTemplates,
+  showRecommendedLink,
   actionsDisabled,
 }: {
   onEnableAll: () => void;
@@ -220,6 +276,8 @@ function EnableAllEmptyState({
   showAdvanced: boolean;
   onToggleAdvanced: () => void;
   onAddCustom: () => void;
+  onBrowseRecommendedTemplates: () => void;
+  showRecommendedLink: boolean;
   actionsDisabled: boolean;
 }) {
   return (
@@ -241,6 +299,18 @@ function EnableAllEmptyState({
           Your agent can use any action from this connector. Every action still
           requires your approval before it runs.
         </p>
+        {showRecommendedLink && (
+          <div>
+            <button
+              type="button"
+              onClick={onBrowseRecommendedTemplates}
+              disabled={actionsDisabled}
+              className="text-muted-foreground hover:text-foreground text-sm underline-offset-4 transition-colors hover:underline disabled:pointer-events-none disabled:opacity-50"
+            >
+              Or start from a recommended template →
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="pt-2">

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Loader2, Plus, Settings, Zap } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -61,7 +61,10 @@ export function ActionConfigurationsSection({
   const { templates, isLoading: templatesLoading } =
     useActionConfigTemplates(connectorId);
 
-  const actionTypeSet = new Set(actions.map((a) => a.action_type));
+  const actionTypeSet = useMemo(
+    () => new Set(actions.map((a) => a.action_type)),
+    [actions],
+  );
   const hasRecommendedTemplates =
     !templatesLoading &&
     templates.some((t) => actionTypeSet.has(t.action_type));

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -36,6 +36,8 @@ interface AddActionConfigDialogProps {
   agentId: number;
   connectorId: string;
   actions: ConnectorAction[];
+  /** When the dialog opens, apply this template (action type, fields, parameters). */
+  initialTemplate?: ActionConfigTemplate | null;
 }
 
 export function AddActionConfigDialog({
@@ -44,6 +46,7 @@ export function AddActionConfigDialog({
   agentId,
   connectorId,
   actions,
+  initialTemplate = null,
 }: AddActionConfigDialogProps) {
   const { createActionConfig, isPending } = useCreateActionConfig();
   const { templates, isLoading: templatesLoading } =
@@ -55,6 +58,8 @@ export function AddActionConfigDialog({
   const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
   const [appliedTemplateId, setAppliedTemplateId] = useState<string | null>(null);
+
+  const prevOpenRef = useRef(false);
 
   const selectedAction = useMemo(
     () => actions.find((a) => a.action_type === selectedActionType) ?? null,
@@ -94,35 +99,50 @@ export function AddActionConfigDialog({
     setAppliedTemplateId(null);
   }
 
-  function handleTemplateSelect(template: ActionConfigTemplate) {
-    // Pre-fill form fields from the template
-    setName(template.name);
-    setDescription(template.description ?? "");
+  const handleTemplateSelect = useCallback(
+    (
+      template: ActionConfigTemplate,
+      options?: { fromInitial?: boolean },
+    ) => {
+      setSelectedActionType(template.action_type);
+      setName(template.name);
+      setDescription(template.description ?? "");
 
-    // Convert template parameters to form values and modes
-    const values: Record<string, string> = {};
-    const modes: Record<string, ParamMode> = {};
-    for (const [key, value] of Object.entries(template.parameters)) {
-      if (value === "*") {
-        values[key] = "*";
-        modes[key] = "wildcard";
-      } else if (isPatternWrapper(value)) {
-        values[key] = value.$pattern;
-        modes[key] = "pattern";
-      } else if (value === null || value === undefined) {
-        values[key] = "";
-        modes[key] = "fixed";
-      } else {
-        values[key] = String(value);
-        modes[key] = "fixed";
+      const values: Record<string, string> = {};
+      const modes: Record<string, ParamMode> = {};
+      for (const [key, value] of Object.entries(template.parameters)) {
+        if (value === "*") {
+          values[key] = "*";
+          modes[key] = "wildcard";
+        } else if (isPatternWrapper(value)) {
+          values[key] = value.$pattern;
+          modes[key] = "pattern";
+        } else if (value === null || value === undefined) {
+          values[key] = "";
+          modes[key] = "fixed";
+        } else {
+          values[key] = String(value);
+          modes[key] = "fixed";
+        }
       }
-    }
-    setParamValues(values);
-    setParamModes(modes);
-    setAppliedTemplateId(template.id);
+      setParamValues(values);
+      setParamModes(modes);
+      setAppliedTemplateId(template.id);
 
-    toast.success(`Template "${template.name}" applied`);
-  }
+      if (!options?.fromInitial) {
+        toast.success(`Template "${template.name}" applied`);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const wasOpen = prevOpenRef.current;
+    prevOpenRef.current = open;
+    if (open && !wasOpen && initialTemplate) {
+      handleTemplateSelect(initialTemplate, { fromInitial: true });
+    }
+  }, [open, initialTemplate, handleTemplateSelect]);
 
   function handleParamChange(key: string, value: string) {
     setParamValues((prev) => ({ ...prev, [key]: value }));

--- a/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
@@ -89,6 +89,8 @@ export function RecommendedTemplatesDialog({
         action_type: template.action_type,
         name: template.name,
         description: template.description ?? undefined,
+        // Cast is safe: OpenAPI types template.parameters as object with
+        // additionalProperties — structurally the same as Record<string, unknown>.
         parameters: template.parameters as Record<string, unknown>,
       });
       toast.success(`Configuration "${template.name}" created`);

--- a/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
+import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
+import type { ConnectorAction } from "@/hooks/useConnectorDetail";
+import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
+import { TemplateParamBadge } from "./TemplatePicker";
+
+export interface RecommendedTemplatesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentId: number;
+  connectorId: string;
+  actions: ConnectorAction[];
+  onCustomize: (template: ActionConfigTemplate) => void;
+}
+
+export function RecommendedTemplatesDialog({
+  open,
+  onOpenChange,
+  agentId,
+  connectorId,
+  actions,
+  onCustomize,
+}: RecommendedTemplatesDialogProps) {
+  const { templates, isLoading, error } =
+    useActionConfigTemplates(connectorId);
+  const { createActionConfig, isPending } = useCreateActionConfig();
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
+    null,
+  );
+
+  const actionTypeSet = useMemo(
+    () => new Set(actions.map((a) => a.action_type)),
+    [actions],
+  );
+
+  const actionNameByType = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of actions) {
+      m.set(a.action_type, a.name);
+    }
+    return m;
+  }, [actions]);
+
+  const liveTemplates = useMemo(
+    () => templates.filter((t) => actionTypeSet.has(t.action_type)),
+    [templates, actionTypeSet],
+  );
+
+  const grouped = useMemo(() => {
+    const byType = new Map<string, ActionConfigTemplate[]>();
+    for (const t of liveTemplates) {
+      const list = byType.get(t.action_type) ?? [];
+      list.push(t);
+      byType.set(t.action_type, list);
+    }
+    const order = actions.map((a) => a.action_type);
+    const groups: { actionType: string; actionName: string; items: ActionConfigTemplate[] }[] =
+      [];
+    for (const actionType of order) {
+      const items = byType.get(actionType);
+      if (items && items.length > 0) {
+        groups.push({
+          actionType,
+          actionName: actionNameByType.get(actionType) ?? actionType,
+          items,
+        });
+      }
+    }
+    return groups;
+  }, [liveTemplates, actions, actionNameByType]);
+
+  async function handleUseTemplate(template: ActionConfigTemplate) {
+    setPendingTemplateId(template.id);
+    try {
+      await createActionConfig({
+        agent_id: agentId,
+        connector_id: connectorId,
+        action_type: template.action_type,
+        name: template.name,
+        description: template.description ?? undefined,
+        parameters: template.parameters as Record<string, unknown>,
+      });
+      toast.success(`Configuration "${template.name}" created`);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to create action configuration",
+      );
+    } finally {
+      setPendingTemplateId(null);
+    }
+  }
+
+  function handleCustomize(template: ActionConfigTemplate) {
+    onOpenChange(false);
+    onCustomize(template);
+  }
+
+  const buttonsDisabled = isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Recommended Templates</DialogTitle>
+          <DialogDescription>
+            Start from a curated configuration for this connector. Use a
+            template as-is or customize it before saving.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center gap-2 py-8">
+            <Loader2
+              className="text-muted-foreground size-5 animate-spin"
+              aria-hidden="true"
+            />
+            <span className="text-muted-foreground text-sm">
+              Loading templates...
+            </span>
+          </div>
+        ) : error ? (
+          <p className="text-destructive py-4 text-sm">{error}</p>
+        ) : grouped.length === 0 ? (
+          <p className="text-muted-foreground py-4 text-sm">
+            No recommended templates are available for this connector.
+          </p>
+        ) : (
+          <div className="space-y-6 py-2">
+            {grouped.map((group) => (
+              <section key={group.actionType} className="space-y-3">
+                <h3 className="text-sm font-semibold">{group.actionName}</h3>
+                <div className="space-y-3">
+                  {group.items.map((template) => (
+                    <RecommendedTemplateCard
+                      key={template.id}
+                      template={template}
+                      onUseTemplate={() => void handleUseTemplate(template)}
+                      onCustomize={() => handleCustomize(template)}
+                      useDisabled={buttonsDisabled}
+                      customizeDisabled={buttonsDisabled}
+                      usePending={
+                        isPending && pendingTemplateId === template.id
+                      }
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RecommendedTemplateCard({
+  template,
+  onUseTemplate,
+  onCustomize,
+  useDisabled,
+  customizeDisabled,
+  usePending,
+}: {
+  template: ActionConfigTemplate;
+  onUseTemplate: () => void;
+  onCustomize: () => void;
+  useDisabled: boolean;
+  customizeDisabled: boolean;
+  usePending: boolean;
+}) {
+  const paramEntries = Object.entries(template.parameters);
+
+  return (
+    <div className="rounded-lg border border-input p-3">
+      <div className="space-y-2">
+        <p className="text-sm font-medium">{template.name}</p>
+        {template.description && (
+          <p className="text-muted-foreground text-sm">{template.description}</p>
+        )}
+        {paramEntries.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {paramEntries.map(([key, value]) => (
+              <TemplateParamBadge key={key} name={key} value={value} />
+            ))}
+          </div>
+        )}
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button
+            type="button"
+            size="sm"
+            onClick={onUseTemplate}
+            disabled={useDisabled}
+          >
+            {usePending && (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            )}
+            Use Template
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onCustomize}
+            disabled={customizeDisabled}
+          >
+            Customize
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/TemplatePicker.tsx
+++ b/frontend/src/pages/agents/connectors/TemplatePicker.tsx
@@ -113,7 +113,7 @@ function TemplateCard({
   );
 }
 
-function TemplateParamBadge({
+export function TemplateParamBadge({
   name,
   value,
 }: {

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderWithProviders } from "../../../../test-helpers";
 import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
 import {
+  mockGet,
   mockPost,
   mockPut,
   mockDelete,
@@ -88,6 +89,12 @@ describe("ActionConfigurationsSection", () => {
     vi.restoreAllMocks();
     resetClientMocks();
     setupAuthMocks({ authenticated: true });
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      return Promise.resolve({ data: null });
+    });
   });
 
   it("shows empty state with Enable All Actions button", () => {
@@ -492,5 +499,125 @@ describe("ActionConfigurationsSection", () => {
     expect(
       screen.getByText("Add Custom Configuration"),
     ).toBeInTheDocument();
+  });
+
+  it("hides Recommended Templates triggers while templates are loading", () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return new Promise(() => {});
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderSection();
+    expect(
+      screen.queryByRole("button", { name: "Recommended Templates" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Or start from a recommended template →"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows empty-state recommended template link when templates exist", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: "tpl_1",
+                connector_id: "github",
+                action_type: "github.create_issue",
+                name: "T",
+                description: null,
+                parameters: {},
+                created_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderSection();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Or start from a recommended template →"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows header Recommended Templates button when configs exist and templates exist", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: "tpl_1",
+                connector_id: "github",
+                action_type: "github.create_issue",
+                name: "T",
+                description: null,
+                parameters: {},
+                created_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderSection({ configs: mockConfigs });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Recommended Templates" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("hides recommended triggers when API returns no matching templates", async () => {
+    let resolveTemplates: (v: unknown) => void;
+    const templatesPromise = new Promise((resolve) => {
+      resolveTemplates = resolve;
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return templatesPromise;
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderSection({ configs: mockConfigs });
+
+    expect(
+      screen.queryByRole("button", { name: "Recommended Templates" }),
+    ).not.toBeInTheDocument();
+
+    resolveTemplates!({
+      data: {
+        data: [
+          {
+            id: "tpl_stale",
+            connector_id: "github",
+            action_type: "removed.action",
+            name: "Stale",
+            description: null,
+            parameters: {},
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Recommended Templates" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/AddActionConfigDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/AddActionConfigDialog.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../../test-helpers";
+import { mockGet, resetClientMocks } from "../../../../api/__mocks__/client";
+import { AddActionConfigDialog } from "../AddActionConfigDialog";
+import type { ConnectorAction } from "../../../../hooks/useConnectorDetail";
+
+vi.mock("../../../../lib/supabaseClient");
+vi.mock("../../../../api/client");
+
+const actions: ConnectorAction[] = [
+  {
+    action_type: "github.create_issue",
+    name: "Create Issue",
+    description: "",
+    risk_level: "low",
+    requires_payment_method: false,
+    parameters_schema: {
+      type: "object",
+      required: ["repo", "title"],
+      properties: {
+        repo: { type: "string" },
+        title: { type: "string" },
+      },
+    },
+  },
+];
+
+const initialTemplate = {
+  id: "tpl_1",
+  connector_id: "github",
+  action_type: "github.create_issue",
+  name: "From template",
+  description: "Template desc",
+  parameters: { repo: "org/repo", title: "*" },
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+describe("AddActionConfigDialog", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      return Promise.resolve({ data: null });
+    });
+    wrapper = createAuthWrapper();
+  });
+
+  it("pre-fills from initialTemplate when dialog opens", async () => {
+    const { rerender } = render(
+      <AddActionConfigDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        agentId={42}
+        connectorId="github"
+        actions={actions}
+        initialTemplate={initialTemplate}
+      />,
+      { wrapper },
+    );
+
+    rerender(
+      <AddActionConfigDialog
+        open
+        onOpenChange={vi.fn()}
+        agentId={42}
+        connectorId="github"
+        actions={actions}
+        initialTemplate={initialTemplate}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Action")).toHaveValue("github.create_issue");
+    });
+
+    expect(screen.getByLabelText("Name")).toHaveValue("From template");
+    expect(screen.getByLabelText("Description (optional)")).toHaveValue(
+      "Template desc",
+    );
+    expect(screen.getByLabelText("Repo")).toHaveValue("org/repo");
+
+    const titleInput = screen.getByLabelText("Title");
+    const titleGroup = titleInput.closest(".space-y-1\\.5")!;
+    expect(
+      within(titleGroup as HTMLElement).getByRole("checkbox"),
+    ).toBeChecked();
+  });
+});

--- a/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
@@ -1,0 +1,367 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../../../test-helpers";
+import {
+  mockGet,
+  mockPost,
+  resetClientMocks,
+} from "../../../../api/__mocks__/client";
+import { RecommendedTemplatesDialog } from "../RecommendedTemplatesDialog";
+import type { ConnectorAction } from "../../../../hooks/useConnectorDetail";
+
+vi.mock("../../../../lib/supabaseClient");
+vi.mock("../../../../api/client");
+
+const actions: ConnectorAction[] = [
+  {
+    action_type: "github.create_issue",
+    name: "Create Issue",
+    description: "",
+    risk_level: "low",
+    requires_payment_method: false,
+    parameters_schema: {},
+  },
+  {
+    action_type: "github.merge_pr",
+    name: "Merge Pull Request",
+    description: "",
+    risk_level: "high",
+    requires_payment_method: false,
+    parameters_schema: {},
+  },
+];
+
+const baseTemplates = [
+  {
+    id: "tpl_a",
+    connector_id: "github",
+    action_type: "github.create_issue",
+    name: "All open",
+    description: "Desc A",
+    parameters: { repo: "*", title: "*" },
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "tpl_b",
+    connector_id: "github",
+    action_type: "github.merge_pr",
+    name: "Merge main",
+    description: "Desc B",
+    parameters: { repo: "supersuit-tech/webapp", pr: 1 },
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "tpl_dead",
+    connector_id: "github",
+    action_type: "removed.action",
+    name: "Stale",
+    description: null,
+    parameters: {},
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+describe("RecommendedTemplatesDialog", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+  const onCustomize = vi.fn();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    setupAuthMocks({ authenticated: true });
+    wrapper = createAuthWrapper();
+    onCustomize.mockReset();
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({ data: { data: baseTemplates } });
+      }
+      return Promise.resolve({ data: null });
+    });
+  });
+
+  function renderDialog(
+    props: Partial<{
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+    }> = {},
+  ) {
+    return render(
+      <RecommendedTemplatesDialog
+        open
+        onOpenChange={props.onOpenChange ?? vi.fn()}
+        agentId={42}
+        connectorId="github"
+        actions={actions}
+        onCustomize={onCustomize}
+        {...props}
+      />,
+      { wrapper },
+    );
+  }
+
+  it("groups templates by action type in connector action order", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Create Issue")).toBeInTheDocument();
+    });
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings.map((h) => h.textContent)).toEqual([
+      "Create Issue",
+      "Merge Pull Request",
+    ]);
+
+    expect(screen.getByText("All open")).toBeInTheDocument();
+    expect(screen.getByText("Merge main")).toBeInTheDocument();
+    expect(screen.queryByText("Stale")).not.toBeInTheDocument();
+  });
+
+  it("filters out dead templates whose action_type is not on the connector", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Stale")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state while templates load", () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return new Promise(() => {});
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderDialog();
+
+    expect(screen.getByText("Loading templates...")).toBeInTheDocument();
+  });
+
+  it("shows error state when template fetch fails", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({
+          data: undefined,
+          error: { message: "fail" },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Unable to load configuration templates. Please try again later.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no live templates", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: "only_dead",
+                connector_id: "github",
+                action_type: "gone.action",
+                name: "Nope",
+                description: null,
+                parameters: {},
+                created_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "No recommended templates are available for this connector.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("creates config on Use Template and closes dialog", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    mockPost.mockResolvedValue({
+      data: {
+        id: "ac_new",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "github.create_issue",
+        parameters: { repo: "*", title: "*" },
+        status: "active",
+        name: "All open",
+        created_at: "2026-02-25T10:00:00Z",
+        updated_at: "2026-02-25T10:00:00Z",
+      },
+    });
+
+    renderDialog({ onOpenChange });
+
+    await waitFor(() => {
+      expect(screen.getByText("All open")).toBeInTheDocument();
+    });
+
+    const tplCard = screen.getByText("All open").closest(".rounded-lg")!;
+    await user.click(within(tplCard as HTMLElement).getByRole("button", { name: "Use Template" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/v1/action-configurations", {
+        headers: { Authorization: "Bearer token" },
+        body: {
+          agent_id: 42,
+          connector_id: "github",
+          action_type: "github.create_issue",
+          name: "All open",
+          description: "Desc A",
+          parameters: { repo: "*", title: "*" },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows error toast and keeps dialog open on failed create", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    mockPost.mockRejectedValue(new Error("network down"));
+
+    renderDialog({ onOpenChange });
+
+    await waitFor(() => {
+      expect(screen.getByText("All open")).toBeInTheDocument();
+    });
+
+    const tplCard = screen.getByText("All open").closest(".rounded-lg")!;
+    await user.click(within(tplCard as HTMLElement).getByRole("button", { name: "Use Template" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Recommended Templates")).toBeInTheDocument();
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("Customize closes dialog and invokes onCustomize with template", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    renderDialog({ onOpenChange });
+
+    await waitFor(() => {
+      expect(screen.getByText("All open")).toBeInTheDocument();
+    });
+
+    const tplCard = screen.getByText("All open").closest(".rounded-lg")!;
+    await user.click(within(tplCard as HTMLElement).getByRole("button", { name: "Customize" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onCustomize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "tpl_a",
+        action_type: "github.create_issue",
+        name: "All open",
+      }),
+    );
+  });
+
+  it("disables both buttons on all cards while create is pending", async () => {
+    const user = userEvent.setup();
+    let resolvePost: (v: unknown) => void;
+    const pending = new Promise((resolve) => {
+      resolvePost = resolve;
+    });
+    mockPost.mockReturnValue(pending);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("All open")).toBeInTheDocument();
+    });
+
+    const firstCard = screen.getByText("All open").closest(".rounded-lg")!;
+    await user.click(
+      within(firstCard as HTMLElement).getByRole("button", { name: "Use Template" }),
+    );
+
+    const useButtons = screen.getAllByRole("button", { name: "Use Template" });
+    const customizeButtons = screen.getAllByRole("button", { name: "Customize" });
+    for (const b of [...useButtons, ...customizeButtons]) {
+      expect(b).toBeDisabled();
+    }
+
+    resolvePost!({
+      data: {
+        id: "ac_new",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "github.create_issue",
+        parameters: {},
+        status: "active",
+        name: "All open",
+        created_at: "2026-02-25T10:00:00Z",
+        updated_at: "2026-02-25T10:00:00Z",
+      },
+    });
+
+    await waitFor(() => {
+      expect(useButtons[0]).not.toBeDisabled();
+    });
+  });
+
+  it("second click on Use Template does not fire while first is pending", async () => {
+    const user = userEvent.setup();
+    let resolvePost: (v: unknown) => void;
+    const pending = new Promise((resolve) => {
+      resolvePost = resolve;
+    });
+    mockPost.mockReturnValue(pending);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("All open")).toBeInTheDocument();
+    });
+
+    const tplCard = screen.getByText("All open").closest(".rounded-lg")!;
+    const useBtn = within(tplCard as HTMLElement).getByRole("button", {
+      name: "Use Template",
+    });
+    await user.click(useBtn);
+    await user.click(useBtn);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    resolvePost!({
+      data: {
+        id: "ac_new",
+        agent_id: 42,
+        connector_id: "github",
+        action_type: "github.create_issue",
+        parameters: {},
+        status: "active",
+        name: "All open",
+        created_at: "2026-02-25T10:00:00Z",
+        updated_at: "2026-02-25T10:00:00Z",
+      },
+    });
+  });
+});

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip
 
-go 1.25.8
+go 1.25.9
 
 require (
 	cloud.google.com/go/bigquery v1.74.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #912: a **Recommended Templates** entry point on the connector action configuration card so users can browse live templates (grouped by action), create in one click, or open **Add Action Configuration** pre-filled from a template.

## Changes

- Exported `TemplateParamBadge` from `TemplatePicker.tsx` for reuse.
- New `RecommendedTemplatesDialog` with grouping by action type (connector action order), filtering of templates whose `action_type` is not in the connector catalog, loading/error/empty states, **Use Template** / **Customize**, and disabled buttons + per-card spinner while create is in flight.
- `AddActionConfigDialog` accepts optional `initialTemplate`; on open transition applies the same pre-fill logic as template pick (including action type) without the duplicate success toast.
- `ActionConfigurationsSection` uses `useActionConfigTemplates`, shows **Recommended Templates** next to **Add Configuration** when configs exist, and the empty-state link between the main CTA and Advanced when at least one live template exists; triggers stay hidden while templates load or when no live templates exist.

## Test plan

- `cd frontend && npm test` (full suite) — passed locally.
- `make build` — frontend `tsc` + `vite build` succeeded; Go `go build` failed in this environment because the toolchain is Go 1.22.2 while a dependency requires Go ≥ 1.25 (pre-existing environment constraint).

### Developer

- [x] Unit tests for dialog, section triggers, and `initialTemplate` pre-fill
- [x] Run `cd frontend && npm test`

### Manual Testing

- [ ] Stripe/PayPal/Trello (or other template-backed connector): empty state shows link; with configs, header shows **Recommended Templates**
- [ ] **Use Template** creates row + success toast; **Customize** opens add dialog pre-filled
- [ ] API failure on create: error toast, dialog stays open

Closes #912
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3367c196-23f9-43e8-a3bb-12e8796bd6ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3367c196-23f9-43e8-a3bb-12e8796bd6ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

