### PR TITLE
Remove standing approval max execution limits

### DIFF
--- a/api/action_config_templates.go
+++ b/api/action_config_templates.go
@@ -23,8 +23,7 @@ type actionConfigTemplateResponse struct {
 }
 
 type standingApprovalTemplateSubResponse struct {
-	DurationDays  *int `json:"duration_days,omitempty"`
-	MaxExecutions *int `json:"max_executions,omitempty"`
+	DurationDays *int `json:"duration_days,omitempty"`
 }
 
 type actionConfigTemplateListResponse struct {

--- a/api/action_config_templates_apply.go
+++ b/api/action_config_templates_apply.go
@@ -24,8 +24,7 @@ type applyActionConfigTemplateResponse struct {
 }
 
 type standingApprovalTemplateSpec struct {
-	DurationDays  *int `json:"duration_days"`
-	MaxExecutions *int `json:"max_executions"`
+	DurationDays *int `json:"duration_days"`
 }
 
 func handleApplyActionConfigTemplate(deps *Deps) http.HandlerFunc {
@@ -221,15 +220,6 @@ func handleApplyActionConfigTemplate(deps *Deps) http.HandlerFunc {
 				expiresAt = &t
 			}
 
-			var maxExec *int
-			if spec.MaxExecutions != nil {
-				if *spec.MaxExecutions < 1 {
-					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "template standing_approval has invalid max_executions"))
-					return
-				}
-				maxExec = spec.MaxExecutions
-			}
-
 			saID, err := generatePrefixedID("sa_", 16)
 			if err != nil {
 				log.Printf("[%s] ApplyActionConfigTemplate: generate sa id: %v", TraceID(r.Context()), err)
@@ -247,7 +237,6 @@ func handleApplyActionConfigTemplate(deps *Deps) http.HandlerFunc {
 				ActionVersion:               "1",
 				Constraints:                 standingBytes,
 				SourceActionConfigurationID: &srcID,
-				MaxExecutions:               maxExec,
 				StartsAt:                    startsAt,
 				ExpiresAt:                   expiresAt,
 			})

--- a/api/action_config_templates_apply_test.go
+++ b/api/action_config_templates_apply_test.go
@@ -205,9 +205,6 @@ func TestApplyActionConfigTemplate_ApprovalModeAutoApprove_OverridesPlainTemplat
 	if resp.StandingApproval.ExpiresAt != nil {
 		t.Fatal("expected nil expires_at (sensible default: no expiry)")
 	}
-	if resp.StandingApproval.MaxExecutions != nil {
-		t.Fatal("expected nil max_executions (sensible default: unlimited)")
-	}
 }
 
 func TestApplyActionConfigTemplate_ApprovalModeRequiresApproval_OverridesStandingTemplate(t *testing.T) {

--- a/api/action_config_templates_bulk_apply.go
+++ b/api/action_config_templates_bulk_apply.go
@@ -392,14 +392,6 @@ func applyOneTemplateCore(
 			expiresAt = &t
 		}
 
-		var maxExec *int
-		if spec.MaxExecutions != nil {
-			if *spec.MaxExecutions < 1 {
-				return &applyOneResult{errorCode: string(ErrInvalidRequest)}, fmt.Errorf("template standing_approval has invalid max_executions")
-			}
-			maxExec = spec.MaxExecutions
-		}
-
 		saID, err := generatePrefixedID("sa_", 16)
 		if err != nil {
 			return &applyOneResult{errorCode: string(ErrInternalError)}, fmt.Errorf("internal error")
@@ -414,7 +406,6 @@ func applyOneTemplateCore(
 			ActionVersion:               "1",
 			Constraints:                 standingBytes,
 			SourceActionConfigurationID: &srcID,
-			MaxExecutions:               maxExec,
 			StartsAt:                    startsAt,
 			ExpiresAt:                   expiresAt,
 		})

--- a/api/action_configurations.go
+++ b/api/action_configurations.go
@@ -51,8 +51,6 @@ type linkedStandingApprovalSummary struct {
 	ActionType         string     `json:"action_type"`
 	Status             string     `json:"status"`
 	ExpiresAt          *time.Time `json:"expires_at,omitempty"`
-	MaxExecutions      *int       `json:"max_executions,omitempty"`
-	ExecutionCount     int        `json:"execution_count"`
 }
 
 type actionConfigListResponse struct {
@@ -485,8 +483,6 @@ func standingApprovalSummariesFromDB(sas []db.StandingApproval) []linkedStanding
 			ActionType:         sa.ActionType,
 			Status:             sa.Status,
 			ExpiresAt:          sa.ExpiresAt,
-			MaxExecutions:      sa.MaxExecutions,
-			ExecutionCount:     sa.ExecutionCount,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -47,9 +47,8 @@ type agentRequestApprovalResponse struct {
 	// ── Auto-approved fields (status="approved") ──
 	// Present only when a standing approval matched and the action was
 	// executed immediately. No polling needed — the result is inline.
-	Result              *json.RawMessage `json:"result,omitempty"`              // Connector execution output (may be null if connector returns no data).
-	StandingApprovalID  string           `json:"standing_approval_id,omitempty"` // Which standing approval authorized this execution (useful for audit tracking).
-	ExecutionsRemaining *int             `json:"executions_remaining,omitempty"` // Remaining uses of this standing approval; absent = unlimited.
+	Result             *json.RawMessage `json:"result,omitempty"`               // Connector execution output (may be null if connector returns no data).
+	StandingApprovalID string           `json:"standing_approval_id,omitempty"` // Which standing approval authorized this execution (useful for audit tracking).
 }
 
 type agentCancelApprovalResponse struct {

--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -46,11 +46,9 @@ type actionConfigCapability struct {
 }
 
 type standingApprovalCapability struct {
-	StandingApprovalID  string          `json:"standing_approval_id"`
-	Constraints         json.RawMessage `json:"constraints"`
-	MaxExecutions       *int            `json:"max_executions"`
-	ExecutionsRemaining *int            `json:"executions_remaining"`
-	ExpiresAt           *time.Time      `json:"expires_at"`
+	StandingApprovalID string          `json:"standing_approval_id"`
+	Constraints        json.RawMessage `json:"constraints"`
+	ExpiresAt          *time.Time      `json:"expires_at"`
 }
 
 // ── Route registration ──────────────────────────────────────────────────────
@@ -174,11 +172,9 @@ func buildCapabilitiesResponse(agentID int64, caps *db.AgentCapabilities, baseUR
 			sas := make([]standingApprovalCapability, 0, len(dbSAs))
 			for _, sa := range dbSAs {
 				sas = append(sas, standingApprovalCapability{
-					StandingApprovalID:  sa.StandingApprovalID,
-					Constraints:         sa.Constraints,
-					MaxExecutions:       sa.MaxExecutions,
-					ExecutionsRemaining: sa.ExecutionsRemaining,
-					ExpiresAt:           sa.ExpiresAt,
+					StandingApprovalID: sa.StandingApprovalID,
+					Constraints:        sa.Constraints,
+					ExpiresAt:          sa.ExpiresAt,
 				})
 			}
 			acap.StandingApprovals = sas

--- a/api/capabilities_test.go
+++ b/api/capabilities_test.go
@@ -51,11 +51,9 @@ func TestGetCapabilities_HappyPath(t *testing.T) {
 
 	// Add a standing approval.
 	saID := testhelper.GenerateID(t, "sa_")
-	maxExec := 100
 	testhelper.InsertStandingApprovalFull(t, tx, saID, agentID, uid, testhelper.StandingApprovalOpts{
-		ActionType:    "email.send",
-		MaxExecutions: &maxExec,
-		Constraints:   []byte(`{"recipient_pattern":"*@mycompany.com"}`),
+		ActionType:  "email.send",
+		Constraints: []byte(`{"recipient_pattern":"*@mycompany.com"}`),
 	})
 
 	router := NewRouter(&Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, BaseURL: "https://app.permissionslip.dev"})
@@ -109,9 +107,6 @@ func TestGetCapabilities_HappyPath(t *testing.T) {
 	}
 	if a.StandingApprovals[0].StandingApprovalID != saID {
 		t.Errorf("expected standing_approval_id %q, got %q", saID, a.StandingApprovals[0].StandingApprovalID)
-	}
-	if a.StandingApprovals[0].MaxExecutions == nil || *a.StandingApprovals[0].MaxExecutions != 100 {
-		t.Error("expected max_executions=100")
 	}
 }
 

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -25,7 +25,6 @@ const (
 	ErrConnectorNotFound            ErrorCode = "connector_not_found"
 	ErrCredentialsNotFound          ErrorCode = "credentials_not_found"
 	ErrNoMatchingStanding           ErrorCode = "no_matching_standing_approval"
-	ErrStandingExhausted            ErrorCode = "standing_approval_exhausted"
 	ErrConstraintViolation          ErrorCode = "constraint_violation"
 	ErrStandingExpired              ErrorCode = "standing_approval_expired"
 	ErrAgentAlreadyRegistered       ErrorCode = "agent_already_registered"

--- a/api/standing_approval_match.go
+++ b/api/standing_approval_match.go
@@ -87,13 +87,11 @@ func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps
 
 	// Execute the action via connector.
 	//
-	// NOTE: The execution slot was already consumed by RecordStandingApprovalExecutionByAgent
+	// NOTE: The execution record was already written by RecordStandingApprovalExecutionByAgent
 	// above. If the connector fails (network timeout, upstream 503, payment gateway error),
-	// the slot is permanently consumed even though no action succeeded. This is intentional:
-	// reversing the atomic CTE would require a compensating transaction and could mask abuse
-	// (an agent retrying indefinitely to bypass rate limits). The trade-off is that transient
-	// failures erode the execution quota. To mitigate, we include executions_remaining in
-	// error responses so agents can observe quota consumption and refresh approvals if needed.
+	// the record remains even though no action succeeded. This is intentional: reversing
+	// the atomic CTE would require a compensating transaction and could mask abuse (an agent
+	// retrying indefinitely to bypass rate limits).
 	result, execErr := executeConnectorAction(r.Context(), deps, exec.AgentID, exec.UserID, actionType, params, pp)
 
 	// Emit audit event (best-effort).
@@ -107,19 +105,8 @@ func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps
 		log.Printf("[%s] AutoApprove: connector execution: %v", TraceID(r.Context()), execErr)
 		CaptureConnectorError(r.Context(), execErr, cc)
 		resp := InternalError("Failed to execute connector action")
-		// Include executions_remaining so agents can track quota erosion on failure.
-		// The execution slot was consumed by RecordStandingApprovalExecutionByAgent
-		// before the connector call, so agents need visibility into remaining quota
-		// even when the action itself failed.
-		if exec.MaxExecutions != nil {
-			remaining := *exec.MaxExecutions - exec.ExecutionCount
-			if remaining < 0 {
-				remaining = 0
-			}
-			resp.Error.Details = map[string]any{
-				"standing_approval_id": sa.StandingApprovalID,
-				"executions_remaining": remaining,
-			}
+		resp.Error.Details = map[string]any{
+			"standing_approval_id": sa.StandingApprovalID,
 		}
 		RespondError(w, r, http.StatusInternalServerError, resp)
 		return true
@@ -133,25 +120,15 @@ func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps
 		actionResultPtr = &result.Data
 	}
 
-	var executionsRemaining *int
-	if exec.MaxExecutions != nil {
-		remaining := *exec.MaxExecutions - exec.ExecutionCount
-		if remaining < 0 {
-			remaining = 0
-		}
-		executionsRemaining = &remaining
-	}
-
 	// Update agent's last_active_at (best-effort).
 	if err := db.TouchAgentLastActive(r.Context(), deps.DB, agent.AgentID); err != nil {
 		log.Printf("[%s] AutoApprove: failed to update last_active_at for agent %d: %v", TraceID(r.Context()), agent.AgentID, err)
 	}
 
 	RespondJSON(w, http.StatusOK, agentRequestApprovalResponse{
-		Status:              "approved",
-		Result:              actionResultPtr,
-		StandingApprovalID:  sa.StandingApprovalID,
-		ExecutionsRemaining: executionsRemaining,
+		Status:             "approved",
+		Result:             actionResultPtr,
+		StandingApprovalID: sa.StandingApprovalID,
 	})
 	return true
 }

--- a/api/standing_approval_match_test.go
+++ b/api/standing_approval_match_test.go
@@ -77,13 +77,7 @@ func TestRequestApproval_AutoApprove_Success(t *testing.T) {
 	if resp.ApprovalID != "" {
 		t.Errorf("expected empty approval_id for auto-approval, got %q", resp.ApprovalID)
 	}
-	// No max_executions set, so executions_remaining should be nil (unlimited).
-	if resp.ExecutionsRemaining != nil {
-		t.Errorf("expected nil executions_remaining, got %v", *resp.ExecutionsRemaining)
-	}
-
-	// Verify execution_count was incremented.
-	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", saID, "execution_count", "1")
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, saID, 1)
 }
 
 func TestRequestApproval_NoStandingApproval_CreatesPending(t *testing.T) {
@@ -175,37 +169,7 @@ func TestRequestApproval_AutoApprove_ConstraintSatisfied(t *testing.T) {
 		t.Errorf("expected status \"approved\", got %q", resp.Status)
 	}
 
-	// Verify execution was recorded.
-	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", saID, "execution_count", "1")
-}
-
-func TestRequestApproval_AutoApprove_ExecutionsRemaining(t *testing.T) {
-	t.Parallel()
-	maxExec := 3
-	_, _, router, agentID, privKey, _, _ := setupStandingApprovalTest(t, "email.read", testhelper.StandingApprovalOpts{
-		MaxExecutions: &maxExec,
-	})
-
-	reqBody := `{"request_id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","action":{"type":"email.read","version":"1","parameters":{}},"context":{"description":"test"}}`
-	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
-	w := httptest.NewRecorder()
-
-	router.ServeHTTP(w, r)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-
-	var resp agentRequestApprovalResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if resp.ExecutionsRemaining == nil {
-		t.Fatal("expected executions_remaining to be non-nil")
-	}
-	if *resp.ExecutionsRemaining != 2 {
-		t.Errorf("expected executions_remaining 2, got %d", *resp.ExecutionsRemaining)
-	}
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, saID, 1)
 }
 
 func TestRequestApproval_AutoApprove_ExpiredApproval_FallsThroughToPending(t *testing.T) {
@@ -352,47 +316,9 @@ func TestRequestApproval_AutoApprove_SecondApprovalMatchesWhenFirstDoesNot(t *te
 		t.Errorf("expected status \"approved\", got %q", resp.Status)
 	}
 
-	// Assert based on execution counts rather than standing_approval_id, since
-	// the query tiebreaker (standing_approval_id DESC) over random IDs makes
-	// the iteration order non-deterministic. What matters: the github.com
-	// constraint matched (execution_count=1) and competitor.com did not (0).
-	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", sa1ID, "execution_count", "1")
-	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", sa2ID, "execution_count", "0")
-}
-
-func TestRequestApproval_AutoApprove_ExhaustedBetweenFindAndRecord_FallsThroughToPending(t *testing.T) {
-	t.Parallel()
-	maxExec := 1
-	tx, _, router, agentID, privKey, saID, _ := setupStandingApprovalTest(t, "email.read", testhelper.StandingApprovalOpts{
-		MaxExecutions: &maxExec,
-	})
-
-	// Simulate race: the standing approval was found by FindActiveStandingApprovalsForAgent
-	// (status=active, execution_count < max_executions), but between that query and
-	// RecordStandingApprovalExecutionByAgent, another request exhausted the quota.
-	// Set execution_count = max_executions to trigger StandingApprovalErrNotActive.
-	testhelper.InsertStandingApprovalExecution(t, tx, saID)
-
-	reqBody := `{"request_id":"exhausted-race-test-001","action":{"type":"email.read","version":"1","parameters":{}},"context":{"description":"test"}}`
-	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, r)
-
-	// Should fall through to pending (exhausted SA triggers StandingApprovalErrNotActive).
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 (pending), got %d: %s", w.Code, w.Body.String())
-	}
-
-	var resp agentRequestApprovalResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if resp.Status != "pending" {
-		t.Errorf("expected status \"pending\" (exhausted SA race), got %q", resp.Status)
-	}
-	if resp.ApprovalID == "" {
-		t.Error("expected non-empty approval_id for pending request")
-	}
+	// Only the github.com constraint can match this request.
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, sa1ID, 1)
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, sa2ID, 0)
 }
 
 func TestRequestApproval_AutoApprove_RevokedApproval_FallsThroughToPending(t *testing.T) {

--- a/api/standing_approval_notify.go
+++ b/api/standing_approval_notify.go
@@ -39,14 +39,7 @@ func NotifyStandingApprovalExecution(ctx context.Context, deps *Deps, exec *db.S
 	agentName := extractAgentName(agent)
 	activityURL := fmt.Sprintf("%s/activity", deps.BaseURL)
 
-	// Build the context JSON with execution count and max executions.
-	execContext := map[string]int{
-		"execution_count": exec.ExecutionCount,
-	}
-	if exec.MaxExecutions != nil {
-		execContext["max_executions"] = *exec.MaxExecutions
-	}
-	contextJSON, _ := json.Marshal(execContext)
+	contextJSON, _ := json.Marshal(map[string]any{})
 
 	// Build the action JSON with type and parameters for the notification
 	// templates (used for parameter summary in emails).

--- a/api/standing_approval_notify.go
+++ b/api/standing_approval_notify.go
@@ -39,7 +39,8 @@ func NotifyStandingApprovalExecution(ctx context.Context, deps *Deps, exec *db.S
 	agentName := extractAgentName(agent)
 	activityURL := fmt.Sprintf("%s/activity", deps.BaseURL)
 
-	contextJSON, _ := json.Marshal(map[string]any{})
+	// Standing execution templates do not use Context; omit empty object noise.
+	var contextJSON json.RawMessage
 
 	// Build the action JSON with type and parameters for the notification
 	// templates (used for parameter summary in emails).
@@ -50,7 +51,7 @@ func NotifyStandingApprovalExecution(ctx context.Context, deps *Deps, exec *db.S
 		AgentID:     exec.AgentID,
 		AgentName:   agentName,
 		Action:      actionJSON,
-		Context:     contextJSON,
+		Context: contextJSON,
 		ApprovalURL: activityURL,
 		CreatedAt:   time.Now(),
 		Type:        notify.NotificationTypeStandingExecution,

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -26,8 +26,6 @@ type standingApprovalResponse struct {
 	Constraints                 any        `json:"constraints"`
 	SourceActionConfigurationID *string    `json:"source_action_configuration_id"`
 	Status                      string     `json:"status"`
-	MaxExecutions               *int       `json:"max_executions"`
-	ExecutionCount              int        `json:"execution_count"`
 	StartsAt                    time.Time  `json:"starts_at"`
 	ExpiresAt                   *time.Time `json:"expires_at"`
 	CreatedAt                   time.Time  `json:"created_at"`
@@ -52,14 +50,12 @@ type createStandingApprovalRequest struct {
 	ActionVersion               string          `json:"action_version"`
 	Constraints                 json.RawMessage `json:"constraints"`
 	SourceActionConfigurationID *string         `json:"source_action_configuration_id" validate:"required"`
-	MaxExecutions               *int            `json:"max_executions" validate:"omitempty,gte=1"`
 	StartsAt                    *time.Time      `json:"starts_at"`
 	ExpiresAt                   *time.Time      `json:"expires_at"`
 }
 
 type updateStandingApprovalRequest struct {
 	Constraints   json.RawMessage `json:"constraints"`
-	MaxExecutions *int            `json:"max_executions" validate:"omitempty,gte=1"`
 	ExpiresAt     *time.Time      `json:"expires_at"`
 	// ExpiresAtSet is true when the JSON payload explicitly included the "expires_at" key
 	// (even if the value was null). This distinguishes "field omitted" (preserve existing)
@@ -95,7 +91,6 @@ var validStandingApprovalStatusFilters = map[string]bool{
 	"active":    true,
 	"expired":   true,
 	"revoked":   true,
-	"exhausted": true,
 	"all":       true,
 }
 
@@ -128,7 +123,7 @@ func handleListStandingApprovals(deps *Deps) http.HandlerFunc {
 			statusFilter = "active"
 		}
 		if !validStandingApprovalStatusFilters[statusFilter] {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Invalid status filter; must be one of: active, expired, revoked, exhausted, all"))
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Invalid status filter; must be one of: active, expired, revoked, all"))
 			return
 		}
 
@@ -337,7 +332,6 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			ActionVersion:               req.ActionVersion,
 			Constraints:                 constraintsBytes,
 			SourceActionConfigurationID: &sourceConfigIDPtr,
-			MaxExecutions:               req.MaxExecutions,
 			StartsAt:                    startsAt,
 			ExpiresAt:                   req.ExpiresAt,
 		})
@@ -415,8 +409,6 @@ func handleStandingApprovalError(w http.ResponseWriter, r *http.Request, err err
 			resp.Error.Details = map[string]any{"status": saErr.Status}
 		}
 		RespondError(w, r, http.StatusGone, resp)
-	case db.StandingApprovalErrMaxExecutionsTooLow:
-		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "max_executions cannot be less than the current execution count"))
 	default:
 		return false
 	}
@@ -528,8 +520,7 @@ func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Fetch the existing approval to validate max_executions against current
-		// execution_count and to preserve expires_at when the field is omitted.
+		// Fetch the existing approval to preserve expires_at when the field is omitted.
 		existing, err := db.GetStandingApprovalByIDAndUser(r.Context(), deps.DB, saID, profile.ID)
 		if err != nil {
 			log.Printf("[%s] UpdateStandingApproval: fetch existing: %v", TraceID(r.Context()), err)
@@ -556,13 +547,6 @@ func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
 			req.ExpiresAt = existing.ExpiresAt
 		}
 
-		// Prevent setting max_executions below the current execution count, which
-		// would leave the approval active in the dashboard but unreachable by agents.
-		if req.MaxExecutions != nil && *req.MaxExecutions < existing.ExecutionCount {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "max_executions cannot be less than the current execution count"))
-			return
-		}
-
 		constraintsBytes, err := validateStandingApprovalConstraints(req.Constraints)
 		if err != nil {
 			resp := BadRequest(ErrInvalidConstraints, err.Error())
@@ -577,7 +561,6 @@ func handleUpdateStandingApproval(deps *Deps) http.HandlerFunc {
 			StandingApprovalID: saID,
 			UserID:             profile.ID,
 			Constraints:        constraintsBytes,
-			MaxExecutions:      req.MaxExecutions,
 			ExpiresAt:          req.ExpiresAt,
 		})
 		if err != nil {
@@ -643,8 +626,6 @@ func toStandingApprovalResponse(sa db.StandingApproval) standingApprovalResponse
 		ActionVersion:               sa.ActionVersion,
 		SourceActionConfigurationID: sa.SourceActionConfigurationID,
 		Status:                      sa.Status,
-		MaxExecutions:               sa.MaxExecutions,
-		ExecutionCount:              sa.ExecutionCount,
 		StartsAt:                    sa.StartsAt,
 		ExpiresAt:                   sa.ExpiresAt,
 		CreatedAt:                   sa.CreatedAt,

--- a/api/standing_approvals_execute_test.go
+++ b/api/standing_approvals_execute_test.go
@@ -46,8 +46,7 @@ func TestExecuteStandingApproval_Success(t *testing.T) {
 		t.Error("expected non-zero executed_at")
 	}
 
-	// Verify execution_count was incremented.
-	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", saID, "execution_count", "1")
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, saID, 1)
 }
 
 func TestExecuteStandingApproval_IncrementsCount(t *testing.T) {
@@ -71,7 +70,7 @@ func TestExecuteStandingApproval_IncrementsCount(t *testing.T) {
 		}
 	}
 
-	testhelper.RequireRowValue(t, tx, "standing_approvals", "standing_approval_id", saID, "execution_count", "2")
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, saID, 2)
 }
 
 func TestExecuteStandingApproval_EmitsAuditEvent(t *testing.T) {

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -502,7 +502,6 @@ func TestCreateStandingApproval_Success(t *testing.T) {
 		"action_version": "1",
 		"constraints": {"recipient_pattern": "*@company.com"},
 		"source_action_configuration_id": %q,
-		"max_executions": 50,
 		"expires_at": "%s"
 	}`, agentID, acID, expiresAt)
 
@@ -527,12 +526,6 @@ func TestCreateStandingApproval_Success(t *testing.T) {
 	}
 	if resp.Status != "active" {
 		t.Errorf("expected status 'active', got %q", resp.Status)
-	}
-	if resp.MaxExecutions == nil || *resp.MaxExecutions != 50 {
-		t.Errorf("expected max_executions 50, got %v", resp.MaxExecutions)
-	}
-	if resp.ExecutionCount != 0 {
-		t.Errorf("expected execution_count 0, got %d", resp.ExecutionCount)
 	}
 	if resp.Constraints == nil {
 		t.Error("expected constraints to be non-nil")

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -274,7 +274,6 @@ export class ApiClient {
       created_at?: string;
       result?: unknown;
       standing_approval_id?: string;
-      executions_remaining?: number | null;
     }>({
       method: "POST",
       routerPath: "/approvals/request",

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -1312,10 +1312,10 @@ func seedUserHasEverything(ctx context.Context, tx db.DBTX, supa *supabaseClient
 	// Standing approvals (2 active, 1 expired) — after action configs (FK)
 	// ---------------------------------------------------------------
 	exec(ctx, tx,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, max_executions, constraints, source_action_configuration_id, starts_at, expires_at)
-		 VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9)`,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, constraints, source_action_configuration_id, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8)`,
 		"sa-everything-1", claude, userHasEverything,
-		"github.create_issue", 100,
+		"github.create_issue",
 		`{"repo": "supersuit-tech/permission-slip", "title": "*"}`,
 		"ac-claude-create-issue",
 		now.Add(-7*24*time.Hour),

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -77,10 +77,9 @@ type ManifestOAuthProvider struct {
 }
 
 // ManifestStandingApproval declares optional auto-approval behavior when a
-// template is applied: duration and execution cap are manifest-authored only.
+// template is applied: duration is manifest-authored only.
 type ManifestStandingApproval struct {
-	DurationDays  *int `json:"duration_days"`
-	MaxExecutions *int `json:"max_executions"`
+	DurationDays *int `json:"duration_days"`
 }
 
 // ManifestTemplate describes a predefined configuration preset for an action.
@@ -334,9 +333,6 @@ func (m *ConnectorManifest) Validate() error {
 			sa := tpl.StandingApproval
 			if sa.DurationDays != nil && *sa.DurationDays <= 0 {
 				return fmt.Errorf("manifest validation: templates[%d].standing_approval.duration_days must be a positive integer or null", i)
-			}
-			if sa.MaxExecutions != nil && *sa.MaxExecutions < 1 {
-				return fmt.Errorf("manifest validation: templates[%d].standing_approval.max_executions must be at least 1 or null", i)
 			}
 		}
 	}

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -49,12 +49,10 @@ type CapabilityActionConfig struct {
 
 // CapabilityStandingApproval represents an active, non-expired standing approval.
 type CapabilityStandingApproval struct {
-	StandingApprovalID  string
-	ActionType          string
-	Constraints         json.RawMessage // raw JSONB
-	MaxExecutions       *int
-	ExecutionsRemaining *int
-	ExpiresAt           *time.Time
+	StandingApprovalID string
+	ActionType         string
+	Constraints        json.RawMessage // raw JSONB
+	ExpiresAt          *time.Time
 }
 
 // GetAgentCapabilities retrieves all data needed for the capabilities endpoint:
@@ -161,11 +159,6 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 	// 3. Active, non-expired standing approvals for this agent.
 	saRows, err := db.Query(ctx, `
 		SELECT sa.standing_approval_id, sa.action_type, sa.constraints,
-		       sa.max_executions,
-		       CASE WHEN sa.max_executions IS NOT NULL
-		            THEN sa.max_executions - sa.execution_count
-		            ELSE NULL
-		       END AS executions_remaining,
 		       sa.expires_at
 		FROM standing_approvals sa
 		WHERE sa.agent_id = $1
@@ -183,7 +176,7 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 
 	for saRows.Next() {
 		var sa CapabilityStandingApproval
-		if err := saRows.Scan(&sa.StandingApprovalID, &sa.ActionType, &sa.Constraints, &sa.MaxExecutions, &sa.ExecutionsRemaining, &sa.ExpiresAt); err != nil {
+		if err := saRows.Scan(&sa.StandingApprovalID, &sa.ActionType, &sa.Constraints, &sa.ExpiresAt); err != nil {
 			return nil, err
 		}
 		caps.StandingApprovals = append(caps.StandingApprovals, sa)

--- a/db/capabilities_test.go
+++ b/db/capabilities_test.go
@@ -82,12 +82,10 @@ func TestGetAgentCapabilities_MultipleConnectors(t *testing.T) {
 	testhelper.InsertAgentConnectorCredential(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, conn1, cred1)
 
 	// Add a standing approval for email.send
-	maxExec := 100
 	constraints := json.RawMessage(`{"recipient_pattern":"*@mycompany.com"}`)
 	testhelper.InsertStandingApprovalFull(t, tx, testhelper.GenerateID(t, "sa_"), agentID, uid, testhelper.StandingApprovalOpts{
-		ActionType:    "email.send",
-		Constraints:   constraints,
-		MaxExecutions: &maxExec,
+		ActionType:  "email.send",
+		Constraints: constraints,
 	})
 
 	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
@@ -163,85 +161,8 @@ func TestGetAgentCapabilities_MultipleConnectors(t *testing.T) {
 	if sa.ActionType != "email.send" {
 		t.Errorf("expected action_type=email.send, got %q", sa.ActionType)
 	}
-	if sa.MaxExecutions == nil || *sa.MaxExecutions != 100 {
-		t.Errorf("expected max_executions=100, got %v", sa.MaxExecutions)
-	}
-	if sa.ExecutionsRemaining == nil || *sa.ExecutionsRemaining != 100 {
-		t.Errorf("expected executions_remaining=100, got %v", sa.ExecutionsRemaining)
-	}
 	if sa.Constraints == nil {
 		t.Error("expected constraints to be non-nil")
-	}
-}
-
-func TestGetAgentCapabilities_StandingApprovals_ExecutionsRemaining(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-
-	uid := testhelper.GenerateUID(t)
-	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
-
-	connID := testhelper.GenerateID(t, "conn_")
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, "test.action", "Test")
-	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-
-	// Standing approval with max_executions=10 and 3 executions used
-	maxExec := 10
-	saID := testhelper.GenerateID(t, "sa_")
-	testhelper.InsertStandingApprovalFull(t, tx, saID, agentID, uid, testhelper.StandingApprovalOpts{
-		ActionType:    "test.action",
-		MaxExecutions: &maxExec,
-	})
-	// Record 3 executions
-	for range 3 {
-		testhelper.InsertStandingApprovalExecution(t, tx, saID)
-	}
-
-	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
-	if err != nil {
-		t.Fatalf("GetAgentCapabilities: %v", err)
-	}
-	if len(caps.StandingApprovals) != 1 {
-		t.Fatalf("expected 1 standing approval, got %d", len(caps.StandingApprovals))
-	}
-	sa := caps.StandingApprovals[0]
-	if sa.ExecutionsRemaining == nil || *sa.ExecutionsRemaining != 7 {
-		t.Errorf("expected executions_remaining=7, got %v", sa.ExecutionsRemaining)
-	}
-}
-
-func TestGetAgentCapabilities_StandingApprovals_Unlimited(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-
-	uid := testhelper.GenerateUID(t)
-	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
-
-	connID := testhelper.GenerateID(t, "conn_")
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertConnectorAction(t, tx, connID, "test.action", "Test")
-	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-
-	// Standing approval with no max_executions (unlimited)
-	testhelper.InsertStandingApprovalFull(t, tx, testhelper.GenerateID(t, "sa_"), agentID, uid, testhelper.StandingApprovalOpts{
-		ActionType:    "test.action",
-		MaxExecutions: nil,
-	})
-
-	caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
-	if err != nil {
-		t.Fatalf("GetAgentCapabilities: %v", err)
-	}
-	if len(caps.StandingApprovals) != 1 {
-		t.Fatalf("expected 1 standing approval, got %d", len(caps.StandingApprovals))
-	}
-	sa := caps.StandingApprovals[0]
-	if sa.MaxExecutions != nil {
-		t.Errorf("expected max_executions=nil (unlimited), got %v", sa.MaxExecutions)
-	}
-	if sa.ExecutionsRemaining != nil {
-		t.Errorf("expected executions_remaining=nil (unlimited), got %v", sa.ExecutionsRemaining)
 	}
 }
 

--- a/db/migrations/20260413222611_remove_standing_approval_max_executions.sql
+++ b/db/migrations/20260413222611_remove_standing_approval_max_executions.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+-- Standing approvals no longer track execution quotas; demote legacy rows.
+UPDATE standing_approvals SET status = 'active' WHERE status = 'exhausted';
+
+ALTER TABLE standing_approvals DROP CONSTRAINT IF EXISTS standing_approvals_status_check;
+ALTER TABLE standing_approvals ADD CONSTRAINT standing_approvals_status_check
+    CHECK (status IN ('active', 'expired', 'revoked'));
+
+ALTER TABLE standing_approvals DROP COLUMN IF EXISTS max_executions;
+ALTER TABLE standing_approvals DROP COLUMN IF EXISTS execution_count;
+ALTER TABLE standing_approvals DROP COLUMN IF EXISTS exhausted_at;
+
+-- +goose Down
+
+ALTER TABLE standing_approvals
+    ADD COLUMN max_executions int,
+    ADD COLUMN execution_count int NOT NULL DEFAULT 0,
+    ADD COLUMN exhausted_at timestamptz;
+
+ALTER TABLE standing_approvals ADD CONSTRAINT standing_approvals_max_executions_positive
+    CHECK (max_executions IS NULL OR max_executions > 0);
+ALTER TABLE standing_approvals ADD CONSTRAINT standing_approvals_execution_count_nonneg
+    CHECK (execution_count >= 0);
+
+ALTER TABLE standing_approvals DROP CONSTRAINT IF EXISTS standing_approvals_status_check;
+ALTER TABLE standing_approvals ADD CONSTRAINT standing_approvals_status_check
+    CHECK (status IN ('active', 'expired', 'revoked', 'exhausted'));

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -20,21 +20,18 @@ type StandingApproval struct {
 	Constraints                 []byte // raw JSONB
 	SourceActionConfigurationID *string
 	Status                      string
-	MaxExecutions               *int
-	ExecutionCount              int
 	StartsAt                    time.Time
 	ExpiresAt                   *time.Time // nil means no expiry (until revoked)
 	CreatedAt                   time.Time
 	RevokedAt                   *time.Time
 	ExpiredAt                   *time.Time
-	ExhaustedAt                 *time.Time
 }
 
 // standingApprovalColumns is the canonical column list for SELECT on the standing_approvals table.
 // Keep in sync with scanStandingApproval.
 const standingApprovalColumns = `standing_approval_id, agent_id, user_id, action_type, action_version,
-	constraints, source_action_configuration_id, status, max_executions, execution_count,
-	starts_at, expires_at, created_at, revoked_at, expired_at, exhausted_at`
+	constraints, source_action_configuration_id, status,
+	starts_at, expires_at, created_at, revoked_at, expired_at`
 
 // MaxStandingApprovalListSize is the maximum number of standing approvals returned per page.
 const MaxStandingApprovalListSize = 100
@@ -61,8 +58,8 @@ func scanStandingApproval(row pgx.Row) (*StandingApproval, error) {
 	var sa StandingApproval
 	err := row.Scan(
 		&sa.StandingApprovalID, &sa.AgentID, &sa.UserID, &sa.ActionType, &sa.ActionVersion,
-		&sa.Constraints, &sa.SourceActionConfigurationID, &sa.Status, &sa.MaxExecutions, &sa.ExecutionCount,
-		&sa.StartsAt, &sa.ExpiresAt, &sa.CreatedAt, &sa.RevokedAt, &sa.ExpiredAt, &sa.ExhaustedAt,
+		&sa.Constraints, &sa.SourceActionConfigurationID, &sa.Status,
+		&sa.StartsAt, &sa.ExpiresAt, &sa.CreatedAt, &sa.RevokedAt, &sa.ExpiredAt,
 	)
 	if err != nil {
 		return nil, err
@@ -101,12 +98,11 @@ type StandingApprovalError struct {
 func (e *StandingApprovalError) Error() string { return e.Code }
 
 const (
-	StandingApprovalErrNotFound            = "not_found"
-	StandingApprovalErrAlreadyRevoked      = "already_revoked"
-	StandingApprovalErrNotActive           = "not_active"
-	StandingApprovalErrAgentNotFound       = "agent_not_found"
-	StandingApprovalErrDuplicateRequest    = "duplicate_request"
-	StandingApprovalErrMaxExecutionsTooLow = "max_executions_too_low"
+	StandingApprovalErrNotFound         = "not_found"
+	StandingApprovalErrAlreadyRevoked   = "already_revoked"
+	StandingApprovalErrNotActive        = "not_active"
+	StandingApprovalErrAgentNotFound     = "agent_not_found"
+	StandingApprovalErrDuplicateRequest  = "duplicate_request"
 )
 
 // CreateStandingApprovalParams holds the parameters for creating a standing approval.
@@ -118,7 +114,6 @@ type CreateStandingApprovalParams struct {
 	ActionVersion               string
 	Constraints                 []byte // raw JSONB, may be nil
 	SourceActionConfigurationID *string
-	MaxExecutions               *int
 	StartsAt                    time.Time
 	ExpiresAt                   *time.Time // nil means no expiry (until revoked)
 }
@@ -133,12 +128,12 @@ func CreateStandingApproval(ctx context.Context, db DBTX, p CreateStandingApprov
 			SELECT 1 FROM agents WHERE agent_id = $2 AND approver_id = $3
 		)
 		INSERT INTO standing_approvals
-		   (standing_approval_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, status, max_executions, starts_at, expires_at)
-		 SELECT $1, $2, $3, $4, $5, $6, $7, 'active', $8, $9, $10
+		   (standing_approval_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, status, starts_at, expires_at)
+		 SELECT $1, $2, $3, $4, $5, $6, $7, 'active', $8, $9
 		 WHERE EXISTS (SELECT 1 FROM agent_check)
 		 RETURNING `+standingApprovalColumns,
 		p.StandingApprovalID, p.AgentID, p.UserID, p.ActionType, p.ActionVersion,
-		p.Constraints, p.SourceActionConfigurationID, p.MaxExecutions, p.StartsAt, p.ExpiresAt,
+		p.Constraints, p.SourceActionConfigurationID, p.StartsAt, p.ExpiresAt,
 	)
 	sa, err := scanStandingApproval(row)
 	if err != nil {
@@ -463,38 +458,34 @@ type StandingApprovalExecution struct {
 	AgentMeta          []byte // raw JSONB from agents.metadata, may be nil
 	Parameters         []byte // raw JSONB, may be nil
 	ExecutedAt         time.Time
-	// MaxExecutions and ExecutionCount are populated by
-	// RecordStandingApprovalExecutionByAgent only.
-	MaxExecutions  *int
-	ExecutionCount int
 }
 
-// RecordStandingApprovalExecution atomically increments the parent standing
-// approval's execution_count and inserts an execution record. Both operations
-// run in a single CTE so they succeed or fail together. The UPDATE enforces
-// user_id and status='active' to prevent unauthorized or stale executions.
+// RecordStandingApprovalExecution inserts an execution record after locking the
+// parent standing approval row. The lock enforces user_id and status='active'
+// to prevent unauthorized or stale executions.
 // Returns a domain error via diagnoseStandingApprovalFailure if no matching row.
 func RecordStandingApprovalExecution(ctx context.Context, db DBTX, standingApprovalID string, userID string, parameters []byte) (*StandingApprovalExecution, error) {
 	var e StandingApprovalExecution
 
 	err := db.QueryRow(ctx,
-		`WITH updated AS (
-			UPDATE standing_approvals
-			SET execution_count = execution_count + 1
+		`WITH locked AS (
+			SELECT standing_approval_id, agent_id, user_id, action_type
+			FROM standing_approvals
 			WHERE standing_approval_id = $1 AND user_id = $2 AND status = 'active'
 			  AND (expires_at IS NULL OR expires_at > now())
-			RETURNING standing_approval_id, agent_id, user_id, action_type
+			FOR UPDATE
 		),
 		ins AS (
 			INSERT INTO standing_approval_executions (standing_approval_id, parameters)
 			SELECT standing_approval_id, $3
-			FROM updated
+			FROM locked
 			RETURNING id, standing_approval_id, parameters, executed_at
 		)
-		SELECT ins.id, ins.standing_approval_id, updated.agent_id, updated.user_id::text,
-		       updated.action_type, a.metadata, ins.parameters, ins.executed_at
-		FROM ins, updated
-		LEFT JOIN agents a ON a.agent_id = updated.agent_id`,
+		SELECT ins.id, ins.standing_approval_id, locked.agent_id, locked.user_id::text,
+		       locked.action_type, a.metadata, ins.parameters, ins.executed_at
+		FROM ins
+		JOIN locked ON locked.standing_approval_id = ins.standing_approval_id
+		LEFT JOIN agents a ON a.agent_id = locked.agent_id`,
 		standingApprovalID, userID, parameters,
 	).Scan(&e.ExecutionID, &e.StandingApprovalID, &e.AgentID, &e.UserID, &e.ActionType, &e.AgentMeta, &e.Parameters, &e.ExecutedAt)
 	if err == nil {
@@ -527,25 +518,19 @@ type UpdateStandingApprovalParams struct {
 	StandingApprovalID string
 	UserID             string
 	Constraints        []byte // raw JSONB
-	MaxExecutions      *int
 	ExpiresAt          *time.Time // nil means no expiry (until revoked)
 }
 
-// UpdateStandingApproval updates the constraints, max_executions, and expires_at of an active
+// UpdateStandingApproval updates the constraints and expires_at of an active
 // standing approval belonging to the given user. Returns the updated approval, or a domain error.
-//
-// The UPDATE atomically guards against setting max_executions below the current
-// execution_count — even in the presence of concurrent executions between the
-// caller's pre-flight validation and this write.
 func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprovalParams) (*StandingApproval, error) {
 	row := db.QueryRow(ctx,
 		`UPDATE standing_approvals
-		 SET constraints = $3, max_executions = $4, expires_at = $5
+		 SET constraints = $3, expires_at = $4
 		 WHERE standing_approval_id = $1 AND user_id = $2
 		   AND status = 'active'
-		   AND ($4::int IS NULL OR $4::int >= execution_count)
 		 RETURNING `+standingApprovalColumns,
-		p.StandingApprovalID, p.UserID, p.Constraints, p.MaxExecutions, p.ExpiresAt,
+		p.StandingApprovalID, p.UserID, p.Constraints, p.ExpiresAt,
 	)
 	updated, err := scanStandingApproval(row)
 	if err == nil {
@@ -555,17 +540,12 @@ func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprov
 		return nil, err
 	}
 
-	// Diagnose why the UPDATE matched zero rows. Check for the max_executions
-	// race before falling back to generic status diagnosis.
 	sa, err := GetStandingApprovalByIDAndUser(ctx, db, p.StandingApprovalID, p.UserID)
 	if err != nil {
 		return nil, err
 	}
 	if sa == nil {
 		return nil, &StandingApprovalError{Code: StandingApprovalErrNotFound}
-	}
-	if sa.Status == "active" && p.MaxExecutions != nil && *p.MaxExecutions < sa.ExecutionCount {
-		return nil, &StandingApprovalError{Code: StandingApprovalErrMaxExecutionsTooLow}
 	}
 	if sa.Status == "revoked" {
 		return nil, &StandingApprovalError{Code: StandingApprovalErrAlreadyRevoked, Status: sa.Status}
@@ -584,12 +564,10 @@ func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID i
 		   SELECT `+standingApprovalColumns+`, 1 AS priority FROM standing_approvals
 		   WHERE agent_id = $1 AND action_type = $2 AND status = 'active'
 		     AND starts_at <= now() AND (expires_at IS NULL OR expires_at > now())
-		     AND (max_executions IS NULL OR execution_count < max_executions)
 		   UNION ALL
 		   SELECT `+standingApprovalColumns+`, 2 AS priority FROM standing_approvals
 		   WHERE agent_id = $1 AND action_type = '*' AND action_type != $2 AND status = 'active'
 		     AND starts_at <= now() AND (expires_at IS NULL OR expires_at > now())
-		     AND (max_executions IS NULL OR execution_count < max_executions)
 		 ) combined
 		 ORDER BY priority, created_at DESC, standing_approval_id DESC
 		 LIMIT 100`,
@@ -614,10 +592,10 @@ func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID i
 	return approvals, nil
 }
 
-// RecordStandingApprovalExecutionByAgent atomically increments the standing
-// approval's execution_count and inserts an execution record, scoped by
-// agent_id. This is used by the auto-approval logic in POST /approvals/request
-// where authentication is via agent signature rather than user session.
+// RecordStandingApprovalExecutionByAgent inserts an execution record after locking
+// the standing approval row, scoped by agent_id. This is used by the auto-approval
+// logic in POST /approvals/request where authentication is via agent signature
+// rather than user session.
 //
 // The requestID is stored in the execution record and enforced via a unique
 // index on (standing_approval_id, request_id) for idempotency. A duplicate
@@ -626,32 +604,30 @@ func RecordStandingApprovalExecutionByAgent(ctx context.Context, db DBTX, standi
 	var e StandingApprovalExecution
 
 	err := db.QueryRow(ctx,
-		`WITH updated AS (
-			UPDATE standing_approvals
-			SET execution_count = execution_count + 1
+		`WITH locked AS (
+			SELECT standing_approval_id, agent_id, user_id, action_type
+			FROM standing_approvals
 			WHERE standing_approval_id = $1
 			  AND agent_id = $2
 			  AND status = 'active'
 			  AND starts_at <= now()
 			  AND (expires_at IS NULL OR expires_at > now())
-			  AND (max_executions IS NULL OR execution_count < max_executions)
-			RETURNING standing_approval_id, agent_id, user_id, action_type, max_executions, execution_count
+			FOR UPDATE
 		),
 		ins AS (
 			INSERT INTO standing_approval_executions (standing_approval_id, parameters, request_id)
 			SELECT standing_approval_id, $3, $4
-			FROM updated
+			FROM locked
 			RETURNING id, standing_approval_id, parameters, executed_at
 		)
-		SELECT ins.id, ins.standing_approval_id, updated.agent_id, updated.user_id::text,
-		       updated.action_type, a.metadata, ins.parameters, ins.executed_at,
-		       updated.max_executions, updated.execution_count
-		FROM ins, updated
-		LEFT JOIN agents a ON a.agent_id = updated.agent_id`,
+		SELECT ins.id, ins.standing_approval_id, locked.agent_id, locked.user_id::text,
+		       locked.action_type, a.metadata, ins.parameters, ins.executed_at
+		FROM ins
+		JOIN locked ON locked.standing_approval_id = ins.standing_approval_id
+		LEFT JOIN agents a ON a.agent_id = locked.agent_id`,
 		standingApprovalID, agentID, parameters, requestID,
 	).Scan(&e.ExecutionID, &e.StandingApprovalID, &e.AgentID, &e.UserID, &e.ActionType,
-		&e.AgentMeta, &e.Parameters, &e.ExecutedAt,
-		&e.MaxExecutions, &e.ExecutionCount)
+		&e.AgentMeta, &e.Parameters, &e.ExecutedAt)
 	if err == nil {
 		return &e, nil
 	}

--- a/db/standing_approvals_test.go
+++ b/db/standing_approvals_test.go
@@ -12,7 +12,7 @@ import (
 
 const standingApprovalDBTestConnector = "standing_approval_db_test"
 
-func insertTestStandingApprovalRow(t *testing.T, tx db.DBTX, agentID int64, uid, standingApprovalID, actionType, status string, startsAt time.Time, expiresAt *time.Time, maxExec *int) error {
+func insertTestStandingApprovalRow(t *testing.T, tx db.DBTX, agentID int64, uid, standingApprovalID, actionType, status string, startsAt time.Time, expiresAt *time.Time) error {
 	t.Helper()
 	ctx := context.Background()
 	_, _ = tx.Exec(ctx,
@@ -27,9 +27,9 @@ func insertTestStandingApprovalRow(t *testing.T, tx db.DBTX, agentID int64, uid,
 		_, _ = tx.Exec(ctx, `DELETE FROM action_configurations WHERE id = $1`, configID)
 	})
 	_, err := tx.Exec(ctx,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, source_action_configuration_id, max_executions, starts_at, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-		standingApprovalID, agentID, uid, actionType, status, configID, maxExec, startsAt, expiresAt)
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, source_action_configuration_id, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		standingApprovalID, agentID, uid, actionType, status, configID, startsAt, expiresAt)
 	return err
 }
 
@@ -38,9 +38,9 @@ func TestStandingApprovalsSchema(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	testhelper.RequireColumns(t, tx, "standing_approvals", []string{
 		"standing_approval_id", "agent_id", "user_id", "action_type",
-		"action_version", "constraints", "status", "max_executions",
-		"execution_count", "starts_at", "expires_at", "created_at",
-		"revoked_at", "expired_at", "exhausted_at",
+		"action_version", "constraints", "status",
+		"starts_at", "expires_at", "created_at",
+		"revoked_at", "expired_at",
 	})
 }
 
@@ -90,11 +90,11 @@ func TestStandingApprovalsStatusCheckConstraint(t *testing.T) {
 
 	base := testhelper.GenerateID(t, "sa_")
 	testhelper.RequireCheckValues(t, tx, "status",
-		[]string{"active", "expired", "revoked", "exhausted"}, "invalid",
+		[]string{"active", "expired", "revoked"}, "invalid",
 		func(value string, i int) error {
 			start := time.Now().UTC()
 			exp := start.Add(30 * 24 * time.Hour)
-			return insertTestStandingApprovalRow(t, tx, agentID, uid, fmt.Sprintf("%s_%d", base, i), "test.action", value, start, &exp, nil)
+			return insertTestStandingApprovalRow(t, tx, agentID, uid, fmt.Sprintf("%s_%d", base, i), "test.action", value, start, &exp)
 		})
 }
 
@@ -109,14 +109,14 @@ func TestStandingApprovalsExpiryConstraints(t *testing.T) {
 	start2026 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// NULL expires_at (no expiry) should succeed
-	err := insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_null_ok", "test.action", "active", start2026, nil, nil)
+	err := insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_null_ok", "test.action", "active", start2026, nil)
 	if err != nil {
 		t.Errorf("NULL expires_at was rejected: %v", err)
 	}
 
 	// 365 days should succeed (no max duration limit)
 	exp365 := start2026.AddDate(1, 0, 0)
-	err = insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_365d_ok", "test.action", "active", start2026, &exp365, nil)
+	err = insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_365d_ok", "test.action", "active", start2026, &exp365)
 	if err != nil {
 		t.Errorf("365 days was rejected: %v", err)
 	}
@@ -125,30 +125,10 @@ func TestStandingApprovalsExpiryConstraints(t *testing.T) {
 	err = testhelper.WithSavepoint(t, tx, func() error {
 		startMar := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 		expFeb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-		return insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_backward", "test.action", "active", startMar, &expFeb, nil)
+		return insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_backward", "test.action", "active", startMar, &expFeb)
 	})
 	if err == nil {
 		t.Error("expected CHECK constraint violation for expires_at before starts_at, but insert succeeded")
-	}
-}
-
-func TestStandingApprovalsExecutionCountCheckConstraint(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-	saID := testhelper.GenerateID(t, "sa_")
-
-	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
-	testhelper.InsertStandingApproval(t, tx, saID, agentID, uid)
-
-	// Setting execution_count to a negative value should fail
-	err := testhelper.WithSavepoint(t, tx, func() error {
-		_, err := tx.Exec(context.Background(),
-			`UPDATE standing_approvals SET execution_count = -1 WHERE standing_approval_id = $1`, saID)
-		return err
-	})
-	if err == nil {
-		t.Error("expected CHECK constraint violation for negative execution_count, but update succeeded")
 	}
 }
 
@@ -202,36 +182,3 @@ func TestStandingApprovalExecutionsCascadeOnProfileDelete(t *testing.T) {
 	)
 }
 
-func TestStandingApprovalsMaxExecutionsCheckConstraint(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-	uid := testhelper.GenerateUID(t)
-
-	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
-
-	base := testhelper.GenerateID(t, "sa_")
-	start := time.Now().UTC()
-	exp := start.Add(30 * 24 * time.Hour)
-	one := 1
-	zero := 0
-
-	// max_executions = NULL (unlimited) should succeed
-	err := insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_null", "test.action", "active", start, &exp, nil)
-	if err != nil {
-		t.Errorf("NULL max_executions was rejected: %v", err)
-	}
-
-	// max_executions = 1 should succeed
-	err = insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_1", "test.action", "active", start, &exp, &one)
-	if err != nil {
-		t.Errorf("max_executions=1 was rejected: %v", err)
-	}
-
-	// max_executions = 0 should fail (must be > 0)
-	err = testhelper.WithSavepoint(t, tx, func() error {
-		return insertTestStandingApprovalRow(t, tx, agentID, uid, base+"_0", "test.action", "active", start, &exp, &zero)
-	})
-	if err == nil {
-		t.Error("expected CHECK constraint violation for max_executions=0, but insert succeeded")
-	}
-}

--- a/db/testhelper/fixtures_standing_approvals.go
+++ b/db/testhelper/fixtures_standing_approvals.go
@@ -95,11 +95,6 @@ func InsertStandingApprovalExecutionWithParams(t *testing.T, d db.DBTX, saID str
 		`INSERT INTO standing_approval_executions (standing_approval_id, parameters)
 		 VALUES ($1, $2)`,
 		saID, params)
-	mustExec(t, d,
-		`UPDATE standing_approvals
-		 SET execution_count = execution_count + 1
-		 WHERE standing_approval_id = $1`,
-		saID)
 }
 
 // StandingApprovalOpts holds optional fields for InsertStandingApprovalFull.
@@ -108,7 +103,6 @@ type StandingApprovalOpts struct {
 	Status                      string
 	Constraints                 []byte
 	SourceActionConfigurationID *string
-	MaxExecutions               *int
 	StartsAt                    time.Time
 	ExpiresAt                   time.Time
 }
@@ -134,7 +128,24 @@ func InsertStandingApprovalFull(t *testing.T, d db.DBTX, saID string, agentID in
 		sourceID = &id
 	}
 	mustExec(t, d,
-		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, constraints, source_action_configuration_id, max_executions, starts_at, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-		saID, agentID, userID, opts.ActionType, opts.Status, opts.Constraints, sourceID, opts.MaxExecutions, opts.StartsAt, opts.ExpiresAt)
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, constraints, source_action_configuration_id, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		saID, agentID, userID, opts.ActionType, opts.Status, opts.Constraints, sourceID, opts.StartsAt, opts.ExpiresAt)
+}
+
+// RequireStandingApprovalExecutionCount asserts the number of rows in
+// standing_approval_executions for the given standing approval.
+func RequireStandingApprovalExecutionCount(t *testing.T, d db.DBTX, standingApprovalID string, want int) {
+	t.Helper()
+	ctx := context.Background()
+	var n int
+	if err := d.QueryRow(ctx,
+		`SELECT COUNT(*) FROM standing_approval_executions WHERE standing_approval_id = $1`,
+		standingApprovalID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count executions for %s: %v", standingApprovalID, err)
+	}
+	if n != want {
+		t.Fatalf("expected %d standing_approval_executions rows for %s, got %d", want, standingApprovalID, n)
+	}
 }

--- a/docs/adr/002-standing-approvals.md
+++ b/docs/adr/002-standing-approvals.md
@@ -98,7 +98,6 @@ Created ──> Active ──> Expired
 2. **Active:** Agent can execute the action freely within constraints.
 3. **Expired:** Duration elapsed. Agent must request a new standing approval or fall back to one-off.
 4. **Revoked:** User manually cancels at any time. Takes effect immediately.
-5. **Exhausted:** Max execution count reached. Same as expired.
 
 ---
 
@@ -110,9 +109,8 @@ Standing approvals **do not relax constraints** — they relax the approval prom
 2. **Standing approval matched** (agent + action type + active status)
 3. **Parameters validated against constraints** (same rules as ADR-001 Decision 4)
 4. **TTL checked** (standing approval not expired)
-5. **Execution count checked** (if max_executions set, not exceeded)
-6. **Action executed** via connector with stored credentials
-7. **Audit log entry created** (every execution, not just the standing approval creation)
+5. **Action executed** via connector with stored credentials
+6. **Audit log entry created** (every execution, not just the standing approval creation)
 
 If parameters violate constraints, the request is **rejected immediately** — same as the one-off flow. The standing approval doesn't make constraint violations pass.
 
@@ -148,17 +146,6 @@ Users set the duration to any value up to a **90-day maximum**. This cap prevent
 
 ---
 
-### Max executions
-
-| Setting | Behavior |
-|---|---|
-| Unlimited (default) | No cap — agent can execute as many times as it wants within the duration |
-| N (positive integer) | Standing approval becomes `exhausted` after N executions |
-
-**Use case for capped executions:** "Send up to 5 summary emails this week" — the user wants to pre-approve a finite batch without being prompted for each one, but doesn't want the agent sending 500 emails.
-
----
-
 ### Security considerations
 
 **Standing approvals shift risk.** Instead of reviewing each action in real-time, the user is making a forward-looking trust decision. This is acceptable when:
@@ -174,7 +161,6 @@ Users set the duration to any value up to a **90-day maximum**. This cap prevent
 The web interface SHOULD warn users when creating standing approvals with:
 - No recipient constraints on `email.send`
 - Maximum duration (90 days) on write actions
-- Unlimited executions on write actions
 - Multiple broad standing approvals for the same agent
 
 ---
@@ -189,9 +175,7 @@ STANDING_APPROVAL {
     string  action_type           "email.read | email.send"
     string  action_version        "1"
     json    constraints           "same schema as ACTION_CONFIG"
-    string  status                "active | expired | revoked | exhausted"
-    int     max_executions        "null = unlimited"
-    int     execution_count       "current count"
+    string  status                "active | expired | revoked"
     timestamp starts_at
     timestamp expires_at          "NOT NULL, max 90 days from starts_at"
     timestamp created_at
@@ -209,14 +193,14 @@ Every execution under a standing approval also writes to `AUDIT_LOG` with `event
 - **Reduces approval fatigue.** Repetitive, predictable actions shouldn't require a prompt every time.
 - **Constraints are still enforced.** This relaxes the *approval prompt*, not the *security boundary*.
 - **90-day cap prevents permanent delegation.** Users must periodically re-evaluate standing approvals, preventing security drift from "set and forget" grants.
-- **User controls the risk window.** Duration (up to 90 days), execution caps, and instant revocation are all user-defined.
+- **User controls the risk window.** Duration (up to 90 days) and instant revocation are user-defined.
 - **Progressive trust.** Users start with one-off approvals, then graduate to standing approvals for actions they trust — the system grows with the user's confidence.
 
 ## Alternatives considered
 
 - **Longer TTL on single-use tokens.** Doesn't solve the problem — you'd need 288 tokens per day for a 5-minute check. And single-use means one execution per token.
-- **Batch approvals (approve N actions at once).** Awkward UX — user has to approve a specific count upfront. Standing approvals with `max_executions` subsume this.
-- **Auto-approve rules as a separate concept.** Standing approvals already cover this — a standing approval with 90-day duration and unlimited executions is functionally an auto-approve rule, but managed through the same UI with periodic renewal.
+- **Batch approvals (approve N actions at once).** Awkward UX — user has to approve a specific count upfront. Standing approvals handle recurring automation via duration and constraints instead.
+- **Auto-approve rules as a separate concept.** Standing approvals already cover this — a standing approval with 90-day duration is functionally an auto-approve rule, but managed through the same UI with periodic renewal.
 - **Refresh tokens.** Adds complexity (refresh flow, token rotation) for something that standing approvals handle more cleanly at the authorization layer rather than the token layer.
 
 ## Consequences

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -308,8 +308,6 @@ X-Permission-Slip-Signature: agent_id="42", algorithm="Ed25519", ...
             {
               "standing_approval_id": "sa_def456",
               "constraints": { "recipient_pattern": "*@mycompany.com" },
-              "max_executions": 100,
-              "executions_remaining": 88,
               "expires_at": "2026-05-15T00:00:00Z"
             }
           ]
@@ -507,13 +505,11 @@ When a standing approval matches, the response returns `status: "approved"` with
 {
   "status": "approved",
   "result": { "message_id": "msg_def456" },
-  "standing_approval_id": "sa_def456",
-  "executions_remaining": 87
+  "standing_approval_id": "sa_def456"
 }
 ```
 
 - **`standing_approval_id`** — identifies which pre-approval authorized this execution (useful for audit tracking and logging).
-- **`executions_remaining`** — how many more times this standing approval can be used. `null` means unlimited. Track this value to avoid hitting the limit unexpectedly.
 - **Idempotency** — if you receive `status: "approved"`, the action has already executed. Do not retry with the same `request_id` — you'll get `409 Conflict`.
 - **CLI `executed` field** — when using the CLI (`permission-slip request`), auto-approved responses include `"executed": true` to signal that the action has already completed and no polling or further action is needed. A `409 duplicate_request_id` is also returned as `{ "status": "duplicate", "executed": true }` with exit code `0`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -395,9 +395,7 @@ erDiagram
         string action_type "email.read | email.send"
         string action_version "1"
         json constraints "same schema as ACTION_CONFIG"
-        string status "active | expired | revoked | exhausted"
-        int max_executions "null = unlimited"
-        int execution_count "current count"
+        string status "active | expired | revoked"
         timestamp starts_at
         timestamp expires_at "null = no expiration"
         timestamp created_at

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -250,21 +250,18 @@ Pre-authorized rules that let agents act without per-request approval, within co
 | `action_type` | text | NOT NULL, max 128 chars |
 | `action_version` | text | NOT NULL, DEFAULT '1', max 10 chars |
 | `constraints` | jsonb | max 64 KB |
-| `status` | text | NOT NULL, CHECK IN ('active', 'expired', 'revoked', 'exhausted') |
-| `max_executions` | int | CHECK > 0 (nullable; NULL = unlimited) |
-| `execution_count` | int | NOT NULL, DEFAULT 0, CHECK >= 0 |
+| `status` | text | NOT NULL, CHECK IN ('active', 'expired', 'revoked') |
 | `starts_at` | timestamptz | NOT NULL |
 | `expires_at` | timestamptz | NOT NULL, CHECK >= starts_at, CHECK duration <= 90 days |
 | `created_at` | timestamptz | NOT NULL, DEFAULT now() |
 | `revoked_at` | timestamptz | |
 | `expired_at` | timestamptz | |
-| `exhausted_at` | timestamptz | |
 
 **Indexes:** `idx_standing_approvals_agent_action_status` on `(agent_id, action_type, status)`
 
 ### `standing_approval_executions`
 
-Per-execution records for standing approvals. Each row represents a single execution with its own timestamp and parameters, enabling accurate audit trail entries. The parent `standing_approvals.execution_count` counter is still incremented alongside each insert for quick aggregate access. Agent and user ownership are derived from the parent `standing_approvals` row via JOIN (not stored here) to prevent cross-tenant inconsistency.
+Per-execution records for standing approvals. Each row represents a single execution with its own timestamp and parameters, enabling accurate audit trail entries. Agent and user ownership are derived from the parent `standing_approvals` row via JOIN (not stored here) to prevent cross-tenant inconsistency.
 
 | Column | Type | Constraints |
 |---|---|---|
@@ -531,8 +528,8 @@ Helpers are split by responsibility:
 | `InsertAgentConnector(t, pool, agentID, approverID, connectorID)` | `fixtures_agent_connectors.go` | Enables a connector for an agent |
 | `InsertStandingApproval(t, pool, saID, agentID, userID)` | `fixtures_standing_approvals.go` | Creates an active standing approval |
 | `InsertStandingApprovalWithStatus(t, pool, ..., status)` | `fixtures_standing_approvals.go` | Creates a standing approval with specific status |
-| `InsertStandingApprovalExecution(t, pool, saID)` | `fixtures_standing_approvals.go` | Records a standing approval execution (also bumps execution_count) |
-| `InsertStandingApprovalExecutionWithParams(t, pool, saID, params)` | `fixtures_standing_approvals.go` | Records a standing approval execution with parameters (also bumps execution_count) |
+| `InsertStandingApprovalExecution(t, pool, saID)` | `fixtures_standing_approvals.go` | Records a standing approval execution |
+| `InsertStandingApprovalExecutionWithParams(t, pool, saID, params)` | `fixtures_standing_approvals.go` | Records a standing approval execution with parameters |
 | `InsertActionConfig(t, pool, configID, agentID, userID, connectorID, actionType)` | `fixtures_action_configurations.go` | Creates an active action configuration with minimal defaults |
 | `InsertActionConfigFull(t, pool, configID, agentID, userID, connectorID, actionType, opts)` | `fixtures_action_configurations.go` | Creates an action configuration with full control over all fields |
 
@@ -560,7 +557,7 @@ Tests are split by domain. Each domain file owns its own schema assertions, CASC
 - `approvals_test.go` — schema, cascades, CHECK constraints, indexes, consumed tokens, pg_cron jobs
 - `credentials_test.go` — schema, cascades, unique constraints (including NULL label), indexes
 - `agent_connectors_test.go` — schema, cascades, indexes
-- `standing_approvals_test.go` — schema, cascades, CHECK constraints (status, 90-day max, execution_count, max_executions), indexes, standing_approval_executions table
+- `standing_approvals_test.go` — schema, cascades, CHECK constraints (status, 90-day max), indexes, standing_approval_executions table
 - `action_configurations_test.go` — schema, cascades, CHECK constraints (status, parameters size), credential SET NULL behavior, CRUD function tests (create, get, list, update, delete), user scoping
 - `audit_events_test.go` — ListAuditEvents query: all event types, filters (agent_id, event_type, outcome), pagination, user isolation, ordering
 - `subscriptions_test.go` — schema, CRUD, UNIQUE constraints

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -733,8 +733,6 @@ X-Permission-Slip-Signature: agent_id="42", algorithm="Ed25519", timestamp="1707
             {
               "standing_approval_id": "sa_def456",
               "constraints": { "recipient_pattern": "*@mycompany.com" },
-              "max_executions": 100,
-              "executions_remaining": 88,
               "expires_at": "2026-05-15T00:00:00Z"
             }
           ]
@@ -788,8 +786,6 @@ X-Permission-Slip-Signature: agent_id="42", algorithm="Ed25519", timestamp="1707
     - `standing_approvals` (array): Active standing approvals for this action type. If non-empty, the agent can execute immediately under matching constraints. If empty, one-off approval is required.
       - `standing_approval_id` (string): Standing approval identifier
       - `constraints` (object): Parameter constraint boundaries
-      - `max_executions` (integer or null): Execution cap (`null` = unlimited)
-      - `executions_remaining` (integer or null): Remaining executions (`null` = unlimited)
       - `expires_at` (string): ISO 8601 expiration timestamp
 
 **Agent Workflow After Calling This Endpoint:**
@@ -1036,9 +1032,8 @@ When a matching standing approval exists, the action is auto-approved and execut
 - `status` (string, required): Approval status (`approved`)
 - `result` (object, required): Action result from the external service
 - `standing_approval_id` (string, required): Which standing approval authorized this execution
-- `executions_remaining` (integer, optional): Remaining executions. Present only when the standing approval has a finite `max_executions`; absent when unlimited.
 
-> **Execution slot consumption on error:** When a standing approval matches, the execution slot is consumed _before_ the connector action runs. If the connector fails (network timeout, upstream error, etc.), the slot is still consumed. On untyped 500 errors, the response includes `executions_remaining` and `standing_approval_id` in the error `details` so agents can track quota erosion. Agents should monitor `executions_remaining` and request a new standing approval if the quota runs low due to transient failures.
+> **Execution record on connector failure:** When a standing approval matches, an execution record may be written before the connector action completes. If the connector fails (network timeout, upstream error, etc.), that record can still exist. Untyped 500 errors may include `standing_approval_id` in the error `details` for correlation.
 
 **Error Responses:**
 
@@ -1499,8 +1494,6 @@ X-Permission-Slip-Signature: agent_id="agent_x7K9mP4n...", algorithm="Ed25519", 
         "max_results": 10
       },
       "status": "active",
-      "max_executions": null,
-      "execution_count": 42,
       "starts_at": "2026-02-10T00:00:00Z",
       "expires_at": "2026-03-12T00:00:00Z"
     },
@@ -1512,8 +1505,6 @@ X-Permission-Slip-Signature: agent_id="agent_x7K9mP4n...", algorithm="Ed25519", 
         "to": "*@mycompany.com"
       },
       "status": "active",
-      "max_executions": 50,
-      "execution_count": 3,
       "starts_at": "2026-02-14T00:00:00Z",
       "expires_at": "2026-02-21T00:00:00Z"
     }
@@ -1529,8 +1520,6 @@ X-Permission-Slip-Signature: agent_id="agent_x7K9mP4n...", algorithm="Ed25519", 
   - `action_version` (string): Action version
   - `constraints` (object or null): Parameter bounds enforced at execution time
   - `status` (string): Always `active` (only active standing approvals are returned)
-  - `max_executions` (integer or null): Execution cap (`null` = unlimited)
-  - `execution_count` (integer): Number of times this standing approval has been used
   - `starts_at` (string): ISO 8601 timestamp when the approval became active
   - `expires_at` (string): ISO 8601 timestamp when the approval expires (max 90 days from `starts_at`)
 
@@ -1552,16 +1541,15 @@ Standing approval matching and execution is handled automatically by `POST /v1/a
 2. **Match standing approval:** Find an active standing approval for this agent + action type
 3. **Validate constraints:** Verify parameters fall within the standing approval's constraint bounds
 4. **Check expiration:** Verify standing approval has not expired
-5. **Check execution count:** If `max_executions` is set, verify count has not been exceeded
-6. **Execute action:** Call external service API using stored credentials
-7. **Increment execution count** and **create audit log entry**
-8. **Return result** to agent with `status: "approved"`
+5. **Execute action:** Call external service API using stored credentials
+6. **Create execution record** and **create audit log entry**
+7. **Return result** to agent with `status: "approved"`
 
 If a matching standing approval is found, the response includes the action result inline (see the auto-approved response format in the [POST /v1/approvals/request](#post-v1approvalsrequest) section above).
 
 **Fallthrough Behavior:**
 
-If no standing approval matches (wrong action type, parameters outside constraints, expired, or exhausted), Permission Slip creates a pending approval as usual and returns `status: "pending"`. The agent then proceeds with the standard one-off approval flow (user review, confirmation code, token).
+If no standing approval matches (wrong action type, parameters outside constraints, or expired), Permission Slip creates a pending approval as usual and returns `status: "pending"`. The agent then proceeds with the standard one-off approval flow (user review, confirmation code, token).
 
 ---
 
@@ -1882,7 +1870,6 @@ For rate limiting errors, include:
 | `approval_already_resolved` | 409 | `false` | Approval already approved/denied/cancelled |
 | `registration_expired` | 410 | `false` | Registration TTL elapsed |
 | `approval_expired` | 410 | `false` | Approval TTL elapsed |
-| `standing_approval_exhausted` | 403 | `false` | Standing approval execution count exceeded |
 | `constraint_violation` | 403 | `false` | Parameters violate standing approval constraints |
 | `no_matching_standing_approval` | 404 | `false` | No active standing approval matches this agent/action/parameters |
 | `standing_approval_expired` | 410 | `false` | Standing approval has expired |

--- a/frontend/src/api/bundled.yaml
+++ b/frontend/src/api/bundled.yaml
@@ -1193,8 +1193,6 @@ paths:
                                 constraints:
                                   recipient_pattern: '*@mycompany.com'
                                   max_recipients: 5
-                                max_executions: 100
-                                executions_remaining: 88
                                 expires_at: '2026-05-15T00:00:00Z'
                             action_configurations:
                               - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -1224,8 +1222,6 @@ paths:
                                 constraints:
                                   sender: '*@github.com'
                                   max_results: 10
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-02-28T00:00:00Z'
                             action_configurations: []
                       - id: stripe
@@ -1296,14 +1292,10 @@ paths:
                               - standing_approval_id: sa_read01
                                 constraints:
                                   sender: '*@github.com'
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-03-15T00:00:00Z'
                               - standing_approval_id: sa_read02
                                 constraints:
                                   sender: '*@linear.app'
-                                max_executions: 50
-                                executions_remaining: 50
                                 expires_at: '2026-03-01T00:00:00Z'
                             action_configurations: []
         '400':
@@ -2198,7 +2190,7 @@ paths:
 
         1. **Parameters validated**: Against standing approval constraints
         2. **Action executed**: Immediately via the connector using stored credentials
-        3. **Result returned**: Response has `status: "approved"` with `result`, `standing_approval_id`, and `executions_remaining`
+        3. **Result returned**: Response has `status: "approved"` with `result` and `standing_approval_id`
         4. **No polling needed**: The agent has the result immediately
 
         ## One-off Approval (No Standing Approval Match)
@@ -2343,7 +2335,6 @@ paths:
                       message_id: msg_abc123
                       delivery_status: queued
                     standing_approval_id: sa_abc123
-                    executions_remaining: 47
         '400':
           description: Invalid request or unsupported action type
           content:
@@ -3930,12 +3921,12 @@ paths:
         - **Agent startup**: Agent queries its standing approvals to understand what it can do
         - **Flow selection**: Agent checks if a standing approval covers a desired action before
           deciding whether to use `POST /v1/actions/execute` (standing) or `POST /v1/approvals/request` (one-off)
-        - **Status monitoring**: Agent checks remaining executions or expiration times
+        - **Status monitoring**: Agent checks expiration times
 
         ## Filtering
 
-        Only standing approvals with status `active` are returned by default. Expired,
-        revoked, and exhausted standing approvals are excluded.
+        Only standing approvals with status `active` are returned by default. Expired
+        and revoked standing approvals are excluded.
 
         ## Security
 
@@ -3988,8 +3979,6 @@ paths:
                       sender: '*@github.com'
                       max_results: 10
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
@@ -4004,8 +3993,6 @@ paths:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
                     status: active
-                    max_executions: 100
-                    execution_count: 12
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-05-15T00:00:00Z'
                     created_at: '2026-02-14T10:35:00Z'
@@ -4077,7 +4064,6 @@ paths:
               - active
               - expired
               - revoked
-              - exhausted
               - all
             default: active
           example: active
@@ -4128,8 +4114,6 @@ paths:
                     constraints:
                       sender: '*@github.com'
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
@@ -4197,7 +4181,6 @@ paths:
               constraints:
                 recipient_pattern: '*@mycompany.com'
               source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-              max_executions: 100
               expires_at: '2026-03-14T00:00:00Z'
       responses:
         '201':
@@ -4325,7 +4308,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -4349,17 +4332,13 @@ paths:
       operationId: updateStandingApproval
       summary: Update Standing Approval
       description: |
-        Update the constraints, max_executions, and expires_at of an active standing approval.
+        Update the constraints and expires_at of an active standing approval.
         The standing approval must belong to the authenticated user and be in `active` status.
-        Agent and action type cannot be changed — only constraints and limits.
+        Agent and action type cannot be changed — only constraints and expiry.
 
         **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
         the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
         not a rolling window from the time of the update call.
-
-        **Execution count**: `max_executions` cannot be set below the approval's current
-        `execution_count`. The update is rejected atomically at the database level to prevent
-        a race condition where concurrent executions could otherwise create a zombie approval.
 
         Emits a `standing_approval.updated` audit event on success.
       tags:
@@ -4377,7 +4356,6 @@ paths:
             example:
               constraints:
                 recipient_pattern: '*@mycompany.com'
-              max_executions: 200
               expires_at: '2026-04-14T00:00:00Z'
       responses:
         '200':
@@ -4413,7 +4391,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -4431,7 +4409,7 @@ paths:
       description: |
         Record an execution of an active standing approval. The standing approval
         must belong to the authenticated user and be in `active` status. Atomically
-        increments the execution count and creates an execution record.
+        creates an execution record.
 
         Emits a `standing_approval.executed` audit event on success.
       tags:
@@ -4501,7 +4479,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -6815,9 +6793,8 @@ components:
         Response after submitting an approval request. Two possible outcomes:
 
         **Auto-approved** (`status: "approved"`): A matching standing approval was found.
-        The action was executed immediately. The response includes `result`,
-        `standing_approval_id`, and optionally `executions_remaining`. No `approval_id`
-        or `approval_url` is returned.
+        The action was executed immediately. The response includes `result` and
+        `standing_approval_id`. No `approval_id` or `approval_url` is returned.
 
         **Pending** (`status: "pending"`): No standing approval matched. A pending approval
         was created. The agent should poll `GET /v1/approvals/{approval_id}/status` for the
@@ -6872,13 +6849,6 @@ components:
           description: |
             ID of the standing approval that matched. Present only when `status` is `approved`.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          description: |
-            Number of executions remaining on the standing approval.
-            Present only when `status` is `approved` and the standing approval has a
-            finite `max_executions`. Absent when unlimited.
-          example: 47
       example:
         approval_id: appr_xyz789
         approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
@@ -8102,7 +8072,6 @@ components:
         - action_type
         - constraints
         - status
-        - execution_count
         - starts_at
         - created_at
         - source_action_configuration_id
@@ -8165,30 +8134,13 @@ components:
             - active
             - expired
             - revoked
-            - exhausted
           description: |
             Current status of the standing approval.
 
             - **active**: Agent can execute actions under this standing approval
             - **expired**: Duration elapsed; agent must request a new standing approval or use one-off
             - **revoked**: User manually cancelled this standing approval
-            - **exhausted**: Max execution count reached
           example: active
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of times the agent can execute under this standing approval.
-            `null` means unlimited — the agent can execute as many times as it wants
-            within the duration.
-          example: null
-        execution_count:
-          type: integer
-          minimum: 0
-          description: |
-            Number of times this standing approval has been used so far.
-          example: 42
         starts_at:
           type: string
           format: date-time
@@ -8238,8 +8190,6 @@ components:
           sender: '*@github.com'
           max_results: 10
         status: active
-        max_executions: null
-        execution_count: 42
         starts_at: '2026-02-14T00:00:00Z'
         expires_at: '2026-02-21T00:00:00Z'
         created_at: '2026-02-14T10:30:00Z'
@@ -8312,7 +8262,6 @@ components:
       required:
         - result
         - standing_approval_id
-        - executions_remaining
       properties:
         result:
           type: object
@@ -8331,14 +8280,6 @@ components:
           description: |
             Which standing approval authorized this execution.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining under this standing approval.
-            `null` means unlimited.
-          example: null
       example:
         result:
           emails:
@@ -8346,7 +8287,6 @@ components:
               subject: PR merged
               sender: noreply@github.com
         standing_approval_id: sa_abc123
-        executions_remaining: null
     StandingApprovalListResponse:
       type: object
       required:
@@ -8386,8 +8326,6 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
@@ -8428,8 +8366,6 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
@@ -8486,12 +8422,6 @@ components:
             `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
             enforce the pattern — only non-empty and max 128 characters.
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Maximum number of executions. Null means unlimited.
-          example: 100
         starts_at:
           type: string
           format: date-time
@@ -8512,7 +8442,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
         source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-        max_executions: 100
         expires_at: null
     RevokeStandingApprovalResponse:
       type: object
@@ -8545,12 +8474,6 @@ components:
             Updated constraint boundaries. Must be non-empty with at least one non-wildcard value.
           example:
             recipient_pattern: '*@mycompany.com'
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Updated maximum number of executions. Null means unlimited.
-          example: 200
         expires_at:
           type: string
           format: date-time
@@ -8563,7 +8486,6 @@ components:
       example:
         constraints:
           recipient_pattern: '*@mycompany.com'
-        max_executions: 200
         expires_at: null
     UserExecuteStandingApprovalRequest:
       type: object
@@ -9084,8 +9006,6 @@ components:
                     constraints:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
-                    max_executions: 100
-                    executions_remaining: 88
                     expires_at: '2026-05-15T00:00:00Z'
                 action_configurations:
                   - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -9335,8 +9255,6 @@ components:
           - standing_approval_id: sa_def456
             constraints:
               recipient_pattern: '*@mycompany.com'
-            max_executions: 100
-            executions_remaining: 88
             expires_at: '2026-05-15T00:00:00Z'
         action_configurations:
           - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -9351,7 +9269,6 @@ components:
       required:
         - standing_approval_id
         - constraints
-        - executions_remaining
         - expires_at
       properties:
         standing_approval_id:
@@ -9378,23 +9295,6 @@ components:
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of executions allowed under this standing approval.
-            `null` means unlimited.
-          example: 100
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining. `null` means unlimited (when
-            `max_executions` is null). When this reaches `0`, the standing
-            approval is exhausted and the agent must use one-off approval.
-          example: 88
         expires_at:
           type: string
           format: date-time
@@ -9408,8 +9308,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
           max_recipients: 5
-        max_executions: 100
-        executions_remaining: 88
         expires_at: '2026-05-15T00:00:00Z'
     ActionConfigCapability:
       type: object
@@ -11430,7 +11328,6 @@ components:
             - agent_limit_reached
             - standing_approval_limit_reached
             - credential_limit_reached
-            - standing_approval_exhausted
             - constraint_violation
             - standing_approval_expired
             - subscription_not_found
@@ -11733,12 +11630,6 @@ components:
           description: |
             Number of days until the standing approval expires. `null` means no
             expiry (until revoked).
-        max_executions:
-          type: integer
-          nullable: true
-          minimum: 1
-          description: |
-            Optional cap on executions. `null` means unlimited within the window.
     BulkApplyActionConfigTemplateRequest:
       type: object
       required:
@@ -11781,7 +11672,6 @@ components:
         - standing_approval_id
         - action_type
         - status
-        - execution_count
       properties:
         standing_approval_id:
           type: string
@@ -11797,15 +11687,6 @@ components:
           format: date-time
           nullable: true
           description: When the standing approval expires, or null if it lasts until revoked.
-        max_executions:
-          type: integer
-          nullable: true
-          minimum: 1
-          description: Execution cap, if any.
-        execution_count:
-          type: integer
-          minimum: 0
-          description: Executions recorded so far.
     BulkApplyResultError:
       type: object
       required:

--- a/frontend/src/lib/standingApprovalStatus.ts
+++ b/frontend/src/lib/standingApprovalStatus.ts
@@ -4,7 +4,6 @@ export type StandingApprovalRowStatus =
   | "none"
   | "active"
   | "expired"
-  | "exhausted"
   | "revoked";
 
 /**
@@ -29,8 +28,6 @@ export function standingApprovalRowStatus(
       return "active";
     case "expired":
       return "expired";
-    case "exhausted":
-      return "exhausted";
     case "revoked":
       return "revoked";
     default:
@@ -48,8 +45,6 @@ export function standingApprovalStatusLabel(
       return "None";
     case "expired":
       return "Expired";
-    case "exhausted":
-      return "Exhausted";
     case "revoked":
       return "Revoked";
     default:

--- a/frontend/src/pages/agents/connectors/ActionConfigStandingApprovalSheet.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigStandingApprovalSheet.tsx
@@ -72,16 +72,12 @@ export function ActionConfigStandingApprovalSheet({
   const isWildcardAction = config.action_type === "*";
   const isEditActive = primary?.status === "active";
 
-  const [maxExecutions, setMaxExecutions] = useState("");
   const [noExpiry, setNoExpiry] = useState(true);
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAtLocal);
 
   useEffect(() => {
     if (!open) return;
     if (isEditActive && primary) {
-      setMaxExecutions(
-        primary.max_executions != null ? String(primary.max_executions) : "",
-      );
       setNoExpiry(!primary.expires_at);
       if (primary.expires_at) {
         const d = new Date(primary.expires_at);
@@ -91,7 +87,6 @@ export function ActionConfigStandingApprovalSheet({
         setExpiresAt(defaultExpiresAtLocal());
       }
     } else {
-      setMaxExecutions("");
       setNoExpiry(true);
       setExpiresAt(defaultExpiresAtLocal());
     }
@@ -131,23 +126,10 @@ export function ActionConfigStandingApprovalSheet({
       return;
     }
 
-    const maxExecParsed =
-      maxExecutions.trim() === "" ? null : Number.parseInt(maxExecutions, 10);
-    if (
-      maxExecutions.trim() !== "" &&
-      (Number.isNaN(maxExecParsed) || maxExecParsed! < 1)
-    ) {
-      toast.error(
-        "Max executions must be a positive integer or empty for unlimited",
-      );
-      return;
-    }
-
     if (isEditActive && primary) {
       try {
         await updateStandingApproval(primary.standing_approval_id, {
           constraints: primary.constraints as Record<string, unknown>,
-          max_executions: maxExecParsed,
           expires_at: noExpiry ? null : new Date(expiresAt).toISOString(),
         });
         toast.success("Standing approval updated");
@@ -174,7 +156,6 @@ export function ActionConfigStandingApprovalSheet({
         action_version: "1",
         constraints,
         source_action_configuration_id: config.id,
-        max_executions: maxExecParsed,
         ...(noExpiry ? {} : { expires_at: new Date(expiresAt).toISOString() }),
       });
       toast.success("Standing approval created");
@@ -202,8 +183,8 @@ export function ActionConfigStandingApprovalSheet({
           <SheetTitle>Standing approval</SheetTitle>
           <SheetDescription>
             {isEditActive
-              ? "Adjust execution limits and expiration for this configuration."
-              : "Auto-approve requests that match this configuration, with optional limits."}
+              ? "Adjust expiration for this configuration."
+              : "Auto-approve requests that match this configuration, with optional expiry."}
           </SheetDescription>
         </SheetHeader>
         <form
@@ -228,22 +209,8 @@ export function ActionConfigStandingApprovalSheet({
             </p>
           )}
           <StepLimits
-            maxExecutions={maxExecutions}
-            onMaxExecutionsChange={(value) => {
-              if (value === "") {
-                setMaxExecutions("");
-                return;
-              }
-              const intValue = parseInt(value, 10);
-              const minAllowed = isEditActive && primary ? primary.execution_count : 1;
-              if (Number.isNaN(intValue) || intValue < minAllowed) return;
-              setMaxExecutions(String(intValue));
-            }}
             expiresAt={expiresAt}
             onExpiresAtChange={setExpiresAt}
-            currentExecutionCount={
-              isEditActive && primary ? primary.execution_count : undefined
-            }
             noExpiry={noExpiry}
             onNoExpiryChange={setNoExpiry}
           />

--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -230,7 +230,6 @@ export function AddActionConfigDialog({
           action_version: "1",
           constraints,
           source_action_configuration_id: ac.id,
-          max_executions: standingSpec?.max_executions ?? null,
           starts_at: startsAt.toISOString(),
           expires_at: expiresAt,
         });

--- a/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/RecommendedTemplatesDialog.test.tsx
@@ -311,7 +311,6 @@ describe("RecommendedTemplatesDialog", () => {
           action_version: "1",
           constraints: { repo: "*", title: "*" },
           status: "active",
-          execution_count: 0,
           starts_at: "2026-02-25T10:00:00Z",
           expires_at: "2026-03-25T10:00:00Z",
           created_at: "2026-02-25T10:00:00Z",

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.stories.tsx
@@ -374,7 +374,7 @@ const STEP_LABELS: Record<Step, string> = {
   1: "Pick Agent",
   2: "Pick Action",
   3: "Set Constraints",
-  4: "Set Limits",
+  4: "Expiry",
 };
 
 function CreateStandingApprovalWizard({
@@ -398,7 +398,6 @@ function CreateStandingApprovalWizard({
   const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [paramModes, setParamModes] = useState<Record<string, ParamMode>>({});
   const [manualConstraintsJson, setManualConstraintsJson] = useState("");
-  const [maxExecutions, setMaxExecutions] = useState("");
   const [noExpiry, setNoExpiry] = useState(true);
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
 
@@ -495,16 +494,6 @@ function CreateStandingApprovalWizard({
 
           {step === 4 && (
             <StepLimits
-              maxExecutions={maxExecutions}
-              onMaxExecutionsChange={(value) => {
-                if (value === "") {
-                  setMaxExecutions("");
-                  return;
-                }
-                const intValue = parseInt(value, 10);
-                if (Number.isNaN(intValue) || intValue < 1) return;
-                setMaxExecutions(String(intValue));
-              }}
               expiresAt={expiresAt}
               onExpiresAtChange={setExpiresAt}
               noExpiry={noExpiry}
@@ -623,12 +612,11 @@ export const Step4Limits: Story = {
     connectorName: "Google Calendar",
     connectorLogo: GOOGLE_LOGO,
   },
-  name: "Step 4 – Limits",
+  name: "Step 4 – Expiry",
 };
 
 // ---------------------------------------------------------------------------
 // Edit mode wizard — starts at step 3, pre-filled, shows "Save" button
-// and "already used N times" hint on step 4
 // ---------------------------------------------------------------------------
 
 function EditStandingApprovalWizard() {
@@ -644,7 +632,6 @@ function EditStandingApprovalWizard() {
     calendar_id: "fixed",
     attendees: "wildcard",
   });
-  const [maxExecutions, setMaxExecutions] = useState("20");
   const [noExpiry, setNoExpiry] = useState(false);
   const [expiresAt, setExpiresAt] = useState(() => {
     const d = new Date();
@@ -652,9 +639,6 @@ function EditStandingApprovalWizard() {
     const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
     return local.toISOString().slice(0, 16);
   });
-
-  // Simulated execution count for the existing approval
-  const currentExecutionCount = 7;
 
   return (
     <Dialog open>
@@ -708,19 +692,8 @@ function EditStandingApprovalWizard() {
 
           {step === 4 && (
             <StepLimits
-              maxExecutions={maxExecutions}
-              onMaxExecutionsChange={(value) => {
-                if (value === "") {
-                  setMaxExecutions("");
-                  return;
-                }
-                const intValue = parseInt(value, 10);
-                if (Number.isNaN(intValue) || intValue < 1) return;
-                setMaxExecutions(String(intValue));
-              }}
               expiresAt={expiresAt}
               onExpiresAtChange={setExpiresAt}
-              currentExecutionCount={currentExecutionCount}
               noExpiry={noExpiry}
               onNoExpiryChange={setNoExpiry}
             />
@@ -759,7 +732,7 @@ function EditStandingApprovalWizard() {
   );
 }
 
-/** Edit mode — pre-filled constraints and limits, "Save" button, execution count hint. */
+/** Edit mode — pre-filled constraints and expiry, "Save" button. */
 export const EditMode: StoryObj = {
   render: () => <EditStandingApprovalWizard />,
   name: "Edit Mode",

--- a/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/CreateStandingApprovalDialog.tsx
@@ -52,7 +52,7 @@ const STEP_LABELS: Record<Step, string> = {
   1: "Pick Agent",
   2: "Pick Action",
   3: "Set Constraints",
-  4: "Set Limits",
+  4: "Expiry",
 };
 
 function defaultExpiresAt(): string {
@@ -137,11 +137,6 @@ export function CreateStandingApprovalDialog({
   const [manualConstraintsJson, setManualConstraintsJson] = useState(
     hasInitialContext && ctxConstraints
       ? JSON.stringify(ctxConstraints, null, 2)
-      : "",
-  );
-  const [maxExecutions, setMaxExecutions] = useState(
-    isEditMode && editTarget.max_executions != null
-      ? String(editTarget.max_executions)
       : "",
   );
   const [noExpiry, setNoExpiry] = useState(isEditMode ? !editTarget.expires_at : true);
@@ -274,11 +269,6 @@ export function CreateStandingApprovalDialog({
         ? JSON.stringify(ctxConstraints, null, 2)
         : "",
     );
-    if (isEditMode && editTarget.max_executions != null) {
-      setMaxExecutions(String(editTarget.max_executions));
-    } else {
-      setMaxExecutions("");
-    }
     setNoExpiry(isEditMode ? !editTarget.expires_at : true);
     if (isEditMode && editTarget.expires_at) {
       const d = new Date(editTarget.expires_at);
@@ -449,7 +439,6 @@ export function CreateStandingApprovalDialog({
       if (isEditMode) {
         await updateStandingApproval(editTarget.standing_approval_id, {
           constraints,
-          max_executions: maxExecutions ? Number(maxExecutions) : null,
           expires_at: noExpiry ? null : new Date(expiresAt).toISOString(),
         });
         toast.success("Standing approval updated");
@@ -468,7 +457,6 @@ export function CreateStandingApprovalDialog({
           action_version: "1",
           constraints,
           source_action_configuration_id: sourceId,
-          max_executions: maxExecutions ? Number(maxExecutions) : null,
           ...(noExpiry ? {} : { expires_at: new Date(expiresAt).toISOString() }),
         });
         toast.success("Standing approval created");
@@ -595,22 +583,8 @@ export function CreateStandingApprovalDialog({
 
           {step === 4 && (
             <StepLimits
-              maxExecutions={maxExecutions}
-              onMaxExecutionsChange={(value) => {
-                if (value === "") {
-                  setMaxExecutions("");
-                  return;
-                }
-                const intValue = parseInt(value, 10);
-                // In edit mode enforce the minimum at execution_count so the
-                // client rejects the input before it ever reaches the server.
-                const minAllowed = isEditMode ? editTarget.execution_count : 1;
-                if (Number.isNaN(intValue) || intValue < minAllowed) return;
-                setMaxExecutions(String(intValue));
-              }}
               expiresAt={expiresAt}
               onExpiresAtChange={setExpiresAt}
-              currentExecutionCount={isEditMode ? editTarget.execution_count : undefined}
               noExpiry={noExpiry}
               onNoExpiryChange={setNoExpiry}
             />

--- a/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalSteps.tsx
@@ -190,47 +190,18 @@ export function StepConstraints({
 }
 
 export function StepLimits({
-  maxExecutions,
-  onMaxExecutionsChange,
   expiresAt,
   onExpiresAtChange,
-  currentExecutionCount,
   noExpiry,
   onNoExpiryChange,
 }: {
-  maxExecutions: string;
-  onMaxExecutionsChange: (value: string) => void;
   expiresAt: string;
   onExpiresAtChange: (value: string) => void;
-  /** When editing an existing approval, the number of times it has already been used. */
-  currentExecutionCount?: number;
   noExpiry?: boolean;
   onNoExpiryChange?: (value: boolean) => void;
 }) {
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="sa-max-executions">Max Executions</Label>
-        <Input
-          id="sa-max-executions"
-          type="number"
-          min={currentExecutionCount != null ? String(currentExecutionCount) : "1"}
-          step="1"
-          placeholder="Unlimited"
-          value={maxExecutions}
-          onChange={(e) => onMaxExecutionsChange(e.target.value)}
-        />
-        {currentExecutionCount != null && currentExecutionCount > 0 ? (
-          <p className="text-muted-foreground text-sm">
-            Already used {currentExecutionCount} time{currentExecutionCount !== 1 ? "s" : ""} — minimum is {currentExecutionCount}. Leave empty for unlimited.
-          </p>
-        ) : (
-          <p className="text-muted-foreground text-sm">
-            Leave empty for unlimited executions.
-          </p>
-        )}
-      </div>
-
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <Label htmlFor="sa-expires-at">Expires At</Label>

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -90,9 +90,6 @@ function StandingApprovalSummaryRow({
       <TableCell className="max-w-[200px] truncate text-xs">
         {agentName}
       </TableCell>
-      <TableCell>
-        <span className="text-muted-foreground text-xs">On</span>
-      </TableCell>
       <TableCell>{formatExpiresIn(sa.expires_at)}</TableCell>
       <TableCell className="text-right">
         <Link
@@ -195,14 +192,13 @@ export function StandingApprovalsCard() {
           <EmptyState />
         ) : (
           <div className="overflow-x-auto">
-            <div className="min-w-[640px] overflow-hidden rounded-lg">
+            <div className="min-w-[560px] overflow-hidden rounded-lg">
               <Table>
                 <TableHeader>
                   <TableRow className="border-none bg-muted/50 hover:bg-muted/50">
                     <TableHead>Configuration</TableHead>
                     <TableHead>Connector</TableHead>
                     <TableHead>Agent</TableHead>
-                    <TableHead>Auto-approve</TableHead>
                     <TableHead>Expires</TableHead>
                     <TableHead className="text-right">
                       <span className="sr-only">Open</span>

--- a/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
+++ b/frontend/src/pages/dashboard/StandingApprovalsCard.tsx
@@ -18,7 +18,6 @@ import {
   TableRow,
   TableCell,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import {
   useStandingApprovals,
   type StandingApproval,
@@ -46,29 +45,6 @@ function formatExpiresIn(expiresAt: string | null | undefined): string {
 
   const diffDays = Math.floor(diffHours / 24);
   return `${diffDays}d`;
-}
-
-function ExecutionBadge({
-  executionCount,
-  maxExecutions,
-}: {
-  executionCount: number;
-  maxExecutions?: number | null;
-}) {
-  if (maxExecutions == null) {
-    return (
-      <span className="text-muted-foreground text-xs">
-        {executionCount} / &infin;
-      </span>
-    );
-  }
-  const ratio = executionCount / maxExecutions;
-  const variant = ratio >= 0.9 ? "destructive" : "secondary";
-  return (
-    <Badge variant={variant}>
-      {executionCount} / {maxExecutions}
-    </Badge>
-  );
 }
 
 function resolveAgentName(
@@ -115,10 +91,7 @@ function StandingApprovalSummaryRow({
         {agentName}
       </TableCell>
       <TableCell>
-        <ExecutionBadge
-          executionCount={sa.execution_count}
-          maxExecutions={sa.max_executions}
-        />
+        <span className="text-muted-foreground text-xs">On</span>
       </TableCell>
       <TableCell>{formatExpiresIn(sa.expires_at)}</TableCell>
       <TableCell className="text-right">
@@ -144,7 +117,7 @@ function EmptyState() {
       <p className="text-muted-foreground mb-4 max-w-md text-xs leading-relaxed">
         Standing approvals are created from an agent&apos;s connector page, on each
         action configuration. Open a connector, then use the Standing Approval column
-        to enable auto-approve with limits you control.
+        to enable auto-approve with expiry you control.
       </p>
     </div>
   );
@@ -198,7 +171,7 @@ export function StandingApprovalsCard() {
           )}
         </div>
         <p className="text-muted-foreground text-sm">
-          Action configurations with an active standing approval. Manage limits and
+          Action configurations with an active standing approval. Manage expiry and
           revocation on each connector&apos;s configuration page.
         </p>
       </CardHeader>
@@ -229,7 +202,7 @@ export function StandingApprovalsCard() {
                     <TableHead>Configuration</TableHead>
                     <TableHead>Connector</TableHead>
                     <TableHead>Agent</TableHead>
-                    <TableHead>Executions</TableHead>
+                    <TableHead>Auto-approve</TableHead>
                     <TableHead>Expires</TableHead>
                     <TableHead className="text-right">
                       <span className="sr-only">Open</span>

--- a/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CreateStandingApprovalDialog.test.tsx
@@ -321,7 +321,7 @@ describe("CreateStandingApprovalDialog", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Step 2 of 2/)).toBeInTheDocument();
-      expect(screen.getByText(/Set Limits/)).toBeInTheDocument();
+      expect(screen.getByText(/Expiry/)).toBeInTheDocument();
     });
 
     await user.click(screen.getByText("Create"));

--- a/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/StandingApprovalsCard.test.tsx
@@ -14,8 +14,6 @@ const mockStandingApprovals = [
     action_type: "email.send",
     agent_id: 1,
     status: "active" as const,
-    execution_count: 3,
-    max_executions: 10,
     expires_at: null,
     constraints: { to: { $pattern: "*@mycompany.com" }, subject: "*" },
     source_action_configuration_id: "ac_config1",

--- a/notify/mobilepush/sender_test.go
+++ b/notify/mobilepush/sender_test.go
@@ -410,7 +410,7 @@ func TestSendBatch_StandingExecution_UsesCorrectCategory(t *testing.T) {
 		ApprovalID:  "appr_standing_001",
 		AgentName:   "Deploy Bot",
 		Action:      json.RawMessage(`{"type":"github.issues.create"}`),
-		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		Context:     json.RawMessage(`{}`),
 		ApprovalURL: "https://app.test/activity",
 		Type:        notify.NotificationTypeStandingExecution,
 	}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -50,8 +50,6 @@ const (
 	// NotificationTypeStandingExecution is sent when an agent executes an
 	// action via a standing approval. Informational only — not an approval
 	// request. Uses a distinct template with a blue accent and activity link.
-	// The Context JSON should contain "execution_count" and "max_executions"
-	// integers; see standing_execution.go for the full contract.
 	NotificationTypeStandingExecution NotificationType = "standing_execution"
 )
 

--- a/notify/standing_execution.go
+++ b/notify/standing_execution.go
@@ -7,12 +7,8 @@
 //
 // # Context JSON contract
 //
-// The Approval.Context field must be a JSON object with these optional keys:
-//
-//	{
-//	    "execution_count": 3,    // int — how many times the standing approval has been used
-//	    "max_executions": 10     // int — total allowed uses (0 = unlimited)
-//	}
+// The Approval.Context field may be empty or a JSON object with optional keys
+// for future extensions. Execution quotas are not tracked in notifications.
 //
 // The Approval.Action field should contain the standard action JSON with a
 // "type" key and optional "parameters" object. Parameter values are included
@@ -36,59 +32,18 @@ import (
 	"time"
 )
 
-// standingExecutionInfo holds the fields extracted from the Context JSON
+// standingExecutionInfo holds the fields extracted from the approval payload
 // for a standing approval execution notification.
 type standingExecutionInfo struct {
-	ExecutionCount int    // how many times the standing approval has been used
-	MaxExecutions  int    // total allowed executions (0 = unlimited)
-	AgentName      string // resolved display name
-	ActionType     string // e.g. "github.issues.create"
+	AgentName  string // resolved display name
+	ActionType string // e.g. "github.issues.create"
 }
 
-// extractStandingExecutionInfo extracts execution metadata from the
-// approval's Action and Context JSON. The Context is expected to contain
-// "execution_count" and "max_executions" integers.
 func extractStandingExecutionInfo(approval Approval) standingExecutionInfo {
-	info := standingExecutionInfo{
+	return standingExecutionInfo{
 		AgentName:  AgentDisplayName(approval.AgentName, approval.AgentID),
 		ActionType: extractActionType(approval.Action),
 	}
-
-	if len(approval.Context) == 0 {
-		return info
-	}
-
-	var ctx map[string]json.RawMessage
-	if json.Unmarshal(approval.Context, &ctx) != nil {
-		return info
-	}
-
-	if raw, ok := ctx["execution_count"]; ok {
-		var n int
-		if json.Unmarshal(raw, &n) == nil {
-			info.ExecutionCount = n
-		}
-	}
-	if raw, ok := ctx["max_executions"]; ok {
-		var n int
-		if json.Unmarshal(raw, &n) == nil {
-			info.MaxExecutions = n
-		}
-	}
-
-	return info
-}
-
-// executionCountLabel returns a human-readable execution count string
-// like "3 of 10" or "3" (when unlimited).
-func (info standingExecutionInfo) executionCountLabel() string {
-	if info.MaxExecutions > 0 && info.ExecutionCount > 0 {
-		return fmt.Sprintf("%d of %d", info.ExecutionCount, info.MaxExecutions)
-	}
-	if info.ExecutionCount > 0 {
-		return fmt.Sprintf("%d", info.ExecutionCount)
-	}
-	return ""
 }
 
 // buildStandingExecutionPushContent constructs push notification content for
@@ -101,9 +56,6 @@ func buildStandingExecutionPushContent(approval Approval) PushContent {
 	body := info.ActionType
 	if body == "" {
 		body = "an action"
-	}
-	if info.ExecutionCount > 0 {
-		body = fmt.Sprintf("%s (#%d)", body, info.ExecutionCount)
 	}
 
 	return PushContent{
@@ -204,7 +156,7 @@ func buildStandingExecutionSubject(approval Approval) string {
 }
 
 // buildStandingExecutionPlainBody returns the plain-text email body with
-// agent name, action type, parameter summary, execution count, and timestamp.
+// agent name, action type, parameter summary, and timestamp.
 func buildStandingExecutionPlainBody(approval Approval) string {
 	info := extractStandingExecutionInfo(approval)
 
@@ -220,10 +172,6 @@ func buildStandingExecutionPlainBody(approval Approval) string {
 		b.WriteString(fmt.Sprintf("Parameters: %s\n", paramSummary))
 	}
 
-	if countLabel := info.executionCountLabel(); countLabel != "" {
-		b.WriteString(fmt.Sprintf("Executions: %s\n", countLabel))
-	}
-
 	b.WriteString(fmt.Sprintf("Time: %s\n", approval.CreatedAt.UTC().Format(time.RFC1123)))
 
 	if approval.ApprovalURL != "" {
@@ -236,7 +184,7 @@ func buildStandingExecutionPlainBody(approval Approval) string {
 }
 
 // formatStandingExecutionSMS builds a concise SMS for a standing approval
-// execution. Format: "[AgentName] ran [action_type] (3 of 10 uses). View: [url]"
+// execution. Format: "[AgentName] ran [action_type]. View: [url]"
 func formatStandingExecutionSMS(a Approval) string {
 	info := extractStandingExecutionInfo(a)
 
@@ -246,10 +194,6 @@ func formatStandingExecutionSMS(a Approval) string {
 	}
 
 	msg := fmt.Sprintf("[Permission Slip] %s ran %s", info.AgentName, actionPart)
-
-	if countLabel := info.executionCountLabel(); countLabel != "" {
-		msg += fmt.Sprintf(" (%s uses)", countLabel)
-	}
 
 	if a.ApprovalURL != "" {
 		return fmt.Sprintf("%s. View: %s", msg, a.ApprovalURL)
@@ -281,9 +225,6 @@ func buildStandingExecutionHTMLBody(approval Approval) string {
 	}
 	if paramSummary := summarizeParameters(approval.Action); paramSummary != "" {
 		b.WriteString(emailDetailRow("Parameters", html.EscapeString(paramSummary)))
-	}
-	if countLabel := info.executionCountLabel(); countLabel != "" {
-		b.WriteString(emailDetailRow("Executions", html.EscapeString(countLabel)))
 	}
 	b.WriteString(emailDetailRow("Time", html.EscapeString(approval.CreatedAt.UTC().Format(time.RFC1123))))
 	b.WriteString(`</table>`)

--- a/notify/standing_execution_test.go
+++ b/notify/standing_execution_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-// ── extractStandingExecutionInfo tests ──────────────────────────────────────
-
 func TestExtractStandingExecutionInfo_Full(t *testing.T) {
 	t.Parallel()
 	a := testStandingExecutionApproval()
@@ -19,12 +17,6 @@ func TestExtractStandingExecutionInfo_Full(t *testing.T) {
 	}
 	if info.ActionType != "github.issues.create" {
 		t.Errorf("expected action type 'github.issues.create', got %q", info.ActionType)
-	}
-	if info.ExecutionCount != 3 {
-		t.Errorf("expected execution count 3, got %d", info.ExecutionCount)
-	}
-	if info.MaxExecutions != 10 {
-		t.Errorf("expected max executions 10, got %d", info.MaxExecutions)
 	}
 }
 
@@ -40,49 +32,6 @@ func TestExtractStandingExecutionInfo_NoContext(t *testing.T) {
 
 	if info.AgentName != "Agent #99" {
 		t.Errorf("expected fallback agent name, got %q", info.AgentName)
-	}
-	if info.ExecutionCount != 0 {
-		t.Errorf("expected 0 execution count, got %d", info.ExecutionCount)
-	}
-}
-
-func TestExtractStandingExecutionInfo_Unlimited(t *testing.T) {
-	t.Parallel()
-	a := Approval{
-		AgentName: "Bot",
-		Action:    json.RawMessage(`{"type":"test"}`),
-		Context:   json.RawMessage(`{"execution_count":5,"max_executions":0}`),
-		Type:      NotificationTypeStandingExecution,
-	}
-	info := extractStandingExecutionInfo(a)
-	if info.executionCountLabel() != "5" {
-		t.Errorf("expected '5' for unlimited, got %q", info.executionCountLabel())
-	}
-}
-
-func TestExecutionCountLabel_WithMax(t *testing.T) {
-	t.Parallel()
-	info := standingExecutionInfo{ExecutionCount: 3, MaxExecutions: 10}
-	if info.executionCountLabel() != "3 of 10" {
-		t.Errorf("expected '3 of 10', got %q", info.executionCountLabel())
-	}
-}
-
-func TestExecutionCountLabel_ZeroCountWithMax(t *testing.T) {
-	t.Parallel()
-	// When execution_count is 0 but max_executions is set, the label should
-	// be empty — not "0 of 10" which contradicts the notification.
-	info := standingExecutionInfo{ExecutionCount: 0, MaxExecutions: 10}
-	if info.executionCountLabel() != "" {
-		t.Errorf("expected empty label for zero count, got %q", info.executionCountLabel())
-	}
-}
-
-func TestExecutionCountLabel_NoCount(t *testing.T) {
-	t.Parallel()
-	info := standingExecutionInfo{}
-	if info.executionCountLabel() != "" {
-		t.Errorf("expected empty label, got %q", info.executionCountLabel())
 	}
 }
 
@@ -122,7 +71,6 @@ func TestBuildEmailPlainBody_StandingExecution(t *testing.T) {
 		"Deploy Bot",
 		"github.issues.create",
 		"Parameters:",
-		"3 of 10",
 		"auto-approved via a standing approval",
 		"https://app.example.com/activity",
 	}
@@ -138,7 +86,6 @@ func TestBuildEmailPlainBody_StandingExecution_NoSensitiveData(t *testing.T) {
 	a := Approval{
 		AgentName: "Bot",
 		Action:    json.RawMessage(`{"type":"email.send","parameters":{"api_key":"sk-secret123"}}`),
-		Context:   json.RawMessage(`{"execution_count":1,"max_executions":5}`),
 		CreatedAt: time.Now(),
 		Type:      NotificationTypeStandingExecution,
 	}
@@ -161,7 +108,6 @@ func TestBuildEmailHTMLBody_StandingExecution(t *testing.T) {
 		"Deploy Bot",                          // agent name
 		"github.issues.create",                // action type
 		"Parameters",                          // parameter summary row
-		"3 of 10",                             // execution count
 		"View Activity",                       // CTA button
 		"https://app.example.com/activity",    // URL
 		"auto-approved via a standing approval", // footer
@@ -178,7 +124,6 @@ func TestBuildEmailHTMLBody_StandingExecution_EscapesHTML(t *testing.T) {
 	a := Approval{
 		AgentName: `<script>alert("xss")</script>`,
 		Action:    json.RawMessage(`{"type":"test"}`),
-		Context:   json.RawMessage(`{"execution_count":1}`),
 		CreatedAt: time.Now(),
 		Type:      NotificationTypeStandingExecution,
 	}
@@ -196,7 +141,6 @@ func TestBuildEmailHTMLBody_StandingExecution_NoURL(t *testing.T) {
 	a := Approval{
 		AgentName: "Bot",
 		Action:    json.RawMessage(`{"type":"test"}`),
-		Context:   json.RawMessage(`{"execution_count":1}`),
 		CreatedAt: time.Now(),
 		Type:      NotificationTypeStandingExecution,
 	}
@@ -216,7 +160,6 @@ func TestFormatSMSBody_StandingExecution(t *testing.T) {
 	checks := []string{
 		"Deploy Bot",
 		"github.issues.create",
-		"3 of 10 uses",
 		"View:",
 		"https://app.example.com/activity",
 	}
@@ -232,30 +175,25 @@ func TestFormatSMSBody_StandingExecution_NoURL(t *testing.T) {
 	a := Approval{
 		AgentName: "Bot",
 		Action:    json.RawMessage(`{"type":"test"}`),
-		Context:   json.RawMessage(`{"execution_count":2,"max_executions":5}`),
 		Type:      NotificationTypeStandingExecution,
 	}
 	body := formatSMSBody(a)
 	if strings.Contains(body, "View:") {
 		t.Error("expected no View URL")
 	}
-	if !strings.Contains(body, "2 of 5 uses") {
-		t.Errorf("expected execution count, got: %s", body)
-	}
 }
 
-func TestFormatSMSBody_StandingExecution_Unlimited(t *testing.T) {
+func TestFormatSMSBody_StandingExecution_WithURL(t *testing.T) {
 	t.Parallel()
 	a := Approval{
 		AgentName:   "Bot",
 		Action:      json.RawMessage(`{"type":"test"}`),
-		Context:     json.RawMessage(`{"execution_count":7}`),
 		ApprovalURL: "https://example.com/activity",
 		Type:        NotificationTypeStandingExecution,
 	}
 	body := formatSMSBody(a)
-	if !strings.Contains(body, "7 uses") {
-		t.Errorf("expected execution count, got: %s", body)
+	if !strings.Contains(body, "View: https://example.com/activity") {
+		t.Errorf("expected View URL in SMS, got: %s", body)
 	}
 }
 
@@ -269,8 +207,8 @@ func TestBuildPushContent_StandingExecution(t *testing.T) {
 	if c.Title != "Deploy Bot auto-executed" {
 		t.Errorf("expected title 'Deploy Bot auto-executed', got %q", c.Title)
 	}
-	if c.Body != "github.issues.create (#3)" {
-		t.Errorf("expected body 'github.issues.create (#3)', got %q", c.Body)
+	if c.Body != "github.issues.create" {
+		t.Errorf("expected body 'github.issues.create', got %q", c.Body)
 	}
 	if c.URL != "https://app.example.com/activity" {
 		t.Errorf("expected activity URL, got %q", c.URL)
@@ -422,11 +360,10 @@ func TestBuildPushContent_StandingExecution_NoAction(t *testing.T) {
 	t.Parallel()
 	a := Approval{
 		AgentName: "Bot",
-		Context:   json.RawMessage(`{"execution_count":1}`),
 		Type:      NotificationTypeStandingExecution,
 	}
 	c := BuildPushContent(a)
-	if c.Body != "an action (#1)" {
+	if c.Body != "an action" {
 		t.Errorf("expected fallback body, got %q", c.Body)
 	}
 }

--- a/notify/testdata_test.go
+++ b/notify/testdata_test.go
@@ -29,7 +29,7 @@ func testStandingExecutionApproval() Approval {
 		AgentID:     42,
 		AgentName:   "Deploy Bot",
 		Action:      json.RawMessage(`{"type":"github.issues.create","parameters":{"repo":"acme/app","title":"Deploy v2.1"}}`),
-		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		Context:     json.RawMessage(`{}`),
 		ApprovalURL: "https://app.example.com/activity",
 		CreatedAt:   time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC),
 		Type:        NotificationTypeStandingExecution,

--- a/notify/webpush/sender_test.go
+++ b/notify/webpush/sender_test.go
@@ -103,7 +103,7 @@ func TestBuildBody_StandingExecution(t *testing.T) {
 		ApprovalID:  "appr_standing_001",
 		AgentName:   "Deploy Bot",
 		Action:      json.RawMessage(`{"type":"github.issues.create"}`),
-		Context:     json.RawMessage(`{"execution_count":3,"max_executions":10}`),
+		Context:     json.RawMessage(`{}`),
 		ApprovalURL: "https://app.test/activity",
 		Type:        notify.NotificationTypeStandingExecution,
 	}
@@ -112,8 +112,8 @@ func TestBuildBody_StandingExecution(t *testing.T) {
 	if body.Title != "Deploy Bot auto-executed" {
 		t.Errorf("expected title 'Deploy Bot auto-executed', got %q", body.Title)
 	}
-	if body.Body != "github.issues.create (#3)" {
-		t.Errorf("expected body 'github.issues.create (#3)', got %q", body.Body)
+	if body.Body != "github.issues.create" {
+		t.Errorf("expected body 'github.issues.create', got %q", body.Body)
 	}
 	if body.URL != "https://app.test/activity" {
 		t.Errorf("expected activity URL, got %q", body.URL)

--- a/spec/openapi.bundle.yaml
+++ b/spec/openapi.bundle.yaml
@@ -3,23 +3,21 @@ info:
   title: Permission Slip API
   version: 0.1.0
   description: |
-    Permission Slip is a centralized middle-man service that sits between AI agents and external 
-    APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 
-    them using the user's stored credentials. Agents never see user credentials and can never 
-    make arbitrary API calls.
+    Permission Slip is the approval layer for Openclaw. Openclaw submits pre-defined **actions**
+    for human approval, and Permission Slip executes them using the user's stored credentials.
+    Openclaw never sees user credentials and can never make arbitrary API calls.
 
-    **Base URL**: `https://app.permissionslip.dev`
+    **Base URL**: `http://localhost:8080`
 
     ## Key Concepts
 
     - **Action**: Pre-defined, structured request with a type, validated parameters, and execution logic — the core primitive
     - **Agent**: Automated system with a cryptographic key pair that submits actions for approval
     - **Approver**: Human authorized to approve or deny agent actions
-    - **Connector**: Integration with an external service (e.g., Gmail, Stripe) that defines available actions
+    - **Connector**: Integration with an external service (e.g., Gmail, Stripe, PayPal) that defines available actions
     - **Credential**: Encrypted API key or OAuth token for an external service, stored in Permission Slip's vault
     - **Registration**: One-time setup where agent proves identity via public key
     - **Approval Request**: Async request for permission to execute a specific action
-    - **Token**: Single-use credential issued after one-off approval, used to execute the approved action
     - **Standing Approval**: Pre-authorized, constraint-scoped grant that lets an agent execute an action repeatedly without per-request approval
 
     ## Authentication
@@ -41,26 +39,27 @@ info:
     3. **Store Credentials** *(if needed)*: User connects external accounts and stores credentials in Permission Slip's vault using the credential management endpoints
     4. **Submit Action**: Agent submits a structured action (e.g., `email.send` with parameters)
     5. **User Approval**: Approver reviews the action in a human-readable format and approves/denies
-    6. **Verify & Get Token**: Agent submits confirmation code, receives single-use token
-    7. **Execute Action**: Agent calls `POST /v1/actions/execute` with the token — Permission Slip calls the external API using stored credentials
+    6. **Direct Execution**: On approval, Permission Slip immediately executes the action via the connector
+    7. **Poll for Result**: Agent calls `GET /v1/approvals/{approval_id}/status` to get the execution result
 
     ### Standing Approval (pre-authorized)
 
     1. **User creates standing approval**: Via web UI — specifies agent, action type, constraints, duration, and optional execution cap
-    2. **Agent executes**: Calls `POST /v1/actions/execute` with agent signature (no token) — Permission Slip matches the standing approval and executes immediately
-    3. **Fallthrough**: If no standing approval matches, falls through to the one-off flow above
+    2. **Agent requests**: Calls `POST /v1/approvals/request` — Permission Slip checks for a matching standing approval
+    3. **Auto-approve**: If a standing approval matches, the action is executed immediately and the result is returned inline with `status: "approved"`
+    4. **Fallthrough**: If no standing approval matches, creates a pending approval for human review (one-off flow above)
 
     ## Architecture
 
     ```
-    Agent ──→ Permission Slip ──→ External Service (Gmail, Stripe, etc.)
+    Agent ──→ Permission Slip ──→ External Service (Gmail, Stripe, PayPal, etc.)
                    │
                    ▼
               User (approve/deny)
     ```
 
     Permission Slip is the **single integration point** for agents. Agents talk to 
-    `https://app.permissionslip.dev` for everything — they never need to know about individual 
+    `http://localhost:8080` for everything — they never need to know about individual 
     service URLs or APIs.
 
     ## Related Documentation
@@ -72,10 +71,8 @@ info:
     name: Permission Slip
     url: https://github.com/supersuit-tech/permission-slip
 servers:
-  - url: https://app.permissionslip.dev
-    description: Production server
-  - url: https://staging.app.permissionslip.dev
-    description: Staging server
+  - url: http://localhost:8080
+    description: Local development server
 tags:
   - name: Connectors
     description: Discover available service integrations and actions
@@ -97,6 +94,20 @@ tags:
     description: Manage standing approvals for pre-authorized agent actions
   - name: Profiles
     description: User profile management (session-authenticated)
+  - name: Push Subscriptions
+    description: Web Push subscription management (session-authenticated)
+  - name: Expo Push Tokens
+    description: Expo push token management for mobile push notifications (session-authenticated)
+  - name: OAuth
+    description: OAuth 2.0 provider authorization and connection management (session-authenticated)
+  - name: Payment Methods
+    description: Stored payment methods for agent-initiated purchases (session-authenticated)
+  - name: Config
+    description: Server configuration and feature flags (session-authenticated)
+  - name: Billing
+    description: Subscription management, checkout, and usage (session-authenticated)
+  - name: Admin
+    description: Internal admin endpoints for usage analytics and abuse detection (session-authenticated)
 paths:
   /v1/connectors:
     get:
@@ -104,12 +115,16 @@ paths:
       summary: List Available Connectors
       description: |
         List all available connectors (external service integrations) that Permission Slip
-        supports. Each connector represents an external service (e.g., GitHub, Stripe, Slack)
+        supports. Each connector represents an external service (e.g., GitHub, Stripe, PayPal, Slack)
         and defines which actions are available.
 
         Agents use this endpoint to discover what actions they can submit for approval. 
         This replaces the old service discovery model — agents don't need to know about 
         individual service URLs, they just query Permission Slip for available actions.
+
+        Built-in connectors (for example `instacart` with `instacart.create_products_link`)
+        appear here automatically from connector manifests; parameter schemas and optional
+        display templates are the source of truth at runtime, not this OpenAPI document.
 
         ## Use Cases
 
@@ -121,6 +136,13 @@ paths:
 
         This endpoint is publicly accessible (no signature required) to allow agents to 
         discover available actions before registration.
+
+        ## PayPal / Venmo
+
+        The **paypal** connector exposes PayPal REST actions (payouts, Checkout orders, invoicing,
+        refunds). Users connect via OAuth (`GET /v1/oauth/paypal/authorize`). Optional credential
+        key `environment`=`sandbox` routes REST calls to PayPal's sandbox API host. See
+        `docs/oauth-setup.md` (PayPal OAuth Setup) and `connectors/paypal/README.md` in the repo.
       tags:
         - Connectors
       security: []
@@ -171,6 +193,9 @@ paths:
 
         This endpoint is publicly accessible (no signature required) to allow agents to 
         discover action schemas before registration.
+
+        For connector-specific setup (e.g. PayPal OAuth and optional `environment` credential for
+        sandbox REST), see the repository docs referenced in the list-connectors description.
       tags:
         - Connectors
       security: []
@@ -226,7 +251,13 @@ paths:
                           description: Pull request number
                 required_credentials:
                   - service: github
+                    auth_type: oauth2
+                    oauth_provider: github
+                    oauth_scopes:
+                      - repo
+                  - service: github_pat
                     auth_type: api_key
+                    instructions_url: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
         '404':
           description: Connector not found
           content:
@@ -340,6 +371,8 @@ paths:
                 agent_id: 42
                 expires_at: '2026-02-11T13:25:00Z'
                 verification_required: true
+                approver:
+                  username: alice
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -365,6 +398,21 @@ paths:
                       message: Invite code is not valid
                       retryable: false
                       trace_id: trace_xyz789
+        '403':
+          description: Agent limit reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: agent_limit_reached
+                  message: Free tier allows up to 3 agents. Upgrade your plan to add more.
+                  retryable: false
+                  details:
+                    current_count: 3
+                    limit: 3
+                  trace_id: trace_xyz789
         '404':
           description: Invite not found
           content:
@@ -514,6 +562,8 @@ paths:
               example:
                 status: registered
                 registered_at: '2026-02-11T13:20:15Z'
+                approver:
+                  username: alice
         '400':
           description: Invalid request or agent ID mismatch
           content:
@@ -965,6 +1015,8 @@ paths:
               example:
                 agent_id: 42
                 status: registered
+                approver:
+                  username: alice
                 metadata:
                   name: My AI Assistant
                   version: 1.0.0
@@ -1068,7 +1120,7 @@ paths:
           ├─ YES → Reference configuration_id in requests
           │        Has standing approval with matching constraints?
           │          ├─ YES → POST /v1/actions/execute (no token, agent signature only)
-          │          └─ NO  → POST /v1/approvals/request → user approves → verify → execute
+          │          └─ NO  → POST /v1/approvals/request → user approves → agent polls status
           └─ NO  → Ask user to create an action configuration
         ```
 
@@ -1100,6 +1152,8 @@ paths:
                   summary: Agent with multiple connectors, mixed readiness
                   value:
                     agent_id: 42
+                    approver:
+                      username: alice
                     connectors:
                       - id: gmail
                         name: Gmail
@@ -1139,8 +1193,6 @@ paths:
                                 constraints:
                                   recipient_pattern: '*@mycompany.com'
                                   max_recipients: 5
-                                max_executions: 100
-                                executions_remaining: 88
                                 expires_at: '2026-05-15T00:00:00Z'
                             action_configurations:
                               - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -1150,7 +1202,6 @@ paths:
                                   to: team@mycompany.com
                                   subject: '*'
                                   body: '*'
-                                credential_ready: true
                           - action_type: email.read
                             name: Read Email
                             description: Read emails from Gmail inbox
@@ -1171,8 +1222,6 @@ paths:
                                 constraints:
                                   sender: '*@github.com'
                                   max_results: 10
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-02-28T00:00:00Z'
                             action_configurations: []
                       - id: stripe
@@ -1213,11 +1262,15 @@ paths:
                   summary: Agent with no enabled connectors
                   value:
                     agent_id: 43
+                    approver:
+                      username: bob
                     connectors: []
                 standing_approval_only:
                   summary: Single connector, all actions with standing approvals
                   value:
                     agent_id: 44
+                    approver:
+                      username: carol
                     connectors:
                       - id: gmail
                         name: Gmail
@@ -1239,14 +1292,10 @@ paths:
                               - standing_approval_id: sa_read01
                                 constraints:
                                   sender: '*@github.com'
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-03-15T00:00:00Z'
                               - standing_approval_id: sa_read02
                                 constraints:
                                   sender: '*@linear.app'
-                                max_executions: 50
-                                executions_remaining: 50
                                 expires_at: '2026-03-01T00:00:00Z'
                             action_configurations: []
         '400':
@@ -1401,6 +1450,20 @@ paths:
         forgotten standing approvals from silently reactivating if the connector
         is re-enabled later.
 
+        ### Disabling vs. Removing
+
+        By default this endpoint **disables** the connector — it removes the
+        agent-connector association but leaves the user's credentials (API keys)
+        and OAuth connections intact so the connector can be re-enabled without
+        re-entering credentials.
+
+        Pass `?delete_credentials=true` to also **permanently delete** the API
+        key credential assigned to this connector. The credential row and its
+        encrypted vault secret are deleted in the same database transaction, so
+        the operation is fully atomic — either everything succeeds or nothing
+        changes. OAuth connections are unaffected by this flag and must be
+        disconnected separately via `DELETE /v1/oauth/connections/{connection_id}`.
+
         Uses session authentication (Supabase JWT).
       tags:
         - Agents
@@ -1409,6 +1472,22 @@ paths:
       parameters:
         - $ref: '#/components/parameters/AgentId'
         - $ref: '#/components/parameters/ConnectorId'
+        - name: delete_credentials
+          in: query
+          required: false
+          description: |
+            When `true`, permanently delete the API key credential assigned to
+            this connector (both the credential record and its encrypted vault
+            secret) as part of the same atomic operation. Defaults to `false`.
+
+            Use this when you want a full "remove" — disabling the connector
+            **and** discarding saved API keys — rather than a temporary disable
+            that preserves credentials for re-enabling later.
+
+            OAuth connections are **not** affected by this flag. To disconnect
+            OAuth, call `DELETE /v1/oauth/connections/{connection_id}` separately.
+          schema:
+            type: boolean
       responses:
         '200':
           description: Connector disabled for agent
@@ -1434,6 +1513,242 @@ paths:
                   message: Connector not enabled for this agent
                   retryable: false
                   trace_id: trace_xyz789
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/credential:
+    put:
+      operationId: assignAgentConnectorCredential
+      summary: Assign Credential to Agent Connector
+      description: |
+        Assign a credential or OAuth connection to an agent-connector pair. This determines
+        which credential the agent uses when executing actions through this connector.
+
+        Exactly one of `credential_id` or `oauth_connection_id` must be provided.
+        If a credential is already assigned, it is replaced (upsert behavior).
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignCredentialRequest'
+            examples:
+              static_credential:
+                summary: Assign a static API key credential
+                value:
+                  credential_id: cred_abc123
+              oauth_connection:
+                summary: Assign an OAuth connection
+                value:
+                  oauth_connection_id: oc_def456
+      responses:
+        '200':
+          description: Credential assigned successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCredentialResponse'
+        '400':
+          description: Invalid request (validation errors, invalid references)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent not found or not owned by user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      operationId: removeAgentConnectorCredential
+      summary: Remove Credential from Agent Connector
+      description: |
+        Remove the credential binding for an agent-connector pair. After removal,
+        the agent falls back to user-global credential resolution for this connector.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Credential binding removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: removed
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No credential binding found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      operationId: getAgentConnectorCredential
+      summary: Get Agent Connector Credential
+      description: |
+        Get the current credential binding for an agent-connector pair.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Credential binding retrieved (fields are null if no binding exists)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCredentialResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/agents/{agent_id}/connectors/{connector_id}/calendars:
+    get:
+      operationId: listAgentConnectorCalendars
+      summary: List calendars for agent connector
+      description: |
+        Returns calendars visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate calendar pickers for Google and Microsoft calendar actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Calendars listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCalendarListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or calendar listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/channels:
+    get:
+      operationId: listAgentConnectorChannels
+      summary: List channels for agent connector
+      description: |
+        Returns Slack channels visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate channel pickers for Slack actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Channels listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorChannelListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or channel listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/users:
+    get:
+      operationId: listAgentConnectorUsers
+      summary: List users for agent connector
+      description: |
+        Returns workspace users visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate user pickers for Slack actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Users listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorUserListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or user listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -1489,6 +1804,175 @@ paths:
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Agent limit reached — user cannot register more agents on their current plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: agent_limit_reached
+                  message: Free plan allows up to 3 agents. Upgrade your plan to add more.
+                  retryable: false
+                  details:
+                    current_count: 3
+                    limit: 3
+                    plan_id: free
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '404':
+          description: Profile not found for the authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: profile_not_found
+                  message: Profile not found
+                  retryable: false
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/audit-logs:
+    get:
+      operationId: exportAuditLogs
+      summary: Export Audit Logs
+      description: |
+        Returns audit log events in chronological order (oldest first) for the
+        authenticated user, starting from the required `since` timestamp. Designed
+        for compliance export and SIEM integration use cases.
+
+        Results are filtered by the user's plan retention window (7 days for free,
+        90 days for paid). If the `since` parameter is earlier than the retention
+        boundary, it is clamped and the response includes `effective_since` with
+        the actual start timestamp used. A 7-day grace period applies after
+        downgrading from paid to free.
+
+        Supports cursor-based pagination via `limit` and `after` query parameters
+        to iterate over large result sets.
+      tags:
+        - Audit Events
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: since
+          in: query
+          required: true
+          description: |
+            Only return events created at or after this timestamp. Must be a valid
+            RFC3339 timestamp (e.g. `2026-01-01T00:00:00Z`).
+          schema:
+            type: string
+            format: date-time
+          example: '2026-01-01T00:00:00Z'
+        - name: until
+          in: query
+          required: false
+          description: |
+            Only return events created before this timestamp (exclusive upper bound).
+            Must be a valid RFC3339 timestamp and must be after `since`. Useful for
+            bounded time-window exports (e.g. monthly compliance reports).
+          schema:
+            type: string
+            format: date-time
+          example: '2026-02-01T00:00:00Z'
+        - name: event_type
+          in: query
+          required: false
+          description: |
+            Filter events by type. Accepts a single type or a comma-separated
+            list of types.
+          schema:
+            type: string
+          example: approval.approved,approval.denied
+        - name: connector_id
+          in: query
+          required: false
+          description: |
+            Filter events to a specific connector (e.g. "github", "slack").
+            Only returns events where the action was handled by this connector.
+          schema:
+            type: string
+          example: github
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of events to return per page (1–1000, default 100).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+          example: 100
+        - name: after
+          in: query
+          required: false
+          description: |
+            Opaque pagination cursor. Pass the `next_cursor` value from a
+            previous response to fetch the next page. Do not construct
+            cursor values manually.
+          schema:
+            type: string
+          example: 2026-02-20T14:30:00.123456789Z,12345
+      responses:
+        '200':
+          description: Audit log events exported successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogExportResponse'
+              example:
+                data:
+                  - id: 12345
+                    event_type: approval.approved
+                    timestamp: '2026-02-20T14:30:00Z'
+                    agent_id: 42
+                    agent_metadata:
+                      name: My AI Assistant
+                    action:
+                      type: email.send
+                      version: '1'
+                      parameters:
+                        to: alice@example.com
+                        subject: Hello
+                    outcome: approved
+                    source_id: appr_abc123
+                    connector_id: email
+                    execution_status: null
+                  - id: 12346
+                    event_type: standing_approval.executed
+                    timestamp: '2026-02-20T14:35:00Z'
+                    agent_id: 42
+                    agent_metadata:
+                      name: My AI Assistant
+                    action:
+                      type: email.read
+                      version: '1'
+                    outcome: auto_executed
+                    source_id: sae_def456
+                    connector_id: email
+                    execution_status: success
+                has_more: true
+                next_cursor: 2026-02-20T14:35:00.123456789Z,12346
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: invalid_request
+                  message: since query parameter is required (RFC3339 timestamp)
+                  retryable: false
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Profile not found for the authenticated user
           content:
@@ -1518,6 +2002,14 @@ paths:
         - **One-off approvals**: approved, denied, or cancelled approval requests
         - **Standing approval executions**: auto-executed actions via standing approvals
         - **Agent lifecycle**: agent registration and deactivation events
+        - **Payment charges**: when a stored payment method is used by a connector
+          action (`payment_method.charged`). The action object contains only safe
+          display metadata (brand, last4, amount, currency) — never raw card details.
+
+        Results are filtered by the user's plan retention window (7 days for free,
+        90 days for paid). The response includes a `retention` object with the
+        effective retention days and any active grace period. A 7-day grace period
+        applies after downgrading from paid to free.
 
         Supports cursor-based pagination via `limit` and `after` query parameters,
         and filtering by agent, event type, and outcome.
@@ -1579,7 +2071,18 @@ paths:
               - deactivated
               - pending
               - expired
+              - charged
+              - updated
           example: approved
+        - name: connector_id
+          in: query
+          required: false
+          description: |
+            Filter events to a specific connector (e.g. "github", "slack").
+            Only returns events where the action was handled by this connector.
+          schema:
+            type: string
+          example: github
       responses:
         '200':
           description: Audit events retrieved successfully
@@ -1601,6 +2104,8 @@ paths:
                         to: alice@example.com
                         subject: Hello
                     outcome: approved
+                    connector_id: email
+                    execution_status: null
                   - event_type: standing_approval.executed
                     timestamp: '2026-02-20T14:25:00Z'
                     agent_id: 42
@@ -1612,6 +2117,23 @@ paths:
                       constraints:
                         sender: '*@mycompany.com'
                     outcome: auto_executed
+                    connector_id: email
+                    execution_status: success
+                  - event_type: payment_method.charged
+                    timestamp: '2026-02-20T14:20:00Z'
+                    agent_id: 42
+                    agent_metadata:
+                      name: My AI Assistant
+                    action:
+                      type: expedia.create_booking
+                      payment_method_id: pm_abc123
+                      brand: visa
+                      last4: '4242'
+                      amount_cents: 15000
+                      currency: usd
+                      description: Hotel booking — 2 nights
+                    outcome: charged
+                    connector_id: expedia
                   - event_type: agent.registered
                     timestamp: '2026-02-19T10:00:00Z'
                     agent_id: 43
@@ -1657,20 +2179,31 @@ paths:
       operationId: requestApproval
       summary: Request Approval for Action
       description: |
-        Request approval for a specific one-off action. The designated approver must review 
-        and approve the action before the agent can execute it.
+        Request approval for an action. If a matching standing approval exists, the action
+        is auto-approved and executed immediately — the result is returned inline with
+        `status: "approved"`. Otherwise, creates a pending approval for human review.
 
-        ## Approval Request Flow
+        ## Auto-Approval (Standing Approval Match)
+
+        Before creating a pending approval, Permission Slip checks for an active standing
+        approval that matches the agent, action type, and parameters. If found:
+
+        1. **Parameters validated**: Against standing approval constraints
+        2. **Action executed**: Immediately via the connector using stored credentials
+        3. **Result returned**: Response has `status: "approved"` with `result` and `standing_approval_id`
+        4. **No polling needed**: The agent has the result immediately
+
+        ## One-off Approval (No Standing Approval Match)
+
+        If no standing approval matches, the request follows the standard flow:
 
         1. **Agent requests**: Sends action details, parameters, and context
         2. **Permission Slip validates**: Verifies agent is registered, signature is valid
-        3. **Permission Slip responds**: Returns approval URL with unique approval_id
+        3. **Permission Slip responds**: Returns approval URL with unique approval_id and `status: "pending"`
         4. **Notification sent**: Permission Slip notifies approver (push notification)
         5. **Approver reviews**: Visits URL, sees full action details, approves/denies
-        6. **Confirmation shown**: If approved, Permission Slip shows 6-character confirmation code
-        7. **Agent verifies**: Collects code from user, submits to verify endpoint
-        8. **Token issued**: Permission Slip returns single-use JWT token
-        9. **Agent executes**: Uses token to call `POST /v1/actions/execute`
+        6. **Direct execution**: If approved, Permission Slip immediately executes the action via the connector
+        7. **Agent polls for result**: Agent calls `GET /v1/approvals/{approval_id}/status` to get execution result
 
         ## Action Types
 
@@ -1699,10 +2232,9 @@ paths:
 
         ## Parameters Hash
 
-        The `action.parameters` object is canonicalized using RFC 8785 (JCS) and hashed with 
-        SHA-256. This hash is embedded in the approval token as `params_hash` to prevent 
-        parameter tampering. Permission Slip verifies the hash matches request parameters before 
-        executing actions.
+        The `action.parameters` object is canonicalized using RFC 8785 (JCS) and hashed with
+        SHA-256. This hash is stored with the approval to prevent parameter tampering.
+        Permission Slip verifies the hash matches request parameters before executing actions.
       tags:
         - Approvals
       security:
@@ -1778,31 +2310,31 @@ paths:
                       estimated_downtime: 2 minutes
       responses:
         '200':
-          description: Approval request created successfully
+          description: |
+            Approval request processed. Check `status` to determine the outcome:
+            - `approved` — auto-approved via standing approval, result inline
+            - `pending` — awaiting human review
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApprovalRequestResponse'
               examples:
-                basic:
-                  summary: Basic approval response
+                pending:
+                  summary: Pending — awaiting human approval
                   value:
                     approval_id: appr_xyz789
                     approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
                     status: pending
                     expires_at: '2026-02-11T13:25:00Z'
-                    verification_required: true
-                with_alternative_urls:
-                  summary: Response with cross-platform URLs
+                    created_at: '2026-02-11T13:20:00Z'
+                auto_approved:
+                  summary: Auto-approved via standing approval
                   value:
-                    approval_id: appr_xyz789
-                    approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
-                    alternative_urls:
-                      deeplink: permissionslip://permission-slip/approve/appr_xyz789
-                      web: https://accounts.permissionslip.dev/permission-slip/approve/appr_xyz789
-                    status: pending
-                    expires_at: '2026-02-11T13:25:00Z'
-                    verification_required: true
+                    status: approved
+                    result:
+                      message_id: msg_abc123
+                      delivery_status: queued
+                    standing_approval_id: sa_abc123
         '400':
           description: Invalid request or unsupported action type
           content:
@@ -1903,228 +2435,6 @@ paths:
                   details:
                     request_id: a925fbe0-db83-4969-9dc5-27f40385f12c
                   trace_id: trace_xyz789
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-  /v1/approvals/{approval_id}/verify:
-    post:
-      operationId: verifyApproval
-      summary: Verify Approval and Retrieve Token
-      description: |
-        Verify approval and retrieve the single-use token by submitting the confirmation code 
-        shown to the approver after they approved the action.
-
-        ## Verification Flow
-
-        1. **Approver approves**: Visits approval URL, reviews action details, approves
-        2. **Code displayed**: Permission Slip shows 6-character confirmation code (e.g., `RK3-P7M`)
-        3. **User provides code**: Approver communicates code to agent owner/operator
-        4. **Agent submits code**: Calls this endpoint with code
-        5. **Permission Slip verifies**: Checks code matches, hasn't expired, attempts < 5
-        6. **Token issued**: Permission Slip returns single-use JWT token with action scope
-        7. **Agent uses token**: Passes token to `POST /v1/actions/execute` to trigger execution
-
-        ## Denial Handling
-
-        If the approver explicitly denied the approval request, this endpoint returns 
-        `403 Forbidden` with error code `approval_denied`. The agent should NOT retry 
-        or re-request approval for the same action without user intervention.
-
-        ## Token Structure
-
-        The returned JWT token contains:
-        - `sub`: Agent ID
-        - `aud`: `permissionslip.dev`
-        - `approver`: Username who approved
-        - `approval_id`: Approval request ID
-        - `scope`: Action type (e.g., `email.send`)
-        - `scope_version`: Action version (e.g., `"1"`)
-        - `params_hash`: SHA-256 hash of JCS-canonicalized action parameters
-        - `iat`, `exp`: Issued/expires timestamps
-        - `jti`: Unique token ID (for single-use enforcement)
-
-        ## Token Usage
-
-        The token is passed to `POST /v1/actions/execute` along with the action ID and 
-        parameters. Permission Slip verifies the token and executes the action using the 
-        user's stored credentials:
-
-        ```http
-        POST https://app.permissionslip.dev/v1/actions/execute
-        X-Permission-Slip-Signature: agent_id="...", algorithm="Ed25519", ...
-        Content-Type: application/json
-
-        {
-          "token": "<approval_token>",
-          "action_id": "email.send",
-          "parameters": { ... }
-        }
-        ```
-
-        Permission Slip verifies:
-        1. JWT signature (token was issued by Permission Slip)
-        2. Expiration (`exp` claim)
-        3. Scope matches `action_id`
-        4. Parameters hash matches request parameters
-        5. Token not already used (`jti` tracking)
-
-        ## Security
-
-        - **Attempt limit**: 5 incorrect code attempts allowed
-        - **Lockout**: After 5 failures, approval expires
-        - **Single-use code**: Code invalidated after successful verification
-        - **Single-use token**: Token invalidated after first successful action
-        - **Expiration**: Both code and token expire with approval TTL
-      tags:
-        - Approvals
-      security:
-        - PermissionSlipSignature: []
-      parameters:
-        - $ref: '#/components/parameters/ApprovalId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VerifyApprovalRequest'
-            examples:
-              with_hyphen:
-                summary: Code with hyphen
-                value:
-                  request_id: a9b2e069-6374-4a65-be1d-b26cc376d7fe
-                  confirmation_code: RK3-P7M
-              without_hyphen:
-                summary: Code without hyphen
-                value:
-                  request_id: dcd35b63-5b5c-473c-a713-154ed643a9b4
-                  confirmation_code: RK3P7M
-      responses:
-        '200':
-          description: Approval verified successfully, token issued
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VerifyApprovalResponse'
-              example:
-                status: approved
-                approved_at: '2026-02-11T13:20:45Z'
-                token:
-                  access_token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ2VudF94N0s5bVA0biIsImF1ZCI6InBlcm1pc3Npb25zbGlwLmRldiIsImFwcHJvdmVyIjoiYWxpY2UiLCJhcHByb3ZhbF9pZCI6ImFwcHJfeHl6Nzg5Iiwic2NvcGUiOiJlbWFpbC5zZW5kIiwic2NvcGVfdmVyc2lvbiI6IjEiLCJwYXJhbXNfaGFzaCI6ImJhMDYxN2IyMzM0MTcwY2I5MzY5MTZkYjIwMjQwMDMwMGExZmRjMWZlNzFlMzZiOTExZDA4YjI1MTlmM2Q2OGMiLCJpYXQiOjE3NzA4MTYwNDUsImV4cCI6MTc3MDgxNjM0NSwianRpIjoidG9rX3VuaXF1ZTEyMyJ9.signature
-                  expires_at: '2026-02-11T13:25:45Z'
-                  scope: email.send
-                  scope_version: '1'
-        '400':
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: invalid_request
-                  message: Invalid confirmation code format
-                  retryable: false
-                  details:
-                    field: confirmation_code
-                  trace_id: trace_xyz789
-        '401':
-          description: Invalid signature or incorrect code
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalid_code:
-                  summary: Incorrect confirmation code
-                  value:
-                    error:
-                      code: invalid_code
-                      message: Incorrect confirmation code
-                      retryable: false
-                      details:
-                        attempts_remaining: 3
-                      trace_id: trace_xyz789
-                invalid_signature:
-                  summary: Signature verification failed
-                  value:
-                    error:
-                      code: invalid_signature
-                      message: Signature verification failed
-                      retryable: false
-                      trace_id: trace_xyz789
-        '403':
-          description: Agent not authorized or approval denied
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                approval_denied:
-                  summary: User explicitly denied the approval
-                  value:
-                    error:
-                      code: approval_denied
-                      message: User denied the approval request
-                      retryable: false
-                      details:
-                        denied_at: '2026-02-11T13:20:30Z'
-                      trace_id: trace_xyz789
-                agent_not_authorized:
-                  summary: Agent not authorized for this approval
-                  value:
-                    error:
-                      code: agent_not_authorized
-                      message: Agent is not authorized for this approval
-                      retryable: false
-                      details:
-                        agent_id: 42
-                        approval_id: appr_xyz789
-                      trace_id: trace_xyz789
-        '404':
-          description: Approval not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: approval_not_found
-                  message: Approval ID not found
-                  retryable: false
-                  details:
-                    approval_id: appr_xyz789
-                  trace_id: trace_xyz789
-        '410':
-          description: Approval expired or locked out
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                expired:
-                  summary: Approval TTL elapsed
-                  value:
-                    error:
-                      code: approval_expired
-                      message: Approval has expired
-                      retryable: false
-                      details:
-                        expired_at: '2026-02-11T13:25:00Z'
-                      trace_id: trace_xyz789
-                too_many_attempts:
-                  summary: Too many failed code attempts (locked out)
-                  value:
-                    error:
-                      code: approval_expired
-                      message: Too many failed verification attempts
-                      retryable: false
-                      details:
-                        failed_attempts: 5
-                        max_attempts: 5
-                      trace_id: trace_xyz789
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -2277,7 +2587,9 @@ paths:
         Returns approval requests for the authenticated user (as approver),
         ordered by creation time (newest first). By default only returns
         pending, non-expired approvals. Use the `status` query parameter to
-        filter by other statuses. Uses session authentication (Supabase JWT).
+        filter by other statuses. Supports cursor-based pagination via the
+        `limit` and `after` query parameters. Uses session authentication
+        (Supabase JWT).
       tags:
         - Approvals
       security:
@@ -2299,6 +2611,26 @@ paths:
               - all
             default: pending
           example: pending
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of approvals to return (1–100, default 50).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          example: 20
+        - name: after
+          in: query
+          required: false
+          description: |
+            Opaque pagination cursor. Pass the `next_cursor` value from a
+            previous response to fetch the next page. Do not construct
+            cursor values manually.
+          schema:
+            type: string
+          example: 2026-02-11T13:20:00.123456Z,appr_xyz789
       responses:
         '200':
           description: Approvals retrieved successfully
@@ -2306,25 +2638,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApprovalListResponse'
-              example:
-                data:
-                  - approval_id: appr_xyz789
-                    agent_id: 42
-                    action:
-                      type: email.send
-                      version: '1'
-                      parameters:
-                        from: alice@example.com
-                        to:
-                          - recipient@example.com
-                        subject: Hello World
-                        body: This is a test email.
-                    context:
-                      description: Send welcome email to new user
-                      risk_level: low
-                    status: pending
-                    expires_at: '2026-02-11T13:25:00Z'
-                    created_at: '2026-02-11T13:20:00Z'
+              examples:
+                pending_approvals:
+                  summary: List of pending approvals
+                  value:
+                    data:
+                      - approval_id: appr_xyz789
+                        agent_id: 42
+                        action:
+                          type: email.send
+                          version: '1'
+                          parameters:
+                            from: alice@example.com
+                            to:
+                              - recipient@example.com
+                            subject: Hello World
+                            body: This is a test email.
+                        context:
+                          description: Send welcome email to new user
+                          risk_level: low
+                        status: pending
+                        expires_at: '2026-02-11T13:25:00Z'
+                        created_at: '2026-02-11T13:20:00Z'
+                    has_more: false
+                approved_with_results:
+                  summary: Approved approval with execution result
+                  value:
+                    data:
+                      - approval_id: appr_abc456
+                        agent_id: 42
+                        action:
+                          type: email.send
+                          version: '1'
+                          parameters:
+                            from: alice@example.com
+                            to:
+                              - recipient@example.com
+                            subject: Hello World
+                            body: This is a test email.
+                        context:
+                          description: Send welcome email to new user
+                          risk_level: low
+                        status: approved
+                        expires_at: '2026-02-11T13:25:00Z'
+                        approved_at: '2026-02-11T13:21:00Z'
+                        created_at: '2026-02-11T13:20:00Z'
+                        execution_status: success
+                        execution_result:
+                          message_id: msg_abc123
+                          delivery_status: queued
+                        executed_at: '2026-02-11T13:21:01Z'
+                    has_more: false
         '400':
           description: Invalid query parameters
           content:
@@ -2334,7 +2698,7 @@ paths:
               example:
                 error:
                   code: invalid_request
-                  message: Invalid status filter
+                  message: limit must be a positive integer
                   retryable: false
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '401':
@@ -2357,6 +2721,184 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/approvals/events:
+    get:
+      operationId: approvalEvents
+      summary: Subscribe to Approval Events (SSE)
+      description: |
+        Server-Sent Events (SSE) endpoint for real-time approval notifications.
+        Opens a persistent connection and streams events as approvals are created,
+        resolved, or cancelled. This eliminates the need for polling the list
+        endpoint.
+
+        ## Authentication
+
+        EventSource (the browser SSE API) does not support custom headers. Pass
+        the Supabase session token as a `?token=` query parameter. The server
+        strips the token from the URL before logging to prevent leaking
+        credentials.
+
+        ## Events
+
+        | Event | Description |
+        |-------|-------------|
+        | `connected` | Sent immediately on connection. Confirms the stream is live. |
+        | `approval_created` | A new approval was requested by an agent. |
+        | `approval_resolved` | An approval was approved or denied. Includes `execution_status` when approved. |
+        | `approval_cancelled` | An agent cancelled an approval. |
+
+        Each event carries a JSON `data` payload with `approval_id` and relevant fields:
+
+        ```
+        event: approval_created
+        data: {"approval_id":"appr_xyz789"}
+
+        event: approval_resolved
+        data: {"approval_id":"appr_xyz789","status":"approved","execution_status":"success"}
+        ```
+
+        A `: heartbeat` comment is sent every 30 seconds to keep the connection
+        alive through proxies and load balancers.
+
+        ## Connection Limits
+
+        Each user may hold at most 10 concurrent SSE connections. Exceeding this
+        limit returns `429 Too Many Requests`. Close unused browser tabs to free
+        connection slots.
+
+        ## Resilience
+
+        The browser's built-in EventSource reconnection handles transient
+        disconnects automatically. A 30-second polling fallback in the frontend
+        ensures updates even when SSE is unavailable.
+      tags:
+        - Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: token
+          in: query
+          required: false
+          description: |
+            Supabase session token for EventSource clients (which cannot set
+            custom headers). Mutually exclusive with the Authorization header.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: SSE stream established
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              example: |
+                event: connected
+                data: {}
+
+                event: approval_created
+                data: {"approval_id":"appr_xyz789"}
+
+                event: approval_resolved
+                data: {"approval_id":"appr_xyz789","status":"approved","execution_status":"success"}
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          description: Too many concurrent SSE connections
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: rate_limited
+                  message: Too many concurrent SSE connections. Close unused tabs and retry.
+                  retryable: true
+                  retry_after: 5
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/approvals/{approval_id}:
+    get:
+      operationId: getApproval
+      summary: Get Approval Details
+      description: |
+        Returns the full details of a single approval by ID. Includes action
+        parameters, context, execution status, and execution result. Used by the
+        activity feed detail panel to show what an agent tried to do and what
+        happened.
+
+        Only returns approvals owned by the authenticated user (as approver).
+      tags:
+        - Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/ApprovalId'
+      responses:
+        '200':
+          description: Approval details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalSummary'
+              examples:
+                approved_with_result:
+                  summary: Approved approval with execution result
+                  value:
+                    approval_id: appr_abc456
+                    agent_id: 42
+                    action:
+                      type: email.send
+                      version: '1'
+                      parameters:
+                        to: recipient@example.com
+                        subject: Hello World
+                    context:
+                      description: Send welcome email to new user
+                      risk_level: low
+                    status: approved
+                    execution_status: success
+                    execution_result:
+                      message_id: msg_abc123
+                    executed_at: '2026-02-11T13:21:01Z'
+                    expires_at: '2026-02-11T13:25:00Z'
+                    approved_at: '2026-02-11T13:21:00Z'
+                    created_at: '2026-02-11T13:20:00Z'
+                denied:
+                  summary: Denied approval
+                  value:
+                    approval_id: appr_xyz789
+                    agent_id: 42
+                    action:
+                      type: file.delete
+                      version: '1'
+                      parameters:
+                        path: /important/data.csv
+                    context:
+                      description: Delete temporary file
+                      risk_level: high
+                    status: denied
+                    expires_at: '2026-02-11T13:25:00Z'
+                    denied_at: '2026-02-11T13:22:00Z'
+                    created_at: '2026-02-11T13:20:00Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Approval not found or not owned by user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: approval_not_found
+                  message: Approval not found
+                  retryable: false
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/approvals/{approval_id}/approve:
     post:
       operationId: approveApproval
@@ -2366,8 +2908,12 @@ paths:
         authenticated user (as approver) and must be in `pending` status and
         not expired.
 
-        This is a dashboard endpoint for human approvers — distinct from the
-        agent-facing verify endpoint which uses confirmation codes.
+        When approved, Permission Slip immediately executes the action via the
+        configured connector using the user's stored credentials. The execution
+        result is stored on the approval row and returned in the response.
+
+        This is a dashboard endpoint for human approvers. Agents can poll for
+        the result via `GET /v1/approvals/{approval_id}/status`.
       tags:
         - Approvals
       security:
@@ -2381,11 +2927,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApproveApprovalResponse'
-              example:
-                approval_id: appr_xyz789
-                status: approved
-                approved_at: '2026-02-21T10:30:00Z'
-                confirmation_code: RK3-P7M
+              examples:
+                success:
+                  summary: Approved and executed successfully
+                  value:
+                    approval_id: appr_xyz789
+                    status: approved
+                    approved_at: '2026-02-21T10:30:00Z'
+                    confirmation_code: RK3-P7M
+                    execution_status: success
+                    execution_result:
+                      message_id: msg_abc123
+                      delivery_status: queued
+                execution_error:
+                  summary: Approved but execution failed
+                  value:
+                    approval_id: appr_xyz789
+                    status: approved
+                    approved_at: '2026-02-21T10:30:00Z'
+                    confirmation_code: RK3-P7M
+                    execution_status: error
+                    execution_result:
+                      error: upstream_error
+                      message: External service returned 503
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -2432,6 +2996,22 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '502':
+          description: External service error during action execution
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: upstream_error
+                  message: External service returned an error
+                  retryable: false
+                  details:
+                    service: gmail
+                    upstream_status: 503
+                    upstream_message: Service temporarily unavailable
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /v1/approvals/{approval_id}/deny:
@@ -2509,6 +3089,280 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/approvals/{approval_id}/status:
+    get:
+      operationId: getApprovalStatus
+      summary: Get Approval Status
+      description: |
+        Poll the status of an approval request and retrieve the execution result.
+        This is an agent-facing endpoint used to check whether an approval has been
+        resolved and, if approved, to get the result of the executed action.
+
+        ## Polling Flow
+
+        1. **Agent submits approval request**: `POST /v1/approvals/request`
+        2. **Agent polls status**: `GET /v1/approvals/{approval_id}/status`
+        3. **Permission Slip responds**: Returns current status and execution result (if available)
+
+        ## Status Transitions
+
+        - `pending` → `approved` (with execution result) or `denied` or `cancelled`
+        - Once resolved, the status is final and will not change
+
+        ## Recommended Polling Strategy
+
+        - Poll every 1–2 seconds for the first 30 seconds
+        - Then every 5 seconds until expiration
+        - Stop polling when status is no longer `pending` or when `expires_at` has passed
+        - Prefer SSE (`GET /v1/approvals/events`) for real-time notifications when possible
+
+        ## Security
+
+        - Request MUST include valid `X-Permission-Slip-Signature` header
+        - Only the agent that created the approval can poll its status
+      tags:
+        - Approvals
+      security:
+        - PermissionSlipSignature: []
+      parameters:
+        - $ref: '#/components/parameters/ApprovalId'
+      responses:
+        '200':
+          description: Approval status retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalStatusResponse'
+              examples:
+                pending:
+                  summary: Approval still pending
+                  value:
+                    approval_id: appr_xyz789
+                    status: pending
+                    expires_at: '2026-02-21T10:35:00Z'
+                approved_with_result:
+                  summary: Approved and executed successfully
+                  value:
+                    approval_id: appr_xyz789
+                    status: approved
+                    approved_at: '2026-02-21T10:30:00Z'
+                    expires_at: '2026-02-21T10:35:00Z'
+                    execution_status: success
+                    execution_result:
+                      message_id: msg_abc123
+                      delivery_status: queued
+                    executed_at: '2026-02-21T10:30:01Z'
+                approved_execution_pending:
+                  summary: Approved but execution still in progress
+                  value:
+                    approval_id: appr_xyz789
+                    status: approved
+                    approved_at: '2026-02-21T10:30:00Z'
+                    expires_at: '2026-02-21T10:35:00Z'
+                    execution_status: pending
+                denied:
+                  summary: Approval denied
+                  value:
+                    approval_id: appr_xyz789
+                    status: denied
+                    denied_at: '2026-02-21T10:30:00Z'
+                    expires_at: '2026-02-21T10:35:00Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: |
+            Approval not found or not owned by this agent. Returns the same error
+            for both cases to prevent approval ID enumeration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: approval_not_found
+                  message: Approval not found
+                  retryable: false
+                  details:
+                    approval_id: appr_xyz789
+                  trace_id: trace_xyz789
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/action-config-templates:
+    get:
+      operationId: listActionConfigTemplates
+      summary: List Action Configuration Templates
+      description: |
+        List predefined configuration templates for a specific connector.
+        Templates provide ready-made parameter presets for common use cases
+        (e.g., "Create issues (all fields open)", "Post to a channel") that
+        users can apply when creating a new action configuration.
+
+        Templates are system-level — they are defined in connector manifests
+        and are the same for all users. Each template ID is namespaced by
+        connector to prevent cross-connector collisions.
+
+        ## Security
+
+        - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
+      tags:
+        - Action Configurations
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: connector_id
+          in: query
+          required: true
+          description: |
+            Connector ID to list templates for.
+          schema:
+            type: string
+            maxLength: 128
+          example: github
+      responses:
+        '200':
+          description: Templates listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionConfigTemplateListResponse'
+        '400':
+          description: Missing or invalid connector_id query parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: invalid_request
+                  message: connector_id query parameter is required
+                  retryable: false
+                  trace_id: trace_xyz789
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/action-config-templates/bulk-apply:
+    post:
+      operationId: bulkApplyActionConfigTemplates
+      summary: Bulk Apply Action Configuration Templates
+      description: |
+        Apply multiple templates in a single request. Creates an action
+        configuration (and optional standing approval) for each template.
+
+        All templates must belong to the same connector. The connector is
+        automatically enabled for the agent if not already enabled.
+
+        Each template is applied independently — if one fails (e.g., standing
+        approval limit reached), the others still succeed. The response
+        includes per-template results.
+      tags:
+        - Action Configurations
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkApplyActionConfigTemplateRequest'
+      responses:
+        '200':
+          description: |
+            Bulk apply completed. Check individual `results[].success` for
+            per-template outcomes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkApplyActionConfigTemplateResponse'
+        '400':
+          description: Invalid request (empty list, mixed connectors, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: |
+            A requested template ID was not found. This is an upfront
+            validation error — no configurations are created.
+            Per-template failures (e.g., agent not found, standing approval
+            limit) are reported in `results[]` with `success: false`, not
+            as HTTP-level errors.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/action-config-templates/{id}/apply:
+    post:
+      operationId: applyActionConfigTemplate
+      summary: Apply Action Configuration Template
+      description: |
+        Create an action configuration from a template in one step. When the
+        template defines `standing_approval`, also creates an active standing
+        approval in the same transaction.
+
+        If the connector is not yet enabled for the agent, it is enabled
+        automatically so the configuration can be created.
+      tags:
+        - Action Configurations
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Template ID (from list templates).
+          schema:
+            type: string
+            maxLength: 255
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyActionConfigTemplateRequest'
+      responses:
+        '201':
+          description: Configuration created (and standing approval if applicable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplyActionConfigTemplateResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Standing approval plan limit reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Template or agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/action-configurations:
     post:
       operationId: createActionConfiguration
@@ -2543,13 +3397,12 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateActionConfigRequest'
             examples:
-              with_credential:
-                summary: Configuration with locked parameters and credential
+              with_params:
+                summary: Configuration with locked parameters
                 value:
                   agent_id: 42
                   connector_id: github
                   action_type: github.create_issue
-                  credential_id: cred_abc123
                   parameters:
                     repo: supersuit-tech/webapp
                     title: '*'
@@ -2557,8 +3410,8 @@ paths:
                     label: bug
                   name: Create bug issues in webapp
                   description: Agent can create issues labeled 'bug'. Title and body are freeform.
-              without_credential:
-                summary: Configuration without credential (assign later)
+              minimal:
+                summary: Configuration with minimal fields
                 value:
                   agent_id: 42
                   connector_id: slack
@@ -2836,336 +3689,6 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /v1/actions/execute:
-    post:
-      operationId: executeAction
-      summary: Execute Action
-      description: |
-        Execute an action via Permission Slip. This endpoint supports two authorization modes:
-
-        ## Mode 1: One-off Approval (Bearer Token)
-
-        The agent redeems a single-use approval token from the one-off approval flow.
-
-        1. **Agent submits token**: Provides the approval token, action ID, and parameters
-        2. **Permission Slip validates**: Verifies token signature, expiration, scope, and parameter hash
-        3. **Permission Slip executes**: Calls the external service API using the user's stored credentials
-        4. **Result returned**: External service response is returned to the agent
-        5. **Token consumed**: Token is invalidated (single-use)
-
-        ## Mode 2: Standing Approval (Agent Signature)
-
-        The agent executes under a pre-authorized standing approval — no token needed.
-
-        1. **Agent submits action**: Provides action type and parameters (no token)
-        2. **Permission Slip matches**: Finds an active standing approval for this agent + action + constraints
-        3. **Permission Slip validates**: Verifies parameters fall within standing approval constraints
-        4. **Permission Slip executes**: Calls the external service API immediately
-        5. **Result returned**: Uses the `StandingApprovalExecuteResponse` schema (includes `standing_approval_id` and `executions_remaining`)
-
-        Permission Slip determines the mode by the presence of the `token` field in the JSON
-        request body. If a non-empty `token` is provided, one-off token verification is used.
-        If `token` is absent, standing approval matching is attempted using the agent signature.
-        If no standing approval matches, the request falls through to the one-off approval flow —
-        Permission Slip returns `404 Not Found` with a hint to use `POST /v1/approvals/request`,
-        indicating the agent should initiate the standard approval flow for this action.
-
-        ## Token Validation (One-off mode)
-
-        Permission Slip verifies:
-        - **JWT signature**: Token was issued by Permission Slip
-        - **Expiration**: `exp` claim has not passed
-        - **Scope**: `scope` claim matches the `action_id` in the request
-        - **Parameters hash**: SHA-256 of JCS-canonicalized `parameters` matches `params_hash` claim
-        - **Single-use**: Token `jti` has not been previously consumed
-
-        ## Standing Approval Validation (Standing approval mode)
-
-        Permission Slip verifies:
-        - **Agent signature**: Valid Ed25519/ECDSA signature
-        - **Standing approval match**: Active standing approval for this agent + action type
-        - **Constraint compliance**: Parameters fall within standing approval constraints
-        - **Expiration**: Standing approval has not expired (or has no expiration)
-        - **Execution count**: Max executions not exceeded (if set)
-
-        ## Credential Lookup
-
-        Permission Slip determines which external service to call based on the action type
-        (via connector configuration) and retrieves the user's stored credentials from the
-        encrypted vault. The agent never sees these credentials.
-
-        ## Error Handling
-
-        If the external service returns an error, Permission Slip returns a `502 Bad Gateway`
-        with details about the upstream failure. For one-off mode, the token is still consumed —
-        the agent must request a new approval to retry. For standing approval mode, the execution
-        count is not incremented on upstream failures.
-
-        ## Security
-
-        - Request MUST include valid `X-Permission-Slip-Signature` header
-        - One-off: Token is single-use — consumed even if the external service call fails
-        - Standing: Constraints are enforced on every execution
-        - Parameters must match what was approved (hash verification for one-off, constraint check for standing)
-        - Agent never sees user credentials
-      tags:
-        - Actions
-      security:
-        - PermissionSlipSignature: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ExecuteActionRequest'
-            examples:
-              email_send_oneoff:
-                summary: 'One-off: Execute email send with approval token'
-                value:
-                  token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ2VudF94N0s5bVA0biIsImFwcHJvdmFsX2lkIjoiYXBwcl94eXo3ODkiLCJzY29wZSI6ImVtYWlsLnNlbmQifQ.signature
-                  action_id: email.send
-                  parameters:
-                    from: alice@example.com
-                    to:
-                      - bob@example.com
-                    subject: Meeting tomorrow
-                    body: Let's meet at 3pm.
-              flight_book_oneoff:
-                summary: 'One-off: Execute flight booking with approval token'
-                value:
-                  token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
-                  action_id: flight.book
-                  parameters:
-                    from: SFO
-                    to: NYC
-                    date: '2026-03-15'
-                    passengers: 1
-                    class: economy
-              payment_charge_oneoff:
-                summary: 'One-off: Execute payment charge with approval token'
-                value:
-                  token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
-                  action_id: payment.charge
-                  parameters:
-                    amount: 9900
-                    currency: USD
-                    customer_id: cus_abc123
-                    description: Subscription renewal
-              email_read_standing:
-                summary: 'Standing approval: Read emails (no token)'
-                value:
-                  request_id: f47ac10b-58cc-4372-a567-0e02b2c3d479
-                  action:
-                    type: email.read
-                    version: '1'
-                    parameters:
-                      sender: '*@github.com'
-                      max_results: 10
-      responses:
-        '200':
-          description: Action executed successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExecuteActionResponse'
-              examples:
-                email_sent_oneoff:
-                  summary: 'One-off: Email sent successfully'
-                  value:
-                    status: success
-                    action_id: email.send
-                    executed_at: '2026-02-11T13:21:00Z'
-                    result:
-                      message_id: msg_abc123
-                      delivery_status: queued
-                flight_booked_oneoff:
-                  summary: 'One-off: Flight booked successfully'
-                  value:
-                    status: success
-                    action_id: flight.book
-                    executed_at: '2026-02-11T13:21:05Z'
-                    result:
-                      confirmation_number: ABC123
-                      airline: United Airlines
-                      total: $347.00
-                      departure: '2026-03-15T08:00:00-08:00'
-                email_read_standing:
-                  summary: 'Standing approval: Emails read successfully'
-                  value:
-                    result:
-                      emails:
-                        - id: msg_001
-                          subject: PR merged
-                          sender: noreply@github.com
-                    standing_approval_id: sa_abc123
-                    executions_remaining: null
-        '400':
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: invalid_request
-                  message: 'Missing required field: token'
-                  retryable: false
-                  details:
-                    field: token
-                  trace_id: trace_xyz789
-        '401':
-          description: Invalid signature or token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalid_token:
-                  summary: Token is invalid or expired
-                  value:
-                    error:
-                      code: invalid_token
-                      message: Token is invalid or has expired
-                      retryable: false
-                      trace_id: trace_xyz789
-                invalid_signature:
-                  summary: Request signature verification failed
-                  value:
-                    error:
-                      code: invalid_signature
-                      message: Signature verification failed
-                      retryable: false
-                      trace_id: trace_xyz789
-        '403':
-          description: Token scope mismatch, parameter mismatch, or token already used
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                insufficient_scope:
-                  summary: Token scope doesn't match action_id
-                  value:
-                    error:
-                      code: insufficient_scope
-                      message: Token does not have the required scope for this action
-                      retryable: false
-                      details:
-                        token_scope: email.send
-                        requested_action: payment.charge
-                      trace_id: trace_xyz789
-                invalid_parameters:
-                  summary: Parameters don't match approved parameters
-                  value:
-                    error:
-                      code: invalid_parameters
-                      message: Request parameters do not match the approved parameters
-                      retryable: false
-                      details:
-                        expected_hash: ba0617b2334170cb...
-                        computed_hash: c7d8e9f0a1b2c3d4...
-                      trace_id: trace_xyz789
-                token_already_used:
-                  summary: Token has already been consumed
-                  value:
-                    error:
-                      code: token_already_used
-                      message: Token has already been consumed
-                      retryable: false
-                      details:
-                        jti: tok_unique123
-                        used_at: '2026-02-11T13:21:00Z'
-                      trace_id: trace_xyz789
-                standing_approval_exhausted:
-                  summary: Standing approval execution count exceeded
-                  value:
-                    error:
-                      code: standing_approval_exhausted
-                      message: Standing approval max execution count has been reached
-                      retryable: false
-                      details:
-                        standing_approval_id: sa_abc123
-                        max_executions: 100
-                        execution_count: 100
-                      trace_id: trace_xyz789
-                constraint_violation:
-                  summary: Parameters violate standing approval constraints
-                  value:
-                    error:
-                      code: constraint_violation
-                      message: Request parameters violate standing approval constraints
-                      retryable: false
-                      details:
-                        standing_approval_id: sa_abc123
-                        violated_constraint: sender
-                        expected: '*@github.com'
-                        actual: '*@competitor.com'
-                      trace_id: trace_xyz789
-        '404':
-          description: Credentials not found or no matching standing approval
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                credentials_not_found:
-                  summary: Credentials not found for the required service
-                  value:
-                    error:
-                      code: credentials_not_found
-                      message: No stored credentials found for the required service
-                      retryable: false
-                      details:
-                        required_service: gmail
-                      trace_id: trace_xyz789
-                no_matching_standing_approval:
-                  summary: No active standing approval matches this request
-                  value:
-                    error:
-                      code: no_matching_standing_approval
-                      message: No active standing approval matches this agent, action type, and parameters
-                      retryable: false
-                      details:
-                        action_type: email.read
-                        hint: Use POST /v1/approvals/request for one-off approval
-                      trace_id: trace_xyz789
-        '410':
-          description: Standing approval has expired
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: standing_approval_expired
-                  message: Standing approval has expired
-                  retryable: false
-                  details:
-                    standing_approval_id: sa_abc123
-                    expired_at: '2026-02-14T00:00:00Z'
-                  trace_id: trace_xyz789
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '502':
-          description: External service error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: upstream_error
-                  message: External service returned an error
-                  retryable: false
-                  details:
-                    service: gmail
-                    upstream_status: 503
-                    upstream_message: Service temporarily unavailable
-                  trace_id: trace_xyz789
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
   /v1/credentials:
     post:
       operationId: storeCredential
@@ -3240,6 +3763,21 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Credential limit reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: credential_limit_reached
+                  message: Free tier allows up to 5 stored credentials. Upgrade your plan to add more.
+                  retryable: false
+                  details:
+                    current_count: 5
+                    limit: 5
+                  trace_id: trace_xyz789
         '409':
           description: Duplicate credentials for this service/label combination
           content:
@@ -3383,12 +3921,12 @@ paths:
         - **Agent startup**: Agent queries its standing approvals to understand what it can do
         - **Flow selection**: Agent checks if a standing approval covers a desired action before
           deciding whether to use `POST /v1/actions/execute` (standing) or `POST /v1/approvals/request` (one-off)
-        - **Status monitoring**: Agent checks remaining executions or expiration times
+        - **Status monitoring**: Agent checks expiration times
 
         ## Filtering
 
-        Only standing approvals with status `active` are returned by default. Expired,
-        revoked, and exhausted standing approvals are excluded.
+        Only standing approvals with status `active` are returned by default. Expired
+        and revoked standing approvals are excluded.
 
         ## Security
 
@@ -3401,6 +3939,28 @@ paths:
         - PermissionSlipSignature: []
       parameters:
         - $ref: '#/components/parameters/AgentIdSigned'
+        - name: limit
+          in: query
+          required: false
+          description: |
+            Maximum number of standing approvals to return per page.
+            Defaults to 50. Must be between 1 and 100.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          example: 50
+        - name: after
+          in: query
+          required: false
+          description: |
+            Opaque pagination cursor from a previous response's `next_cursor`
+            field. When provided, returns the next page of results after this
+            cursor position.
+          schema:
+            type: string
+          example: 2026-02-14T10:30:00.123456789Z,sa_abc123
       responses:
         '200':
           description: Standing approvals listed successfully
@@ -3419,12 +3979,11 @@ paths:
                       sender: '*@github.com'
                       max_results: 10
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
                     revoked_at: null
+                    source_action_configuration_id: null
                   - standing_approval_id: sa_def456
                     agent_id: 42
                     user_id: alice
@@ -3434,12 +3993,13 @@ paths:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
                     status: active
-                    max_executions: 100
-                    execution_count: 12
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-05-15T00:00:00Z'
                     created_at: '2026-02-14T10:35:00Z'
                     revoked_at: null
+                    source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+                has_more: true
+                next_cursor: 2026-02-14T10:30:00.000000000Z,sa_abc123
         '400':
           description: Invalid request or agent ID mismatch
           content:
@@ -3482,9 +4042,10 @@ paths:
       operationId: userListStandingApprovals
       summary: List User Standing Approvals
       description: |
-        Returns standing approvals for the authenticated user, ordered by
-        creation time (newest first). By default only returns active standing
-        approvals. Use the `status` query parameter to filter by other statuses.
+        Returns standing approvals for the authenticated user with cursor-based
+        pagination, ordered by creation time (newest first). By default only
+        returns active standing approvals. Use the `status` query parameter to
+        filter by other statuses. Use `limit` and `after` for pagination.
         Uses session authentication (Supabase JWT).
       tags:
         - Standing Approvals
@@ -3503,10 +4064,39 @@ paths:
               - active
               - expired
               - revoked
-              - exhausted
               - all
             default: active
           example: active
+        - name: limit
+          in: query
+          required: false
+          description: |
+            Maximum number of results to return per page. Must be between 1 and 100.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          example: 50
+        - name: after
+          in: query
+          required: false
+          description: |
+            Opaque cursor from a previous response's `next_cursor` field.
+            Used to fetch the next page of results.
+          schema:
+            type: string
+          example: 2026-02-14T10:30:00Z,sa_abc123
+        - name: source_action_configuration_id
+          in: query
+          required: false
+          description: |
+            When set, only standing approvals whose `source_action_configuration_id`
+            matches this value are returned (e.g. to filter approvals linked to a
+            specific action configuration).
+          schema:
+            type: string
+            maxLength: 128
       responses:
         '200':
           description: Standing approvals retrieved successfully
@@ -3524,12 +4114,12 @@ paths:
                     constraints:
                       sender: '*@github.com'
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
                     revoked_at: null
+                    source_action_configuration_id: null
+                has_more: false
         '400':
           description: Invalid query parameters
           content:
@@ -3570,6 +4160,10 @@ paths:
         Create a new standing approval for an agent. The agent must belong to
         the authenticated user. The standing approval becomes active immediately
         (or at `starts_at` if specified).
+
+        **Constraints are required.** The `constraints` object must be non-empty and
+        contain at least one non-wildcard (`"*"`) value. This prevents "blank check"
+        standing approvals that auto-approve any parameters.
       tags:
         - Standing Approvals
       security:
@@ -3586,7 +4180,7 @@ paths:
               action_version: '1'
               constraints:
                 recipient_pattern: '*@mycompany.com'
-              max_executions: 100
+              source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
               expires_at: '2026-03-14T00:00:00Z'
       responses:
         '201':
@@ -3596,19 +4190,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/StandingApproval'
         '400':
-          description: Invalid request (validation errors, duration exceeds 90 days, etc.)
+          description: |
+            Invalid request. Common causes:
+            - Missing or empty `constraints` (`invalid_constraints`)
+            - All constraint values are wildcards (`invalid_constraints`)
+            - Duration exceeds 90 days (`invalid_request`)
+            - Invalid field values (`invalid_request`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalid_constraints:
+                  summary: Constraints are required
+                  value:
+                    error:
+                      code: invalid_constraints
+                      message: constraints are required for standing approvals
+                      retryable: false
+                      details:
+                        hint: 'Provide a JSON object with at least one non-wildcard constraint, e.g. {"repo": "my-org/my-repo", "title": "*"}'
+                      trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+                duration_exceeded:
+                  summary: Duration exceeds maximum
+                  value:
+                    error:
+                      code: invalid_request
+                      message: Duration exceeds maximum of 90 days
+                      retryable: false
+                      trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Standing approval limit reached
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error:
-                  code: invalid_request
-                  message: Duration exceeds maximum of 90 days
+                  code: standing_approval_limit_reached
+                  message: Free tier allows up to 5 active standing approvals. Upgrade your plan to add more.
                   retryable: false
+                  details:
+                    current_count: 5
+                    limit: 5
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Agent not found or not owned by user
           content:
@@ -3681,7 +4308,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -3700,6 +4327,81 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/standing-approvals/{standing_approval_id}/update:
+    post:
+      operationId: updateStandingApproval
+      summary: Update Standing Approval
+      description: |
+        Update the constraints and expires_at of an active standing approval.
+        The standing approval must belong to the authenticated user and be in `active` status.
+        Agent and action type cannot be changed — only constraints and expiry.
+
+        **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
+        the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
+        not a rolling window from the time of the update call.
+
+        Emits a `standing_approval.updated` audit event on success.
+      tags:
+        - Standing Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/StandingApprovalId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateStandingApprovalRequest'
+            example:
+              constraints:
+                recipient_pattern: '*@mycompany.com'
+              expires_at: '2026-04-14T00:00:00Z'
+      responses:
+        '200':
+          description: Standing approval updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandingApproval'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Standing approval not found or not owned by user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: approval_not_found
+                  message: Standing approval not found
+                  retryable: false
+                  trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        '409':
+          description: Standing approval already revoked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '410':
+          description: Standing approval no longer active (expired or revoked)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/standing-approvals/{standing_approval_id}/execute:
     post:
       operationId: executeStandingApproval
@@ -3707,7 +4409,7 @@ paths:
       description: |
         Record an execution of an active standing approval. The standing approval
         must belong to the authenticated user and be in `active` status. Atomically
-        increments the execution count and creates an execution record.
+        creates an execution record.
 
         Emits a `standing_approval.executed` audit event on success.
       tags:
@@ -3777,7 +4479,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -3892,6 +4594,8 @@ paths:
               example:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 username: alice
+                email: alice@example.com
+                phone: '+15551234567'
                 created_at: '2026-02-16T00:27:36Z'
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -3911,6 +4615,1794 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    patch:
+      operationId: updateProfile
+      summary: Update Profile Contact Fields
+      description: |
+        Updates the authenticated user's contact fields (email, phone).
+        Supports true PATCH semantics — only fields included in the request
+        body are updated; omitted fields are left unchanged.
+
+        To clear a field, pass `null` or an empty string `""`.
+
+        Validation:
+        - **email**: must match RFC-5321 local@domain format
+        - **phone**: must be E.164 format (e.g. `+15551234567`)
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProfileRequest'
+            example:
+              email: alice@example.com
+              phone: '+15551234567'
+      responses:
+        '200':
+          description: Profile updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfileResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    delete:
+      operationId: deleteAccount
+      summary: Delete Account
+      description: |
+        Permanently deletes the authenticated user's account and all associated
+        data including agents, approvals, credentials (and their vault secrets),
+        standing approvals, audit events, and subscription. The Supabase auth
+        user is also removed. This action is irreversible.
+
+        The request body must include `"confirmation": "DELETE"` as a safety
+        check to prevent accidental deletion.
+
+        **What gets deleted:**
+        - Profile and contact information
+        - All registered agents and their configurations
+        - All stored credentials (including encrypted vault secrets)
+        - All approval history and audit log events
+        - All standing approvals and their execution history
+        - Subscription and usage data
+        - Notification preferences and push subscriptions
+        - The Supabase authentication user (best-effort)
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteAccountRequest'
+            example:
+              confirmation: DELETE
+      responses:
+        '200':
+          description: Account deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteAccountResponse'
+              example:
+                deleted: true
+                message: Account and all associated data have been permanently deleted.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/profile/data-retention:
+    get:
+      operationId: getDataRetention
+      summary: Get Data Retention Policy
+      description: |
+        Returns the data retention policy for the authenticated user based on
+        their current plan.
+
+        **Retention periods by plan:**
+        - **Free:** 7-day audit log retention
+        - **Pay As You Go:** 90-day audit log retention
+
+        Account data (profile, credentials) is retained indefinitely until
+        the user explicitly deletes their account via `DELETE /v1/profile`.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Data retention policy retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataRetentionResponse'
+              example:
+                plan_id: free
+                plan_name: Free
+                audit_retention_days: 7
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/profile/notification-preferences:
+    get:
+      operationId: getNotificationPreferences
+      summary: Get Notification Preferences
+      description: |
+        Returns the authenticated user's notification preferences for all
+        channels. Channels without an explicit preference default to enabled.
+
+        The `available` field on each preference indicates whether the user's
+        plan supports the channel. SMS requires a paid plan — free-tier users
+        see `available: false` for the SMS channel.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Notification preferences retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferencesResponse'
+              example:
+                preferences:
+                  - channel: email
+                    enabled: true
+                    available: true
+                  - channel: sms
+                    enabled: false
+                    available: false
+                  - channel: web-push
+                    enabled: true
+                    available: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    put:
+      operationId: updateNotificationPreferences
+      summary: Update Notification Preferences
+      description: |
+        Updates the authenticated user's notification preferences. Accepts an
+        array of channel/enabled pairs. Channels not included in the request
+        are left unchanged.
+
+        Enabling the SMS channel requires a paid plan. Free-tier users receive
+        a 403 (sms_requires_paid_plan) with `details.current_plan` and
+        `details.required_plan` indicating which plan is needed.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateNotificationPreferencesRequest'
+            example:
+              preferences:
+                - channel: email
+                  enabled: true
+                - channel: web-push
+                  enabled: false
+      responses:
+        '200':
+          description: Notification preferences updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferencesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: |
+            SMS notifications require a paid plan. Returned when attempting to
+            enable the SMS channel on the free tier. The error details include
+            `current_plan` and `required_plan` fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: sms_requires_paid_plan
+                  message: SMS notifications require a paid plan. Upgrade to Pay As You Go to enable SMS.
+                  retryable: false
+                  details:
+                    current_plan: free
+                    required_plan: pay_as_you_go
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/push-subscriptions:
+    get:
+      summary: List push subscriptions
+      description: |
+        Returns push subscriptions registered by the authenticated user.
+        Optionally filter by channel type using the `channel` query parameter.
+      operationId: listPushSubscriptions
+      tags:
+        - Push Subscriptions
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          description: Filter by push channel type. Omit to list all subscriptions.
+          schema:
+            type: string
+            enum:
+              - web-push
+              - mobile-push
+      responses:
+        '200':
+          description: Push subscriptions retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushSubscriptionListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Register push subscription
+      description: |
+        Register a push subscription for notifications. Supports two types:
+
+        - **Web Push** (`type: "web-push"` or omitted): Requires `endpoint`, `p256dh`,
+          and `auth` from the browser's PushSubscription. If a subscription with the
+          same endpoint already exists, the keys are updated (subscription refresh).
+
+        - **Expo** (`type: "expo"`): Requires `expo_token` from the mobile app's
+          `expo-notifications` module. If a subscription with the same token already
+          exists, it is refreshed.
+      operationId: createPushSubscription
+      tags:
+        - Push Subscriptions
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePushSubscriptionRequest'
+      responses:
+        '201':
+          description: Push subscription created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushSubscriptionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/push-subscriptions/{subscription_id}:
+    delete:
+      summary: Delete push subscription
+      description: Remove a push subscription by ID.
+      operationId: deletePushSubscription
+      tags:
+        - Push Subscriptions
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: subscription_id
+          in: path
+          required: true
+          description: Push subscription ID
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Push subscription deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletePushSubscriptionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/push-subscriptions/unregister:
+    post:
+      summary: Unregister Expo push token
+      description: |
+        Remove an Expo push token by value. This is more convenient for mobile
+        clients than DELETE by ID, since the device knows its own token but may
+        not have cached the subscription ID. Typically called on logout.
+      operationId: unregisterExpoPushToken
+      tags:
+        - Push Subscriptions
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UnregisterExpoPushTokenRequest'
+      responses:
+        '200':
+          description: Expo push token unregistered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnregisterExpoPushTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/expo-push-tokens:
+    get:
+      summary: List Expo push tokens
+      description: Returns all Expo push tokens registered by the authenticated user.
+      operationId: listExpoPushTokens
+      tags:
+        - Expo Push Tokens
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Expo push tokens retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExpoPushTokenListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Register Expo push token
+      description: |
+        Register an Expo push token from the mobile app. If the same token
+        already exists for this user, the request is idempotent (no duplicate
+        is created).
+      operationId: createExpoPushToken
+      tags:
+        - Expo Push Tokens
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExpoPushTokenRequest'
+      responses:
+        '201':
+          description: Expo push token registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExpoPushTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/expo-push-tokens/{token_id}:
+    delete:
+      summary: Delete Expo push token
+      description: Remove an Expo push token registration by ID.
+      operationId: deleteExpoPushToken
+      tags:
+        - Expo Push Tokens
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: token_id
+          in: path
+          required: true
+          description: Expo push token registration ID
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Expo push token deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteExpoPushTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/billing/subscription:
+    get:
+      summary: Get current subscription
+      deprecated: true
+      description: |
+        Returns the authenticated user's subscription details including plan info,
+        billing period, and current usage metrics.
+
+        **Deprecated:** Use `GET /v1/billing/plan` instead, which returns structured
+        plan, subscription, and usage data in a single response.
+
+        Only available when `billing_enabled` is `true` in the server config.
+      operationId: getSubscription
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Subscription details returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriptionResponse'
+              example:
+                plan_id: free
+                plan_name: Free
+                status: active
+                current_period_start: '2026-03-01T00:00:00Z'
+                current_period_end: '2026-04-01T00:00:00Z'
+                has_payment_method: false
+                can_upgrade: true
+                plan_limits:
+                  max_requests_per_month: 1000
+                  max_agents: 5
+                  max_standing_approvals: 10
+                  max_credentials: 5
+                  audit_retention_days: 7
+                usage:
+                  request_count: 42
+                  sms_count: 0
+                  request_limit: 1000
+                  over_limit: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/billing/usage:
+    get:
+      summary: Get detailed usage breakdown
+      description: |
+        Returns detailed usage metrics for a billing period, including request
+        totals, overage calculations, SMS counts, costs, and an optional breakdown
+        by agent, connector, and action type.
+
+        Defaults to the current billing period. Pass `period_start` to view a
+        historical period (e.g., last month's usage).
+
+        Only available when `billing_enabled` is `true` in the server config.
+      operationId: getBillingUsage
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: period_start
+          in: query
+          required: false
+          description: |
+            Start of the billing period to query, as an ISO 8601 date-time.
+            Must be the first day of a month in UTC (e.g., `2026-02-01T00:00:00Z`).
+            Defaults to the current billing period if omitted.
+          schema:
+            type: string
+            format: date-time
+          example: '2026-02-01T00:00:00Z'
+      responses:
+        '200':
+          description: Usage details returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageDetail'
+              example:
+                period_start: '2026-03-01T00:00:00Z'
+                period_end: '2026-04-01T00:00:00Z'
+                requests:
+                  total: 1542
+                  included: 1000
+                  overage: 542
+                  cost_cents: 271
+                sms:
+                  total: 5
+                  cost_cents: 5
+                breakdown:
+                  by_agent:
+                    '1': 500
+                    '2': 1042
+                  by_connector:
+                    gmail: 300
+                    stripe: 1242
+                  by_action_type:
+                    email.send: 300
+                    payment.create: 1242
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No usage data found for this period
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/checkout:
+    post:
+      summary: Create checkout session
+      deprecated: true
+      description: |
+        Creates a Stripe Checkout Session for upgrading from the free plan to
+        pay-as-you-go. Returns a URL to redirect the user to Stripe's hosted
+        checkout page.
+
+        **Deprecated:** Use `POST /v1/billing/upgrade` instead, which has the
+        same behavior but a clearer name and response schema.
+
+        If the user doesn't have a Stripe Customer yet, one is created automatically.
+        If the user is already on a paid plan, returns 409 Conflict.
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: createCheckout
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Checkout session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckoutResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Already subscribed to a paid plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/upgrade:
+    post:
+      summary: Initiate plan upgrade
+      description: |
+        Initiates an upgrade from the free plan to pay-as-you-go by creating a
+        Stripe Checkout Session. Returns a URL to redirect the user to Stripe's
+        hosted checkout page to complete the upgrade.
+
+        If the user doesn't have a Stripe Customer yet, one is created automatically.
+        If the user is already on a paid plan, returns 409 Conflict.
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: upgradePlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Checkout session created for upgrade
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpgradeResponse'
+              example:
+                checkout_url: https://checkout.stripe.com/c/pay/cs_test_...
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Already subscribed to a paid plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/downgrade:
+    post:
+      summary: Downgrade to free plan
+      description: |
+        Downgrades the user from the pay-as-you-go plan to the free plan.
+        Cancels the Stripe subscription and sets a 7-day grace period during
+        which the user retains the longer audit retention window to export data.
+
+        If the user is already on the free plan with no active paid-quota grace window
+        (`quota_entitlements_until` in the past or unset), returns 409 Conflict.
+
+        If the user is already on the free plan but still has paid-plan quotas until
+        the end of the cancelled billing period, this call clears that grace immediately
+        so free-tier limits apply right away (same limit warnings as a normal downgrade).
+
+        Only available when `billing_enabled` is `true`.
+      operationId: downgradePlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Successfully downgraded to free plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DowngradeResponse'
+              example:
+                status: cancelled
+                plan_id: free
+                downgraded_at: '2026-03-02T12:00:00Z'
+                grace_period_ends_at: '2026-03-09T12:00:00Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: |
+            Conflict — already fully on the free plan, or entitlements already ended when
+            attempting to end quota grace early.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error (failed to cancel subscription)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/invoices:
+    get:
+      summary: List invoices
+      description: |
+        Returns a paginated list of the authenticated user's past invoices from
+        Stripe, including the amount, status, and a link to view the invoice.
+
+        Results are ordered by date descending (most recent first). Use
+        `starting_after` for cursor-based pagination.
+
+        Only available when `billing_enabled` is `true` and the user has a
+        Stripe customer ID (i.e., has previously been on a paid plan).
+      operationId: listInvoices
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of invoices to return (1–100). Defaults to 10.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+        - name: starting_after
+          in: query
+          required: false
+          description: |
+            Cursor for pagination. Pass the `id` of the last invoice from the
+            previous page to fetch the next page of results.
+          schema:
+            type: string
+          example: inv_1234567890
+      responses:
+        '200':
+          description: Invoices returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceListResponse'
+              example:
+                invoices:
+                  - id: inv_1234567890
+                    date: '2026-02-01T00:00:00Z'
+                    period_start: '2026-02-01T00:00:00Z'
+                    period_end: '2026-03-01T00:00:00Z'
+                    amount_cents: 271
+                    status: paid
+                    stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_1234567890
+                  - id: inv_0987654321
+                    date: '2026-01-01T00:00:00Z'
+                    period_start: '2026-01-01T00:00:00Z'
+                    period_end: '2026-02-01T00:00:00Z'
+                    amount_cents: 0
+                    status: paid
+                    stripe_invoice_url: https://invoice.stripe.com/i/acct_1234/inv_0987654321
+                has_more: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /api/webhooks/stripe:
+    post:
+      summary: Stripe webhook
+      description: |
+        Receives and processes Stripe webhook events. This endpoint lives outside
+        `/api/v1/` to bypass auth and rate-limiting middleware. Security is provided
+        by Stripe's webhook signature verification using `STRIPE_WEBHOOK_SECRET`.
+
+        **Handled event types:**
+
+        - `checkout.session.completed`: Stores the Stripe subscription ID and
+          atomically upgrades the user from free → pay_as_you_go (idempotent —
+          duplicate events are safely ignored).
+        - `invoice.paid`: Updates subscription status to active (clearing any
+          past_due state from previous failed payments) and syncs billing period
+          dates from the invoice.
+        - `invoice.payment_failed`: Marks subscription as past_due and sends a
+          notification to the user so they can update their payment method.
+          Stripe will continue to retry per its Smart Retries schedule.
+        - `customer.subscription.updated`: Maps the Stripe subscription status
+          (active/trialing → active, past_due/unpaid → past_due, other → cancelled)
+          to the local subscription status.
+        - `customer.subscription.deleted`: Downgrades user to free plan, marks
+          status as cancelled, and sets `downgraded_at` to trigger the 7-day
+          audit retention grace period.
+
+        **Payment failure flow:**
+        1. `invoice.payment_failed` → status set to `past_due`, user notified
+        2. Stripe retries payment per Smart Retries schedule
+        3. If retry succeeds → `invoice.paid` → status set back to `active`
+        4. If all retries fail → `customer.subscription.deleted` → downgrade to free
+
+        **Idempotency:** Each event ID is recorded after successful processing.
+        Duplicate events (from Stripe retries) are safely skipped.
+
+        Returns 200 on success. Returns 500 on retryable errors (DB failures) so
+        Stripe will retry the event. Returns 400 on invalid signature.
+
+        **No authentication required** — security is provided by Stripe's webhook
+        signature verification (`STRIPE_WEBHOOK_SECRET` is required in production).
+      operationId: stripeWebhook
+      tags:
+        - Billing
+      security: []
+      parameters:
+        - name: Stripe-Signature
+          in: header
+          required: true
+          description: |
+            Stripe webhook signature header. Contains the timestamp and signature(s)
+            used to verify that the request originated from Stripe. The server verifies
+            this against `STRIPE_WEBHOOK_SECRET` before processing any event.
+          schema:
+            type: string
+          example: t=1614556236,v1=abc123...
+      requestBody:
+        required: true
+        description: |
+          Raw Stripe webhook event payload. **Must be passed as raw bytes** (not parsed JSON)
+          to the signature verification step — parsing before verification would invalidate
+          the signature check.
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Stripe Event object (structure varies by event type)
+              properties:
+                id:
+                  type: string
+                  description: Unique event identifier (used for idempotency)
+                type:
+                  type: string
+                  description: Event type (e.g., checkout.session.completed)
+              required:
+                - id
+                - type
+      responses:
+        '200':
+          description: Webhook processed successfully (always returned to prevent Stripe retries)
+        '400':
+          description: Invalid signature or malformed event
+        '500':
+          description: Processing failed — Stripe will retry the event
+  /v1/billing/plan:
+    get:
+      summary: Get billing plan details
+      description: |
+        Returns the authenticated user's current plan details, subscription status,
+        and a summary of current resource usage (request counts, agent count, etc.).
+
+        This is the primary billing endpoint for the frontend — it provides everything
+        needed to render the billing section of the settings page in a single request.
+
+        Only available when `billing_enabled` is `true` in the server config.
+
+        Plan IDs include `free_pro` for complimentary Pro (unlimited usage, no
+        Stripe per-request billing) granted via coupon.
+      operationId: getBillingPlan
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Billing plan details returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingPlanResponse'
+              example:
+                plan:
+                  id: free
+                  name: Free
+                  max_requests_per_month: 1000
+                  max_agents: 3
+                  max_standing_approvals: 5
+                  max_credentials: 5
+                  audit_retention_days: 7
+                subscription:
+                  status: active
+                  current_period_start: '2026-03-01T00:00:00Z'
+                  current_period_end: '2026-04-01T00:00:00Z'
+                  has_payment_method: false
+                  can_upgrade: true
+                  can_downgrade: false
+                  grace_period_ends_at: null
+                usage:
+                  requests: 42
+                  agents: 2
+                  standing_approvals: 3
+                  credentials: 1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No subscription found for this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/activate:
+    post:
+      summary: Activate upgrade from checkout
+      description: |
+        Verifies a completed Stripe Checkout Session and activates the paid
+        plan synchronously. Called by the frontend after returning from Stripe
+        checkout as a reliable alternative to waiting for the webhook.
+
+        If the checkout session is complete and paid, the user's plan is
+        atomically upgraded from free to pay-as-you-go (same logic as the
+        webhook handler). If the webhook already processed the upgrade, this
+        endpoint returns `already_active` — both paths are idempotent.
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: activateUpgrade
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ActivateRequest'
+      responses:
+        '200':
+          description: Activation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivateResponse'
+              example:
+                plan_id: pay_as_you_go
+                status: activated
+        '400':
+          description: Missing or invalid session_id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Checkout session does not belong to this account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/redeem-coupon:
+    post:
+      summary: Redeem complimentary Pro coupon
+      description: |
+        Applies a one-time coupon that upgrades the authenticated user from the
+        free plan to complimentary Pro (`free_pro`) when the coupon matches
+        `HMAC-SHA256(COUPON_SECRET, trimmed username)` as lowercase hex (64 chars).
+
+        **Requirements:** `billing_enabled` is `true` and the server has a
+        non-empty `COUPON_SECRET` environment variable. If the secret is unset,
+        this route is not registered.
+
+        Returns `403` with `invalid_coupon` for a wrong code. Returns `409`
+        `already_subscribed` if the user is already on pay-as-you-go. Idempotent
+        for users already on `free_pro` (`already_redeemed`).
+      operationId: redeemComplimentaryProCoupon
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedeemCouponRequest'
+      responses:
+        '200':
+          description: Coupon applied or already active
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedeemCouponResponse'
+        '400':
+          description: Missing coupon
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Invalid coupon
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No subscription found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Not on free plan or already on paid Stripe plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/billing/portal:
+    post:
+      summary: Create billing portal session
+      description: |
+        Creates a Stripe Billing Portal session for the authenticated user.
+        Returns a URL to redirect the user to Stripe's hosted portal where they
+        can manage their subscription, update payment methods, and view invoices.
+
+        Requires the user to have a Stripe customer ID (i.e., has previously
+        been on a paid plan or initiated checkout).
+
+        Only available when `billing_enabled` is `true` and Stripe is configured.
+      operationId: createBillingPortal
+      tags:
+        - Billing
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Portal session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortalResponse'
+              example:
+                url: https://billing.stripe.com/p/session/test_...
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No billing account found (user has no Stripe customer ID)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Stripe API error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/admin/usage:
+    get:
+      summary: Get your usage for a billing period
+      description: |
+        Returns the authenticated user's usage metrics for a billing period.
+        Includes request/SMS totals and an optional breakdown by agent,
+        connector, and action type.
+
+        Defaults to the current billing period when no period parameter
+        is provided. All data is scoped to the authenticated user — there
+        is no way to query another user's usage through this endpoint.
+      operationId: adminGetUsage
+      tags:
+        - Admin
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: period
+          in: query
+          required: false
+          description: |
+            Billing period to query. Accepts `YYYY-MM` (e.g., `2026-03`),
+            `YYYY-MM-DD` (e.g., `2026-03-01`), or full ISO 8601 date-time
+            (e.g., `2026-03-01T00:00:00Z`). Defaults to the current billing period.
+          schema:
+            type: string
+          examples:
+            month:
+              value: 2026-03
+              summary: Month shorthand
+            date:
+              value: '2026-03-01'
+              summary: Date format
+            iso8601:
+              value: '2026-03-01T00:00:00Z'
+              summary: Full ISO 8601 timestamp
+      responses:
+        '200':
+          description: Usage data returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUsageResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/admin/usage/by-connector:
+    get:
+      summary: Get your usage breakdown by connector
+      description: |
+        Returns the authenticated user's per-connector request counts for a
+        billing period, ordered by request count descending. Each entry
+        includes the connector name when available.
+
+        Useful for understanding which integrations drive the most usage.
+      operationId: adminGetUsageByConnector
+      tags:
+        - Admin
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: period
+          in: query
+          required: false
+          description: |
+            Billing period to query. Accepts `YYYY-MM`, `YYYY-MM-DD`, or
+            full ISO 8601 date-time. Defaults to the current billing period.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Connector usage breakdown returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorUsageResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/admin/usage/by-agent:
+    get:
+      summary: Get your usage breakdown by agent
+      description: |
+        Returns the authenticated user's per-agent request counts for a
+        billing period, ordered by request count descending. Each entry
+        includes the agent name from metadata when available.
+
+        Useful for identifying which agents consume the most quota.
+      operationId: adminGetUsageByAgent
+      tags:
+        - Admin
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: period
+          in: query
+          required: false
+          description: |
+            Billing period to query. Accepts `YYYY-MM`, `YYYY-MM-DD`, or
+            full ISO 8601 date-time. Defaults to the current billing period.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Agent usage breakdown returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentUsageResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/oauth/providers:
+    get:
+      operationId: listOAuthProviders
+      summary: List OAuth Providers
+      description: |
+        Returns all registered OAuth providers and their configuration status.
+        This lets the frontend discover which providers are available and which are
+        ready to use (have credentials configured).
+
+        Providers come from two sources:
+        - **built_in**: Platform-provided providers (e.g. Google, Microsoft)
+        - **manifest**: Declared in a connector manifest (e.g. Salesforce)
+      tags:
+        - OAuth
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: OAuth providers listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthProviderListResponse'
+              example:
+                providers:
+                  - id: google
+                    scopes:
+                      - openid
+                      - https://www.googleapis.com/auth/userinfo.email
+                    source: built_in
+                    has_credentials: true
+                    pkce: false
+                  - id: microsoft
+                    scopes:
+                      - openid
+                      - offline_access
+                      - User.Read
+                    source: built_in
+                    has_credentials: true
+                    pkce: false
+                  - id: dropbox
+                    scopes:
+                      - files.content.read
+                      - files.content.write
+                      - sharing.write
+                    source: built_in
+                    has_credentials: true
+                    pkce: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/oauth/{provider}/authorize:
+    get:
+      operationId: oauthAuthorize
+      summary: Initiate OAuth Authorization
+      description: |
+        Generates an authorization URL for the given OAuth provider and redirects
+        the user's browser to the provider's consent screen. The redirect includes
+        a signed CSRF state parameter that ties the flow to the authenticated user.
+
+        After the user grants consent, the provider redirects back to the callback
+        endpoint (`GET /v1/oauth/{provider}/callback`) with an authorization code.
+
+        ## Security
+
+        - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
+        - A signed state token prevents CSRF and session-fixation attacks
+        - The provider must have client credentials configured (via environment variables)
+
+        ### Slack (`provider=slack`)
+
+        Slack uses **user-token-only** OAuth: the server sends Slack **user** scopes via
+        the `user_scope` query parameter and does **not** send a bot `scope` parameter.
+        After consent, the stored connection uses the Slack user token (`xoxp-`) as the
+        primary secret. Workspace bot install is not required.
+
+        ### PKCE (`pkce: true` on the provider)
+
+        For providers that require PKCE (e.g. Dropbox), the server adds an S256 code
+        challenge to the provider authorization URL and stores the verifier only inside
+        the signed state token (encrypted at rest in the JWT payload). No client-side
+        PKCE logic is required.
+      tags:
+        - OAuth
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          description: The OAuth provider ID (e.g. "google", "microsoft", "slack", "zoom")
+          schema:
+            type: string
+        - name: scope
+          in: query
+          required: false
+          description: Additional OAuth scopes to request beyond the provider defaults
+          schema:
+            type: array
+            items:
+              type: string
+        - name: replace
+          in: query
+          required: false
+          description: |
+            ID of an existing OAuth connection to replace (reconnect flow). When set, the specified connection is deleted and replaced by the new one after successful authorization. When omitted, a new connection is created alongside any existing ones for the same provider. The connection must belong to the authenticated user and the same provider being authorized.
+          schema:
+            type: string
+      responses:
+        '307':
+          description: Redirects to the OAuth provider's authorization endpoint
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: OAuth provider not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/oauth/{provider}/callback:
+    get:
+      operationId: oauthCallback
+      summary: OAuth Callback
+      description: |
+        Handles the OAuth provider's redirect after user consent. Validates the
+        CSRF state token, exchanges the authorization code for access/refresh
+        tokens, encrypts them in the vault, and creates an `oauth_connections` row.
+
+        On success, redirects the user to the frontend settings page with
+        `?oauth_status=success`. On failure, redirects with `?oauth_status=error`.
+
+        This endpoint is called by the OAuth provider, not directly by the frontend.
+
+        ### Slack (`provider=slack`)
+
+        The callback requires Slack to return `authed_user.access_token` (user token).
+        If that field is missing (e.g. app still configured for bot-only scopes), the
+        user is redirected with `oauth_status=error` and an actionable message.
+        When Slack token rotation is enabled, user `refresh_token` and expiry may be
+        nested under `authed_user` in the token response; the server normalizes these
+        before persisting.
+
+        ### PKCE
+
+        When the provider uses PKCE, the callback recovers the code verifier from the
+        validated state token and passes it to the token exchange per RFC 7636.
+      tags:
+        - OAuth
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          description: The OAuth provider ID
+          schema:
+            type: string
+        - name: code
+          in: query
+          required: false
+          description: The authorization code from the provider
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: false
+          description: The signed CSRF state token
+          schema:
+            type: string
+        - name: error
+          in: query
+          required: false
+          description: Error code from the provider (e.g. "access_denied")
+          schema:
+            type: string
+        - name: error_description
+          in: query
+          required: false
+          description: Human-readable error description from the provider
+          schema:
+            type: string
+      responses:
+        '307':
+          description: Redirects to frontend settings page with success/error status
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/oauth/connections:
+    get:
+      operationId: listOAuthConnections
+      summary: List OAuth Connections
+      description: |
+        Returns all active OAuth connections for the authenticated user. Each
+        connection includes the provider, granted scopes, status, and when it
+        was established. Tokens are never included in the response.
+
+        ## Security
+
+        - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
+        - Only returns connections belonging to the authenticated user
+      tags:
+        - OAuth
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: OAuth connections listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthConnectionListResponse'
+              example:
+                connections:
+                  - id: oconn_abc123
+                    provider: google
+                    scopes:
+                      - openid
+                      - https://www.googleapis.com/auth/userinfo.email
+                    status: active
+                    connected_at: '2026-03-05T10:00:00Z'
+                    display_name: user@gmail.com
+                  - id: oconn_def456
+                    provider: google
+                    scopes:
+                      - openid
+                      - https://www.googleapis.com/auth/gmail.send
+                    status: active
+                    connected_at: '2026-03-06T09:00:00Z'
+                    display_name: work@company.com
+                  - id: oconn_ghi789
+                    provider: microsoft
+                    scopes:
+                      - openid
+                      - offline_access
+                      - User.Read
+                    status: active
+                    connected_at: '2026-03-05T11:30:00Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/oauth/connections/{connection_id}:
+    delete:
+      operationId: deleteOAuthConnection
+      summary: Disconnect OAuth Connection
+      description: |
+        Disconnects a specific OAuth connection by its ID. Deletes the
+        OAuth connection row, removes the encrypted tokens from the vault,
+        and cascades to remove any agent-connector credential bindings that
+        reference this connection.
+
+        After disconnection, any connector actions that depend on this OAuth
+        connection will fail until the user connects a new account.
+
+        ## Security
+
+        - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
+        - Only the user who created the connection can delete it
+      tags:
+        - OAuth
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: connection_id
+          in: path
+          required: true
+          description: The OAuth connection ID to disconnect (e.g. "oconn_abc123")
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OAuth provider disconnected successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthDisconnectResponse'
+              example:
+                provider: google
+                disconnected_at: '2026-03-05T15:00:00Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: OAuth connection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/payment-method:
+    get:
+      operationId: getAgentPaymentMethod
+      summary: Get agent payment method
+      description: |
+        Returns the payment method assigned to this agent, or null if none is assigned.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+      responses:
+        '200':
+          description: Payment method assignment retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPaymentMethodResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: assignAgentPaymentMethod
+      summary: Assign payment method to agent
+      description: |
+        Assigns a payment method to this agent. If the agent already has a payment
+        method assigned, it is replaced. The payment method must belong to the
+        authenticated user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignAgentPaymentMethodRequest'
+      responses:
+        '200':
+          description: Payment method assigned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPaymentMethodResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: removeAgentPaymentMethod
+      summary: Remove payment method from agent
+      description: |
+        Removes the payment method assignment from this agent. Does not delete
+        the payment method itself.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+      responses:
+        '200':
+          description: Payment method assignment removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveAgentPaymentMethodResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/payment-methods:
+    get:
+      tags:
+        - Payment Methods
+      summary: List stored payment methods
+      description: |
+        Returns all stored payment methods for the authenticated user, ordered by
+        default status (default first) then creation date. Each method includes
+        its current monthly spend (rolling 30-day window) and the maximum number
+        of payment methods allowed per user.
+      operationId: listPaymentMethods
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Payment methods retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentMethodListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Payment Methods
+      summary: Confirm and store a payment method
+      description: |
+        Saves a payment method after it has been set up via Stripe Elements.
+        The payment_method_id must be a valid Stripe pm_* token returned by the
+        SetupIntent confirmation flow on the client.
+
+        **Flow:**
+        1. Client calls POST /payment-methods/setup-intent to get a client_secret
+        2. Client uses stripe.confirmCardSetup(client_secret) with Stripe Elements
+        3. Client calls this endpoint with the resulting pm_* token
+
+        **Constraints:**
+        - Maximum 10 payment methods per user (returns 409 if exceeded)
+        - Label must be 100 characters or fewer
+        - payment_method_id must start with "pm_"
+        - Raw card data never touches our servers — only Stripe tokens are stored
+      operationId: confirmPaymentMethod
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmPaymentMethodRequest'
+      responses:
+        '201':
+          description: Payment method saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentMethod'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/payment-methods/setup-intent:
+    post:
+      tags:
+        - Payment Methods
+      summary: Create a SetupIntent for card collection
+      description: |
+        Creates a Stripe SetupIntent for collecting payment method details
+        via Stripe Elements. Returns a client_secret to use with
+        stripe.confirmCardSetup() on the frontend.
+
+        If the user does not yet have a Stripe customer record, one is created
+        automatically and associated with their subscription.
+
+        The client_secret is single-use and expires after 24 hours.
+      operationId: createSetupIntent
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: SetupIntent created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetupIntentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/payment-methods/{id}:
+    patch:
+      tags:
+        - Payment Methods
+      summary: Update a payment method
+      description: |
+        Update label, spending limits, or default status of a stored payment method.
+
+        **Spending limits:**
+        - Values are in cents (e.g. 5000 = $50.00)
+        - Per-transaction limit cannot exceed monthly limit
+        - Negative values are rejected
+        - Use clear_per_transaction_limit / clear_monthly_limit to remove a limit
+        - Label must be 100 characters or fewer
+      operationId: updatePaymentMethod
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePaymentMethodRequest'
+      responses:
+        '200':
+          description: Payment method updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentMethod'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Payment Methods
+      summary: Delete a payment method
+      description: |
+        Removes a stored payment method and detaches it from the Stripe customer.
+        The detachment from Stripe is best-effort — the local record is always
+        deleted even if the Stripe API call fails.
+      operationId: deletePaymentMethod
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Payment method deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletePaymentMethodResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/config:
+    get:
+      summary: Get server configuration
+      description: |
+        Returns server-level feature flags that the frontend uses to adapt its UI.
+
+        **`billing_enabled`**: When `false` (the default for self-hosted deployments),
+        all users are auto-assigned the unlimited `pay_as_you_go` plan and billing-related
+        UI (plan selection, upgrade prompts, usage meters) should be hidden. When `true`,
+        the server enforces plan limits and integrates with Stripe for subscription management.
+
+        This endpoint requires authentication but does not require a profile, so it can
+        be called during the onboarding flow to determine what UI to show.
+      operationId: getConfig
+      tags:
+        - Config
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Server configuration returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+              example:
+                billing_enabled: false
+                sms_enabled: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/config/vapid-key:
+    get:
+      summary: Get VAPID public key
+      description: |
+        Returns the server's VAPID public key, needed by the browser to create
+        a Web Push subscription. Requires authentication so VAPID keys aren't
+        publicly enumerable.
+      operationId: getVAPIDPublicKey
+      tags:
+        - Push Subscriptions
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: VAPID public key returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VAPIDPublicKeyResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
 components:
@@ -4011,97 +6503,6 @@ components:
         - `exp` (integer): Token expiration (Unix timestamp)
         - `aud` (string): `authenticated`
         - `role` (string): `authenticated`
-    BearerToken:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-      description: |
-        JWT Bearer token issued by Permission Slip after approval verification. Used in the `POST /v1/actions/execute` endpoint.
-
-        ## Token Structure
-
-        Single-use JWT token issued after approval. Contains:
-
-        ### Header
-
-        ```json
-        {
-          "alg": "ES256",
-          "typ": "JWT",
-          "kid": "key-2026-01"
-        }
-        ```
-
-        ### Payload Claims
-
-        - `sub` (string): Agent ID
-        - `aud` (string): `permissionslip.dev`
-        - `approver` (string): Username who approved
-        - `approval_id` (string): Approval request ID
-        - `scope` (string): Action type (e.g., `email.send`)
-        - `scope_version` (string): Action version (e.g., `"1"`)
-        - `params_hash` (string): SHA-256 hash of JCS-canonicalized action parameters
-        - `iat` (integer): Issued at (Unix timestamp)
-        - `exp` (integer): Expires at (Unix timestamp)
-        - `jti` (string): Unique token ID (for single-use enforcement)
-
-        ### Example Payload
-
-        ```json
-        {
-          "sub": "42",
-          "aud": "permissionslip.dev",
-          "approver": "alice",
-          "approval_id": "appr_xyz789",
-          "scope": "email.send",
-          "scope_version": "1",
-          "params_hash": "ba0617b2334170cb936916db202400300a1fdc1fe71e36b911d08b2519f3d68c",
-          "iat": 1770816045,
-          "exp": 1770816345,
-          "jti": "tok_unique123"
-        }
-        ```
-
-        ## Usage
-
-        Tokens are passed in the `token` field of `POST /v1/actions/execute`:
-
-        ```http
-        POST https://app.permissionslip.dev/v1/actions/execute
-        X-Permission-Slip-Signature: agent_id="...", algorithm="Ed25519", ...
-        Content-Type: application/json
-
-        {
-          "token": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...",
-          "action_id": "email.send",
-          "parameters": {
-            "from": "alice@example.com",
-            "to": ["bob@example.com"],
-            "subject": "Hello",
-            "body": "Message body"
-          }
-        }
-        ```
-
-        Permission Slip validates the token and executes the action using stored credentials.
-
-        ## Token Verification (Permission Slip)
-
-        Permission Slip verifies:
-
-        1. **JWT Signature**: Token was issued by Permission Slip
-        2. **Expiration**: `exp` claim not exceeded
-        3. **Audience**: `aud` is `permissionslip.dev`
-        4. **Scope**: Matches the `action_id` in the execute request
-        5. **Parameters Hash**: Request parameters match `params_hash` claim
-        6. **Single-Use**: `jti` not already consumed (atomic check-and-set)
-
-        ## Token Lifecycle
-
-        - **Expiration**: Typically 5 minutes
-        - **Single-Use**: Token invalidated after first successful use
-        - **No Refresh**: Protocol does not support token refresh
-        - **Retry Guidance**: Use token immediately; request new approval if expired
   schemas:
     RegisterAgentRequest:
       type: object
@@ -4205,10 +6606,19 @@ components:
             agent registers. The agent must collect the code from the user and submit
             it via `POST /v1/agents/{agent_id}/verify`.
           example: true
+        approver:
+          allOf:
+            - $ref: '#/components/schemas/ApproverInfo'
+          description: |
+            The user (approver) this agent is registering with. Included so the
+            agent knows whose account it's connecting to — especially useful when
+            an agent registers with multiple users and needs to distinguish them.
       example:
         agent_id: 42
         expires_at: '2026-02-11T13:25:00Z'
         verification_required: true
+        approver:
+          username: alice
     VerifyRegistrationRequest:
       type: object
       required:
@@ -4264,9 +6674,18 @@ components:
           description: |
             ISO 8601 timestamp (RFC 3339 format, UTC) when registration was completed.
           example: '2026-02-11T13:20:15Z'
+        approver:
+          allOf:
+            - $ref: '#/components/schemas/ApproverInfo'
+          description: |
+            The user (approver) this agent is now registered with. The agent should
+            store this alongside the `agent_id` to identify which user this
+            registration belongs to.
       example:
         status: registered
         registered_at: '2026-02-11T13:20:15Z'
+        approver:
+          username: alice
     ApprovalRequest:
       type: object
       required:
@@ -4291,7 +6710,7 @@ components:
           description: |
             Unique request identifier for replay protection and idempotency. UUID v4 recommended.
 
-            Permission Slip tracks this value within the timestamp window (300 seconds) and rejects 
+            Permission Slip tracks this value within the timestamp window (300 seconds) and rejects
             duplicate requests with `409 Conflict` error code `duplicate_request_id`.
           example: a925fbe0-db83-4969-9dc5-27f40385f12c
         approver:
@@ -4334,6 +6753,21 @@ components:
           $ref: '#/components/schemas/Action'
         context:
           $ref: '#/components/schemas/ActionContext'
+        payment_method_id:
+          type: string
+          description: |
+            Optional payment method ID for actions that require payment (e.g., `requires_payment_method: true`
+            in the connector action definition). When a standing approval auto-approves the request, this
+            value is forwarded to the connector for payment processing.
+          example: pm_abc123
+        amount_cents:
+          type: integer
+          minimum: 0
+          description: |
+            Optional transaction amount in cents for payment-required actions. Required when
+            `payment_method_id` is provided. Validated against per-transaction and monthly spending
+            limits configured on the payment method.
+          example: 9900
       example:
         agent_id: 42
         request_id: a925fbe0-db83-4969-9dc5-27f40385f12c
@@ -4355,20 +6789,25 @@ components:
             recipient_count: 1
     ApprovalRequestResponse:
       type: object
+      description: |
+        Response after submitting an approval request. Two possible outcomes:
+
+        **Auto-approved** (`status: "approved"`): A matching standing approval was found.
+        The action was executed immediately. The response includes `result` and
+        `standing_approval_id`. No `approval_id` or `approval_url` is returned.
+
+        **Pending** (`status: "pending"`): No standing approval matched. A pending approval
+        was created. The agent should poll `GET /v1/approvals/{approval_id}/status` for the
+        result, or listen via `GET /v1/approvals/events` (SSE).
       required:
-        - approval_id
-        - approval_url
         - status
-        - expires_at
-        - verification_required
       properties:
         approval_id:
           type: string
           pattern: ^appr_[a-zA-Z0-9]{6,64}$
           maxLength: 70
           description: |
-            Unique approval identifier assigned by Permission Slip. Used to reference this approval 
-            in subsequent operations (verify, cancel).
+            Unique approval identifier. Present only when `status` is `pending`.
           example: appr_xyz789
         approval_url:
           type: string
@@ -4376,11 +6815,7 @@ components:
           maxLength: 4096
           pattern: ^https://
           description: |
-            Primary approval URL (universal link) that the approver must visit to review and 
-            approve/deny the action. This is the canonical URL that clients MUST support.
-
-            The URL contains context about the approval request and allows the approver to see 
-            full action details before making a decision.
+            Approval URL for the approver to review. Present only when `status` is `pending`.
           example: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
         alternative_urls:
           $ref: '#/components/schemas/AlternativeUrls'
@@ -4388,103 +6823,37 @@ components:
           type: string
           enum:
             - pending
+            - approved
           description: |
-            Approval status. Always `pending` when first created. Status changes to `approved` 
-            or `denied` after approver makes a decision.
+            `pending` — approval created, awaiting human review.
+            `approved` — auto-approved via standing approval, result is inline.
           example: pending
         expires_at:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp (RFC 3339 format, UTC) when approval expires. After this time, 
-            the approval becomes invalid and cannot be approved or verified.
-
-            Typically set to 5 minutes from creation, but may vary based on configuration 
-            or action risk level.
+            When the pending approval expires. Present only when `status` is `pending`.
           example: '2026-02-11T13:25:00Z'
-        verification_required:
-          type: boolean
-          enum:
-            - true
-          description: |
-            Always `true`. Indicates that a confirmation code is required to verify the approval. 
-            The approver will see this code after approving, and the agent must collect it and 
-            submit via verify endpoint.
-          example: true
-      example:
-        approval_id: appr_xyz789
-        approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
-        alternative_urls:
-          deeplink: permissionslip://permission-slip/approve/appr_xyz789
-          web: https://accounts.permissionslip.dev/permission-slip/approve/appr_xyz789
-        status: pending
-        expires_at: '2026-02-11T13:25:00Z'
-        verification_required: true
-    VerifyApprovalRequest:
-      type: object
-      required:
-        - request_id
-        - confirmation_code
-      properties:
-        request_id:
-          type: string
-          format: uuid
-          maxLength: 64
-          description: |
-            Unique request identifier for replay protection. UUID v4 recommended.
-          example: a9b2e069-6374-4a65-be1d-b26cc376d7fe
-        confirmation_code:
-          type: string
-          pattern: ^[A-Za-z2-9]{3}-?[A-Za-z2-9]{3}$
-          minLength: 6
-          maxLength: 7
-          description: |
-            6-character confirmation code shown to approver after they approve the action.
-
-            **Format**:
-            - 6 characters from set: `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (32 chars)
-            - Excluded confusing characters: `0`, `O`, `1`, `I`
-            - May include hyphen for readability: `XXX-XXX` or `XXXXXX`
-            - Case-insensitive (Permission Slip normalizes to uppercase)
-
-            **Security**: Permission Slip enforces a 5 attempt limit. After 5 failed attempts, 
-            approval expires.
-          example: RK3-P7M
-      example:
-        request_id: a9b2e069-6374-4a65-be1d-b26cc376d7fe
-        confirmation_code: RK3-P7M
-    VerifyApprovalResponse:
-      type: object
-      required:
-        - status
-        - approved_at
-        - token
-      properties:
-        status:
-          type: string
-          enum:
-            - approved
-          description: |
-            Approval status. Always `approved` for successful verification. If the approver 
-            denied the request, the endpoint returns `403 Forbidden` with error code 
-            `approval_denied` instead.
-          example: approved
-        approved_at:
+        created_at:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp (RFC 3339 format, UTC) when the approver approved the action.
-          example: '2026-02-11T13:20:45Z'
-        token:
-          $ref: '#/components/schemas/ApprovalToken'
+            When the approval was created. Present only when `status` is `pending`.
+          example: '2026-02-11T13:20:00Z'
+        result:
+          description: |
+            Execution result from the connector. Present only when `status` is `approved`
+            (auto-approved via standing approval).
+        standing_approval_id:
+          type: string
+          description: |
+            ID of the standing approval that matched. Present only when `status` is `approved`.
+          example: sa_abc123
       example:
-        status: approved
-        approved_at: '2026-02-11T13:20:45Z'
-        token:
-          access_token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ2VudF94N0s5bVA0biIsImF1ZCI6InBlcm1pc3Npb25zbGlwLmRldiIsImFwcHJvdmVyIjoiYWxpY2UiLCJhcHByb3ZhbF9pZCI6ImFwcHJfeHl6Nzg5Iiwic2NvcGUiOiJlbWFpbC5zZW5kIiwic2NvcGVfdmVyc2lvbiI6IjEiLCJwYXJhbXNfaGFzaCI6ImJhMDYxN2IyMzM0MTcwY2I5MzY5MTZkYjIwMjQwMDMwMGExZmRjMWZlNzFlMzZiOTExZDA4YjI1MTlmM2Q2OGMiLCJpYXQiOjE3NzA4MTYwNDUsImV4cCI6MTc3MDgxNjM0NSwianRpIjoidG9rX3VuaXF1ZTEyMyJ9.signature
-          expires_at: '2026-02-11T13:25:45Z'
-          scope: email.send
-          scope_version: '1'
+        approval_id: appr_xyz789
+        approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
+        status: pending
+        expires_at: '2026-02-11T13:25:00Z'
     CancelApprovalRequest:
       type: object
       required:
@@ -4553,7 +6922,8 @@ components:
             - approved
             - denied
             - cancelled
-          description: Current approval status
+            - expired
+          description: Current approval status. Pending approvals past their expiration time are returned as "expired".
           example: pending
         expires_at:
           type: string
@@ -4580,16 +6950,52 @@ components:
           format: date-time
           description: When the approval request was created
           example: '2026-02-11T13:20:00Z'
+        resource_details:
+          type: object
+          nullable: true
+          description: |
+            Human-readable metadata for resources referenced by opaque IDs in the
+            action parameters. Populated at request time via the connector's
+            ResourceDetailResolver. Null when the connector doesn't support
+            resource resolution or the lookup failed.
+          additionalProperties: true
+          example:
+            title: Q1 Planning Meeting
+            start_time: '2026-03-15T14:00:00Z'
+            end_time: '2026-03-15T15:00:00Z'
+        execution_status:
+          allOf:
+            - $ref: '#/components/schemas/ExecutionStatus'
+            - nullable: true
+              description: |
+                Status of the action execution. Only present when status is `approved`.
+                Null for pending, denied, or cancelled approvals.
+        execution_result:
+          $ref: '#/components/schemas/ExecutionResult'
+        executed_at:
+          $ref: '#/components/schemas/ExecutedAt'
     ApprovalListResponse:
       type: object
-      description: List of approval requests.
+      description: Paginated list of approval requests.
       required:
         - data
+        - has_more
       properties:
         data:
           type: array
           items:
             $ref: '#/components/schemas/ApprovalSummary'
+        has_more:
+          type: boolean
+          description: Whether more approvals exist beyond this page.
+          example: false
+        next_cursor:
+          type: string
+          description: |
+            Opaque cursor to pass as the `after` query parameter to fetch the
+            next page. Only present when `has_more` is true. Do not construct
+            or parse cursor values — they may change format without notice.
+          example: 2026-02-11T13:20:00.123456Z,appr_xyz789
     ApproveApprovalResponse:
       type: object
       required:
@@ -4597,6 +7003,7 @@ components:
         - status
         - approved_at
         - confirmation_code
+        - execution_status
       properties:
         approval_id:
           type: string
@@ -4615,15 +7022,16 @@ components:
           example: '2026-02-21T10:30:00Z'
         confirmation_code:
           type: string
-          pattern: ^[A-HJ-NP-Za-hj-np-z2-9]{3}-[A-HJ-NP-Za-hj-np-z2-9]{3}$
           description: |
-            6-character confirmation code that the approver must share with the
-            agent. The agent submits this code via the verify endpoint to obtain
-            an action token.
-
-            Format: `XXX-XXX` from the set `ABCDEFGHJKLMNPQRSTUVWXYZ23456789`
-            (excludes confusing characters 0/O/1/I). Case-insensitive.
+            Ephemeral confirmation code in `XXX-XXX` format. Displayed to the
+            approver as a visual receipt and shared with the agent to confirm
+            the approval. Generated at approval time and not persisted.
+          pattern: ^[A-Z2-9]{3}-[A-Z2-9]{3}$
           example: RK3-P7M
+        execution_status:
+          $ref: '#/components/schemas/ExecutionStatus'
+        execution_result:
+          $ref: '#/components/schemas/ExecutionResult'
     DenyApprovalResponse:
       type: object
       required:
@@ -4646,6 +7054,163 @@ components:
           format: date-time
           description: When the approval was denied
           example: '2026-02-21T10:30:00Z'
+    ApprovalStatusResponse:
+      type: object
+      description: |
+        Response for agent polling of approval status and execution result.
+        Agents use this to check whether their approval has been resolved and,
+        if approved, to retrieve the execution result.
+      required:
+        - approval_id
+        - status
+      properties:
+        approval_id:
+          type: string
+          description: Unique approval identifier
+          example: appr_xyz789
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - denied
+            - cancelled
+            - expired
+          description: Current status of the approval request. Pending approvals past their expiration time are returned as "expired".
+          example: approved
+        approved_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the approval was approved (null if not yet approved)
+          example: '2026-02-21T10:30:00Z'
+        denied_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the approval was denied (null if not denied)
+        cancelled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the approval was cancelled (null if not cancelled)
+        expires_at:
+          type: string
+          format: date-time
+          description: When the approval expires
+          example: '2026-02-21T10:35:00Z'
+        execution_status:
+          allOf:
+            - $ref: '#/components/schemas/ExecutionStatus'
+            - nullable: true
+              description: |
+                Status of the action execution. Only present when approval status is `approved`.
+                Null when the approval has not been approved yet.
+        execution_result:
+          $ref: '#/components/schemas/ExecutionResult'
+        executed_at:
+          $ref: '#/components/schemas/ExecutedAt'
+    ActionConfigTemplate:
+      type: object
+      required:
+        - id
+        - connector_id
+        - action_type
+        - name
+        - parameters
+        - created_at
+      properties:
+        id:
+          type: string
+          maxLength: 255
+          description: |
+            Unique template identifier.
+          example: tpl_github_create_issue_all
+        connector_id:
+          type: string
+          maxLength: 128
+          description: |
+            Connector this template applies to.
+          example: github
+        action_type:
+          type: string
+          maxLength: 128
+          description: |
+            Action type this template is designed for.
+          example: github.create_issue
+        name:
+          type: string
+          maxLength: 255
+          description: |
+            Human-readable name for this template.
+          example: Create issues (all fields open)
+        description:
+          type: string
+          maxLength: 4096
+          nullable: true
+          description: |
+            Longer description of what this template configures.
+          example: Agent can create issues in any repo with any title and body.
+        parameters:
+          type: object
+          additionalProperties: true
+          description: |
+            Pre-configured parameter values. Uses the same constraint syntax as
+            action configurations: fixed values, `"*"` wildcards, and
+            `{"$pattern": "<glob>"}` patterns.
+          example:
+            owner: '*'
+            repo: '*'
+            title: '*'
+            body: '*'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApprovalTemplateSpec'
+          description: |
+            When present, applying this template also creates an active standing
+            approval with constraints derived from `parameters`. Omitted when the
+            template does not bundle auto-approval.
+        created_at:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 timestamp (RFC 3339 format, UTC) when this template was created.
+          example: '2026-02-28T10:00:00Z'
+      example:
+        id: tpl_github_create_issue_all
+        connector_id: github
+        action_type: github.create_issue
+        name: Create issues (all fields open)
+        description: Agent can create issues in any repo with any title and body.
+        parameters:
+          owner: '*'
+          repo: '*'
+          title: '*'
+          body: '*'
+        created_at: '2026-02-28T10:00:00Z'
+    ActionConfigTemplateListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActionConfigTemplate'
+          description: |
+            List of action configuration templates for the specified connector.
+      example:
+        data:
+          - id: tpl_github_create_issue_all
+            connector_id: github
+            action_type: github.create_issue
+            name: Create issues (all fields open)
+            description: Agent can create issues in any repo with any title and body.
+            parameters:
+              owner: '*'
+              repo: '*'
+              title: '*'
+              body: '*'
+            created_at: '2026-02-28T10:00:00Z'
     ActionConfiguration:
       type: object
       required:
@@ -4682,15 +7247,12 @@ components:
           type: string
           maxLength: 128
           description: |
-            Action type from the connector's action catalog.
+            Action type from the connector's action catalog, or `"*"` to enable
+            **all** actions on this connector. A wildcard configuration covers
+            every current and future action — the agent can choose any action and
+            any parameter values. Only one wildcard configuration is allowed per
+            agent + connector pair.
           example: github.create_issue
-        credential_id:
-          type: string
-          nullable: true
-          description: |
-            Credential bound to this configuration. Required before execution but
-            can be omitted during creation and assigned later.
-          example: cred_abc123
         parameters:
           type: object
           additionalProperties: true
@@ -4740,6 +7302,13 @@ components:
           description: |
             Optional longer description of what this configuration permits.
           example: Agent can create issues labeled 'bug' in the main repo. Title and body are freeform.
+        linked_standing_approvals:
+          type: array
+          description: |
+            Active standing approvals that reference this configuration via
+            `source_action_configuration_id`. Omitted when empty.
+          items:
+            $ref: '#/components/schemas/LinkedStandingApprovalSummary'
         created_at:
           type: string
           format: date-time
@@ -4757,7 +7326,6 @@ components:
         agent_id: 42
         connector_id: github
         action_type: github.create_issue
-        credential_id: cred_abc123
         parameters:
           repo:
             $pattern: supersuit-tech/*
@@ -4790,15 +7358,12 @@ components:
         action_type:
           type: string
           maxLength: 128
-          description: Action type from the connector's action catalog.
-          example: github.create_issue
-        credential_id:
-          type: string
-          nullable: true
           description: |
-            Optional credential to bind to this configuration. Can be assigned later
-            via update. Required before the agent can execute actions through this config.
-          example: cred_abc123
+            Action type from the connector's action catalog, or `"*"` to enable
+            **all** actions on this connector. When `"*"` is used, parameters are
+            forced to `{}` (the agent can choose any parameter values at execution
+            time). Only one wildcard configuration is allowed per agent + connector.
+          example: github.create_issue
         parameters:
           type: object
           additionalProperties: true
@@ -4832,7 +7397,6 @@ components:
         agent_id: 42
         connector_id: github
         action_type: github.create_issue
-        credential_id: cred_abc123
         parameters:
           repo: supersuit-tech/webapp
           title: '*'
@@ -4845,15 +7409,12 @@ components:
       description: |
         Partial update — only provided fields are changed. At least one field must be provided.
       properties:
-        credential_id:
-          type: string
-          nullable: true
-          description: New credential to bind to this configuration.
-          example: cred_def456
         parameters:
           type: object
           additionalProperties: true
-          description: Updated parameter values.
+          description: |
+            Updated parameter values. Cannot be modified on wildcard (`action_type = "*"`)
+            configurations — their parameters are always `{}`.
           example:
             repo: supersuit-tech/api
             title: '*'
@@ -4895,7 +7456,6 @@ components:
             agent_id: 42
             connector_id: github
             action_type: github.create_issue
-            credential_id: cred_abc123
             parameters:
               repo: supersuit-tech/webapp
               title: '*'
@@ -4926,151 +7486,6 @@ components:
       example:
         id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         deleted_at: '2026-02-25T15:00:00Z'
-    ExecuteActionRequest:
-      description: |
-        Execute an action via Permission Slip. Supports two authorization modes:
-
-        - **One-off (token-based):** Include the `token` field with a single-use JWT from the approval flow.
-        - **Standing approval (signature-based):** Omit the `token` field and include the `action` object.
-          Permission Slip matches an active standing approval for the agent + action type + constraints.
-
-        Permission Slip determines the mode by the presence of the `token` field. If `token` is present
-        and non-empty, one-off token verification is used. If `token` is absent, standing approval
-        matching is attempted using the agent signature.
-      oneOf:
-        - $ref: '#/components/schemas/ExecuteActionTokenRequest'
-        - $ref: '#/components/schemas/StandingApprovalExecuteRequest'
-      discriminator:
-        propertyName: token
-    ExecuteActionTokenRequest:
-      type: object
-      description: |
-        One-off approval execution request. The agent redeems a single-use token from the
-        approval flow to execute the approved action.
-      required:
-        - token
-        - action_id
-        - parameters
-      properties:
-        token:
-          type: string
-          maxLength: 4096
-          description: |
-            Single-use token issued after the user approved the action. This token authorizes 
-            Permission Slip to execute the action on behalf of the user.
-
-            Tokens are returned from the `/v1/approvals/{approval_id}/verify` endpoint after 
-            the agent submits the correct confirmation code.
-
-            **Lifecycle**:
-            - Single-use: consumed after successful execution
-            - Short-lived: typically expires 5 minutes after issuance
-            - Scoped: bound to the specific action type and parameters that were approved
-          example: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ2VudF94N0s5bVA0biIsImFwcHJvdmFsX2lkIjoiYXBwcl94eXo3ODkiLCJzY29wZSI6ImVtYWlsLnNlbmQifQ.signature
-        action_id:
-          type: string
-          maxLength: 128
-          description: |
-            The action type to execute. Must match the action type that was approved.
-
-            Permission Slip verifies this matches the `scope` claim in the approval token. 
-            If mismatch, returns `403 Forbidden` with error code `insufficient_scope`.
-
-            Examples: `email.send`, `flight.book`, `payment.charge`
-          example: email.send
-        parameters:
-          type: object
-          additionalProperties: true
-          description: |
-            Action-specific parameters. Must match the parameters that were approved — 
-            Permission Slip verifies the parameter hash matches the `params_hash` claim 
-            in the approval token.
-
-            The structure of parameters depends on the action type. See the connector 
-            documentation (`GET /v1/connectors/{id}`) for parameter schemas per action.
-
-            **Security**: Parameters are hashed (SHA-256 of JCS-canonicalized JSON) and compared 
-            against the token's `params_hash` claim. Any modification after approval is rejected.
-          example:
-            from: alice@example.com
-            to:
-              - bob@example.com
-            subject: Meeting tomorrow
-            body: Let's meet at 3pm.
-      example:
-        token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
-        action_id: email.send
-        parameters:
-          from: alice@example.com
-          to:
-            - bob@example.com
-          subject: Meeting tomorrow
-          body: Let's meet at 3pm.
-    ExecuteActionResponse:
-      description: |
-        Response from executing an action. The shape depends on the authorization mode:
-
-        - **One-off (token-based):** Returns `ExecuteActionTokenResponse` with `status`, `action_id`,
-          `executed_at`, and `result`.
-        - **Standing approval:** Returns `StandingApprovalExecuteResponse` with `result`,
-          `standing_approval_id`, and `executions_remaining`.
-      oneOf:
-        - $ref: '#/components/schemas/ExecuteActionTokenResponse'
-        - $ref: '#/components/schemas/StandingApprovalExecuteResponse'
-    ExecuteActionTokenResponse:
-      type: object
-      description: |
-        Response from executing an action via the one-off (token-based) approval flow.
-      required:
-        - status
-        - action_id
-        - executed_at
-      properties:
-        status:
-          type: string
-          enum:
-            - success
-            - partial
-          description: |
-            Execution status.
-
-            - **success**: Action executed successfully via the external service API
-            - **partial**: Action partially completed (e.g., some recipients failed)
-          example: success
-        action_id:
-          type: string
-          maxLength: 128
-          description: |
-            The action type that was executed (echoed from request).
-          example: email.send
-        executed_at:
-          type: string
-          format: date-time
-          description: |
-            ISO 8601 timestamp (RFC 3339 format, UTC) when the action was executed against 
-            the external service.
-          example: '2026-02-11T13:21:00Z'
-        result:
-          type: object
-          additionalProperties: true
-          description: |
-            Action-specific result data returned from the external service. The structure 
-            varies by action type.
-
-            Examples:
-            - `email.send`: `{ "message_id": "msg_abc123" }`
-            - `flight.book`: `{ "confirmation_number": "ABC123", "total": "$347.00" }`
-            - `payment.charge`: `{ "charge_id": "ch_xyz789", "receipt_url": "https://..." }`
-          example:
-            message_id: msg_abc123
-            delivery_status: queued
-      example:
-        status: success
-        action_id: email.send
-        executed_at: '2026-02-11T13:21:00Z'
-        result:
-          message_id: msg_abc123
-          delivery_status: queued
     StoreCredentialRequest:
       type: object
       required:
@@ -5258,7 +7673,14 @@ components:
             description: GitHub integration for repository management
             actions:
               - github.create_issue
+              - github.close_issue
+              - github.add_label
+              - github.add_comment
+              - github.create_pr
               - github.merge_pr
+              - github.add_reviewer
+              - github.create_release
+              - github.create_branch
             required_credentials:
               - github
     ConnectorSummary:
@@ -5266,6 +7688,7 @@ components:
       required:
         - id
         - name
+        - status
         - actions
         - required_credentials
       properties:
@@ -5288,6 +7711,25 @@ components:
           description: |
             Brief description of what this connector does.
           example: GitHub integration for repository management
+        status:
+          type: string
+          enum:
+            - tested
+            - early_preview
+            - untested
+          description: |
+            Readiness status of this connector. Indicates how thoroughly the connector
+            has been tested and whether it's ready for production use.
+            - "tested": Fully tested and production-ready.
+            - "early_preview": Functional but still being validated — expect rough edges.
+            - "untested": Connector code exists but has not been verified against the live service.
+          example: tested
+        logo_svg:
+          type: string
+          description: |
+            SVG markup for the connector's logo. Defined by the connector itself.
+            May be absent for connectors that have not yet provided a logo.
+          example: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">...</svg>
         actions:
           type: array
           items:
@@ -5297,7 +7739,14 @@ components:
             List of action types supported by this connector.
           example:
             - github.create_issue
+            - github.close_issue
+            - github.add_label
+            - github.add_comment
+            - github.create_pr
             - github.merge_pr
+            - github.add_reviewer
+            - github.create_release
+            - github.create_branch
         required_credentials:
           type: array
           items:
@@ -5313,9 +7762,17 @@ components:
         id: github
         name: GitHub
         description: GitHub integration for repository management
+        status: tested
         actions:
           - github.create_issue
+          - github.close_issue
+          - github.add_label
+          - github.add_comment
+          - github.create_pr
           - github.merge_pr
+          - github.add_reviewer
+          - github.create_release
+          - github.create_branch
         required_credentials:
           - github
     ConnectorDetailResponse:
@@ -5323,6 +7780,7 @@ components:
       required:
         - id
         - name
+        - status
         - actions
         - required_credentials
       properties:
@@ -5345,6 +7803,21 @@ components:
           description: |
             Brief description of what this connector does.
           example: GitHub integration for repository management
+        status:
+          type: string
+          enum:
+            - tested
+            - early_preview
+            - untested
+          description: |
+            Readiness status of this connector.
+          example: tested
+        logo_svg:
+          type: string
+          description: |
+            SVG markup for the connector's logo. Defined by the connector itself.
+            May be absent for connectors that have not yet provided a logo.
+          example: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">...</svg>
         actions:
           type: array
           items:
@@ -5363,6 +7836,7 @@ components:
         description: GitHub integration for repository management
         actions:
           - action_type: github.create_issue
+            operation_type: write
             name: Create Issue
             description: Create a new issue in a repository
             risk_level: low
@@ -5383,6 +7857,7 @@ components:
                   type: string
                   description: Issue body (markdown)
           - action_type: github.merge_pr
+            operation_type: write
             name: Merge Pull Request
             description: Merge an open pull request
             risk_level: medium
@@ -5400,12 +7875,18 @@ components:
                   description: Pull request number
         required_credentials:
           - service: github
+            auth_type: oauth2
+            oauth_provider: github
+            oauth_scopes:
+              - repo
+          - service: github_pat
             auth_type: api_key
             instructions_url: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
     ConnectorAction:
       type: object
       required:
         - action_type
+        - operation_type
         - name
       properties:
         action_type:
@@ -5415,6 +7896,16 @@ components:
             Action type identifier. Use this value as the `action.type` when submitting 
             approval requests and as `action_id` when executing actions.
           example: github.create_issue
+        operation_type:
+          type: string
+          enum:
+            - read
+            - write
+            - delete
+          description: |
+            High-level classification for bulk template setup and grouping in the UI.
+            Derived from verb-based action naming (e.g. list/get → read, create/update → write,
+            delete/cancel → delete) unless overridden in the connector manifest.
         name:
           type: string
           maxLength: 256
@@ -5454,11 +7945,66 @@ components:
                 type: string
               body:
                 type: string
+        requires_payment_method:
+          type: boolean
+          default: false
+          description: |
+            Whether this action requires a payment method to execute. When `true`, the
+            agent must include `payment_method_id` and `amount_cents` in the execute request.
+            The payment method is resolved to a Stripe token at execution time — raw card
+            details are never exposed to the agent.
+          example: false
+        display_template:
+          type: string
+          maxLength: 500
+          description: |
+            Template string for rendering a human-readable summary of action parameters.
+            Uses `{{param}}` for raw value insertion, `{{param:datetime}}` for date formatting,
+            and `{{param:count}}` for array length. Falls back to generic rendering when absent.
+          example: Send email to {{to}} — {{subject}}
+        preview:
+          type: object
+          description: |
+            Structured preview layout config for rich rendering in the approval UI.
+            Defines a layout type and maps layout-specific field roles to action parameter names.
+            When present, the frontend renders a visually rich preview card instead of plain text.
+          properties:
+            layout:
+              type: string
+              enum:
+                - event
+                - message
+                - record
+              description: |
+                Layout template type. Determines which visual layout the frontend uses.
+                - "event": Calendar-style card with date block, title, time range, duration
+                - "message": Communication card with recipient, subject, body preview
+                - "record": Entity card with title, subtitle, and key metadata fields
+            fields:
+              type: object
+              additionalProperties:
+                type: string
+              description: |
+                Maps layout-specific field roles to action parameter names. For example,
+                an "event" layout expects "title", "start", and "end" fields mapped to
+                the corresponding parameter names from the action's schema.
+          required:
+            - layout
+            - fields
+          example:
+            layout: event
+            fields:
+              title: summary
+              start: start_time
+              end: end_time
       example:
         action_type: github.create_issue
+        operation_type: write
         name: Create Issue
         description: Create a new issue in a repository
         risk_level: low
+        requires_payment_method: false
+        display_template: Create issue {{title}} in {{owner}}/{{repo}}
         parameters_schema:
           type: object
           required:
@@ -5482,8 +8028,13 @@ components:
             - api_key
             - basic
             - custom
+            - oauth2
           description: |
-            Authentication type required by the external service.
+            Authentication type required by the external service. When `oauth2`, the user
+            must connect their account via the OAuth flow instead of providing static credentials.
+            A connector may declare multiple credentials for the same service with different
+            auth types (e.g. both `oauth2` and `api_key`). In that case, the platform tries
+            OAuth first and falls back to static credentials if OAuth is not configured.
           example: api_key
         instructions_url:
           type: string
@@ -5493,6 +8044,21 @@ components:
             URL to human-readable documentation explaining how to obtain credentials
             for this service. Only present when the connector provides setup instructions.
           example: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+        oauth_provider:
+          type: string
+          maxLength: 255
+          description: |
+            OAuth provider identifier. Only present when `auth_type` is `oauth2`.
+            Identifies which OAuth provider the user must connect to (e.g. "google", "microsoft", "zoom").
+          example: google
+        oauth_scopes:
+          type: array
+          items:
+            type: string
+          description: |
+            OAuth scopes required by this connector. Only present when `auth_type` is `oauth2`.
+          example:
+            - https://www.googleapis.com/auth/gmail.send
       example:
         service: github
         auth_type: api_key
@@ -5504,11 +8070,11 @@ components:
         - agent_id
         - user_id
         - action_type
+        - constraints
         - status
-        - execution_count
         - starts_at
-        - expires_at
         - created_at
+        - source_action_configuration_id
       properties:
         standing_approval_id:
           type: string
@@ -5568,30 +8134,13 @@ components:
             - active
             - expired
             - revoked
-            - exhausted
           description: |
             Current status of the standing approval.
 
             - **active**: Agent can execute actions under this standing approval
             - **expired**: Duration elapsed; agent must request a new standing approval or use one-off
             - **revoked**: User manually cancelled this standing approval
-            - **exhausted**: Max execution count reached
           example: active
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of times the agent can execute under this standing approval.
-            `null` means unlimited — the agent can execute as many times as it wants
-            within the duration.
-          example: null
-        execution_count:
-          type: integer
-          minimum: 0
-          description: |
-            Number of times this standing approval has been used so far.
-          example: 42
         starts_at:
           type: string
           format: date-time
@@ -5601,11 +8150,12 @@ components:
         expires_at:
           type: string
           format: date-time
+          nullable: true
           description: |
             ISO 8601 timestamp (RFC 3339 format, UTC) when this standing approval expires.
-            Required when creating a standing approval. Maximum duration is 90 days from
-            `starts_at`.
-          example: '2026-02-21T00:00:00Z'
+            `null` means the standing approval never expires and remains active until
+            explicitly revoked.
+          example: null
         created_at:
           type: string
           format: date-time
@@ -5620,6 +8170,16 @@ components:
             ISO 8601 timestamp (RFC 3339 format, UTC) when this standing approval was revoked.
             `null` if not revoked.
           example: null
+        source_action_configuration_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: |
+            The action configuration this standing approval is tied to. Every standing
+            approval references a backing configuration row.
+            Expected format: `ac_` prefix followed by 32 hex characters, but the
+            backend does not enforce the pattern.
+          example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
       example:
         standing_approval_id: sa_abc123
         agent_id: 42
@@ -5630,12 +8190,11 @@ components:
           sender: '*@github.com'
           max_results: 10
         status: active
-        max_executions: null
-        execution_count: 42
         starts_at: '2026-02-14T00:00:00Z'
         expires_at: '2026-02-21T00:00:00Z'
         created_at: '2026-02-14T10:30:00Z'
         revoked_at: null
+        source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
     StandingApprovalExecuteRequest:
       type: object
       required:
@@ -5671,6 +8230,24 @@ components:
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         action:
           $ref: '#/components/schemas/Action'
+        payment_method_id:
+          type: string
+          format: uuid
+          description: |
+            ID of a stored payment method to use for this action. Required when the
+            action declares `requires_payment_method: true`. The payment method must
+            belong to the user who owns the agent. Permission Slip resolves it to a
+            Stripe token at execution time — raw card details are never exposed.
+          example: 550e8400-e29b-41d4-a716-446655440000
+        amount_cents:
+          type: integer
+          minimum: 0
+          description: |
+            Transaction amount in cents. Required when the action declares
+            `requires_payment_method: true`. Used for spending limit enforcement
+            (per-transaction and monthly limits). The authorized amount is passed to
+            the connector alongside the Stripe payment method token.
+          example: 4999
       example:
         request_id: f47ac10b-58cc-4372-a567-0e02b2c3d479
         configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -5685,7 +8262,6 @@ components:
       required:
         - result
         - standing_approval_id
-        - executions_remaining
       properties:
         result:
           type: object
@@ -5704,14 +8280,6 @@ components:
           description: |
             Which standing approval authorized this execution.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining under this standing approval.
-            `null` means unlimited.
-          example: null
       example:
         result:
           emails:
@@ -5719,11 +8287,11 @@ components:
               subject: PR merged
               sender: noreply@github.com
         standing_approval_id: sa_abc123
-        executions_remaining: null
     StandingApprovalListResponse:
       type: object
       required:
         - standing_approvals
+        - has_more
       properties:
         standing_approvals:
           type: array
@@ -5732,6 +8300,21 @@ components:
           description: |
             List of active standing approvals for the agent. Only standing approvals
             with status `active` are included.
+        has_more:
+          type: boolean
+          description: |
+            Whether there are more standing approvals beyond this page.
+            When `true`, use the `next_cursor` value with the `after` query
+            parameter to fetch the next page.
+          example: false
+        next_cursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque cursor for fetching the next page. Pass as the `after`
+            query parameter in the next request. Only present when `has_more`
+            is `true`.
+          example: 2026-02-14T10:30:00.123456789Z,sa_abc123
       example:
         standing_approvals:
           - standing_approval_id: sa_abc123
@@ -5743,16 +8326,17 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
             revoked_at: null
+            source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+        has_more: false
     UserStandingApprovalListResponse:
       type: object
       required:
         - data
+        - has_more
       properties:
         data:
           type: array
@@ -5760,6 +8344,17 @@ components:
             $ref: '#/components/schemas/StandingApproval'
           description: |
             List of standing approvals for the authenticated user.
+        has_more:
+          type: boolean
+          description: |
+            Whether there are more results available beyond this page.
+          example: false
+        next_cursor:
+          type: string
+          description: |
+            Opaque cursor to pass as the `after` query parameter to fetch the next page.
+            Only present when `has_more` is `true`.
+          example: 2026-02-14T10:30:00Z,sa_abc123
       example:
         data:
           - standing_approval_id: sa_abc123
@@ -5771,18 +8366,19 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
             revoked_at: null
+            source_action_configuration_id: null
+        has_more: false
     CreateStandingApprovalRequest:
       type: object
       required:
         - agent_id
         - action_type
-        - expires_at
+        - constraints
+        - source_action_configuration_id
       properties:
         agent_id:
           type: integer
@@ -5804,16 +8400,28 @@ components:
         constraints:
           type: object
           additionalProperties: true
-          description: Constraint boundaries for this standing approval.
+          description: |
+            Constraint boundaries for this standing approval. Normally required and must
+            contain at least one non-wildcard parameter constraint; the backend rejects
+            empty objects or constraints where every value is a wildcard (`"*"`).
+
+            When tied to an action configuration (always required for create), trusted flows
+            such as template customize may send `{}` to mean **match all** parameter values for
+            this action type (stored as empty constraints in the database).
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Maximum number of executions. Null means unlimited.
-          example: 100
+        source_action_configuration_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: |
+            Action configuration this standing approval is created from. Must exist,
+            belong to the same `agent_id`, and have the same `action_type` as the request.
+            Expected format: `ac_` prefix followed by 32 hex characters (e.g.,
+            `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
+            enforce the pattern — only non-empty and max 128 characters.
+          example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         starts_at:
           type: string
           format: date-time
@@ -5822,16 +8430,19 @@ components:
         expires_at:
           type: string
           format: date-time
-          description: When this standing approval expires. Required. Maximum 90 days from starts_at.
-          example: '2026-03-14T00:00:00Z'
+          nullable: true
+          description: |
+            When this standing approval expires. Omit or set to null for no expiry
+            (the approval remains active until revoked).
+          example: null
       example:
         agent_id: 42
         action_type: email.send
         action_version: '1'
         constraints:
           recipient_pattern: '*@mycompany.com'
-        max_executions: 100
-        expires_at: '2026-03-14T00:00:00Z'
+        source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+        expires_at: null
     RevokeStandingApprovalResponse:
       type: object
       required:
@@ -5851,6 +8462,31 @@ components:
           type: string
           format: date-time
           example: '2026-02-21T10:30:00Z'
+    UpdateStandingApprovalRequest:
+      type: object
+      required:
+        - constraints
+      properties:
+        constraints:
+          type: object
+          additionalProperties: true
+          description: |
+            Updated constraint boundaries. Must be non-empty with at least one non-wildcard value.
+          example:
+            recipient_pattern: '*@mycompany.com'
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            Updated expiration time. Must be in the future. Null means the approval remains active until revoked.
+            Omitting the field preserves the current expiration
+            (the approval remains active until revoked).
+          example: '2026-04-14T00:00:00Z'
+      example:
+        constraints:
+          recipient_pattern: '*@mycompany.com'
+        expires_at: null
     UserExecuteStandingApprovalRequest:
       type: object
       properties:
@@ -5906,12 +8542,16 @@ components:
         event_type:
           type: string
           enum:
+            - approval.requested
             - approval.approved
             - approval.denied
             - approval.cancelled
+            - action.executed
             - standing_approval.executed
+            - standing_approval.updated
             - agent.registered
             - agent.deactivated
+            - payment_method.charged
           description: The type of event.
           example: approval.approved
         timestamp:
@@ -5938,8 +8578,12 @@ components:
             approvals, contains `type`, `version`, and `parameters`. For standing
             approval executions, contains `type`, `version`, `parameters` (the
             actual parameters used in the execution), and `constraints` (the
-            boundary rules from the standing approval). Null for agent lifecycle
-            events.
+            boundary rules from the standing approval). For standing_approval.updated,
+            contains `type` (action type) only. For payment_method.charged
+            events, contains `type`, `payment_method_id`, `brand`, `last4`,
+            `amount_cents`, `currency`, and optionally `description` (a human-readable
+            summary of the charge). Never includes raw card details.
+            Null for agent lifecycle events.
         outcome:
           type: string
           enum:
@@ -5951,8 +8595,49 @@ components:
             - deactivated
             - pending
             - expired
+            - charged
+            - updated
           description: The outcome of the event.
           example: approved
+        source_id:
+          type: string
+          description: |
+            Identifier linking this event to its source record (e.g. approval_id,
+            standing approval execution id, agent id). Used by the frontend to
+            fetch full details for click-through views.
+          example: appr_abc123
+        source_type:
+          type: string
+          description: |
+            The type of source record this event originated from. Possible values:
+            "approval", "standing_approval", "agent", "payment_method_transaction".
+          example: approval
+        connector_id:
+          type: string
+          nullable: true
+          description: |
+            The connector that handled this action (e.g. "github", "slack").
+            Null for agent lifecycle events (registered, deactivated).
+          example: github
+        execution_status:
+          type: string
+          nullable: true
+          enum:
+            - success
+            - failure
+            - timeout
+            - skipped
+          description: |
+            Whether the executed action succeeded or failed at the third-party
+            service. Only present for action.executed and standing_approval.executed
+            events.
+          example: success
+        execution_error:
+          type: string
+          nullable: true
+          description: |
+            Details about why the execution failed. Only present when
+            execution_status is "failure".
     AuditEventListResponse:
       type: object
       description: Paginated list of audit events.
@@ -5975,6 +8660,144 @@ components:
             next page. Only present when `has_more` is true. Do not construct
             or parse cursor values — they may change format without notice.
           example: 2026-02-20T14:25:00.123456789Z,42
+        retention:
+          $ref: '#/components/schemas/RetentionMeta'
+    AuditLogEvent:
+      type: object
+      description: |
+        A single event in the audit log export. Extends the base AuditEvent with
+        `id` and `source_id` fields for SIEM deduplication and event correlation.
+      required:
+        - id
+        - event_type
+        - timestamp
+        - agent_id
+        - outcome
+        - source_id
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Unique, stable event identifier for deduplication.
+          example: 12345
+        event_type:
+          type: string
+          enum:
+            - approval.requested
+            - approval.approved
+            - approval.denied
+            - approval.cancelled
+            - action.executed
+            - standing_approval.executed
+            - standing_approval.updated
+            - agent.registered
+            - agent.deactivated
+            - payment_method.charged
+          description: The type of event.
+          example: approval.approved
+        timestamp:
+          type: string
+          format: date-time
+          description: When the event occurred.
+          example: '2026-02-20T14:30:00Z'
+        agent_id:
+          type: integer
+          format: int64
+          description: The agent associated with this event.
+          example: 42
+        agent_metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Snapshot of agent metadata at the time the event was recorded.
+        action:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: |
+            Action details for approval and standing approval events. For
+            payment_method.charged events, contains `type`, `payment_method_id`,
+            `brand`, `last4`, `amount_cents`, and `currency`.
+        outcome:
+          type: string
+          enum:
+            - approved
+            - denied
+            - cancelled
+            - auto_executed
+            - registered
+            - deactivated
+            - pending
+            - expired
+            - charged
+            - updated
+          description: The outcome of the event.
+          example: approved
+        source_id:
+          type: string
+          description: |
+            Identifier linking this event to its source record (e.g. approval_id,
+            standing approval execution id, agent id). Useful for correlating
+            events back to their originating resource.
+          example: appr_abc123
+        connector_id:
+          type: string
+          nullable: true
+          description: |
+            The connector that handled this action (e.g. "github", "slack").
+            Null for agent lifecycle events (registered, deactivated).
+          example: github
+        execution_status:
+          type: string
+          nullable: true
+          enum:
+            - success
+            - failure
+            - timeout
+            - skipped
+          description: |
+            Whether the executed action succeeded or failed at the third-party
+            service. Only present for action.executed and standing_approval.executed
+            events.
+          example: success
+        execution_error:
+          type: string
+          nullable: true
+          description: |
+            Details about why the execution failed. Only present when
+            execution_status is "failure".
+    AuditLogExportResponse:
+      type: object
+      description: Paginated export of audit log events in chronological order.
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLogEvent'
+        has_more:
+          type: boolean
+          description: Whether more events exist beyond this page.
+          example: false
+        next_cursor:
+          type: string
+          description: |
+            Opaque cursor to pass as the `after` query parameter to fetch the
+            next page. Only present when `has_more` is true.
+          example: 2026-02-20T14:25:00.123456789Z,42
+        retention:
+          $ref: '#/components/schemas/RetentionMeta'
+        effective_since:
+          type: string
+          format: date-time
+          description: |
+            The actual start timestamp used for the query. Only present when the
+            requested `since` was earlier than the retention window allows, indicating
+            the query was clamped to the retention boundary. Helps SIEM integrations
+            detect when their requested time range exceeds the user's plan limits.
+          example: '2026-02-22T00:00:00Z'
     AgentSummary:
       type: object
       description: Summary of an agent owned by the authenticated user.
@@ -6069,6 +8892,12 @@ components:
             - deactivated
           description: Current agent status (always "registered" for successful requests, since the middleware requires it)
           example: registered
+        approver:
+          allOf:
+            - $ref: '#/components/schemas/ApproverInfo'
+          description: |
+            The user (approver) this agent is registered to. Identifies whose
+            account and permissions this agent operates under.
         metadata:
           type: object
           nullable: true
@@ -6125,6 +8954,13 @@ components:
           description: |
             The authenticated agent's identifier.
           example: 42
+        approver:
+          allOf:
+            - $ref: '#/components/schemas/ApproverInfo'
+          description: |
+            The user (approver) whose capabilities are being returned. Identifies
+            which user's connectors, standing approvals, and action configurations
+            are represented in this response.
         connectors:
           type: array
           items:
@@ -6137,6 +8973,8 @@ components:
             If the agent has no enabled connectors, this array is empty.
       example:
         agent_id: 42
+        approver:
+          username: alice
         connectors:
           - id: gmail
             name: Gmail
@@ -6168,8 +9006,6 @@ components:
                     constraints:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
-                    max_executions: 100
-                    executions_remaining: 88
                     expires_at: '2026-05-15T00:00:00Z'
                 action_configurations:
                   - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -6179,7 +9015,6 @@ components:
                       to: team@mycompany.com
                       subject: '*'
                       body: '*'
-                    credential_ready: true
               - action_type: email.read
                 name: Read Email
                 description: Read emails from Gmail inbox
@@ -6247,10 +9082,12 @@ components:
         credentials_ready:
           type: boolean
           description: |
-            Whether the user has stored the required credentials for this connector.
+            Whether required credentials for this connector are assigned to this
+            agent+connector pair (via `agent_connector_credentials`). Unassigned
+            global credentials alone do not make this `true`.
 
-            - `true`: Credentials are stored — actions can be executed.
-            - `false`: Credentials are missing — action execution will fail with
+            - `true`: A credential or OAuth connection is bound — actions can be executed.
+            - `false`: No valid binding — action execution will fail with
               `404 credentials_not_found`. The agent should direct the user to
               `credentials_setup_url` to connect their account.
 
@@ -6376,8 +9213,7 @@ components:
             will match the best standing approval automatically.
 
             **If empty**: The agent must use the one-off approval flow —
-            `POST /v1/approvals/request` → user approves → `POST /v1/approvals/{id}/verify`
-            → `POST /v1/actions/execute` with token.
+            `POST /v1/approvals/request` → user approves via dashboard.
 
             **If parameters don't match any standing approval's constraints**: The
             request falls through to the one-off approval flow automatically (Permission
@@ -6419,8 +9255,6 @@ components:
           - standing_approval_id: sa_def456
             constraints:
               recipient_pattern: '*@mycompany.com'
-            max_executions: 100
-            executions_remaining: 88
             expires_at: '2026-05-15T00:00:00Z'
         action_configurations:
           - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -6430,13 +9264,11 @@ components:
               to: team@mycompany.com
               subject: '*'
               body: '*'
-            credential_ready: true
     StandingApprovalCapability:
       type: object
       required:
         - standing_approval_id
         - constraints
-        - executions_remaining
         - expires_at
       properties:
         standing_approval_id:
@@ -6463,23 +9295,6 @@ components:
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of executions allowed under this standing approval.
-            `null` means unlimited.
-          example: 100
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining. `null` means unlimited (when
-            `max_executions` is null). When this reaches `0`, the standing
-            approval is exhausted and the agent must use one-off approval.
-          example: 88
         expires_at:
           type: string
           format: date-time
@@ -6493,8 +9308,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
           max_recipients: 5
-        max_executions: 100
-        executions_remaining: 88
         expires_at: '2026-05-15T00:00:00Z'
     ActionConfigCapability:
       type: object
@@ -6503,7 +9316,6 @@ components:
         - action_type
         - name
         - parameters
-        - credential_ready
       properties:
         configuration_id:
           type: string
@@ -6550,17 +9362,6 @@ components:
             to: team@mycompany.com
             subject: '*'
             body: '*'
-        credential_ready:
-          type: boolean
-          description: |
-            Whether the credential bound to this configuration is present and valid.
-
-            - `true`: A credential is assigned and exists — the action can be executed.
-            - `false`: Either no credential is assigned or the assigned credential
-              has been deleted. The user must assign a credential before execution.
-
-            **Security**: No credential values or identifiers are exposed to the agent.
-          example: true
       example:
         configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         action_type: email.send
@@ -6570,7 +9371,6 @@ components:
           to: team@mycompany.com
           subject: '*'
           body: '*'
-        credential_ready: true
     AgentConnectorListResponse:
       type: object
       required:
@@ -6757,6 +9557,11 @@ components:
           maxLength: 32
           pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,31}$
           example: alice
+        marketing_opt_in:
+          type: boolean
+          description: Whether the user opts in to product update emails. Defaults to false.
+          default: false
+          example: false
     OnboardingResponse:
       type: object
       description: The newly created (or existing) user profile.
@@ -6785,6 +9590,7 @@ components:
       required:
         - id
         - username
+        - marketing_opt_in
         - created_at
       properties:
         id:
@@ -6797,11 +9603,1504 @@ components:
           description: Protocol-level username (unique)
           maxLength: 255
           example: alice
+        email:
+          type: string
+          nullable: true
+          description: Contact email address (user-provided, opt-in for email notifications)
+          example: alice@example.com
+        phone:
+          type: string
+          nullable: true
+          description: Contact phone number in E.164 format (user-provided, opt-in for SMS notifications)
+          example: '+15551234567'
+        marketing_opt_in:
+          type: boolean
+          description: Whether the user has opted in to product update emails.
+          example: false
         created_at:
           type: string
           format: date-time
           description: Account creation timestamp (ISO 8601)
           example: '2026-02-16T00:27:36Z'
+    UpdateProfileRequest:
+      type: object
+      description: Request body for updating profile fields.
+      properties:
+        email:
+          type: string
+          nullable: true
+          description: Contact email address. Pass null or empty string to clear.
+          example: alice@example.com
+        phone:
+          type: string
+          nullable: true
+          description: Contact phone number in E.164 format. Pass null or empty string to clear.
+          example: '+15551234567'
+        marketing_opt_in:
+          type: boolean
+          description: |
+            Whether the user opts in to product update emails. Omit the field to leave the current value unchanged; unlike email/phone this field cannot be null.
+          example: true
+    NotificationPreference:
+      type: object
+      description: |
+        A single notification channel preference. The `available` field indicates
+        whether the user's plan supports this channel. Channels that require a
+        paid plan (e.g. SMS) return `available: false` for free-tier users.
+      required:
+        - channel
+        - enabled
+        - available
+      properties:
+        channel:
+          type: string
+          description: Notification channel identifier
+          enum:
+            - email
+            - web-push
+            - sms
+            - mobile-push
+          example: email
+        enabled:
+          type: boolean
+          description: Whether notifications are enabled for this channel
+          example: true
+        available:
+          type: boolean
+          description: |
+            Whether this channel is available on the user's current plan.
+            When false, the channel is plan-gated and cannot be enabled.
+            SMS requires a paid plan (pay_as_you_go or higher).
+          example: true
+    NotificationPreferencesResponse:
+      type: object
+      description: All notification preferences for the authenticated user.
+      required:
+        - preferences
+      properties:
+        preferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationPreference'
+          description: List of notification channel preferences
+    UpdateNotificationPreferencesRequest:
+      type: object
+      description: Request body for updating notification preferences.
+      required:
+        - preferences
+      properties:
+        preferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationPreferenceUpdate'
+          description: Channel preferences to update. Channels not included are unchanged.
+          minItems: 1
+    DeleteAccountRequest:
+      type: object
+      description: Request body for deleting the authenticated user's account.
+      required:
+        - confirmation
+      properties:
+        confirmation:
+          type: string
+          description: Must be the literal string "DELETE" to confirm the irreversible deletion.
+          enum:
+            - DELETE
+          example: DELETE
+    DeleteAccountResponse:
+      type: object
+      description: Response confirming the account was deleted.
+      required:
+        - deleted
+        - message
+      properties:
+        deleted:
+          type: boolean
+          description: Always true on success.
+          example: true
+        message:
+          type: string
+          description: Human-readable confirmation message.
+          example: Account and all associated data have been permanently deleted.
+    DataRetentionResponse:
+      type: object
+      description: The data retention policy for the authenticated user's current plan.
+      required:
+        - plan_id
+        - plan_name
+        - audit_retention_days
+        - effective_retention_days
+      properties:
+        plan_id:
+          type: string
+          description: The user's current plan ID.
+          example: free
+        plan_name:
+          type: string
+          description: Human-readable plan name.
+          example: Free
+        audit_retention_days:
+          type: integer
+          description: |
+            The plan's base retention period in days. This is the plan's configured
+            value, without considering any active grace period.
+          example: 7
+        effective_retention_days:
+          type: integer
+          description: |
+            The currently enforced retention period in days, accounting for any
+            active downgrade grace period. During the 7-day grace period after a
+            downgrade, this will be 90 (the previous paid plan's retention) even
+            though audit_retention_days shows the new plan's shorter value.
+          example: 7
+        grace_period_ends_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When the downgrade grace period expires. Only present if the user
+            recently downgraded from a paid plan. After this timestamp,
+            effective_retention_days will match audit_retention_days.
+    CreatePushSubscriptionRequest:
+      description: |
+        Register a push subscription. Use `type: "web-push"` (or omit type) for
+        browser Web Push subscriptions, or `type: "expo"` / `type: "mobile-push"`
+        for Expo push tokens from the mobile app.
+      oneOf:
+        - $ref: '#/components/schemas/CreateWebPushSubscriptionRequest'
+        - $ref: '#/components/schemas/CreateExpoPushSubscriptionRequest'
+      discriminator:
+        propertyName: type
+        mapping:
+          web-push: '#/components/schemas/CreateWebPushSubscriptionRequest'
+          expo: '#/components/schemas/CreateExpoPushSubscriptionRequest'
+          mobile-push: '#/components/schemas/CreateExpoPushSubscriptionRequest'
+    CreateWebPushSubscriptionRequest:
+      type: object
+      description: Register a Web Push subscription from a browser PushSubscription.
+      required:
+        - endpoint
+        - p256dh
+        - auth
+      properties:
+        type:
+          type: string
+          description: Subscription type. Defaults to "web-push" when omitted.
+          enum:
+            - web-push
+          default: web-push
+          example: web-push
+        endpoint:
+          type: string
+          format: uri
+          description: Push service endpoint URL from the browser PushSubscription
+          example: https://fcm.googleapis.com/fcm/send/abc123...
+        p256dh:
+          type: string
+          description: Base64url-encoded P-256 public key from the browser PushSubscription keys
+          example: BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8p8REqnSw
+        auth:
+          type: string
+          description: Base64url-encoded auth secret from the browser PushSubscription keys
+          example: tBHItJI5svbpC7RB5gg6bQ
+    CreateExpoPushSubscriptionRequest:
+      type: object
+      description: Register an Expo push token from the mobile app.
+      required:
+        - type
+        - expo_token
+      properties:
+        type:
+          type: string
+          description: |
+            Subscription type. Use "expo" or "mobile-push" — both are accepted
+            and create a mobile-push channel subscription.
+          enum:
+            - expo
+            - mobile-push
+          example: expo
+        expo_token:
+          type: string
+          description: Expo push token from expo-notifications
+          example: ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
+    PushSubscriptionResponse:
+      type: object
+      description: A registered push subscription (Web Push or Expo).
+      required:
+        - id
+        - channel
+        - created_at
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Subscription ID
+          example: 1
+        channel:
+          type: string
+          description: The push channel type
+          enum:
+            - web-push
+            - mobile-push
+          example: web-push
+        endpoint:
+          type: string
+          format: uri
+          description: Push service endpoint URL (present for web-push subscriptions)
+          example: https://fcm.googleapis.com/fcm/send/abc123...
+        expo_token:
+          type: string
+          description: Expo push token (present for mobile-push subscriptions)
+          example: ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
+        created_at:
+          type: string
+          format: date-time
+          description: When the subscription was registered
+          example: '2026-02-27T10:00:00Z'
+    PushSubscriptionListResponse:
+      type: object
+      description: List of registered push subscriptions.
+      required:
+        - subscriptions
+      properties:
+        subscriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PushSubscriptionResponse'
+    DeletePushSubscriptionResponse:
+      type: object
+      description: Confirmation of push subscription deletion.
+      required:
+        - id
+        - deleted_at
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Deleted subscription ID
+          example: 1
+        deleted_at:
+          type: string
+          format: date-time
+          description: Deletion timestamp
+          example: '2026-02-27T10:05:00Z'
+    UnregisterExpoPushTokenRequest:
+      type: object
+      description: Request to unregister an Expo push token (e.g. on mobile logout).
+      required:
+        - expo_token
+      properties:
+        expo_token:
+          type: string
+          description: The Expo push token to unregister
+          example: ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
+    UnregisterExpoPushTokenResponse:
+      type: object
+      description: Confirmation that the Expo push token was unregistered.
+      required:
+        - unregistered_at
+      properties:
+        unregistered_at:
+          type: string
+          format: date-time
+          description: When the token was unregistered
+          example: '2026-02-27T10:05:00Z'
+    VAPIDPublicKeyResponse:
+      type: object
+      description: The server's VAPID public key for Web Push subscription.
+      required:
+        - public_key
+      properties:
+        public_key:
+          type: string
+          description: Base64url-encoded VAPID public key
+          example: BNx...
+    CreateExpoPushTokenRequest:
+      type: object
+      description: Register an Expo push token from the mobile app.
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: Expo push token from the mobile device (e.g. "ExponentPushToken[...]")
+          example: ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
+    ExpoPushTokenResponse:
+      type: object
+      description: A registered Expo push token.
+      required:
+        - id
+        - token
+        - created_at
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Token registration ID
+          example: 1
+        token:
+          type: string
+          description: Expo push token string
+          example: ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
+        created_at:
+          type: string
+          format: date-time
+          description: When the token was registered
+          example: '2026-03-04T10:00:00Z'
+    ExpoPushTokenListResponse:
+      type: object
+      description: List of registered Expo push tokens.
+      required:
+        - tokens
+      properties:
+        tokens:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExpoPushTokenResponse'
+    DeleteExpoPushTokenResponse:
+      type: object
+      description: Confirmation of Expo push token deletion.
+      required:
+        - id
+        - deleted_at
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Deleted token ID
+          example: 1
+        deleted_at:
+          type: string
+          format: date-time
+          description: Deletion timestamp
+          example: '2026-03-04T10:05:00Z'
+    SubscriptionResponse:
+      type: object
+      required:
+        - plan_id
+        - plan_name
+        - status
+        - current_period_start
+        - current_period_end
+        - has_payment_method
+        - can_upgrade
+        - plan_limits
+        - effective_limits
+      properties:
+        plan_id:
+          type: string
+          description: The plan ID (e.g., "free", "pay_as_you_go", "free_pro")
+          example: free
+        plan_name:
+          type: string
+          description: Human-readable plan name
+          example: Free
+        status:
+          type: string
+          enum:
+            - active
+            - past_due
+            - cancelled
+          description: Subscription status
+          example: active
+        current_period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (inclusive)
+        current_period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (exclusive)
+        has_payment_method:
+          type: boolean
+          description: Whether the user has a Stripe payment method on file
+          example: false
+        can_upgrade:
+          type: boolean
+          description: Whether the user can upgrade to a paid plan (true when on the free plan)
+          example: true
+        plan_limits:
+          $ref: '#/components/schemas/PlanLimits'
+        effective_limits:
+          $ref: '#/components/schemas/PlanLimits'
+          description: |
+            Resource and request limits currently enforced (may match a paid plan during
+            quota grace after downgrade while `plan_id` is already `free`).
+        usage:
+          $ref: '#/components/schemas/UsageInfo'
+    UsageInfo:
+      type: object
+      required:
+        - request_count
+        - sms_count
+        - over_limit
+      properties:
+        request_count:
+          type: integer
+          description: Number of API requests in the current billing period
+          example: 42
+        sms_count:
+          type: integer
+          description: Number of SMS messages sent in the current billing period
+          example: 0
+        request_limit:
+          type: integer
+          nullable: true
+          description: Monthly request limit for the current plan (null = unlimited)
+          example: 1000
+        over_limit:
+          type: boolean
+          description: Whether current usage exceeds the plan's request limit
+          example: false
+    UsageResponse:
+      type: object
+      required:
+        - period_start
+        - period_end
+        - requests
+        - sms
+      properties:
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (inclusive)
+        period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (exclusive)
+        requests:
+          $ref: '#/components/schemas/RequestsUsage'
+        sms:
+          $ref: '#/components/schemas/SMSUsage'
+    RequestsUsage:
+      type: object
+      required:
+        - total
+        - included
+        - overage
+        - overage_cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total API requests in the current billing period
+          example: 450
+        included:
+          type: integer
+          description: Number of requests included in the plan for free (0 = unlimited on paid plans)
+          example: 1000
+        overage:
+          type: integer
+          description: Number of requests exceeding the included allowance
+          example: 0
+        overage_cost_cents:
+          type: integer
+          description: |
+            Estimated overage cost in cents, calculated at $0.005 per request
+            (0.5 cents), rounded up to the nearest cent
+          example: 0
+    SMSUsage:
+      type: object
+      required:
+        - total
+        - cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total SMS messages sent in the current billing period
+          example: 12
+        cost_cents:
+          type: integer
+          description: |
+            Estimated SMS cost in cents at the US/CA rate ($0.01 per message).
+            International rates may apply for non-US/CA destinations.
+          example: 12
+    InvoiceSummary:
+      type: object
+      required:
+        - id
+        - status
+        - currency
+        - amount_due
+        - amount_paid
+        - created
+      properties:
+        id:
+          type: string
+          description: Stripe Invoice ID
+          example: in_1234567890
+        number:
+          type: string
+          description: Invoice number
+          example: INV-0001
+        status:
+          type: string
+          description: Invoice status
+          example: paid
+        currency:
+          type: string
+          description: Three-letter ISO currency code
+          example: usd
+        amount_due:
+          type: integer
+          description: Amount due in cents
+          example: 500
+        amount_paid:
+          type: integer
+          description: Amount paid in cents
+          example: 500
+        period_start:
+          type: integer
+          description: Billing period start (Unix timestamp)
+          example: 1709251200
+        period_end:
+          type: integer
+          description: Billing period end (Unix timestamp)
+          example: 1711929600
+        created:
+          type: integer
+          description: Invoice creation time (Unix timestamp)
+          example: 1711929600
+        hosted_invoice_url:
+          type: string
+          format: uri
+          description: URL to view the invoice on Stripe's hosted page
+        invoice_pdf:
+          type: string
+          format: uri
+          description: URL to download the invoice PDF
+    CheckoutResponse:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          format: uri
+          pattern: ^https://
+          description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
+          example: https://checkout.stripe.com/c/pay/cs_test_...
+    Plan:
+      description: |
+        A billing plan with its resource limits. Composes `PlanLimits` with
+        plan identity fields to avoid duplicating the limit definitions.
+      allOf:
+        - type: object
+          required:
+            - id
+            - name
+          properties:
+            id:
+              type: string
+              description: Unique plan identifier
+              example: free
+            name:
+              type: string
+              description: Human-readable plan name
+              example: Free
+        - $ref: '#/components/schemas/PlanLimits'
+    Subscription:
+      type: object
+      required:
+        - status
+        - current_period_start
+        - current_period_end
+        - has_payment_method
+        - can_upgrade
+        - can_downgrade
+        - can_end_quota_grace_now
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+            - past_due
+            - cancelled
+          description: |
+            Current subscription status.
+            - `active`: Subscription is in good standing.
+            - `past_due`: Payment failed — prompt the user to update their payment method.
+            - `cancelled`: Subscription was cancelled (user was downgraded to free).
+          example: active
+        current_period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (inclusive)
+          example: '2026-03-01T00:00:00Z'
+        current_period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (exclusive)
+          example: '2026-04-01T00:00:00Z'
+        has_payment_method:
+          type: boolean
+          description: Whether the user has a Stripe payment method on file. Use this to decide whether to show "Add payment method" prompts.
+          example: false
+        can_upgrade:
+          type: boolean
+          description: Whether the user can upgrade (true when on the free plan). Use this to show/hide the upgrade button.
+          example: true
+        can_downgrade:
+          type: boolean
+          description: Whether the user can downgrade (true when on a paid plan). Use this to show/hide the downgrade button.
+          example: false
+        can_end_quota_grace_now:
+          type: boolean
+          description: |
+            True when the user is already on the free plan but still has paid-plan quotas
+            until `quota_entitlements_until` (post–pay-as-you-go cancellation). The client may
+            offer "Downgrade now" to apply free-tier limits immediately via `POST /billing/downgrade`.
+          example: false
+        grace_period_ends_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When the 7-day audit retention grace period expires after downgrade, or null
+            if not active. During this window the user keeps the longer paid-plan audit
+            retention (e.g. 90 days) to export data; afterward retention matches the
+            free plan. This is separate from quota entitlements (`quota_entitlements_until`).
+        quota_entitlements_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When paid-plan quotas stop applying after a downgrade to free, or null if not
+            in quota grace. Until this instant, API enforcement uses the snapshotted paid
+            plan limits even though `plan_id` is `free`.
+    UsageSummary:
+      type: object
+      required:
+        - requests
+        - agents
+        - standing_approvals
+        - credentials
+      properties:
+        requests:
+          type: integer
+          description: Number of API requests in the current billing period
+          example: 42
+        agents:
+          type: integer
+          description: Current number of registered agents
+          example: 2
+        standing_approvals:
+          type: integer
+          description: Current number of active standing approvals
+          example: 3
+        credentials:
+          type: integer
+          description: Current number of stored credentials
+          example: 1
+    BillingPlanResponse:
+      type: object
+      description: |
+        Complete billing information for the authenticated user. Combines plan
+        details (including resource limits), subscription status, and current
+        usage counts. Used by the frontend to render limit badges, upgrade
+        prompts, and gate features like SMS notifications.
+      required:
+        - plan
+        - effective_limits
+        - subscription
+        - usage
+        - pricing
+        - coupon_redemption_enabled
+      properties:
+        plan:
+          $ref: '#/components/schemas/Plan'
+        effective_limits:
+          $ref: '#/components/schemas/PlanLimits'
+          description: |
+            Limits currently enforced for quotas and resource caps. During quota grace
+            after downgrade, this reflects the previous paid plan while `plan` reflects
+            the billing plan (`free`).
+        subscription:
+          $ref: '#/components/schemas/Subscription'
+        usage:
+          $ref: '#/components/schemas/UsageSummary'
+        pricing:
+          $ref: '#/components/schemas/BillingPricing'
+        coupon_redemption_enabled:
+          type: boolean
+          description: |
+            True when the server has `COUPON_SECRET` set so `POST /v1/billing/redeem-coupon`
+            is available. The frontend may show a coupon entry form when true and the user
+            is on the free plan.
+          example: false
+    UsageDetail:
+      type: object
+      description: |
+        Detailed usage metrics for a single billing period. Includes request
+        and SMS totals, overage/cost calculations, and an optional breakdown
+        by agent, connector, and action type. Used by the billing dashboard
+        to render the usage overview and per-agent breakdown table.
+      required:
+        - period_start
+        - period_end
+        - requests
+        - sms
+      properties:
+        period_start:
+          type: string
+          format: date-time
+          description: |
+            Start of the billing period (inclusive, UTC). Always the first
+            instant of a calendar month, e.g. `2026-03-01T00:00:00Z`.
+          example: '2026-03-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          description: |
+            End of the billing period (exclusive, UTC). Always the first
+            instant of the following month. Uses half-open interval convention:
+            the period covers [period_start, period_end).
+          example: '2026-04-01T00:00:00Z'
+        requests:
+          $ref: '#/components/schemas/RequestUsageDetail'
+        sms:
+          $ref: '#/components/schemas/SMSUsageDetail'
+        breakdown:
+          $ref: '#/components/schemas/UsageBreakdown'
+    RequestUsageDetail:
+      type: object
+      description: |
+        Request usage metrics for a billing period. The `included` count
+        comes from the plan's `max_requests_per_month` (0 for unlimited
+        paid plans). Overage and cost are only non-zero when the total
+        exceeds the included allowance.
+      required:
+        - total
+        - included
+        - overage
+        - cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total API requests made during this billing period.
+          example: 1542
+        included:
+          type: integer
+          description: |
+            Number of requests included in the plan at no extra cost.
+            0 when the plan has no request limit (e.g. pay-as-you-go).
+          example: 1000
+        overage:
+          type: integer
+          description: |
+            Number of requests exceeding the included allowance.
+            Always 0 when total <= included or when there is no limit.
+          example: 542
+        cost_cents:
+          type: integer
+          description: |
+            Estimated cost of overage requests in cents, calculated at
+            $0.005 per request (0.5 cents), rounded up to the nearest cent.
+            Formula: ceil(overage * 0.5). Always 0 when there is no overage.
+          example: 271
+    SMSUsageDetail:
+      type: object
+      description: |
+        SMS usage metrics for a billing period. Cost is calculated at
+        the US/CA rate ($0.01 per message). International rates may
+        apply for non-US/CA destinations in the future.
+      required:
+        - total
+        - cost_cents
+      properties:
+        total:
+          type: integer
+          description: Total SMS messages sent during this billing period.
+          example: 5
+        cost_cents:
+          type: integer
+          description: |
+            Estimated SMS cost in cents at the US/CA rate ($0.01/message).
+          example: 5
+    UsageBreakdown:
+      type: object
+      description: |
+        Hierarchical breakdown of request counts by agent, connector, and
+        action type. Each map uses string keys (IDs or type names) with
+        integer count values. Omitted from the response when no breakdown
+        data has been recorded for the period.
+      properties:
+        by_agent:
+          type: object
+          additionalProperties:
+            type: integer
+          description: |
+            Request counts keyed by agent ID (as a string). Sorted by
+            count descending on the frontend for the per-agent table.
+          example:
+            '1': 500
+            '2': 1042
+        by_connector:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Request counts keyed by connector ID.
+          example:
+            gmail: 300
+            stripe: 1242
+        by_action_type:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Request counts keyed by action type
+          example:
+            email.send: 300
+            payment.create: 1242
+    UpgradeResponse:
+      type: object
+      required:
+        - checkout_url
+      properties:
+        checkout_url:
+          type: string
+          format: uri
+          pattern: ^https://
+          description: Stripe Checkout Session URL — redirect the user here to complete payment. Always HTTPS.
+          example: https://checkout.stripe.com/c/pay/cs_test_...
+    Invoice:
+      type: object
+      required:
+        - id
+        - date
+        - amount_cents
+        - status
+      properties:
+        id:
+          type: string
+          description: Invoice identifier
+          example: inv_1234567890
+        date:
+          type: string
+          format: date-time
+          description: Invoice creation date
+          example: '2026-02-01T00:00:00Z'
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the billing period this invoice covers
+          example: '2026-02-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          description: End of the billing period this invoice covers
+          example: '2026-03-01T00:00:00Z'
+        amount_cents:
+          type: integer
+          description: Total invoice amount in cents (0 for periods within the free allowance)
+          example: 271
+        status:
+          type: string
+          enum:
+            - draft
+            - open
+            - paid
+            - void
+            - uncollectible
+          description: |
+            Invoice payment status.
+            - `draft`: Invoice is being prepared (not yet finalized).
+            - `open`: Invoice is finalized and awaiting payment.
+            - `paid`: Payment was collected successfully.
+            - `void`: Invoice was voided (no payment required).
+            - `uncollectible`: Payment could not be collected after all retries.
+          example: paid
+        stripe_invoice_url:
+          type: string
+          format: uri
+          pattern: ^https://
+          description: URL to view the full invoice details on Stripe's hosted page. Always HTTPS.
+          example: https://invoice.stripe.com/i/acct_1234/inv_1234567890
+    QuotaExceededError:
+      description: |
+        Returned when the user exceeds their plan's monthly request quota (HTTP 429).
+        Uses the standard ErrorResponse structure. The `details` object contains
+        quota-specific fields to help the frontend render an upgrade prompt.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: monthly_quota_exceeded
+          message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
+          retryable: true
+          retry_after: 2419200
+          details:
+            limit: 1000
+            current_usage: 1000
+            plan_id: free
+            reset_at: '2026-04-01T00:00:00Z'
+    QuotaExceededDetails:
+      type: object
+      description: Shape of `error.details` for monthly_quota_exceeded errors.
+      properties:
+        limit:
+          type: integer
+          description: The plan's request limit
+          example: 1000
+        current_count:
+          type: integer
+          description: Current usage count
+          example: 251
+        plan_id:
+          type: string
+          description: The user's current plan
+          example: free
+        reset_at:
+          type: string
+          format: date-time
+          description: When the usage counter resets (next billing period start)
+    ResourceLimitError:
+      description: |
+        Returned when the user hits a plan-based resource limit (HTTP 403).
+        Uses the standard ErrorResponse structure. The `details` object contains
+        limit-specific fields to help the frontend render an upgrade prompt.
+
+        Possible error codes: `agent_limit_reached`, `standing_approval_limit_reached`,
+        `credential_limit_reached`.
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        error:
+          code: agent_limit_reached
+          message: Free plan allows up to 3 agents. Upgrade your plan to add more.
+          retryable: false
+          details:
+            current_count: 3
+            limit: 3
+            plan_id: free
+    ResourceLimitDetails:
+      type: object
+      description: Shape of `error.details` for resource limit errors.
+      properties:
+        current_count:
+          type: integer
+          description: Current number of the resource
+          example: 3
+        limit:
+          type: integer
+          description: Maximum allowed by the plan
+          example: 3
+        plan_id:
+          type: string
+          description: The user's current plan
+          example: free
+    ActivateRequest:
+      type: object
+      required:
+        - session_id
+      properties:
+        session_id:
+          type: string
+          description: The Stripe Checkout Session ID from the success redirect URL
+          example: cs_test_abc123
+    ActivateResponse:
+      type: object
+      required:
+        - plan_id
+        - status
+      properties:
+        plan_id:
+          type: string
+          description: The user's plan after activation (free if pending, pay_as_you_go if activated)
+          example: pay_as_you_go
+        status:
+          type: string
+          enum:
+            - activated
+            - already_active
+            - pending
+          description: |
+            Activation result:
+            - `activated`: Plan was successfully upgraded.
+            - `already_active`: Plan was already upgraded (webhook or previous call).
+            - `pending`: Checkout session is not yet complete (payment still processing).
+          example: activated
+    AdminUsageResponse:
+      type: object
+      description: |
+        Summary of a user's billable usage for a single billing period.
+        The `breakdown` field is only present when at least one breakdown
+        dimension (agent, connector, or action type) has recorded data.
+      required:
+        - user_id
+        - period_start
+        - period_end
+        - request_count
+        - sms_count
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: The authenticated user whose usage is reported
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the billing period (inclusive, UTC)
+          example: '2026-03-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          description: End of the billing period (exclusive, UTC)
+          example: '2026-04-01T00:00:00Z'
+        request_count:
+          type: integer
+          description: Total billable requests in the period
+          example: 542
+        sms_count:
+          type: integer
+          description: Total SMS messages sent in the period
+          example: 3
+        breakdown:
+          $ref: '#/components/schemas/UsageBreakdown'
+    ConnectorUsageResponse:
+      type: object
+      description: |
+        Per-connector request counts for the authenticated user within a billing
+        period. Connectors are sorted by request count descending.
+      required:
+        - user_id
+        - period_start
+        - period_end
+        - connectors
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: The authenticated user whose connector usage is reported
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        period_start:
+          type: string
+          format: date-time
+          example: '2026-03-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          example: '2026-04-01T00:00:00Z'
+        connectors:
+          type: array
+          description: Connector usage entries, ordered by request_count descending
+          items:
+            $ref: '#/components/schemas/ConnectorUsageEntry'
+    ConnectorUsageEntry:
+      type: object
+      required:
+        - connector_id
+        - request_count
+      properties:
+        connector_id:
+          type: string
+          description: Connector identifier (matches the `id` field in the connectors table)
+          example: gmail
+        name:
+          type: string
+          description: Human-readable connector name. Omitted if the connector has been deleted.
+          example: Gmail
+        request_count:
+          type: integer
+          description: Number of billable requests made through this connector
+          example: 1542
+    AgentUsageResponse:
+      type: object
+      description: |
+        Per-agent request counts for the authenticated user within a billing
+        period. Agents are sorted by request count descending.
+      required:
+        - user_id
+        - period_start
+        - period_end
+        - agents
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          description: The authenticated user whose agent usage is reported
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        period_start:
+          type: string
+          format: date-time
+          example: '2026-03-01T00:00:00Z'
+        period_end:
+          type: string
+          format: date-time
+          example: '2026-04-01T00:00:00Z'
+        agents:
+          type: array
+          description: Agent usage entries, ordered by request_count descending
+          items:
+            $ref: '#/components/schemas/AgentUsageEntry'
+    AgentUsageEntry:
+      type: object
+      required:
+        - agent_id
+        - request_count
+      properties:
+        agent_id:
+          type: string
+          description: Agent ID (numeric, serialized as string)
+          example: '42'
+        name:
+          type: string
+          description: |
+            Agent name from the agent's metadata. Omitted if not set or if the
+            agent has been deleted.
+          example: deploy-bot
+        request_count:
+          type: integer
+          description: Number of billable requests attributed to this agent
+          example: 500
+    OAuthProvider:
+      type: object
+      required:
+        - id
+        - scopes
+        - source
+        - has_credentials
+      properties:
+        id:
+          type: string
+          description: The OAuth provider ID (e.g. "google", "microsoft", "zoom")
+          example: google
+        scopes:
+          type: array
+          items:
+            type: string
+          description: Default OAuth scopes for this provider
+          example:
+            - openid
+            - https://www.googleapis.com/auth/userinfo.email
+        source:
+          type: string
+          enum:
+            - built_in
+            - manifest
+          description: Where the provider configuration originated
+          example: built_in
+        has_credentials:
+          type: boolean
+          description: Whether the provider has client credentials configured and is ready to use
+          example: true
+        pkce:
+          type: boolean
+          description: |
+            When true, the platform uses PKCE (RFC 7636) for this provider's authorize and token exchange. The browser still follows the normal redirect to `GET /v1/oauth/{provider}/authorize`; the code verifier is generated and recovered server-side inside the signed OAuth state JWT (sealed so the JWT payload does not contain the verifier in plaintext).
+          default: false
+          example: true
+    OAuthProviderListResponse:
+      type: object
+      required:
+        - providers
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/OAuthProvider'
+          description: List of available OAuth providers
+    OAuthConnection:
+      type: object
+      required:
+        - id
+        - provider
+        - scopes
+        - status
+        - connected_at
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this OAuth connection.
+          example: oc_abc123
+        provider:
+          type: string
+          description: The OAuth provider ID (e.g. "google", "microsoft", "zoom")
+          example: google
+        scopes:
+          type: array
+          items:
+            type: string
+          description: The OAuth scopes granted by the provider
+          example:
+            - openid
+            - https://www.googleapis.com/auth/userinfo.email
+        status:
+          type: string
+          enum:
+            - active
+            - needs_reauth
+            - revoked
+          description: |
+            The current status of the connection. `active` — connection is valid and tokens are current (automatically refreshed before expiry). `needs_reauth` — token refresh failed (token revoked, expired refresh token, or no refresh token available); user must re-authorize via Settings. `revoked` — user explicitly disconnected the provider.
+          example: active
+        connected_at:
+          type: string
+          format: date-time
+          description: When the OAuth connection was established
+          example: '2026-03-05T10:00:00Z'
+        instance:
+          type: string
+          description: |
+            For providers with per-instance OAuth URLs (e.g. Zendesk, Shopify), the instance identifier — subdomain for Zendesk (e.g. "mycompany.zendesk.com") or shop domain for Shopify (e.g. "mystore.myshopify.com"). Omitted for providers with static OAuth endpoints (e.g. Google, Slack).
+          example: mycompany.zendesk.com
+        display_name:
+          type: string
+          description: |
+            A human-readable identifier for this connection — the provider username (e.g. GitHub login) when available, otherwise the authenticated user's email address. Omitted when no identifying information is available.
+          example: octocat
+    OAuthConnectionListResponse:
+      type: object
+      required:
+        - connections
+      properties:
+        connections:
+          type: array
+          items:
+            $ref: '#/components/schemas/OAuthConnection'
+          description: List of OAuth connections for the authenticated user
+    OAuthDisconnectResponse:
+      type: object
+      required:
+        - provider
+        - disconnected_at
+      properties:
+        provider:
+          type: string
+          description: The OAuth provider that was disconnected
+          example: google
+        disconnected_at:
+          type: string
+          format: date-time
+          description: When the OAuth provider was disconnected
+          example: '2026-03-05T15:00:00Z'
+    AgentPaymentMethodResponse:
+      type: object
+      required:
+        - agent_id
+        - payment_method_id
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+        payment_method_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The assigned payment method ID, or null if none is assigned
+        created_at:
+          type: string
+          format: date-time
+    AssignAgentPaymentMethodRequest:
+      type: object
+      required:
+        - payment_method_id
+      properties:
+        payment_method_id:
+          type: string
+          format: uuid
+          description: The payment method to assign to this agent
+    RemoveAgentPaymentMethodResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - removed
+    PaymentMethod:
+      type: object
+      description: |
+        A stored payment method (credit/debit card) tokenized via Stripe.
+        Raw card data is never stored — only the Stripe token and display
+        metadata (last4, brand, expiry).
+      required:
+        - id
+        - brand
+        - last4
+        - exp_month
+        - exp_year
+        - is_default
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        label:
+          type: string
+          maxLength: 100
+          description: User-friendly label for the card (e.g. "Personal Visa")
+        brand:
+          type: string
+          description: Card brand (e.g. visa, mastercard, amex)
+        last4:
+          type: string
+          description: Last 4 digits of the card number
+          pattern: ^\d{4}$
+        exp_month:
+          type: integer
+          minimum: 1
+          maximum: 12
+          description: Card expiration month (1-12)
+        exp_year:
+          type: integer
+          description: Card expiration year (e.g. 2027)
+        is_default:
+          type: boolean
+          description: Whether this is the user's default payment method
+        per_transaction_limit:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: Maximum amount in cents per individual agent transaction (null = no limit)
+        monthly_limit:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: Maximum total spend in cents across all agent transactions in the last 30 days (null = no limit)
+        monthly_spend:
+          type: integer
+          minimum: 0
+          description: Current total spend in cents for the rolling 30-day window. Always included in list responses.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    PaymentMethodListResponse:
+      type: object
+      required:
+        - payment_methods
+        - max_allowed
+      properties:
+        payment_methods:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentMethod'
+        max_allowed:
+          type: integer
+          description: Maximum number of payment methods a user can store (currently 10)
+    SetupIntentResponse:
+      type: object
+      required:
+        - client_secret
+      properties:
+        client_secret:
+          type: string
+          description: |
+            Stripe SetupIntent client secret for use with stripe.confirmCardSetup()
+            in Stripe Elements on the frontend. Single-use, expires after 24 hours.
+    ConfirmPaymentMethodRequest:
+      type: object
+      required:
+        - payment_method_id
+      properties:
+        payment_method_id:
+          type: string
+          pattern: ^pm_
+          description: Stripe payment method ID (must start with "pm_")
+        label:
+          type: string
+          maxLength: 100
+          description: User-friendly label for the card (e.g. "Personal Visa")
+        is_default:
+          type: boolean
+          default: false
+          description: Set to true to make this the default payment method
+    UpdatePaymentMethodRequest:
+      type: object
+      properties:
+        label:
+          type: string
+          maxLength: 100
+          description: User-friendly label for the card
+        is_default:
+          type: boolean
+          description: Set to true to make this the default payment method
+        per_transaction_limit:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: |
+            Per-transaction limit in cents. Must not exceed monthly_limit if both
+            are set. Set to a value to create/update the limit.
+        monthly_limit:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: |
+            Monthly spend limit in cents (rolling 30-day window). Must be >= per_transaction_limit
+            if both are set. Set to a value to create/update the limit.
+        clear_label:
+          type: boolean
+          description: Set to true to remove the card nickname/label
+        clear_per_transaction_limit:
+          type: boolean
+          description: Set to true to remove the per-transaction limit entirely
+        clear_monthly_limit:
+          type: boolean
+          description: Set to true to remove the monthly limit entirely
+    DeletePaymentMethodResponse:
+      type: object
+      required:
+        - deleted
+        - affected_agents
+      properties:
+        deleted:
+          type: boolean
+          description: Always true on successful deletion
+        affected_agents:
+          type: integer
+          minimum: 0
+          description: Number of agents that had this payment method assigned (bindings are cascade-deleted)
+    ConfigResponse:
+      type: object
+      description: |
+        Server-level configuration and feature flags. The frontend should
+        fetch this once at startup to determine which UI features to show.
+      required:
+        - billing_enabled
+        - google_oauth_configured
+        - microsoft_oauth_configured
+        - sms_enabled
+      properties:
+        billing_enabled:
+          type: boolean
+          description: |
+            Whether billing features (Stripe integration, request metering, plan
+            limits) are active. When `false` (the default), all users have the
+            unlimited `pay_as_you_go` plan and billing UI should be hidden.
+            Controlled by the `BILLING_ENABLED` server environment variable.
+          example: false
+        google_oauth_configured:
+          type: boolean
+          description: |
+            Whether Google OAuth client credentials are configured on the server.
+            When `true`, the built-in Google connector can initiate OAuth flows.
+            When `false`, the Google connector will not be usable until credentials
+            are set via environment variables.
+          example: true
+        microsoft_oauth_configured:
+          type: boolean
+          description: |
+            Whether Microsoft OAuth client credentials are configured on the server.
+            When `true`, the built-in Microsoft connector can initiate OAuth flows.
+            When `false`, the Microsoft connector will not be usable until credentials
+            are set via environment variables.
+          example: true
+        sms_enabled:
+          type: boolean
+          description: |
+            Whether SMS notifications are configured and available on this server.
+            When `true`, users can enable SMS notifications in their preferences.
+            SMS is enabled when the server has a working AWS SNS sender configured
+            (`AWS_REGION` is set) and the `SMS_NOTIFICATIONS_HIDDEN` env var is not
+            set to `"true"`. Self-hosted deployments that configure SNS will have
+            this set automatically; the hosted platform (app.permissionslip.dev)
+            sets `SMS_NOTIFICATIONS_HIDDEN=true` to hide SMS from users.
+          example: false
     Action:
       type: object
       required:
@@ -6857,12 +11156,12 @@ components:
           description: |
             Action-specific parameters. Structure is defined by the action type and version.
 
-            Permission Slip validates parameters against the expected schema for the action type. 
-            The parameters object is hashed (using RFC 8785 JSON Canonicalization Scheme) and 
-            included in approval tokens as `params_hash` to prevent parameter tampering.
+            Permission Slip validates parameters against the expected schema for the action type.
+            The parameters object is hashed (using RFC 8785 JSON Canonicalization Scheme) and
+            stored with the approval to prevent parameter tampering.
 
-            **Security**: Permission Slip verifies that request parameters match the params_hash 
-            in the approval token before executing actions.
+            **Security**: Permission Slip verifies that request parameters match the stored
+            params_hash before executing actions.
           example:
             from: alice@example.com
             to:
@@ -6926,87 +11225,6 @@ components:
         details:
           recipient_count: 1
           estimated_time: 5 minutes
-    ApprovalToken:
-      type: object
-      required:
-        - access_token
-        - expires_at
-        - scope
-        - scope_version
-      properties:
-        access_token:
-          type: string
-          format: jwt
-          description: |
-            Single-use JWT bearer token for executing the approved action. The token is signed 
-            by Permission Slip using ES256 (ECDSA P-256).
-
-            ## Token Structure
-
-            ### Header
-            ```json
-            {
-              "alg": "ES256",
-              "typ": "JWT",
-              "kid": "key-2026-01"
-            }
-            ```
-
-            ### Payload
-            - `sub` (string): Agent ID
-            - `aud` (string): `permissionslip.dev`
-            - `approver` (string): Username who approved
-            - `approval_id` (string): Approval request ID
-            - `scope` (string): Action type (e.g., `email.send`)
-            - `scope_version` (string): Action version (e.g., `"1"`)
-            - `params_hash` (string): SHA-256 hash of JCS-canonicalized parameters
-            - `iat` (integer): Issued at (Unix timestamp)
-            - `exp` (integer): Expires at (Unix timestamp)
-            - `jti` (string): Unique token ID (for single-use enforcement)
-
-            ## Usage
-
-            Pass this token in the `token` field when calling `POST /v1/actions/execute`. 
-            Permission Slip validates the token and executes the approved action using the 
-            user's stored credentials.
-
-            ## Token Lifecycle
-
-            - **Single-use**: Consumed after first successful use (enforced via `jti` claim)
-            - **Expiration**: Typically 5 minutes (matches approval TTL)
-            - **No refresh**: Protocol does not support token refresh
-            - **Retry guidance**: Use immediately; request new approval if expired or already used
-          example: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ2VudF94N0s5bVA0biIsImF1ZCI6InBlcm1pc3Npb25zbGlwLmRldiIsImFwcHJvdmVyIjoiYWxpY2UiLCJhcHByb3ZhbF9pZCI6ImFwcHJfeHl6Nzg5Iiwic2NvcGUiOiJlbWFpbC5zZW5kIiwic2NvcGVfdmVyc2lvbiI6IjEiLCJwYXJhbXNfaGFzaCI6ImJhMDYxN2IyMzM0MTcwY2I5MzY5MTZkYjIwMjQwMDMwMGExZmRjMWZlNzFlMzZiOTExZDA4YjI1MTlmM2Q2OGMiLCJpYXQiOjE3NzA4MTYwNDUsImV4cCI6MTc3MDgxNjM0NSwianRpIjoidG9rX3VuaXF1ZTEyMyJ9.signature
-        expires_at:
-          type: string
-          format: date-time
-          description: |
-            ISO 8601 timestamp (RFC 3339 format, UTC) when the token expires. After this time, 
-            the token is invalid and services will reject it with `401 Unauthorized` error code 
-            `invalid_token`.
-
-            Typically matches the approval request expiration (5 minutes from approval time).
-          example: '2026-02-11T13:25:45Z'
-        scope:
-          type: string
-          maxLength: 128
-          description: |
-            Action type this token authorizes. Must match the `type` from the approval request.
-            Permission Slip verifies this matches the `action_id` in the execute request.
-          example: email.send
-        scope_version:
-          type: string
-          pattern: ^\d+$
-          maxLength: 10
-          description: |
-            Action type version this token authorizes. Must match the `version` from the approval 
-            request.
-          example: '1'
-      example:
-        access_token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
-        expires_at: '2026-02-11T13:25:45Z'
-        scope: email.send
-        scope_version: '1'
     AlternativeUrls:
       type: object
       description: |
@@ -7033,6 +11251,40 @@ components:
       example:
         deeplink: permissionslip://permission-slip/approve?token=eyJ...
         web: https://accounts.permissionslip.dev/permission-slip/approve?token=eyJ...
+    ExecutionStatus:
+      type: string
+      enum:
+        - pending
+        - success
+        - partial
+        - error
+      description: |
+        Status of the action execution.
+
+        - **pending**: Execution is still in progress
+        - **success**: Action executed successfully via the external service
+        - **partial**: Action partially completed (e.g., some recipients failed)
+        - **error**: Action execution failed
+      example: success
+    ExecutionResult:
+      type: object
+      additionalProperties: true
+      nullable: true
+      description: |
+        Result data from executing the action. Structure varies by action type.
+        May be null if execution is still pending or if an error occurred.
+
+        On success, contains the external service response (e.g., `{ "message_id": "msg_abc123" }`).
+        On error, contains error details (e.g., `{ "error": "upstream_timeout", "message": "..." }`).
+      example:
+        message_id: msg_abc123
+        delivery_status: queued
+    ExecutedAt:
+      type: string
+      format: date-time
+      nullable: true
+      description: When the action was executed (null if not yet executed)
+      example: '2026-02-21T10:30:01Z'
     Error:
       type: object
       required:
@@ -7059,6 +11311,7 @@ components:
             - timestamp_expired
             - invalid_code
             - invalid_token
+            - oauth_refresh_failed
             - agent_not_authorized
             - approval_denied
             - token_already_used
@@ -7072,20 +11325,28 @@ components:
             - agent_connector_not_found
             - credentials_not_found
             - no_matching_standing_approval
-            - standing_approval_exhausted
+            - agent_limit_reached
+            - standing_approval_limit_reached
+            - credential_limit_reached
             - constraint_violation
             - standing_approval_expired
+            - subscription_not_found
             - agent_already_registered
             - duplicate_request_id
             - approval_already_resolved
             - duplicate_credential
+            - already_subscribed
+            - invalid_coupon
+            - plan_change_not_allowed
             - registration_expired
             - verification_locked
             - approval_expired
             - rate_limited
+            - monthly_quota_exceeded
             - internal_error
             - upstream_error
             - service_unavailable
+            - billing_not_enabled
           example: invalid_signature
         message:
           type: string
@@ -7124,8 +11385,8 @@ components:
           type: integer
           minimum: 1
           description: |
-            Present only for `rate_limited` errors. Number of seconds the client should wait 
-            before retrying the request.
+            Present for `rate_limited` and `monthly_quota_exceeded` errors. Number of seconds
+            the client should wait before retrying the request.
           example: 60
     ErrorResponse:
       type: object
@@ -7143,6 +11404,26 @@ components:
             timestamp: '1770816000'
             expected_window: 300 seconds
           trace_id: trace_xyz789
+    ApproverInfo:
+      type: object
+      description: |
+        Identifies the user (approver) an agent is registered to. Included in
+        agent-facing responses so the agent knows which user it's working with.
+
+        Only the username is exposed — email, phone, and other PII are never
+        sent to agents.
+      required:
+        - username
+      properties:
+        username:
+          type: string
+          maxLength: 40
+          description: |
+            The approver's username on Permission Slip. This is the user's
+            public-facing identifier — safe to display and log.
+          example: alice
+      example:
+        username: alice
     AgentListResponse:
       type: object
       description: Paginated list of agents.
@@ -7165,6 +11446,517 @@ components:
             next page. Only present when `has_more` is true. Do not construct
             or parse cursor values — they may change format without notice.
           example: 2026-02-11T13:15:00.123456Z,42
+    AgentConnectorCredentialResponse:
+      type: object
+      required:
+        - agent_id
+        - connector_id
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+          description: Agent identifier.
+          example: 42
+        connector_id:
+          type: string
+          maxLength: 128
+          description: Connector identifier.
+          example: gmail
+        credential_id:
+          type: string
+          nullable: true
+          description: Static credential ID if assigned.
+          example: cred_abc123
+        oauth_connection_id:
+          type: string
+          nullable: true
+          description: OAuth connection ID if assigned.
+          example: oc_def456
+      example:
+        agent_id: 42
+        connector_id: gmail
+        oauth_connection_id: oc_def456
+    AssignCredentialRequest:
+      type: object
+      description: |
+        Assign a credential to an agent-connector pair. Exactly one of `credential_id`
+        or `oauth_connection_id` must be provided.
+      properties:
+        credential_id:
+          type: string
+          description: Static credential ID to assign.
+          example: cred_abc123
+        oauth_connection_id:
+          type: string
+          description: OAuth connection ID to assign.
+          example: oc_def456
+    CalendarListItem:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Provider calendar identifier (Google calendar ID or Microsoft Graph calendar id).
+        summary:
+          type: string
+          description: Human-readable name (Google Calendar `summary`).
+        name:
+          type: string
+          description: Human-readable name (Microsoft Graph `name`).
+        primary:
+          type: boolean
+          description: True when this is the user's primary Google calendar.
+        isDefaultCalendar:
+          type: boolean
+          description: True when this is the default Microsoft Graph calendar.
+    AgentConnectorCalendarListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarListItem'
+    ChannelListItem:
+      type: object
+      required:
+        - id
+        - display_label
+      properties:
+        id:
+          type: string
+          description: Slack channel ID (C…, G…, or D…).
+        name:
+          type: string
+          description: Channel name when available (may be empty for some DMs).
+        user:
+          type: string
+          description: For IM channels, the other participant's user ID when present.
+        is_private:
+          type: boolean
+          description: True for private channels (no
+        is_im:
+          type: boolean
+          description: True for direct messages.
+        is_mpim:
+          type: boolean
+          description: True for group direct messages.
+        num_members:
+          type: integer
+          description: Member count when provided by Slack.
+        display_label:
+          type: string
+          description: Human-readable label for pickers (#public-name, private name, DM label).
+    AgentConnectorChannelListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelListItem'
+    UserListItem:
+      type: object
+      required:
+        - id
+        - display_label
+      properties:
+        id:
+          type: string
+          description: Slack user ID (U…).
+        name:
+          type: string
+          description: Slack username.
+        real_name:
+          type: string
+          description: User's real name.
+        display_name:
+          type: string
+          description: User's display name.
+        email:
+          type: string
+          description: User's email address when available.
+        is_bot:
+          type: boolean
+          description: True for bot users.
+        display_label:
+          type: string
+          description: Human-readable label for pickers (real name with email).
+    AgentConnectorUserListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserListItem'
+    RetentionMeta:
+      type: object
+      description: |
+        Retention policy metadata for audit events. Included in responses when
+        billing is enabled to help clients display contextual information about
+        the user's data retention window.
+      required:
+        - days
+      properties:
+        days:
+          type: integer
+          description: |
+            The effective number of days audit events are retained. During a
+            downgrade grace period, this reflects the previous (longer) retention.
+          example: 7
+        grace_period_ends_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When the downgrade grace period expires. Only present if the user
+            recently downgraded from a paid plan. After this time, the shorter
+            retention window takes effect.
+          example: '2026-03-08T14:30:00Z'
+    StandingApprovalTemplateSpec:
+      type: object
+      description: |
+        Manifest-authored standing approval behavior when a template is applied.
+      properties:
+        duration_days:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: |
+            Number of days until the standing approval expires. `null` means no
+            expiry (until revoked).
+    BulkApplyActionConfigTemplateRequest:
+      type: object
+      required:
+        - agent_id
+        - template_ids
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+          description: Agent to attach the new configurations and standing approvals to.
+          example: 42
+        template_ids:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+          minItems: 1
+          maxItems: 50
+          description: |
+            Template IDs to apply. All templates must belong to the same connector.
+            Duplicates are silently deduplicated.
+          example:
+            - tpl_github_create_issue_all
+            - tpl_github_merge_pr_all
+        approval_modes:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - auto_approve
+              - requires_approval
+          description: |
+            Optional per-template approval mode overrides keyed by template ID.
+            Templates not in this map use their built-in behavior.
+          example:
+            tpl_github_create_issue_all: auto_approve
+    LinkedStandingApprovalSummary:
+      type: object
+      required:
+        - standing_approval_id
+        - action_type
+        - status
+      properties:
+        standing_approval_id:
+          type: string
+          description: Standing approval identifier.
+        action_type:
+          type: string
+          description: Action type covered by this standing approval.
+        status:
+          type: string
+          description: Standing approval status (typically `active` in this summary).
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the standing approval expires, or null if it lasts until revoked.
+    BulkApplyResultError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+          example: standing_approval_limit_reached
+        message:
+          type: string
+          description: Human-readable error message.
+          example: Standing approval limit reached
+    BulkApplyResult:
+      type: object
+      required:
+        - template_id
+        - success
+      properties:
+        template_id:
+          type: string
+          description: The template ID that was applied (or failed).
+        success:
+          type: boolean
+          description: Whether this template was applied successfully.
+        action_configuration:
+          $ref: '#/components/schemas/ActionConfiguration'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApproval'
+          description: Present when the template bundles a standing approval and it was created successfully.
+        error:
+          $ref: '#/components/schemas/BulkApplyResultError'
+          description: Present when `success` is false.
+    BulkApplyActionConfigTemplateResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkApplyResult'
+          description: |
+            Per-template results. Order matches the deduplicated input order.
+    ApplyActionConfigTemplateRequest:
+      type: object
+      required:
+        - agent_id
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+          description: Agent to attach the new configuration and standing approval to.
+          example: 42
+        approval_mode:
+          type: string
+          enum:
+            - auto_approve
+            - requires_approval
+          description: |
+            Override the template's built-in approval behavior.
+            `auto_approve` creates a standing approval (using the template's spec
+            if present, otherwise sensible defaults: no expiry, unlimited executions).
+            `requires_approval` skips standing approval creation.
+            When omitted, falls back to the template's built-in behavior.
+    ApplyActionConfigTemplateResponse:
+      type: object
+      required:
+        - action_configuration
+      properties:
+        action_configuration:
+          $ref: '#/components/schemas/ActionConfiguration'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApproval'
+          description: Present when the template bundles a standing approval.
+    NotificationPreferenceUpdate:
+      type: object
+      description: A channel preference update (request-only, no `available` field).
+      required:
+        - channel
+        - enabled
+      properties:
+        channel:
+          type: string
+          description: Notification channel identifier
+          enum:
+            - email
+            - web-push
+            - sms
+            - mobile-push
+          example: email
+        enabled:
+          type: boolean
+          description: Whether notifications should be enabled for this channel
+          example: true
+    PlanLimits:
+      type: object
+      required:
+        - max_requests_per_month
+        - max_agents
+        - max_standing_approvals
+        - max_credentials
+        - audit_retention_days
+      properties:
+        max_requests_per_month:
+          type: integer
+          nullable: true
+          description: Monthly request limit (null = unlimited)
+          example: 1000
+        max_agents:
+          type: integer
+          nullable: true
+          description: Maximum number of agents (null = unlimited)
+          example: 3
+        max_standing_approvals:
+          type: integer
+          nullable: true
+          description: Maximum active standing approvals (null = unlimited)
+          example: 5
+        max_credentials:
+          type: integer
+          nullable: true
+          description: Maximum stored credentials (null = unlimited)
+          example: 5
+        audit_retention_days:
+          type: integer
+          description: Number of days audit logs are retained
+          example: 7
+    DowngradeLimitWarning:
+      type: object
+      required:
+        - resource
+        - current
+        - max_allowed
+      properties:
+        resource:
+          type: string
+          description: Resource type over the free-tier cap (e.g. agents, credentials)
+          example: agents
+        current:
+          type: integer
+          description: Current count for that resource
+          example: 5
+        max_allowed:
+          type: integer
+          description: Maximum allowed on the free plan (applies after quota grace ends)
+          example: 3
+    DowngradeResponse:
+      type: object
+      required:
+        - status
+        - plan_id
+        - downgraded_at
+        - grace_period_ends_at
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+            - past_due
+            - cancelled
+          description: Updated subscription status (will be `cancelled` after downgrade)
+          example: cancelled
+        plan_id:
+          type: string
+          description: The plan the user was downgraded to
+          example: free
+        downgraded_at:
+          type: string
+          format: date-time
+          description: Timestamp when the downgrade was processed
+        grace_period_ends_at:
+          type: string
+          format: date-time
+          description: |
+            When the 7-day audit retention grace period expires. Until this time, the user
+            retains the longer paid-plan audit retention window to export data.
+        quota_entitlements_until:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When paid-plan resource and request quotas stop applying. Until then, limits
+            match the previous paid plan even though the billing plan is now free.
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/DowngradeLimitWarning'
+          description: |
+            Non-blocking notices when the user exceeds free-tier caps; those limits apply
+            after `quota_entitlements_until`.
+    InvoiceListResponse:
+      type: object
+      required:
+        - invoices
+        - has_more
+      properties:
+        invoices:
+          type: array
+          items:
+            $ref: '#/components/schemas/Invoice'
+        has_more:
+          type: boolean
+          description: Whether there are more invoices beyond this page. If true, pass the last invoice's `id` as `starting_after` to fetch the next page.
+          example: false
+    BillingPricing:
+      type: object
+      description: |
+        Per-request pricing information sourced from Stripe. Included for all
+        plans so the upgrade flow can show Stripe-sourced pricing to free users.
+        The frontend should use these values instead of deriving pricing from
+        plans.json, so Stripe remains the single source of truth.
+      required:
+        - free_request_allowance
+        - price_per_request_display
+      properties:
+        free_request_allowance:
+          type: integer
+          description: Number of requests included free each billing period before per-request charges apply.
+          example: 1000
+        price_per_request_display:
+          type: string
+          description: Human-readable per-request price string (e.g. "$0.005"), sourced from the Stripe price object.
+          example: $0.005
+    RedeemCouponRequest:
+      type: object
+      required:
+        - coupon
+      properties:
+        coupon:
+          type: string
+          description: |
+            Lowercase hex HMAC-SHA256(`COUPON_SECRET`, trimmed username) for the
+            authenticated user's profile username. One-time grant from free to
+            complimentary Pro when valid.
+          minLength: 64
+          maxLength: 64
+          pattern: ^[0-9a-f]{64}$
+          example: a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456
+    RedeemCouponResponse:
+      type: object
+      required:
+        - plan_id
+        - status
+      properties:
+        plan_id:
+          type: string
+          description: Plan after redemption (typically "free_pro")
+          example: free_pro
+        status:
+          type: string
+          description: |
+            `redeemed` when the plan was upgraded, `already_redeemed` when the
+            account was already on complimentary Pro.
+          enum:
+            - redeemed
+            - already_redeemed
+          example: redeemed
+    PortalResponse:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          format: uri
+          pattern: ^https://
+          description: Stripe Billing Portal URL — redirect the user here to manage their subscription. Always HTTPS.
+          example: https://billing.stripe.com/p/session/test_...
   parameters:
     ActionConfigId:
       name: config_id
@@ -7270,6 +12062,24 @@ components:
         pattern: ^sa_[a-zA-Z0-9]{6,64}$
         maxLength: 70
       example: sa_abc123
+    PushSubscriptionId:
+      name: subscription_id
+      in: path
+      required: true
+      description: Push subscription ID (auto-incrementing integer).
+      schema:
+        type: integer
+        format: int64
+      example: 1
+    ExpoPushTokenId:
+      name: token_id
+      in: path
+      required: true
+      description: Expo push token registration ID (auto-incrementing integer).
+      schema:
+        type: integer
+        format: int64
+      example: 1
   responses:
     BadRequest:
       description: Bad Request - Invalid or malformed request
@@ -7514,22 +12324,44 @@ components:
                     max_attempts: 5
                   trace_id: trace_xyz789
     TooManyRequests:
-      description: Too Many Requests - Rate limit exceeded
+      description: Too Many Requests - Rate limit or monthly quota exceeded
+      headers:
+        Retry-After:
+          description: Seconds until the rate limit resets or the billing period ends
+          schema:
+            type: integer
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-          example:
-            error:
-              code: rate_limited
-              message: Too many requests. Please retry after 60 seconds.
-              retryable: true
-              retry_after: 60
-              details:
-                limit: 100
-                window: 1 minute
-                reset_at: '2026-02-11T13:26:00Z'
-              trace_id: trace_xyz789
+          examples:
+            rate_limited:
+              summary: Per-IP or per-agent rate limit exceeded
+              value:
+                error:
+                  code: rate_limited
+                  message: Too many requests. Please retry after 60 seconds.
+                  retryable: true
+                  retry_after: 60
+                  details:
+                    limit: 100
+                    window: 1 minute
+                    reset_at: '2026-02-11T13:26:00Z'
+                  trace_id: trace_xyz789
+            monthly_quota_exceeded:
+              summary: Free tier monthly request quota exhausted
+              value:
+                error:
+                  code: monthly_quota_exceeded
+                  message: Free tier limit of 1000 requests/month reached. Upgrade to continue.
+                  retryable: true
+                  retry_after: 86400
+                  details:
+                    current_usage: 1000
+                    limit: 1000
+                    plan_id: free
+                    reset_at: '2026-04-01T00:00:00Z'
+                  trace_id: trace_xyz789
     InternalServerError:
       description: Internal Server Error - Unexpected server error
       content:

--- a/spec/openapi/bundled.yaml
+++ b/spec/openapi/bundled.yaml
@@ -3,10 +3,9 @@ info:
   title: Permission Slip API
   version: 0.1.0
   description: |
-    Permission Slip is a centralized middle-man service that sits between AI agents and external 
-    APIs. Agents submit pre-defined **actions** for human approval, and Permission Slip executes 
-    them using the user's stored credentials. Agents never see user credentials and can never 
-    make arbitrary API calls.
+    Permission Slip is the approval layer for Openclaw. Openclaw submits pre-defined **actions**
+    for human approval, and Permission Slip executes them using the user's stored credentials.
+    Openclaw never sees user credentials and can never make arbitrary API calls.
 
     **Base URL**: `http://localhost:8080`
 
@@ -15,7 +14,7 @@ info:
     - **Action**: Pre-defined, structured request with a type, validated parameters, and execution logic — the core primitive
     - **Agent**: Automated system with a cryptographic key pair that submits actions for approval
     - **Approver**: Human authorized to approve or deny agent actions
-    - **Connector**: Integration with an external service (e.g., Gmail, Stripe) that defines available actions
+    - **Connector**: Integration with an external service (e.g., Gmail, Stripe, PayPal) that defines available actions
     - **Credential**: Encrypted API key or OAuth token for an external service, stored in Permission Slip's vault
     - **Registration**: One-time setup where agent proves identity via public key
     - **Approval Request**: Async request for permission to execute a specific action
@@ -53,7 +52,7 @@ info:
     ## Architecture
 
     ```
-    Agent ──→ Permission Slip ──→ External Service (Gmail, Stripe, etc.)
+    Agent ──→ Permission Slip ──→ External Service (Gmail, Stripe, PayPal, etc.)
                    │
                    ▼
               User (approve/deny)
@@ -116,12 +115,16 @@ paths:
       summary: List Available Connectors
       description: |
         List all available connectors (external service integrations) that Permission Slip
-        supports. Each connector represents an external service (e.g., GitHub, Stripe, Slack)
+        supports. Each connector represents an external service (e.g., GitHub, Stripe, PayPal, Slack)
         and defines which actions are available.
 
         Agents use this endpoint to discover what actions they can submit for approval. 
         This replaces the old service discovery model — agents don't need to know about 
         individual service URLs, they just query Permission Slip for available actions.
+
+        Built-in connectors (for example `instacart` with `instacart.create_products_link`)
+        appear here automatically from connector manifests; parameter schemas and optional
+        display templates are the source of truth at runtime, not this OpenAPI document.
 
         ## Use Cases
 
@@ -133,6 +136,13 @@ paths:
 
         This endpoint is publicly accessible (no signature required) to allow agents to 
         discover available actions before registration.
+
+        ## PayPal / Venmo
+
+        The **paypal** connector exposes PayPal REST actions (payouts, Checkout orders, invoicing,
+        refunds). Users connect via OAuth (`GET /v1/oauth/paypal/authorize`). Optional credential
+        key `environment`=`sandbox` routes REST calls to PayPal's sandbox API host. See
+        `docs/oauth-setup.md` (PayPal OAuth Setup) and `connectors/paypal/README.md` in the repo.
       tags:
         - Connectors
       security: []
@@ -183,6 +193,9 @@ paths:
 
         This endpoint is publicly accessible (no signature required) to allow agents to 
         discover action schemas before registration.
+
+        For connector-specific setup (e.g. PayPal OAuth and optional `environment` credential for
+        sandbox REST), see the repository docs referenced in the list-connectors description.
       tags:
         - Connectors
       security: []
@@ -1180,8 +1193,6 @@ paths:
                                 constraints:
                                   recipient_pattern: '*@mycompany.com'
                                   max_recipients: 5
-                                max_executions: 100
-                                executions_remaining: 88
                                 expires_at: '2026-05-15T00:00:00Z'
                             action_configurations:
                               - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -1211,8 +1222,6 @@ paths:
                                 constraints:
                                   sender: '*@github.com'
                                   max_results: 10
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-02-28T00:00:00Z'
                             action_configurations: []
                       - id: stripe
@@ -1283,14 +1292,10 @@ paths:
                               - standing_approval_id: sa_read01
                                 constraints:
                                   sender: '*@github.com'
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-03-15T00:00:00Z'
                               - standing_approval_id: sa_read02
                                 constraints:
                                   sender: '*@linear.app'
-                                max_executions: 50
-                                executions_remaining: 50
                                 expires_at: '2026-03-01T00:00:00Z'
                             action_configurations: []
         '400':
@@ -1661,6 +1666,85 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           description: Agent, connector, or calendar listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/channels:
+    get:
+      operationId: listAgentConnectorChannels
+      summary: List channels for agent connector
+      description: |
+        Returns Slack channels visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate channel pickers for Slack actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Channels listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorChannelListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or channel listing not supported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/users:
+    get:
+      operationId: listAgentConnectorUsers
+      summary: List users for agent connector
+      description: |
+        Returns workspace users visible to the OAuth credential assigned to this agent–connector pair.
+        Used by the dashboard to populate user pickers for Slack actions.
+
+        Requires session authentication (Supabase JWT). The agent must belong to the current user.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Users listed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorUserListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent, connector, or user listing not supported
           content:
             application/json:
               schema:
@@ -2106,7 +2190,7 @@ paths:
 
         1. **Parameters validated**: Against standing approval constraints
         2. **Action executed**: Immediately via the connector using stored credentials
-        3. **Result returned**: Response has `status: "approved"` with `result`, `standing_approval_id`, and `executions_remaining`
+        3. **Result returned**: Response has `status: "approved"` with `result` and `standing_approval_id`
         4. **No polling needed**: The agent has the result immediately
 
         ## One-off Approval (No Standing Approval Match)
@@ -2251,7 +2335,6 @@ paths:
                       message_id: msg_abc123
                       delivery_status: queued
                     standing_approval_id: sa_abc123
-                    executions_remaining: 47
         '400':
           description: Invalid request or unsupported action type
           content:
@@ -3164,6 +3247,122 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /v1/action-config-templates/bulk-apply:
+    post:
+      operationId: bulkApplyActionConfigTemplates
+      summary: Bulk Apply Action Configuration Templates
+      description: |
+        Apply multiple templates in a single request. Creates an action
+        configuration (and optional standing approval) for each template.
+
+        All templates must belong to the same connector. The connector is
+        automatically enabled for the agent if not already enabled.
+
+        Each template is applied independently — if one fails (e.g., standing
+        approval limit reached), the others still succeed. The response
+        includes per-template results.
+      tags:
+        - Action Configurations
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkApplyActionConfigTemplateRequest'
+      responses:
+        '200':
+          description: |
+            Bulk apply completed. Check individual `results[].success` for
+            per-template outcomes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkApplyActionConfigTemplateResponse'
+        '400':
+          description: Invalid request (empty list, mixed connectors, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: |
+            A requested template ID was not found. This is an upfront
+            validation error — no configurations are created.
+            Per-template failures (e.g., agent not found, standing approval
+            limit) are reported in `results[]` with `success: false`, not
+            as HTTP-level errors.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/action-config-templates/{id}/apply:
+    post:
+      operationId: applyActionConfigTemplate
+      summary: Apply Action Configuration Template
+      description: |
+        Create an action configuration from a template in one step. When the
+        template defines `standing_approval`, also creates an active standing
+        approval in the same transaction.
+
+        If the connector is not yet enabled for the agent, it is enabled
+        automatically so the configuration can be created.
+      tags:
+        - Action Configurations
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Template ID (from list templates).
+          schema:
+            type: string
+            maxLength: 255
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyActionConfigTemplateRequest'
+      responses:
+        '201':
+          description: Configuration created (and standing approval if applicable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplyActionConfigTemplateResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Standing approval plan limit reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Template or agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/action-configurations:
     post:
       operationId: createActionConfiguration
@@ -3722,12 +3921,12 @@ paths:
         - **Agent startup**: Agent queries its standing approvals to understand what it can do
         - **Flow selection**: Agent checks if a standing approval covers a desired action before
           deciding whether to use `POST /v1/actions/execute` (standing) or `POST /v1/approvals/request` (one-off)
-        - **Status monitoring**: Agent checks remaining executions or expiration times
+        - **Status monitoring**: Agent checks expiration times
 
         ## Filtering
 
-        Only standing approvals with status `active` are returned by default. Expired,
-        revoked, and exhausted standing approvals are excluded.
+        Only standing approvals with status `active` are returned by default. Expired
+        and revoked standing approvals are excluded.
 
         ## Security
 
@@ -3780,8 +3979,6 @@ paths:
                       sender: '*@github.com'
                       max_results: 10
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
@@ -3796,8 +3993,6 @@ paths:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
                     status: active
-                    max_executions: 100
-                    execution_count: 12
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-05-15T00:00:00Z'
                     created_at: '2026-02-14T10:35:00Z'
@@ -3869,7 +4064,6 @@ paths:
               - active
               - expired
               - revoked
-              - exhausted
               - all
             default: active
           example: active
@@ -3893,6 +4087,16 @@ paths:
           schema:
             type: string
           example: 2026-02-14T10:30:00Z,sa_abc123
+        - name: source_action_configuration_id
+          in: query
+          required: false
+          description: |
+            When set, only standing approvals whose `source_action_configuration_id`
+            matches this value are returned (e.g. to filter approvals linked to a
+            specific action configuration).
+          schema:
+            type: string
+            maxLength: 128
       responses:
         '200':
           description: Standing approvals retrieved successfully
@@ -3910,8 +4114,6 @@ paths:
                     constraints:
                       sender: '*@github.com'
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
@@ -3979,7 +4181,6 @@ paths:
               constraints:
                 recipient_pattern: '*@mycompany.com'
               source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-              max_executions: 100
               expires_at: '2026-03-14T00:00:00Z'
       responses:
         '201':
@@ -4107,7 +4308,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -4131,17 +4332,13 @@ paths:
       operationId: updateStandingApproval
       summary: Update Standing Approval
       description: |
-        Update the constraints, max_executions, and expires_at of an active standing approval.
+        Update the constraints and expires_at of an active standing approval.
         The standing approval must belong to the authenticated user and be in `active` status.
-        Agent and action type cannot be changed — only constraints and limits.
+        Agent and action type cannot be changed — only constraints and expiry.
 
         **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
         the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
         not a rolling window from the time of the update call.
-
-        **Execution count**: `max_executions` cannot be set below the approval's current
-        `execution_count`. The update is rejected atomically at the database level to prevent
-        a race condition where concurrent executions could otherwise create a zombie approval.
 
         Emits a `standing_approval.updated` audit event on success.
       tags:
@@ -4159,7 +4356,6 @@ paths:
             example:
               constraints:
                 recipient_pattern: '*@mycompany.com'
-              max_executions: 200
               expires_at: '2026-04-14T00:00:00Z'
       responses:
         '200':
@@ -4195,7 +4391,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -4213,7 +4409,7 @@ paths:
       description: |
         Record an execution of an active standing approval. The standing approval
         must belong to the authenticated user and be in `active` status. Atomically
-        increments the execution count and creates an execution record.
+        creates an execution record.
 
         Emits a `standing_approval.executed` audit event on success.
       tags:
@@ -4283,7 +4479,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -5635,6 +5831,7 @@ paths:
                       - https://www.googleapis.com/auth/userinfo.email
                     source: built_in
                     has_credentials: true
+                    pkce: false
                   - id: microsoft
                     scopes:
                       - openid
@@ -5642,6 +5839,15 @@ paths:
                       - User.Read
                     source: built_in
                     has_credentials: true
+                    pkce: false
+                  - id: dropbox
+                    scopes:
+                      - files.content.read
+                      - files.content.write
+                      - sharing.write
+                    source: built_in
+                    has_credentials: true
+                    pkce: true
         '401':
           $ref: '#/components/responses/Unauthorized'
         '429':
@@ -5672,6 +5878,13 @@ paths:
         the `user_scope` query parameter and does **not** send a bot `scope` parameter.
         After consent, the stored connection uses the Slack user token (`xoxp-`) as the
         primary secret. Workspace bot install is not required.
+
+        ### PKCE (`pkce: true` on the provider)
+
+        For providers that require PKCE (e.g. Dropbox), the server adds an S256 code
+        challenge to the provider authorization URL and stores the verifier only inside
+        the signed state token (encrypted at rest in the JWT payload). No client-side
+        PKCE logic is required.
       tags:
         - OAuth
       security:
@@ -5737,6 +5950,11 @@ paths:
         When Slack token rotation is enabled, user `refresh_token` and expiry may be
         nested under `authed_user` in the token response; the server normalizes these
         before persisting.
+
+        ### PKCE
+
+        When the provider uses PKCE, the callback recovers the code verifier from the
+        validated state token and passes it to the token exchange per RFC 7636.
       tags:
         - OAuth
       security:
@@ -6575,9 +6793,8 @@ components:
         Response after submitting an approval request. Two possible outcomes:
 
         **Auto-approved** (`status: "approved"`): A matching standing approval was found.
-        The action was executed immediately. The response includes `result`,
-        `standing_approval_id`, and optionally `executions_remaining`. No `approval_id`
-        or `approval_url` is returned.
+        The action was executed immediately. The response includes `result` and
+        `standing_approval_id`. No `approval_id` or `approval_url` is returned.
 
         **Pending** (`status: "pending"`): No standing approval matched. A pending approval
         was created. The agent should poll `GET /v1/approvals/{approval_id}/status` for the
@@ -6632,13 +6849,6 @@ components:
           description: |
             ID of the standing approval that matched. Present only when `status` is `approved`.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          description: |
-            Number of executions remaining on the standing approval.
-            Present only when `status` is `approved` and the standing approval has a
-            finite `max_executions`. Absent when unlimited.
-          example: 47
       example:
         approval_id: appr_xyz789
         approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
@@ -6953,6 +7163,12 @@ components:
             repo: '*'
             title: '*'
             body: '*'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApprovalTemplateSpec'
+          description: |
+            When present, applying this template also creates an active standing
+            approval with constraints derived from `parameters`. Omitted when the
+            template does not bundle auto-approval.
         created_at:
           type: string
           format: date-time
@@ -7086,6 +7302,13 @@ components:
           description: |
             Optional longer description of what this configuration permits.
           example: Agent can create issues labeled 'bug' in the main repo. Title and body are freeform.
+        linked_standing_approvals:
+          type: array
+          description: |
+            Active standing approvals that reference this configuration via
+            `source_action_configuration_id`. Omitted when empty.
+          items:
+            $ref: '#/components/schemas/LinkedStandingApprovalSummary'
         created_at:
           type: string
           format: date-time
@@ -7613,6 +7836,7 @@ components:
         description: GitHub integration for repository management
         actions:
           - action_type: github.create_issue
+            operation_type: write
             name: Create Issue
             description: Create a new issue in a repository
             risk_level: low
@@ -7633,6 +7857,7 @@ components:
                   type: string
                   description: Issue body (markdown)
           - action_type: github.merge_pr
+            operation_type: write
             name: Merge Pull Request
             description: Merge an open pull request
             risk_level: medium
@@ -7661,6 +7886,7 @@ components:
       type: object
       required:
         - action_type
+        - operation_type
         - name
       properties:
         action_type:
@@ -7670,6 +7896,16 @@ components:
             Action type identifier. Use this value as the `action.type` when submitting 
             approval requests and as `action_id` when executing actions.
           example: github.create_issue
+        operation_type:
+          type: string
+          enum:
+            - read
+            - write
+            - delete
+          description: |
+            High-level classification for bulk template setup and grouping in the UI.
+            Derived from verb-based action naming (e.g. list/get → read, create/update → write,
+            delete/cancel → delete) unless overridden in the connector manifest.
         name:
           type: string
           maxLength: 256
@@ -7763,6 +7999,7 @@ components:
               end: end_time
       example:
         action_type: github.create_issue
+        operation_type: write
         name: Create Issue
         description: Create a new issue in a repository
         risk_level: low
@@ -7835,7 +8072,6 @@ components:
         - action_type
         - constraints
         - status
-        - execution_count
         - starts_at
         - created_at
         - source_action_configuration_id
@@ -7898,30 +8134,13 @@ components:
             - active
             - expired
             - revoked
-            - exhausted
           description: |
             Current status of the standing approval.
 
             - **active**: Agent can execute actions under this standing approval
             - **expired**: Duration elapsed; agent must request a new standing approval or use one-off
             - **revoked**: User manually cancelled this standing approval
-            - **exhausted**: Max execution count reached
           example: active
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of times the agent can execute under this standing approval.
-            `null` means unlimited — the agent can execute as many times as it wants
-            within the duration.
-          example: null
-        execution_count:
-          type: integer
-          minimum: 0
-          description: |
-            Number of times this standing approval has been used so far.
-          example: 42
         starts_at:
           type: string
           format: date-time
@@ -7953,16 +8172,14 @@ components:
           example: null
         source_action_configuration_id:
           type: string
+          minLength: 1
           maxLength: 128
-          nullable: true
           description: |
-            The action configuration this standing approval was derived from, if any.
-            Nullable — `null` when the standing approval was created with a custom
-            action type rather than from an existing configuration. The referenced
-            configuration may have been deleted since creation.
+            The action configuration this standing approval is tied to. Every standing
+            approval references a backing configuration row.
             Expected format: `ac_` prefix followed by 32 hex characters, but the
             backend does not enforce the pattern.
-          example: null
+          example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
       example:
         standing_approval_id: sa_abc123
         agent_id: 42
@@ -7973,13 +8190,11 @@ components:
           sender: '*@github.com'
           max_results: 10
         status: active
-        max_executions: null
-        execution_count: 42
         starts_at: '2026-02-14T00:00:00Z'
         expires_at: '2026-02-21T00:00:00Z'
         created_at: '2026-02-14T10:30:00Z'
         revoked_at: null
-        source_action_configuration_id: null
+        source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
     StandingApprovalExecuteRequest:
       type: object
       required:
@@ -8047,7 +8262,6 @@ components:
       required:
         - result
         - standing_approval_id
-        - executions_remaining
       properties:
         result:
           type: object
@@ -8066,14 +8280,6 @@ components:
           description: |
             Which standing approval authorized this execution.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining under this standing approval.
-            `null` means unlimited.
-          example: null
       example:
         result:
           emails:
@@ -8081,7 +8287,6 @@ components:
               subject: PR merged
               sender: noreply@github.com
         standing_approval_id: sa_abc123
-        executions_remaining: null
     StandingApprovalListResponse:
       type: object
       required:
@@ -8121,13 +8326,11 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
             revoked_at: null
-            source_action_configuration_id: null
+            source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
         has_more: false
     UserStandingApprovalListResponse:
       type: object
@@ -8163,8 +8366,6 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
@@ -8177,6 +8378,7 @@ components:
         - agent_id
         - action_type
         - constraints
+        - source_action_configuration_id
       properties:
         agent_id:
           type: integer
@@ -8199,11 +8401,13 @@ components:
           type: object
           additionalProperties: true
           description: |
-            Constraint boundaries for this standing approval. Required and must
-            contain at least one non-wildcard parameter constraint. A standing
-            approval without parameter constraints is a blank check — the backend
-            rejects empty constraints or constraints where every value is a
-            wildcard (`"*"`).
+            Constraint boundaries for this standing approval. Normally required and must
+            contain at least one non-wildcard parameter constraint; the backend rejects
+            empty objects or constraints where every value is a wildcard (`"*"`).
+
+            When tied to an action configuration (always required for create), trusted flows
+            such as template customize may send `{}` to mean **match all** parameter values for
+            this action type (stored as empty constraints in the database).
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
@@ -8212,19 +8416,12 @@ components:
           minLength: 1
           maxLength: 128
           description: |
-            Optional reference to the action configuration this standing approval
-            was derived from. When provided, the backend records it for traceability.
-            No foreign-key enforcement — the configuration may be deleted later.
+            Action configuration this standing approval is created from. Must exist,
+            belong to the same `agent_id`, and have the same `action_type` as the request.
             Expected format: `ac_` prefix followed by 32 hex characters (e.g.,
             `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
             enforce the pattern — only non-empty and max 128 characters.
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Maximum number of executions. Null means unlimited.
-          example: 100
         starts_at:
           type: string
           format: date-time
@@ -8245,7 +8442,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
         source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-        max_executions: 100
         expires_at: null
     RevokeStandingApprovalResponse:
       type: object
@@ -8278,12 +8474,6 @@ components:
             Updated constraint boundaries. Must be non-empty with at least one non-wildcard value.
           example:
             recipient_pattern: '*@mycompany.com'
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Updated maximum number of executions. Null means unlimited.
-          example: 200
         expires_at:
           type: string
           format: date-time
@@ -8296,7 +8486,6 @@ components:
       example:
         constraints:
           recipient_pattern: '*@mycompany.com'
-        max_executions: 200
         expires_at: null
     UserExecuteStandingApprovalRequest:
       type: object
@@ -8817,8 +9006,6 @@ components:
                     constraints:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
-                    max_executions: 100
-                    executions_remaining: 88
                     expires_at: '2026-05-15T00:00:00Z'
                 action_configurations:
                   - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -9068,8 +9255,6 @@ components:
           - standing_approval_id: sa_def456
             constraints:
               recipient_pattern: '*@mycompany.com'
-            max_executions: 100
-            executions_remaining: 88
             expires_at: '2026-05-15T00:00:00Z'
         action_configurations:
           - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -9084,7 +9269,6 @@ components:
       required:
         - standing_approval_id
         - constraints
-        - executions_remaining
         - expires_at
       properties:
         standing_approval_id:
@@ -9111,23 +9295,6 @@ components:
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of executions allowed under this standing approval.
-            `null` means unlimited.
-          example: 100
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining. `null` means unlimited (when
-            `max_executions` is null). When this reaches `0`, the standing
-            approval is exhausted and the agent must use one-off approval.
-          example: 88
         expires_at:
           type: string
           format: date-time
@@ -9141,8 +9308,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
           max_recipients: 5
-        max_executions: 100
-        executions_remaining: 88
         expires_at: '2026-05-15T00:00:00Z'
     ActionConfigCapability:
       type: object
@@ -10618,6 +10783,12 @@ components:
           type: boolean
           description: Whether the provider has client credentials configured and is ready to use
           example: true
+        pkce:
+          type: boolean
+          description: |
+            When true, the platform uses PKCE (RFC 7636) for this provider's authorize and token exchange. The browser still follows the normal redirect to `GET /v1/oauth/{provider}/authorize`; the code verifier is generated and recovered server-side inside the signed OAuth state JWT (sealed so the JWT payload does not contain the verifier in plaintext).
+          default: false
+          example: true
     OAuthProviderListResponse:
       type: object
       required:
@@ -11157,7 +11328,6 @@ components:
             - agent_limit_reached
             - standing_approval_limit_reached
             - credential_limit_reached
-            - standing_approval_exhausted
             - constraint_violation
             - standing_approval_expired
             - subscription_not_found
@@ -11349,6 +11519,81 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CalendarListItem'
+    ChannelListItem:
+      type: object
+      required:
+        - id
+        - display_label
+      properties:
+        id:
+          type: string
+          description: Slack channel ID (C…, G…, or D…).
+        name:
+          type: string
+          description: Channel name when available (may be empty for some DMs).
+        user:
+          type: string
+          description: For IM channels, the other participant's user ID when present.
+        is_private:
+          type: boolean
+          description: True for private channels (no
+        is_im:
+          type: boolean
+          description: True for direct messages.
+        is_mpim:
+          type: boolean
+          description: True for group direct messages.
+        num_members:
+          type: integer
+          description: Member count when provided by Slack.
+        display_label:
+          type: string
+          description: Human-readable label for pickers (#public-name, private name, DM label).
+    AgentConnectorChannelListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelListItem'
+    UserListItem:
+      type: object
+      required:
+        - id
+        - display_label
+      properties:
+        id:
+          type: string
+          description: Slack user ID (U…).
+        name:
+          type: string
+          description: Slack username.
+        real_name:
+          type: string
+          description: User's real name.
+        display_name:
+          type: string
+          description: User's display name.
+        email:
+          type: string
+          description: User's email address when available.
+        is_bot:
+          type: boolean
+          description: True for bot users.
+        display_label:
+          type: string
+          description: Human-readable label for pickers (real name with email).
+    AgentConnectorUserListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserListItem'
     RetentionMeta:
       type: object
       description: |
@@ -11373,6 +11618,151 @@ components:
             recently downgraded from a paid plan. After this time, the shorter
             retention window takes effect.
           example: '2026-03-08T14:30:00Z'
+    StandingApprovalTemplateSpec:
+      type: object
+      description: |
+        Manifest-authored standing approval behavior when a template is applied.
+      properties:
+        duration_days:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: |
+            Number of days until the standing approval expires. `null` means no
+            expiry (until revoked).
+    BulkApplyActionConfigTemplateRequest:
+      type: object
+      required:
+        - agent_id
+        - template_ids
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+          description: Agent to attach the new configurations and standing approvals to.
+          example: 42
+        template_ids:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+          minItems: 1
+          maxItems: 50
+          description: |
+            Template IDs to apply. All templates must belong to the same connector.
+            Duplicates are silently deduplicated.
+          example:
+            - tpl_github_create_issue_all
+            - tpl_github_merge_pr_all
+        approval_modes:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - auto_approve
+              - requires_approval
+          description: |
+            Optional per-template approval mode overrides keyed by template ID.
+            Templates not in this map use their built-in behavior.
+          example:
+            tpl_github_create_issue_all: auto_approve
+    LinkedStandingApprovalSummary:
+      type: object
+      required:
+        - standing_approval_id
+        - action_type
+        - status
+      properties:
+        standing_approval_id:
+          type: string
+          description: Standing approval identifier.
+        action_type:
+          type: string
+          description: Action type covered by this standing approval.
+        status:
+          type: string
+          description: Standing approval status (typically `active` in this summary).
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the standing approval expires, or null if it lasts until revoked.
+    BulkApplyResultError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+          example: standing_approval_limit_reached
+        message:
+          type: string
+          description: Human-readable error message.
+          example: Standing approval limit reached
+    BulkApplyResult:
+      type: object
+      required:
+        - template_id
+        - success
+      properties:
+        template_id:
+          type: string
+          description: The template ID that was applied (or failed).
+        success:
+          type: boolean
+          description: Whether this template was applied successfully.
+        action_configuration:
+          $ref: '#/components/schemas/ActionConfiguration'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApproval'
+          description: Present when the template bundles a standing approval and it was created successfully.
+        error:
+          $ref: '#/components/schemas/BulkApplyResultError'
+          description: Present when `success` is false.
+    BulkApplyActionConfigTemplateResponse:
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkApplyResult'
+          description: |
+            Per-template results. Order matches the deduplicated input order.
+    ApplyActionConfigTemplateRequest:
+      type: object
+      required:
+        - agent_id
+      properties:
+        agent_id:
+          type: integer
+          format: int64
+          description: Agent to attach the new configuration and standing approval to.
+          example: 42
+        approval_mode:
+          type: string
+          enum:
+            - auto_approve
+            - requires_approval
+          description: |
+            Override the template's built-in approval behavior.
+            `auto_approve` creates a standing approval (using the template's spec
+            if present, otherwise sensible defaults: no expiry, unlimited executions).
+            `requires_approval` skips standing approval creation.
+            When omitted, falls back to the template's built-in behavior.
+    ApplyActionConfigTemplateResponse:
+      type: object
+      required:
+        - action_configuration
+      properties:
+        action_configuration:
+          $ref: '#/components/schemas/ActionConfiguration'
+        standing_approval:
+          $ref: '#/components/schemas/StandingApproval'
+          description: Present when the template bundles a standing approval.
     NotificationPreferenceUpdate:
       type: object
       description: A channel preference update (request-only, no `available` field).

--- a/spec/openapi/components/paths/actions.yaml
+++ b/spec/openapi/components/paths/actions.yaml
@@ -13,7 +13,7 @@ execute:
       2. **Permission Slip matches**: Finds an active standing approval for this agent + action type + constraints
       3. **Permission Slip validates**: Verifies parameters fall within standing approval constraints
       4. **Permission Slip executes**: Calls the external service API using stored credentials
-      5. **Result returned**: Returns `StandingApprovalExecuteResponse` with `standing_approval_id` and `executions_remaining`
+      5. **Result returned**: Returns `StandingApprovalExecuteResponse` with `standing_approval_id`
 
       ## One-off Approvals
 
@@ -29,8 +29,6 @@ execute:
       - **Standing approval match**: Active standing approval for this agent + action type
       - **Constraint compliance**: Parameters fall within standing approval constraints
       - **Expiration**: Standing approval has not expired (or has no expiration)
-      - **Execution count**: Max executions not exceeded (if set)
-
       ## Credential Lookup
 
       Permission Slip determines which external service to call based on the action type
@@ -46,7 +44,7 @@ execute:
       ## Error Handling
 
       If the external service returns an error, Permission Slip returns a `502 Bad Gateway`
-      with details about the upstream failure. The execution count is still incremented to
+      with details about the upstream failure. An execution record may still be written to
       prevent unbounded retry loops; the agent should use a new `request_id` for each
       retry attempt.
 
@@ -111,7 +109,6 @@ execute:
                         subject: "PR merged"
                         sender: "noreply@github.com"
                   standing_approval_id: "sa_abc123"
-                  executions_remaining: null
 
               email_sent_standing:
                 summary: "Standing approval: Email sent successfully"
@@ -120,7 +117,6 @@ execute:
                     message_id: "msg_abc123"
                     delivery_status: "queued"
                   standing_approval_id: "sa_def456"
-                  executions_remaining: 47
 
       '400':
         description: Invalid request
@@ -165,25 +161,12 @@ execute:
                     trace_id: "trace_xyz789"
 
       '403':
-        description: Standing approval exhausted or constraint violation
+        description: Constraint violation
         content:
           application/json:
             schema:
               $ref: '../schemas/errors.yaml#/ErrorResponse'
             examples:
-              standing_approval_exhausted:
-                summary: Standing approval execution count exceeded
-                value:
-                  error:
-                    code: "standing_approval_exhausted"
-                    message: "Standing approval max execution count has been reached"
-                    retryable: false
-                    details:
-                      standing_approval_id: "sa_abc123"
-                      max_executions: 100
-                      execution_count: 100
-                    trace_id: "trace_xyz789"
-
               constraint_violation:
                 summary: Parameters violate standing approval constraints
                 value:

--- a/spec/openapi/components/paths/approvals.yaml
+++ b/spec/openapi/components/paths/approvals.yaml
@@ -14,7 +14,7 @@ request:
 
       1. **Parameters validated**: Against standing approval constraints
       2. **Action executed**: Immediately via the connector using stored credentials
-      3. **Result returned**: Response has `status: "approved"` with `result`, `standing_approval_id`, and `executions_remaining`
+      3. **Result returned**: Response has `status: "approved"` with `result` and `standing_approval_id`
       4. **No polling needed**: The agent has the result immediately
 
       ## One-off Approval (No Standing Approval Match)
@@ -166,7 +166,6 @@ request:
                     message_id: "msg_abc123"
                     delivery_status: "queued"
                   standing_approval_id: "sa_abc123"
-                  executions_remaining: 47
       
       '400':
         description: Invalid request or unsupported action type

--- a/spec/openapi/components/paths/capabilities.yaml
+++ b/spec/openapi/components/paths/capabilities.yaml
@@ -144,8 +144,6 @@ agentCapabilities:
                               constraints:
                                 recipient_pattern: "*@mycompany.com"
                                 max_recipients: 5
-                              max_executions: 100
-                              executions_remaining: 88
                               expires_at: "2026-05-15T00:00:00Z"
                           action_configurations:
                             - configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
@@ -175,8 +173,6 @@ agentCapabilities:
                               constraints:
                                 sender: "*@github.com"
                                 max_results: 10
-                              max_executions: null
-                              executions_remaining: null
                               expires_at: "2026-02-28T00:00:00Z"
                           action_configurations: []
                     - id: "stripe"
@@ -249,14 +245,10 @@ agentCapabilities:
                             - standing_approval_id: "sa_read01"
                               constraints:
                                 sender: "*@github.com"
-                              max_executions: null
-                              executions_remaining: null
                               expires_at: "2026-03-15T00:00:00Z"
                             - standing_approval_id: "sa_read02"
                               constraints:
                                 sender: "*@linear.app"
-                              max_executions: 50
-                              executions_remaining: 50
                               expires_at: "2026-03-01T00:00:00Z"
                           action_configurations: []
 

--- a/spec/openapi/components/paths/standing_approvals.yaml
+++ b/spec/openapi/components/paths/standing_approvals.yaml
@@ -15,12 +15,12 @@ listStandingApprovals:
       - **Agent startup**: Agent queries its standing approvals to understand what it can do
       - **Flow selection**: Agent checks if a standing approval covers a desired action before
         deciding whether to use `POST /v1/actions/execute` (standing) or `POST /v1/approvals/request` (one-off)
-      - **Status monitoring**: Agent checks remaining executions or expiration times
+      - **Status monitoring**: Agent checks expiration times
 
       ## Filtering
 
-      Only standing approvals with status `active` are returned by default. Expired,
-      revoked, and exhausted standing approvals are excluded.
+      Only standing approvals with status `active` are returned by default. Expired
+      and revoked standing approvals are excluded.
 
       ## Security
 
@@ -77,8 +77,6 @@ listStandingApprovals:
                     sender: "*@github.com"
                     max_results: 10
                   status: "active"
-                  max_executions: null
-                  execution_count: 42
                   starts_at: "2026-02-14T00:00:00Z"
                   expires_at: "2026-02-21T00:00:00Z"
                   created_at: "2026-02-14T10:30:00Z"
@@ -93,8 +91,6 @@ listStandingApprovals:
                     recipient_pattern: "*@mycompany.com"
                     max_recipients: 5
                   status: "active"
-                  max_executions: 100
-                  execution_count: 12
                   starts_at: "2026-02-14T00:00:00Z"
                   expires_at: "2026-05-15T00:00:00Z"
                   created_at: "2026-02-14T10:35:00Z"
@@ -178,7 +174,6 @@ userListStandingApprovals:
             - active
             - expired
             - revoked
-            - exhausted
             - all
           default: active
         example: active
@@ -233,8 +228,6 @@ userListStandingApprovals:
                   constraints:
                     sender: "*@github.com"
                   status: "active"
-                  max_executions: null
-                  execution_count: 42
                   starts_at: "2026-02-14T00:00:00Z"
                   expires_at: "2026-02-21T00:00:00Z"
                   created_at: "2026-02-14T10:30:00Z"
@@ -312,7 +305,6 @@ createStandingApproval:
             constraints:
               recipient_pattern: "*@mycompany.com"
             source_action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
-            max_executions: 100
             expires_at: "2026-03-14T00:00:00Z"
 
     responses:
@@ -400,17 +392,13 @@ updateStandingApproval:
     operationId: updateStandingApproval
     summary: Update Standing Approval
     description: |
-      Update the constraints, max_executions, and expires_at of an active standing approval.
+      Update the constraints and expires_at of an active standing approval.
       The standing approval must belong to the authenticated user and be in `active` status.
-      Agent and action type cannot be changed — only constraints and limits.
+      Agent and action type cannot be changed — only constraints and expiry.
 
       **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
       the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
       not a rolling window from the time of the update call.
-
-      **Execution count**: `max_executions` cannot be set below the approval's current
-      `execution_count`. The update is rejected atomically at the database level to prevent
-      a race condition where concurrent executions could otherwise create a zombie approval.
 
       Emits a `standing_approval.updated` audit event on success.
 
@@ -432,7 +420,6 @@ updateStandingApproval:
           example:
             constraints:
               recipient_pattern: "*@mycompany.com"
-            max_executions: 200
             expires_at: "2026-04-14T00:00:00Z"
 
     responses:
@@ -474,7 +461,7 @@ updateStandingApproval:
               $ref: '../schemas/errors.yaml#/ErrorResponse'
 
       '410':
-        description: Standing approval no longer active (expired or exhausted)
+        description: Standing approval no longer active (expired or revoked)
         content:
           application/json:
             schema:
@@ -551,7 +538,7 @@ revokeStandingApproval:
                 trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
 
       '410':
-        description: Standing approval no longer active (expired or exhausted)
+        description: Standing approval no longer active (expired or revoked)
         content:
           application/json:
             schema:
@@ -581,7 +568,7 @@ executeStandingApproval:
     description: |
       Record an execution of an active standing approval. The standing approval
       must belong to the authenticated user and be in `active` status. Atomically
-      increments the execution count and creates an execution record.
+      creates an execution record.
 
       Emits a `standing_approval.executed` audit event on success.
 
@@ -661,7 +648,7 @@ executeStandingApproval:
                 trace_id: "trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
 
       '410':
-        description: Standing approval no longer active (expired or exhausted)
+        description: Standing approval no longer active (expired or revoked)
         content:
           application/json:
             schema:

--- a/spec/openapi/components/schemas/action_config_templates.yaml
+++ b/spec/openapi/components/schemas/action_config_templates.yaml
@@ -96,12 +96,6 @@ StandingApprovalTemplateSpec:
       description: |
         Number of days until the standing approval expires. `null` means no
         expiry (until revoked).
-    max_executions:
-      type: integer
-      nullable: true
-      minimum: 1
-      description: |
-        Optional cap on executions. `null` means unlimited within the window.
 
 ApplyActionConfigTemplateRequest:
   type: object

--- a/spec/openapi/components/schemas/action_configurations.yaml
+++ b/spec/openapi/components/schemas/action_configurations.yaml
@@ -142,7 +142,6 @@ LinkedStandingApprovalSummary:
     - standing_approval_id
     - action_type
     - status
-    - execution_count
   properties:
     standing_approval_id:
       type: string
@@ -158,15 +157,6 @@ LinkedStandingApprovalSummary:
       format: date-time
       nullable: true
       description: When the standing approval expires, or null if it lasts until revoked.
-    max_executions:
-      type: integer
-      nullable: true
-      minimum: 1
-      description: Execution cap, if any.
-    execution_count:
-      type: integer
-      minimum: 0
-      description: Executions recorded so far.
 
 CreateActionConfigRequest:
   type: object

--- a/spec/openapi/components/schemas/actions.yaml
+++ b/spec/openapi/components/schemas/actions.yaml
@@ -24,5 +24,5 @@ ExecuteActionResponse:
   allOf:
     - $ref: '../schemas/standing_approvals.yaml#/StandingApprovalExecuteResponse'
     - description: |
-        Response from executing an action via a standing approval. Returns the action result,
-        the standing approval that authorized execution, and the remaining execution count.
+        Response from executing an action via a standing approval. Returns the action result
+        and the standing approval that authorized execution.

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -114,9 +114,8 @@ ApprovalRequestResponse:
     Response after submitting an approval request. Two possible outcomes:
 
     **Auto-approved** (`status: "approved"`): A matching standing approval was found.
-    The action was executed immediately. The response includes `result`,
-    `standing_approval_id`, and optionally `executions_remaining`. No `approval_id`
-    or `approval_url` is returned.
+    The action was executed immediately. The response includes `result` and
+    `standing_approval_id`. No `approval_id` or `approval_url` is returned.
 
     **Pending** (`status: "pending"`): No standing approval matched. A pending approval
     was created. The agent should poll `GET /v1/approvals/{approval_id}/status` for the
@@ -178,14 +177,6 @@ ApprovalRequestResponse:
       description: |
         ID of the standing approval that matched. Present only when `status` is `approved`.
       example: "sa_abc123"
-
-    executions_remaining:
-      type: integer
-      description: |
-        Number of executions remaining on the standing approval.
-        Present only when `status` is `approved` and the standing approval has a
-        finite `max_executions`. Absent when unlimited.
-      example: 47
 
   example:
     approval_id: "appr_xyz789"

--- a/spec/openapi/components/schemas/capabilities.yaml
+++ b/spec/openapi/components/schemas/capabilities.yaml
@@ -65,8 +65,6 @@ AgentCapabilitiesResponse:
                 constraints:
                   recipient_pattern: "*@mycompany.com"
                   max_recipients: 5
-                max_executions: 100
-                executions_remaining: 88
                 expires_at: "2026-05-15T00:00:00Z"
             action_configurations:
               - configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
@@ -331,8 +329,6 @@ ActionCapability:
       - standing_approval_id: "sa_def456"
         constraints:
           recipient_pattern: "*@mycompany.com"
-        max_executions: 100
-        executions_remaining: 88
         expires_at: "2026-05-15T00:00:00Z"
     action_configurations:
       - configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
@@ -348,7 +344,6 @@ StandingApprovalCapability:
   required:
     - standing_approval_id
     - constraints
-    - executions_remaining
     - expires_at
   properties:
     standing_approval_id:
@@ -377,25 +372,6 @@ StandingApprovalCapability:
         recipient_pattern: "*@mycompany.com"
         max_recipients: 5
 
-    max_executions:
-      type: integer
-      minimum: 1
-      nullable: true
-      description: |
-        Maximum number of executions allowed under this standing approval.
-        `null` means unlimited.
-      example: 100
-
-    executions_remaining:
-      type: integer
-      minimum: 0
-      nullable: true
-      description: |
-        Number of executions remaining. `null` means unlimited (when
-        `max_executions` is null). When this reaches `0`, the standing
-        approval is exhausted and the agent must use one-off approval.
-      example: 88
-
     expires_at:
       type: string
       format: date-time
@@ -410,8 +386,6 @@ StandingApprovalCapability:
     constraints:
       recipient_pattern: "*@mycompany.com"
       max_recipients: 5
-    max_executions: 100
-    executions_remaining: 88
     expires_at: "2026-05-15T00:00:00Z"
 
 ActionConfigCapability:

--- a/spec/openapi/components/schemas/errors.yaml
+++ b/spec/openapi/components/schemas/errors.yaml
@@ -47,7 +47,6 @@ Error:
         - standing_approval_limit_reached
         - credential_limit_reached
         # 403 Forbidden (standing approval)
-        - standing_approval_exhausted
         - constraint_violation
         # 410 Gone (standing approval)
         - standing_approval_expired

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -40,8 +40,6 @@ StandingApprovalListResponse:
           sender: "*@github.com"
           max_results: 10
         status: "active"
-        max_executions: null
-        execution_count: 42
         starts_at: "2026-02-14T00:00:00Z"
         expires_at: "2026-02-21T00:00:00Z"
         created_at: "2026-02-14T10:30:00Z"
@@ -58,7 +56,6 @@ StandingApproval:
     - action_type
     - constraints
     - status
-    - execution_count
     - starts_at
     - created_at
     - source_action_configuration_id
@@ -127,32 +124,13 @@ StandingApproval:
         - active
         - expired
         - revoked
-        - exhausted
       description: |
         Current status of the standing approval.
 
         - **active**: Agent can execute actions under this standing approval
         - **expired**: Duration elapsed; agent must request a new standing approval or use one-off
         - **revoked**: User manually cancelled this standing approval
-        - **exhausted**: Max execution count reached
       example: "active"
-
-    max_executions:
-      type: integer
-      minimum: 1
-      nullable: true
-      description: |
-        Maximum number of times the agent can execute under this standing approval.
-        `null` means unlimited — the agent can execute as many times as it wants
-        within the duration.
-      example: null
-
-    execution_count:
-      type: integer
-      minimum: 0
-      description: |
-        Number of times this standing approval has been used so far.
-      example: 42
 
     starts_at:
       type: string
@@ -208,8 +186,6 @@ StandingApproval:
       sender: "*@github.com"
       max_results: 10
     status: "active"
-    max_executions: null
-    execution_count: 42
     starts_at: "2026-02-14T00:00:00Z"
     expires_at: "2026-02-21T00:00:00Z"
     created_at: "2026-02-14T10:30:00Z"
@@ -251,8 +227,6 @@ UserStandingApprovalListResponse:
           sender: "*@github.com"
           max_results: 10
         status: "active"
-        max_executions: null
-        execution_count: 42
         starts_at: "2026-02-14T00:00:00Z"
         expires_at: "2026-02-21T00:00:00Z"
         created_at: "2026-02-14T10:30:00Z"
@@ -315,13 +289,6 @@ CreateStandingApprovalRequest:
         enforce the pattern — only non-empty and max 128 characters.
       example: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
 
-    max_executions:
-      type: integer
-      minimum: 1
-      nullable: true
-      description: Maximum number of executions. Null means unlimited.
-      example: 100
-
     starts_at:
       type: string
       format: date-time
@@ -344,7 +311,6 @@ CreateStandingApprovalRequest:
     constraints:
       recipient_pattern: "*@mycompany.com"
     source_action_configuration_id: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
-    max_executions: 100
     expires_at: null
 
 UpdateStandingApprovalRequest:
@@ -360,13 +326,6 @@ UpdateStandingApprovalRequest:
       example:
         recipient_pattern: "*@mycompany.com"
 
-    max_executions:
-      type: integer
-      minimum: 1
-      nullable: true
-      description: Updated maximum number of executions. Null means unlimited.
-      example: 200
-
     expires_at:
       type: string
       format: date-time
@@ -380,7 +339,6 @@ UpdateStandingApprovalRequest:
   example:
     constraints:
       recipient_pattern: "*@mycompany.com"
-    max_executions: 200
     expires_at: null
 
 
@@ -524,7 +482,6 @@ StandingApprovalExecuteResponse:
   required:
     - result
     - standing_approval_id
-    - executions_remaining
   properties:
     result:
       type: object
@@ -545,15 +502,6 @@ StandingApprovalExecuteResponse:
         Which standing approval authorized this execution.
       example: "sa_abc123"
 
-    executions_remaining:
-      type: integer
-      minimum: 0
-      nullable: true
-      description: |
-        Number of executions remaining under this standing approval.
-        `null` means unlimited.
-      example: null
-
   example:
     result:
       emails:
@@ -561,4 +509,3 @@ StandingApprovalExecuteResponse:
           subject: "PR merged"
           sender: "noreply@github.com"
     standing_approval_id: "sa_abc123"
-    executions_remaining: null

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1193,8 +1193,6 @@ paths:
                                 constraints:
                                   recipient_pattern: '*@mycompany.com'
                                   max_recipients: 5
-                                max_executions: 100
-                                executions_remaining: 88
                                 expires_at: '2026-05-15T00:00:00Z'
                             action_configurations:
                               - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -1224,8 +1222,6 @@ paths:
                                 constraints:
                                   sender: '*@github.com'
                                   max_results: 10
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-02-28T00:00:00Z'
                             action_configurations: []
                       - id: stripe
@@ -1296,14 +1292,10 @@ paths:
                               - standing_approval_id: sa_read01
                                 constraints:
                                   sender: '*@github.com'
-                                max_executions: null
-                                executions_remaining: null
                                 expires_at: '2026-03-15T00:00:00Z'
                               - standing_approval_id: sa_read02
                                 constraints:
                                   sender: '*@linear.app'
-                                max_executions: 50
-                                executions_remaining: 50
                                 expires_at: '2026-03-01T00:00:00Z'
                             action_configurations: []
         '400':
@@ -2198,7 +2190,7 @@ paths:
 
         1. **Parameters validated**: Against standing approval constraints
         2. **Action executed**: Immediately via the connector using stored credentials
-        3. **Result returned**: Response has `status: "approved"` with `result`, `standing_approval_id`, and `executions_remaining`
+        3. **Result returned**: Response has `status: "approved"` with `result` and `standing_approval_id`
         4. **No polling needed**: The agent has the result immediately
 
         ## One-off Approval (No Standing Approval Match)
@@ -2343,7 +2335,6 @@ paths:
                       message_id: msg_abc123
                       delivery_status: queued
                     standing_approval_id: sa_abc123
-                    executions_remaining: 47
         '400':
           description: Invalid request or unsupported action type
           content:
@@ -3930,12 +3921,12 @@ paths:
         - **Agent startup**: Agent queries its standing approvals to understand what it can do
         - **Flow selection**: Agent checks if a standing approval covers a desired action before
           deciding whether to use `POST /v1/actions/execute` (standing) or `POST /v1/approvals/request` (one-off)
-        - **Status monitoring**: Agent checks remaining executions or expiration times
+        - **Status monitoring**: Agent checks expiration times
 
         ## Filtering
 
-        Only standing approvals with status `active` are returned by default. Expired,
-        revoked, and exhausted standing approvals are excluded.
+        Only standing approvals with status `active` are returned by default. Expired
+        and revoked standing approvals are excluded.
 
         ## Security
 
@@ -3988,8 +3979,6 @@ paths:
                       sender: '*@github.com'
                       max_results: 10
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
@@ -4004,8 +3993,6 @@ paths:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
                     status: active
-                    max_executions: 100
-                    execution_count: 12
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-05-15T00:00:00Z'
                     created_at: '2026-02-14T10:35:00Z'
@@ -4077,7 +4064,6 @@ paths:
               - active
               - expired
               - revoked
-              - exhausted
               - all
             default: active
           example: active
@@ -4128,8 +4114,6 @@ paths:
                     constraints:
                       sender: '*@github.com'
                     status: active
-                    max_executions: null
-                    execution_count: 42
                     starts_at: '2026-02-14T00:00:00Z'
                     expires_at: '2026-02-21T00:00:00Z'
                     created_at: '2026-02-14T10:30:00Z'
@@ -4197,7 +4181,6 @@ paths:
               constraints:
                 recipient_pattern: '*@mycompany.com'
               source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-              max_executions: 100
               expires_at: '2026-03-14T00:00:00Z'
       responses:
         '201':
@@ -4325,7 +4308,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -4349,17 +4332,13 @@ paths:
       operationId: updateStandingApproval
       summary: Update Standing Approval
       description: |
-        Update the constraints, max_executions, and expires_at of an active standing approval.
+        Update the constraints and expires_at of an active standing approval.
         The standing approval must belong to the authenticated user and be in `active` status.
-        Agent and action type cannot be changed — only constraints and limits.
+        Agent and action type cannot be changed — only constraints and expiry.
 
         **Duration policy**: The total lifespan from the approval's original `starts_at` may not exceed
         the maximum allowed window (90 days). Expiry headroom shrinks as the approval ages — this is
         not a rolling window from the time of the update call.
-
-        **Execution count**: `max_executions` cannot be set below the approval's current
-        `execution_count`. The update is rejected atomically at the database level to prevent
-        a race condition where concurrent executions could otherwise create a zombie approval.
 
         Emits a `standing_approval.updated` audit event on success.
       tags:
@@ -4377,7 +4356,6 @@ paths:
             example:
               constraints:
                 recipient_pattern: '*@mycompany.com'
-              max_executions: 200
               expires_at: '2026-04-14T00:00:00Z'
       responses:
         '200':
@@ -4413,7 +4391,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -4431,7 +4409,7 @@ paths:
       description: |
         Record an execution of an active standing approval. The standing approval
         must belong to the authenticated user and be in `active` status. Atomically
-        increments the execution count and creates an execution record.
+        creates an execution record.
 
         Emits a `standing_approval.executed` audit event on success.
       tags:
@@ -4501,7 +4479,7 @@ paths:
                     status: revoked
                   trace_id: trace_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
         '410':
-          description: Standing approval no longer active (expired or exhausted)
+          description: Standing approval no longer active (expired or revoked)
           content:
             application/json:
               schema:
@@ -6815,9 +6793,8 @@ components:
         Response after submitting an approval request. Two possible outcomes:
 
         **Auto-approved** (`status: "approved"`): A matching standing approval was found.
-        The action was executed immediately. The response includes `result`,
-        `standing_approval_id`, and optionally `executions_remaining`. No `approval_id`
-        or `approval_url` is returned.
+        The action was executed immediately. The response includes `result` and
+        `standing_approval_id`. No `approval_id` or `approval_url` is returned.
 
         **Pending** (`status: "pending"`): No standing approval matched. A pending approval
         was created. The agent should poll `GET /v1/approvals/{approval_id}/status` for the
@@ -6872,13 +6849,6 @@ components:
           description: |
             ID of the standing approval that matched. Present only when `status` is `approved`.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          description: |
-            Number of executions remaining on the standing approval.
-            Present only when `status` is `approved` and the standing approval has a
-            finite `max_executions`. Absent when unlimited.
-          example: 47
       example:
         approval_id: appr_xyz789
         approval_url: https://app.permissionslip.dev/permission-slip/approve/appr_xyz789
@@ -8102,7 +8072,6 @@ components:
         - action_type
         - constraints
         - status
-        - execution_count
         - starts_at
         - created_at
         - source_action_configuration_id
@@ -8165,30 +8134,13 @@ components:
             - active
             - expired
             - revoked
-            - exhausted
           description: |
             Current status of the standing approval.
 
             - **active**: Agent can execute actions under this standing approval
             - **expired**: Duration elapsed; agent must request a new standing approval or use one-off
             - **revoked**: User manually cancelled this standing approval
-            - **exhausted**: Max execution count reached
           example: active
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of times the agent can execute under this standing approval.
-            `null` means unlimited — the agent can execute as many times as it wants
-            within the duration.
-          example: null
-        execution_count:
-          type: integer
-          minimum: 0
-          description: |
-            Number of times this standing approval has been used so far.
-          example: 42
         starts_at:
           type: string
           format: date-time
@@ -8238,8 +8190,6 @@ components:
           sender: '*@github.com'
           max_results: 10
         status: active
-        max_executions: null
-        execution_count: 42
         starts_at: '2026-02-14T00:00:00Z'
         expires_at: '2026-02-21T00:00:00Z'
         created_at: '2026-02-14T10:30:00Z'
@@ -8312,7 +8262,6 @@ components:
       required:
         - result
         - standing_approval_id
-        - executions_remaining
       properties:
         result:
           type: object
@@ -8331,14 +8280,6 @@ components:
           description: |
             Which standing approval authorized this execution.
           example: sa_abc123
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining under this standing approval.
-            `null` means unlimited.
-          example: null
       example:
         result:
           emails:
@@ -8346,7 +8287,6 @@ components:
               subject: PR merged
               sender: noreply@github.com
         standing_approval_id: sa_abc123
-        executions_remaining: null
     StandingApprovalListResponse:
       type: object
       required:
@@ -8386,8 +8326,6 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
@@ -8428,8 +8366,6 @@ components:
               sender: '*@github.com'
               max_results: 10
             status: active
-            max_executions: null
-            execution_count: 42
             starts_at: '2026-02-14T00:00:00Z'
             expires_at: '2026-02-21T00:00:00Z'
             created_at: '2026-02-14T10:30:00Z'
@@ -8486,12 +8422,6 @@ components:
             `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
             enforce the pattern — only non-empty and max 128 characters.
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Maximum number of executions. Null means unlimited.
-          example: 100
         starts_at:
           type: string
           format: date-time
@@ -8512,7 +8442,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
         source_action_configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-        max_executions: 100
         expires_at: null
     RevokeStandingApprovalResponse:
       type: object
@@ -8545,12 +8474,6 @@ components:
             Updated constraint boundaries. Must be non-empty with at least one non-wildcard value.
           example:
             recipient_pattern: '*@mycompany.com'
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: Updated maximum number of executions. Null means unlimited.
-          example: 200
         expires_at:
           type: string
           format: date-time
@@ -8563,7 +8486,6 @@ components:
       example:
         constraints:
           recipient_pattern: '*@mycompany.com'
-        max_executions: 200
         expires_at: null
     UserExecuteStandingApprovalRequest:
       type: object
@@ -9084,8 +9006,6 @@ components:
                     constraints:
                       recipient_pattern: '*@mycompany.com'
                       max_recipients: 5
-                    max_executions: 100
-                    executions_remaining: 88
                     expires_at: '2026-05-15T00:00:00Z'
                 action_configurations:
                   - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -9335,8 +9255,6 @@ components:
           - standing_approval_id: sa_def456
             constraints:
               recipient_pattern: '*@mycompany.com'
-            max_executions: 100
-            executions_remaining: 88
             expires_at: '2026-05-15T00:00:00Z'
         action_configurations:
           - configuration_id: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
@@ -9351,7 +9269,6 @@ components:
       required:
         - standing_approval_id
         - constraints
-        - executions_remaining
         - expires_at
       properties:
         standing_approval_id:
@@ -9378,23 +9295,6 @@ components:
           example:
             recipient_pattern: '*@mycompany.com'
             max_recipients: 5
-        max_executions:
-          type: integer
-          minimum: 1
-          nullable: true
-          description: |
-            Maximum number of executions allowed under this standing approval.
-            `null` means unlimited.
-          example: 100
-        executions_remaining:
-          type: integer
-          minimum: 0
-          nullable: true
-          description: |
-            Number of executions remaining. `null` means unlimited (when
-            `max_executions` is null). When this reaches `0`, the standing
-            approval is exhausted and the agent must use one-off approval.
-          example: 88
         expires_at:
           type: string
           format: date-time
@@ -9408,8 +9308,6 @@ components:
         constraints:
           recipient_pattern: '*@mycompany.com'
           max_recipients: 5
-        max_executions: 100
-        executions_remaining: 88
         expires_at: '2026-05-15T00:00:00Z'
     ActionConfigCapability:
       type: object
@@ -11430,7 +11328,6 @@ components:
             - agent_limit_reached
             - standing_approval_limit_reached
             - credential_limit_reached
-            - standing_approval_exhausted
             - constraint_violation
             - standing_approval_expired
             - subscription_not_found
@@ -11733,12 +11630,6 @@ components:
           description: |
             Number of days until the standing approval expires. `null` means no
             expiry (until revoked).
-        max_executions:
-          type: integer
-          nullable: true
-          minimum: 1
-          description: |
-            Optional cap on executions. `null` means unlimited within the window.
     BulkApplyActionConfigTemplateRequest:
       type: object
       required:
@@ -11781,7 +11672,6 @@ components:
         - standing_approval_id
         - action_type
         - status
-        - execution_count
       properties:
         standing_approval_id:
           type: string
@@ -11797,15 +11687,6 @@ components:
           format: date-time
           nullable: true
           description: When the standing approval expires, or null if it lasts until revoked.
-        max_executions:
-          type: integer
-          nullable: true
-          minimum: 1
-          description: Execution cap, if any.
-        execution_count:
-          type: integer
-          minimum: 0
-          description: Executions recorded so far.
     BulkApplyResultError:
       type: object
       required:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the max-executions / execution-count model for standing approvals per issue #931. The migration drops `max_executions`, `execution_count`, and `exhausted_at`, demotes legacy `exhausted` rows to `active`, and tightens the status CHECK to `active`, `expired`, `revoked`. API, OpenAPI, frontend, seed, templates, notifications, and docs are updated accordingly. `standing_approval_executions` remains the audit trail; `RecordStandingApprovalExecution*` now locks the parent row and inserts without maintaining a counter.

Closes #931

### Developer

- [x] Migration `20260413222611_remove_standing_approval_max_executions.sql`
- [x] DB, API, OpenAPI bundle + frontend `schema.d.ts` regeneration
- [x] Frontend UI and tests updated
- [x] `go mod tidy` / `go build ./...` with `GOTOOLCHAIN=go1.25.4` (local Go 1.22 could not satisfy module `go` version)
- [ ] Full `make test` / DB-backed tests (PostgreSQL not available in this agent environment; connection refused on :5432)

### Manual Testing

- [ ] Create/edit standing approval: confirm max executions is gone; expiry still works
- [ ] Agent auto-approve path: no `executions_remaining` in response
- [ ] Apply migration on staging: legacy `exhausted` rows become `active`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d46ee34d-2f03-4b18-9642-d4e0a10fdfe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d46ee34d-2f03-4b18-9642-d4e0a10fdfe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

