### PR TITLE
Bulk template approval: operation_type + quick setup UI

### DIFF
--- a/api/connectors.go
+++ b/api/connectors.go
@@ -27,6 +27,7 @@ type connectorListResponse struct {
 
 type connectorActionResponse struct {
 	ActionType            string  `json:"action_type"`
+	OperationType         string  `json:"operation_type"`
 	Name                  string  `json:"name"`
 	Description           *string `json:"description,omitempty"`
 	RiskLevel             *string `json:"risk_level,omitempty"`
@@ -45,12 +46,12 @@ type requiredCredentialResponse struct {
 }
 
 type connectorDetailResponse struct {
-	ID                  string                      `json:"id"`
-	Name                string                      `json:"name"`
-	Description         *string                     `json:"description,omitempty"`
-	Status              string                      `json:"status"`
-	LogoSVG             *string                     `json:"logo_svg,omitempty"`
-	Actions             []connectorActionResponse   `json:"actions"`
+	ID                  string                       `json:"id"`
+	Name                string                       `json:"name"`
+	Description         *string                      `json:"description,omitempty"`
+	Status              string                       `json:"status"`
+	LogoSVG             *string                      `json:"logo_svg,omitempty"`
+	Actions             []connectorActionResponse    `json:"actions"`
 	RequiredCredentials []requiredCredentialResponse `json:"required_credentials"`
 }
 
@@ -125,6 +126,7 @@ func toConnectorDetailResponse(ctx context.Context, c db.ConnectorDetail) connec
 	for i, a := range c.Actions {
 		resp := connectorActionResponse{
 			ActionType:            a.ActionType,
+			OperationType:         a.OperationType,
 			Name:                  a.Name,
 			Description:           a.Description,
 			RiskLevel:             a.RiskLevel,

--- a/api/connectors_test.go
+++ b/api/connectors_test.go
@@ -129,6 +129,9 @@ func TestGetConnector_Found(t *testing.T) {
 	if resp.Actions[0].ActionType != "test.act" {
 		t.Errorf("expected action_type 'test.act', got %q", resp.Actions[0].ActionType)
 	}
+	if resp.Actions[0].OperationType != "write" {
+		t.Errorf("expected operation_type 'write' (column default), got %q", resp.Actions[0].OperationType)
+	}
 	if len(resp.RequiredCredentials) != 1 {
 		t.Fatalf("expected 1 credential, got %d", len(resp.RequiredCredentials))
 	}

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -32,6 +32,7 @@ type ConnectorManifest struct {
 // ManifestAction describes a single action exposed by an external connector.
 type ManifestAction struct {
 	ActionType            string          `json:"action_type"`
+	OperationType         string          `json:"operation_type,omitempty"` // read, write, or delete; inferred from action_type when empty
 	Name                  string          `json:"name"`
 	Description           string          `json:"description"`
 	RiskLevel             string          `json:"risk_level"`
@@ -113,6 +114,13 @@ var validRiskLevels = map[string]bool{
 	"low":    true,
 	"medium": true,
 	"high":   true,
+}
+
+// validOperationTypes are the allowed values for ManifestAction.OperationType.
+var validOperationTypes = map[string]bool{
+	"read":   true,
+	"write":  true,
+	"delete": true,
 }
 
 // validPreviewLayouts are the allowed values for ActionPreview.Layout.
@@ -247,6 +255,9 @@ func (m *ConnectorManifest) Validate() error {
 		actionTypes[a.ActionType] = true
 		if a.Name == "" {
 			return fmt.Errorf("manifest validation: actions[%d].name is required", i)
+		}
+		if a.OperationType != "" && !validOperationTypes[a.OperationType] {
+			return fmt.Errorf("manifest validation: actions[%d].operation_type %q must be read, write, or delete", i, a.OperationType)
 		}
 		if a.RiskLevel != "" && !validRiskLevels[a.RiskLevel] {
 			return fmt.Errorf("manifest validation: actions[%d].risk_level %q must be low, medium, or high", i, a.RiskLevel)
@@ -643,8 +654,13 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 				log.Printf("warning: failed to marshal preview for action %s: %v", a.ActionType, err)
 			}
 		}
+		opType := a.OperationType
+		if opType == "" {
+			opType = string(InferOperationType(a.ActionType))
+		}
 		out.Actions = append(out.Actions, db.ExternalConnectorAction{
 			ActionType:            a.ActionType,
+			OperationType:         opType,
 			Name:                  a.Name,
 			Description:           a.Description,
 			RiskLevel:             a.RiskLevel,

--- a/connectors/operation_type.go
+++ b/connectors/operation_type.go
@@ -1,0 +1,108 @@
+package connectors
+
+import "strings"
+
+// OperationType classifies connector actions for bulk template UX (read / write / delete).
+type OperationType string
+
+const (
+	OperationRead   OperationType = "read"
+	OperationWrite  OperationType = "write"
+	OperationDelete OperationType = "delete"
+)
+
+// InferOperationType derives read/write/delete from the action_type suffix (after the first '.').
+// Manifests may override via ManifestAction.OperationType; this is used when unset.
+func InferOperationType(actionType string) OperationType {
+	dot := strings.IndexByte(actionType, '.')
+	if dot < 0 || dot == len(actionType)-1 {
+		return OperationWrite
+	}
+	suffix := actionType[dot+1:]
+	if suffix == "" {
+		return OperationWrite
+	}
+	for _, seg := range strings.Split(suffix, "_") {
+		if seg == "" {
+			continue
+		}
+		if deleteVerbs[seg] {
+			return OperationDelete
+		}
+		if readVerbs[seg] {
+			return OperationRead
+		}
+		if writeVerbs[seg] {
+			return OperationWrite
+		}
+	}
+	return OperationWrite
+}
+
+// Multi-word or domain-specific segments that imply read operations.
+var readVerbs = map[string]bool{
+	"get":         true,
+	"list":        true,
+	"read":        true,
+	"search":      true,
+	"describe":    true,
+	"query":       true,
+	"check":       true,
+	"download":    true,
+	"export":      true,
+	"fetch":       true,
+	"view":        true,
+	"price":       true, // price_check → split gives price? Actually "price_check" is one segment — see below
+	"price_check": true,
+}
+
+var deleteVerbs = map[string]bool{
+	"delete":    true,
+	"remove":    true,
+	"cancel":    true,
+	"close":     true,
+	"archive":   true,
+	"purge":     true,
+	"void":      true,
+	"unfollow":  true,
+	"unlike":    true,
+	"unretweet": true,
+}
+
+var writeVerbs = map[string]bool{
+	"create":     true,
+	"update":     true,
+	"send":       true,
+	"post":       true,
+	"put":        true,
+	"patch":      true,
+	"add":        true,
+	"merge":      true,
+	"trigger":    true,
+	"upload":     true,
+	"share":      true,
+	"move":       true,
+	"complete":   true,
+	"transition": true,
+	"assign":     true,
+	"invite":     true,
+	"set":        true,
+	"schedule":   true,
+	"fulfill":    true,
+	"enroll":     true,
+	"reply":      true,
+	"retweet":    true,
+	"like":       true,
+	"follow":     true,
+	"swap":       true,
+	"book":       true,
+	"issue":      true,
+	"adjust":     true,
+	"record":     true,
+	"convert":    true,
+	"run":        true,
+	"append":     true,
+	"write":      true,
+	"tag":        true,
+	"reconcile":  true,
+}

--- a/connectors/operation_type_test.go
+++ b/connectors/operation_type_test.go
@@ -1,0 +1,29 @@
+package connectors
+
+import "testing"
+
+func TestInferOperationType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		actionType string
+		want       OperationType
+	}{
+		{"github.list_repos", OperationRead},
+		{"github.get_repo", OperationRead},
+		{"github.search_code", OperationRead},
+		{"github.create_issue", OperationWrite},
+		{"github.merge_pr", OperationWrite},
+		{"github.close_issue", OperationDelete},
+		{"expedia.price_check", OperationRead},
+		{"google.read_email", OperationRead},
+		{"google.archive_email", OperationDelete},
+		{"docusign.void_envelope", OperationDelete},
+		{"no_dot", OperationWrite},
+	}
+	for _, tc := range cases {
+		got := InferOperationType(tc.actionType)
+		if got != tc.want {
+			t.Errorf("InferOperationType(%q) = %q, want %q", tc.actionType, got, tc.want)
+		}
+	}
+}

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -33,6 +33,7 @@ type ConnectorDetail struct {
 // ConnectorAction represents a row from the connector_actions table.
 type ConnectorAction struct {
 	ActionType            string
+	OperationType         string // read, write, or delete
 	Name                  string
 	Description           *string
 	RiskLevel             *string
@@ -96,7 +97,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	// Fetch actions.
 	actionRows, err := db.Query(ctx,
-		`SELECT action_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template, preview
+		`SELECT action_type, operation_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template, preview
 		 FROM connector_actions
 		 WHERE connector_id = $1
 		 ORDER BY action_type`,
@@ -109,7 +110,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	for actionRows.Next() {
 		var a ConnectorAction
-		if err := actionRows.Scan(&a.ActionType, &a.Name, &a.Description, &a.RiskLevel, &a.ParametersSchema, &a.RequiresPaymentMethod, &a.DisplayTemplate, &a.Preview); err != nil {
+		if err := actionRows.Scan(&a.ActionType, &a.OperationType, &a.Name, &a.Description, &a.RiskLevel, &a.ParametersSchema, &a.RequiresPaymentMethod, &a.DisplayTemplate, &a.Preview); err != nil {
 			return nil, err
 		}
 		cd.Actions = append(cd.Actions, a)
@@ -260,6 +261,7 @@ type ExternalConnectorManifest struct {
 // ExternalConnectorAction describes an action from an external connector manifest.
 type ExternalConnectorAction struct {
 	ActionType            string
+	OperationType         string // read, write, or delete
 	Name                  string
 	Description           string
 	RiskLevel             string
@@ -322,10 +324,15 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 	actionTypes := make([]string, 0, len(m.Actions))
 	for _, a := range m.Actions {
 		actionTypes = append(actionTypes, a.ActionType)
+		opType := a.OperationType
+		if opType == "" {
+			opType = "write"
+		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO connector_actions (connector_id, action_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template, preview)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			INSERT INTO connector_actions (connector_id, action_type, operation_type, name, description, risk_level, parameters_schema, requires_payment_method, display_template, preview)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			ON CONFLICT (connector_id, action_type) DO UPDATE SET
+				operation_type = EXCLUDED.operation_type,
 				name = EXCLUDED.name,
 				description = EXCLUDED.description,
 				risk_level = EXCLUDED.risk_level,
@@ -333,7 +340,7 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 				requires_payment_method = EXCLUDED.requires_payment_method,
 				display_template = EXCLUDED.display_template,
 				preview = EXCLUDED.preview`,
-			m.ID, a.ActionType, a.Name, nilIfEmpty(a.Description), nilIfEmpty(a.RiskLevel), nilIfEmptyBytes(a.ParametersSchema), a.RequiresPaymentMethod, nilIfEmpty(a.DisplayTemplate), nilIfEmptyBytes(a.Preview))
+			m.ID, a.ActionType, opType, a.Name, nilIfEmpty(a.Description), nilIfEmpty(a.RiskLevel), nilIfEmptyBytes(a.ParametersSchema), a.RequiresPaymentMethod, nilIfEmpty(a.DisplayTemplate), nilIfEmptyBytes(a.Preview))
 		if err != nil {
 			return err
 		}

--- a/db/connectors_test.go
+++ b/db/connectors_test.go
@@ -17,7 +17,7 @@ func TestConnectorsSchema(t *testing.T) {
 	})
 	t.Run("connector_actions", func(t *testing.T) {
 		testhelper.RequireColumns(t, tx, "connector_actions", []string{
-			"connector_id", "action_type", "name", "description",
+			"connector_id", "action_type", "operation_type", "name", "description",
 			"risk_level", "parameters_schema",
 		})
 	})
@@ -195,8 +195,8 @@ func TestUpsertConnectorFromManifest_Insert(t *testing.T) {
 		Name:        "External Test",
 		Description: "A test connector",
 		Actions: []db.ExternalConnectorAction{
-			{ActionType: "ext-test.create", Name: "Create", Description: "Create thing", RiskLevel: "low"},
-			{ActionType: "ext-test.delete", Name: "Delete", RiskLevel: "high"},
+			{ActionType: "ext-test.create", OperationType: "write", Name: "Create", Description: "Create thing", RiskLevel: "low"},
+			{ActionType: "ext-test.delete", OperationType: "delete", Name: "Delete", RiskLevel: "high"},
 		},
 		Credentials: []db.ExternalConnectorCredential{
 			{Service: "ext-test", AuthType: "api_key"},
@@ -238,6 +238,26 @@ func TestUpsertConnectorFromManifest_Insert(t *testing.T) {
 	}
 	if credCount != 1 {
 		t.Errorf("credential count = %d, want 1", credCount)
+	}
+
+	var opCreate, opDelete string
+	err = tx.QueryRow(ctx,
+		`SELECT operation_type FROM connector_actions WHERE connector_id = $1 AND action_type = $2`,
+		"ext-test", "ext-test.create").Scan(&opCreate)
+	if err != nil {
+		t.Fatalf("querying operation_type for create: %v", err)
+	}
+	if opCreate != "write" {
+		t.Errorf("ext-test.create operation_type = %q, want write", opCreate)
+	}
+	err = tx.QueryRow(ctx,
+		`SELECT operation_type FROM connector_actions WHERE connector_id = $1 AND action_type = $2`,
+		"ext-test", "ext-test.delete").Scan(&opDelete)
+	if err != nil {
+		t.Fatalf("querying operation_type for delete: %v", err)
+	}
+	if opDelete != "delete" {
+		t.Errorf("ext-test.delete operation_type = %q, want delete", opDelete)
 	}
 }
 

--- a/db/migrations/20260413145754_add_operation_type_to_connector_actions.sql
+++ b/db/migrations/20260413145754_add_operation_type_to_connector_actions.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+ALTER TABLE connector_actions
+  ADD COLUMN operation_type text NOT NULL DEFAULT 'write'
+    CHECK (operation_type IN ('read', 'write', 'delete'));
+
+COMMENT ON COLUMN connector_actions.operation_type IS
+  'Whether the action is a read, write, or delete for UI grouping. Synced from connector manifests on upsert; default write applies until the connector is re-seeded.';
+
+-- +goose Down
+
+ALTER TABLE connector_actions DROP COLUMN IF EXISTS operation_type;

--- a/db/testhelper/fixtures_connectors.go
+++ b/db/testhelper/fixtures_connectors.go
@@ -35,16 +35,21 @@ func InsertConnectorActionWithPayment(t *testing.T, d db.DBTX, connectorID, acti
 type ConnectorActionOpts struct {
 	Description      *string
 	RiskLevel        *string
-	ParametersSchema []byte // raw JSON
+	ParametersSchema []byte  // raw JSON
+	OperationType    *string // read, write, delete — defaults to write when nil
 }
 
 // InsertConnectorActionFull creates an action with full details for the given connector.
 func InsertConnectorActionFull(t *testing.T, d db.DBTX, connectorID, actionType, name string, opts ConnectorActionOpts) {
 	t.Helper()
+	op := "write"
+	if opts.OperationType != nil && *opts.OperationType != "" {
+		op = *opts.OperationType
+	}
 	mustExec(t, d,
-		`INSERT INTO connector_actions (connector_id, action_type, name, description, risk_level, parameters_schema)
-		 VALUES ($1, $2, $3, $4, $5, $6)`,
-		connectorID, actionType, name, opts.Description, opts.RiskLevel, opts.ParametersSchema)
+		`INSERT INTO connector_actions (connector_id, action_type, operation_type, name, description, risk_level, parameters_schema)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		connectorID, actionType, op, name, opts.Description, opts.RiskLevel, opts.ParametersSchema)
 }
 
 // InsertConnectorWithDescription creates a connector with a custom description.

--- a/frontend/src/hooks/__tests__/useActionSchema.test.tsx
+++ b/frontend/src/hooks/__tests__/useActionSchema.test.tsx
@@ -14,6 +14,7 @@ const mockConnectorDetail = {
   actions: [
     {
       action_type: "github.create_issue",
+      operation_type: "write",
       name: "Create Issue",
       description: "Create a new issue",
       risk_level: "low",
@@ -29,6 +30,7 @@ const mockConnectorDetail = {
     },
     {
       action_type: "github.merge_pr",
+      operation_type: "write",
       name: "Merge Pull Request",
       risk_level: "medium",
     },

--- a/frontend/src/hooks/__tests__/useConnectorDetail.test.tsx
+++ b/frontend/src/hooks/__tests__/useConnectorDetail.test.tsx
@@ -14,6 +14,7 @@ const mockDetailResponse = {
   actions: [
     {
       action_type: "github.create_issue",
+      operation_type: "write",
       name: "Create Issue",
       description: "Create a new issue in a repository",
       risk_level: "low",

--- a/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
@@ -17,8 +18,11 @@ import { useApplyActionConfigTemplate } from "@/hooks/useApplyActionConfigTempla
 import { useBulkApplyActionConfigTemplates } from "@/hooks/useBulkApplyActionConfigTemplates";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { TemplateParamBadge } from "./TemplatePicker";
+import { cn } from "@/lib/utils";
 
 export type ApprovalMode = "auto_approve" | "requires_approval";
+
+export type OperationTypeUI = ConnectorAction["operation_type"];
 
 export interface RecommendedTemplatesDialogProps {
   open: boolean;
@@ -33,6 +37,12 @@ const approvalModeOptions: { label: string; value: ApprovalMode }[] = [
   { label: "Auto-approve", value: "auto_approve" },
   { label: "Requires approval", value: "requires_approval" },
 ];
+
+const operationSectionTitle: Record<OperationTypeUI, string> = {
+  read: "Read actions",
+  write: "Write actions",
+  delete: "Delete actions",
+};
 
 function defaultApprovalMode(template: ActionConfigTemplate): ApprovalMode {
   return template.standing_approval != null ? "auto_approve" : "requires_approval";
@@ -55,6 +65,10 @@ export function RecommendedTemplatesDialog({
   );
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [approvalModes, setApprovalModes] = useState<Record<string, ApprovalMode>>({});
+
+  const [quickRead, setQuickRead] = useState<ApprovalMode>("auto_approve");
+  const [quickWrite, setQuickWrite] = useState<ApprovalMode>("requires_approval");
+  const [quickDelete, setQuickDelete] = useState<ApprovalMode>("requires_approval");
 
   const getApprovalMode = useCallback(
     (template: ActionConfigTemplate): ApprovalMode =>
@@ -82,33 +96,68 @@ export function RecommendedTemplatesDialog({
     return m;
   }, [actions]);
 
+  const operationTypeByActionType = useMemo(() => {
+    const m = new Map<string, OperationTypeUI>();
+    for (const a of actions) {
+      m.set(a.action_type, a.operation_type);
+    }
+    return m;
+  }, [actions]);
+
+  const getOperationType = useCallback(
+    (template: ActionConfigTemplate): OperationTypeUI =>
+      operationTypeByActionType.get(template.action_type) ?? "write",
+    [operationTypeByActionType],
+  );
+
   const liveTemplates = useMemo(
     () => templates.filter((t) => actionTypeSet.has(t.action_type)),
     [templates, actionTypeSet],
   );
 
-  const grouped = useMemo(() => {
-    const byType = new Map<string, ActionConfigTemplate[]>();
-    for (const t of liveTemplates) {
-      const list = byType.get(t.action_type) ?? [];
-      list.push(t);
-      byType.set(t.action_type, list);
-    }
-    const order = actions.map((a) => a.action_type);
-    const groups: { actionType: string; actionName: string; items: ActionConfigTemplate[] }[] =
-      [];
-    for (const actionType of order) {
-      const items = byType.get(actionType);
-      if (items && items.length > 0) {
-        groups.push({
+  const groupedByOperation = useMemo(() => {
+    const opOrder: OperationTypeUI[] = ["read", "write", "delete"];
+    const firstActionIndex = new Map<string, number>();
+    actions.forEach((a, i) => {
+      if (!firstActionIndex.has(a.action_type)) {
+        firstActionIndex.set(a.action_type, i);
+      }
+    });
+
+    const out: {
+      operationType: OperationTypeUI;
+      subgroups: {
+        actionType: string;
+        actionName: string;
+        items: ActionConfigTemplate[];
+      }[];
+    }[] = [];
+
+    for (const op of opOrder) {
+      const byAction = new Map<string, ActionConfigTemplate[]>();
+      for (const t of liveTemplates) {
+        if (getOperationType(t) !== op) continue;
+        const list = byAction.get(t.action_type) ?? [];
+        list.push(t);
+        byAction.set(t.action_type, list);
+      }
+      if (byAction.size === 0) continue;
+
+      const subgroups = [...byAction.entries()]
+        .sort(
+          ([a], [b]) =>
+            (firstActionIndex.get(a) ?? 999) - (firstActionIndex.get(b) ?? 999),
+        )
+        .map(([actionType, items]) => ({
           actionType,
           actionName: actionNameByType.get(actionType) ?? actionType,
           items,
-        });
-      }
+        }));
+
+      out.push({ operationType: op, subgroups });
     }
-    return groups;
-  }, [liveTemplates, actions, actionNameByType]);
+    return out;
+  }, [liveTemplates, actions, actionNameByType, getOperationType]);
 
   const toggleSelected = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -132,6 +181,60 @@ export function RecommendedTemplatesDialog({
       setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
     }
   }, [allSelected, liveTemplates]);
+
+  const templateIdsForOperation = useCallback(
+    (op: OperationTypeUI) =>
+      liveTemplates.filter((t) => getOperationType(t) === op).map((t) => t.id),
+    [liveTemplates, getOperationType],
+  );
+
+  const allSelectedInOperation = useCallback(
+    (op: OperationTypeUI) => {
+      const ids = templateIdsForOperation(op);
+      return (
+        ids.length > 0 && ids.every((id) => selectedIds.has(id))
+      );
+    },
+    [templateIdsForOperation, selectedIds],
+  );
+
+  const toggleSelectOperation = useCallback(
+    (op: OperationTypeUI) => {
+      const ids = templateIdsForOperation(op);
+      const allOn = ids.length > 0 && ids.every((id) => selectedIds.has(id));
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (allOn) {
+          for (const id of ids) {
+            next.delete(id);
+          }
+        } else {
+          for (const id of ids) {
+            next.add(id);
+          }
+        }
+        return next;
+      });
+    },
+    [templateIdsForOperation],
+  );
+
+  const handleQuickApply = useCallback(() => {
+    setApprovalModes((prev) => {
+      const next = { ...prev };
+      for (const t of liveTemplates) {
+        const op = getOperationType(t);
+        next[t.id] =
+          op === "read"
+            ? quickRead
+            : op === "write"
+              ? quickWrite
+              : quickDelete;
+      }
+      return next;
+    });
+    setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
+  }, [liveTemplates, getOperationType, quickRead, quickWrite, quickDelete]);
 
   async function handleUseTemplate(template: ActionConfigTemplate) {
     const approvalMode = getApprovalMode(template);
@@ -169,7 +272,6 @@ export function RecommendedTemplatesDialog({
     const ids = Array.from(selectedIds);
     if (ids.length === 0) return;
 
-    // Collect per-template approval modes for overrides only.
     const modes: Record<string, ApprovalMode> = {};
     for (const id of ids) {
       const tpl = liveTemplates.find((t) => t.id === id);
@@ -213,6 +315,13 @@ export function RecommendedTemplatesDialog({
 
   const anyPending = isPending || isBulkPending;
 
+  const selectClassName = cn(
+    "border-input bg-background text-foreground",
+    "h-9 max-w-[11rem] min-w-0 flex-1 rounded-md border px-2 text-sm shadow-xs",
+    "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[85dvh] flex-col sm:max-w-lg">
@@ -236,13 +345,97 @@ export function RecommendedTemplatesDialog({
           </div>
         ) : error ? (
           <p className="text-destructive py-4 text-sm">{error}</p>
-        ) : grouped.length === 0 ? (
+        ) : groupedByOperation.length === 0 ? (
           <p className="text-muted-foreground py-4 text-sm">
             No recommended templates are available for this connector.
           </p>
         ) : (
           <>
-            {/* Select all toggle */}
+            <div className="bg-muted/40 space-y-3 rounded-lg border border-input p-3">
+              <p className="text-sm font-semibold">Quick setup</p>
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                  <Label
+                    htmlFor="quick-read"
+                    className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
+                  >
+                    Read actions
+                  </Label>
+                  <select
+                    id="quick-read"
+                    className={selectClassName}
+                    value={quickRead}
+                    onChange={(e) =>
+                      setQuickRead(e.target.value as ApprovalMode)
+                    }
+                    disabled={anyPending}
+                  >
+                    {approvalModeOptions.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                  <Label
+                    htmlFor="quick-write"
+                    className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
+                  >
+                    Write actions
+                  </Label>
+                  <select
+                    id="quick-write"
+                    className={selectClassName}
+                    value={quickWrite}
+                    onChange={(e) =>
+                      setQuickWrite(e.target.value as ApprovalMode)
+                    }
+                    disabled={anyPending}
+                  >
+                    {approvalModeOptions.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                  <Label
+                    htmlFor="quick-delete"
+                    className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
+                  >
+                    Delete actions
+                  </Label>
+                  <select
+                    id="quick-delete"
+                    className={selectClassName}
+                    value={quickDelete}
+                    onChange={(e) =>
+                      setQuickDelete(e.target.value as ApprovalMode)
+                    }
+                    disabled={anyPending}
+                  >
+                    {approvalModeOptions.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                className="w-full sm:w-auto"
+                onClick={handleQuickApply}
+                disabled={anyPending || liveTemplates.length === 0}
+              >
+                Apply
+              </Button>
+            </div>
+
             <label className="flex items-center gap-2 py-1">
               <Checkbox
                 checked={allSelected}
@@ -254,38 +447,68 @@ export function RecommendedTemplatesDialog({
               </span>
             </label>
 
-            {/* Scrollable template list */}
             <div className="min-h-0 flex-1 overflow-y-auto">
               <div className="space-y-6 py-2">
-                {grouped.map((group) => (
-                  <section key={group.actionType} className="space-y-3">
-                    <h3 className="text-sm font-semibold">{group.actionName}</h3>
-                    <div className="space-y-3">
-                      {group.items.map((template) => (
-                        <RecommendedTemplateCard
-                          key={template.id}
-                          template={template}
-                          selected={selectedIds.has(template.id)}
-                          onToggleSelected={() => toggleSelected(template.id)}
-                          approvalMode={getApprovalMode(template)}
-                          onApprovalModeChange={(mode) =>
-                            handleApprovalModeChange(template.id, mode)
-                          }
-                          onUseTemplate={() => void handleUseTemplate(template)}
-                          onCustomize={() => handleCustomize(template)}
-                          disabled={anyPending}
-                          usePending={
-                            isPending && pendingTemplateId === template.id
-                          }
-                        />
-                      ))}
-                    </div>
-                  </section>
-                ))}
+                {groupedByOperation.map((section) => {
+                  const op = section.operationType;
+                  const countInOp = templateIdsForOperation(op).length;
+                  return (
+                    <section key={op} className="space-y-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <h2 className="text-base font-semibold">
+                          {operationSectionTitle[op]}
+                        </h2>
+                        <label className="flex items-center gap-2">
+                          <Checkbox
+                            checked={allSelectedInOperation(op)}
+                            onCheckedChange={() => toggleSelectOperation(op)}
+                            disabled={anyPending || countInOp === 0}
+                          />
+                          <span className="text-muted-foreground text-xs sm:text-sm">
+                            Select all in section ({countInOp})
+                          </span>
+                        </label>
+                      </div>
+                      <div className="space-y-5 pl-0 sm:pl-1">
+                        {section.subgroups.map((group) => (
+                          <div key={group.actionType} className="space-y-3">
+                            <h3 className="text-sm font-medium">
+                              {group.actionName}
+                            </h3>
+                            <div className="space-y-3">
+                              {group.items.map((template) => (
+                                <RecommendedTemplateCard
+                                  key={template.id}
+                                  template={template}
+                                  selected={selectedIds.has(template.id)}
+                                  onToggleSelected={() =>
+                                    toggleSelected(template.id)
+                                  }
+                                  approvalMode={getApprovalMode(template)}
+                                  onApprovalModeChange={(mode) =>
+                                    handleApprovalModeChange(template.id, mode)
+                                  }
+                                  onUseTemplate={() =>
+                                    void handleUseTemplate(template)
+                                  }
+                                  onCustomize={() => handleCustomize(template)}
+                                  disabled={anyPending}
+                                  usePending={
+                                    isPending &&
+                                    pendingTemplateId === template.id
+                                  }
+                                />
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </section>
+                  );
+                })}
               </div>
             </div>
 
-            {/* Sticky footer */}
             <div className="flex items-center justify-between border-t pt-3">
               <span className="text-muted-foreground text-sm">
                 {selectedIds.size} of {liveTemplates.length} selected

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../../../../api/client");
 const mockActions: ConnectorAction[] = [
   {
     action_type: "github.create_issue",
+    operation_type: "write",
     name: "Create Issue",
     description: "Create a new issue in a repository",
     risk_level: "low",
@@ -35,6 +36,7 @@ const mockActions: ConnectorAction[] = [
   },
   {
     action_type: "github.merge_pr",
+    operation_type: "write",
     name: "Merge Pull Request",
     description: "Merge an open pull request",
     risk_level: "high",

--- a/frontend/src/pages/agents/connectors/__tests__/AddActionConfigDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/AddActionConfigDialog.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../../../api/client");
 const actions: ConnectorAction[] = [
   {
     action_type: "github.create_issue",
+    operation_type: "write",
     name: "Create Issue",
     description: "",
     risk_level: "low",

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
@@ -20,6 +20,7 @@ const mockDetailResponse = {
   actions: [
     {
       action_type: "github.create_issue",
+      operation_type: "write",
       name: "Create Issue",
       description: "Create a new issue in a repository",
       risk_level: "low",
@@ -34,6 +35,7 @@ const mockDetailResponse = {
     },
     {
       action_type: "github.merge_pr",
+      operation_type: "write",
       name: "Merge Pull Request",
       description: "Merge an open pull request",
       risk_level: "high",

--- a/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../../../api/client");
 const actions: ConnectorAction[] = [
   {
     action_type: "github.create_issue",
+    operation_type: "write",
     name: "Create Issue",
     description: "",
     risk_level: "low",
@@ -25,6 +26,7 @@ const actions: ConnectorAction[] = [
   },
   {
     action_type: "github.merge_pr",
+    operation_type: "write",
     name: "Merge Pull Request",
     description: "",
     risk_level: "high",

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -61,6 +61,7 @@ function setupMocks() {
           actions: [
             {
               action_type: "github.create_issue",
+              operation_type: "write",
               name: "Create Issue",
               parameters_schema: {
                 type: "object",

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -197,6 +197,7 @@ ConnectorDetailResponse:
     description: "GitHub integration for repository management"
     actions:
       - action_type: "github.create_issue"
+        operation_type: "write"
         name: "Create Issue"
         description: "Create a new issue in a repository"
         risk_level: "low"
@@ -217,6 +218,7 @@ ConnectorDetailResponse:
               type: "string"
               description: "Issue body (markdown)"
       - action_type: "github.merge_pr"
+        operation_type: "write"
         name: "Merge Pull Request"
         description: "Merge an open pull request"
         risk_level: "medium"
@@ -246,6 +248,7 @@ ConnectorAction:
   type: object
   required:
     - action_type
+    - operation_type
     - name
   properties:
     action_type:
@@ -255,6 +258,17 @@ ConnectorAction:
         Action type identifier. Use this value as the `action.type` when submitting 
         approval requests and as `action_id` when executing actions.
       example: "github.create_issue"
+
+    operation_type:
+      type: string
+      enum:
+        - read
+        - write
+        - delete
+      description: |
+        High-level classification for bulk template setup and grouping in the UI.
+        Derived from verb-based action naming (e.g. list/get → read, create/update → write,
+        delete/cancel → delete) unless overridden in the connector manifest.
 
     name:
       type: string
@@ -356,6 +370,7 @@ ConnectorAction:
 
   example:
     action_type: "github.create_issue"
+    operation_type: "write"
     name: "Create Issue"
     description: "Create a new issue in a repository"
     risk_level: "low"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7866,6 +7866,7 @@ components:
         description: GitHub integration for repository management
         actions:
           - action_type: github.create_issue
+            operation_type: write
             name: Create Issue
             description: Create a new issue in a repository
             risk_level: low
@@ -7886,6 +7887,7 @@ components:
                   type: string
                   description: Issue body (markdown)
           - action_type: github.merge_pr
+            operation_type: write
             name: Merge Pull Request
             description: Merge an open pull request
             risk_level: medium
@@ -7914,6 +7916,7 @@ components:
       type: object
       required:
         - action_type
+        - operation_type
         - name
       properties:
         action_type:
@@ -7923,6 +7926,16 @@ components:
             Action type identifier. Use this value as the `action.type` when submitting 
             approval requests and as `action_id` when executing actions.
           example: github.create_issue
+        operation_type:
+          type: string
+          enum:
+            - read
+            - write
+            - delete
+          description: |
+            High-level classification for bulk template setup and grouping in the UI.
+            Derived from verb-based action naming (e.g. list/get → read, create/update → write,
+            delete/cancel → delete) unless overridden in the connector manifest.
         name:
           type: string
           maxLength: 256
@@ -8016,6 +8029,7 @@ components:
               end: end_time
       example:
         action_type: github.create_issue
+        operation_type: write
         name: Create Issue
         description: Create a new issue in a repository
         risk_level: low


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #925](https://github.com/supersuit-tech/permission-slip/issues/925): classify connector actions as read/write/delete for the Recommended Templates dialog, with a Quick setup panel (per-category approval mode + Apply) and grouping by operation type (with action name subgroups). Per-operation “Select all in section” is included.

### Backend

- Added `operation_type` column on `connector_actions` (migration) with CHECK constraint.
- `ManifestAction` accepts optional `operation_type`; when omitted, `ToDBManifest` fills it via `InferOperationType` from the action suffix (verb segments).
- Connector detail API includes `operation_type` on each action. OpenAPI `ConnectorAction` updated and bundle regenerated.

### Frontend

- `RecommendedTemplatesDialog` groups templates under Read / Write / Delete, adds Quick setup dropdowns + Apply (bulk-select + set approval modes), global “Select all”, and per-section select.

Closes #925

### Developer

- [x] `make build` passes (OpenAPI bundle, frontend build, Go compile)
- [x] `go test ./connectors/...` and frontend `npm test` pass locally
- [ ] Run `make test-backend` / DB migration in an environment with Postgres (CI should cover)

### Manual Testing

- [ ] Open Recommended Templates for a connector with many templates (e.g. Google); use Quick setup (read auto-approve, write/delete require approval), Apply, then Enable Selected
- [ ] Confirm per-section “Select all” and individual toggles still work after quick setup

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a62270d-60f8-4e9c-95d8-89b0db2e2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a62270d-60f8-4e9c-95d8-89b0db2e2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

