### PR TITLE
Remap Google Sheets "Unable to parse range" 400 to a ValidationError

### DIFF
--- a/connectors/google/sheets_append.go
+++ b/connectors/google/sheets_append.go
@@ -74,7 +74,7 @@ func (a *sheetsAppendRowsAction) Execute(ctx context.Context, req connectors.Act
 
 	var resp sheetsAppendValuesResponse
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, appendURL, body, &resp); err != nil {
-		return nil, err
+		return nil, remapInvalidRangeError(ctx, a.conn, req.Credentials, params.SpreadsheetID, params.Range, err)
 	}
 
 	return connectors.JSONResult(map[string]any{

--- a/connectors/google/sheets_append_test.go
+++ b/connectors/google/sheets_append_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
@@ -206,5 +207,116 @@ func TestSheetsAppendRows_InvalidJSON(t *testing.T) {
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+// TestSheetsAppendRows_InvalidRange_ListsAvailableTabs verifies that when the
+// Google Sheets API returns "Unable to parse range" (i.e. the named tab does
+// not exist), the connector remaps it into a ValidationError that lists the
+// spreadsheet's actual tab titles. This keeps the error out of Sentry and
+// gives the agent enough context to self-correct.
+func TestSheetsAppendRows_InvalidRange_ListsAvailableTabs(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/spreadsheets/spreadsheet-999/values/Sheet1!A:C:append":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 400, "message": "Unable to parse range: Sheet1!A:C"},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/spreadsheets/spreadsheet-999":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(sheetsSpreadsheetResponse{
+				Sheets: []struct {
+					Properties sheetsProperties `json:"properties"`
+				}{
+					{Properties: sheetsProperties{Title: "Data"}},
+					{Properties: sheetsProperties{Title: "Summary"}},
+				},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", "", srv.URL)
+	action := &sheetsAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(sheetsAppendRowsParams{
+		SpreadsheetID: "spreadsheet-999",
+		Range:         "Sheet1!A:C",
+		Values:        [][]any{{"a", "b", "c"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.sheets_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid range")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	msg := err.Error()
+	for _, want := range []string{`"Sheet1!A:C"`, `"Data"`, `"Summary"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected error message to contain %s, got: %s", want, msg)
+		}
+	}
+}
+
+// TestSheetsAppendRows_InvalidRange_ListFailureFallsBack verifies that if
+// Google's "Unable to parse range" 400 is followed by a failed tab-list
+// lookup (e.g. permission issue), the original ExternalError is returned
+// unchanged — we never mask a genuine external failure with a misleading
+// validation message.
+func TestSheetsAppendRows_InvalidRange_ListFailureFallsBack(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 400, "message": "Unable to parse range: Sheet1!A:C"},
+			})
+		case r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 500, "message": "backend error"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", "", srv.URL)
+	action := &sheetsAppendRowsAction{conn: conn}
+
+	params, _ := json.Marshal(sheetsAppendRowsParams{
+		SpreadsheetID: "spreadsheet-999",
+		Range:         "Sheet1!A:C",
+		Values:        [][]any{{"a", "b", "c"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.sheets_append_rows",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if connectors.IsValidationError(err) {
+		t.Fatalf("expected original ExternalError to be preserved, got ValidationError: %v", err)
+	}
+	if !connectors.IsExternalError(err) {
+		t.Fatalf("expected ExternalError, got %T: %v", err, err)
 	}
 }

--- a/connectors/google/sheets_helpers.go
+++ b/connectors/google/sheets_helpers.go
@@ -1,7 +1,12 @@
 package google
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
@@ -56,4 +61,58 @@ func validateValues(values [][]any) error {
 		}
 	}
 	return nil
+}
+
+// remapInvalidRangeError converts Google's "Unable to parse range" HTTP 400
+// into a ValidationError that lists the spreadsheet's actual tab titles, so
+// the agent can self-correct on the next call instead of this surfacing as
+// an opaque ExternalError (which gets captured in Sentry). For any other
+// error, or if listing the spreadsheet's tabs fails, the original error is
+// returned unchanged so we never mask a genuine external failure.
+func remapInvalidRangeError(ctx context.Context, conn *GoogleConnector, creds connectors.Credentials, spreadsheetID, rangeStr string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var extErr *connectors.ExternalError
+	if !errors.As(err, &extErr) {
+		return err
+	}
+	if !strings.Contains(extErr.Message, "Unable to parse range") {
+		return err
+	}
+
+	titles, listErr := fetchSheetTitles(ctx, conn, creds, spreadsheetID)
+	if listErr != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("range %q refers to a tab that does not exist in this spreadsheet. ", rangeStr)
+	if len(titles) == 0 {
+		msg += "The spreadsheet has no worksheets."
+	} else {
+		quoted := make([]string, len(titles))
+		for i, t := range titles {
+			quoted[i] = fmt.Sprintf("%q", t)
+		}
+		msg += "Available tabs: " + strings.Join(quoted, ", ") + ". Use google.sheets_list_sheets to discover tab names."
+	}
+	return &connectors.ValidationError{Message: msg}
+}
+
+// fetchSheetTitles calls the Google Sheets API to list the tab titles in a
+// spreadsheet. It uses the same endpoint as sheetsListSheetsAction.Execute.
+func fetchSheetTitles(ctx context.Context, conn *GoogleConnector, creds connectors.Credentials, spreadsheetID string) ([]string, error) {
+	listURL := conn.sheetsBaseURL + "/spreadsheets/" +
+		url.PathEscape(spreadsheetID) +
+		"?fields=sheets.properties(title)"
+
+	var resp sheetsSpreadsheetResponse
+	if err := conn.doJSON(ctx, creds, http.MethodGet, listURL, nil, &resp); err != nil {
+		return nil, err
+	}
+	titles := make([]string, 0, len(resp.Sheets))
+	for _, s := range resp.Sheets {
+		titles = append(titles, s.Properties.Title)
+	}
+	return titles, nil
 }

--- a/connectors/google/sheets_write.go
+++ b/connectors/google/sheets_write.go
@@ -72,7 +72,7 @@ func (a *sheetsWriteRangeAction) Execute(ctx context.Context, req connectors.Act
 
 	var resp sheetsUpdateValuesResponse
 	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPut, writeURL, body, &resp); err != nil {
-		return nil, err
+		return nil, remapInvalidRangeError(ctx, a.conn, req.Credentials, params.SpreadsheetID, params.Range, err)
 	}
 
 	return connectors.JSONResult(map[string]any{

--- a/connectors/google/sheets_write_test.go
+++ b/connectors/google/sheets_write_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
@@ -222,5 +223,110 @@ func TestSheetsWriteRange_InvalidJSON(t *testing.T) {
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+// TestSheetsWriteRange_InvalidRange_ListsAvailableTabs verifies that when the
+// Google Sheets API returns "Unable to parse range", the connector remaps the
+// error to a ValidationError listing the spreadsheet's actual tab titles.
+func TestSheetsWriteRange_InvalidRange_ListsAvailableTabs(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/spreadsheets/ss-1/values/Sheet1!A1:C3":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 400, "message": "Unable to parse range: Sheet1!A1:C3"},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/spreadsheets/ss-1":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(sheetsSpreadsheetResponse{
+				Sheets: []struct {
+					Properties sheetsProperties `json:"properties"`
+				}{
+					{Properties: sheetsProperties{Title: "Dashboard"}},
+				},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", "", srv.URL)
+	action := &sheetsWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(sheetsWriteRangeParams{
+		SpreadsheetID: "ss-1",
+		Range:         "Sheet1!A1:C3",
+		Values:        [][]any{{"a", "b", "c"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.sheets_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid range")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	msg := err.Error()
+	for _, want := range []string{`"Sheet1!A1:C3"`, `"Dashboard"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected error message to contain %s, got: %s", want, msg)
+		}
+	}
+}
+
+// TestSheetsWriteRange_InvalidRange_ListFailureFallsBack verifies that if the
+// follow-up tab list lookup fails, the original ExternalError is returned.
+func TestSheetsWriteRange_InvalidRange_ListFailureFallsBack(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 400, "message": "Unable to parse range: Sheet1!A1"},
+			})
+		case r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 500, "message": "backend error"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), "", "", srv.URL)
+	action := &sheetsWriteRangeAction{conn: conn}
+
+	params, _ := json.Marshal(sheetsWriteRangeParams{
+		SpreadsheetID: "ss-1",
+		Range:         "Sheet1!A1",
+		Values:        [][]any{{"v"}},
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.sheets_write_range",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if connectors.IsValidationError(err) {
+		t.Fatalf("expected original ExternalError to be preserved, got ValidationError: %v", err)
+	}
+	if !connectors.IsExternalError(err) {
+		t.Fatalf("expected ExternalError, got %T: %v", err, err)
 	}
 }


### PR DESCRIPTION
When the agent passes a range like "Sheet1!A:C" but the spreadsheet has
no tab literally named "Sheet1" (renamed, localized, or a different
default), Google returns HTTP 400. That surfaced as an opaque
ExternalError and was captured in Sentry as a server-side failure —
issue 7426813341 — even though it is really a correctable input problem.

On this specific 400, call the existing spreadsheets.get endpoint to
list actual tab titles and return a ValidationError like:

  range "Sheet1!A:C" refers to a tab that does not exist in this
  spreadsheet. Available tabs: "Data", "Summary". Use
  google.sheets_list_sheets to discover tab names.

ValidationError is classified by classifyConnectorError as "validation",
which skips Sentry capture and gives the agent enough context to
self-correct on retry. If the follow-up list call itself fails, the
original ExternalError is returned unchanged so genuine external
failures are never masked.

Applied to both sheets_append_rows and sheets_write_range (both hit the
same /values/{range} endpoint with the same failure mode).

https://claude.ai/code/session_01UaJCE2GFTHbMzJuEDJqkda