### PR TITLE
Let users choose approval mode independently of template

### DIFF
--- a/api/action_config_templates_apply.go
+++ b/api/action_config_templates_apply.go
@@ -14,7 +14,8 @@ import (
 )
 
 type applyActionConfigTemplateRequest struct {
-	AgentID int64 `json:"agent_id" validate:"gt=0"`
+	AgentID      int64   `json:"agent_id" validate:"gt=0"`
+	ApprovalMode *string `json:"approval_mode,omitempty" validate:"omitempty,oneof=auto_approve requires_approval"`
 }
 
 type applyActionConfigTemplateResponse struct {
@@ -107,14 +108,25 @@ func handleApplyActionConfigTemplate(deps *Deps) http.HandlerFunc {
 
 		var standingBytes []byte
 		var spec standingApprovalTemplateSpec
-		wantStanding := len(tpl.StandingApprovalSpec) > 0 && string(tpl.StandingApprovalSpec) != "null"
-		if wantStanding {
+		templateHasStanding := len(tpl.StandingApprovalSpec) > 0 && string(tpl.StandingApprovalSpec) != "null"
+		wantStanding := templateHasStanding // default: follow template
+		if req.ApprovalMode != nil {
+			switch *req.ApprovalMode {
+			case "auto_approve":
+				wantStanding = true
+			case "requires_approval":
+				wantStanding = false
+			}
+		}
+		if wantStanding && templateHasStanding {
 			if err := json.Unmarshal(tpl.StandingApprovalSpec, &spec); err != nil {
 				log.Printf("[%s] ApplyActionConfigTemplate: parse standing spec: %v", TraceID(r.Context()), err)
 				CaptureError(r.Context(), err)
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply template"))
 				return
 			}
+		}
+		if wantStanding {
 			standingBytes, err = buildStandingApprovalConstraintsFromTemplate(params)
 			if err != nil {
 				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))

--- a/api/action_config_templates_apply_test.go
+++ b/api/action_config_templates_apply_test.go
@@ -169,3 +169,109 @@ func TestApplyActionConfigTemplate_Unauthorized(t *testing.T) {
 		t.Fatalf("expected 401, got %d", w.Code)
 	}
 }
+
+func TestApplyActionConfigTemplate_ApprovalModeAutoApprove_OverridesPlainTemplate(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	at := connID + ".plain_override"
+	testhelper.InsertConnectorAction(t, tx, connID, at, "Plain Override")
+
+	testhelper.InsertActionConfigTemplateFull(t, tx, "tpl_plain_ov", connID, at, "Plain override tpl", testhelper.ActionConfigTemplateOpts{
+		Parameters: []byte(`{"x":"*"}`),
+	})
+
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := fmt.Sprintf(`{"agent_id": %d, "approval_mode": "auto_approve"}`, agentID)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/action-config-templates/tpl_plain_ov/apply", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeApplyTemplateResponse(t, w.Body.Bytes())
+	if resp.StandingApproval == nil {
+		t.Fatal("expected standing approval when approval_mode=auto_approve overrides plain template")
+	}
+	if resp.StandingApproval.ExpiresAt != nil {
+		t.Fatal("expected nil expires_at (sensible default: no expiry)")
+	}
+	if resp.StandingApproval.MaxExecutions != nil {
+		t.Fatal("expected nil max_executions (sensible default: unlimited)")
+	}
+}
+
+func TestApplyActionConfigTemplate_ApprovalModeRequiresApproval_OverridesStandingTemplate(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	at := connID + ".sa_override"
+	testhelper.InsertConnectorAction(t, tx, connID, at, "SA Override")
+
+	testhelper.InsertActionConfigTemplateFull(t, tx, "tpl_sa_ov", connID, at, "SA override tpl", testhelper.ActionConfigTemplateOpts{
+		Parameters:           []byte(`{"repo":"*"}`),
+		StandingApprovalSpec: []byte(`{"duration_days":7}`),
+	})
+
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := fmt.Sprintf(`{"agent_id": %d, "approval_mode": "requires_approval"}`, agentID)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/action-config-templates/tpl_sa_ov/apply", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeApplyTemplateResponse(t, w.Body.Bytes())
+	if resp.StandingApproval != nil {
+		t.Fatal("expected no standing approval when approval_mode=requires_approval overrides template with SA spec")
+	}
+	if resp.ActionConfiguration.ID == "" {
+		t.Fatal("expected action_configuration.id")
+	}
+}
+
+func TestApplyActionConfigTemplate_ApprovalModeInvalid(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	at := connID + ".inv_action"
+	testhelper.InsertConnectorAction(t, tx, connID, at, "Inv Action")
+
+	testhelper.InsertActionConfigTemplateFull(t, tx, "tpl_inv", connID, at, "Inv tpl", testhelper.ActionConfigTemplateOpts{
+		Parameters: []byte(`{"x":"*"}`),
+	})
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := fmt.Sprintf(`{"agent_id": %d, "approval_mode": "bogus"}`, agentID)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/action-config-templates/tpl_inv/apply", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid approval_mode, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/frontend/src/hooks/useApplyActionConfigTemplate.ts
+++ b/frontend/src/hooks/useApplyActionConfigTemplate.ts
@@ -13,14 +13,21 @@ export function useApplyActionConfigTemplate() {
   const token = session?.access_token;
 
   const mutation = useMutation({
-    mutationFn: async (input: { templateId: string; agentId: number }) => {
+    mutationFn: async (input: {
+      templateId: string;
+      agentId: number;
+      approvalMode?: "auto_approve" | "requires_approval";
+    }) => {
       if (!token) throw new Error("Missing access token");
       const { data, error } = await client.POST(
         "/v1/action-config-templates/{id}/apply",
         {
           headers: { Authorization: `Bearer ${token}` },
           params: { path: { id: input.templateId } },
-          body: { agent_id: input.agentId },
+          body: {
+            agent_id: input.agentId,
+            ...(input.approvalMode && { approval_mode: input.approvalMode }),
+          },
         },
       );
       if (error || !data) {

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -20,6 +20,7 @@ import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
 import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
+import type { ApprovalMode } from "./RecommendedTemplatesDialog";
 import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 import { ActionConfigRow } from "./ActionConfigRow";
 import { AddActionConfigDialog } from "./AddActionConfigDialog";
@@ -49,6 +50,8 @@ export function ActionConfigurationsSection({
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [initialTemplateForAdd, setInitialTemplateForAdd] =
     useState<ActionConfigTemplate | null>(null);
+  const [initialApprovalModeForAdd, setInitialApprovalModeForAdd] =
+    useState<ApprovalMode | undefined>(undefined);
   const [recommendedDialogOpen, setRecommendedDialogOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ActionConfiguration | null>(
     null,
@@ -95,14 +98,16 @@ export function ActionConfigurationsSection({
     }
   };
 
-  function openAddDialog(fromTemplate?: ActionConfigTemplate | null) {
+  function openAddDialog(fromTemplate?: ActionConfigTemplate | null, approvalMode?: ApprovalMode) {
     setInitialTemplateForAdd(fromTemplate ?? null);
+    setInitialApprovalModeForAdd(approvalMode);
     setAddDialogOpen(true);
   }
 
   function handleAddDialogOpenChange(open: boolean) {
     if (!open) {
       setInitialTemplateForAdd(null);
+      setInitialApprovalModeForAdd(undefined);
     }
     setAddDialogOpen(open);
   }
@@ -224,6 +229,7 @@ export function ActionConfigurationsSection({
         connectorId={connectorId}
         actions={actions}
         initialTemplate={initialTemplateForAdd}
+        initialApprovalMode={initialApprovalModeForAdd}
       />
 
       <RecommendedTemplatesDialog
@@ -232,8 +238,8 @@ export function ActionConfigurationsSection({
         agentId={agentId}
         connectorId={connectorId}
         actions={actions}
-        onCustomize={(template) => {
-          openAddDialog(template);
+        onCustomize={(template, approvalMode) => {
+          openAddDialog(template, approvalMode);
         }}
       />
 

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
-import { Link } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -12,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { SegmentedControl } from "@/components/ui/segmented-control";
 import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
 import { useCreateStandingApproval } from "@/hooks/useCreateStandingApproval";
 import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
@@ -31,6 +31,12 @@ import {
   type ParamMode,
 } from "./ActionConfigFormFields";
 import { TemplatePicker } from "./TemplatePicker";
+import type { ApprovalMode } from "./RecommendedTemplatesDialog";
+
+const approvalModeOptions: { label: string; value: ApprovalMode }[] = [
+  { label: "Auto-approve", value: "auto_approve" },
+  { label: "Requires approval", value: "requires_approval" },
+];
 
 interface AddActionConfigDialogProps {
   open: boolean;
@@ -40,6 +46,8 @@ interface AddActionConfigDialogProps {
   actions: ConnectorAction[];
   /** When the dialog opens, apply this template (action type, fields, parameters). */
   initialTemplate?: ActionConfigTemplate | null;
+  /** Override the template's default approval mode. */
+  initialApprovalMode?: ApprovalMode;
 }
 
 export function AddActionConfigDialog({
@@ -49,6 +57,7 @@ export function AddActionConfigDialog({
   connectorId,
   actions,
   initialTemplate = null,
+  initialApprovalMode,
 }: AddActionConfigDialogProps) {
   const { createActionConfig, isPending: isCreatingConfig } =
     useCreateActionConfig();
@@ -64,6 +73,7 @@ export function AddActionConfigDialog({
   const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
   const [appliedTemplateId, setAppliedTemplateId] = useState<string | null>(null);
+  const [approvalMode, setApprovalMode] = useState<ApprovalMode>("requires_approval");
 
   const prevOpenRef = useRef(false);
 
@@ -71,11 +81,6 @@ export function AddActionConfigDialog({
     () => actions.find((a) => a.action_type === selectedActionType) ?? null,
     [actions, selectedActionType],
   );
-
-  const standingSpecFromTemplate = useMemo(() => {
-    if (!initialTemplate?.standing_approval) return null;
-    return initialTemplate.standing_approval;
-  }, [initialTemplate]);
 
   const schema = useMemo(
     // Cast is safe: parameters_schema is typed as `{ [key: string]: unknown }` in
@@ -96,6 +101,7 @@ export function AddActionConfigDialog({
     setParamValues({});
     setParamModes({});
     setAppliedTemplateId(null);
+    setApprovalMode("requires_approval");
   }
 
   function handleOpenChange(nextOpen: boolean) {
@@ -140,7 +146,12 @@ export function AddActionConfigDialog({
       setParamModes(modes);
       setAppliedTemplateId(template.id);
 
+      // When selecting a new template via the picker (not from initial),
+      // reset approval mode to the template's default.
       if (!options?.fromInitial) {
+        setApprovalMode(
+          template.standing_approval != null ? "auto_approve" : "requires_approval",
+        );
         toast.success(`Template "${template.name}" applied`);
       }
     },
@@ -152,8 +163,12 @@ export function AddActionConfigDialog({
     prevOpenRef.current = open;
     if (open && !wasOpen && initialTemplate) {
       handleTemplateSelect(initialTemplate, { fromInitial: true });
+      setApprovalMode(
+        initialApprovalMode ??
+          (initialTemplate.standing_approval != null ? "auto_approve" : "requires_approval"),
+      );
     }
-  }, [open, initialTemplate, handleTemplateSelect]);
+  }, [open, initialTemplate, initialApprovalMode, handleTemplateSelect]);
 
   function handleParamChange(key: string, value: string) {
     setParamValues((prev) => ({ ...prev, [key]: value }));
@@ -192,14 +207,13 @@ export function AddActionConfigDialog({
         parameters: builtParams,
       });
 
-      if (standingSpecFromTemplate && ac?.id) {
+      if (approvalMode === "auto_approve" && ac?.id) {
+        const standingSpec = initialTemplate?.standing_approval;
         const startsAt = new Date();
         let expiresAt: string | null = null;
-        if (standingSpecFromTemplate.duration_days != null) {
+        if (standingSpec?.duration_days != null) {
           const exp = new Date(startsAt);
-          exp.setUTCDate(
-            exp.getUTCDate() + standingSpecFromTemplate.duration_days,
-          );
+          exp.setUTCDate(exp.getUTCDate() + standingSpec.duration_days);
           expiresAt = exp.toISOString();
         }
         const constraints = standingApprovalConstraintsForCreate(
@@ -211,14 +225,14 @@ export function AddActionConfigDialog({
           action_version: "1",
           constraints,
           source_action_configuration_id: ac.id,
-          max_executions: standingSpecFromTemplate.max_executions ?? null,
+          max_executions: standingSpec?.max_executions ?? null,
           starts_at: startsAt.toISOString(),
           expires_at: expiresAt,
         });
       }
 
       toast.success(
-        standingSpecFromTemplate
+        approvalMode === "auto_approve"
           ? `Configuration "${name.trim()}" created with auto-approval`
           : `Configuration "${name.trim()}" created`,
       );
@@ -265,20 +279,20 @@ export function AddActionConfigDialog({
               />
             )}
 
-            {standingSpecFromTemplate && (
+            <div className="space-y-2">
+              <Label>Approval mode</Label>
+              <SegmentedControl
+                options={approvalModeOptions}
+                value={approvalMode}
+                onChange={setApprovalMode}
+                ariaLabel="Approval mode"
+              />
               <p className="text-muted-foreground text-xs">
-                Saving will also create a standing approval from this template’s
-                auto-approve settings. You can change duration or limits later
-                on the{" "}
-                <Link
-                  to="/standing-approvals"
-                  className="text-primary underline-offset-4 hover:underline"
-                >
-                  standing approvals
-                </Link>{" "}
-                page.
+                {approvalMode === "auto_approve"
+                  ? "A standing approval will be created so matching requests run automatically."
+                  : "Each request will require your explicit approval before it runs."}
               </p>
-            )}
+            </div>
 
             <NameField
               id="config-name"

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -208,7 +208,12 @@ export function AddActionConfigDialog({
       });
 
       if (approvalMode === "auto_approve" && ac?.id) {
-        const standingSpec = initialTemplate?.standing_approval;
+        const activeTemplate =
+          appliedTemplateId != null
+            ? templates.find((t) => t.id === appliedTemplateId) ?? null
+            : null;
+        const standingSpec =
+          activeTemplate?.standing_approval ?? initialTemplate?.standing_approval;
         const startsAt = new Date();
         let expiresAt: string | null = null;
         if (standingSpec?.duration_days != null) {

--- a/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -13,8 +13,10 @@ import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import { useApplyActionConfigTemplate } from "@/hooks/useApplyActionConfigTemplate";
-import { Badge } from "@/components/ui/badge";
+import { SegmentedControl } from "@/components/ui/segmented-control";
 import { TemplateParamBadge } from "./TemplatePicker";
+
+export type ApprovalMode = "auto_approve" | "requires_approval";
 
 export interface RecommendedTemplatesDialogProps {
   open: boolean;
@@ -22,7 +24,16 @@ export interface RecommendedTemplatesDialogProps {
   agentId: number;
   connectorId: string;
   actions: ConnectorAction[];
-  onCustomize: (template: ActionConfigTemplate) => void;
+  onCustomize: (template: ActionConfigTemplate, approvalMode: ApprovalMode) => void;
+}
+
+const approvalModeOptions: { label: string; value: ApprovalMode }[] = [
+  { label: "Auto-approve", value: "auto_approve" },
+  { label: "Requires approval", value: "requires_approval" },
+];
+
+function defaultApprovalMode(template: ActionConfigTemplate): ApprovalMode {
+  return template.standing_approval != null ? "auto_approve" : "requires_approval";
 }
 
 export function RecommendedTemplatesDialog({
@@ -38,6 +49,20 @@ export function RecommendedTemplatesDialog({
   const { applyTemplate, isPending } = useApplyActionConfigTemplate();
   const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
     null,
+  );
+  const [approvalModes, setApprovalModes] = useState<Record<string, ApprovalMode>>({});
+
+  const getApprovalMode = useCallback(
+    (template: ActionConfigTemplate): ApprovalMode =>
+      approvalModes[template.id] ?? defaultApprovalMode(template),
+    [approvalModes],
+  );
+
+  const handleApprovalModeChange = useCallback(
+    (templateId: string, mode: ApprovalMode) => {
+      setApprovalModes((prev) => ({ ...prev, [templateId]: mode }));
+    },
+    [],
   );
 
   const actionTypeSet = useMemo(
@@ -82,9 +107,14 @@ export function RecommendedTemplatesDialog({
   }, [liveTemplates, actions, actionNameByType]);
 
   async function handleUseTemplate(template: ActionConfigTemplate) {
+    const approvalMode = getApprovalMode(template);
     setPendingTemplateId(template.id);
     try {
-      const res = await applyTemplate({ templateId: template.id, agentId });
+      const res = await applyTemplate({
+        templateId: template.id,
+        agentId,
+        approvalMode,
+      });
       const sa = res.standing_approval;
       toast.success(
         sa
@@ -105,7 +135,7 @@ export function RecommendedTemplatesDialog({
 
   function handleCustomize(template: ActionConfigTemplate) {
     onOpenChange(false);
-    onCustomize(template);
+    onCustomize(template, getApprovalMode(template));
   }
 
   const buttonsDisabled = isPending;
@@ -147,6 +177,10 @@ export function RecommendedTemplatesDialog({
                     <RecommendedTemplateCard
                       key={template.id}
                       template={template}
+                      approvalMode={getApprovalMode(template)}
+                      onApprovalModeChange={(mode) =>
+                        handleApprovalModeChange(template.id, mode)
+                      }
                       onUseTemplate={() => void handleUseTemplate(template)}
                       onCustomize={() => handleCustomize(template)}
                       useDisabled={buttonsDisabled}
@@ -168,6 +202,8 @@ export function RecommendedTemplatesDialog({
 
 function RecommendedTemplateCard({
   template,
+  approvalMode,
+  onApprovalModeChange,
   onUseTemplate,
   onCustomize,
   useDisabled,
@@ -175,6 +211,8 @@ function RecommendedTemplateCard({
   usePending,
 }: {
   template: ActionConfigTemplate;
+  approvalMode: ApprovalMode;
+  onApprovalModeChange: (mode: ApprovalMode) => void;
   onUseTemplate: () => void;
   onCustomize: () => void;
   useDisabled: boolean;
@@ -182,21 +220,11 @@ function RecommendedTemplateCard({
   usePending: boolean;
 }) {
   const paramEntries = Object.entries(template.parameters);
-  const autoApproved = template.standing_approval != null;
 
   return (
     <div className="rounded-lg border border-input p-3">
       <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="text-sm font-medium">{template.name}</p>
-          {autoApproved ? (
-            <Badge>Auto-approved</Badge>
-          ) : (
-            <Badge variant="secondary" className="text-muted-foreground">
-              Requires approval each time
-            </Badge>
-          )}
-        </div>
+        <p className="text-sm font-medium">{template.name}</p>
         {template.description && (
           <p className="text-muted-foreground text-sm">{template.description}</p>
         )}
@@ -207,6 +235,12 @@ function RecommendedTemplateCard({
             ))}
           </div>
         )}
+        <SegmentedControl
+          options={approvalModeOptions}
+          value={approvalMode}
+          onChange={onApprovalModeChange}
+          ariaLabel="Approval mode"
+        />
         <div className="flex flex-wrap gap-2 pt-1">
           <Button
             type="button"

--- a/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
@@ -196,7 +196,7 @@ describe("RecommendedTemplatesDialog", () => {
     });
   });
 
-  it("creates config on Use Template and closes dialog", async () => {
+  it("creates config on Use Template with default approval_mode and closes dialog", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
     mockPost.mockResolvedValue({
@@ -243,11 +243,11 @@ describe("RecommendedTemplatesDialog", () => {
     });
     const [url, opts] = mockPost.mock.calls[0] as [
       string,
-      { body: { agent_id: number }; params: { path: { id: string } } },
+      { body: { agent_id: number; approval_mode: string }; params: { path: { id: string } } },
     ];
     expect(url).toContain("/v1/action-config-templates/{id}/apply");
     expect(opts.params.path.id).toBe("tpl_a");
-    expect(opts.body).toEqual({ agent_id: 42 });
+    expect(opts.body).toEqual({ agent_id: 42, approval_mode: "auto_approve" });
 
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -274,7 +274,7 @@ describe("RecommendedTemplatesDialog", () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
-  it("Customize closes dialog and invokes onCustomize with template", async () => {
+  it("Customize closes dialog and invokes onCustomize with template and approval mode", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
@@ -294,6 +294,7 @@ describe("RecommendedTemplatesDialog", () => {
         action_type: "github.create_issue",
         name: "All open",
       }),
+      "auto_approve",
     );
   });
 
@@ -383,19 +384,98 @@ describe("RecommendedTemplatesDialog", () => {
     });
   });
 
-  it("shows auto-approve badge when template has standing_approval", async () => {
+  it("defaults approval mode based on template standing_approval", async () => {
     renderDialog();
     await waitFor(() => {
       expect(screen.getByText("All open")).toBeInTheDocument();
     });
-    const tplCard = screen.getByText("All open").closest(".rounded-lg")!;
-    expect(
-      within(tplCard as HTMLElement).getByText("Auto-approved"),
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByText("Merge main").closest(".rounded-lg")!).getByText(
-        "Requires approval each time",
-      ),
-    ).toBeInTheDocument();
+
+    // tpl_a has standing_approval → defaults to Auto-approve
+    const tplACard = screen.getByText("All open").closest(".rounded-lg")!;
+    const autoRadioA = within(tplACard as HTMLElement).getByRole("radio", { name: "Auto-approve" });
+    expect(autoRadioA).toHaveAttribute("aria-checked", "true");
+
+    // tpl_b has no standing_approval → defaults to Requires approval
+    const tplBCard = screen.getByText("Merge main").closest(".rounded-lg")!;
+    const reqRadioB = within(tplBCard as HTMLElement).getByRole("radio", { name: "Requires approval" });
+    expect(reqRadioB).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("sends toggled approval_mode when user switches before Use Template", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({
+      data: {
+        action_configuration: {
+          id: "ac_new",
+          agent_id: 42,
+          connector_id: "github",
+          action_type: "github.merge_pr",
+          parameters: { repo: "supersuit-tech/webapp", pr: 1 },
+          status: "active",
+          name: "Merge main",
+          created_at: "2026-02-25T10:00:00Z",
+          updated_at: "2026-02-25T10:00:00Z",
+        },
+      },
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Merge main")).toBeInTheDocument();
+    });
+
+    // tpl_b defaults to requires_approval — switch to auto_approve
+    const tplBCard = screen.getByText("Merge main").closest(".rounded-lg")!;
+    await user.click(within(tplBCard as HTMLElement).getByRole("radio", { name: "Auto-approve" }));
+    await user.click(within(tplBCard as HTMLElement).getByRole("button", { name: "Use Template" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+    const [, opts] = mockPost.mock.calls[0] as [
+      string,
+      { body: { agent_id: number; approval_mode: string } },
+    ];
+    expect(opts.body.approval_mode).toBe("auto_approve");
+  });
+
+  it("sends requires_approval when user switches off auto-approve", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({
+      data: {
+        action_configuration: {
+          id: "ac_new",
+          agent_id: 42,
+          connector_id: "github",
+          action_type: "github.create_issue",
+          parameters: { repo: "*", title: "*" },
+          status: "active",
+          name: "All open",
+          created_at: "2026-02-25T10:00:00Z",
+          updated_at: "2026-02-25T10:00:00Z",
+        },
+      },
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("All open")).toBeInTheDocument();
+    });
+
+    // tpl_a defaults to auto_approve — switch to requires_approval
+    const tplACard = screen.getByText("All open").closest(".rounded-lg")!;
+    await user.click(within(tplACard as HTMLElement).getByRole("radio", { name: "Requires approval" }));
+    await user.click(within(tplACard as HTMLElement).getByRole("button", { name: "Use Template" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+    const [, opts] = mockPost.mock.calls[0] as [
+      string,
+      { body: { agent_id: number; approval_mode: string } },
+    ];
+    expect(opts.body.approval_mode).toBe("requires_approval");
   });
 });

--- a/spec/openapi/components/schemas/action_config_templates.yaml
+++ b/spec/openapi/components/schemas/action_config_templates.yaml
@@ -113,6 +113,17 @@ ApplyActionConfigTemplateRequest:
       format: int64
       description: Agent to attach the new configuration and standing approval to.
       example: 42
+    approval_mode:
+      type: string
+      enum:
+        - auto_approve
+        - requires_approval
+      description: |
+        Override the template's built-in approval behavior.
+        `auto_approve` creates a standing approval (using the template's spec
+        if present, otherwise sensible defaults: no expiry, unlimited executions).
+        `requires_approval` skips standing approval creation.
+        When omitted, falls back to the template's built-in behavior.
 
 ApplyActionConfigTemplateResponse:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -11681,6 +11681,17 @@ components:
           format: int64
           description: Agent to attach the new configuration and standing approval to.
           example: 42
+        approval_mode:
+          type: string
+          enum:
+            - auto_approve
+            - requires_approval
+          description: |
+            Override the template's built-in approval behavior.
+            `auto_approve` creates a standing approval (using the template's spec
+            if present, otherwise sensible defaults: no expiry, unlimited executions).
+            `requires_approval` skips standing approval creation.
+            When omitted, falls back to the template's built-in behavior.
     LinkedStandingApprovalSummary:
       type: object
       required:


### PR DESCRIPTION
## Summary

- Templates previously dictated whether actions would be auto-approved or require approval each time — users had no choice
- Now each template card has a **SegmentedControl** toggle letting users pick "Auto-approve" vs "Requires approval" regardless of the template's built-in default
- Added optional `approval_mode` field to `POST /v1/action-config-templates/{id}/apply` so the backend respects the user's choice
- The same toggle is available in the Customize (AddActionConfigDialog) flow

## Test plan

### Developer
- [x] Frontend tests pass (974/974 across 101 test files)
- [x] TypeScript compilation passes (zero errors)
- [x] Go files parse cleanly (gofmt -e)
- [x] Backend test cases added for approval_mode override scenarios
- [ ] Backend tests pass in CI (blocked locally by Go 1.25 toolchain requirement for bigquery dep)

### Manual Testing
- [ ] Open Recommended Templates dialog — verify each card shows a SegmentedControl defaulting to the template's built-in mode
- [ ] Toggle a template from "Requires approval" to "Auto-approve", click "Use Template" — verify standing approval is created
- [ ] Toggle a template from "Auto-approve" to "Requires approval", click "Use Template" — verify no standing approval is created
- [ ] Click "Customize" after toggling — verify the approval mode carries into the Add Action Config form
- [ ] In the Customize form, switch approval mode and submit — verify correct behavior

https://claude.ai/code/session_011jD84oduCNJDS3C59ctd4o