### PR TITLE
Add iOS app download link to settings nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Permission Slip is an open-source approval layer for [Openclaw](https://openclaw
 
 **[permissionslip.dev](https://www.permissionslip.dev)** — hosted, no setup required.
 
+Get the **[iPhone app](https://apps.apple.com/us/app/permission-slip/id6761718603)** to approve requests on the go.
+
 Or **[self-host it](docs/deployment-self-hosted.md)** on Docker, Fly.io, or bare metal. Even runs on a [Raspberry Pi 5](docs/raspberry-pi-quickstart.md) in under 30 minutes.
 
 ---
@@ -52,6 +54,7 @@ Permission Slip solves this with a **secure proxy + human-in-the-loop approval**
 - 🙈 **Zero credential exposure** — Openclaw never sees your API keys or passwords
 - 📋 **Full audit trail** — every request, approval, and execution logged
 - 🔌 **OAuth 2.0 connections** — Google, Microsoft, Dropbox, and custom providers; PKCE where required; tokens encrypted at rest with automatic refresh
+- 📱 **iPhone app** — approve on the go from your phone
 - 🏠 **Self-hostable** — your data, your infrastructure
 - 📦 **Single binary deployment** — Go server with embedded React frontend
 

--- a/frontend/src/hooks/__tests__/useIsFullyConfigured.test.tsx
+++ b/frontend/src/hooks/__tests__/useIsFullyConfigured.test.tsx
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../test-helpers";
+import { mockGet, resetClientMocks } from "../../api/__mocks__/client";
+import { useIsFullyConfigured } from "../useIsFullyConfigured";
+
+vi.mock("../../lib/supabaseClient");
+vi.mock("../../api/client");
+
+function mockAgentsResponse(agents: object[]) {
+  return { data: { data: agents } };
+}
+
+function mockConnectorsResponse(connectors: object[]) {
+  return { data: { data: connectors } };
+}
+
+const registeredAgent = {
+  agent_id: 1,
+  status: "registered",
+  created_at: "2026-01-01T00:00:00Z",
+  metadata: { name: "Test Agent" },
+};
+
+const sampleConnector = {
+  id: "github",
+  name: "GitHub",
+  actions: ["github.create_issue"],
+  required_credentials: [],
+  enabled_at: "2026-01-01T00:00:00Z",
+};
+
+describe("useIsFullyConfigured", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+  });
+
+  it("returns false when not authenticated", () => {
+    setupAuthMocks({ authenticated: false });
+
+    const { result } = renderHook(() => useIsFullyConfigured(), { wrapper });
+
+    expect(result.current.isFullyConfigured).toBe(false);
+  });
+
+  it("returns false when no agents exist", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockResolvedValue(mockAgentsResponse([]));
+
+    const { result } = renderHook(() => useIsFullyConfigured(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isFullyConfigured).toBe(false);
+  });
+
+  it("returns false when agent exists but has no connectors", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/agents") return Promise.resolve(mockAgentsResponse([registeredAgent]));
+      return Promise.resolve(mockConnectorsResponse([]));
+    });
+
+    const { result } = renderHook(() => useIsFullyConfigured(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isFullyConfigured).toBe(false);
+  });
+
+  it("returns true when agent has at least one connector", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/v1/agents") return Promise.resolve(mockAgentsResponse([registeredAgent]));
+      return Promise.resolve(mockConnectorsResponse([sampleConnector]));
+    });
+
+    const { result } = renderHook(() => useIsFullyConfigured(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isFullyConfigured).toBe(true);
+    });
+  });
+
+  it("returns false when only pending agents exist", async () => {
+    setupAuthMocks({ authenticated: true });
+    const pendingAgent = { ...registeredAgent, status: "pending" };
+    mockGet.mockResolvedValue(mockAgentsResponse([pendingAgent]));
+
+    const { result } = renderHook(() => useIsFullyConfigured(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isFullyConfigured).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useIsFullyConfigured.ts
+++ b/frontend/src/hooks/useIsFullyConfigured.ts
@@ -1,0 +1,27 @@
+import { useAgents } from "./useAgents";
+import { useAgentConnectors } from "./useAgentConnectors";
+
+/**
+ * Returns whether the current user has at least one registered agent
+ * with at least one connector configured. Used to gate the iOS app
+ * download link in the settings navigation.
+ */
+export function useIsFullyConfigured(): {
+  isFullyConfigured: boolean;
+  isLoading: boolean;
+} {
+  const { agents, isLoading: agentsLoading } = useAgents();
+
+  const registeredAgents = agents.filter((a) => a.status === "registered");
+  const firstAgentId = registeredAgents[0]?.agent_id ?? 0;
+
+  const { connectors, isLoading: connectorsLoading } =
+    useAgentConnectors(firstAgentId);
+
+  const isLoading = agentsLoading || (firstAgentId > 0 && connectorsLoading);
+
+  const isFullyConfigured =
+    !isLoading && firstAgentId > 0 && connectors.length > 0;
+
+  return { isFullyConfigured, isLoading };
+}

--- a/frontend/src/pages/settings/SettingsNav.tsx
+++ b/frontend/src/pages/settings/SettingsNav.tsx
@@ -4,9 +4,11 @@ import {
   Shield,
   CreditCard,
   Settings,
+  Smartphone,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useIsFullyConfigured } from "@/hooks/useIsFullyConfigured";
 
 interface SettingsNavItem {
   label: string;
@@ -21,8 +23,12 @@ const settingsNavItems: SettingsNavItem[] = [
   { label: "Account", path: "/settings/account", icon: Settings },
 ];
 
+const IOS_APP_URL =
+  "https://apps.apple.com/us/app/permission-slip/id6761718603";
+
 export function SettingsNav() {
   const { pathname } = useLocation();
+  const { isFullyConfigured } = useIsFullyConfigured();
 
   return (
     <>
@@ -50,6 +56,19 @@ export function SettingsNav() {
               </li>
             );
           })}
+          {isFullyConfigured && (
+            <li>
+              <a
+                href={IOS_APP_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+              >
+                <Smartphone className="size-4" aria-hidden="true" />
+                iPhone App
+              </a>
+            </li>
+          )}
         </ul>
       </nav>
 
@@ -78,6 +97,17 @@ export function SettingsNav() {
             </Link>
           );
         })}
+        {isFullyConfigured && (
+          <a
+            href={IOS_APP_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex shrink-0 items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+          >
+            <Smartphone className="size-4" aria-hidden="true" />
+            iPhone App
+          </a>
+        )}
       </nav>
     </>
   );


### PR DESCRIPTION
## Summary

- Adds an "iPhone App" link at the bottom of the settings navigation (both desktop sidebar and mobile tab row)
- Link only appears once the user has ≥1 registered agent with ≥1 connector configured — gating it behind meaningful setup means users see it exactly when they're ready to use the app
- Introduces `useIsFullyConfigured` hook that checks agent + connector state to drive the conditional

## How it works

`useIsFullyConfigured` fetches the user's agents, finds the first registered one, then checks whether that agent has any connectors enabled. If yes, `SettingsNav` appends an `<a>` tag linking to the App Store with a `Smartphone` icon, styled to match the existing nav items.

## Test plan

### Developer
- [x] `useIsFullyConfigured` unit tests (5 cases: unauthenticated, no agents, agent with no connectors, agent with connectors, pending-only agent)
- [x] Existing `SettingsPage` integration tests still pass (mock fallback returns no agents → link hidden)

### Manual Testing
- [ ] Log in as a user with no agents — confirm "iPhone App" link is absent from settings nav
- [ ] Register an agent but add no connectors — confirm link is still absent
- [ ] Add at least one connector to the agent — confirm "iPhone App" link appears at the bottom of the nav on desktop and in the mobile tab row
- [ ] Click the link — confirm it opens the App Store page in a new tab
