### PR TITLE
Restore Slack v2_user OAuth endpoints to fix callback

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -9,8 +9,10 @@
 //     and creates an oauth_connections row
 //  6. Server redirects to /settings?oauth_status=success (or error)
 //
-// Slack uses user-token-only OAuth: the callback requires authed_user.access_token
-// and rejects exchanges that only return a bot token (misconfigured Slack app).
+// Slack uses user-token-only OAuth via the oauth.v2.user.access endpoint, which
+// returns the user token (xoxp-) at the top level. NormalizeSlackUserOAuthToken
+// remains as a defensive fallback in case a response ever comes back with the
+// token nested under authed_user (e.g., misconfigured app using oauth.v2.access).
 //
 // Security:
 //   - CSRF protection via signed JWT state tokens (HS256, 10-min TTL)

--- a/api/oauth_slack_callback_test.go
+++ b/api/oauth_slack_callback_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+	"github.com/supersuit-tech/permission-slip/oauth"
+	"github.com/supersuit-tech/permission-slip/vault"
+	"golang.org/x/oauth2"
+)
+
+// slackCallbackDeps registers a "slack" provider pointing at a fake token
+// server. It mirrors oauthDepsWithSlack but lets each test control the token
+// endpoint response.
+func slackCallbackDeps(tx db.DBTX, tokenURL string) *Deps {
+	reg := oauth.NewRegistry()
+	_ = reg.Register(oauth.Provider{
+		ID:           "slack",
+		AuthorizeURL: "https://slack.com/oauth/v2_user/authorize",
+		TokenURL:     tokenURL,
+		Scopes:       []string{"channels:read"},
+		AuthorizeParams: map[string]string{
+			"scope": "channels:read",
+		},
+		AuthStyle:    oauth2.AuthStyleInParams,
+		ClientID:     "test-slack-client-id",
+		ClientSecret: "test-slack-client-secret",
+		Source:       oauth.SourceBuiltIn,
+	})
+	return &Deps{
+		DB:                tx,
+		Vault:             vault.NewMockVaultStore(),
+		SupabaseJWTSecret: testJWTSecret,
+		OAuthProviders:    reg,
+		OAuthStateSecret:  testOAuthStateSecret,
+		BaseURL:           "http://localhost:3000",
+	}
+}
+
+// TestOAuthCallback_SlackV2UserEndpointSucceeds verifies that when the Slack
+// token endpoint returns a v2_user-shaped response (top-level access_token),
+// the callback completes the flow and redirects with oauth_status=success.
+//
+// This locks in the contract our production config relies on: oauth.v2.user.access
+// returns the user token at the top level, so Go's oauth2 library accepts it.
+func TestOAuthCallback_SlackV2UserEndpointSucceeds(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	// Fake oauth.v2.user.access: user token at the top level.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"ok": true,
+			"access_token": "xoxp-user-token",
+			"token_type": "user",
+			"scope": "channels:read",
+			"team": {"id": "T123", "name": "Acme Corp"},
+			"authed_user": {"id": "U123", "scope": "channels:read"}
+		}`))
+	}))
+	defer tokenSrv.Close()
+
+	deps := slackCallbackDeps(tx, tokenSrv.URL)
+	state, err := createOAuthState(deps, uid, "slack", []string{"channels:read"}, "", "", "", "")
+	if err != nil {
+		t.Fatalf("create state: %v", err)
+	}
+
+	router := NewRouter(deps)
+	r := httptest.NewRequest(http.MethodGet,
+		"/oauth/slack/callback?code=test-code&state="+url.QueryEscape(state), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
+	}
+	location := w.Header().Get("Location")
+	if !strings.Contains(location, "oauth_status=success") {
+		t.Errorf("expected success status in redirect, got: %s", location)
+	}
+	if !strings.Contains(location, "oauth_connection_id=") {
+		t.Errorf("expected connection id in redirect, got: %s", location)
+	}
+}
+
+// TestOAuthCallback_SlackV2AccessNestedResponseFails is the regression guard
+// for Sentry PERMISSION-SLIP-GO-N. If someone points Slack at the standard
+// oauth.v2.access endpoint (or a compatible mock), the response omits the
+// top-level access_token when only user scopes are requested — and Go's
+// oauth2 library rejects it at cfg.Exchange with "server response missing
+// access_token" BEFORE our NormalizeSlackUserOAuthToken can run.
+//
+// This test documents that failure mode so anyone swapping endpoints sees
+// exactly why it breaks. Do not "fix" this test by adding a custom exchange
+// or by reverting to oauth.v2.access — use the v2_user endpoints instead.
+func TestOAuthCallback_SlackV2AccessNestedResponseFails(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	// Fake oauth.v2.access response: empty top-level access_token, user token
+	// nested under authed_user. This is what Slack returns from oauth.v2.access
+	// when only user scopes are requested.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"ok": true,
+			"access_token": "",
+			"token_type": "",
+			"scope": "",
+			"team": {"id": "T123", "name": "Acme Corp"},
+			"authed_user": {
+				"id": "U123",
+				"scope": "channels:read",
+				"access_token": "xoxp-user-token",
+				"token_type": "user"
+			}
+		}`))
+	}))
+	defer tokenSrv.Close()
+
+	deps := slackCallbackDeps(tx, tokenSrv.URL)
+	state, err := createOAuthState(deps, uid, "slack", []string{"channels:read"}, "", "", "", "")
+	if err != nil {
+		t.Fatalf("create state: %v", err)
+	}
+
+	router := NewRouter(deps)
+	r := httptest.NewRequest(http.MethodGet,
+		"/oauth/slack/callback?code=test-code&state="+url.QueryEscape(state), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d: %s", w.Code, w.Body.String())
+	}
+	location := w.Header().Get("Location")
+	if !strings.Contains(location, "oauth_status=error") {
+		t.Errorf("expected error status in redirect (nested-only response should fail), got: %s", location)
+	}
+	if !strings.Contains(location, "Token+exchange+failed") && !strings.Contains(location, "Token%20exchange%20failed") {
+		t.Errorf("expected 'Token exchange failed' in redirect, got: %s", location)
+	}
+}

--- a/oauth/builtin_test.go
+++ b/oauth/builtin_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/oauth2"
+
 	"github.com/supersuit-tech/permission-slip/oauth"
 	_ "github.com/supersuit-tech/permission-slip/oauth/providers"
 )
@@ -186,6 +188,42 @@ func TestBuiltInProviders(t *testing.T) {
 		}
 		if len(a.Scopes) != 6 {
 			t.Errorf("expected 6 scopes, got %d: %v", len(a.Scopes), a.Scopes)
+		}
+	})
+
+	t.Run("slack", func(t *testing.T) {
+		// REGRESSION GUARD: do NOT change these endpoints to oauth.v2.access /
+		// oauth/v2/authorize. Slack's standard oauth.v2.access endpoint nests
+		// the user token under authed_user and leaves top-level access_token
+		// empty when only user scopes are requested, which causes the Go
+		// oauth2 library to reject the response with "server response missing
+		// access_token" at cfg.Exchange — before any normalization can run.
+		// The dedicated user-token-only endpoints below return the user token
+		// at the top level. See Sentry PERMISSION-SLIP-GO-N and PR #958.
+		s, ok := byID["slack"]
+		if !ok {
+			t.Fatal("slack provider not found")
+		}
+		if s.AuthorizeURL != "https://slack.com/oauth/v2_user/authorize" {
+			t.Errorf("AuthorizeURL = %q, want https://slack.com/oauth/v2_user/authorize", s.AuthorizeURL)
+		}
+		if s.TokenURL != "https://slack.com/api/oauth.v2.user.access" {
+			t.Errorf("TokenURL = %q, want https://slack.com/api/oauth.v2.user.access", s.TokenURL)
+		}
+		if _, bad := s.AuthorizeParams["user_scope"]; bad {
+			t.Error("AuthorizeParams must not contain user_scope — v2_user endpoints use scope; user_scope is only valid for the standard v2 flow")
+		}
+		if s.AuthorizeParams["scope"] == "" {
+			t.Error("AuthorizeParams must set scope (comma-separated) for the v2_user authorize endpoint")
+		}
+		if s.AuthStyle != oauth2.AuthStyleInParams {
+			t.Errorf("AuthStyle = %v, want AuthStyleInParams (Slack token endpoint returns HTTP 200 for errors so auto-detect picks Basic and fails silently)", s.AuthStyle)
+		}
+		if s.Source != oauth.SourceBuiltIn {
+			t.Errorf("Source = %q, want %q", s.Source, oauth.SourceBuiltIn)
+		}
+		if len(s.Scopes) == 0 {
+			t.Error("expected default scopes")
 		}
 	})
 

--- a/oauth/providers/slack.go
+++ b/oauth/providers/slack.go
@@ -14,21 +14,19 @@ func init() {
 	oauth.RegisterBuiltIn(func() oauth.Provider {
 		return oauth.Provider{
 			ID: "slack",
-			// Standard Slack OAuth v2 endpoints. The authorize URL uses the
-			// standard /oauth/v2/authorize path with user_scope (not scope)
-			// to request user-level permissions. The token URL is the standard
-			// oauth.v2.access endpoint. When only user scopes are requested
-			// (no bot scopes), Slack nests the user token inside authed_user
-			// rather than at the top level — the OAuth callback handles this
-			// via NormalizeSlackUserOAuthToken.
-			AuthorizeURL: "https://slack.com/oauth/v2/authorize",
-			TokenURL:     "https://slack.com/api/oauth.v2.access",
+			// User-token-only OAuth: use the v2_user authorize and token
+			// endpoints so Slack returns the user token (xoxp-) at the top
+			// level of the response. The standard v2 endpoints nest user
+			// tokens inside authed_user and omit the top-level access_token
+			// when no bot scopes are requested, which breaks Go's oauth2
+			// library ("server response missing access_token").
+			AuthorizeURL: "https://slack.com/oauth/v2_user/authorize",
+			TokenURL:     "https://slack.com/api/oauth.v2.user.access",
 			Scopes:       slackconnector.OAuthScopes,
-			// Slack requires user_scope (not scope) for user-level OAuth
-			// permissions, and scopes must be comma-separated (the oauth2
-			// library sends space-separated). Override via AuthorizeParams.
+			// Slack requires comma-separated scopes; the oauth2 library sends
+			// space-separated. Override via AuthorizeParams so the URL is correct.
 			AuthorizeParams: map[string]string{
-				"user_scope": strings.Join(slackconnector.OAuthScopes, ","),
+				"scope": strings.Join(slackconnector.OAuthScopes, ","),
 			},
 			// Slack's token endpoint requires client credentials as POST body
 			// params and returns HTTP 200 for all responses (even errors).


### PR DESCRIPTION
## Summary

- Slack OAuth callback is failing in production with `oauth2: server response missing access_token` (Sentry [PERMISSION-SLIP-GO-N](https://supersuit-technologies.sentry.io/issues/7426915613/)).
- Root cause: PR #800 reverted the working fix from PR #778, switching Slack back to `oauth/v2/authorize` + `oauth.v2.access` with `user_scope`. When only user scopes are requested, that endpoint returns the user token nested under `authed_user` and leaves the top-level `access_token` empty, which Go's `oauth2` library rejects with `server response missing access_token` at `cfg.Exchange` — *before* `NormalizeSlackUserOAuthToken` in `api/oauth.go` can normalize it.
- `oauth/refresh.go:68` was never updated to match that revert: its comment still assumes `v2_user`, which is more evidence the revert was incomplete.
- Fix: restore the dedicated user-token-only endpoints `oauth/v2_user/authorize` and `oauth.v2.user.access` (both [documented by Slack](https://docs.slack.dev/reference/methods/oauth.v2.user.access/)), which return the user token at the top level. Keep `NormalizeSlackUserOAuthToken` as a defensive fallback.

## Test plan

### Developer
- [ ] CI passes (`make test` — backend tests could not be run locally due to the sandbox's Go 1.25 + bigquery constraint documented in CLAUDE.md; relying on CI).
- [ ] `gofmt` clean on touched files (verified locally).

### Manual Testing
- [ ] Trigger the Slack OAuth flow from production (`/oauth/slack/callback`) and confirm the token is stored and the connector works.
- [ ] Confirm the Sentry issue stops reproducing after deploy.

Closes Sentry PERMISSION-SLIP-GO-N.

https://claude.ai/code/session_01Ce7rs7jTq4GHjNSjqeRF1y