### PR TITLE
Remove "enable all actions" from the frontend

### DIFF
--- a/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigFormFields.tsx
@@ -5,9 +5,6 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import validation from "@/lib/validation";
 
-/** Reserved action_type value meaning "all actions on this connector". */
-export const WILDCARD_ACTION_TYPE = "*";
-
 const selectClassName =
   "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
 

--- a/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigRow.tsx
@@ -11,7 +11,6 @@ import {
   standingApprovalRowStatus,
   standingApprovalStatusLabel,
 } from "@/lib/standingApprovalStatus";
-import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 import { ActionConfigStandingApprovalSheet } from "./ActionConfigStandingApprovalSheet";
 
 interface ActionConfigRowProps {
@@ -33,10 +32,7 @@ export function ActionConfigRow({
   onEdit,
   onDelete,
 }: ActionConfigRowProps) {
-  const isWildcardConfig = config.action_type === WILDCARD_ACTION_TYPE;
-  const action = isWildcardConfig
-    ? null
-    : actions.find((a) => a.action_type === config.action_type);
+  const action = actions.find((a) => a.action_type === config.action_type);
 
   const paramEntries = Object.entries(config.parameters);
   const isDisabled = config.status === "disabled";
@@ -69,28 +65,15 @@ export function ActionConfigRow({
         </div>
       </TableCell>
       <TableCell>
-        {isWildcardConfig ? (
-          <div>
-            <Badge className="bg-primary/10 text-primary border-primary/20 border">
-              All Actions
-            </Badge>
-            <p className="text-muted-foreground mt-0.5 font-mono text-xs">*</p>
-          </div>
-        ) : (
-          <div>
-            <p className="text-sm">{action?.name ?? config.action_type}</p>
-            <p className="text-muted-foreground font-mono text-xs">
-              {config.action_type}
-            </p>
-          </div>
-        )}
+        <div>
+          <p className="text-sm">{action?.name ?? config.action_type}</p>
+          <p className="text-muted-foreground font-mono text-xs">
+            {config.action_type}
+          </p>
+        </div>
       </TableCell>
       <TableCell>
-        {isWildcardConfig ? (
-          <span className="text-muted-foreground text-xs italic">
-            All parameters — agent chooses freely
-          </span>
-        ) : paramEntries.length > 0 ? (
+        {paramEntries.length > 0 ? (
           <div className="space-y-0.5">
             {paramEntries.map(([key, value]) => (
               <ParameterPill key={key} name={key} value={value} />

--- a/frontend/src/pages/agents/connectors/ActionConfigStandingApprovalSheet.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigStandingApprovalSheet.tsx
@@ -69,7 +69,6 @@ export function ActionConfigStandingApprovalSheet({
 
   const primary = pickPrimaryStandingApproval(standingRows);
   const rowStatus = standingApprovalRowStatus(standingRows);
-  const isWildcardAction = config.action_type === "*";
   const isEditActive = primary?.status === "active";
 
   const [noExpiry, setNoExpiry] = useState(true);
@@ -108,12 +107,6 @@ export function ActionConfigStandingApprovalSheet({
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    if (isWildcardAction) {
-      toast.error(
-        "Standing approvals cannot be created for enable-all (* wildcard) configurations.",
-      );
-      return;
-    }
     if (config.status !== "active") {
       toast.error(
         "Enable this action configuration before adding a standing approval.",
@@ -172,7 +165,6 @@ export function ActionConfigStandingApprovalSheet({
 
   const canSubmit =
     !isPending &&
-    !isWildcardAction &&
     config.status === "active" &&
     (noExpiry || !!expiresAt);
 
@@ -195,12 +187,6 @@ export function ActionConfigStandingApprovalSheet({
             <p className="text-muted-foreground text-xs">
               Current status: {rowStatus}. Create a new standing approval to replace
               the inactive one.
-            </p>
-          )}
-          {isWildcardAction && (
-            <p className="text-muted-foreground text-sm">
-              Enable-all configurations cover every action with free parameters — standing
-              approvals are tied to a specific action configuration.
             </p>
           )}
           {config.status !== "active" && (

--- a/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ActionConfigurationsSection.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { useStandingApprovalsForConfigs } from "@/hooks/useStandingApprovalsForConfigs";
-import { ChevronDown, ChevronRight, Loader2, Plus, Settings, Zap } from "lucide-react";
-import { toast } from "sonner";
+import { Loader2, Plus, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -18,12 +17,10 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
-import { useCreateActionConfig } from "@/hooks/useCreateActionConfig";
 import { useActionConfigTemplates } from "@/hooks/useActionConfigTemplates";
 import type { ActionConfigTemplate } from "@/hooks/useActionConfigTemplates";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
 import type { ApprovalMode } from "./RecommendedTemplatesDialog";
-import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 import { ActionConfigRow } from "./ActionConfigRow";
 import { AddActionConfigDialog } from "./AddActionConfigDialog";
 import { EditActionConfigDialog } from "./EditActionConfigDialog";
@@ -44,7 +41,6 @@ interface ActionConfigurationsSectionProps {
 export function ActionConfigurationsSection({
   agentId,
   connectorId,
-  connectorName,
   actions,
   configs,
   isLoading,
@@ -63,7 +59,6 @@ export function ActionConfigurationsSection({
   const [deleteTarget, setDeleteTarget] = useState<ActionConfiguration | null>(
     null,
   );
-  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const { templates, isLoading: templatesLoading } =
     useActionConfigTemplates(connectorId);
@@ -76,38 +71,12 @@ export function ActionConfigurationsSection({
     !templatesLoading &&
     templates.some((t) => actionTypeSet.has(t.action_type));
 
-  const hasWildcardConfig = configs.some(
-    (c) => c.action_type === WILDCARD_ACTION_TYPE,
-  );
-
   const configIds = useMemo(() => configs.map((c) => c.id), [configs]);
   const {
     byConfigId: standingByConfig,
     error: standingError,
     refetch: refetchStanding,
   } = useStandingApprovalsForConfigs(configIds);
-
-  const { createActionConfig, isPending: isEnablingAll } =
-    useCreateActionConfig();
-
-  const handleEnableAll = async () => {
-    try {
-      await createActionConfig({
-        agent_id: agentId,
-        connector_id: connectorId,
-        action_type: WILDCARD_ACTION_TYPE,
-        name: `All ${connectorName} Actions`,
-        parameters: {},
-      });
-      toast.success(`All ${connectorName} actions enabled`);
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : "Failed to enable all actions",
-      );
-    }
-  };
 
   function openAddDialog(fromTemplate?: ActionConfigTemplate | null, approvalMode?: ApprovalMode) {
     setInitialTemplateForAdd(fromTemplate ?? null);
@@ -132,23 +101,6 @@ export function ActionConfigurationsSection({
         </div>
         {configs.length > 0 && (
           <div className="flex flex-wrap items-center gap-2 self-start sm:self-center">
-            {!hasWildcardConfig && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="shrink-0"
-                onClick={handleEnableAll}
-                disabled={isEnablingAll || actions.length === 0}
-              >
-                {isEnablingAll ? (
-                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                ) : (
-                  <Zap className="size-4" aria-hidden="true" />
-                )}
-                Enable All Actions
-              </Button>
-            )}
             {hasRecommendedTemplates && (
               <Button
                 type="button"
@@ -185,11 +137,7 @@ export function ActionConfigurationsSection({
         ) : error ? (
           <p className="text-destructive text-sm">{error}</p>
         ) : configs.length === 0 ? (
-          <EnableAllEmptyState
-            onEnableAll={handleEnableAll}
-            isEnablingAll={isEnablingAll}
-            showAdvanced={showAdvanced}
-            onToggleAdvanced={() => setShowAdvanced((v) => !v)}
+          <EmptyState
             onAddCustom={() => openAddDialog()}
             onBrowseRecommendedTemplates={() =>
               setRecommendedDialogOpen(true)
@@ -300,20 +248,12 @@ export function ActionConfigurationsSection({
   );
 }
 
-function EnableAllEmptyState({
-  onEnableAll,
-  isEnablingAll,
-  showAdvanced,
-  onToggleAdvanced,
+function EmptyState({
   onAddCustom,
   onBrowseRecommendedTemplates,
   showRecommendedLink,
   actionsDisabled,
 }: {
-  onEnableAll: () => void;
-  isEnablingAll: boolean;
-  showAdvanced: boolean;
-  onToggleAdvanced: () => void;
   onAddCustom: () => void;
   onBrowseRecommendedTemplates: () => void;
   showRecommendedLink: boolean;
@@ -322,21 +262,13 @@ function EnableAllEmptyState({
   return (
     <div className="space-y-4 py-4 text-center">
       <div className="space-y-3">
-        <Button
-          size="lg"
-          onClick={onEnableAll}
-          disabled={isEnablingAll || actionsDisabled}
-        >
-          {isEnablingAll ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <Zap className="size-4" />
-          )}
-          Enable All Actions
+        <Button size="lg" onClick={onAddCustom} disabled={actionsDisabled}>
+          <Plus className="size-4" />
+          Add Configuration
         </Button>
         <p className="text-muted-foreground mx-auto max-w-md text-sm">
-          Your agent can use any action from this connector. Every action still
-          requires your approval before it runs.
+          Define which actions this agent can use and lock in parameter values
+          or mark them as wildcards to give the agent freedom.
         </p>
         {showRecommendedLink && (
           <div>
@@ -348,38 +280,6 @@ function EnableAllEmptyState({
             >
               Or start from a recommended template →
             </button>
-          </div>
-        )}
-      </div>
-
-      <div className="pt-2">
-        <button
-          type="button"
-          onClick={onToggleAdvanced}
-          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
-        >
-          {showAdvanced ? (
-            <ChevronDown className="size-3" />
-          ) : (
-            <ChevronRight className="size-3" />
-          )}
-          Advanced: configure individual actions
-        </button>
-        {showAdvanced && (
-          <div className="mt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onAddCustom}
-              disabled={actionsDisabled}
-            >
-              <Plus className="size-4" />
-              Add Custom Configuration
-            </Button>
-            <p className="text-muted-foreground mt-1 text-xs">
-              Lock specific parameters or restrict which actions your agent can
-              use.
-            </p>
           </div>
         )}
       </div>

--- a/frontend/src/pages/agents/connectors/DeleteActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/DeleteActionConfigDialog.tsx
@@ -12,7 +12,6 @@ import {
 import { useDeleteActionConfig } from "@/hooks/useDeleteActionConfig";
 import { useLinkedStandingApprovalsForConfig } from "@/hooks/useLinkedStandingApprovalsForConfig";
 import type { ActionConfiguration } from "@/hooks/useActionConfigs";
-import { WILDCARD_ACTION_TYPE } from "./ActionConfigFormFields";
 
 interface DeleteActionConfigDialogProps {
   open: boolean;
@@ -59,21 +58,10 @@ export function DeleteActionConfigDialog({
         <DialogHeader>
           <DialogTitle>Delete Action Configuration</DialogTitle>
           <DialogDescription>
-            {config.action_type === WILDCARD_ACTION_TYPE ? (
-              <>
-                This will permanently delete the enable-all configuration{" "}
-                <strong>{config.name}</strong>. The agent will lose access to{" "}
-                <strong>all actions</strong> on this connector. This action is
-                irreversible.
-              </>
-            ) : (
-              <>
-                This will permanently delete the configuration{" "}
-                <strong>{config.name}</strong> ({config.action_type}). The agent
-                will no longer be able to reference this configuration. This
-                action is irreversible.
-              </>
-            )}
+            This will permanently delete the configuration{" "}
+            <strong>{config.name}</strong> ({config.action_type}). The agent
+            will no longer be able to reference this configuration. This
+            action is irreversible.
             {linkedCount > 0 && (
               <>
                 {" "}

--- a/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditActionConfigDialog.tsx
@@ -19,7 +19,6 @@ import {
   parseParametersSchema,
 } from "./ActionConfigParameterFields";
 import {
-  WILDCARD_ACTION_TYPE,
   NameField,
   DescriptionField,
   StatusSelect,
@@ -61,13 +60,9 @@ export function EditActionConfigDialog({
     inferModesFromConfig(config.parameters),
   );
 
-  const isWildcard = config.action_type === WILDCARD_ACTION_TYPE;
   const action = useMemo(
-    () =>
-      isWildcard
-        ? null
-        : actions.find((a) => a.action_type === config.action_type) ?? null,
-    [actions, config.action_type, isWildcard],
+    () => actions.find((a) => a.action_type === config.action_type) ?? null,
+    [actions, config.action_type],
   );
 
   const schema = useMemo(
@@ -127,11 +122,9 @@ export function EditActionConfigDialog({
           <DialogHeader>
             <DialogTitle>Edit Action Configuration</DialogTitle>
             <DialogDescription>
-              {isWildcard
-                ? "Update the name, description, or status for this enable-all configuration. Parameters cannot be changed on wildcard configurations."
-                : <>Update the configuration for{" "}
-                  <strong>{action?.name ?? config.action_type}</strong>. The action
-                  type and connector cannot be changed.</>}
+              Update the configuration for{" "}
+              <strong>{action?.name ?? config.action_type}</strong>. The action
+              type and connector cannot be changed.
             </DialogDescription>
           </DialogHeader>
 
@@ -139,16 +132,12 @@ export function EditActionConfigDialog({
             {/* Action (read-only) */}
             <div className="space-y-2">
               <Label>Action</Label>
-              {isWildcard ? (
-                <p className="text-sm font-medium">All Actions <span className="text-muted-foreground font-mono text-xs">(*)</span></p>
-              ) : (
-                <p className="text-sm">
-                  {action?.name ?? config.action_type}{" "}
-                  <span className="text-muted-foreground font-mono text-xs">
-                    ({config.action_type})
-                  </span>
-                </p>
-              )}
+              <p className="text-sm">
+                {action?.name ?? config.action_type}{" "}
+                <span className="text-muted-foreground font-mono text-xs">
+                  ({config.action_type})
+                </span>
+              </p>
             </div>
 
             <NameField
@@ -172,14 +161,7 @@ export function EditActionConfigDialog({
               disabled={isPending}
             />
 
-            {isWildcard ? (
-              <div className="space-y-2">
-                <Label>Parameters</Label>
-                <p className="text-muted-foreground text-sm italic">
-                  All parameters — agent chooses freely. Parameters cannot be modified on wildcard configurations.
-                </p>
-              </div>
-            ) : action ? (
+            {action ? (
               <div className="space-y-2">
                 <Label>Parameters</Label>
                 <ActionConfigParameterFields

--- a/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ActionConfigurationsSection.test.tsx
@@ -99,16 +99,15 @@ describe("ActionConfigurationsSection", () => {
     });
   });
 
-  it("shows empty state with Enable All Actions button", () => {
+  it("shows empty state with Add Configuration button", () => {
     renderSection();
     expect(
-      screen.getByText("Enable All Actions"),
+      screen.getByRole("button", { name: /Add Configuration/ }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Your agent can use any action from this connector/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Advanced: configure individual actions"),
+      screen.getByText(
+        /Define which actions this agent can use and lock in parameter values/,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -148,14 +147,19 @@ describe("ActionConfigurationsSection", () => {
     expect(wildcardBadges.length).toBe(2); // title and body
   });
 
-  it("hides Add Configuration button in empty state", () => {
-    renderSection();
-    expect(screen.queryByText("Add Configuration")).not.toBeInTheDocument();
-  });
-
   it("shows Add Configuration button when configs exist", () => {
     renderSection({ configs: mockConfigs });
     expect(screen.getByText("Add Configuration")).toBeInTheDocument();
+  });
+
+  it("opens Add dialog when clicking empty-state Add Configuration button", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(
+      screen.getByRole("button", { name: /Add Configuration/ }),
+    );
+    expect(screen.getByText("Add Action Configuration")).toBeInTheDocument();
   });
 
   it("opens Add dialog when clicking Add Configuration with configs", async () => {
@@ -310,197 +314,6 @@ describe("ActionConfigurationsSection", () => {
     ];
     renderSection({ configs: disabledConfig });
     expect(screen.getByText("Disabled")).toBeInTheDocument();
-  });
-
-  it("calls create with wildcard action_type when clicking Enable All Actions", async () => {
-    const user = userEvent.setup();
-    mockPost.mockResolvedValue({
-      data: {
-        id: "ac_wildcard",
-        agent_id: 42,
-        connector_id: "github",
-        action_type: "*",
-        parameters: {},
-        status: "active",
-        name: "All GitHub Actions",
-        created_at: "2026-03-11T10:00:00Z",
-        updated_at: "2026-03-11T10:00:00Z",
-      },
-    });
-
-    renderSection();
-    await user.click(screen.getByText("Enable All Actions"));
-
-    await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith("/v1/action-configurations", {
-        headers: { Authorization: "Bearer token" },
-        body: {
-          agent_id: 42,
-          connector_id: "github",
-          action_type: "*",
-          name: "All GitHub Actions",
-          parameters: {},
-        },
-      });
-    });
-  });
-
-  it("renders wildcard config with All Actions badge", () => {
-    const wildcardConfig: ActionConfiguration[] = [
-      {
-        id: "ac_wildcard",
-        agent_id: 42,
-        connector_id: "github",
-        action_type: "*",
-        parameters: {},
-        status: "active",
-        name: "All GitHub Actions",
-        description: null,
-        created_at: "2026-03-11T10:00:00Z",
-        updated_at: "2026-03-11T10:00:00Z",
-      },
-    ];
-    renderSection({ configs: wildcardConfig });
-
-    expect(screen.getByText("All GitHub Actions")).toBeInTheDocument();
-    expect(screen.getByText("All Actions")).toBeInTheDocument();
-    expect(
-      screen.getByText(/All parameters — agent chooses freely/),
-    ).toBeInTheDocument();
-  });
-
-  it("shows Enable All Actions in the header when configs exist and none are wildcard", () => {
-    renderSection({ configs: mockConfigs });
-    expect(
-      screen.getByRole("button", { name: /Enable All Actions/ }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Add Configuration")).toBeInTheDocument();
-  });
-
-  it("hides header Enable All Actions when wildcard and non-wildcard configs coexist", () => {
-    const mixedConfigs: ActionConfiguration[] = [
-      ...mockConfigs,
-      {
-        id: "ac_wildcard",
-        agent_id: 42,
-        connector_id: "github",
-        action_type: "*",
-        parameters: {},
-        status: "active",
-        name: "All GitHub Actions",
-        description: null,
-        created_at: "2026-03-11T10:00:00Z",
-        updated_at: "2026-03-11T10:00:00Z",
-      },
-    ];
-    renderSection({ configs: mixedConfigs });
-    expect(
-      screen.queryByRole("button", { name: /Enable All Actions/ }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText("Add Configuration")).toBeInTheDocument();
-  });
-
-  it("hides Enable All Actions header button when a wildcard config exists", () => {
-    const wildcardConfig: ActionConfiguration[] = [
-      {
-        id: "ac_wildcard",
-        agent_id: 42,
-        connector_id: "github",
-        action_type: "*",
-        parameters: {},
-        status: "active",
-        name: "All GitHub Actions",
-        description: null,
-        created_at: "2026-03-11T10:00:00Z",
-        updated_at: "2026-03-11T10:00:00Z",
-      },
-    ];
-    renderSection({ configs: wildcardConfig });
-    expect(
-      screen.queryByRole("button", { name: /Enable All Actions/ }),
-    ).not.toBeInTheDocument();
-    // The "All Actions" badge in the table row should still be present
-    expect(screen.getByText("All Actions")).toBeInTheDocument();
-  });
-
-  it("calls create with wildcard action_type when clicking header Enable All Actions with existing configs", async () => {
-    const user = userEvent.setup();
-    mockPost.mockResolvedValue({
-      data: {
-        id: "ac_wildcard",
-        agent_id: 42,
-        connector_id: "github",
-        action_type: "*",
-        parameters: {},
-        status: "active",
-        name: "All GitHub Actions",
-        created_at: "2026-03-11T10:00:00Z",
-        updated_at: "2026-03-11T10:00:00Z",
-      },
-    });
-
-    renderSection({ configs: mockConfigs });
-    await user.click(screen.getByRole("button", { name: /Enable All Actions/ }));
-
-    await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith("/v1/action-configurations", {
-        headers: { Authorization: "Bearer token" },
-        body: {
-          agent_id: 42,
-          connector_id: "github",
-          action_type: "*",
-          name: "All GitHub Actions",
-          parameters: {},
-        },
-      });
-    });
-  });
-
-  it("shows loading spinner and disables header Enable All Actions while create is pending", async () => {
-    const user = userEvent.setup();
-    let resolvePost: (value: unknown) => void;
-    const pending = new Promise((resolve) => {
-      resolvePost = resolve;
-    });
-    mockPost.mockReturnValue(pending);
-
-    renderSection({ configs: mockConfigs });
-    await user.click(screen.getByRole("button", { name: /Enable All Actions/ }));
-
-    const btn = screen.getByRole("button", { name: /Enable All Actions/ });
-    expect(btn).toBeDisabled();
-    expect(btn.querySelector(".animate-spin")).toBeTruthy();
-
-    resolvePost!({
-      data: {
-        id: "ac_wildcard",
-        agent_id: 42,
-        connector_id: "github",
-        action_type: "*",
-        parameters: {},
-        status: "active",
-        name: "All GitHub Actions",
-        created_at: "2026-03-11T10:00:00Z",
-        updated_at: "2026-03-11T10:00:00Z",
-      },
-    });
-
-    await waitFor(() => {
-      expect(btn).not.toBeDisabled();
-    });
-  });
-
-  it("shows advanced option to add custom config in empty state", async () => {
-    const user = userEvent.setup();
-    renderSection();
-
-    // Click the advanced toggle
-    await user.click(
-      screen.getByText("Advanced: configure individual actions"),
-    );
-    expect(
-      screen.getByText("Add Custom Configuration"),
-    ).toBeInTheDocument();
   });
 
   it("hides Recommended Templates triggers while templates are loading", () => {


### PR DESCRIPTION
Drops the Enable All Actions CTA, wildcard (*) action_type special-casing,
and the "All Actions" badge/row from the connector action-configurations UI.
Also removes the wildcard copy in the edit/delete dialogs and the
wildcard-action guard in the standing-approval sheet.

Backend continues to accept action_type="*" for now; existing wildcard
configs still render (as a row with action_type "*"). No new UI path
creates one.

https://claude.ai/code/session_012KXxyp4ZXXwnrh5CvTsrqT