### PR TITLE
Update review skill: 5min interval, 3 clean rounds to exit

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: review
-description: Perform a comprehensive, multi-round code review on a GitHub PR. Leaves inline review comments prioritized by severity (Critical/High/Medium/Low) across up to 6 rounds, with 90-second waits between rounds to check for fixes.
+description: Perform a comprehensive, multi-round code review on a GitHub PR. Leaves inline review comments prioritized by severity (Critical/High/Medium/Low) across up to 6 rounds, with 5-minute waits between rounds to check for fixes.
 argument-hint: "<PR_URL> [--max-turns <N>]"
 ---
 
 # Review PR — Multi-Round Comprehensive Code Review
 
-Performs up to 6 rounds of thorough code review on a GitHub Pull Request. Each round submits a PR review with inline comments covering security, architecture, maintainability, code quality, documentation, and performance. Between rounds, waits 90 seconds and re-fetches the diff to check for fixes before reviewing again.
+Performs up to 6 rounds of thorough code review on a GitHub Pull Request. Each round submits a PR review with inline comments covering security, architecture, maintainability, code quality, documentation, and performance. Between rounds, waits 5 minutes and re-fetches the diff to check for fixes before reviewing again.
 
 This skill is **strictly read-only** — it never modifies code, creates branches, or makes commits.
 
@@ -97,9 +97,9 @@ Repeat for `ROUND` = 1 to `MAX_TURNS`:
 
 If `ROUND > 1`:
 
-1. **Wait 90 seconds** using the Bash tool with `run_in_background: true`:
+1. **Wait 5 minutes** using the Bash tool with `run_in_background: true`:
    ```bash
-   sleep 90 && echo "WAIT_COMPLETE"
+   sleep 300 && echo "WAIT_COMPLETE"
    ```
    Set `run_in_background: true` on this Bash call so the agent is not blocked. You will be notified when the sleep completes. While waiting, do NOT proceed to the next step — wait for the background task notification before continuing.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -45,6 +45,7 @@ Set these variables for the session:
 - `LAST_HEAD_SHA` — empty string initially, updated after each round
 - `LAST_ACTIVITY_TIME` — timestamp of the most recent new commit detection (or session start). Used for inactivity timeout.
 - `ROUND` — current round number, starting at 1
+- `CONSECUTIVE_CLEAN_ROUNDS` — number of consecutive rounds with no findings and no new commits. Starts at 0. Reset to 0 whenever new commits are detected or new findings are posted.
 
 ## Step 1: Gather Context
 
@@ -295,9 +296,13 @@ No new issues found.
 
 ### 2e. Early Exit Check
 
-After submitting the review, check whether to continue:
+After submitting the review, update `CONSECUTIVE_CLEAN_ROUNDS`:
+- If this round had **no findings** and **no new commits** since the previous round → increment `CONSECUTIVE_CLEAN_ROUNDS`.
+- Otherwise (new findings were posted OR new commits were detected) → reset `CONSECUTIVE_CLEAN_ROUNDS` to 0.
 
-- If this round had **no findings** → exit early, go to Step 3. There is no reason to wait and re-review a clean PR.
+Then check whether to continue:
+
+- If `CONSECUTIVE_CLEAN_ROUNDS >= 3` → exit, go to Step 3 with reason "3 consecutive clean rounds with no new findings or commits".
 - If `ROUND >= MAX_TURNS` → exit, go to Step 3.
 - If time since `LAST_ACTIVITY_TIME` exceeds **10 minutes** → exit, go to Step 3 with reason "no activity for 10 minutes".
 - Otherwise → increment `ROUND`, loop back to 2a.
@@ -324,7 +329,7 @@ Summary format:
 **PR:** #{PR_NUMBER} — {PR_TITLE}
 **Author:** @{PR_AUTHOR}
 **Rounds completed:** {ROUND}/{MAX_TURNS}
-**Reason for stopping:** {completed all rounds | no issues remaining | PR merged | PR closed | max turns reached | no activity for 10 minutes}
+**Reason for stopping:** {completed all rounds | 3 consecutive clean rounds | PR merged | PR closed | max turns reached | no activity for 10 minutes}
 
 ### Outstanding Issues
 {any unresolved concerns from the final round, or "None — this PR looks good to merge."}
@@ -354,4 +359,4 @@ Summary format:
 - **Check diff lines** — inline comments can only be placed on lines that appear in the PR diff. If you need to comment on an unchanged line, include it in the review body instead.
 - **Acknowledge good work** — every round summary should include a "What Looks Good" section. Reviews that only criticize are demoralizing.
 - **Re-fetch between rounds** — always check for new commits before reviewing again to avoid flagging already-fixed issues.
-- **Exit early when clean** — if any round has no findings, stop immediately. Don't wait just to re-review a clean PR.
+- **Exit after 3 consecutive clean rounds** — if 3 rounds in a row have no findings and no new commits, stop. This avoids endlessly re-reviewing a stable PR while still giving authors time to push fixes.


### PR DESCRIPTION
## Summary

- Change the between-round wait from 90 seconds to 5 minutes, giving authors more time to address review comments before re-checking
- Replace the "exit on first clean round" logic with a `CONSECUTIVE_CLEAN_ROUNDS` counter that requires 3 consecutive rounds with no findings and no new commits before stopping
- Update the final summary template and important rules to reflect the new exit behavior

## Test plan

### Developer
- [ ] Verify the skill description, instructions, and sleep command all reference 5 minutes / 300 seconds consistently
- [ ] Verify the early exit logic references `CONSECUTIVE_CLEAN_ROUNDS >= 3`
- [ ] Confirm no stale 90-second references remain in the file

### Manual Testing
- [ ] Run `/review` on a test PR and confirm rounds wait ~5 minutes between checks
- [ ] Verify the skill exits after 3 consecutive clean rounds, not after the first

https://claude.ai/code/session_01Eb3TwHarRoUxijPwWoRRub