### PR TITLE
Add Supabase local setup: reverse proxy + zero-account Pi quickstart

### DIFF
--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -88,7 +88,7 @@ This gives you PostgreSQL, Auth (GoTrue), Vault, and Inbucket (email capture) â€
 | API URL | `SUPABASE_URL` | `http://127.0.0.1:54321` |
 | anon key | `VITE_SUPABASE_PUBLISHABLE_KEY` | `eyJhbGci...` |
 
-**Built-in Supabase proxy:** The Go server includes a reverse proxy at `/supabase/*` that forwards requests to `SUPABASE_URL`. When `VITE_SUPABASE_URL` is omitted at build time, the frontend uses this proxy automatically. This means:
+**Built-in Supabase proxy:** The Go server includes a reverse proxy at `/supabase/auth/v1/*` that forwards Supabase Auth requests to `SUPABASE_URL`. When `VITE_SUPABASE_URL` is omitted at build time, the frontend uses this proxy automatically. This means:
 - No need to expose Supabase ports to the network
 - No CORS configuration needed
 - The frontend works regardless of hostname or IP changes

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -35,7 +35,7 @@ Before deploying, you'll need:
 The server handles everything on a single port:
 - API endpoints under `/api/v1/`
 - Health check at `/api/health`
-- Supabase reverse proxy at `/supabase/*` (forwards to `SUPABASE_URL`)
+- Supabase Auth reverse proxy at `/supabase/auth/v1/*` (forwards to `SUPABASE_URL`)
 - React SPA for all other routes
 - Database migrations run automatically on startup
 
@@ -70,8 +70,8 @@ If you prefer to run everything locally with zero external accounts, you can use
 git clone https://github.com/supersuit-tech/permission-slip.git
 cd permission-slip
 
-# Generate a vault encryption key
-echo "VAULT_SECRET_KEY=$(openssl rand -hex 32)" > .env
+# Generate a vault encryption key (appends to .env if the key isn't already set)
+grep -q "^VAULT_SECRET_KEY=" .env 2>/dev/null || echo "VAULT_SECRET_KEY=$(openssl rand -hex 32)" >> .env
 
 # Start local Supabase (pulls Docker images on first run)
 supabase start
@@ -93,6 +93,8 @@ This gives you PostgreSQL, Auth (GoTrue), Vault, and Inbucket (email capture) �
 - No CORS configuration needed
 - The frontend works regardless of hostname or IP changes
 - Only port 8080 needs to be reachable
+
+The proxy is deliberately narrow — it **only forwards `/auth/v1/*`** (the Supabase Auth surface, which is all the frontend uses). Requests for other Supabase surfaces (`/rest/v1/`, `/storage/v1/`, `/realtime/v1/`, `/functions/v1/`) return 404. This prevents the proxy from being usable as an open HTTP relay into arbitrary upstream paths.
 
 **Auth emails** are captured by Inbucket at `http://localhost:54324` (no real emails are sent). Check Inbucket for OTP verification codes during signup and login.
 
@@ -155,7 +157,7 @@ These are inlined into the JavaScript bundle by Vite at build time. They must be
 
 > The publishable key is safe to include in the build — it's a public key visible in client-side JavaScript by design. (Supabase previously called this the "anon key.")
 
-**Supabase reverse proxy:** The Go server proxies `/supabase/*` to `SUPABASE_URL` at runtime. When `VITE_SUPABASE_URL` is omitted from the build, the frontend automatically uses this proxy. This is the recommended approach for self-hosted deployments because it eliminates hostname/IP dependencies in the frontend build and avoids CORS issues. Cloud Supabase deployments should still set `VITE_SUPABASE_URL` for direct browser-to-Supabase communication.
+**Supabase reverse proxy:** The Go server proxies `/supabase/auth/v1/*` to `SUPABASE_URL` at runtime. When `VITE_SUPABASE_URL` is omitted from the build, the frontend automatically uses this proxy. Only the Supabase Auth surface is forwarded — other Supabase surfaces (rest, storage, realtime, functions) return 404 to prevent the proxy from being used as an open HTTP relay. This is the recommended approach for self-hosted deployments because it eliminates hostname/IP dependencies in the frontend build and avoids CORS issues. Cloud Supabase deployments should still set `VITE_SUPABASE_URL` for direct browser-to-Supabase communication.
 
 ### Web Push Notifications (VAPID)
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -11,8 +11,8 @@ Before deploying, you'll need:
 | Service | Purpose | Notes |
 |---|---|---|
 | **PostgreSQL 16+** | Application database | Any managed provider works (Supabase, Neon, AWS RDS, self-hosted) |
-| **Supabase project** | User authentication (JWT-based) | Free tier is sufficient. Provides login, MFA, and JWT verification |
-| **Docker** (optional) | Container-based deployment | Only needed if deploying via Docker |
+| **Supabase** | User authentication (JWT-based) | Cloud (free tier) **or** local via `supabase start` — no account needed |
+| **Docker** (optional) | Container-based deployment | Required for local Supabase; optional otherwise |
 
 ## Architecture Overview
 
@@ -35,6 +35,7 @@ Before deploying, you'll need:
 The server handles everything on a single port:
 - API endpoints under `/api/v1/`
 - Health check at `/api/health`
+- Supabase reverse proxy at `/supabase/*` (forwards to `SUPABASE_URL`)
 - React SPA for all other routes
 - Database migrations run automatically on startup
 
@@ -59,6 +60,43 @@ Permission Slip uses [Supabase Auth](https://supabase.com/auth) for user authent
 | **Session timeouts** | Authentication > Sessions | Set timebox and inactivity timeout per your security policy |
 
 > **Note:** You can use Supabase's hosted database as your `DATABASE_URL` too, or use a separate PostgreSQL instance. Either works.
+
+### Alternative: Local Supabase (no cloud account)
+
+If you prefer to run everything locally with zero external accounts, you can use the Supabase CLI to run the full auth stack in Docker:
+
+```bash
+# Clone the repo (contains supabase/config.toml)
+git clone https://github.com/supersuit-tech/permission-slip.git
+cd permission-slip
+
+# Generate a vault encryption key
+echo "VAULT_SECRET_KEY=$(openssl rand -hex 32)" > .env
+
+# Start local Supabase (pulls Docker images on first run)
+supabase start
+
+# Get credentials
+supabase status
+```
+
+This gives you PostgreSQL, Auth (GoTrue), Vault, and Inbucket (email capture) — all running locally. Use the credentials from `supabase status`:
+
+| `supabase status` field | Environment variable | Example |
+|---|---|---|
+| DB URL | `DATABASE_URL` | `postgresql://postgres:postgres@127.0.0.1:54322/postgres` |
+| API URL | `SUPABASE_URL` | `http://127.0.0.1:54321` |
+| anon key | `VITE_SUPABASE_PUBLISHABLE_KEY` | `eyJhbGci...` |
+
+**Built-in Supabase proxy:** The Go server includes a reverse proxy at `/supabase/*` that forwards requests to `SUPABASE_URL`. When `VITE_SUPABASE_URL` is omitted at build time, the frontend uses this proxy automatically. This means:
+- No need to expose Supabase ports to the network
+- No CORS configuration needed
+- The frontend works regardless of hostname or IP changes
+- Only port 8080 needs to be reachable
+
+**Auth emails** are captured by Inbucket at `http://localhost:54324` (no real emails are sent). Check Inbucket for OTP verification codes during signup and login.
+
+> For a complete step-by-step guide with systemd services, notifications, and internet exposure, see the **[Raspberry Pi Quickstart](raspberry-pi-quickstart.md)** — it works on any Linux machine, not just Pis.
 
 ## Step 2: Set Up PostgreSQL
 
@@ -111,11 +149,13 @@ These are inlined into the JavaScript bundle by Vite at build time. They must be
 
 | Variable | Description | Example |
 |---|---|---|
-| `VITE_SUPABASE_URL` | Supabase project URL (frontend auth) | `https://abcdefgh.supabase.co` |
-| `VITE_SUPABASE_PUBLISHABLE_KEY` | Supabase publishable key | From Supabase dashboard |
+| `VITE_SUPABASE_URL` | Supabase project URL (frontend auth). **Optional** — when omitted, the frontend uses the built-in `/supabase` reverse proxy (see below). | `https://abcdefgh.supabase.co` |
+| `VITE_SUPABASE_PUBLISHABLE_KEY` | Supabase publishable key | From Supabase dashboard or `supabase status` |
 | `VITE_SENTRY_DSN` | Frontend error tracking (optional) | `https://key@o0.ingest.sentry.io/0` |
 
 > The publishable key is safe to include in the build — it's a public key visible in client-side JavaScript by design. (Supabase previously called this the "anon key.")
+
+**Supabase reverse proxy:** The Go server proxies `/supabase/*` to `SUPABASE_URL` at runtime. When `VITE_SUPABASE_URL` is omitted from the build, the frontend automatically uses this proxy. This is the recommended approach for self-hosted deployments because it eliminates hostname/IP dependencies in the frontend build and avoids CORS issues. Cloud Supabase deployments should still set `VITE_SUPABASE_URL` for direct browser-to-Supabase communication.
 
 ### Web Push Notifications (VAPID)
 
@@ -455,7 +495,7 @@ Migrations run automatically on startup. If they fail, check database connectivi
 |---|---|---|---|
 | `DATABASE_URL` | Yes | Runtime | PostgreSQL connection string |
 | `SUPABASE_URL` | Yes | Runtime | Supabase project URL (JWT + auth) |
-| `VITE_SUPABASE_URL` | Yes | Build | Supabase URL for frontend auth |
+| `VITE_SUPABASE_URL` | No | Build | Supabase URL for frontend auth (omit for self-hosted — uses built-in proxy) |
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | Yes | Build | Supabase publishable key |
 | `BASE_URL` | Recommended | Runtime | Public deployment URL |
 | `ALLOWED_ORIGINS` | Recommended | Runtime | CORS allowed origins (comma-separated, exact match, no trailing slash). Same-origin only when unset. |

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -1,30 +1,34 @@
 # Raspberry Pi Quickstart
 
-Get Permission Slip running on a Raspberry Pi in under 30 minutes. This is an opinionated guide that gets you to a working self-hosted instance with the minimum number of services and accounts.
+Get Permission Slip running on a Raspberry Pi with **zero external accounts**. Everything runs locally — Supabase handles auth and the database in Docker containers, and Permission Slip runs alongside it.
 
 ## What You'll Need
 
 ### Hardware
 
-- **[Raspberry Pi 5 (8GB)](https://a.co/d/0cQXzRi1)** — recommended for running Permission Slip, PostgreSQL, and Docker comfortably
+- **[Raspberry Pi 5 (8GB)](https://a.co/d/0cQXzRi1)** — recommended; the Supabase stack uses ~1.5GB RAM
 - A microSD card (32GB+) or USB SSD (preferred for better performance and longevity)
 - Power supply (USB-C, 27W for Pi 5)
 - Ethernet cable or Wi-Fi connection
 
-### Accounts to Sign Up For
+> **4GB Pi 5?** It works, but you'll want to [disable unused Supabase services](#slim-down-supabase-4gb-pi) to free up RAM.
 
-You need **two** external accounts:
+### What Gets Installed
 
-| Service | Why | Cost |
+| Component | Purpose | How it runs |
 |---|---|---|
-| [Supabase](https://supabase.com) | User authentication (login, MFA, JWTs) | Free tier is sufficient |
-| [AWS](https://aws.amazon.com) | SMS notifications via Amazon SNS | Pay-as-you-go (~$0.0075/SMS in the US) |
+| Docker | Container runtime for Supabase | System package |
+| Supabase CLI | Manages local auth, database, and vault | arm64 binary |
+| PostgreSQL 17 | Application database | Inside Supabase's Docker stack |
+| GoTrue | Auth (login, MFA, JWTs) | Inside Supabase's Docker stack |
+| Inbucket | Captures auth emails locally | Inside Supabase's Docker stack |
+| Permission Slip | The app itself | Docker container or native binary |
 
-Amazon SNS ensures approvers get notified on their phone immediately — even without the app installed, without a browser open, and regardless of iOS vs Android. PostgreSQL runs locally on the Pi — no managed database needed.
+**No cloud accounts.** No Supabase subscription, no AWS, no third-party services. Everything runs on the Pi.
 
 ## Step 1: Set Up Your Raspberry Pi
 
-If your Pi is already running Raspberry Pi OS, skip to Step 2.
+If your Pi is already running Raspberry Pi OS (64-bit), skip to Step 2.
 
 1. Download and install [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
 2. Flash **Raspberry Pi OS (64-bit)** to your SD card or SSD
@@ -35,7 +39,7 @@ If your Pi is already running Raspberry Pi OS, skip to Step 2.
 ssh pi@raspberrypi.local
 ```
 
-## Step 2: Install Dependencies
+## Step 2: Install Docker and Supabase CLI
 
 ```bash
 # Update system packages
@@ -45,214 +49,231 @@ sudo apt update && sudo apt upgrade -y
 curl -fsSL https://get.docker.com | sh
 sudo usermod -aG docker $USER
 
-# Log out and back in for group changes to take effect
+# Log out and back in for the docker group to take effect
 exit
-# SSH back in
+```
+
+SSH back in, then install the Supabase CLI:
+
+```bash
 ssh pi@raspberrypi.local
 
-# Install PostgreSQL
-sudo apt install -y postgresql postgresql-client
+# Install Supabase CLI (arm64)
+curl -sSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_arm64.deb -o /tmp/supabase.deb
+sudo dpkg -i /tmp/supabase.deb
 
-# Start PostgreSQL and enable on boot
-sudo systemctl enable --now postgresql
-```
-
-Verify both are working:
-
-```bash
+# Verify
 docker --version
-sudo -u postgres psql -c "SELECT version();"
+supabase --version
 ```
 
-## Step 3: Create the Database
+## Step 3: Start the Local Supabase Stack
+
+Clone the repository — it contains the Supabase configuration:
 
 ```bash
-# Create a database and user for Permission Slip
-sudo -u postgres psql <<'SQL'
-CREATE USER permissionslip WITH PASSWORD 'changeme-use-a-real-password';
-CREATE DATABASE permissionslip OWNER permissionslip;
--- Install required extensions for credential vault
-\c permissionslip
-CREATE EXTENSION IF NOT EXISTS pgsodium;
-CREATE EXTENSION IF NOT EXISTS supabase_vault;
-SQL
+git clone https://github.com/supersuit-tech/permission-slip.git
+cd permission-slip
 ```
 
-> **Note:** The `pgsodium` and `supabase_vault` extensions are needed for credential encryption. If they're not available in your Postgres packages, Permission Slip will still work — you just won't be able to store encrypted credentials in the vault. You can skip those two `CREATE EXTENSION` lines if they fail.
-
-## Step 4: Set Up Supabase Auth
-
-1. Go to [supabase.com](https://supabase.com) and create a free account
-2. Create a new project (any region)
-3. From your project dashboard, grab:
-   - **Project URL** (e.g., `https://abcdefgh.supabase.co`)
-   - **Publishable key** (under Project Settings > API)
-4. Configure auth settings:
-   - **Authentication > URL Configuration > Site URL:** Set to your Pi's URL (e.g., `http://raspberrypi.local:8080` for LAN access, or your domain/tunnel URL)
-   - **Authentication > URL Configuration > Redirect URLs:** Add the same URL
-   - **Authentication > Email:** Ensure email sign-in is enabled
-
-## Step 5: Set Up Notifications
-
-Permission Slip is an approval system — approvers need to know when something's waiting for them. Without notifications, they'd have to keep checking the web UI manually.
-
-### Amazon SNS SMS (works on any phone)
-
-SMS is the most reliable way to reach approvers on the go. It works on every phone — no app to install, no browser to keep open.
-
-1. Sign up for an [AWS account](https://aws.amazon.com) if you don't have one
-2. Create an IAM user with `sns:Publish` permission and generate access keys
-3. In the SNS console, request to move out of the SMS sandbox for production use
-
-You'll add these values to your environment in the next step:
-
-| Variable | Value |
-|---|---|
-| `AWS_REGION` | AWS region (e.g. `us-east-1`) |
-| `AWS_ACCESS_KEY_ID` | Your IAM access key (`AKIAxxxx`) |
-| `AWS_SECRET_ACCESS_KEY` | Your IAM secret key |
-
-> For more notification options (web push, email, mobile app), see the [Self-Hosted Deployment Guide](deployment-self-hosted.md).
-
-## Step 6: Deploy with Docker
-
-Create a directory for your deployment:
+Generate a vault encryption key (Supabase Vault uses this to encrypt stored credentials at rest):
 
 ```bash
-mkdir ~/permission-slip && cd ~/permission-slip
+echo "VAULT_SECRET_KEY=$(openssl rand -hex 32)" > .env
 ```
 
-Create a `.env` file with your secrets:
+Start the local Supabase stack. The first run pulls Docker images — expect this to take 5-10 minutes on a Pi:
 
 ```bash
-cat > .env <<'EOF'
-# Required
-DATABASE_URL=postgres://permissionslip:changeme-use-a-real-password@host.docker.internal:5432/permissionslip?sslmode=disable
-SUPABASE_URL=https://abcdefgh.supabase.co
-BASE_URL=http://raspberrypi.local:8080
-ALLOWED_ORIGINS=http://raspberrypi.local:8080
-
-# Generate with: openssl rand -hex 32
-INVITE_HMAC_KEY=generate-me
-
-# SMS (Amazon SNS) — paste your values from Step 5
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=AKIAxxxx
-AWS_SECRET_ACCESS_KEY=your-secret-key
-EOF
+supabase start
 ```
 
-Fill in the real values, then generate the HMAC key:
+Once it's running, verify and grab your credentials:
 
 ```bash
-sed -i "s/INVITE_HMAC_KEY=generate-me/INVITE_HMAC_KEY=$(openssl rand -hex 32)/" .env
+supabase status
 ```
 
-Create a `docker-compose.yml`:
+You'll see output like:
 
-```yaml
-services:
-  permission-slip:
-    image: ghcr.io/supersuit-tech/permission-slip:latest
-    # Or build from source (uncomment below, comment out image above):
-    # build:
-    #   context: .
-    #   args:
-    #     VITE_SUPABASE_URL: https://abcdefgh.supabase.co
-    #     VITE_SUPABASE_PUBLISHABLE_KEY: your-publishable-key
-    ports:
-      - "8080:8080"
-    env_file: .env
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8080/api/health"]
-      interval: 15s
-      timeout: 3s
-      retries: 3
+```
+         API URL: http://127.0.0.1:54321
+          DB URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+      Studio URL: http://127.0.0.1:54323
+    Inbucket URL: http://127.0.0.1:54324
+        anon key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+service_role key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
-> **Note:** `host.docker.internal` lets the container reach PostgreSQL running on the host. The `extra_hosts` line makes this work on Linux.
+The **anon key** is the publishable key used by the frontend. The **DB URL** is the PostgreSQL connection string.
 
-Start it up:
+## Step 4: Deploy Permission Slip
+
+### Option A: Docker (recommended)
+
+Build the Docker image. The only build-time argument needed is the Supabase publishable key:
 
 ```bash
-docker compose up -d
+# Extract the anon key automatically
+ANON_KEY=$(supabase status -o env 2>/dev/null | grep '^ANON_KEY=' | cut -d= -f2-)
+
+# Build (takes 10-20 minutes on a Pi 5 — Go + Node.js compilation)
+docker build \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="$ANON_KEY" \
+  -t permission-slip .
 ```
+
+> **Note:** `VITE_SUPABASE_URL` is intentionally omitted. The Go server includes a built-in reverse proxy that routes `/supabase/*` to the local Supabase stack. The frontend uses this automatically when no explicit Supabase URL is baked in, so it works regardless of your Pi's hostname or IP address.
+
+Run the container:
+
+```bash
+docker run -d --name permission-slip \
+  --network host \
+  -e DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+  -e SUPABASE_URL="http://127.0.0.1:54321" \
+  -e BASE_URL="http://raspberrypi.local:8080" \
+  -e ALLOWED_ORIGINS="http://raspberrypi.local:8080" \
+  -e INVITE_HMAC_KEY="$(openssl rand -hex 32)" \
+  --restart unless-stopped \
+  permission-slip
+```
+
+> **`--network host`** lets the container reach Supabase on localhost without Docker networking complexity.
 
 Check that it's healthy:
 
 ```bash
-docker compose ps
-# Should show "healthy" after ~30 seconds
-
+docker ps
+# Wait ~30 seconds, then:
 curl http://localhost:8080/api/health
-# Should return 200 OK
 ```
 
-## Step 7: Build from Source (Alternative)
+### Option B: Build from Source
 
-If you prefer to build and run the binary directly instead of Docker:
+If you prefer to run the binary directly:
 
 ```bash
-# Install Go
+# Install Go (arm64)
 wget https://go.dev/dl/go1.24.1.linux-arm64.tar.gz
 sudo tar -C /usr/local -xzf go1.24.1.linux-arm64.tar.gz
 echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
 source ~/.bashrc
 
-# Install Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Install Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt install -y nodejs
 
-# Clone and build
-git clone https://github.com/supersuit-tech/permission-slip.git
-cd permission-slip
+# Install dependencies and build
 make install
 
-export VITE_SUPABASE_URL=https://abcdefgh.supabase.co
-export VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+ANON_KEY=$(supabase status -o env 2>/dev/null | grep '^ANON_KEY=' | cut -d= -f2-)
+export VITE_SUPABASE_PUBLISHABLE_KEY="$ANON_KEY"
 make build
 
-# Run (set all env vars, or use an .env file with source)
-export DATABASE_URL="postgres://permissionslip:changeme-use-a-real-password@localhost:5432/permissionslip?sslmode=disable"
-export SUPABASE_URL="https://abcdefgh.supabase.co"
+# Run
+export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+export SUPABASE_URL="http://127.0.0.1:54321"
 export BASE_URL="http://raspberrypi.local:8080"
 export ALLOWED_ORIGINS="http://raspberrypi.local:8080"
 export INVITE_HMAC_KEY="$(openssl rand -hex 32)"
-export AWS_REGION="us-east-1"
-export AWS_ACCESS_KEY_ID="AKIAxxxx"
-export AWS_SECRET_ACCESS_KEY="your-secret-key"
 ./bin/server
 ```
 
-> **Tip:** To keep the server running after you close the terminal, use a systemd service. See [Running as a systemd service](#running-as-a-systemd-service) below.
+> **Tip:** To keep the server running after you close the terminal, use a systemd service. See [Running on boot](#running-on-boot) below.
 
-## Step 8: Access Permission Slip
+## Step 5: Create Your Account
 
-Open your browser and go to:
+1. Open your browser and go to:
 
+   ```
+   http://raspberrypi.local:8080
+   ```
+
+2. Sign up with your email address.
+
+3. Since Supabase runs locally, the confirmation email is captured by **Inbucket** (the built-in email testing server). Open it in another tab:
+
+   ```
+   http://raspberrypi.local:54324
+   ```
+
+4. Find the email, copy the 6-digit OTP code, and enter it back in the app.
+
+You're in! After the initial signup, your session stays active via JWT refresh — you won't need Inbucket again unless you log out or sign up another user.
+
+> **Can't reach `raspberrypi.local`?** Not all networks support mDNS. Find your Pi's IP with `hostname -I` and use that instead (e.g., `http://192.168.1.100:8080`).
+
+## Running on Boot
+
+### Supabase
+
+Create a systemd service so Supabase starts automatically on boot:
+
+```bash
+sudo tee /etc/systemd/system/supabase.service > /dev/null <<'EOF'
+[Unit]
+Description=Supabase Local Stack
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=pi
+WorkingDirectory=/home/pi/permission-slip
+ExecStart=/usr/bin/supabase start
+ExecStop=/usr/bin/supabase stop
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable supabase
 ```
-http://raspberrypi.local:8080
+
+### Permission Slip (Docker)
+
+The `--restart unless-stopped` flag on the Docker container already handles restarts. Docker starts automatically on boot, and the container restarts with it.
+
+To make Permission Slip wait for Supabase, add a dependency:
+
+```bash
+sudo tee /etc/systemd/system/permission-slip-wait.service > /dev/null <<'EOF'
+[Unit]
+Description=Wait for Supabase before Permission Slip
+After=supabase.service
+Requires=supabase.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'until curl -sf http://localhost:54321/auth/v1/health > /dev/null 2>&1; do sleep 2; done && docker restart permission-slip'
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable permission-slip-wait
 ```
 
-Sign up with your email. You'll receive a confirmation email via Supabase Auth.
-
-## Optional: Running as a systemd Service
-
-To start Permission Slip automatically on boot (for the build-from-source approach):
+### Permission Slip (build from source)
 
 ```bash
 sudo tee /etc/systemd/system/permission-slip.service > /dev/null <<'EOF'
 [Unit]
 Description=Permission Slip
-After=network.target postgresql.service
+After=supabase.service docker.service
+Requires=supabase.service
 
 [Service]
 Type=simple
 User=pi
 WorkingDirectory=/home/pi/permission-slip
+ExecStartPre=/bin/bash -c 'until curl -sf http://localhost:54321/auth/v1/health > /dev/null 2>&1; do sleep 2; done'
 ExecStart=/home/pi/permission-slip/bin/server
 EnvironmentFile=/home/pi/permission-slip/.env
 Restart=on-failure
@@ -263,14 +284,58 @@ WantedBy=multi-user.target
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now permission-slip
+sudo systemctl enable permission-slip
 ```
 
-Create `/home/pi/permission-slip/.env` with your environment variables (one per line, `KEY=value` format).
+Create `/home/pi/permission-slip/.env` with your runtime environment variables (one per line, `KEY=value` format):
+
+```bash
+cat > /home/pi/permission-slip/.env <<'EOF'
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+SUPABASE_URL=http://127.0.0.1:54321
+BASE_URL=http://raspberrypi.local:8080
+ALLOWED_ORIGINS=http://raspberrypi.local:8080
+INVITE_HMAC_KEY=your-generated-key-here
+EOF
+```
+
+## Optional: Add Notifications
+
+The base setup works without any notification service. Approvers can check the web UI manually. When you're ready to add notifications, here are your options — none require a cloud account unless noted:
+
+### Web Push (no account needed)
+
+Browser push notifications work entirely with self-generated VAPID keys:
+
+```bash
+# Requires Go (install per Option B above if not already installed)
+cd /home/pi/permission-slip
+go run ./cmd/generate-vapid-keys
+```
+
+Add the output (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) to your `.env` file and restart Permission Slip.
+
+### Email (SMTP)
+
+Use any SMTP server — Gmail with an app password, self-hosted Postfix, Mailgun, etc.:
+
+```bash
+# Add to .env
+NOTIFICATION_EMAIL_PROVIDER=smtp
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=you@gmail.com
+SMTP_PASSWORD=your-app-password
+NOTIFICATION_EMAIL_FROM=you@gmail.com
+```
+
+### SMS (requires AWS account)
+
+If you want SMS notifications, set up Amazon SNS. See the [Self-Hosted Deployment Guide — SMS Notifications](deployment-self-hosted.md#sms-notifications-amazon-sns--recommended-for-self-hosted) for instructions.
 
 ## Optional: Expose to the Internet
 
-To access your Pi from outside your local network, you have a few options:
+To access your Pi from outside your local network:
 
 **Cloudflare Tunnel (recommended — free, no port forwarding needed):**
 
@@ -289,9 +354,7 @@ cloudflared tunnel route dns permission-slip permissions.yourdomain.com
 cloudflared tunnel run --url http://localhost:8080 permission-slip
 ```
 
-After setting up a tunnel, update your environment:
-- `BASE_URL` and `ALLOWED_ORIGINS` → your public URL (e.g., `https://permissions.yourdomain.com`)
-- Supabase **Site URL** and **Redirect URLs** → same public URL
+After setting up a tunnel, update `BASE_URL` and `ALLOWED_ORIGINS` in your `.env` to your public URL (e.g., `https://permissions.yourdomain.com`) and restart Permission Slip.
 
 **Tailscale (good for personal use):**
 
@@ -304,37 +367,45 @@ Access via your Tailscale IP or MagicDNS hostname. No config changes needed sinc
 
 ## Troubleshooting
 
-**Docker container can't connect to PostgreSQL:**
+**`supabase start` fails or hangs:**
 
-PostgreSQL defaults to rejecting non-local connections. Edit `pg_hba.conf` to allow Docker's network:
+Ensure Docker is running and your user is in the `docker` group:
 
 ```bash
-# Find the config file
-sudo -u postgres psql -c "SHOW hba_file;"
-
-# Add this line (adjust the subnet to match your Docker network)
-# host all all 172.17.0.0/16 md5
-sudo nano /etc/postgresql/*/main/pg_hba.conf
-
-# Also ensure PostgreSQL listens on all interfaces
-sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/*/main/postgresql.conf
-
-sudo systemctl restart postgresql
+docker info > /dev/null 2>&1 || echo "Docker is not running"
+groups | grep -q docker || echo "User not in docker group — run: sudo usermod -aG docker $USER && exit"
 ```
 
-**Slow builds on the Pi:**
+If it's pulling images slowly, this is normal on first run. Subsequent starts are fast (~10 seconds).
 
-Building from source (especially the frontend) can take several minutes on a Pi. This is normal. If it's too slow, consider cross-compiling on a faster machine:
+**Docker container can't connect to Supabase (connection refused):**
+
+If you're using `--network host`, the container shares the host's network and can reach Supabase at `127.0.0.1:54321`. Verify Supabase is running:
 
 ```bash
-# On your development machine (Linux/macOS with Go installed)
+curl http://localhost:54321/auth/v1/health
+# Should return {"status":"ready"}
+```
+
+If not, run `supabase start` again from the `permission-slip` directory.
+
+**Can't access Inbucket from your laptop:**
+
+Inbucket listens on port 54324. If `http://raspberrypi.local:54324` doesn't load, try the Pi's IP address directly. Docker binds to all interfaces by default, so it should be accessible on the LAN.
+
+**Slow Docker build on the Pi:**
+
+Building the Docker image involves compiling Go and Node.js — expect 10-20 minutes on a Pi 5. This is normal. For faster iteration, use the [build from source](#option-b-build-from-source) approach (incremental builds are much faster after the first one). Alternatively, cross-compile on a faster machine:
+
+```bash
+# On your development machine
 GOOS=linux GOARCH=arm64 CGO_ENABLED=0 make build
-# Then copy bin/server to your Pi
+# Copy bin/server to the Pi via scp
 ```
 
 **Out of memory during build:**
 
-The 8GB Pi 5 should be fine, but if you're on a 4GB model, add swap:
+The 8GB Pi 5 should be fine. On a 4GB model, add swap:
 
 ```bash
 sudo dphys-swapfile swapoff
@@ -345,17 +416,61 @@ sudo dphys-swapfile swapon
 
 **Can't reach `raspberrypi.local`:**
 
-Not all networks support mDNS. Find your Pi's IP address instead:
+Not all networks support mDNS. Find your Pi's IP address:
 
 ```bash
 # On the Pi
 hostname -I
 ```
 
-Then use the IP directly (e.g., `http://192.168.1.100:8080`).
+Then use the IP directly (e.g., `http://192.168.1.100:8080`). Consider setting a static IP in your router's DHCP settings for a stable address.
+
+### Slim Down Supabase (4GB Pi)
+
+If you're on a 4GB Pi, you can disable unused Supabase services before running `supabase start` to save ~500MB of RAM. Edit `supabase/config.toml` in your cloned repo:
+
+```bash
+cd ~/permission-slip
+
+# Disable Studio (database admin UI)
+sed -i '/^\[studio\]$/,/^\[/{s/^enabled = true$/enabled = false/}' supabase/config.toml
+
+# Disable Edge Runtime (serverless functions — not used)
+sed -i '/^\[edge_runtime\]$/,/^\[/{s/^enabled = true$/enabled = false/}' supabase/config.toml
+
+# Disable Analytics (log analytics — not needed for personal use)
+sed -i '/^\[analytics\]$/,/^\[/{s/^enabled = true$/enabled = false/}' supabase/config.toml
+```
+
+Then run `supabase start` as normal. To undo, run `git checkout supabase/config.toml`.
+
+## Updating Permission Slip
+
+To update to a newer version:
+
+```bash
+cd ~/permission-slip
+
+# Stop Permission Slip
+docker stop permission-slip && docker rm permission-slip
+# Or: sudo systemctl stop permission-slip (if using systemd)
+
+# Pull latest code
+git pull origin main
+
+# Rebuild
+ANON_KEY=$(supabase status -o env 2>/dev/null | grep '^ANON_KEY=' | cut -d= -f2-)
+docker build \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="$ANON_KEY" \
+  -t permission-slip .
+
+# Start again (same docker run command from Step 4)
+```
+
+Database migrations run automatically on startup — no manual migration step needed.
 
 ## What's Next?
 
 - **Add agents:** Follow the [Agent Integration Guide](agents.md) to connect your first AI agent
-- **Custom connectors:** Add integrations beyond the built-in GitHub, HubSpot, Slack, and PostgreSQL connectors — see [Custom Connectors](custom-connectors.md)
-- **More configuration:** For web push, email notifications, error tracking, analytics, and more — read the full [Self-Hosted Deployment Guide](deployment-self-hosted.md)
+- **Custom connectors:** Add integrations beyond the built-in ones — see [Custom Connectors](custom-connectors.md)
+- **More configuration:** For billing, error tracking, analytics, and more — read the full [Self-Hosted Deployment Guide](deployment-self-hosted.md)

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -76,10 +76,10 @@ git clone https://github.com/supersuit-tech/permission-slip.git
 cd permission-slip
 ```
 
-Generate a vault encryption key (Supabase Vault uses this to encrypt stored credentials at rest):
+Generate a vault encryption key (Supabase Vault uses this to encrypt stored credentials at rest). The append-if-missing pattern protects any existing `.env`:
 
 ```bash
-echo "VAULT_SECRET_KEY=$(openssl rand -hex 32)" > .env
+grep -q "^VAULT_SECRET_KEY=" .env 2>/dev/null || echo "VAULT_SECRET_KEY=$(openssl rand -hex 32)" >> .env
 ```
 
 Start the local Supabase stack. The first run pulls Docker images — expect this to take 5-10 minutes on a Pi:

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -123,7 +123,7 @@ docker build \
   -t permission-slip .
 ```
 
-> **Note:** `VITE_SUPABASE_URL` is intentionally omitted. The Go server includes a built-in reverse proxy that routes `/supabase/*` to the local Supabase stack. The frontend uses this automatically when no explicit Supabase URL is baked in, so it works regardless of your Pi's hostname or IP address.
+> **Note:** `VITE_SUPABASE_URL` is intentionally omitted. The Go server includes a built-in reverse proxy at `/supabase/auth/v1/*` that routes Supabase Auth requests to the local Supabase stack. The frontend uses this automatically when no explicit Supabase URL is baked in, so it works regardless of your Pi's hostname or IP address. (Non-auth Supabase surfaces — rest/storage/realtime/functions — are intentionally blocked to keep the proxy narrow.)
 
 Run the container:
 

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -1,22 +1,20 @@
 import { createClient } from "@supabase/supabase-js";
 
-// In development, resolve Supabase via a relative path so requests always go
-// to the same origin as the page — whether that's localhost:5173, the dev
-// proxy on :3000, or the ngrok tunnel. The dev proxy routes /supabase/* →
-// http://127.0.0.1:54321. This avoids cross-origin CORS failures when the
-// browser is on a different host than VITE_SUPABASE_URL points to.
-//
-// In production, VITE_SUPABASE_URL must be set to the real Supabase project URL.
+// Resolve the Supabase URL:
+// 1. If VITE_SUPABASE_URL is set (cloud Supabase), use it directly.
+// 2. Otherwise, use a relative /supabase path — the Go server proxies
+//    /supabase/* → SUPABASE_URL. In dev mode, Vite's proxy handles the same
+//    path. This eliminates CORS issues and avoids exposing extra ports,
+//    which is especially useful for self-hosted and Raspberry Pi deployments.
 const supabaseUrl =
-  import.meta.env.DEV
-    ? `${window.location.origin}/supabase`
-    : import.meta.env.VITE_SUPABASE_URL;
+  import.meta.env.VITE_SUPABASE_URL ||
+  `${window.location.origin}/supabase`;
 
 const supabasePublishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-if (!supabaseUrl || !supabasePublishableKey) {
+if (!supabasePublishableKey) {
   throw new Error(
-    "Missing VITE_SUPABASE_URL or VITE_SUPABASE_PUBLISHABLE_KEY environment variables"
+    "Missing VITE_SUPABASE_PUBLISHABLE_KEY environment variable"
   );
 }
 

--- a/main.go
+++ b/main.go
@@ -427,6 +427,19 @@ func main() {
 		w.Write([]byte(`{"applinks":{"apps":[],"details":[{"appID":"AWUV887E3B.dev.permissionslip.app","paths":["*"]}]}}`))
 	})
 
+	// Supabase reverse proxy — lets the frontend reach Supabase Auth through
+	// the same origin as the app, eliminating CORS issues and extra port
+	// exposure. Active when SUPABASE_URL is set. The frontend falls back to
+	// this proxy automatically when VITE_SUPABASE_URL is not baked in.
+	if deps.SupabaseURL != "" {
+		supabaseTarget, err := url.Parse(deps.SupabaseURL)
+		if err != nil {
+			log.Fatalf("invalid SUPABASE_URL for proxy: %v", err)
+		}
+		mux.Handle("/supabase/", supabaseProxy(supabaseTarget))
+		log.Printf("Supabase proxy: /supabase/* → %s", deps.SupabaseURL)
+	}
+
 	// In production, serve the built React app.
 	// In development, use Vite's dev server (port 5173) instead.
 	if os.Getenv("MODE") != "development" {

--- a/supabase_proxy.go
+++ b/supabase_proxy.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+// supabaseProxy returns an http.Handler that reverse-proxies requests from
+// /supabase/* to the given Supabase URL, stripping the /supabase prefix.
+//
+// This allows the frontend to reach Supabase Auth through the same origin as
+// the app itself, eliminating the need for CORS configuration and extra port
+// exposure. It is especially useful for self-hosted deployments where the
+// Supabase stack runs alongside the app (e.g., via `supabase start` on a
+// Raspberry Pi).
+//
+// When VITE_SUPABASE_URL is set at build time (cloud Supabase deployments),
+// the frontend talks to Supabase directly and this proxy is unused.
+func supabaseProxy(target *url.URL) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	// Preserve the original Director but override Host to match the target.
+	// Without this, the reverse proxy sends the request with the original
+	// Host header (e.g., "raspberrypi.local:8080"), which can confuse
+	// upstream services that route by Host.
+	defaultDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		defaultDirector(req)
+		req.Host = target.Host
+	}
+
+	return http.StripPrefix("/supabase", proxy)
+}

--- a/supabase_proxy.go
+++ b/supabase_proxy.go
@@ -4,16 +4,37 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 )
 
+// allowedSupabasePrefixes restricts which upstream Supabase paths the proxy
+// will forward. Anything outside these prefixes returns 404 — this prevents
+// the proxy from being used as an open/SSRF-style relay into arbitrary
+// upstream paths (cloud Supabase management endpoints, cloud metadata
+// services via misconfigured SUPABASE_URL, etc.).
+//
+// Permission Slip's frontend only uses Supabase Auth, so we only allow
+// /auth/v1. Adding more surfaces (rest/v1, storage/v1, realtime/v1,
+// functions/v1) is intentionally gated behind code changes so the attack
+// surface grows deliberately, not by accident.
+var allowedSupabasePrefixes = []string{
+	"/auth/v1",
+}
+
 // supabaseProxy returns an http.Handler that reverse-proxies requests from
-// /supabase/* to the given Supabase URL, stripping the /supabase prefix.
+// /supabase/<allowed-prefix>/* to the given Supabase URL, stripping the
+// /supabase prefix.
 //
 // This allows the frontend to reach Supabase Auth through the same origin as
 // the app itself, eliminating the need for CORS configuration and extra port
 // exposure. It is especially useful for self-hosted deployments where the
 // Supabase stack runs alongside the app (e.g., via `supabase start` on a
 // Raspberry Pi).
+//
+// The proxy is deliberately narrow: it only forwards paths matching one of
+// allowedSupabasePrefixes. Everything else returns 404. This prevents the
+// proxy from acting as an open HTTP forwarder into the Supabase upstream
+// (or, if SUPABASE_URL is misconfigured, into internal networks).
 //
 // When VITE_SUPABASE_URL is set at build time (cloud Supabase deployments),
 // the frontend talks to Supabase directly and this proxy is unused.
@@ -30,5 +51,30 @@ func supabaseProxy(target *url.URL) http.Handler {
 		req.Host = target.Host
 	}
 
-	return http.StripPrefix("/supabase", proxy)
+	stripped := http.StripPrefix("/supabase", proxy)
+
+	// Wrap with a prefix allow-list. The /supabase route catches everything
+	// under that path; we check the upstream path (with /supabase stripped)
+	// against the allow-list before forwarding.
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPath := strings.TrimPrefix(r.URL.Path, "/supabase")
+		if !isAllowedSupabasePath(upstreamPath) {
+			http.NotFound(w, r)
+			return
+		}
+		stripped.ServeHTTP(w, r)
+	})
+}
+
+// isAllowedSupabasePath reports whether path matches one of the allow-listed
+// Supabase upstream path prefixes. Matching is either an exact match on the
+// prefix or the prefix followed by "/" — so "/auth/v1" allows "/auth/v1" and
+// "/auth/v1/token" but not "/auth/v1other".
+func isAllowedSupabasePath(path string) bool {
+	for _, prefix := range allowedSupabasePrefixes {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/supabase_proxy_test.go
+++ b/supabase_proxy_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestIsAllowedSupabasePath(t *testing.T) {
+	tests := []struct {
+		path    string
+		allowed bool
+	}{
+		// /auth/v1 surface — allowed
+		{"/auth/v1", true},
+		{"/auth/v1/token", true},
+		{"/auth/v1/signup", true},
+		{"/auth/v1/.well-known/jwks.json", true},
+		{"/auth/v1/factors/enroll", true},
+
+		// Prefix-boundary — must not allow /auth/v1otherthing
+		{"/auth/v1other", false},
+		{"/auth/v1a", false},
+
+		// Other Supabase surfaces — not allowed (would widen the attack surface)
+		{"/rest/v1/users", false},
+		{"/storage/v1/object/public/bucket/file", false},
+		{"/realtime/v1/websocket", false},
+		{"/functions/v1/my-func", false},
+
+		// Management / internal / escape attempts — not allowed
+		{"/pg/v1/query", false},
+		{"/", false},
+		{"", false},
+		{"/health", false},
+		{"/auth", false},
+		{"/auth/", false},
+
+		// Path traversal is a URL parsing concern; these are the raw strings
+		// the handler would see after TrimPrefix. Any non-/auth/v1 prefix
+		// should be denied.
+		{"/../auth/v1/token", false},
+		{"/auth//v1/token", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			got := isAllowedSupabasePath(tc.path)
+			if got != tc.allowed {
+				t.Errorf("isAllowedSupabasePath(%q) = %v, want %v", tc.path, got, tc.allowed)
+			}
+		})
+	}
+}
+
+func TestSupabaseProxy_AllowedPathReaches(t *testing.T) {
+	var upstreamHit atomic.Int32
+	var lastPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit.Add(1)
+		lastPath = r.URL.Path
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	handler := supabaseProxy(target)
+
+	req := httptest.NewRequest("GET", "/supabase/auth/v1/token", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if rw.Code != 200 {
+		t.Fatalf("allowed path: got status %d, want 200", rw.Code)
+	}
+	if upstreamHit.Load() != 1 {
+		t.Fatalf("allowed path: upstream was not called (hits=%d)", upstreamHit.Load())
+	}
+	if lastPath != "/auth/v1/token" {
+		t.Fatalf("allowed path: upstream saw path %q, want %q", lastPath, "/auth/v1/token")
+	}
+}
+
+func TestSupabaseProxy_DisallowedPathBlocked(t *testing.T) {
+	var upstreamHit atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit.Add(1)
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	handler := supabaseProxy(target)
+
+	blocked := []string{
+		"/supabase/rest/v1/users",
+		"/supabase/storage/v1/object/public/bucket/file",
+		"/supabase/pg/v1/query",
+		"/supabase/",
+		"/supabase/health",
+		"/supabase/auth/v1other",
+	}
+
+	for _, path := range blocked {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", path, nil)
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, req)
+
+			if rw.Code != 404 {
+				body, _ := io.ReadAll(rw.Body)
+				t.Errorf("disallowed path %q: got status %d, body %q — want 404", path, rw.Code, string(body))
+			}
+		})
+	}
+
+	if upstreamHit.Load() != 0 {
+		t.Fatalf("upstream should never be called for disallowed paths (hits=%d)", upstreamHit.Load())
+	}
+}
+
+func TestSupabaseProxy_HostHeaderRewritten(t *testing.T) {
+	// Verify the Director sets req.Host to the upstream target so
+	// virtual-host routing works.
+	var gotHost string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(200)
+	}))
+	defer upstream.Close()
+
+	target, _ := url.Parse(upstream.URL)
+	handler := supabaseProxy(target)
+
+	req := httptest.NewRequest("GET", "/supabase/auth/v1/token", nil)
+	req.Host = "raspberrypi.local:8080" // incoming host (from the browser)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if rw.Code != 200 {
+		t.Fatalf("got status %d, want 200", rw.Code)
+	}
+	// Upstream Host header should match the target's Host (NOT the incoming Host).
+	if !strings.Contains(gotHost, strings.TrimPrefix(upstream.URL, "http://")) {
+		t.Errorf("upstream saw Host %q, want target host %q", gotHost, upstream.URL)
+	}
+}


### PR DESCRIPTION
## Summary

- **Add a built-in Supabase reverse proxy** (`/supabase/*` → `SUPABASE_URL`) to the Go server, so the frontend can reach Supabase Auth through the same origin — no CORS issues, no extra port exposure, no hostname baked into the build
- **Make `VITE_SUPABASE_URL` optional** — when omitted, the frontend automatically uses the `/supabase` proxy. Cloud deployments can still set it for direct browser→Supabase communication
- **Rewrite the Raspberry Pi quickstart** for fully local Supabase via `supabase start` — zero cloud accounts needed (no Supabase subscription, no AWS)
- **Update the self-hosted deployment guide** with a "Local Supabase" alternative section documenting the proxy and local setup

### Why

The Pi quickstart previously required signing up for Supabase Cloud and AWS SNS. For a personal single-user deployment, everything can run locally on the Pi using `supabase start` (auth, database, vault, email capture). The reverse proxy is the key enabler — it lets the frontend reach local Supabase without exposing extra ports or dealing with hostname/IP changes in the build.

### Files changed

| File | Change |
|---|---|
| `supabase_proxy.go` | New reverse proxy handler using `httputil.NewSingleHostReverseProxy` |
| `main.go` | Register `/supabase/` route when `SUPABASE_URL` is set |
| `frontend/src/lib/supabaseClient.ts` | Fall back to relative `/supabase` path; relax validation to only require publishable key |
| `docs/raspberry-pi-quickstart.md` | Complete rewrite for local Supabase (Docker + Supabase CLI, Inbucket for email, systemd for boot, optional notifications) |
| `docs/deployment-self-hosted.md` | Add local Supabase section, document proxy, mark `VITE_SUPABASE_URL` as optional |

## Test plan

### Developer
- [x] Frontend TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All 978 frontend tests pass (`vitest run`)
- [x] All 225 mobile tests pass (`npx jest --ci`)
- [ ] Go builds and tests pass (blocked in sandbox by pre-existing bigquery Go 1.25 dep — CI will verify)
- [ ] Verify proxy works: start with `SUPABASE_URL=http://localhost:54321`, hit `GET /supabase/auth/v1/health` through the proxy
- [ ] Verify frontend auth works without `VITE_SUPABASE_URL` set (uses proxy fallback)
- [ ] Verify frontend auth still works WITH `VITE_SUPABASE_URL` set (direct, for cloud deployments)

### Manual Testing
- [ ] Follow the Pi quickstart end-to-end on a Raspberry Pi 5 (or any Linux machine with Docker)
- [ ] Verify `supabase start` → build → run → signup via Inbucket flow works
- [ ] Verify existing cloud Supabase deployments are unaffected (VITE_SUPABASE_URL still works as before)

https://claude.ai/code/session_01PCoHqutquifz9fGTcTwPS4