### PR TITLE
Prepare repo for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a defect or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error messages, stack traces, or logs. -->
+
+## Environment
+
+- Permission Slip version / commit:
+- Deployment: <!-- hosted / self-hosted / local dev -->
+- Browser / OS (if relevant):
+- Connector involved (if relevant):
+
+## Additional Context
+
+<!-- Screenshots, config snippets (redacted), or anything else useful. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/supersuit-tech/permission-slip/security/advisories/new
+    about: Report a security issue privately via GitHub Security Advisories. Do not open a public issue.
+  - name: Question or discussion
+    url: https://github.com/supersuit-tech/permission-slip/discussions
+    about: Ask questions or discuss ideas with the community.

--- a/.github/ISSUE_TEMPLATE/connector_report.md
+++ b/.github/ISSUE_TEMPLATE/connector_report.md
@@ -1,0 +1,35 @@
+---
+name: Connector report
+about: Report the status of a connector (tested, broken, or new)
+title: "[Connector] "
+labels: connector
+assignees: ''
+---
+
+## Connector
+
+<!-- e.g., Slack, GitHub, Notion -->
+
+## Status
+
+- [ ] I tested this connector and it works (please add details below)
+- [ ] I tested this connector and it does NOT work (please add repro)
+- [ ] I'd like to see this connector supported (feature request)
+
+## What You Tested
+
+<!-- Which actions/tools did you exercise? Which scopes? -->
+
+## What Worked / What Didn't
+
+<!-- Be specific. Include error messages for anything that failed. -->
+
+## Environment
+
+- Permission Slip version / commit:
+- Deployment: <!-- hosted / self-hosted / local dev -->
+- Auth method used: <!-- OAuth / API key / etc. -->
+
+## Additional Context
+
+<!-- Links to docs, API quirks, rate-limit notes, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? Who is affected? -->
+
+## Proposed Solution
+
+<!-- Describe the feature you'd like to see. -->
+
+## Alternatives Considered
+
+<!-- Other approaches you've thought about and why they fall short. -->
+
+## Additional Context
+
+<!-- Mockups, links to related issues, example use cases, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for contributing! Please fill in the sections below.
+If this PR addresses an open issue, include "Closes #<issue>" so it's
+automatically closed when the PR merges.
+-->
+
+## Summary
+
+<!-- 1–3 bullet points describing what this PR changes and why. -->
+
+-
+-
+
+## Related Issue
+
+<!-- e.g., Closes #123, or "N/A" if this is not tied to an issue. -->
+
+## Test Plan
+
+### Developer
+
+<!-- Automated checks the author (or a bot) should run. -->
+
+- [ ] Unit tests added / updated
+- [ ] `make test` passes locally
+- [ ] `make build` succeeds
+- [ ] Lint / typecheck clean
+
+### Manual Testing
+
+<!-- Anything a human needs to verify by hand. -->
+
+- [ ]
+
+## Screenshots / Recordings
+
+<!-- For UI changes. Delete this section if not applicable. -->
+
+## Notes for Reviewers
+
+<!-- Anything you'd like reviewers to pay special attention to. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, v2.1][covenant] as its Code of
+Conduct. Contributors and maintainers are expected to follow it in all project
+spaces (issues, pull requests, discussions, and any community channels).
+
+## Reporting
+
+If you experience or witness conduct that violates the Code of Conduct, please
+report it to **conduct@permissionslip.dev**. All reports will be reviewed and
+investigated promptly and confidentially.
+
+Maintainers are obligated to respect the privacy and safety of anyone who
+reports an incident.
+
+## Full Text
+
+The full text of the Contributor Covenant v2.1 is available at:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ spaces (issues, pull requests, discussions, and any community channels).
 ## Reporting
 
 If you experience or witness conduct that violates the Code of Conduct, please
-report it to **conduct@permissionslip.dev**. All reports will be reviewed and
+report it to **support@supersuit.tech**. All reports will be reviewed and
 investigated promptly and confidentially.
 
 Maintainers are obligated to respect the privacy and safety of anyone who

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Permission Slip solves this with a **secure proxy + human-in-the-loop approval**
 | Google | 🟡 Early Preview |
 | Microsoft | 🟡 Early Preview |
 | Slack | 🟡 Early Preview |
+
+<details>
+<summary>🔴 Untested connectors (click to expand)</summary>
+
+These connectors are wired up but have not yet been end-to-end verified. If you try one, we'd love a report — see the "connector report" issue template.
+
+| Connector | Status |
+|-----------|--------|
 | Airtable | 🔴 Untested |
 | Amadeus | 🔴 Untested |
 | Asana | 🔴 Untested |
@@ -116,7 +124,9 @@ Permission Slip solves this with a **secure proxy + human-in-the-loop approval**
 | Zendesk | 🔴 Untested |
 | Zoom | 🔴 Untested |
 
-Have you tested a connector? [Open an issue](https://github.com/supersuit-tech/permission-slip/issues) to let us know!
+</details>
+
+Have you tested a connector? [Open an issue](https://github.com/supersuit-tech/permission-slip/issues/new?template=connector_report.md) to let us know!
 
 ---
 
@@ -277,6 +287,10 @@ Built by [SuperSuit](https://supersuit.tech) — questions or feedback welcome a
 
 ## 👥 Contributors
 
-<a href="https://github.com/chiedo"><img src="https://github.com/chiedo.png" width="50" height="50" alt="chiedo" style="border-radius:50%"></a>
-<a href="https://github.com/chiedobot"><img src="https://github.com/chiedobot.png" width="50" height="50" alt="chiedobot" style="border-radius:50%"></a>
-<a href="https://github.com/chiedoclaude"><img src="https://github.com/chiedoclaude.png" width="50" height="50" alt="chiedoclaude" style="border-radius:50%"></a>
+Thanks to everyone who has contributed!
+
+<a href="https://github.com/supersuit-tech/permission-slip/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=supersuit-tech/permission-slip" alt="Contributors" />
+</a>
+
+<sub>Made with [contrib.rocks](https://contrib.rocks).</sub>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ If you discover a security vulnerability in Permission Slip, please report it re
 ### How to report
 
 - **GitHub Private Vulnerability Reporting**: Use the [Security Advisories](https://github.com/supersuit-tech/permission-slip/security/advisories/new) page to submit a private report directly on GitHub.
-- **Email**: Send details to **security@permissionslip.dev**.
+- **Email**: Send details to **support@supersuit.tech**.
 
 ### What to include
 

--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,9 @@ kill_timeout = '30s'
 [env]
   PORT = '8080'
   CLOUDFLARE_INSIGHTS = 'true'
-  POSTHOG_HOST = 'https://hydro.permissionslip.dev'
+  # POSTHOG_HOST is set via Fly secrets for the hosted deployment
+  # (see: fly secrets set POSTHOG_HOST=...). Self-hosters should set
+  # their own value or leave unset to use the PostHog default.
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

Gets the repo ready to be made public. Based on a pre-open-source audit that flagged: (a) no leaked secrets in history, (b) one internal URL baked into `fly.toml`, and (c) several community-health files that GitHub expects on public repos.

- **Add community health files**: `CODE_OF_CONDUCT.md` (references Contributor Covenant v2.1), `.github/ISSUE_TEMPLATE/` (bug / feature / connector report + `config.yml` routing security + discussions), `.github/pull_request_template.md` (split into Developer / Manual Testing per CLAUDE.md conventions)
- **README polish**: collapse the ~45 untested connectors into a `<details>` block so the default view leads with Tested / Early Preview; swap the three static contributor avatars for a `contrib.rocks` widget that grows with the community; update "report a connector" link to point at the new issue template
- **`fly.toml`**: remove `POSTHOG_HOST = 'https://hydro.permissionslip.dev'` from `[env]` and move it to Fly secrets for the hosted deploy — keeps the internal analytics-proxy hostname out of the public config without changing production behavior

## Deploy note

**Before merging / next deploy**, run this once against the hosted app so analytics keeps flowing through the hydro subdomain:

```
fly secrets set POSTHOG_HOST=https://hydro.permissionslip.dev -a permission-slip
```

Fly secrets override `[env]` at runtime, so production behavior is unchanged — the value just isn't in the public repo anymore.

## Not in this PR (flagged in audit, deferred)

- `CLAUDE.md` stays public as-is per user direction
- `CHANGELOG.md` — optional, skipped for now
- `.github/CODEOWNERS` still points at `@chiedo` — fine for solo maintainer; revisit when a team forms
- `SECURITY.md` reporting inbox (`security@permissionslip.dev`) — confirm it's monitored before flipping public

## Test Plan

### Developer

- [ ] CI passes (no code changes — docs/config only)
- [ ] Render the README on GitHub after merge and confirm the `<details>` block collapses/expands cleanly
- [ ] Confirm `contrib.rocks` image loads once the repo is public (it requires a public repo to render)

### Manual Testing

- [ ] After flipping repo to public, click "New issue" and confirm the three templates + security/discussion links appear in the chooser
- [ ] Open a test PR and confirm `pull_request_template.md` auto-populates
- [ ] Run `fly secrets set POSTHOG_HOST=...` on the hosted deploy and verify analytics still flows through `hydro.permissionslip.dev`
- [ ] Verify `conduct@permissionslip.dev` is a monitored inbox (or swap to an existing one) before publicizing the CoC
