### PR TITLE
Update watch skill: 10m initial delay, 10 idle cycles

### DIFF
--- a/.claude/skills/watch/SKILL.md
+++ b/.claude/skills/watch/SKILL.md
@@ -82,7 +82,8 @@ The script handles:
 - Deduplication via last-seen ID tracking per endpoint
 - Merging from main and detecting conflicts
 - Parsing the PR body for unchecked `### Claude Code` checklist items
-- Idle counter tracking (6 consecutive empty cycles = timeout)
+- Initial delay before first poll (10 minutes by default, skipped on re-invocations)
+- Idle counter tracking (10 consecutive empty cycles = timeout)
 - Turn limit tracking (exits when `--max-turns` agent invocations reached)
 - Generating and posting the wrap-up comment on idle timeout **or** at the **start** of the next poll after the turn counter reaches `--max-turns`
 

--- a/.claude/skills/watch/watch-poll.sh
+++ b/.claude/skills/watch/watch-poll.sh
@@ -135,7 +135,8 @@ echo "$PR_NUMBER" > "$PR_NUMBER_FILE"
 # Constants
 # ---------------------------------------------------------------------------
 POLL_INTERVAL="${POLL_INTERVAL_OVERRIDE:-60}"
-MAX_IDLE_CYCLES="${MAX_IDLE_CYCLES_OVERRIDE:-6}"
+MAX_IDLE_CYCLES="${MAX_IDLE_CYCLES_OVERRIDE:-10}"
+INITIAL_DELAY="${INITIAL_DELAY_OVERRIDE:-600}"  # seconds to wait before first poll (default: 10 minutes)
 MAX_DRAIN_PASSES=2
 IDLE_COUNTER=0
 CYCLE=0
@@ -741,6 +742,14 @@ pending_count=$(echo "$pending_comments" | jq 'length')
 if [[ "$pending_count" -gt 0 ]]; then
   echo "[pending] Found ${pending_count} unprocessed items from previous run"
   echo "[pending] Re-including in next work batch"
+fi
+
+# --- Initial delay before first poll ---
+# Give reviewers time to leave comments before we start polling.
+# Only applies on fresh sessions (not re-invocations with --work-dir).
+if [[ -z "$EXISTING_WORK_DIR" && "$INITIAL_DELAY" -gt 0 ]]; then
+  echo "[setup] Waiting ${INITIAL_DELAY}s ($((INITIAL_DELAY / 60))m) before first poll to let reviewers comment..."
+  sleep "$INITIAL_DELAY"
 fi
 
 # --- Polling loop ---


### PR DESCRIPTION
## Summary

- Add a 10-minute initial delay before the first poll cycle on fresh sessions, giving reviewers time to leave comments before the watch skill starts acting. Skipped on re-invocations (`--work-dir`).
- Increase idle timeout from 6 to 10 consecutive empty poll cycles so sessions stay alive longer waiting for reviewer activity.
- Both values are overridable via `INITIAL_DELAY_OVERRIDE` and `MAX_IDLE_CYCLES_OVERRIDE` env vars.

## Test plan

### Developer
- [ ] Verify `INITIAL_DELAY_OVERRIDE=0` skips the delay
- [ ] Verify `--work-dir` re-invocations skip the initial delay
- [ ] Verify `MAX_IDLE_CYCLES_OVERRIDE` still works as before

### Manual Testing
- [ ] Run `/watch` on a test PR and confirm the 10m delay message appears before first poll
- [ ] Confirm idle timeout fires after 10 empty cycles, not 6

https://claude.ai/code/session_014HANzRwvAr3vFMRpp3Xkhh