### PR TITLE
Fix operation_type bulk templates: stale closure, backfill, tests, Select UI

### DIFF
--- a/connectors/operation_type.go
+++ b/connectors/operation_type.go
@@ -41,21 +41,24 @@ func InferOperationType(actionType string) OperationType {
 
 // Multi-word or domain-specific segments that imply read operations.
 var readVerbs = map[string]bool{
-	"get":         true,
-	"list":        true,
-	"read":        true,
-	"search":      true,
-	"describe":    true,
-	"query":       true,
-	"check":       true,
-	"download":    true,
-	"export":      true,
-	"fetch":       true,
-	"view":        true,
-	"price":       true, // price_check → split gives price? Actually "price_check" is one segment — see below
-	"price_check": true,
+	"get":      true,
+	"list":     true,
+	"read":     true,
+	"search":   true,
+	"describe": true,
+	"query":    true,
+	"check":    true,
+	"download": true,
+	"export":   true,
+	"fetch":    true,
+	"view":     true,
+	"price":    true, // e.g. expedia.price_check → segment "price" matches before "check"
 }
 
+// deleteVerbs includes verbs that remove or irreversibly change external state. Note that
+// connectors often use "close", "archive", or "cancel" for non-destructive workflow moves;
+// we still classify those as delete so bulk "Delete actions" approval covers them — users
+// who need finer control can approve per template.
 var deleteVerbs = map[string]bool{
 	"delete":    true,
 	"remove":    true,

--- a/db/migrations/20260413174414_backfill_connector_actions_operation_type.sql
+++ b/db/migrations/20260413174414_backfill_connector_actions_operation_type.sql
@@ -1,0 +1,71 @@
+-- +goose Up
+
+-- Backfill operation_type for rows that still have the column default from
+-- 20260413145754_add_operation_type_to_connector_actions. Uses the same
+-- verb-segment rules as connectors.InferOperationType (delete > read > write).
+CREATE OR REPLACE FUNCTION _tmp_infer_operation_type(p_action_type text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  dot_pos int;
+  suffix text;
+  seg text;
+  segs text[];
+BEGIN
+  dot_pos := strpos(p_action_type, '.');
+  IF dot_pos = 0 OR dot_pos = length(p_action_type) THEN
+    RETURN 'write';
+  END IF;
+  suffix := substring(p_action_type from dot_pos + 1);
+  IF suffix = '' THEN
+    RETURN 'write';
+  END IF;
+
+  segs := string_to_array(suffix, '_');
+  FOREACH seg IN ARRAY segs
+  LOOP
+    IF seg IS NULL OR seg = '' THEN
+      CONTINUE;
+    END IF;
+
+    IF seg IN (
+      'delete', 'remove', 'cancel', 'close', 'archive', 'purge', 'void',
+      'unfollow', 'unlike', 'unretweet'
+    ) THEN
+      RETURN 'delete';
+    END IF;
+
+    IF seg IN (
+      'get', 'list', 'read', 'search', 'describe', 'query', 'check',
+      'download', 'export', 'fetch', 'view', 'price'
+    ) THEN
+      RETURN 'read';
+    END IF;
+
+    IF seg IN (
+      'create', 'update', 'send', 'post', 'put', 'patch', 'add', 'merge',
+      'trigger', 'upload', 'share', 'move', 'complete', 'transition', 'assign',
+      'invite', 'set', 'schedule', 'fulfill', 'enroll', 'reply', 'retweet',
+      'like', 'follow', 'swap', 'book', 'issue', 'adjust', 'record', 'convert',
+      'run', 'append', 'write', 'tag', 'reconcile'
+    ) THEN
+      RETURN 'write';
+    END IF;
+  END LOOP;
+
+  RETURN 'write';
+END;
+$$;
+
+UPDATE connector_actions
+SET operation_type = _tmp_infer_operation_type(action_type)
+WHERE operation_type = 'write';
+
+DROP FUNCTION _tmp_infer_operation_type(text);
+
+-- +goose Down
+
+-- Data-only migration; previous operation_type values are not recoverable.
+SELECT 1;

--- a/db/migrations/20260413174414_backfill_connector_actions_operation_type.sql
+++ b/db/migrations/20260413174414_backfill_connector_actions_operation_type.sql
@@ -3,6 +3,7 @@
 -- Backfill operation_type for rows that still have the column default from
 -- 20260413145754_add_operation_type_to_connector_actions. Uses the same
 -- verb-segment rules as connectors.InferOperationType (delete > read > write).
+-- +goose StatementBegin
 CREATE OR REPLACE FUNCTION _tmp_infer_operation_type(p_action_type text)
 RETURNS text
 LANGUAGE plpgsql
@@ -58,6 +59,7 @@ BEGIN
   RETURN 'write';
 END;
 $$;
+-- +goose StatementEnd
 
 -- Rows with operation_type = 'write' are indistinguishable from the column default added in
 -- 20260413145754. At the time of this backfill, no manifest had yet persisted a different

--- a/db/migrations/20260413174414_backfill_connector_actions_operation_type.sql
+++ b/db/migrations/20260413174414_backfill_connector_actions_operation_type.sql
@@ -59,6 +59,10 @@ BEGIN
 END;
 $$;
 
+-- Rows with operation_type = 'write' are indistinguishable from the column default added in
+-- 20260413145754. At the time of this backfill, no manifest had yet persisted a different
+-- explicit override as 'write', so inferring from action_type is safe. If this migration is
+-- delayed after connectors start storing explicit overrides, revisit before applying.
 UPDATE connector_actions
 SET operation_type = _tmp_infer_operation_type(action_type)
 WHERE operation_type = 'write';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
@@ -2167,6 +2168,67 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
@@ -2392,6 +2454,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",

--- a/frontend/src/api/bundled.yaml
+++ b/frontend/src/api/bundled.yaml
@@ -7663,6 +7663,7 @@ components:
       type: object
       required:
         - action_type
+        - operation_type
         - name
       properties:
         action_type:
@@ -7672,6 +7673,16 @@ components:
             Action type identifier. Use this value as the `action.type` when submitting 
             approval requests and as `action_id` when executing actions.
           example: github.create_issue
+        operation_type:
+          type: string
+          enum:
+            - read
+            - write
+            - delete
+          description: |
+            High-level classification for bulk template setup and grouping in the UI.
+            Derived from verb-based action naming (e.g. list/get → read, create/update → write,
+            delete/cancel → delete) unless overridden in the connector manifest.
         name:
           type: string
           maxLength: 256
@@ -7765,6 +7776,7 @@ components:
               end: end_time
       example:
         action_type: github.create_issue
+        operation_type: write
         name: Create Issue
         description: Create a new issue in a repository
         risk_level: low

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,192 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "default" | "sm";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input bg-background text-foreground",
+        "flex w-full items-center justify-between gap-1 rounded-md border px-2 text-sm shadow-xs",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "[&>span]:min-w-0 [&>span]:truncate",
+        size === "sm" ? "h-8 py-1" : "h-9 py-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground pointer-events-auto",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "relative z-[100] max-h-[--radix-select-content-available-height] min-w-[8rem] origin-[--radix-select-content-transform-origin] overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground",
+        "relative flex w-full cursor-default cursor-pointer select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("-mx-1 my-1 h-px bg-border pointer-events-none", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -113,7 +113,7 @@ function SelectItem({
       data-slot="select-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground",
-        "relative flex w-full cursor-default cursor-pointer select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none",
+        "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none",
         "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}

--- a/frontend/src/pages/agents/connectors/QuickSetupPanel.tsx
+++ b/frontend/src/pages/agents/connectors/QuickSetupPanel.tsx
@@ -1,0 +1,137 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { approvalModeOptions, type ApprovalMode } from "./recommendedTemplatesTypes";
+
+export function QuickSetupPanel({
+  quickRead,
+  quickWrite,
+  quickDelete,
+  onQuickReadChange,
+  onQuickWriteChange,
+  onQuickDeleteChange,
+  onApply,
+  disabled,
+  applyDisabled,
+}: {
+  quickRead: ApprovalMode;
+  quickWrite: ApprovalMode;
+  quickDelete: ApprovalMode;
+  onQuickReadChange: (v: ApprovalMode) => void;
+  onQuickWriteChange: (v: ApprovalMode) => void;
+  onQuickDeleteChange: (v: ApprovalMode) => void;
+  onApply: () => void;
+  disabled: boolean;
+  applyDisabled: boolean;
+}) {
+  return (
+    <div className="bg-muted/40 space-y-3 rounded-lg border border-input p-3">
+      <p className="text-sm font-semibold">Quick setup</p>
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+          <Label
+            htmlFor="quick-read"
+            className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
+          >
+            Read actions
+          </Label>
+          <Select
+            value={quickRead}
+            onValueChange={(v) => onQuickReadChange(v as ApprovalMode)}
+            disabled={disabled}
+          >
+            <SelectTrigger
+              id="quick-read"
+              data-testid="quick-setup-read"
+              size="sm"
+              className="max-w-[11rem] min-w-0 flex-1"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {approvalModeOptions.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+          <Label
+            htmlFor="quick-write"
+            className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
+          >
+            Write actions
+          </Label>
+          <Select
+            value={quickWrite}
+            onValueChange={(v) => onQuickWriteChange(v as ApprovalMode)}
+            disabled={disabled}
+          >
+            <SelectTrigger
+              id="quick-write"
+              data-testid="quick-setup-write"
+              size="sm"
+              className="max-w-[11rem] min-w-0 flex-1"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {approvalModeOptions.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+          <Label
+            htmlFor="quick-delete"
+            className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
+          >
+            Delete actions
+          </Label>
+          <Select
+            value={quickDelete}
+            onValueChange={(v) => onQuickDeleteChange(v as ApprovalMode)}
+            disabled={disabled}
+          >
+            <SelectTrigger
+              id="quick-delete"
+              data-testid="quick-setup-delete"
+              size="sm"
+              className="max-w-[11rem] min-w-0 flex-1"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {approvalModeOptions.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        className="w-full sm:w-auto"
+        onClick={onApply}
+        disabled={disabled || applyDisabled}
+      >
+        Apply
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
+++ b/frontend/src/pages/agents/connectors/RecommendedTemplatesDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
@@ -18,11 +17,15 @@ import { useApplyActionConfigTemplate } from "@/hooks/useApplyActionConfigTempla
 import { useBulkApplyActionConfigTemplates } from "@/hooks/useBulkApplyActionConfigTemplates";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { TemplateParamBadge } from "./TemplatePicker";
-import { cn } from "@/lib/utils";
+import { QuickSetupPanel } from "./QuickSetupPanel";
+import {
+  approvalModeOptions,
+  type ApprovalMode,
+  type OperationTypeUI,
+} from "./recommendedTemplatesTypes";
+import { useRecommendedTemplateSelection } from "./useRecommendedTemplateSelection";
 
-export type ApprovalMode = "auto_approve" | "requires_approval";
-
-export type OperationTypeUI = ConnectorAction["operation_type"];
+export type { ApprovalMode, OperationTypeUI };
 
 export interface RecommendedTemplatesDialogProps {
   open: boolean;
@@ -33,20 +36,11 @@ export interface RecommendedTemplatesDialogProps {
   onCustomize: (template: ActionConfigTemplate, approvalMode: ApprovalMode) => void;
 }
 
-const approvalModeOptions: { label: string; value: ApprovalMode }[] = [
-  { label: "Auto-approve", value: "auto_approve" },
-  { label: "Requires approval", value: "requires_approval" },
-];
-
 const operationSectionTitle: Record<OperationTypeUI, string> = {
   read: "Read actions",
   write: "Write actions",
   delete: "Delete actions",
 };
-
-function defaultApprovalMode(template: ActionConfigTemplate): ApprovalMode {
-  return template.standing_approval != null ? "auto_approve" : "requires_approval";
-}
 
 export function RecommendedTemplatesDialog({
   open,
@@ -62,25 +56,6 @@ export function RecommendedTemplatesDialog({
   const { bulkApply, isBulkPending } = useBulkApplyActionConfigTemplates();
   const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
     null,
-  );
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [approvalModes, setApprovalModes] = useState<Record<string, ApprovalMode>>({});
-
-  const [quickRead, setQuickRead] = useState<ApprovalMode>("auto_approve");
-  const [quickWrite, setQuickWrite] = useState<ApprovalMode>("requires_approval");
-  const [quickDelete, setQuickDelete] = useState<ApprovalMode>("requires_approval");
-
-  const getApprovalMode = useCallback(
-    (template: ActionConfigTemplate): ApprovalMode =>
-      approvalModes[template.id] ?? defaultApprovalMode(template),
-    [approvalModes],
-  );
-
-  const handleApprovalModeChange = useCallback(
-    (templateId: string, mode: ApprovalMode) => {
-      setApprovalModes((prev) => ({ ...prev, [templateId]: mode }));
-    },
-    [],
   );
 
   const actionTypeSet = useMemo(
@@ -114,6 +89,26 @@ export function RecommendedTemplatesDialog({
     () => templates.filter((t) => actionTypeSet.has(t.action_type)),
     [templates, actionTypeSet],
   );
+
+  const {
+    selectedIds,
+    setSelectedIds,
+    getApprovalMode,
+    handleApprovalModeChange,
+    allSelected,
+    toggleSelectAll,
+    toggleSelected,
+    templateIdsForOperation,
+    allSelectedInOperation,
+    toggleSelectOperation,
+    handleQuickApply,
+    quickRead,
+    setQuickRead,
+    quickWrite,
+    setQuickWrite,
+    quickDelete,
+    setQuickDelete,
+  } = useRecommendedTemplateSelection(liveTemplates, getOperationType);
 
   const groupedByOperation = useMemo(() => {
     const opOrder: OperationTypeUI[] = ["read", "write", "delete"];
@@ -158,83 +153,6 @@ export function RecommendedTemplatesDialog({
     }
     return out;
   }, [liveTemplates, actions, actionNameByType, getOperationType]);
-
-  const toggleSelected = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  }, []);
-
-  const allSelected =
-    liveTemplates.length > 0 && selectedIds.size === liveTemplates.length;
-
-  const toggleSelectAll = useCallback(() => {
-    if (allSelected) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
-    }
-  }, [allSelected, liveTemplates]);
-
-  const templateIdsForOperation = useCallback(
-    (op: OperationTypeUI) =>
-      liveTemplates.filter((t) => getOperationType(t) === op).map((t) => t.id),
-    [liveTemplates, getOperationType],
-  );
-
-  const allSelectedInOperation = useCallback(
-    (op: OperationTypeUI) => {
-      const ids = templateIdsForOperation(op);
-      return (
-        ids.length > 0 && ids.every((id) => selectedIds.has(id))
-      );
-    },
-    [templateIdsForOperation, selectedIds],
-  );
-
-  const toggleSelectOperation = useCallback(
-    (op: OperationTypeUI) => {
-      const ids = templateIdsForOperation(op);
-      const allOn = ids.length > 0 && ids.every((id) => selectedIds.has(id));
-      setSelectedIds((prev) => {
-        const next = new Set(prev);
-        if (allOn) {
-          for (const id of ids) {
-            next.delete(id);
-          }
-        } else {
-          for (const id of ids) {
-            next.add(id);
-          }
-        }
-        return next;
-      });
-    },
-    [templateIdsForOperation],
-  );
-
-  const handleQuickApply = useCallback(() => {
-    setApprovalModes((prev) => {
-      const next = { ...prev };
-      for (const t of liveTemplates) {
-        const op = getOperationType(t);
-        next[t.id] =
-          op === "read"
-            ? quickRead
-            : op === "write"
-              ? quickWrite
-              : quickDelete;
-      }
-      return next;
-    });
-    setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
-  }, [liveTemplates, getOperationType, quickRead, quickWrite, quickDelete]);
 
   async function handleUseTemplate(template: ActionConfigTemplate) {
     const approvalMode = getApprovalMode(template);
@@ -315,13 +233,6 @@ export function RecommendedTemplatesDialog({
 
   const anyPending = isPending || isBulkPending;
 
-  const selectClassName = cn(
-    "border-input bg-background text-foreground",
-    "h-9 max-w-[11rem] min-w-0 flex-1 rounded-md border px-2 text-sm shadow-xs",
-    "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
-    "disabled:cursor-not-allowed disabled:opacity-50",
-  );
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[85dvh] flex-col sm:max-w-lg">
@@ -351,90 +262,17 @@ export function RecommendedTemplatesDialog({
           </p>
         ) : (
           <>
-            <div className="bg-muted/40 space-y-3 rounded-lg border border-input p-3">
-              <p className="text-sm font-semibold">Quick setup</p>
-              <div className="space-y-2">
-                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-                  <Label
-                    htmlFor="quick-read"
-                    className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
-                  >
-                    Read actions
-                  </Label>
-                  <select
-                    id="quick-read"
-                    className={selectClassName}
-                    value={quickRead}
-                    onChange={(e) =>
-                      setQuickRead(e.target.value as ApprovalMode)
-                    }
-                    disabled={anyPending}
-                  >
-                    {approvalModeOptions.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-                  <Label
-                    htmlFor="quick-write"
-                    className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
-                  >
-                    Write actions
-                  </Label>
-                  <select
-                    id="quick-write"
-                    className={selectClassName}
-                    value={quickWrite}
-                    onChange={(e) =>
-                      setQuickWrite(e.target.value as ApprovalMode)
-                    }
-                    disabled={anyPending}
-                  >
-                    {approvalModeOptions.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-                  <Label
-                    htmlFor="quick-delete"
-                    className="text-muted-foreground w-28 shrink-0 text-xs sm:text-sm"
-                  >
-                    Delete actions
-                  </Label>
-                  <select
-                    id="quick-delete"
-                    className={selectClassName}
-                    value={quickDelete}
-                    onChange={(e) =>
-                      setQuickDelete(e.target.value as ApprovalMode)
-                    }
-                    disabled={anyPending}
-                  >
-                    {approvalModeOptions.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary"
-                className="w-full sm:w-auto"
-                onClick={handleQuickApply}
-                disabled={anyPending || liveTemplates.length === 0}
-              >
-                Apply
-              </Button>
-            </div>
+            <QuickSetupPanel
+              quickRead={quickRead}
+              quickWrite={quickWrite}
+              quickDelete={quickDelete}
+              onQuickReadChange={setQuickRead}
+              onQuickWriteChange={setQuickWrite}
+              onQuickDeleteChange={setQuickDelete}
+              onApply={handleQuickApply}
+              disabled={anyPending}
+              applyDisabled={liveTemplates.length === 0}
+            />
 
             <label className="flex items-center gap-2 py-1">
               <Checkbox
@@ -609,3 +447,4 @@ function RecommendedTemplateCard({
     </div>
   );
 }
+

--- a/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
@@ -32,6 +32,67 @@ const actions: ConnectorAction[] = [
     risk_level: "high",
     requires_payment_method: false,
     parameters_schema: {},
+  },
+];
+
+const mixedActions: ConnectorAction[] = [
+  {
+    action_type: "github.list_repos",
+    operation_type: "read",
+    name: "List Repos",
+    description: "",
+    risk_level: "low",
+    requires_payment_method: false,
+    parameters_schema: {},
+  },
+  {
+    action_type: "github.create_issue",
+    operation_type: "write",
+    name: "Create Issue",
+    description: "",
+    risk_level: "low",
+    requires_payment_method: false,
+    parameters_schema: {},
+  },
+  {
+    action_type: "github.close_issue",
+    operation_type: "delete",
+    name: "Close Issue",
+    description: "",
+    risk_level: "medium",
+    requires_payment_method: false,
+    parameters_schema: {},
+  },
+];
+
+const mixedTemplates = [
+  {
+    id: "tpl_read",
+    connector_id: "github",
+    action_type: "github.list_repos",
+    name: "List all",
+    description: "R",
+    parameters: {},
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "tpl_a",
+    connector_id: "github",
+    action_type: "github.create_issue",
+    name: "All open",
+    description: "Desc A",
+    parameters: { repo: "*", title: "*" },
+    standing_approval: { duration_days: 30 },
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "tpl_del",
+    connector_id: "github",
+    action_type: "github.close_issue",
+    name: "Close stale",
+    description: "D",
+    parameters: {},
+    created_at: "2026-01-01T00:00:00Z",
   },
 ];
 
@@ -72,6 +133,7 @@ describe("RecommendedTemplatesDialog", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
     resetClientMocks();
     setupAuthMocks({ authenticated: true });
     wrapper = createAuthWrapper();
@@ -88,15 +150,42 @@ describe("RecommendedTemplatesDialog", () => {
     props: Partial<{
       open: boolean;
       onOpenChange: (open: boolean) => void;
+      actions: ConnectorAction[];
     }> = {},
   ) {
+    return render(
+      <RecommendedTemplatesDialog
+        open
+        onOpenChange={vi.fn()}
+        agentId={42}
+        connectorId="github"
+        onCustomize={onCustomize}
+        {...props}
+        actions={props.actions ?? actions}
+      />,
+      { wrapper },
+    );
+  }
+
+  function renderMixedDialog(
+    props: Partial<{
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+    }> = {},
+  ) {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({ data: { data: mixedTemplates } });
+      }
+      return Promise.resolve({ data: null });
+    });
     return render(
       <RecommendedTemplatesDialog
         open
         onOpenChange={props.onOpenChange ?? vi.fn()}
         agentId={42}
         connectorId="github"
-        actions={actions}
+        actions={mixedActions}
         onCustomize={onCustomize}
         {...props}
       />,
@@ -108,7 +197,7 @@ describe("RecommendedTemplatesDialog", () => {
     renderDialog();
 
     await waitFor(() => {
-      expect(screen.getByText("Create Issue")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Write actions" })).toBeInTheDocument();
     });
 
     const headings = screen.getAllByRole("heading", { level: 3 });
@@ -479,5 +568,148 @@ describe("RecommendedTemplatesDialog", () => {
       { body: { agent_id: number; approval_mode: string } },
     ];
     expect(opts.body.approval_mode).toBe("requires_approval");
+  });
+
+  it("renders Read / Write / Delete section headings when operation types differ", async () => {
+    renderMixedDialog();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Read actions" })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("heading", { name: "Write actions" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Delete actions" })).toBeInTheDocument();
+  });
+
+  it("shows a single operation section when the connector has one operation type only", async () => {
+    const readOnlyActions: ConnectorAction[] = [
+      {
+        action_type: "github.list_repos",
+        operation_type: "read",
+        name: "List Repos",
+        description: "",
+        risk_level: "low",
+        requires_payment_method: false,
+        parameters_schema: {},
+      },
+    ];
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/action-config-templates") {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: "tpl_read",
+                connector_id: "github",
+                action_type: "github.list_repos",
+                name: "List all",
+                description: "",
+                parameters: {},
+                created_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+
+    renderDialog({ actions: readOnlyActions });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Read actions" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("heading", { name: "Write actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Delete actions" })).not.toBeInTheDocument();
+  });
+
+  it("Quick setup Apply sets approval modes per operation and selects all templates", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({
+      data: {
+        results: [
+          { template_id: "tpl_read", success: true },
+          { template_id: "tpl_a", success: true },
+          { template_id: "tpl_del", success: true },
+        ],
+      },
+    });
+
+    renderMixedDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("List all")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("quick-setup-read"));
+    fireEvent.click(await screen.findByRole("option", { name: "Requires approval" }));
+
+    fireEvent.click(screen.getByTestId("quick-setup-write"));
+    fireEvent.click(await screen.findByRole("option", { name: "Auto-approve" }));
+
+    fireEvent.click(screen.getByTestId("quick-setup-delete"));
+    fireEvent.click(await screen.findByRole("option", { name: "Requires approval" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      const readCard = screen.getByText("List all").closest(".rounded-lg")!;
+      expect(
+        within(readCard as HTMLElement).getByRole("radio", { name: "Requires approval" }),
+      ).toHaveAttribute("aria-checked", "true");
+    });
+
+    const writeCard = screen.getByText("All open").closest(".rounded-lg")!;
+    expect(
+      within(writeCard as HTMLElement).getByRole("radio", { name: "Auto-approve" }),
+    ).toHaveAttribute("aria-checked", "true");
+
+    const delCard = screen.getByText("Close stale").closest(".rounded-lg")!;
+    expect(
+      within(delCard as HTMLElement).getByRole("radio", { name: "Requires approval" }),
+    ).toHaveAttribute("aria-checked", "true");
+
+    expect(screen.getByText("3 of 3 selected")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Enable Selected (3)" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+    const [, bulkOpts] = mockPost.mock.calls[0] as [
+      string,
+      {
+        body: {
+          agent_id: number;
+          template_ids: string[];
+          approval_modes: Record<string, string>;
+        };
+      },
+    ];
+    expect(bulkOpts.body.template_ids).toEqual(["tpl_read", "tpl_a", "tpl_del"]);
+    expect(bulkOpts.body.approval_modes).toEqual({
+      tpl_read: "requires_approval",
+      tpl_a: "auto_approve",
+      tpl_del: "requires_approval",
+    });
+  });
+
+  it("Select all in section toggles only that section's templates", async () => {
+    const user = userEvent.setup();
+    renderMixedDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("List all")).toBeInTheDocument();
+    });
+
+    const writeSection = screen.getByRole("heading", { name: "Write actions" }).closest("section")!;
+    const writeSelectAll = within(writeSection as HTMLElement).getByRole("checkbox", {
+      name: /Select all in section/,
+    });
+    await user.click(writeSelectAll);
+
+    expect(screen.getByText("1 of 3 selected")).toBeInTheDocument();
+
+    await user.click(writeSelectAll);
+    expect(screen.getByText("0 of 3 selected")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
@@ -647,7 +647,7 @@ describe("RecommendedTemplatesDialog", () => {
     fireEvent.click(await screen.findByRole("option", { name: "Auto-approve" }));
 
     fireEvent.click(screen.getByTestId("quick-setup-delete"));
-    fireEvent.click(await screen.findByRole("option", { name: "Requires approval" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Auto-approve" }));
 
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
@@ -665,7 +665,7 @@ describe("RecommendedTemplatesDialog", () => {
 
     const delCard = screen.getByText("Close stale").closest(".rounded-lg")!;
     expect(
-      within(delCard as HTMLElement).getByRole("radio", { name: "Requires approval" }),
+      within(delCard as HTMLElement).getByRole("radio", { name: "Auto-approve" }),
     ).toHaveAttribute("aria-checked", "true");
 
     expect(screen.getByText("3 of 3 selected")).toBeInTheDocument();
@@ -689,7 +689,7 @@ describe("RecommendedTemplatesDialog", () => {
     expect(bulkOpts.body.approval_modes).toEqual({
       tpl_read: "requires_approval",
       tpl_a: "auto_approve",
-      tpl_del: "requires_approval",
+      tpl_del: "auto_approve",
     });
   });
 

--- a/frontend/src/pages/agents/connectors/recommendedTemplatesTypes.ts
+++ b/frontend/src/pages/agents/connectors/recommendedTemplatesTypes.ts
@@ -1,0 +1,10 @@
+import type { ConnectorAction } from "@/hooks/useConnectorDetail";
+
+export type ApprovalMode = "auto_approve" | "requires_approval";
+
+export type OperationTypeUI = ConnectorAction["operation_type"];
+
+export const approvalModeOptions: { label: string; value: ApprovalMode }[] = [
+  { label: "Auto-approve", value: "auto_approve" },
+  { label: "Requires approval", value: "requires_approval" },
+];

--- a/frontend/src/pages/agents/connectors/useRecommendedTemplateSelection.ts
+++ b/frontend/src/pages/agents/connectors/useRecommendedTemplateSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ApprovalMode, OperationTypeUI } from "./recommendedTemplatesTypes";
 
@@ -103,44 +103,24 @@ export function useRecommendedTemplateSelection(
     setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
   }, [liveTemplates, getOperationType, quickRead, quickWrite, quickDelete]);
 
-  const selection = useMemo(
-    () => ({
-      selectedIds,
-      setSelectedIds,
-      approvalModes,
-      getApprovalMode,
-      handleApprovalModeChange,
-      allSelected,
-      toggleSelectAll,
-      toggleSelected,
-      templateIdsForOperation,
-      allSelectedInOperation,
-      toggleSelectOperation,
-      handleQuickApply,
-      quickRead,
-      setQuickRead,
-      quickWrite,
-      setQuickWrite,
-      quickDelete,
-      setQuickDelete,
-    }),
-    [
-      selectedIds,
-      approvalModes,
-      getApprovalMode,
-      handleApprovalModeChange,
-      allSelected,
-      toggleSelectAll,
-      toggleSelected,
-      templateIdsForOperation,
-      allSelectedInOperation,
-      toggleSelectOperation,
-      handleQuickApply,
-      quickRead,
-      quickWrite,
-      quickDelete,
-    ],
-  );
-
-  return selection;
+  return {
+    selectedIds,
+    setSelectedIds,
+    approvalModes,
+    getApprovalMode,
+    handleApprovalModeChange,
+    allSelected,
+    toggleSelectAll,
+    toggleSelected,
+    templateIdsForOperation,
+    allSelectedInOperation,
+    toggleSelectOperation,
+    handleQuickApply,
+    quickRead,
+    setQuickRead,
+    quickWrite,
+    setQuickWrite,
+    quickDelete,
+    setQuickDelete,
+  };
 }

--- a/frontend/src/pages/agents/connectors/useRecommendedTemplateSelection.ts
+++ b/frontend/src/pages/agents/connectors/useRecommendedTemplateSelection.ts
@@ -1,0 +1,146 @@
+import { useCallback, useMemo, useState } from "react";
+import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
+import type { ApprovalMode, OperationTypeUI } from "./recommendedTemplatesTypes";
+
+export function useRecommendedTemplateSelection(
+  liveTemplates: ActionConfigTemplate[],
+  getOperationType: (template: ActionConfigTemplate) => OperationTypeUI,
+) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [approvalModes, setApprovalModes] = useState<Record<string, ApprovalMode>>({});
+
+  const [quickRead, setQuickRead] = useState<ApprovalMode>("auto_approve");
+  const [quickWrite, setQuickWrite] = useState<ApprovalMode>("requires_approval");
+  const [quickDelete, setQuickDelete] = useState<ApprovalMode>("requires_approval");
+
+  const getApprovalMode = useCallback(
+    (template: ActionConfigTemplate): ApprovalMode =>
+      approvalModes[template.id] ??
+      (template.standing_approval != null ? "auto_approve" : "requires_approval"),
+    [approvalModes],
+  );
+
+  const handleApprovalModeChange = useCallback(
+    (templateId: string, mode: ApprovalMode) => {
+      setApprovalModes((prev) => ({ ...prev, [templateId]: mode }));
+    },
+    [],
+  );
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const allSelected =
+    liveTemplates.length > 0 && selectedIds.size === liveTemplates.length;
+
+  const toggleSelectAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
+    }
+  }, [allSelected, liveTemplates]);
+
+  const templateIdsForOperation = useCallback(
+    (op: OperationTypeUI) =>
+      liveTemplates.filter((t) => getOperationType(t) === op).map((t) => t.id),
+    [liveTemplates, getOperationType],
+  );
+
+  const allSelectedInOperation = useCallback(
+    (op: OperationTypeUI) => {
+      const ids = templateIdsForOperation(op);
+      return ids.length > 0 && ids.every((id) => selectedIds.has(id));
+    },
+    [templateIdsForOperation, selectedIds],
+  );
+
+  const toggleSelectOperation = useCallback(
+    (op: OperationTypeUI) => {
+      const ids = templateIdsForOperation(op);
+      const allOn =
+        ids.length > 0 && ids.every((id) => selectedIds.has(id));
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (allOn) {
+          for (const id of ids) {
+            next.delete(id);
+          }
+        } else {
+          for (const id of ids) {
+            next.add(id);
+          }
+        }
+        return next;
+      });
+    },
+    [templateIdsForOperation, selectedIds],
+  );
+
+  const handleQuickApply = useCallback(() => {
+    setApprovalModes((prev) => {
+      const next = { ...prev };
+      for (const t of liveTemplates) {
+        const op = getOperationType(t);
+        next[t.id] =
+          op === "read"
+            ? quickRead
+            : op === "write"
+              ? quickWrite
+              : quickDelete;
+      }
+      return next;
+    });
+    setSelectedIds(new Set(liveTemplates.map((t) => t.id)));
+  }, [liveTemplates, getOperationType, quickRead, quickWrite, quickDelete]);
+
+  const selection = useMemo(
+    () => ({
+      selectedIds,
+      setSelectedIds,
+      approvalModes,
+      getApprovalMode,
+      handleApprovalModeChange,
+      allSelected,
+      toggleSelectAll,
+      toggleSelected,
+      templateIdsForOperation,
+      allSelectedInOperation,
+      toggleSelectOperation,
+      handleQuickApply,
+      quickRead,
+      setQuickRead,
+      quickWrite,
+      setQuickWrite,
+      quickDelete,
+      setQuickDelete,
+    }),
+    [
+      selectedIds,
+      approvalModes,
+      getApprovalMode,
+      handleApprovalModeChange,
+      allSelected,
+      toggleSelectAll,
+      toggleSelected,
+      templateIdsForOperation,
+      allSelectedInOperation,
+      toggleSelectOperation,
+      handleQuickApply,
+      quickRead,
+      quickWrite,
+      quickDelete,
+    ],
+  );
+
+  return selection;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [GitHub issue #927](https://github.com/supersuit-tech/permission-slip/issues/927) (follow-up from bulk template approval / `operation_type` work).

- **Bug:** `toggleSelectOperation` now depends on `selectedIds` so the per-section “select all” checkbox cannot use a stale snapshot when toggling quickly.
- **Tests:** Expanded `RecommendedTemplatesDialog` coverage for Read/Write/Delete headings, Quick setup Apply (per-operation modes + select all), single-operation-type connectors, and per-section select-all. Tests polyfill `scrollIntoView` for Radix Select in jsdom.
- **Data:** New migration backfills `connector_actions.operation_type` from `action_type` suffix segments (aligned with Go `InferOperationType` rules).
- **API copy:** `frontend/src/api/bundled.yaml` `ConnectorAction` now includes `operation_type` to match the canonical OpenAPI bundle.
- **UI:** Quick setup uses a new shadcn-style Radix `Select` (`@radix-ui/react-select` + `frontend/src/components/ui/select.tsx`). Quick setup state lives in `useRecommendedTemplateSelection`; the panel is `QuickSetupPanel`.
- **Go:** Removed unreachable `price_check` read-verb entry; documented why destructive-sounding verbs map to “delete” for bulk UX.

Closes #927

### Developer

- [x] Fix stale closure in `toggleSelectOperation`
- [x] Add tests with mixed `operation_type` fixtures
- [x] Add SQL backfill migration for existing rows
- [x] Sync `frontend/src/api/bundled.yaml` `ConnectorAction` with `operation_type`
- [x] Replace native `<select>` with Radix Select wrapper
- [x] Extract Quick setup into hook + panel component

### Manual Testing

- [ ] Open Recommended Templates for a connector with read, write, and delete actions — verify grouping and section headers
- [ ] Use Quick setup (different approval modes per type), Apply, then toggle per-section select-all — confirm expected selection behavior
- [ ] After migrations, confirm actions show sensible `operation_type` without re-seeding (spot-check a few `action_type` patterns)

### Test plan

- `make test-frontend` (passes)
- Targeted Go test: `go test` on `operation_type.go` + `operation_type_test.go` (passes)
- `make build` could not be completed in this agent environment: `GOPROXY=off` blocks module fetch; with proxy enabled the toolchain reports `cloud.google.com/go/bigquery` requires Go 1.25+ while the runner has Go 1.22. CI should validate the full `go build` on the supported toolchain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30550317-3aeb-4f42-ae57-663d645224ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30550317-3aeb-4f42-ae57-663d645224ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

