### PR TITLE
Add bulk enable for recommended templates

### DIFF
--- a/api/action_config_templates.go
+++ b/api/action_config_templates.go
@@ -41,6 +41,7 @@ func init() {
 func RegisterActionConfigTemplateRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /action-config-templates", requireProfile(handleListActionConfigTemplates(deps)))
+	mux.Handle("POST /action-config-templates/bulk-apply", requireProfile(handleBulkApplyActionConfigTemplates(deps)))
 	mux.Handle("POST /action-config-templates/{id}/apply", requireProfile(handleApplyActionConfigTemplate(deps)))
 }
 

--- a/api/action_config_templates_bulk_apply.go
+++ b/api/action_config_templates_bulk_apply.go
@@ -1,0 +1,429 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/shared"
+)
+
+// --- Request / Response types ---
+
+type bulkApplyActionConfigTemplateRequest struct {
+	AgentID     int64    `json:"agent_id" validate:"gt=0"`
+	TemplateIDs []string `json:"template_ids" validate:"required,min=1,max=50,dive,required,max=255"`
+}
+
+type bulkApplyResultError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type bulkApplyResult struct {
+	TemplateID          string                        `json:"template_id"`
+	Success             bool                          `json:"success"`
+	ActionConfiguration *actionConfigResponse         `json:"action_configuration,omitempty"`
+	StandingApproval    *standingApprovalResponse     `json:"standing_approval,omitempty"`
+	Error               *bulkApplyResultError         `json:"error,omitempty"`
+}
+
+type bulkApplyActionConfigTemplateResponse struct {
+	Results []bulkApplyResult `json:"results"`
+}
+
+// --- Handler ---
+
+func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		var req bulkApplyActionConfigTemplateRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+		if !ValidateRequest(w, r, &req) {
+			return
+		}
+
+		// Deduplicate template IDs while preserving order.
+		uniqueIDs := deduplicateStrings(req.TemplateIDs)
+
+		// Fetch all templates in one query.
+		templates, err := db.GetActionConfigTemplatesByIDs(r.Context(), deps.DB, uniqueIDs)
+		if err != nil {
+			log.Printf("[%s] BulkApplyTemplates: fetch templates: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+			return
+		}
+
+		// Build lookup map and check for missing templates.
+		tplByID := make(map[string]*db.ActionConfigTemplate, len(templates))
+		for i := range templates {
+			tplByID[templates[i].ID] = &templates[i]
+		}
+		for _, id := range uniqueIDs {
+			if _, ok := tplByID[id]; !ok {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrActionConfigTemplateNotFound,
+					fmt.Sprintf("Template %q not found", id)))
+				return
+			}
+		}
+
+		// Verify all templates belong to the same connector.
+		var connectorID string
+		for _, id := range uniqueIDs {
+			tpl := tplByID[id]
+			if connectorID == "" {
+				connectorID = tpl.ConnectorID
+			} else if tpl.ConnectorID != connectorID {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					"All templates must belong to the same connector"))
+				return
+			}
+		}
+
+		// Begin transaction.
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] BulkApplyTemplates: begin tx: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx)
+		}
+
+		// Enable connector once for the agent.
+		enabled, err := db.AgentConnectorEnabled(r.Context(), tx, req.AgentID, profile.ID, connectorID)
+		if err != nil {
+			log.Printf("[%s] BulkApplyTemplates: connector check: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+			return
+		}
+		if !enabled {
+			if _, err := db.EnableAgentConnector(r.Context(), tx, req.AgentID, profile.ID, connectorID); err != nil {
+				var acErr *db.AgentConnectorError
+				if errors.As(err, &acErr) && acErr.Code == db.AgentConnectorErrAgentNotFound {
+					RespondError(w, r, http.StatusNotFound, NotFound(ErrAgentNotFound, "Agent not found"))
+					return
+				}
+				if errors.As(err, &acErr) && acErr.Code == db.AgentConnectorErrConnectorNotFound {
+					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Invalid connector reference"))
+					return
+				}
+				log.Printf("[%s] BulkApplyTemplates: enable connector: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+				return
+			}
+		}
+
+		// Check if any template needs a standing approval — acquire the lock once.
+		anyWantSA := false
+		for _, id := range uniqueIDs {
+			tpl := tplByID[id]
+			if len(tpl.StandingApprovalSpec) > 0 && string(tpl.StandingApprovalSpec) != "null" {
+				anyWantSA = true
+				break
+			}
+		}
+		if anyWantSA {
+			if err := db.AcquireStandingApprovalLimitLock(r.Context(), tx, profile.ID); err != nil {
+				log.Printf("[%s] BulkApplyTemplates: advisory lock: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+				return
+			}
+		}
+
+		// Apply each template. Use savepoints so individual failures don't
+		// abort the entire batch.
+		pgxTx, _ := tx.(pgx.Tx)
+		results := make([]bulkApplyResult, 0, len(uniqueIDs))
+
+		for _, id := range uniqueIDs {
+			tpl := tplByID[id]
+			res, err := applyOneTemplateInSavepoint(r.Context(), pgxTx, tx, profile, tpl, req.AgentID)
+			if err != nil {
+				results = append(results, bulkApplyResult{
+					TemplateID: id,
+					Success:    false,
+					Error:      &bulkApplyResultError{Code: res.errorCode, Message: err.Error()},
+				})
+				continue
+			}
+
+			br := bulkApplyResult{
+				TemplateID:          id,
+				Success:             true,
+				ActionConfiguration: res.actionConfig,
+			}
+			if res.standingApproval != nil {
+				br.StandingApproval = res.standingApproval
+			}
+			results = append(results, br)
+		}
+
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] BulkApplyTemplates: commit: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+				return
+			}
+		}
+
+		RespondJSON(w, http.StatusOK, bulkApplyActionConfigTemplateResponse{Results: results})
+	}
+}
+
+// --- Internal helpers ---
+
+type applyOneResult struct {
+	actionConfig     *actionConfigResponse
+	standingApproval *standingApprovalResponse
+	errorCode        string
+}
+
+// applyOneTemplateInSavepoint applies a single template within a savepoint.
+// If pgxTx is non-nil, savepoints are used for isolation. Otherwise, the
+// operation runs directly on fallbackTx (e.g., in tests where DBTX is already a tx).
+func applyOneTemplateInSavepoint(
+	ctx context.Context,
+	pgxTx pgx.Tx,
+	fallbackTx db.DBTX,
+	profile *db.Profile,
+	tpl *db.ActionConfigTemplate,
+	agentID int64,
+) (*applyOneResult, error) {
+	var dtx db.DBTX
+	var sp pgx.Tx
+
+	if pgxTx != nil {
+		var err error
+		sp, err = pgxTx.Begin(ctx)
+		if err != nil {
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+		}
+		defer sp.Rollback(ctx) //nolint:errcheck
+		dtx = sp
+	} else {
+		dtx = fallbackTx
+	}
+
+	res, err := applyOneTemplateCore(ctx, dtx, profile, tpl, agentID)
+	if err != nil {
+		return res, err
+	}
+
+	if sp != nil {
+		if err := sp.Commit(ctx); err != nil {
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+		}
+	}
+
+	return res, nil
+}
+
+// applyOneTemplateCore contains the validation and creation logic for a
+// single template, without transaction management.
+func applyOneTemplateCore(
+	ctx context.Context,
+	tx db.DBTX,
+	profile *db.Profile,
+	tpl *db.ActionConfigTemplate,
+	agentID int64,
+) (*applyOneResult, error) {
+	// Validate template fields.
+	if len(tpl.Name) > shared.ActionConfigNameMaxLength {
+		return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("template name exceeds maximum length")
+	}
+	if tpl.Description != nil && len(*tpl.Description) > shared.ActionConfigDescMaxLength {
+		return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("template description exceeds maximum length")
+	}
+
+	params := tpl.Parameters
+	if len(params) == 0 {
+		params = []byte("{}")
+	} else if err := ValidateJSONObject(params); err != nil {
+		return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("invalid template parameters")
+	}
+
+	actionType := strings.TrimSpace(tpl.ActionType)
+	if actionType != db.WildcardActionType && strings.Contains(actionType, "*") {
+		return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("invalid template action_type")
+	}
+
+	if actionType != db.WildcardActionType {
+		if err := db.ValidateConfigParameters(params); err != nil {
+			return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("%s", err.Error())
+		}
+		exists, err := db.ConnectorActionExists(ctx, tx, tpl.ConnectorID, actionType)
+		if err != nil {
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+		}
+		if !exists {
+			return &applyOneResult{errorCode: string(ErrInvalidReference)}, fmt.Errorf("invalid connector or action type reference")
+		}
+	}
+
+	configID, err := generatePrefixedID("ac_", 16)
+	if err != nil {
+		return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+	}
+
+	// Parse standing approval spec before creating the config.
+	var spec standingApprovalTemplateSpec
+	var standingBytes []byte
+	wantStanding := len(tpl.StandingApprovalSpec) > 0 && string(tpl.StandingApprovalSpec) != "null"
+	if wantStanding {
+		if err := json.Unmarshal(tpl.StandingApprovalSpec, &spec); err != nil {
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("invalid standing approval spec")
+		}
+		standingBytes, err = buildStandingApprovalConstraintsFromTemplate(params)
+		if err != nil {
+			return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("%s", err.Error())
+		}
+	}
+
+	ac, err := db.CreateActionConfig(ctx, tx, db.CreateActionConfigParams{
+		ID:          configID,
+		AgentID:     agentID,
+		UserID:      profile.ID,
+		ConnectorID: tpl.ConnectorID,
+		ActionType:  actionType,
+		Parameters:  params,
+		Name:        tpl.Name,
+		Description: tpl.Description,
+	})
+	if err != nil {
+		var acErr *db.ActionConfigError
+		if errors.As(err, &acErr) {
+			switch acErr.Code {
+			case db.ActionConfigErrAgentNotFound:
+				return &applyOneResult{errorCode: string(ErrAgentNotFound)}, fmt.Errorf("agent not found or not owned by user")
+			case db.ActionConfigErrInvalidRef:
+				return &applyOneResult{errorCode: string(ErrInvalidReference)}, fmt.Errorf("invalid connector, action type, or credential reference")
+			}
+		}
+		return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+	}
+
+	var saOut *db.StandingApproval
+	if wantStanding {
+		// Check standing approval limit.
+		exceeded, err := isStandingApprovalLimitReached(ctx, tx, profile.ID)
+		if err != nil {
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+		}
+		if exceeded {
+			return &applyOneResult{errorCode: string(ErrStandingApprovalLimitReached)}, fmt.Errorf("standing approval limit reached")
+		}
+
+		var expiresAt *time.Time
+		startsAt := time.Now().UTC()
+		if spec.DurationDays != nil {
+			if *spec.DurationDays <= 0 {
+				return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("template standing_approval has invalid duration_days")
+			}
+			t := startsAt.Add(time.Duration(*spec.DurationDays) * 24 * time.Hour)
+			expiresAt = &t
+		}
+
+		var maxExec *int
+		if spec.MaxExecutions != nil {
+			if *spec.MaxExecutions < 1 {
+				return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("template standing_approval has invalid max_executions")
+			}
+			maxExec = spec.MaxExecutions
+		}
+
+		saID, err := generatePrefixedID("sa_", 16)
+		if err != nil {
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+		}
+
+		srcID := ac.ID
+		sa, err := db.CreateStandingApproval(ctx, tx, db.CreateStandingApprovalParams{
+			StandingApprovalID:          saID,
+			AgentID:                     agentID,
+			UserID:                      profile.ID,
+			ActionType:                  actionType,
+			ActionVersion:               "1",
+			Constraints:                 standingBytes,
+			SourceActionConfigurationID: &srcID,
+			MaxExecutions:               maxExec,
+			StartsAt:                    startsAt,
+			ExpiresAt:                   expiresAt,
+		})
+		if err != nil {
+			var saErr *db.StandingApprovalError
+			if errors.As(err, &saErr) && saErr.Code == db.StandingApprovalErrAgentNotFound {
+				return &applyOneResult{errorCode: string(ErrAgentNotFound)}, fmt.Errorf("agent not found")
+			}
+			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
+		}
+		saOut = sa
+	}
+
+	var linkedSA []db.StandingApproval
+	if saOut != nil {
+		linkedSA = append(linkedSA, *saOut)
+	}
+	acResp := toActionConfigResponseWithLinked(*ac, linkedSA)
+	result := &applyOneResult{actionConfig: &acResp}
+	if saOut != nil {
+		s := toStandingApprovalResponse(*saOut)
+		result.standingApproval = &s
+	}
+
+	return result, nil
+}
+
+// isStandingApprovalLimitReached checks whether the user has reached their
+// plan's standing approval limit. Returns (exceeded, error).
+func isStandingApprovalLimitReached(ctx context.Context, d db.DBTX, userID string) (bool, error) {
+	sp, err := db.GetSubscriptionWithPlan(ctx, d, userID)
+	if err != nil {
+		return false, fmt.Errorf("get subscription: %w", err)
+	}
+	if sp == nil {
+		return false, nil // no subscription — bypass limits
+	}
+	eff := sp.EffectiveQuotaPlan()
+	limit := eff.MaxStandingApprovals
+	if limit == nil {
+		return false, nil // unlimited
+	}
+	count, err := db.CountActiveStandingApprovalsByUser(ctx, d, userID)
+	if err != nil {
+		return false, fmt.Errorf("count standing approvals: %w", err)
+	}
+	return count >= *limit, nil
+}
+
+// deduplicateStrings returns a new slice with duplicates removed, preserving
+// the first occurrence order.
+func deduplicateStrings(ss []string) []string {
+	seen := make(map[string]struct{}, len(ss))
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/api/action_config_templates_bulk_apply.go
+++ b/api/action_config_templates_bulk_apply.go
@@ -139,13 +139,17 @@ func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		// Check if any template needs a standing approval — acquire the lock
-		// once and pre-compute remaining SA slots to avoid per-iteration
-		// race conditions within the same transaction.
+		// Check if any template will effectively want a standing approval,
+		// considering both the template's built-in spec and any approval_mode
+		// overrides. A template wants SA if it has a standing approval spec
+		// (and isn't overridden to requires_approval), or if approval_mode
+		// is auto_approve (even without a built-in spec).
 		anyWantSA := false
 		for _, id := range uniqueIDs {
 			tpl := tplByID[id]
-			if len(tpl.StandingApprovalSpec) > 0 && string(tpl.StandingApprovalSpec) != "null" {
+			templateHasSA := len(tpl.StandingApprovalSpec) > 0 && string(tpl.StandingApprovalSpec) != "null"
+			mode := req.ApprovalModes[id]
+			if mode == "auto_approve" || (templateHasSA && mode != "requires_approval") {
 				anyWantSA = true
 				break
 			}

--- a/api/action_config_templates_bulk_apply.go
+++ b/api/action_config_templates_bulk_apply.go
@@ -54,6 +54,15 @@ func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		// Validate approval_modes values.
+		for tid, mode := range req.ApprovalModes {
+			if mode != "auto_approve" && mode != "requires_approval" {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					fmt.Sprintf("invalid approval_mode %q for template %q", mode, tid)))
+				return
+			}
+		}
+
 		// Deduplicate template IDs while preserving order.
 		uniqueIDs := deduplicateStrings(req.TemplateIDs)
 
@@ -130,7 +139,9 @@ func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		// Check if any template needs a standing approval — acquire the lock once.
+		// Check if any template needs a standing approval — acquire the lock
+		// once and pre-compute remaining SA slots to avoid per-iteration
+		// race conditions within the same transaction.
 		anyWantSA := false
 		for _, id := range uniqueIDs {
 			tpl := tplByID[id]
@@ -139,6 +150,7 @@ func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
 				break
 			}
 		}
+		saRemaining := -1 // -1 = unlimited
 		if anyWantSA {
 			if err := db.AcquireStandingApprovalLimitLock(r.Context(), tx, profile.ID); err != nil {
 				log.Printf("[%s] BulkApplyTemplates: advisory lock: %v", TraceID(r.Context()), err)
@@ -146,6 +158,14 @@ func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
 				return
 			}
+			remaining, err := standingApprovalSlotsRemaining(r.Context(), tx, profile.ID)
+			if err != nil {
+				log.Printf("[%s] BulkApplyTemplates: SA limit check: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to apply templates"))
+				return
+			}
+			saRemaining = remaining
 		}
 
 		// Apply each template. Use savepoints so individual failures don't
@@ -161,12 +181,16 @@ func handleBulkApplyActionConfigTemplates(deps *Deps) http.HandlerFunc {
 					approvalMode = &m
 				}
 			}
-			res, err := applyOneTemplateInSavepoint(r.Context(), pgxTx, tx, profile, tpl, req.AgentID, approvalMode)
+			res, err := applyOneTemplateInSavepoint(r.Context(), pgxTx, tx, profile, tpl, req.AgentID, approvalMode, &saRemaining)
 			if err != nil {
+				code := string(ErrInternalError)
+				if res != nil {
+					code = res.errorCode
+				}
 				results = append(results, bulkApplyResult{
 					TemplateID: id,
 					Success:    false,
-					Error:      &bulkApplyResultError{Code: res.errorCode, Message: err.Error()},
+					Error:      &bulkApplyResultError{Code: code, Message: err.Error()},
 				})
 				continue
 			}
@@ -214,6 +238,7 @@ func applyOneTemplateInSavepoint(
 	tpl *db.ActionConfigTemplate,
 	agentID int64,
 	approvalMode *string,
+	saRemaining *int,
 ) (*applyOneResult, error) {
 	var dtx db.DBTX
 	var sp pgx.Tx
@@ -230,7 +255,7 @@ func applyOneTemplateInSavepoint(
 		dtx = fallbackTx
 	}
 
-	res, err := applyOneTemplateCore(ctx, dtx, profile, tpl, agentID, approvalMode)
+	res, err := applyOneTemplateCore(ctx, dtx, profile, tpl, agentID, approvalMode, saRemaining)
 	if err != nil {
 		return res, err
 	}
@@ -245,7 +270,9 @@ func applyOneTemplateInSavepoint(
 }
 
 // applyOneTemplateCore contains the validation and creation logic for a
-// single template, without transaction management.
+// single template, without transaction management. saRemaining tracks remaining
+// standing approval slots across the batch (-1 = unlimited); on successful SA
+// creation it is decremented so subsequent iterations see the correct count.
 func applyOneTemplateCore(
 	ctx context.Context,
 	tx db.DBTX,
@@ -253,6 +280,7 @@ func applyOneTemplateCore(
 	tpl *db.ActionConfigTemplate,
 	agentID int64,
 	approvalMode *string,
+	saRemaining *int,
 ) (*applyOneResult, error) {
 	// Validate template fields.
 	if len(tpl.Name) > shared.ActionConfigNameMaxLength {
@@ -342,12 +370,11 @@ func applyOneTemplateCore(
 
 	var saOut *db.StandingApproval
 	if wantStanding {
-		// Check standing approval limit.
-		exceeded, err := isStandingApprovalLimitReached(ctx, tx, profile.ID)
-		if err != nil {
-			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
-		}
-		if exceeded {
+		// Check standing approval limit using the pre-computed remaining
+		// slot counter. This avoids re-querying the DB inside each savepoint
+		// (which would see the same pre-batch count) and correctly tracks
+		// consumption across the batch.
+		if saRemaining != nil && *saRemaining >= 0 && *saRemaining == 0 {
 			return &applyOneResult{errorCode: string(ErrStandingApprovalLimitReached)}, fmt.Errorf("standing approval limit reached")
 		}
 
@@ -395,6 +422,11 @@ func applyOneTemplateCore(
 			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
 		}
 		saOut = sa
+		// Decrement remaining SA slots so subsequent templates see the
+		// updated count.
+		if saRemaining != nil && *saRemaining > 0 {
+			*saRemaining--
+		}
 	}
 
 	var linkedSA []db.StandingApproval
@@ -411,26 +443,31 @@ func applyOneTemplateCore(
 	return result, nil
 }
 
-// isStandingApprovalLimitReached checks whether the user has reached their
-// plan's standing approval limit. Returns (exceeded, error).
-func isStandingApprovalLimitReached(ctx context.Context, d db.DBTX, userID string) (bool, error) {
+// standingApprovalSlotsRemaining returns how many standing approvals the user
+// can still create. Returns -1 when there is no limit (no subscription or
+// unlimited plan).
+func standingApprovalSlotsRemaining(ctx context.Context, d db.DBTX, userID string) (int, error) {
 	sp, err := db.GetSubscriptionWithPlan(ctx, d, userID)
 	if err != nil {
-		return false, fmt.Errorf("get subscription: %w", err)
+		return 0, fmt.Errorf("get subscription: %w", err)
 	}
 	if sp == nil {
-		return false, nil // no subscription — bypass limits
+		return -1, nil // no subscription — bypass limits
 	}
 	eff := sp.EffectiveQuotaPlan()
 	limit := eff.MaxStandingApprovals
 	if limit == nil {
-		return false, nil // unlimited
+		return -1, nil // unlimited
 	}
 	count, err := db.CountActiveStandingApprovalsByUser(ctx, d, userID)
 	if err != nil {
-		return false, fmt.Errorf("count standing approvals: %w", err)
+		return 0, fmt.Errorf("count standing approvals: %w", err)
 	}
-	return count >= *limit, nil
+	remaining := *limit - count
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining, nil
 }
 
 // deduplicateStrings returns a new slice with duplicates removed, preserving

--- a/db/action_config_templates.go
+++ b/db/action_config_templates.go
@@ -54,6 +54,33 @@ func ListTemplatesByConnector(ctx context.Context, db DBTX, connectorID string) 
 	return templates, rows.Err()
 }
 
+// GetActionConfigTemplatesByIDs returns templates matching the given IDs.
+// The result order is not guaranteed to match the input order. Missing IDs are
+// silently omitted (the caller should compare counts to detect missing templates).
+func GetActionConfigTemplatesByIDs(ctx context.Context, db DBTX, ids []string) ([]ActionConfigTemplate, error) {
+	rows, err := db.Query(ctx,
+		`SELECT id, connector_id, action_type, name, description, parameters, standing_approval_spec, created_at
+		 FROM action_config_templates
+		 WHERE id = ANY($1)`,
+		ids,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var templates []ActionConfigTemplate
+	for rows.Next() {
+		var t ActionConfigTemplate
+		if err := rows.Scan(&t.ID, &t.ConnectorID, &t.ActionType, &t.Name,
+			&t.Description, &t.Parameters, &t.StandingApprovalSpec, &t.CreatedAt); err != nil {
+			return nil, err
+		}
+		templates = append(templates, t)
+	}
+	return templates, rows.Err()
+}
+
 // GetActionConfigTemplateByID returns the action configuration template with the
 // given ID, or nil if not found.
 func GetActionConfigTemplateByID(ctx context.Context, db DBTX, templateID string) (*ActionConfigTemplate, error) {

--- a/frontend/src/hooks/useBulkApplyActionConfigTemplates.ts
+++ b/frontend/src/hooks/useBulkApplyActionConfigTemplates.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+import type { components } from "@/api/schema";
+
+export type BulkApplyResult = components["schemas"]["BulkApplyResult"];
+export type BulkApplyActionConfigTemplateResponse =
+  components["schemas"]["BulkApplyActionConfigTemplateResponse"];
+
+export function useBulkApplyActionConfigTemplates() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+  const token = session?.access_token;
+
+  const mutation = useMutation({
+    mutationFn: async (input: {
+      templateIds: string[];
+      agentId: number;
+    }): Promise<BulkApplyActionConfigTemplateResponse> => {
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.POST(
+        "/v1/action-config-templates/bulk-apply",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          body: {
+            agent_id: input.agentId,
+            template_ids: input.templateIds,
+          },
+        },
+      );
+      if (error || !data) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to apply templates"),
+        );
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["action-configs", variables.agentId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
+    },
+  });
+
+  return {
+    bulkApply: mutation.mutateAsync,
+    isBulkPending: mutation.isPending,
+  };
+}

--- a/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -13,6 +14,7 @@ import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import { useApplyActionConfigTemplate } from "@/hooks/useApplyActionConfigTemplate";
+import { useBulkApplyActionConfigTemplates } from "@/hooks/useBulkApplyActionConfigTemplates";
 import { Badge } from "@/components/ui/badge";
 import { TemplateParamBadge } from "./TemplatePicker";
 
@@ -36,9 +38,11 @@ export function RecommendedTemplatesDialog({
   const { templates, isLoading, error } =
     useActionConfigTemplates(connectorId);
   const { applyTemplate, isPending } = useApplyActionConfigTemplate();
+  const { bulkApply, isBulkPending } = useBulkApplyActionConfigTemplates();
   const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
     null,
   );
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const actionTypeSet = useMemo(
     () => new Set(actions.map((a) => a.action_type)),
@@ -81,6 +85,29 @@ export function RecommendedTemplatesDialog({
     return groups;
   }, [liveTemplates, actions, actionNameByType]);
 
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const allSelected =
+    liveTemplates.length > 0 && selectedIds.size === liveTemplates.length;
+
+  const toggleSelectAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
+    }
+  }, [allSelected, liveTemplates]);
+
   async function handleUseTemplate(template: ActionConfigTemplate) {
     setPendingTemplateId(template.id);
     try {
@@ -108,11 +135,45 @@ export function RecommendedTemplatesDialog({
     onCustomize(template);
   }
 
-  const buttonsDisabled = isPending;
+  async function handleBulkApply() {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+
+    try {
+      const res = await bulkApply({ templateIds: ids, agentId });
+      const succeeded = res.results.filter((r) => r.success);
+      const failed = res.results.filter((r) => !r.success);
+
+      if (failed.length === 0) {
+        toast.success(
+          `${succeeded.length} configuration${succeeded.length === 1 ? "" : "s"} created`,
+        );
+        setSelectedIds(new Set());
+        onOpenChange(false);
+      } else if (succeeded.length === 0) {
+        toast.error("Failed to create configurations");
+      } else {
+        toast.warning(
+          `${succeeded.length} of ${res.results.length} created. ${failed.length} failed.`,
+        );
+        // Keep only the failed templates selected.
+        const failedIds = new Set(failed.map((r) => r.template_id));
+        setSelectedIds(failedIds);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to apply templates",
+      );
+    }
+  }
+
+  const anyPending = isPending || isBulkPending;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="flex max-h-[85dvh] flex-col sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Recommended Templates</DialogTitle>
           <DialogDescription>
@@ -138,28 +199,63 @@ export function RecommendedTemplatesDialog({
             No recommended templates are available for this connector.
           </p>
         ) : (
-          <div className="space-y-6 py-2">
-            {grouped.map((group) => (
-              <section key={group.actionType} className="space-y-3">
-                <h3 className="text-sm font-semibold">{group.actionName}</h3>
-                <div className="space-y-3">
-                  {group.items.map((template) => (
-                    <RecommendedTemplateCard
-                      key={template.id}
-                      template={template}
-                      onUseTemplate={() => void handleUseTemplate(template)}
-                      onCustomize={() => handleCustomize(template)}
-                      useDisabled={buttonsDisabled}
-                      customizeDisabled={buttonsDisabled}
-                      usePending={
-                        isPending && pendingTemplateId === template.id
-                      }
-                    />
-                  ))}
-                </div>
-              </section>
-            ))}
-          </div>
+          <>
+            {/* Select all toggle */}
+            <label className="flex items-center gap-2 py-1">
+              <Checkbox
+                checked={allSelected}
+                onCheckedChange={toggleSelectAll}
+                disabled={anyPending}
+              />
+              <span className="text-muted-foreground text-sm">
+                Select all ({liveTemplates.length})
+              </span>
+            </label>
+
+            {/* Scrollable template list */}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="space-y-6 py-2">
+                {grouped.map((group) => (
+                  <section key={group.actionType} className="space-y-3">
+                    <h3 className="text-sm font-semibold">{group.actionName}</h3>
+                    <div className="space-y-3">
+                      {group.items.map((template) => (
+                        <RecommendedTemplateCard
+                          key={template.id}
+                          template={template}
+                          selected={selectedIds.has(template.id)}
+                          onToggleSelected={() => toggleSelected(template.id)}
+                          onUseTemplate={() => void handleUseTemplate(template)}
+                          onCustomize={() => handleCustomize(template)}
+                          disabled={anyPending}
+                          usePending={
+                            isPending && pendingTemplateId === template.id
+                          }
+                        />
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            </div>
+
+            {/* Sticky footer */}
+            <div className="flex items-center justify-between border-t pt-3">
+              <span className="text-muted-foreground text-sm">
+                {selectedIds.size} of {liveTemplates.length} selected
+              </span>
+              <Button
+                size="sm"
+                onClick={() => void handleBulkApply()}
+                disabled={selectedIds.size === 0 || anyPending}
+              >
+                {isBulkPending && (
+                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                )}
+                Enable Selected ({selectedIds.size})
+              </Button>
+            </div>
+          </>
         )}
       </DialogContent>
     </Dialog>
@@ -168,17 +264,19 @@ export function RecommendedTemplatesDialog({
 
 function RecommendedTemplateCard({
   template,
+  selected,
+  onToggleSelected,
   onUseTemplate,
   onCustomize,
-  useDisabled,
-  customizeDisabled,
+  disabled,
   usePending,
 }: {
   template: ActionConfigTemplate;
+  selected: boolean;
+  onToggleSelected: () => void;
   onUseTemplate: () => void;
   onCustomize: () => void;
-  useDisabled: boolean;
-  customizeDisabled: boolean;
+  disabled: boolean;
   usePending: boolean;
 }) {
   const paramEntries = Object.entries(template.parameters);
@@ -186,48 +284,57 @@ function RecommendedTemplateCard({
 
   return (
     <div className="rounded-lg border border-input p-3">
-      <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="text-sm font-medium">{template.name}</p>
-          {autoApproved ? (
-            <Badge>Auto-approved</Badge>
-          ) : (
-            <Badge variant="secondary" className="text-muted-foreground">
-              Requires approval each time
-            </Badge>
-          )}
+      <div className="flex gap-3">
+        <div className="pt-0.5">
+          <Checkbox
+            checked={selected}
+            onCheckedChange={onToggleSelected}
+            disabled={disabled}
+          />
         </div>
-        {template.description && (
-          <p className="text-muted-foreground text-sm">{template.description}</p>
-        )}
-        {paramEntries.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {paramEntries.map(([key, value]) => (
-              <TemplateParamBadge key={key} name={key} value={value} />
-            ))}
-          </div>
-        )}
-        <div className="flex flex-wrap gap-2 pt-1">
-          <Button
-            type="button"
-            size="sm"
-            onClick={onUseTemplate}
-            disabled={useDisabled}
-          >
-            {usePending && (
-              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-medium">{template.name}</p>
+            {autoApproved ? (
+              <Badge>Auto-approved</Badge>
+            ) : (
+              <Badge variant="secondary" className="text-muted-foreground">
+                Requires approval each time
+              </Badge>
             )}
-            Use Template
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            onClick={onCustomize}
-            disabled={customizeDisabled}
-          >
-            Customize
-          </Button>
+          </div>
+          {template.description && (
+            <p className="text-muted-foreground text-sm">{template.description}</p>
+          )}
+          {paramEntries.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {paramEntries.map(([key, value]) => (
+                <TemplateParamBadge key={key} name={key} value={value} />
+              ))}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Button
+              type="button"
+              size="sm"
+              onClick={onUseTemplate}
+              disabled={disabled}
+            >
+              {usePending && (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              )}
+              Use Template
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={onCustomize}
+              disabled={disabled}
+            >
+              Customize
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/spec/openapi/components/paths/action_config_templates.yaml
+++ b/spec/openapi/components/paths/action_config_templates.yaml
@@ -63,6 +63,67 @@ actionConfigTemplates:
       '500':
         $ref: '../responses/errors.yaml#/InternalServerError'
 
+bulkApplyActionConfigTemplates:
+  post:
+    operationId: bulkApplyActionConfigTemplates
+    summary: Bulk Apply Action Configuration Templates
+    description: |
+      Apply multiple templates in a single request. Creates an action
+      configuration (and optional standing approval) for each template.
+
+      All templates must belong to the same connector. The connector is
+      automatically enabled for the agent if not already enabled.
+
+      Each template is applied independently — if one fails (e.g., standing
+      approval limit reached), the others still succeed. The response
+      includes per-template results.
+
+    tags:
+      - Action Configurations
+
+    security:
+      - SupabaseSession: []
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/action_config_templates.yaml#/BulkApplyActionConfigTemplateRequest'
+
+    responses:
+      '200':
+        description: |
+          Bulk apply completed. Check individual `results[].success` for
+          per-template outcomes.
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/action_config_templates.yaml#/BulkApplyActionConfigTemplateResponse'
+
+      '400':
+        description: Invalid request (empty list, mixed connectors, etc.)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Template or agent not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
 applyActionConfigTemplate:
   post:
     operationId: applyActionConfigTemplate

--- a/spec/openapi/components/paths/action_config_templates.yaml
+++ b/spec/openapi/components/paths/action_config_templates.yaml
@@ -112,7 +112,12 @@ bulkApplyActionConfigTemplates:
         $ref: '../responses/errors.yaml#/Unauthorized'
 
       '404':
-        description: Template or agent not found
+        description: |
+          A requested template ID was not found. This is an upfront
+          validation error — no configurations are created.
+          Per-template failures (e.g., agent not found, standing approval
+          limit) are reported in `results[]` with `success: false`, not
+          as HTTP-level errors.
         content:
           application/json:
             schema:

--- a/spec/openapi/components/schemas/action_config_templates.yaml
+++ b/spec/openapi/components/schemas/action_config_templates.yaml
@@ -125,6 +125,79 @@ ApplyActionConfigTemplateResponse:
       $ref: '../schemas/standing_approvals.yaml#/StandingApproval'
       description: Present when the template bundles a standing approval.
 
+BulkApplyActionConfigTemplateRequest:
+  type: object
+  required:
+    - agent_id
+    - template_ids
+  properties:
+    agent_id:
+      type: integer
+      format: int64
+      description: Agent to attach the new configurations and standing approvals to.
+      example: 42
+    template_ids:
+      type: array
+      items:
+        type: string
+        maxLength: 255
+      minItems: 1
+      maxItems: 50
+      description: |
+        Template IDs to apply. All templates must belong to the same connector.
+        Duplicates are silently deduplicated.
+      example:
+        - "tpl_github_create_issue_all"
+        - "tpl_github_merge_pr_all"
+
+BulkApplyResultError:
+  type: object
+  required:
+    - code
+    - message
+  properties:
+    code:
+      type: string
+      description: Machine-readable error code.
+      example: "standing_approval_limit_reached"
+    message:
+      type: string
+      description: Human-readable error message.
+      example: "Standing approval limit reached"
+
+BulkApplyResult:
+  type: object
+  required:
+    - template_id
+    - success
+  properties:
+    template_id:
+      type: string
+      description: The template ID that was applied (or failed).
+    success:
+      type: boolean
+      description: Whether this template was applied successfully.
+    action_configuration:
+      $ref: '../schemas/action_configurations.yaml#/ActionConfiguration'
+    standing_approval:
+      $ref: '../schemas/standing_approvals.yaml#/StandingApproval'
+      description: Present when the template bundles a standing approval and it was created successfully.
+    error:
+      $ref: '../schemas/action_config_templates.yaml#/BulkApplyResultError'
+      description: Present when `success` is false.
+
+BulkApplyActionConfigTemplateResponse:
+  type: object
+  required:
+    - results
+  properties:
+    results:
+      type: array
+      items:
+        $ref: '../schemas/action_config_templates.yaml#/BulkApplyResult'
+      description: |
+        Per-template results. Order matches the deduplicated input order.
+
 ActionConfigTemplateListResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -3298,7 +3298,12 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
-          description: Template or agent not found
+          description: |
+            A requested template ID was not found. This is an upfront
+            validation error — no configurations are created.
+            Per-template failures (e.g., agent not found, standing approval
+            limit) are reported in `results[]` with `success: false`, not
+            as HTTP-level errors.
           content:
             application/json:
               schema:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -3256,6 +3256,57 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /v1/action-config-templates/bulk-apply:
+    post:
+      operationId: bulkApplyActionConfigTemplates
+      summary: Bulk Apply Action Configuration Templates
+      description: |
+        Apply multiple templates in a single request. Creates an action
+        configuration (and optional standing approval) for each template.
+
+        All templates must belong to the same connector. The connector is
+        automatically enabled for the agent if not already enabled.
+
+        Each template is applied independently — if one fails (e.g., standing
+        approval limit reached), the others still succeed. The response
+        includes per-template results.
+      tags:
+        - Action Configurations
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkApplyActionConfigTemplateRequest'
+      responses:
+        '200':
+          description: |
+            Bulk apply completed. Check individual `results[].success` for
+            per-template outcomes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkApplyActionConfigTemplateResponse'
+        '400':
+          description: Invalid request (empty list, mixed connectors, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Template or agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/action-config-templates/{id}/apply:
     post:
       operationId: applyActionConfigTemplate
@@ -11671,16 +11722,30 @@ components:
           minimum: 1
           description: |
             Optional cap on executions. `null` means unlimited within the window.
-    ApplyActionConfigTemplateRequest:
+    BulkApplyActionConfigTemplateRequest:
       type: object
       required:
         - agent_id
+        - template_ids
       properties:
         agent_id:
           type: integer
           format: int64
-          description: Agent to attach the new configuration and standing approval to.
+          description: Agent to attach the new configurations and standing approvals to.
           example: 42
+        template_ids:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+          minItems: 1
+          maxItems: 50
+          description: |
+            Template IDs to apply. All templates must belong to the same connector.
+            Duplicates are silently deduplicated.
+          example:
+            - tpl_github_create_issue_all
+            - tpl_github_merge_pr_all
     LinkedStandingApprovalSummary:
       type: object
       required:
@@ -11712,6 +11777,61 @@ components:
           type: integer
           minimum: 0
           description: Executions recorded so far.
+    BulkApplyResultError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+          example: standing_approval_limit_reached
+        message:
+          type: string
+          description: Human-readable error message.
+          example: Standing approval limit reached
+    BulkApplyResult:
+      type: object
+      required:
+        - template_id
+        - success
+      properties:
+        template_id:
+          type: string
+          description: The template ID that was applied (or failed).
+        success:
+          type: boolean
+          description: Whether this template was applied successfully.
+        action_configuration:
+          $ref: '#/components/schemas/ActionConfiguration'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApproval'
+          description: Present when the template bundles a standing approval and it was created successfully.
+        error:
+          $ref: '#/components/schemas/BulkApplyResultError'
+          description: Present when `success` is false.
+    BulkApplyActionConfigTemplateResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkApplyResult'
+          description: |
+            Per-template results. Order matches the deduplicated input order.
+    ApplyActionConfigTemplateRequest:
+      type: object
+      required:
+        - agent_id
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+          description: Agent to attach the new configuration and standing approval to.
+          example: 42
     ApplyActionConfigTemplateResponse:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -198,6 +198,9 @@ paths:
   /v1/action-config-templates:
     $ref: './components/paths/action_config_templates.yaml#/actionConfigTemplates'
 
+  /v1/action-config-templates/bulk-apply:
+    $ref: './components/paths/action_config_templates.yaml#/bulkApplyActionConfigTemplates'
+
   /v1/action-config-templates/{id}/apply:
     $ref: './components/paths/action_config_templates.yaml#/applyActionConfigTemplate'
 


### PR DESCRIPTION
## Summary

- Adds a new `POST /v1/action-config-templates/bulk-apply` endpoint that applies multiple templates in a single transaction with per-template savepoints for partial failure isolation
- Redesigns the Recommended Templates dialog with checkboxes on each template card, a "Select All" toggle, and an "Enable Selected (N)" footer button
- Adds `useBulkApplyActionConfigTemplates` React Query hook and `GetActionConfigTemplatesByIDs` batch DB query

Previously, enabling recommended templates required clicking "Use Template" one at a time — tedious when a connector has 10-30 templates. Now users can select multiple (or all) and apply them in one click.

## Test plan

### Developer
- [x] Go builds cleanly (`go build ./...`)
- [x] Frontend TypeScript compiles (`npx tsc --noEmit`)
- [x] All 972 frontend tests pass (`make test-frontend`)
- [x] All backend tests pass (`make test-backend`)
- [x] Existing RecommendedTemplatesDialog tests pass (11/11)

### Manual Testing
- [ ] Open a connector's Recommended Templates dialog — verify checkboxes appear on each template card
- [ ] Click "Select All" — verify all templates are checked and count updates
- [ ] Deselect individual templates — verify count decreases and "Select All" unchecks
- [ ] Click "Enable Selected" with multiple selected — verify all configurations are created and dialog closes
- [ ] Test partial failure (e.g., standing approval limit) — verify success toast shows partial count and failed templates remain selected
- [ ] Verify individual "Use Template" and "Customize" buttons still work as before
- [ ] Verify all buttons/checkboxes are disabled during a pending bulk operation

https://claude.ai/code/session_011sMFHJRwTct9odNGn82TEx