### PR TITLE
Document GATEWAY_SECRET for private deployments

### DIFF
--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -420,6 +420,27 @@ The server listens on plain HTTP. In production, terminate TLS in front of it:
 
 If using a reverse proxy other than Fly.io, set `TRUSTED_PROXY_HEADER` to the header your proxy uses for the real client IP (e.g., `X-Forwarded-For` or `X-Real-IP`). The default is `Fly-Client-IP`.
 
+## Private Deployments: Gateway Secret
+
+For private deployments (home servers, Raspberry Pis, internal-only instances) you can require a shared secret on every request as an outer access gate. This is most useful in combination with a tunnel like Cloudflare Tunnel or Tailscale Funnel, where leaking the tunnel hostname would otherwise expose the login page to the internet.
+
+Set `GATEWAY_SECRET` to a long random string (generate with `openssl rand -hex 32`). When the variable is set, the server rejects any non-preflight request without a matching `X-Gateway-Secret` header and returns `403 Forbidden` before routing, CORS, or auth runs. When the variable is unset, the middleware is a no-op — existing deployments are unaffected.
+
+```bash
+export GATEWAY_SECRET="$(openssl rand -hex 32)"
+```
+
+**Client configuration:**
+
+- **Mobile app:** In Settings → Server, enable **Custom Server**, enter your deployment URL, and paste the gateway secret. The app persists the value in the platform keystore (iOS Keychain / Android EncryptedSharedPreferences) and injects the header on every request. Changes take effect after an app restart.
+- **curl / scripts:** Send `X-Gateway-Secret: <your secret>` with every request.
+- **Web browser:** Because the header can't be injected by the browser, the web UI is not usable with `GATEWAY_SECRET` enabled. Use the mobile app, or put the web UI behind a VPN / Tailscale instead.
+
+**Scope:**
+
+- Genuine CORS preflights (`OPTIONS` with `Access-Control-Request-Method`) are exempt; all other requests are gated, including the health check.
+- The comparison is constant-time over SHA-256 digests to avoid leaking the secret length.
+
 ## Custom Connectors
 
 Permission Slip ships with built-in GitHub, HubSpot, Slack, and PostgreSQL connectors. To add custom connectors:
@@ -465,6 +486,7 @@ Rotate secrets on a regular cadence (every 90 days recommended for API keys and 
 - **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`** — rotate in AWS IAM console, deploy new credentials, then delete the old access key.
 - **`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`** — only rotate if compromised. **Invalidates all push subscriptions** (users must re-subscribe).
 - **`STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`** — roll keys in Stripe dashboard (supports overlap periods), update env var, then revoke old key.
+- **`GATEWAY_SECRET`** — regenerate with `openssl rand -hex 32`. **Every client must be updated simultaneously** (mobile app Settings, scripts, curl) — there is no overlap window. Consider a brief maintenance window when rotating.
 
 For detailed rotation instructions and a full schedule, see the [Production Deployment Guide — Rotating Secrets](deployment-production.md#rotating-secrets).
 
@@ -540,3 +562,4 @@ Migrations run automatically on startup. If they fail, check database connectivi
 | `VITE_STRIPE_PUBLISHABLE_KEY` | For billing | Build | Stripe publishable key (frontend) |
 | `CONNECTORS_DIR` | No | Runtime | Custom connector directory |
 | `CUSTOM_CONNECTORS_JSON` | No | Runtime | Inline connector JSON config |
+| `GATEWAY_SECRET` | No | Runtime | Shared secret for private deployments. When set, every non-preflight request must include a matching `X-Gateway-Secret` header or receive 403. No-op when unset. See [Private Deployments: Gateway Secret](#private-deployments-gateway-secret). |

--- a/docs/raspberry-pi-quickstart.md
+++ b/docs/raspberry-pi-quickstart.md
@@ -356,6 +356,8 @@ cloudflared tunnel run --url http://localhost:8080 permission-slip
 
 After setting up a tunnel, update `BASE_URL` and `ALLOWED_ORIGINS` in your `.env` to your public URL (e.g., `https://permissions.yourdomain.com`) and restart Permission Slip.
 
+> **Strongly recommended:** Once your Pi is reachable from the internet, anyone who learns the hostname can hit the login page. Pair the tunnel with a **gateway secret** so a leaked hostname alone isn't enough to reach the app. See [Lock Down the Tunnel with a Gateway Secret](#lock-down-the-tunnel-with-a-gateway-secret) below.
+
 **Tailscale (good for personal use):**
 
 ```bash
@@ -364,6 +366,44 @@ sudo tailscale up
 ```
 
 Access via your Tailscale IP or MagicDNS hostname. No config changes needed since it's a private network.
+
+### Lock Down the Tunnel with a Gateway Secret
+
+When Permission Slip is exposed through Cloudflare Tunnel (or any other public URL), set a **gateway secret** so the app rejects any request that doesn't present a matching header. This protects the login page itself from being probed by anyone who discovers your hostname.
+
+1. Generate a secret and add it to your `.env`:
+
+   ```bash
+   echo "GATEWAY_SECRET=$(openssl rand -hex 32)" >> ~/permission-slip/.env
+   ```
+
+2. Restart Permission Slip so it picks up the new env var:
+
+   ```bash
+   docker restart permission-slip
+   # Or: sudo systemctl restart permission-slip
+   ```
+
+   With `GATEWAY_SECRET` set, any request without a matching `X-Gateway-Secret` header returns `403 Forbidden` — including browser traffic, so the web UI will stop working until you configure clients.
+
+3. Configure the **mobile app**:
+
+   - Open **Settings → Server**, enable **Custom Server**
+   - Set the server URL to your public URL (e.g., `https://permissions.yourdomain.com`)
+   - Paste the same `GATEWAY_SECRET` value into the gateway secret field
+   - Save and restart the app
+
+   The app stores the secret in the platform keystore (iOS Keychain / Android EncryptedSharedPreferences) and injects the header on every request.
+
+4. For **curl / scripts**, always send the header:
+
+   ```bash
+   curl -H "X-Gateway-Secret: $GATEWAY_SECRET" https://permissions.yourdomain.com/api/health
+   ```
+
+> **Note:** With `GATEWAY_SECRET` enabled, the web UI won't work from a browser (browsers can't inject custom headers). Use the mobile app, or leave `GATEWAY_SECRET` unset and rely on Tailscale/VPN for access control if you need the web UI.
+
+See the [Self-Hosted Deployment Guide — Private Deployments: Gateway Secret](deployment-self-hosted.md#private-deployments-gateway-secret) for the full reference.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

PR #936 shipped the gateway-secret feature (new `GATEWAY_SECRET` env var, `X-Gateway-Secret` header, mobile Custom Server settings) but no documentation. This PR backfills the setup / deployment guides so operators know the feature exists and how to use it.

- **`docs/deployment-self-hosted.md`**
  - New "Private Deployments: Gateway Secret" section under TLS / Reverse Proxy covering what the gate does, how to enable it, which clients are supported (mobile, curl — browsers can't inject the header), and the CORS preflight exemption.
  - `GATEWAY_SECRET` added to the Complete Environment Variable Reference table.
  - `GATEWAY_SECRET` added to the Secret Rotation list, calling out the no-overlap constraint.
- **`docs/raspberry-pi-quickstart.md`**
  - Warning added to the Cloudflare Tunnel step: once a tunnel hostname is reachable, a gateway secret is what prevents someone from hitting the login page if the hostname leaks.
  - New "Lock Down the Tunnel with a Gateway Secret" subsection with the full flow: generate the secret, restart the server, configure the mobile app's Custom Server settings, and hit the API with curl.

Docs-only change — no code, tests, or schemas touched.

## Test plan

### Developer
- [x] `docs/deployment-self-hosted.md` renders cleanly (no broken anchors; new `#private-deployments-gateway-secret` anchor is linked from the env-var table and the Pi guide)
- [x] `docs/raspberry-pi-quickstart.md` renders cleanly (new `#lock-down-the-tunnel-with-a-gateway-secret` anchor is linked from the Cloudflare Tunnel warning)
- [x] Docs accurately describe the shipped behavior: constant-time comparison, CORS preflight exempt, no-op when unset, mobile SecureStore persistence, restart required

### Manual Testing
- [ ] Preview the rendered Markdown on GitHub and verify table formatting, code blocks, and anchor links
- [ ] Follow the Raspberry Pi "Lock Down the Tunnel" steps end-to-end on a real deployment to confirm the instructions match current mobile app UX
- [ ] Confirm with product/design that recommending users turn off `GATEWAY_SECRET` when they need the web UI is the intended guidance (vs. e.g. documenting a browser extension workaround)

https://claude.ai/code/session_01AtdTB1iVtCgGdgmEjkTwct