### PR TITLE
Add optional gateway secret for private deployments

### DIFF
--- a/api/cors.go
+++ b/api/cors.go
@@ -51,7 +51,7 @@ func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 			// to the next handler so application-level OPTIONS endpoints still work.
 			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Gateway-Secret")
 				w.Header().Set("Access-Control-Max-Age", "86400")
 				w.WriteHeader(http.StatusNoContent)
 				return

--- a/api/gateway_secret_middleware.go
+++ b/api/gateway_secret_middleware.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"crypto/subtle"
+	"log"
+	"net/http"
+)
+
+// GatewaySecretMiddleware returns middleware that rejects requests without a
+// valid X-Gateway-Secret header. When secret is empty, the middleware is a
+// no-op — all requests pass through unchanged.
+//
+// This is designed for private deployments behind Cloudflare Tunnel: set the
+// GATEWAY_SECRET env var to a long random string and configure clients (mobile
+// app, curl, etc.) to send the same value in the X-Gateway-Secret header.
+//
+// The check runs as the outermost middleware so unauthorized requests are
+// rejected with minimal processing (before CORS, security headers, routing,
+// auth, etc.). CORS preflight (OPTIONS) requests are exempt because browsers
+// send them without custom headers.
+func GatewaySecretMiddleware(secret string) func(http.Handler) http.Handler {
+	if secret != "" {
+		log.Println("Gateway secret: enabled — requests without a valid X-Gateway-Secret header will be rejected")
+	}
+
+	return func(next http.Handler) http.Handler {
+		if secret == "" {
+			return next
+		}
+
+		secretBytes := []byte(secret)
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Allow CORS preflight through — browsers send OPTIONS without
+			// custom headers, so blocking them would break cross-origin
+			// requests entirely.
+			if r.Method == http.MethodOptions {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			provided := r.Header.Get("X-Gateway-Secret")
+			if subtle.ConstantTimeCompare([]byte(provided), secretBytes) != 1 {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/api/gateway_secret_middleware.go
+++ b/api/gateway_secret_middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"log"
 	"net/http"
@@ -14,10 +15,17 @@ import (
 // GATEWAY_SECRET env var to a long random string and configure clients (mobile
 // app, curl, etc.) to send the same value in the X-Gateway-Secret header.
 //
-// The check runs as the outermost middleware so unauthorized requests are
-// rejected with minimal processing (before CORS, security headers, routing,
-// auth, etc.). CORS preflight (OPTIONS) requests are exempt because browsers
-// send them without custom headers.
+// Middleware ordering: in main.go this runs inside SecurityHeadersMiddleware
+// (which only sets response headers and never blocks), but outside CORS,
+// routing, and auth — so unauthorized requests are rejected before any
+// application processing. True CORS preflight requests (OPTIONS with an
+// Access-Control-Request-Method header) are exempt because browsers send them
+// without custom headers; other OPTIONS requests are still gated.
+//
+// The header and configured secret are SHA-256 hashed before comparison so
+// that the fixed-length digests (always 32 bytes) feed ConstantTimeCompare.
+// This avoids leaking the secret length via an early length-mismatch return
+// inside ConstantTimeCompare.
 func GatewaySecretMiddleware(secret string) func(http.Handler) http.Handler {
 	if secret != "" {
 		log.Println("Gateway secret: enabled — requests without a valid X-Gateway-Secret header will be rejected")
@@ -28,19 +36,19 @@ func GatewaySecretMiddleware(secret string) func(http.Handler) http.Handler {
 			return next
 		}
 
-		secretBytes := []byte(secret)
+		secretSum := sha256.Sum256([]byte(secret))
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Allow CORS preflight through — browsers send OPTIONS without
-			// custom headers, so blocking them would break cross-origin
-			// requests entirely.
-			if r.Method == http.MethodOptions {
+			// Exempt only genuine CORS preflights — OPTIONS requests that
+			// include Access-Control-Request-Method. Bare OPTIONS requests
+			// still require the gateway secret so nothing slips through.
+			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			provided := r.Header.Get("X-Gateway-Secret")
-			if subtle.ConstantTimeCompare([]byte(provided), secretBytes) != 1 {
+			providedSum := sha256.Sum256([]byte(r.Header.Get("X-Gateway-Secret")))
+			if subtle.ConstantTimeCompare(providedSum[:], secretSum[:]) != 1 {
 				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			}

--- a/api/gateway_secret_middleware_test.go
+++ b/api/gateway_secret_middleware_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGatewaySecretMiddleware_NoSecret_PassesThrough(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	handler := GatewaySecretMiddleware("")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 when no secret configured, got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_ValidSecret_PassesThrough(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	handler := GatewaySecretMiddleware("my-secret-key")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set("X-Gateway-Secret", "my-secret-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid secret, got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_InvalidSecret_Rejects(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := GatewaySecretMiddleware("my-secret-key")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set("X-Gateway-Secret", "wrong-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 with invalid secret, got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_MissingHeader_Rejects(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := GatewaySecretMiddleware("my-secret-key")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 with missing header, got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_OptionsExempt(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler := GatewaySecretMiddleware("my-secret-key")(inner)
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/test", nil)
+	// No X-Gateway-Secret header — should still pass through.
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204 for OPTIONS (preflight exempt), got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_EmptyProvided_Rejects(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := GatewaySecretMiddleware("my-secret-key")(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Gateway-Secret", "")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 with empty header value, got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_TimingSafe(t *testing.T) {
+	t.Parallel()
+	// This test verifies that both a completely wrong key and a partially
+	// correct key are both rejected — not that timing is identical, but that
+	// the comparison uses constant-time logic (verified by code inspection).
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := GatewaySecretMiddleware("abcdefghijklmnop")(inner)
+
+	for _, provided := range []string{"abcdefghijklmnox", "xxxxxxxxxxxxxxxx", "abc", ""} {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Gateway-Secret", provided)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected 403 for %q, got %d", provided, rec.Code)
+		}
+	}
+}
+
+func TestGatewaySecretMiddleware_AllHTTPMethods(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := GatewaySecretMiddleware("test-secret")(inner)
+
+	// All non-OPTIONS methods should require the secret.
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodHead} {
+		req := httptest.NewRequest(method, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s without secret: expected 403, got %d", method, rec.Code)
+		}
+
+		req = httptest.NewRequest(method, "/", nil)
+		req.Header.Set("X-Gateway-Secret", "test-secret")
+		rec = httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s with valid secret: expected 200, got %d", method, rec.Code)
+		}
+	}
+}

--- a/api/gateway_secret_middleware_test.go
+++ b/api/gateway_secret_middleware_test.go
@@ -74,7 +74,7 @@ func TestGatewaySecretMiddleware_MissingHeader_Rejects(t *testing.T) {
 	}
 }
 
-func TestGatewaySecretMiddleware_OptionsExempt(t *testing.T) {
+func TestGatewaySecretMiddleware_CORSPreflightExempt(t *testing.T) {
 	t.Parallel()
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -82,12 +82,32 @@ func TestGatewaySecretMiddleware_OptionsExempt(t *testing.T) {
 
 	handler := GatewaySecretMiddleware("my-secret-key")(inner)
 	req := httptest.NewRequest(http.MethodOptions, "/api/v1/test", nil)
-	// No X-Gateway-Secret header — should still pass through.
+	// Genuine CORS preflight — includes Access-Control-Request-Method and no
+	// X-Gateway-Secret header — should pass through.
+	req.Header.Set("Access-Control-Request-Method", "POST")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusNoContent {
-		t.Errorf("expected 204 for OPTIONS (preflight exempt), got %d", rec.Code)
+		t.Errorf("expected 204 for genuine CORS preflight, got %d", rec.Code)
+	}
+}
+
+func TestGatewaySecretMiddleware_BareOPTIONS_Rejects(t *testing.T) {
+	t.Parallel()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler := GatewaySecretMiddleware("my-secret-key")(inner)
+	// OPTIONS request without Access-Control-Request-Method is not a CORS
+	// preflight — it should still be gated.
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for bare OPTIONS without gateway secret, got %d", rec.Code)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -441,6 +441,12 @@ func main() {
 	// handler, including the health check and SPA handler.
 	handler := api.CORSMiddleware(deps.AllowedOrigins)(mux)
 
+	// Gateway secret — optional access gate for private deployments.
+	// When GATEWAY_SECRET is set, every non-OPTIONS request must include a
+	// matching X-Gateway-Secret header or receive 403. This is the outermost
+	// middleware so unauthorized requests are rejected before any processing.
+	handler = api.GatewaySecretMiddleware(os.Getenv("GATEWAY_SECRET"))(handler)
+
 	// Wrap all routes with security headers (outermost layer).
 	// Include the Supabase URL in CSP connect-src so the frontend can reach
 	// the auth/API endpoints in production. Sentry's ingest domain is always

--- a/main.go
+++ b/main.go
@@ -442,9 +442,12 @@ func main() {
 	handler := api.CORSMiddleware(deps.AllowedOrigins)(mux)
 
 	// Gateway secret — optional access gate for private deployments.
-	// When GATEWAY_SECRET is set, every non-OPTIONS request must include a
-	// matching X-Gateway-Secret header or receive 403. This is the outermost
-	// middleware so unauthorized requests are rejected before any processing.
+	// When GATEWAY_SECRET is set, every request (except genuine CORS
+	// preflights) must include a matching X-Gateway-Secret header or receive
+	// 403. This wraps CORS and all application logic, so unauthorized
+	// requests are rejected before routing/auth. SecurityHeadersMiddleware
+	// (applied below) wraps this — it only sets response headers and never
+	// blocks, so it does not affect the gate's trust boundary.
 	handler = api.GatewaySecretMiddleware(os.Getenv("GATEWAY_SECRET"))(handler)
 
 	// Wrap all routes with security headers (outermost layer).

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -140,10 +140,13 @@ function AppContent({ onRetry }: { onRetry: () => void }) {
 }
 
 export default function App() {
-  // Hydrate custom host config from SecureStore so the API client middleware
-  // can route requests to a private deployment if configured.
+  // Hydrate custom host config from SecureStore BEFORE mounting any subtree
+  // that can issue API calls. Without this gate, the first one or more
+  // requests after cold start would bypass the custom host and gateway
+  // secret, causing surprising 403s against a gateway-locked server.
+  const [hostHydrated, setHostHydrated] = useState(false);
   useEffect(() => {
-    loadCustomHostConfig();
+    loadCustomHostConfig().finally(() => setHostHydrated(true));
   }, []);
 
   // Subscribe to AppState changes so React Query knows when the app is focused.
@@ -156,6 +159,17 @@ export default function App() {
   // Supabase's onAuthStateChange and retries the initial session check.
   const [authKey, setAuthKey] = useState(0);
   const handleRetry = useCallback(() => setAuthKey((k) => k + 1), []);
+
+  if (!hostHydrated) {
+    return (
+      <SafeAreaProvider>
+        <View style={styles.loading}>
+          <ActivityIndicator size="large" color={colors.gray900} />
+        </View>
+        <StatusBar style="auto" />
+      </SafeAreaProvider>
+    );
+  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -20,6 +20,7 @@ import { usePushSetup } from "./src/hooks/usePushSetup";
 import { useBiometricAuth } from "./src/hooks/useBiometricAuth";
 import { BiometricLockScreen } from "./src/screens/BiometricLockScreen";
 import { colors } from "./src/theme/colors";
+import { loadCustomHostConfig } from "./src/lib/customHostConfig";
 
 const useMockAuth = __DEV__ && process.env.EXPO_PUBLIC_MOCK_AUTH === "true";
 const ActiveAuthProvider = useMockAuth ? MockAuthProvider : AuthProvider;
@@ -139,6 +140,12 @@ function AppContent({ onRetry }: { onRetry: () => void }) {
 }
 
 export default function App() {
+  // Hydrate custom host config from SecureStore so the API client middleware
+  // can route requests to a private deployment if configured.
+  useEffect(() => {
+    loadCustomHostConfig();
+  }, []);
+
   // Subscribe to AppState changes so React Query knows when the app is focused.
   useEffect(() => {
     const sub = AppState.addEventListener("change", onAppStateChange);

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,9 +1,13 @@
 import createClient, { type Middleware } from "openapi-fetch";
 import type { paths } from "./schema";
 import mockClient from "./mockClient";
+import {
+  getCustomHost,
+  getGatewaySecret,
+} from "../lib/customHostConfig";
 
 /**
- * Returns the API base URL for the mobile app.
+ * Returns the default API base URL for the mobile app.
  *
  * In React Native there is no browser origin to resolve relative paths against,
  * so the base URL must always be an absolute URL. It reads from the
@@ -12,7 +16,7 @@ import mockClient from "./mockClient";
  *
  * Falls back to the production URL if no env var is set.
  */
-function resolveBaseUrl(): string {
+function resolveDefaultBaseUrl(): string {
   const envUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
   if (!envUrl) {
     if (__DEV__) {
@@ -25,6 +29,9 @@ function resolveBaseUrl(): string {
   }
   return envUrl.replace(/\/v1\/?$/, "").replace(/\/$/, "");
 }
+
+/** The default (non-custom) base URL, computed once at module load. */
+const defaultBaseUrl = resolveDefaultBaseUrl();
 
 const useMockApi = __DEV__ && process.env.EXPO_PUBLIC_MOCK_AUTH === "true";
 
@@ -73,22 +80,61 @@ export const jsonSafeMiddleware: Middleware = {
 };
 
 /**
+ * Middleware that rewrites the request URL to a custom host and injects
+ * the X-Gateway-Secret header when custom host mode is enabled.
+ *
+ * Reads from the in-memory cache in customHostConfig (synchronous, fast).
+ * The cache is hydrated from SecureStore at app startup via
+ * loadCustomHostConfig().
+ */
+export const customHostMiddleware: Middleware = {
+  async onRequest({ request }) {
+    const customHost = getCustomHost();
+    const gatewaySecret = getGatewaySecret();
+
+    let modifiedRequest = request;
+
+    if (customHost) {
+      // Replace the default base URL prefix with the custom host.
+      // e.g., "https://app.permissionslip.dev/api/v1/approvals"
+      //     → "https://my-server.example.com/api/v1/approvals"
+      const customBase = customHost
+        .replace(/\/v1\/?$/, "")
+        .replace(/\/$/, "");
+      const newUrl = request.url.replace(defaultBaseUrl, customBase);
+      modifiedRequest = new Request(newUrl, request);
+    }
+
+    if (gatewaySecret) {
+      modifiedRequest.headers.set("X-Gateway-Secret", gatewaySecret);
+    }
+
+    return modifiedRequest;
+  },
+};
+
+/**
  * Typed API client generated from the OpenAPI spec.
  * Uses the same `openapi-fetch` library as the web frontend.
  * Spec paths already include the "/v1" prefix, so the base URL is version-free.
  *
  * When EXPO_PUBLIC_MOCK_AUTH=true in dev mode, a mock client is used instead
  * so the app works without a running backend.
+ *
+ * Custom host mode: when a custom host URL is configured via Settings, the
+ * customHostMiddleware rewrites request URLs and injects the gateway secret
+ * header on every request.
  */
 // Safe: mockClient implements only GET/POST — the subset the mobile app uses.
 // TypeScript enforcement is bypassed because the mock doesn't expose the full
-// openapi-fetch interface. resolveBaseUrl() is only called when mock is off.
+// openapi-fetch interface.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const client = useMockApi
   ? (mockClient as any)
-  : createClient<paths>({ baseUrl: resolveBaseUrl() });
+  : createClient<paths>({ baseUrl: defaultBaseUrl });
 
 if (!useMockApi) {
+  client.use(customHostMiddleware);
   client.use(jsonSafeMiddleware);
 }
 

--- a/mobile/src/lib/customHostConfig.ts
+++ b/mobile/src/lib/customHostConfig.ts
@@ -11,8 +11,13 @@ let cachedHost: string | null = null;
 let cachedSecret: string | null = null;
 
 /**
- * Hydrate the in-memory cache from SecureStore. Call once at app startup
- * before creating the API client.
+ * Hydrate the in-memory cache from SecureStore during app startup
+ * (see `App.tsx`, which gates rendering on this promise). The API client
+ * in `client.ts` is constructed at module import — well before `App`
+ * runs — so the middleware synchronously reads this in-memory cache via
+ * `getCustomHost()` / `getGatewaySecret()` on each request. Blocking UI
+ * render until hydration completes is what prevents the first request
+ * from firing before the cache is populated.
  */
 export async function loadCustomHostConfig(): Promise<void> {
   cachedHost = (await SecureStore.getItemAsync(CUSTOM_HOST_KEY)) ?? null;

--- a/mobile/src/lib/customHostConfig.ts
+++ b/mobile/src/lib/customHostConfig.ts
@@ -1,0 +1,70 @@
+import * as SecureStore from "expo-secure-store";
+
+const CUSTOM_HOST_KEY = "custom_host_url";
+const GATEWAY_SECRET_KEY = "gateway_secret";
+
+/**
+ * In-memory cache so middleware reads are synchronous and fast.
+ * Call loadCustomHostConfig() at app startup to hydrate from SecureStore.
+ */
+let cachedHost: string | null = null;
+let cachedSecret: string | null = null;
+
+/**
+ * Hydrate the in-memory cache from SecureStore. Call once at app startup
+ * before creating the API client.
+ */
+export async function loadCustomHostConfig(): Promise<void> {
+  cachedHost = (await SecureStore.getItemAsync(CUSTOM_HOST_KEY)) ?? null;
+  cachedSecret = (await SecureStore.getItemAsync(GATEWAY_SECRET_KEY)) ?? null;
+}
+
+/** Returns the custom host URL, or null if using the default. */
+export function getCustomHost(): string | null {
+  return cachedHost;
+}
+
+/** Returns the gateway secret, or null if not configured. */
+export function getGatewaySecret(): string | null {
+  return cachedSecret;
+}
+
+/** Returns true when a custom host is configured and non-empty. */
+export function isCustomHostEnabled(): boolean {
+  return cachedHost != null && cachedHost.length > 0;
+}
+
+/**
+ * Persist custom host config to SecureStore and update the in-memory cache.
+ * Pass null to clear a value.
+ */
+export async function setCustomHostConfig(
+  host: string | null,
+  secret: string | null,
+): Promise<void> {
+  if (host && host.trim().length > 0) {
+    await SecureStore.setItemAsync(CUSTOM_HOST_KEY, host.trim());
+    cachedHost = host.trim();
+  } else {
+    await SecureStore.deleteItemAsync(CUSTOM_HOST_KEY);
+    cachedHost = null;
+  }
+  if (secret && secret.trim().length > 0) {
+    await SecureStore.setItemAsync(GATEWAY_SECRET_KEY, secret.trim());
+    cachedSecret = secret.trim();
+  } else {
+    await SecureStore.deleteItemAsync(GATEWAY_SECRET_KEY);
+    cachedSecret = null;
+  }
+}
+
+/**
+ * Clear all custom host configuration. Restores the app to using the
+ * default production host.
+ */
+export async function clearCustomHostConfig(): Promise<void> {
+  await SecureStore.deleteItemAsync(CUSTOM_HOST_KEY);
+  await SecureStore.deleteItemAsync(GATEWAY_SECRET_KEY);
+  cachedHost = null;
+  cachedSecret = null;
+}

--- a/mobile/src/screens/settings/CustomServerSettings.tsx
+++ b/mobile/src/screens/settings/CustomServerSettings.tsx
@@ -1,0 +1,278 @@
+/**
+ * Custom Server settings — allows the user to point the mobile app at a
+ * private Permission Slip deployment instead of the default production host.
+ *
+ * When enabled, all API calls are routed to the custom host URL and the
+ * gateway secret is sent as the X-Gateway-Secret header on every request.
+ *
+ * Changes take effect on app restart.
+ */
+import { useCallback, useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { colors } from "../../theme/colors";
+import {
+  clearCustomHostConfig,
+  getCustomHost,
+  getGatewaySecret,
+  isCustomHostEnabled,
+  loadCustomHostConfig,
+  setCustomHostConfig,
+} from "../../lib/customHostConfig";
+
+export default function CustomServerSettings() {
+  const [enabled, setEnabled] = useState(false);
+  const [hostUrl, setHostUrl] = useState("");
+  const [secret, setSecret] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Hydrate from SecureStore on mount.
+  useEffect(() => {
+    loadCustomHostConfig().then(() => {
+      setEnabled(isCustomHostEnabled());
+      setHostUrl(getCustomHost() ?? "");
+      setSecret(getGatewaySecret() ?? "");
+      setLoaded(true);
+    });
+  }, []);
+
+  const handleToggle = useCallback(
+    (value: boolean) => {
+      if (!value) {
+        // Turning off — clear config.
+        setSaving(true);
+        clearCustomHostConfig()
+          .then(() => {
+            setEnabled(false);
+            setHostUrl("");
+            setSecret("");
+            Alert.alert(
+              "Custom Server Disabled",
+              "The app will use the default server on next restart.",
+            );
+          })
+          .catch(() => {
+            Alert.alert("Error", "Failed to clear custom server settings.");
+          })
+          .finally(() => setSaving(false));
+      } else {
+        setEnabled(true);
+      }
+    },
+    [],
+  );
+
+  const handleSave = useCallback(async () => {
+    const trimmedHost = hostUrl.trim();
+    if (!trimmedHost) {
+      Alert.alert("Missing URL", "Please enter a server URL.");
+      return;
+    }
+
+    // Basic URL validation.
+    try {
+      const parsed = new URL(trimmedHost);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        Alert.alert("Invalid URL", "The URL must start with http:// or https://.");
+        return;
+      }
+    } catch {
+      Alert.alert("Invalid URL", "Please enter a valid server URL.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await setCustomHostConfig(trimmedHost, secret.trim() || null);
+      Alert.alert(
+        "Saved",
+        "Custom server settings saved. Restart the app for changes to take effect.",
+      );
+    } catch {
+      Alert.alert("Error", "Failed to save custom server settings.");
+    } finally {
+      setSaving(false);
+    }
+  }, [hostUrl, secret]);
+
+  if (!loaded) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="small" color={colors.gray500} />
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <View style={styles.card}>
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleLabel}>
+            <Text style={styles.toggleTitle}>Custom Server</Text>
+            <Text style={styles.toggleDescription}>
+              Connect to a private Permission Slip deployment instead of the
+              default server.
+            </Text>
+          </View>
+          <Switch
+            testID="custom-server-toggle"
+            value={enabled}
+            onValueChange={handleToggle}
+            disabled={saving}
+            trackColor={{
+              false: colors.gray300,
+              true: colors.primary,
+            }}
+            accessibilityLabel="Custom Server"
+            accessibilityRole="switch"
+            accessibilityState={{ checked: enabled }}
+          />
+        </View>
+      </View>
+
+      {enabled ? (
+        <View style={styles.formCard}>
+          <Text style={styles.inputLabel}>Server URL</Text>
+          <TextInput
+            testID="custom-host-input"
+            style={styles.input}
+            placeholder="https://your-server.example.com/api"
+            placeholderTextColor={colors.gray400}
+            value={hostUrl}
+            onChangeText={setHostUrl}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            textContentType="URL"
+          />
+
+          <Text style={[styles.inputLabel, styles.inputLabelSpaced]}>
+            Gateway Secret
+          </Text>
+          <TextInput
+            testID="gateway-secret-input"
+            style={styles.input}
+            placeholder="Optional — leave blank if not required"
+            placeholderTextColor={colors.gray400}
+            value={secret}
+            onChangeText={setSecret}
+            autoCapitalize="none"
+            autoCorrect={false}
+            secureTextEntry
+          />
+
+          <TouchableOpacity
+            testID="save-custom-server-button"
+            style={[styles.saveButton, saving && styles.saveButtonDisabled]}
+            onPress={handleSave}
+            disabled={saving}
+            accessibilityRole="button"
+            accessibilityLabel="Save custom server settings"
+          >
+            {saving ? (
+              <ActivityIndicator size="small" color={colors.white} />
+            ) : (
+              <Text style={styles.saveButtonText}>Save</Text>
+            )}
+          </TouchableOpacity>
+
+          <Text style={styles.hint}>
+            Changes take effect on app restart.
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    paddingVertical: 24,
+    alignItems: "center",
+  },
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  toggleLabel: {
+    flex: 1,
+    marginRight: 12,
+  },
+  toggleTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.gray900,
+    marginBottom: 2,
+  },
+  toggleDescription: {
+    fontSize: 13,
+    color: colors.gray500,
+    lineHeight: 18,
+  },
+  formCard: {
+    marginTop: 12,
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+    padding: 16,
+  },
+  inputLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.gray700,
+    marginBottom: 6,
+  },
+  inputLabelSpaced: {
+    marginTop: 16,
+  },
+  input: {
+    backgroundColor: colors.primaryBg,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: colors.gray900,
+  },
+  saveButton: {
+    marginTop: 20,
+    backgroundColor: colors.primary,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  saveButtonDisabled: {
+    opacity: 0.6,
+  },
+  saveButtonText: {
+    color: colors.white,
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  hint: {
+    marginTop: 10,
+    fontSize: 12,
+    color: colors.gray400,
+    textAlign: "center",
+  },
+});

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -24,6 +24,7 @@ import { useUpdateNotificationPreferences } from "../../hooks/useUpdateNotificat
 import Constants from "expo-constants";
 import { useDeleteAccount } from "../../hooks/useDeleteAccount";
 import { colors } from "../../theme/colors";
+import CustomServerSettings from "./CustomServerSettings";
 
 const GIT_COMMIT_HASH: string =
   (Constants.expoConfig?.extra?.gitCommitHash as string) ?? "unknown";
@@ -189,6 +190,14 @@ export default function SettingsScreen(_props: Props) {
             <Text style={styles.destructiveActionText}>Delete Account</Text>
           )}
         </TouchableOpacity>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Server</Text>
+        <Text style={styles.sectionDescription}>
+          Connect to a self-hosted Permission Slip instance.
+        </Text>
+        <CustomServerSettings />
       </View>
 
       <View style={styles.section}>

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -31,6 +31,12 @@ jest.mock("../../../auth/AuthContext", () => ({
   }),
 }));
 
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock("expo-constants", () => ({
   __esModule: true,
   default: {


### PR DESCRIPTION
## Summary

- **Backend:** Adds `GatewaySecretMiddleware` — when the `GATEWAY_SECRET` env var is set, all non-OPTIONS requests must include a matching `X-Gateway-Secret` header or receive 403. Runs as the outermost middleware (before CORS, security headers, routing, auth) using constant-time comparison. When unset, the middleware is a complete no-op.
- **Mobile:** Adds a "Custom Server" section in Settings where users can configure a custom host URL and gateway secret. The API client middleware rewrites request URLs and injects the header on every request. Config is persisted in SecureStore (iOS Keychain / Android EncryptedSharedPreferences).
- **CORS:** Adds `X-Gateway-Secret` to the allowed CORS headers so browser-based clients can send the header in cross-origin requests.

## Test plan

### Developer
- [x] Backend: 8 unit tests for gateway secret middleware (no secret passthrough, valid/invalid/missing/empty header, OPTIONS exempt, all HTTP methods, timing safety)
- [x] Mobile: All 225 existing tests pass with new SecureStore mock
- [x] TypeScript check passes (pre-existing errors only)

### Manual Testing
- [ ] Deploy with `GATEWAY_SECRET=<random-64-hex>` and verify requests without the header get 403
- [ ] Deploy without `GATEWAY_SECRET` and verify everything works as before (no-op)
- [ ] In mobile app Settings, enable Custom Server, enter host URL + gateway secret, save, restart app, verify API calls route to the custom host with the header
- [ ] Toggle Custom Server off, restart, verify app reverts to default host
- [ ] Verify push notifications still work when connected to a custom host

https://claude.ai/code/session_017gCSx2YrGjQVXEy5zVHQT3