### PR TITLE
Fingerprint connector errors and downgrade 4xx externals to warning

### DIFF
--- a/api/sentry.go
+++ b/api/sentry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/supersuit-tech/permission-slip/connectors"
@@ -107,7 +108,43 @@ func CaptureConnectorError(ctx context.Context, err error, cc ConnectorContext) 
 		if cc.AgentID != 0 {
 			scope.SetTag("agent_id", fmt.Sprintf("%d", cc.AgentID))
 		}
-		scope.SetTag("error_type", classifyConnectorError(err))
+		errorType := classifyConnectorError(err)
+		scope.SetTag("error_type", errorType)
+
+		// Fingerprint by connector + action + error class (+ status for external
+		// errors) so distinct upstream failures land in their own Sentry issues
+		// instead of collapsing into one bucket keyed only by exception type +
+		// stack trace. Without this, every ExternalError — regardless of which
+		// connector, action, or status code — merges into a single issue,
+		// making triage impossible.
+		fp := []string{"connector", errorType}
+		connID := cc.ConnectorID
+		if connID == "" && cc.ActionType != "" {
+			if derived := connectorIDFromActionType(cc.ActionType); derived != nil {
+				connID = *derived
+			}
+		}
+		if connID != "" {
+			fp = append(fp, connID)
+		}
+		if cc.ActionType != "" {
+			fp = append(fp, cc.ActionType)
+		}
+		var extErr *connectors.ExternalError
+		if errors.As(err, &extErr) {
+			fp = append(fp, strconv.Itoa(extErr.StatusCode))
+			// 4xx from an external service means the request we sent was
+			// rejected (bad params, missing resource, user-level config
+			// problem). These are worth keeping in Sentry for visibility and
+			// product-side follow-up, but they aren't backend outages and
+			// shouldn't page via error-level alert rules. 5xx stays at the
+			// default error level so genuine upstream outages still alert.
+			if extErr.StatusCode >= 400 && extErr.StatusCode < 500 {
+				scope.SetLevel(sentry.LevelWarning)
+			}
+		}
+		scope.SetFingerprint(fp)
+
 		hub.CaptureException(err)
 	})
 }

--- a/api/sentry_test.go
+++ b/api/sentry_test.go
@@ -279,6 +279,100 @@ func TestClassifyConnectorError(t *testing.T) {
 	}
 }
 
+func TestCaptureConnectorError_FingerprintSplitsByConnectorActionStatus(t *testing.T) {
+	t.Parallel()
+
+	transport := &sentryTestTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@sentry.example.com/1",
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("failed to create sentry client: %v", err)
+	}
+
+	hub := sentry.NewHub(client, sentry.NewScope())
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	CaptureConnectorError(ctx, &connectors.ExternalError{StatusCode: 404, Message: "Chat app not found"}, ConnectorContext{
+		ActionType: "google.chat_send_message",
+		AgentID:    1,
+	})
+
+	events := transport.getEvents()
+	if len(events) == 0 {
+		t.Fatal("expected event to be captured")
+	}
+	fp := events[0].Fingerprint
+	wantParts := []string{"connector", "external", "google", "google.chat_send_message", "404"}
+	if len(fp) != len(wantParts) {
+		t.Fatalf("fingerprint = %v, want %v", fp, wantParts)
+	}
+	for i, want := range wantParts {
+		if fp[i] != want {
+			t.Errorf("fingerprint[%d] = %q, want %q", i, fp[i], want)
+		}
+	}
+}
+
+func TestCaptureConnectorError_4xxExternalErrorIsWarning(t *testing.T) {
+	t.Parallel()
+
+	transport := &sentryTestTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@sentry.example.com/1",
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("failed to create sentry client: %v", err)
+	}
+
+	hub := sentry.NewHub(client, sentry.NewScope())
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	CaptureConnectorError(ctx, &connectors.ExternalError{StatusCode: 400, Message: "bad range"}, ConnectorContext{
+		ConnectorID: "google",
+		ActionType:  "google.sheets_read_range",
+	})
+
+	events := transport.getEvents()
+	if len(events) == 0 {
+		t.Fatal("expected event to be captured")
+	}
+	if got := events[0].Level; got != sentry.LevelWarning {
+		t.Errorf("level = %q, want %q (4xx external errors should not page)", got, sentry.LevelWarning)
+	}
+}
+
+func TestCaptureConnectorError_5xxExternalErrorStaysError(t *testing.T) {
+	t.Parallel()
+
+	transport := &sentryTestTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@sentry.example.com/1",
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("failed to create sentry client: %v", err)
+	}
+
+	hub := sentry.NewHub(client, sentry.NewScope())
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	CaptureConnectorError(ctx, &connectors.ExternalError{StatusCode: 503, Message: "upstream down"}, ConnectorContext{
+		ConnectorID: "google",
+		ActionType:  "google.sheets_read_range",
+	})
+
+	events := transport.getEvents()
+	if len(events) == 0 {
+		t.Fatal("expected event to be captured")
+	}
+	if got := events[0].Level; got == sentry.LevelWarning {
+		t.Errorf("level = %q, expected default error-level (5xx is a real outage)", got)
+	}
+}
+
 // sentryTestTransport captures events in memory for test assertions.
 // A mutex guards the events slice in case the SDK delivers events from a
 // background goroutine (defensive — our tests are single-goroutine but
@@ -294,9 +388,9 @@ func (t *sentryTestTransport) SendEvent(event *sentry.Event) {
 	defer t.mu.Unlock()
 	t.events = append(t.events, event)
 }
-func (t *sentryTestTransport) Flush(_ time.Duration) bool             { return true }
+func (t *sentryTestTransport) Flush(_ time.Duration) bool              { return true }
 func (t *sentryTestTransport) FlushWithContext(_ context.Context) bool { return true }
-func (t *sentryTestTransport) Close()                                 {}
+func (t *sentryTestTransport) Close()                                  {}
 
 // getEvents returns a snapshot of captured events (safe for concurrent use).
 func (t *sentryTestTransport) getEvents() []*sentry.Event {


### PR DESCRIPTION
## Summary

- Fixes Sentry issue [PERMISSION-SLIP-GO-M (7426826283)](https://supersuit-technologies.sentry.io/issues/7426826283/), where unrelated upstream failures were piling into a single issue and paging on every occurrence.
- `CaptureConnectorError` now sets a custom fingerprint (`connector` / error class / connector id / action type / status code), so e.g. "Google Chat app not found" (404) and "Unable to parse range: Sheet1!A1:C10" (400) land in their own issues instead of collapsing into one bucket keyed only by exception type + stack trace.
- `*connectors.ExternalError` with a 4xx status code is now captured at `level=warning` instead of `error`. 4xx upstream responses are user/agent-correctable configuration problems (missing resource, bad params, not-installed app), not backend outages — still worth keeping in Sentry for visibility, but they shouldn't page through error-level alert rules. 5xx stays at `error` so real upstream outages still alert.
- HTTP responses to agents are unchanged; they still get a 502 with the upstream message so the user can act on it.

## Rationale

The referenced Sentry issue's title (`Google Chat app not found`) didn't match its latest event (`Unable to parse range: Sheet1!A1:C10`, from `google.sheets_read_range`). Root cause: every connector error flowed through the same stack into `hub.CaptureException(err)`, giving Sentry an identical fingerprint regardless of connector/action/status. That also meant each new 4xx from a totally different user or connector inflated the alert threshold of this one issue.

## Test plan

### Developer
- [ ] `make test-backend` passes in CI (backend tests can't run in the sandbox due to the Go 1.25 transitive dep, so relying on CI)
- [ ] New tests in `api/sentry_test.go` cover:
  - Fingerprint is `[connector, external, google, google.chat_send_message, 404]` for a 404 external error
  - 4xx `ExternalError` produces `level=warning`
  - 5xx `ExternalError` stays at the default (non-warning) level

### Manual Testing
- [ ] In a dev env, trigger a 4xx connector failure (e.g. `google.sheets_read_range` with an invalid range) and confirm the Sentry event lands at `level=warning` in its own fingerprinted issue, while the agent still receives the 502 with the upstream message.
- [ ] Simulate a 5xx upstream and confirm the event arrives at the default `error` level and fires the usual alert rule, separately from other connector issues.
- [ ] After merge, mark Sentry issue 7426826283 as **Resolved in next release** so it stops aggregating events; any recurrence will land in a properly fingerprinted new issue.

https://claude.ai/code/session_014w1Uq65Zjq7Qi97af9o8aQ