### PR TITLE
CLI: persist default server URL in config (closes #933)

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -89,7 +89,7 @@ export class ApiClient {
     if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
       throw new Error(
         `Server URL must use http or https (got ${parsed.protocol}). ` +
-        "Check the --server flag.",
+        "Check --server, PS_SERVER, or config default_server.",
       );
     }
     this.base = normalizeBase(opts.serverUrl);

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -7,6 +7,7 @@
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
 import { resolveAgentId } from "./status.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 
 export function capabilitiesCommand(program: Command): void {
@@ -15,20 +16,20 @@ export function capabilitiesCommand(program: Command): void {
     .description("List available action configurations and standing approvals")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
-      server: string;
+      server?: string;
       agentId?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
-        const agentId = resolveAgentId(opts.server, opts.agentId);
-        const client = new ApiClient({ serverUrl: opts.server, agentId });
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
+        const agentId = resolveAgentId(server, opts.agentId);
+        const client = new ApiClient({ serverUrl: server, agentId });
         const result = await client.capabilities(agentId);
         output(result, outputOpts);
       } catch (err) {

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -52,7 +52,12 @@ export function configCommand(program: Command): void {
         if (key === "default_server") {
           saveConfig({ default_server: value.trim() });
         }
-        output({ ok: true, key, value: value.trim() }, outputOpts);
+        const saved = loadConfig();
+        const persisted =
+          key === "default_server"
+            ? (saved.default_server ?? value.trim())
+            : value.trim();
+        output({ ok: true, key, value: persisted }, outputOpts);
       } catch (err) {
         output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
         process.exit(1);

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,7 +1,9 @@
 /**
  * permission-slip config [--server <url>]
+ * permission-slip config set <key> <value>
+ * permission-slip config unset <key>
  *
- * Shows all saved registrations or the registration for a specific server.
+ * Shows saved configuration and registrations, or updates ~/.permission-slip/config.json.
  */
 
 import type { Command } from "commander";
@@ -9,33 +11,94 @@ import {
   loadRegistrations,
   findRegistration,
   CONFIG_DIR,
+  CONFIG_FILE,
   REGISTRATIONS_FILE,
+  loadConfig,
+  saveConfig,
+  unsetConfigKey,
   PRIVATE_KEY_FILE,
   PUBLIC_KEY_FILE,
 } from "../config/store.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { keyPairExists } from "../auth/keys.js";
 import { output, type OutputOptions } from "../output.js";
 
+const CONFIG_KEYS = ["default_server"] as const;
+type ConfigKey = (typeof CONFIG_KEYS)[number];
+
+function assertConfigKey(key: string): asserts key is ConfigKey {
+  if (!CONFIG_KEYS.includes(key as ConfigKey)) {
+    throw new Error(
+      `Unknown config key: ${key}. Supported keys: ${CONFIG_KEYS.join(", ")}`,
+    );
+  }
+}
+
 export function configCommand(program: Command): void {
-  program
+  const configCmd = program
     .command("config")
-    .description("Show saved configuration and registrations")
+    .description("Show or update saved configuration and registrations");
+
+  configCmd
+    .command("set")
+    .description("Persist a preference (e.g. default_server for the API URL)")
+    .argument("<key>", `Preference key (${CONFIG_KEYS.join(", ")})`)
+    .argument("<value>", "Value to store")
+    .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
+    .action((key: string, value: string, cmdOpts: { pretty?: boolean }) => {
+      const outputOpts: OutputOptions = { pretty: cmdOpts.pretty ?? false };
+      try {
+        assertConfigKey(key);
+        if (key === "default_server") {
+          saveConfig({ default_server: value.trim() });
+        }
+        output({ ok: true, key, value: value.trim() }, outputOpts);
+      } catch (err) {
+        output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
+        process.exit(1);
+      }
+    });
+
+  configCmd
+    .command("unset")
+    .description("Remove a preference (reverts to built-in defaults / env)")
+    .argument("<key>", `Preference key (${CONFIG_KEYS.join(", ")})`)
+    .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
+    .action((key: string, cmdOpts: { pretty?: boolean }) => {
+      const outputOpts: OutputOptions = { pretty: cmdOpts.pretty ?? false };
+      try {
+        assertConfigKey(key);
+        unsetConfigKey(key);
+        output({ ok: true, key }, outputOpts);
+      } catch (err) {
+        output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
+        process.exit(1);
+      }
+    });
+
+  configCmd
     .option("--server <url>", "Show registration for a specific server only")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action((opts: { server?: string; pretty?: boolean }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
+        const resolved = resolveServerUrl({});
+        const regForServer = opts.server ? findRegistration(opts.server) : undefined;
         const data = {
           config_dir: CONFIG_DIR,
+          preferences_file: CONFIG_FILE,
+          preferences: loadConfig(),
+          default_server: {
+            resolved: resolved.url,
+            source: resolved.source,
+          },
           registrations_file: REGISTRATIONS_FILE,
           key: {
             private_key_file: PRIVATE_KEY_FILE,
             public_key_file: PUBLIC_KEY_FILE,
             exists: keyPairExists(),
           },
-          registrations: opts.server
-            ? (findRegistration(opts.server) ? [findRegistration(opts.server)] : [])
-            : loadRegistrations(),
+          registrations: opts.server ? (regForServer ? [regForServer] : []) : loadRegistrations(),
         };
         output(data, outputOpts);
       } catch (err) {

--- a/cli/src/commands/connectors.ts
+++ b/cli/src/commands/connectors.ts
@@ -7,6 +7,7 @@
 
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 
 export function connectorsCommand(program: Command): void {
@@ -15,20 +16,20 @@ export function connectorsCommand(program: Command): void {
     .description("List available connectors (public — no registration required)")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--id <connector_id>", "Get details for a specific connector")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
-      server: string;
+      server?: string;
       id?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
         const client = new ApiClient({
-          serverUrl: opts.server,
+          serverUrl: server,
           agentId: 0, // unused for public endpoints
         });
         const result = opts.id

--- a/cli/src/commands/register.ts
+++ b/cli/src/commands/register.ts
@@ -15,6 +15,7 @@ import { generateKeyPair, keyPairExists, displayPath } from "../auth/keys.js";
 import { ApiClient } from "../api/client.js";
 import { REGISTRATION_AGENT_ID } from "../auth/signing.js";
 import { saveRegistration } from "../config/store.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
 
@@ -25,21 +26,21 @@ export function registerCommand(program: Command): void {
     .requiredOption("--invite-code <code>", "Invite code from the dashboard")
     .option(
       "--server <url>",
-      "Permission Slip server URL (default: https://app.permissionslip.dev)",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--name <name>", "Agent name shown in the dashboard", "Agent")
     .option("--version <version>", "Agent version metadata", "1.0.0")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       inviteCode: string;
-      server: string;
+      server?: string;
       name: string;
       version: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
         // Key generation
         const hadKey = keyPairExists();
         const kp = generateKeyPair(false);
@@ -56,7 +57,7 @@ export function registerCommand(program: Command): void {
 
         // Register
         const client = new ApiClient({
-          serverUrl: opts.server,
+          serverUrl: server,
           agentId: REGISTRATION_AGENT_ID,
         });
 
@@ -69,7 +70,7 @@ export function registerCommand(program: Command): void {
 
         // Save a partial registration (will be completed after verify)
         saveRegistration({
-          server: opts.server,
+          server,
           agent_id: result.agent_id,
           registered_at: new Date().toISOString(),
         });
@@ -80,7 +81,7 @@ export function registerCommand(program: Command): void {
             expires_at: result.expires_at,
             verification_required: result.verification_required,
             key_file: displayPath(kp.privateKeyFile),
-            next_step: `Run: permission-slip verify --code <confirmation_code> --server ${shellQuote(opts.server)}`,
+            next_step: `Run: permission-slip verify --code <confirmation_code> --server ${shellQuote(server)}`,
           },
           outputOpts,
         );

--- a/cli/src/commands/register.ts
+++ b/cli/src/commands/register.ts
@@ -15,7 +15,7 @@ import { generateKeyPair, keyPairExists, displayPath } from "../auth/keys.js";
 import { ApiClient } from "../api/client.js";
 import { REGISTRATION_AGENT_ID } from "../auth/signing.js";
 import { saveRegistration } from "../config/store.js";
-import { resolveServerUrl } from "../config/serverUrl.js";
+import { resolveServerUrl, isBuiltInDefaultServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
 
@@ -81,7 +81,11 @@ export function registerCommand(program: Command): void {
             expires_at: result.expires_at,
             verification_required: result.verification_required,
             key_file: displayPath(kp.privateKeyFile),
-            next_step: `Run: permission-slip verify --code <confirmation_code> --server ${shellQuote(server)}`,
+            next_step:
+              `Run: permission-slip verify --code <confirmation_code>` +
+              (!isBuiltInDefaultServerUrl(server)
+                ? ` --server ${shellQuote(server)}`
+                : ""),
           },
           outputOpts,
         );

--- a/cli/src/commands/request-status.ts
+++ b/cli/src/commands/request-status.ts
@@ -10,6 +10,7 @@
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
 import { resolveAgentId } from "./status.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 
 export function requestStatusCommand(program: Command): void {
@@ -19,21 +20,21 @@ export function requestStatusCommand(program: Command): void {
     .requiredOption("--approval-id <id>", "Approval ID returned by the request command")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       approvalId: string;
-      server: string;
+      server?: string;
       agentId?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
-        const agentId = resolveAgentId(opts.server, opts.agentId);
-        const client = new ApiClient({ serverUrl: opts.server, agentId });
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
+        const agentId = resolveAgentId(server, opts.agentId);
+        const client = new ApiClient({ serverUrl: server, agentId });
 
         const result = await client.approvalStatus(opts.approvalId);
         output(result, outputOpts);

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -10,6 +10,7 @@
 import type { Command } from "commander";
 import { ApiClient, PermissionSlipApiError } from "../api/client.js";
 import { resolveAgentId } from "./status.js";
+import { resolveServerUrl, isBuiltInDefaultServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
 
@@ -23,8 +24,7 @@ export function requestCommand(program: Command): void {
     .option("--risk-level <level>", "Risk level: low, medium, high")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--request-id <id>", "Idempotency key — reuse across retries to prevent duplicate execution")
@@ -36,7 +36,7 @@ export function requestCommand(program: Command): void {
       params: string;
       description?: string;
       riskLevel?: string;
-      server: string;
+      server?: string;
       agentId?: string;
       requestId?: string;
       paymentMethodId?: string;
@@ -45,6 +45,7 @@ export function requestCommand(program: Command): void {
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
         let params: unknown;
         try {
           params = JSON.parse(opts.params);
@@ -52,8 +53,8 @@ export function requestCommand(program: Command): void {
           throw new Error(`--params must be valid JSON. Got: ${opts.params}`);
         }
 
-        const agentId = resolveAgentId(opts.server, opts.agentId);
-        const client = new ApiClient({ serverUrl: opts.server, agentId });
+        const agentId = resolveAgentId(server, opts.agentId);
+        const client = new ApiClient({ serverUrl: server, agentId });
 
         const context =
           opts.description || opts.riskLevel
@@ -83,7 +84,7 @@ export function requestCommand(program: Command): void {
               next_step:
                 "Approval requested. To check the result, run: " +
                 `permission-slip status ${shellQuote(result.approval_id ?? "")}` +
-                (opts.server !== "https://app.permissionslip.dev" ? ` --server ${shellQuote(opts.server)}` : ""),
+                (!isBuiltInDefaultServerUrl(server) ? ` --server ${shellQuote(server)}` : ""),
             },
             outputOpts,
           );

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -9,6 +9,7 @@
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
 import { findRegistration } from "../config/store.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 
 export function statusCommand(program: Command): void {
@@ -18,20 +19,20 @@ export function statusCommand(program: Command): void {
     .argument("[approval_id]", "Approval ID to check (omit for registration status)")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (approvalId: string | undefined, opts: {
-      server: string;
+      server?: string;
       agentId?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
-        const agentId = resolveAgentId(opts.server, opts.agentId);
-        const client = new ApiClient({ serverUrl: opts.server, agentId });
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
+        const agentId = resolveAgentId(server, opts.agentId);
+        const client = new ApiClient({ serverUrl: server, agentId });
 
         if (!approvalId) {
           // No approval_id: show registration state.

--- a/cli/src/commands/verify.ts
+++ b/cli/src/commands/verify.ts
@@ -8,6 +8,7 @@
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
 import { findRegistration, saveRegistration } from "../config/store.js";
+import { resolveServerUrl, isBuiltInDefaultServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
 
@@ -18,19 +19,19 @@ export function verifyCommand(program: Command): void {
     .requiredOption("--code <confirmation_code>", "Confirmation code from the dashboard")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       code: string;
-      server: string;
+      server?: string;
       agentId?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
         let agentId: number;
         if (opts.agentId) {
           agentId = parseInt(opts.agentId, 10);
@@ -38,10 +39,10 @@ export function verifyCommand(program: Command): void {
             throw new Error(`Invalid agent ID: ${opts.agentId}`);
           }
         } else {
-          const reg = findRegistration(opts.server);
+          const reg = findRegistration(server);
           if (!reg) {
             throw new Error(
-              `No registration found for ${opts.server}. ` +
+              `No registration found for ${server}. ` +
               "Run 'permission-slip register --invite-code <code>' first, " +
               "or pass --agent-id explicitly.",
             );
@@ -49,12 +50,12 @@ export function verifyCommand(program: Command): void {
           agentId = reg.agent_id;
         }
 
-        const client = new ApiClient({ serverUrl: opts.server, agentId });
+        const client = new ApiClient({ serverUrl: server, agentId });
         const result = await client.verify(agentId, opts.code);
 
         // Update the registration with the confirmed timestamp
         saveRegistration({
-          server: opts.server,
+          server,
           agent_id: agentId,
           registered_at: result.registered_at,
         });
@@ -64,9 +65,9 @@ export function verifyCommand(program: Command): void {
             status: result.status,
             agent_id: agentId,
             registered_at: result.registered_at,
-            next_step: opts.server === "https://app.permissionslip.dev"
+            next_step: isBuiltInDefaultServerUrl(server)
               ? "Run: permission-slip capabilities"
-              : `Run: permission-slip capabilities --server ${shellQuote(opts.server)}`,
+              : `Run: permission-slip capabilities --server ${shellQuote(server)}`,
           },
           outputOpts,
         );

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -7,6 +7,7 @@
 import type { Command } from "commander";
 import { ApiClient } from "../api/client.js";
 import { loadRegistrations, findRegistration } from "../config/store.js";
+import { resolveServerUrl } from "../config/serverUrl.js";
 import { keyPairExists, readPublicKey } from "../auth/keys.js";
 import { output, type OutputOptions } from "../output.js";
 
@@ -16,18 +17,18 @@ export function whoamiCommand(program: Command): void {
     .description("Show agent identity and registration info")
     .option(
       "--server <url>",
-      "Permission Slip server URL",
-      "https://app.permissionslip.dev",
+      "Permission Slip server URL (overrides PS_SERVER and config default_server)",
     )
     .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
-      server: string;
+      server?: string;
       agentId?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
       try {
+        const { url: server } = resolveServerUrl({ serverFlag: opts.server });
         const hasKey = keyPairExists();
         let publicKey: string | null = null;
         if (hasKey) {
@@ -39,7 +40,7 @@ export function whoamiCommand(program: Command): void {
         }
 
         const registrations = loadRegistrations();
-        const reg = findRegistration(opts.server);
+        const reg = findRegistration(server);
         let agentId: number | undefined;
         if (opts.agentId) {
           agentId = parseInt(opts.agentId, 10);
@@ -50,7 +51,7 @@ export function whoamiCommand(program: Command): void {
         let liveStatus: unknown = null;
         if (agentId !== undefined) {
           try {
-            const client = new ApiClient({ serverUrl: opts.server, agentId });
+            const client = new ApiClient({ serverUrl: server, agentId });
             liveStatus = await client.status();
           } catch {
             liveStatus = null;
@@ -62,7 +63,7 @@ export function whoamiCommand(program: Command): void {
             key: { exists: hasKey, public_key: publicKey },
             registrations,
             current_server: {
-              server: opts.server,
+              server,
               registration: reg ?? null,
               live_status: liveStatus,
             },

--- a/cli/src/config/serverUrl.ts
+++ b/cli/src/config/serverUrl.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolves the Permission Slip server URL from flag, env, config file, or built-in default.
+ * Precedence: --server > PS_SERVER > config.json default_server > built-in.
+ */
+
+import { loadConfig } from "./store.js";
+
+export const BUILT_IN_DEFAULT_SERVER = "https://app.permissionslip.dev";
+
+export type ServerUrlSource = "flag" | "env" | "config" | "built-in";
+
+export interface ResolvedServerUrl {
+  url: string;
+  source: ServerUrlSource;
+}
+
+export function resolveServerUrl(opts: { serverFlag?: string }): ResolvedServerUrl {
+  if (opts.serverFlag !== undefined && opts.serverFlag !== "") {
+    return { url: opts.serverFlag, source: "flag" };
+  }
+  const fromEnv = process.env["PS_SERVER"]?.trim();
+  if (fromEnv) {
+    return { url: fromEnv, source: "env" };
+  }
+  const cfg = loadConfig();
+  const fromFile = cfg.default_server?.trim();
+  if (fromFile) {
+    return { url: fromFile, source: "config" };
+  }
+  return { url: BUILT_IN_DEFAULT_SERVER, source: "built-in" };
+}
+
+export function isBuiltInDefaultServerUrl(url: string): boolean {
+  return url.replace(/\/+$/, "") === BUILT_IN_DEFAULT_SERVER;
+}

--- a/cli/src/config/store.ts
+++ b/cli/src/config/store.ts
@@ -130,7 +130,11 @@ export function loadConfig(): CliConfigFile {
     return typeof data === "object" && data !== null && !Array.isArray(data)
       ? data
       : {};
-  } catch {
+  } catch (err) {
+    console.error(
+      `Warning: could not parse ${CONFIG_FILE}, using defaults. ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
     return {};
   }
 }

--- a/cli/src/config/store.ts
+++ b/cli/src/config/store.ts
@@ -1,5 +1,8 @@
 /**
- * Manages ~/.permission-slip/ — config directory and registrations file.
+ * Manages ~/.permission-slip/ — config directory, preferences, and registrations.
+ *
+ * User preferences:
+ *   ~/.permission-slip/config.json
  *
  * Registrations are stored as:
  *   ~/.permission-slip/registrations.json
@@ -28,6 +31,7 @@ export const CONFIG_DIR =
   process.env["PS_CLI_TEST_CONFIG_DIR"] ??
   path.join(os.homedir(), ".permission-slip");
 export const REGISTRATIONS_FILE = path.join(CONFIG_DIR, "registrations.json");
+export const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
 export const SSH_DIR =
   process.env["PS_CLI_TEST_SSH_DIR"] ?? path.join(os.homedir(), ".ssh");
 export const PRIVATE_KEY_FILE =
@@ -91,4 +95,74 @@ export function findRegistration(server: string): Registration | undefined {
     (a, b) =>
       new Date(b.registered_at).getTime() - new Date(a.registered_at).getTime(),
   )[0];
+}
+
+/** Stored in ~/.permission-slip/config.json — extend with new optional fields as needed. */
+export interface CliConfigFile {
+  default_server?: string;
+}
+
+export function normalizeServerUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function assertValidServerUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid server URL: ${url}`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(
+      `Server URL must use http or https (got ${parsed.protocol}).`,
+    );
+  }
+}
+
+export function loadConfig(): CliConfigFile {
+  if (!fs.existsSync(CONFIG_FILE)) {
+    return {};
+  }
+  try {
+    const raw = fs.readFileSync(CONFIG_FILE, "utf-8");
+    const data = JSON.parse(raw) as CliConfigFile;
+    return typeof data === "object" && data !== null && !Array.isArray(data)
+      ? data
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveConfig(partial: CliConfigFile): void {
+  ensureConfigDir();
+  const current = loadConfig();
+  const next: CliConfigFile = { ...current, ...partial };
+  if (next.default_server !== undefined) {
+    next.default_server = normalizeServerUrl(next.default_server);
+    assertValidServerUrl(next.default_server);
+  }
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(next, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+export function unsetConfigKey(key: keyof CliConfigFile): void {
+  if (!fs.existsSync(CONFIG_FILE)) {
+    return;
+  }
+  const current = loadConfig();
+  if (!(key in current)) {
+    return;
+  }
+  const next = { ...current };
+  delete next[key];
+  if (Object.keys(next).length === 0) {
+    fs.unlinkSync(CONFIG_FILE);
+    return;
+  }
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(next, null, 2) + "\n", {
+    mode: 0o600,
+  });
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,7 +13,7 @@
  *   connectors    List available connectors
  *   request        Request approval for an action (auto-approves if standing approval matches)
  *   request-status Check the status/outcome of an approval request
- *   config        Show saved configuration and registrations
+ *   config        Show or update saved configuration and registrations
  *   whoami        Show agent identity and registration info
  *
  * All commands output compact JSON by default. Pass --pretty for pretty-printed JSON.
@@ -37,6 +37,8 @@ program
   .description(
     "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers.\n\n" +
     "All commands output compact JSON by default. Pass --pretty for pretty-printed JSON.\n\n" +
+    "Server URL: use --server, or set PS_SERVER, or run: permission-slip config set default_server <url> " +
+    "(stored in ~/.permission-slip/config.json).\n\n" +
     "Quick start:\n" +
     "  1. Register:  permission-slip register --invite-code <code>\n" +
     "  2. Verify:    permission-slip verify --code <confirmation_code>\n" +

--- a/cli/tests/serverUrl.test.ts
+++ b/cli/tests/serverUrl.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for server URL resolution (flag > PS_SERVER > config > built-in).
+ */
+
+import {
+  loadConfig,
+  saveConfig,
+  unsetConfigKey,
+} from "../src/config/store.js";
+import {
+  resolveServerUrl,
+  BUILT_IN_DEFAULT_SERVER,
+  isBuiltInDefaultServerUrl,
+} from "../src/config/serverUrl.js";
+
+describe("resolveServerUrl", () => {
+  const prevServer = process.env["PS_SERVER"];
+
+  afterEach(() => {
+    if (prevServer === undefined) {
+      delete process.env["PS_SERVER"];
+    } else {
+      process.env["PS_SERVER"] = prevServer;
+    }
+    unsetConfigKey("default_server");
+  });
+
+  it("uses built-in default when nothing else is set", () => {
+    delete process.env["PS_SERVER"];
+    expect(loadConfig().default_server).toBeUndefined();
+    const r = resolveServerUrl({});
+    expect(r.url).toBe(BUILT_IN_DEFAULT_SERVER);
+    expect(r.source).toBe("built-in");
+  });
+
+  it("uses default_server from config when no flag or env", () => {
+    delete process.env["PS_SERVER"];
+    saveConfig({ default_server: "https://pi.local:8080" });
+    const r = resolveServerUrl({});
+    expect(r.url).toBe("https://pi.local:8080");
+    expect(r.source).toBe("config");
+  });
+
+  it("prefers PS_SERVER over config file", () => {
+    saveConfig({ default_server: "https://from-config.dev" });
+    process.env["PS_SERVER"] = "https://from-env.dev";
+    const r = resolveServerUrl({});
+    expect(r.url).toBe("https://from-env.dev");
+    expect(r.source).toBe("env");
+  });
+
+  it("prefers --server flag over env and config", () => {
+    saveConfig({ default_server: "https://from-config.dev" });
+    process.env["PS_SERVER"] = "https://from-env.dev";
+    const r = resolveServerUrl({ serverFlag: "https://from-flag.dev" });
+    expect(r.url).toBe("https://from-flag.dev");
+    expect(r.source).toBe("flag");
+  });
+
+  it("trims PS_SERVER whitespace", () => {
+    process.env["PS_SERVER"] = "  https://trimmed.dev  ";
+    const r = resolveServerUrl({});
+    expect(r.url).toBe("https://trimmed.dev");
+    expect(r.source).toBe("env");
+  });
+});
+
+describe("isBuiltInDefaultServerUrl", () => {
+  it("matches the canonical host with or without trailing slash", () => {
+    expect(isBuiltInDefaultServerUrl("https://app.permissionslip.dev")).toBe(true);
+    expect(isBuiltInDefaultServerUrl("https://app.permissionslip.dev/")).toBe(true);
+    expect(isBuiltInDefaultServerUrl("https://other.dev")).toBe(false);
+  });
+});

--- a/cli/tests/store.test.ts
+++ b/cli/tests/store.test.ts
@@ -8,14 +8,20 @@ import {
   loadRegistrations,
   saveRegistration,
   findRegistration,
+  loadConfig,
+  saveConfig,
+  unsetConfigKey,
   CONFIG_DIR,
   REGISTRATIONS_FILE,
+  CONFIG_FILE,
 } from "../src/config/store.js";
+import fs from "node:fs";
 
 describe("CONFIG_DIR / REGISTRATIONS_FILE", () => {
   it("uses the test temp dir (not ~/.permission-slip)", () => {
     expect(CONFIG_DIR).toContain("ps-cli-test-");
     expect(REGISTRATIONS_FILE).toContain("ps-cli-test-");
+    expect(CONFIG_FILE).toContain("ps-cli-test-");
   });
 });
 
@@ -64,6 +70,40 @@ describe("saveRegistration / loadRegistrations", () => {
     });
     const afterCount = loadRegistrations().length;
     expect(afterCount).toBe(beforeCount + 1);
+  });
+});
+
+describe("loadConfig / saveConfig / unsetConfigKey", () => {
+  afterEach(() => {
+    unsetConfigKey("default_server");
+    if (fs.existsSync(CONFIG_FILE)) {
+      fs.unlinkSync(CONFIG_FILE);
+    }
+  });
+
+  it("returns empty object when config file is missing", () => {
+    expect(loadConfig()).toEqual({});
+  });
+
+  it("saves and loads default_server", () => {
+    saveConfig({ default_server: "https://cfg.example.dev" });
+    expect(loadConfig().default_server).toBe("https://cfg.example.dev");
+  });
+
+  it("normalizes trailing slashes on default_server", () => {
+    saveConfig({ default_server: "https://cfg.example.dev/" });
+    expect(loadConfig().default_server).toBe("https://cfg.example.dev");
+  });
+
+  it("rejects invalid default_server URLs", () => {
+    expect(() => saveConfig({ default_server: "not-a-url" })).toThrow(/Invalid server URL/);
+  });
+
+  it("unset removes key and deletes file when empty", () => {
+    saveConfig({ default_server: "https://cfg.example.dev" });
+    unsetConfigKey("default_server");
+    expect(loadConfig()).toEqual({});
+    expect(fs.existsSync(CONFIG_FILE)).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #933](https://github.com/supersuit-tech/permission-slip/issues/933): a `~/.permission-slip/config.json` file for `default_server`, `PS_SERVER` support, and `permission-slip config set|unset` subcommands. Every command that accepts `--server` now resolves the URL in order: **flag → `PS_SERVER` → `default_server` in config → built-in** `https://app.permissionslip.dev`.

`permission-slip config` (no subcommand) now includes `preferences_file`, raw `preferences`, and `default_server: { resolved, source }` so users can see which layer won.

## Test plan

- `cd cli && npm test && npm run build`

### Developer

- [x] Add `loadConfig` / `saveConfig` / `unsetConfigKey` in `cli/src/config/store.ts`
- [x] Add `config set` / `config unset` and extend `config` output
- [x] Add `PS_SERVER` and precedence helper + tests
- [x] Update `--server` help strings and root `--help` blurb

### Manual Testing

- [ ] `config set default_server <url>` then run a command without `--server`
- [ ] `--server` still overrides config/env
- [ ] `config unset default_server` reverts behavior
- [ ] Fresh install (no `config.json`) unchanged

Closes #933
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fea50a7-e598-43b8-a75d-474ea4bc3e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fea50a7-e598-43b8-a75d-474ea4bc3e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

