### PR TITLE
Show commit timestamp in Settings build info

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -11,6 +11,15 @@ try {
   // Git not available at build time — leave as "unknown"
 }
 
+let gitCommitTimestamp = "unknown";
+try {
+  gitCommitTimestamp = execSync("git log -1 --format=%cI HEAD", {
+    encoding: "utf-8",
+  }).trim();
+} catch {
+  // Git not available at build time — leave as "unknown"
+}
+
 const config: ExpoConfig = {
   name: "Permission Slip",
   slug: "permission-slip",
@@ -82,6 +91,7 @@ const config: ExpoConfig = {
   },
   extra: {
     gitCommitHash,
+    gitCommitTimestamp,
     eas: {
       projectId,
     },

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -29,6 +29,20 @@ import CustomServerSettings from "./CustomServerSettings";
 const GIT_COMMIT_HASH: string =
   (Constants.expoConfig?.extra?.gitCommitHash as string) ?? "unknown";
 
+const GIT_COMMIT_TIMESTAMP: string =
+  (Constants.expoConfig?.extra?.gitCommitTimestamp as string) ?? "unknown";
+
+function formatCommitTimestamp(iso: string): string {
+  if (iso === "unknown") return "";
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 const PRIVACY_POLICY_URL = "https://app.permissionslip.dev/policy/privacy";
 const TERMS_OF_SERVICE_URL = "https://app.permissionslip.dev/policy/terms";
 
@@ -238,6 +252,9 @@ export default function SettingsScreen(_props: Props) {
       <View style={styles.buildInfo}>
         <Text style={styles.buildInfoText} testID="git-commit-hash">
           Build {GIT_COMMIT_HASH.slice(0, 7)}
+          {formatCommitTimestamp(GIT_COMMIT_TIMESTAMP)
+            ? ` · ${formatCommitTimestamp(GIT_COMMIT_TIMESTAMP)}`
+            : ""}
         </Text>
       </View>
     </ScrollView>

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -41,7 +41,10 @@ jest.mock("expo-constants", () => ({
   __esModule: true,
   default: {
     expoConfig: {
-      extra: { gitCommitHash: "abc1234def5678" },
+      extra: {
+        gitCommitHash: "abc1234def5678",
+        gitCommitTimestamp: "2026-04-16T10:30:00+00:00",
+      },
     },
   },
 }));
@@ -314,6 +317,7 @@ describe("SettingsScreen", () => {
     expect(hashNodes.length).toBeGreaterThanOrEqual(1);
     const textContent = hashNodes[0]?.children?.join("") ?? "";
     expect(textContent).toContain("abc1234");
+    expect(textContent).toContain("Apr 16, 2026");
   });
 
   it("opens terms of service URL when tapped", async () => {


### PR DESCRIPTION
## Summary

- Captures the git commit timestamp at build time via `git log -1 --format=%cI HEAD` in `app.config.ts`, alongside the existing commit hash
- Exposes it as `gitCommitTimestamp` in the Expo `extra` config
- Formats and displays it in the Settings screen as `Build 03aedf8 · Apr 16, 2026`
- Falls back gracefully to no timestamp if git isn't available at build time

## Test plan

### Developer
- [x] Unit test updated to assert timestamp appears in build info text
- [x] All 15 SettingsScreen tests pass

### Manual Testing
- [ ] Build the app and verify the Settings screen shows e.g. `Build 03aedf8 · Apr 16, 2026` at the bottom
- [ ] Verify graceful fallback: if `gitCommitTimestamp` is `"unknown"`, only the hash is shown (no `·` separator)

https://claude.ai/code/session_01WiqvLTrAQ4dgjQnqcAaWPK