### PR TITLE
feat: silence auto-approval notifications (per-type preferences)

### DIFF
--- a/api/notification_type_preferences.go
+++ b/api/notification_type_preferences.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"log"
+	"net/http"
+	"sort"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+// validNotificationTypes is the set of notification_type values the DB allows.
+var validNotificationTypes = map[string]bool{
+	db.NotificationTypeStandingExecution: true,
+}
+
+var allNotificationTypes = func() []string {
+	types := make([]string, 0, len(validNotificationTypes))
+	for t := range validNotificationTypes {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
+}()
+
+type notificationTypePreferenceResponse struct {
+	NotificationType string `json:"notification_type"`
+	Enabled          bool   `json:"enabled"`
+}
+
+type notificationTypePreferencesResponse struct {
+	Preferences []notificationTypePreferenceResponse `json:"preferences"`
+}
+
+type updateNotificationTypePreferencesRequest struct {
+	Preferences []notificationTypePreferenceUpdate `json:"preferences"`
+}
+
+type notificationTypePreferenceUpdate struct {
+	NotificationType string `json:"notification_type"`
+	Enabled          bool   `json:"enabled"`
+}
+
+func handleGetNotificationTypePreferences(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		prefs, err := db.GetNotificationTypePreferences(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] handleGetNotificationTypePreferences: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to load notification type preferences"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, notificationTypePreferencesResponse{
+			Preferences: buildNotificationTypePreferencesResponse(prefs),
+		})
+	}
+}
+
+func handleUpdateNotificationTypePreferences(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		var req updateNotificationTypePreferencesRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		if len(req.Preferences) == 0 {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "At least one preference is required"))
+			return
+		}
+
+		seen := make(map[string]bool)
+		for _, p := range req.Preferences {
+			if !validNotificationTypes[p.NotificationType] {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Invalid notification type: "+p.NotificationType))
+				return
+			}
+			if seen[p.NotificationType] {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Duplicate notification type: "+p.NotificationType))
+				return
+			}
+			seen[p.NotificationType] = true
+		}
+
+		for _, p := range req.Preferences {
+			if err := db.UpsertNotificationTypePreference(r.Context(), deps.DB, profile.ID, p.NotificationType, p.Enabled); err != nil {
+				log.Printf("[%s] handleUpdateNotificationTypePreferences: upsert %q: %v", TraceID(r.Context()), p.NotificationType, err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update notification type preferences"))
+				return
+			}
+		}
+
+		prefs, err := db.GetNotificationTypePreferences(r.Context(), deps.DB, profile.ID)
+		if err != nil {
+			log.Printf("[%s] handleUpdateNotificationTypePreferences: re-fetch: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to load notification type preferences"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, notificationTypePreferencesResponse{
+			Preferences: buildNotificationTypePreferencesResponse(prefs),
+		})
+	}
+}
+
+func buildNotificationTypePreferencesResponse(prefs []db.NotificationTypePreference) []notificationTypePreferenceResponse {
+	prefMap := make(map[string]bool)
+	for _, p := range prefs {
+		prefMap[p.NotificationType] = p.Enabled
+	}
+
+	result := make([]notificationTypePreferenceResponse, 0, len(allNotificationTypes))
+	for _, nt := range allNotificationTypes {
+		enabled, exists := prefMap[nt]
+		if !exists {
+			enabled = true
+		}
+		result = append(result, notificationTypePreferenceResponse{
+			NotificationType: nt,
+			Enabled:          enabled,
+		})
+	}
+	return result
+}

--- a/api/notification_type_preferences.go
+++ b/api/notification_type_preferences.go
@@ -85,16 +85,37 @@ func handleUpdateNotificationTypePreferences(deps *Deps) http.HandlerFunc {
 			seen[p.NotificationType] = true
 		}
 
+		ctx := r.Context()
+		tx, owned, err := db.BeginOrContinue(ctx, deps.DB)
+		if err != nil {
+			log.Printf("[%s] handleUpdateNotificationTypePreferences: begin tx: %v", TraceID(ctx), err)
+			CaptureError(ctx, err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update notification type preferences"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(ctx, tx)
+		}
+
 		for _, p := range req.Preferences {
-			if err := db.UpsertNotificationTypePreference(r.Context(), deps.DB, profile.ID, p.NotificationType, p.Enabled); err != nil {
-				log.Printf("[%s] handleUpdateNotificationTypePreferences: upsert %q: %v", TraceID(r.Context()), p.NotificationType, err)
-				CaptureError(r.Context(), err)
+			if err := db.UpsertNotificationTypePreference(ctx, tx, profile.ID, p.NotificationType, p.Enabled); err != nil {
+				log.Printf("[%s] handleUpdateNotificationTypePreferences: upsert %q: %v", TraceID(ctx), p.NotificationType, err)
+				CaptureError(ctx, err)
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update notification type preferences"))
 				return
 			}
 		}
 
-		prefs, err := db.GetNotificationTypePreferences(r.Context(), deps.DB, profile.ID)
+		if owned {
+			if err := db.CommitTx(ctx, tx); err != nil {
+				log.Printf("[%s] handleUpdateNotificationTypePreferences: commit: %v", TraceID(ctx), err)
+				CaptureError(ctx, err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update notification type preferences"))
+				return
+			}
+		}
+
+		prefs, err := db.GetNotificationTypePreferences(ctx, deps.DB, profile.ID)
 		if err != nil {
 			log.Printf("[%s] handleUpdateNotificationTypePreferences: re-fetch: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)

--- a/api/notification_type_preferences_test.go
+++ b/api/notification_type_preferences_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestGetNotificationTypePreferences_DefaultEnabled(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, "/profile/notification-type-preferences", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp notificationTypePreferencesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Preferences) != 1 {
+		t.Fatalf("expected 1 preference, got %d", len(resp.Preferences))
+	}
+	p := resp.Preferences[0]
+	if p.NotificationType != db.NotificationTypeStandingExecution || !p.Enabled {
+		t.Errorf("unexpected default: %+v", p)
+	}
+}
+
+func TestUpdateNotificationTypePreferences_StandingExecution(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"preferences":[{"notification_type":"standing_execution","enabled":false}]}`
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-type-preferences", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp notificationTypePreferencesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Preferences) != 1 || resp.Preferences[0].Enabled {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+
+	enabled, err := db.IsNotificationTypeEnabled(context.Background(), tx, uid, db.NotificationTypeStandingExecution)
+	if err != nil {
+		t.Fatalf("db check: %v", err)
+	}
+	if enabled {
+		t.Error("expected disabled in DB")
+	}
+}
+
+func TestUpdateNotificationTypePreferences_UnknownType(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"preferences":[{"notification_type":"bogus","enabled":false}]}`
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-type-preferences", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateNotificationTypePreferences_EmptyPreferences(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"preferences":[]}`
+	r := authenticatedJSONRequest(t, http.MethodPut, "/profile/notification-type-preferences", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/api/profiles.go
+++ b/api/profiles.go
@@ -58,6 +58,8 @@ func RegisterProfileRoutes(mux *http.ServeMux, deps *Deps) {
 	// Notification preferences (sub-resource of profile)
 	mux.Handle("GET /profile/notification-preferences", requireProfile(handleGetNotificationPreferences(deps)))
 	mux.Handle("PUT /profile/notification-preferences", requireProfile(handleUpdateNotificationPreferences(deps)))
+	mux.Handle("GET /profile/notification-type-preferences", requireProfile(handleGetNotificationTypePreferences(deps)))
+	mux.Handle("PUT /profile/notification-type-preferences", requireProfile(handleUpdateNotificationTypePreferences(deps)))
 
 	// Data retention policy
 	mux.Handle("GET /profile/data-retention", requireProfile(handleGetDataRetention(deps)))

--- a/api/standing_approval_notify.go
+++ b/api/standing_approval_notify.go
@@ -59,9 +59,10 @@ func NotifyStandingApprovalExecution(ctx context.Context, deps *Deps, exec *db.S
 
 	enabled, err := db.IsNotificationTypeEnabled(ctx, deps.DB, exec.UserID, db.NotificationTypeStandingExecution)
 	if err != nil {
-		log.Printf("notify: standing execution: failed to load notification type preference for user %s: %v", exec.UserID, err)
+		log.Printf("notify: standing execution: failed to load notification type preference for user %s: %v — defaulting to enabled", exec.UserID, err)
 		CaptureError(ctx, err)
-		return
+		// Fail open: missing rows already default to enabled; on read errors, do the same.
+		enabled = true
 	}
 	if !enabled {
 		log.Printf("notify: skipping standing execution notification for user %s — notification type disabled", exec.UserID)

--- a/api/standing_approval_notify.go
+++ b/api/standing_approval_notify.go
@@ -51,10 +51,21 @@ func NotifyStandingApprovalExecution(ctx context.Context, deps *Deps, exec *db.S
 		AgentID:     exec.AgentID,
 		AgentName:   agentName,
 		Action:      actionJSON,
-		Context: contextJSON,
+		Context:     contextJSON,
 		ApprovalURL: activityURL,
 		CreatedAt:   time.Now(),
 		Type:        notify.NotificationTypeStandingExecution,
+	}
+
+	enabled, err := db.IsNotificationTypeEnabled(ctx, deps.DB, exec.UserID, db.NotificationTypeStandingExecution)
+	if err != nil {
+		log.Printf("notify: standing execution: failed to load notification type preference for user %s: %v", exec.UserID, err)
+		CaptureError(ctx, err)
+		return
+	}
+	if !enabled {
+		log.Printf("notify: skipping standing execution notification for user %s — notification type disabled", exec.UserID)
+		return
 	}
 
 	recipient := notify.Recipient{

--- a/db/migrations/20260420130248_add_notification_type_preferences.sql
+++ b/db/migrations/20260420130248_add_notification_type_preferences.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- Per-user, per-notification-type preferences (e.g. silence auto-approval execution
+-- notifications). Missing rows default to enabled — insert enabled=false to opt out.
+
+CREATE TABLE notification_type_preferences (
+    user_id uuid    NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    notification_type text NOT NULL CHECK (notification_type IN ('standing_execution')),
+    enabled boolean NOT NULL DEFAULT true,
+    PRIMARY KEY (user_id, notification_type)
+);
+
+ALTER TABLE notification_type_preferences ENABLE ROW LEVEL SECURITY;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_backend') THEN
+        CREATE POLICY app_backend_all ON notification_type_preferences
+            FOR ALL TO app_backend USING (true) WITH CHECK (true);
+        GRANT SELECT, INSERT, UPDATE, DELETE ON notification_type_preferences TO app_backend;
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TABLE IF EXISTS notification_type_preferences;

--- a/db/notification_type_preferences.go
+++ b/db/notification_type_preferences.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// NotificationTypeStandingExecution is stored in notification_type_preferences.notification_type
+// for standing-approval (auto-approval) execution notifications.
+const NotificationTypeStandingExecution = "standing_execution"
+
+// NotificationTypePreference represents a row from notification_type_preferences.
+type NotificationTypePreference struct {
+	UserID           string
+	NotificationType string
+	Enabled          bool
+}
+
+// GetNotificationTypePreferences returns all notification type preference rows for the user.
+func GetNotificationTypePreferences(ctx context.Context, db DBTX, userID string) ([]NotificationTypePreference, error) {
+	rows, err := db.Query(ctx,
+		"SELECT user_id, notification_type, enabled FROM notification_type_preferences WHERE user_id = $1",
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var prefs []NotificationTypePreference
+	for rows.Next() {
+		var p NotificationTypePreference
+		if err := rows.Scan(&p.UserID, &p.NotificationType, &p.Enabled); err != nil {
+			return nil, err
+		}
+		prefs = append(prefs, p)
+	}
+	return prefs, rows.Err()
+}
+
+// IsNotificationTypeEnabled returns whether notifications for the given logical type are enabled.
+// A missing preference row defaults to true (enabled).
+func IsNotificationTypeEnabled(ctx context.Context, db DBTX, userID, notificationType string) (bool, error) {
+	var enabled bool
+	err := db.QueryRow(ctx,
+		"SELECT enabled FROM notification_type_preferences WHERE user_id = $1 AND notification_type = $2",
+		userID, notificationType,
+	).Scan(&enabled)
+	if err == pgx.ErrNoRows {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return enabled, nil
+}
+
+// UpsertNotificationTypePreference inserts or updates a single notification type preference.
+func UpsertNotificationTypePreference(ctx context.Context, db DBTX, userID, notificationType string, enabled bool) error {
+	_, err := db.Exec(ctx,
+		`INSERT INTO notification_type_preferences (user_id, notification_type, enabled)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (user_id, notification_type)
+		 DO UPDATE SET enabled = EXCLUDED.enabled`,
+		userID, notificationType, enabled,
+	)
+	return err
+}

--- a/db/notification_type_preferences_test.go
+++ b/db/notification_type_preferences_test.go
@@ -1,0 +1,106 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestNotificationTypePreferencesSchema(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	testhelper.RequireColumns(t, tx, "notification_type_preferences", []string{"user_id", "notification_type", "enabled"})
+}
+
+func TestNotificationTypePreferencesCascadeDelete(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+	err := db.UpsertNotificationTypePreference(ctx, tx, uid, db.NotificationTypeStandingExecution, true)
+	if err != nil {
+		t.Fatalf("upsert preference: %v", err)
+	}
+
+	testhelper.RequireCascadeDeletes(t, tx,
+		"DELETE FROM auth.users WHERE id = '"+uid+"'",
+		[]string{"notification_type_preferences"},
+		"user_id = '"+uid+"'",
+	)
+}
+
+func TestNotificationTypePreferencesTypeConstraint(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+	err := db.UpsertNotificationTypePreference(ctx, tx, uid, "unknown_type", true)
+	if err == nil {
+		t.Fatal("expected error for invalid notification type, got nil")
+	}
+}
+
+func TestIsNotificationTypeEnabled_Default(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+	enabled, err := db.IsNotificationTypeEnabled(ctx, tx, uid, db.NotificationTypeStandingExecution)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Error("missing preference should default to enabled")
+	}
+}
+
+func TestIsNotificationTypeEnabled_Disabled(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+	if err := db.UpsertNotificationTypePreference(ctx, tx, uid, db.NotificationTypeStandingExecution, false); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	enabled, err := db.IsNotificationTypeEnabled(ctx, tx, uid, db.NotificationTypeStandingExecution)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Error("expected standing_execution to be disabled")
+	}
+}
+
+func TestGetNotificationTypePreferences(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	ctx := context.Background()
+	if err := db.UpsertNotificationTypePreference(ctx, tx, uid, db.NotificationTypeStandingExecution, false); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	prefs, err := db.GetNotificationTypePreferences(ctx, tx, uid)
+	if err != nil {
+		t.Fatalf("get preferences: %v", err)
+	}
+	if len(prefs) != 1 {
+		t.Fatalf("expected 1 preference, got %d", len(prefs))
+	}
+	if prefs[0].NotificationType != db.NotificationTypeStandingExecution || prefs[0].Enabled {
+		t.Errorf("unexpected preference: %+v", prefs[0])
+	}
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6429,9 +6429,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -8254,9 +8254,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/frontend/src/hooks/useNotificationTypePreferences.ts
+++ b/frontend/src/hooks/useNotificationTypePreferences.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type NotificationTypePreference =
+  components["schemas"]["NotificationTypePreference"];
+
+export const NOTIFICATION_TYPE_PREFS_QUERY_KEY = "notification-type-preferences" as const;
+
+/**
+ * Fetches per-notification-type preferences (e.g. auto-approval execution notifications).
+ * Missing types default to enabled on the server.
+ */
+export function useNotificationTypePreferences() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [NOTIFICATION_TYPE_PREFS_QUERY_KEY],
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Not authenticated");
+      const { data, error } = await client.GET(
+        "/v1/profile/notification-type-preferences",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      );
+      if (error) throw new Error("Failed to load notification type preferences");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    preferences: data?.preferences ?? [],
+    isLoading,
+    error: error?.message ?? null,
+  };
+}

--- a/frontend/src/hooks/useNotificationTypePreferences.ts
+++ b/frontend/src/hooks/useNotificationTypePreferences.ts
@@ -2,11 +2,15 @@ import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
+import { getApiErrorMessage } from "@/api/errors";
 
 export type NotificationTypePreference =
   components["schemas"]["NotificationTypePreference"];
 
 export const NOTIFICATION_TYPE_PREFS_QUERY_KEY = "notification-type-preferences" as const;
+
+/** Matches OpenAPI enum and `db.NotificationTypeStandingExecution`. */
+export const NOTIFICATION_TYPE_STANDING_EXECUTION = "standing_execution" as const;
 
 /**
  * Fetches per-notification-type preferences (e.g. auto-approval execution notifications).
@@ -26,7 +30,14 @@ export function useNotificationTypePreferences() {
           headers: { Authorization: `Bearer ${accessToken}` },
         },
       );
-      if (error) throw new Error("Failed to load notification type preferences");
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(
+            error,
+            "Failed to load notification type preferences",
+          ),
+        );
+      }
       return data;
     },
     enabled: !!accessToken,

--- a/frontend/src/hooks/useUpdateNotificationTypePreferences.ts
+++ b/frontend/src/hooks/useUpdateNotificationTypePreferences.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
+import { getApiErrorMessage } from "@/api/errors";
 import { NOTIFICATION_TYPE_PREFS_QUERY_KEY } from "./useNotificationTypePreferences";
 
 type NotificationTypePreferenceUpdate =
@@ -27,10 +28,17 @@ export function useUpdateNotificationTypePreferences() {
           body: { preferences },
         },
       );
-      if (error) throw new Error("Failed to update notification type preferences");
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(
+            error,
+            "Failed to update notification type preferences",
+          ),
+        );
+      }
       return data;
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [NOTIFICATION_TYPE_PREFS_QUERY_KEY],
       });
@@ -39,7 +47,7 @@ export function useUpdateNotificationTypePreferences() {
 
   return {
     updatePreferences: mutation.mutateAsync,
-    isLoading: mutation.isPending,
+    isUpdating: mutation.isPending,
     error: mutation.error,
   };
 }

--- a/frontend/src/hooks/useUpdateNotificationTypePreferences.ts
+++ b/frontend/src/hooks/useUpdateNotificationTypePreferences.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+import { NOTIFICATION_TYPE_PREFS_QUERY_KEY } from "./useNotificationTypePreferences";
+
+type NotificationTypePreferenceUpdate =
+  components["schemas"]["NotificationTypePreferenceUpdate"];
+
+/**
+ * Updates per-notification-type preferences. Types not included are unchanged.
+ */
+export function useUpdateNotificationTypePreferences() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (preferences: NotificationTypePreferenceUpdate[]) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.PUT(
+        "/v1/profile/notification-type-preferences",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          body: { preferences },
+        },
+      );
+      if (error) throw new Error("Failed to update notification type preferences");
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [NOTIFICATION_TYPE_PREFS_QUERY_KEY],
+      });
+    },
+  });
+
+  return {
+    updatePreferences: mutation.mutateAsync,
+    isLoading: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -6,7 +6,10 @@ import { useUpdateProfile } from "@/hooks/useUpdateProfile";
 import { trackEvent, PostHogEvents } from "@/lib/posthog";
 import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "@/hooks/useUpdateNotificationPreferences";
-import { useNotificationTypePreferences } from "@/hooks/useNotificationTypePreferences";
+import {
+  NOTIFICATION_TYPE_STANDING_EXECUTION,
+  useNotificationTypePreferences,
+} from "@/hooks/useNotificationTypePreferences";
 import { useUpdateNotificationTypePreferences } from "@/hooks/useUpdateNotificationTypePreferences";
 import type { components } from "@/api/schema";
 import { Switch } from "@/components/ui/switch";
@@ -48,11 +51,11 @@ export function NotificationSection() {
     useUpdateNotificationPreferences();
   const {
     updatePreferences: updateTypePreferences,
-    isLoading: isUpdatingTypePrefs,
+    isUpdating: isUpdatingTypePrefs,
   } = useUpdateNotificationTypePreferences();
 
   const standingExecutionPref = typePreferences.find(
-    (p) => p.notification_type === "standing_execution",
+    (p) => p.notification_type === NOTIFICATION_TYPE_STANDING_EXECUTION,
   );
   const standingExecutionEnabled = standingExecutionPref?.enabled ?? true;
 
@@ -83,7 +86,7 @@ export function NotificationSection() {
     try {
       await updateTypePreferences([
         {
-          notification_type: "standing_execution",
+          notification_type: NOTIFICATION_TYPE_STANDING_EXECUTION,
           enabled,
         },
       ]);

--- a/frontend/src/pages/settings/NotificationSection.tsx
+++ b/frontend/src/pages/settings/NotificationSection.tsx
@@ -6,8 +6,11 @@ import { useUpdateProfile } from "@/hooks/useUpdateProfile";
 import { trackEvent, PostHogEvents } from "@/lib/posthog";
 import { useNotificationPreferences } from "@/hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "@/hooks/useUpdateNotificationPreferences";
+import { useNotificationTypePreferences } from "@/hooks/useNotificationTypePreferences";
+import { useUpdateNotificationTypePreferences } from "@/hooks/useUpdateNotificationTypePreferences";
 import type { components } from "@/api/schema";
 import { Switch } from "@/components/ui/switch";
+import { NotifyAboutAutoApprovalsRow } from "./NotifyAboutAutoApprovalsRow";
 import {
   Card,
   CardContent,
@@ -36,8 +39,22 @@ export function NotificationSection() {
   const { profile } = useProfile();
   const { updateProfile, isLoading: isUpdatingProfile } = useUpdateProfile();
   const { preferences, isLoading, error } = useNotificationPreferences();
+  const {
+    preferences: typePreferences,
+    isLoading: isLoadingTypePrefs,
+    error: typePrefsError,
+  } = useNotificationTypePreferences();
   const { updatePreferences, isLoading: isUpdating } =
     useUpdateNotificationPreferences();
+  const {
+    updatePreferences: updateTypePreferences,
+    isLoading: isUpdatingTypePrefs,
+  } = useUpdateNotificationTypePreferences();
+
+  const standingExecutionPref = typePreferences.find(
+    (p) => p.notification_type === "standing_execution",
+  );
+  const standingExecutionEnabled = standingExecutionPref?.enabled ?? true;
 
   // Determine which channels are missing required contact info.
   const missingContact: Record<string, string> = {};
@@ -59,6 +76,22 @@ export function NotificationSection() {
       );
     } catch {
       toast.error("Failed to update product updates preference.");
+    }
+  }
+
+  async function handleToggleStandingExecution(enabled: boolean) {
+    try {
+      await updateTypePreferences([
+        {
+          notification_type: "standing_execution",
+          enabled,
+        },
+      ]);
+      toast.success(
+        `Auto-approval execution notifications ${enabled ? "enabled" : "silenced"}.`,
+      );
+    } catch {
+      toast.error("Failed to update notification preference.");
     }
   }
 
@@ -88,7 +121,7 @@ export function NotificationSection() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {isLoading ? (
+        {isLoading || isLoadingTypePrefs ? (
           <div
             className="flex items-center justify-center py-8"
             role="status"
@@ -96,8 +129,10 @@ export function NotificationSection() {
           >
             <Loader2 className="text-muted-foreground size-5 animate-spin" />
           </div>
-        ) : error ? (
-          <p className="text-destructive text-sm">{error}</p>
+        ) : error || typePrefsError ? (
+          <p className="text-destructive text-sm">
+            {error ?? typePrefsError}
+          </p>
         ) : (
           <div className="space-y-4">
             {preferences
@@ -148,6 +183,19 @@ export function NotificationSection() {
                 </div>
               );
             })}
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Notify me about
+              </p>
+              <NotifyAboutAutoApprovalsRow
+                enabled={standingExecutionEnabled}
+                disabled={isUpdating || isUpdatingTypePrefs}
+                onCheckedChange={(checked) =>
+                  void handleToggleStandingExecution(checked)
+                }
+              />
+            </div>
 
             <hr className="border-border" />
 

--- a/frontend/src/pages/settings/NotifyAboutAutoApprovalsRow.stories.tsx
+++ b/frontend/src/pages/settings/NotifyAboutAutoApprovalsRow.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NotifyAboutAutoApprovalsRow } from "./NotifyAboutAutoApprovalsRow";
+
+const meta: Meta<typeof NotifyAboutAutoApprovalsRow> = {
+  title: "Settings/NotifyAboutAutoApprovalsRow",
+  component: NotifyAboutAutoApprovalsRow,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof NotifyAboutAutoApprovalsRow>;
+
+export const Enabled: Story = {
+  args: {
+    enabled: true,
+    disabled: false,
+    onCheckedChange: () => {},
+  },
+};
+
+export const Silenced: Story = {
+  args: {
+    enabled: false,
+    disabled: false,
+    onCheckedChange: () => {},
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    enabled: true,
+    disabled: true,
+    onCheckedChange: () => {},
+  },
+};

--- a/frontend/src/pages/settings/NotifyAboutAutoApprovalsRow.tsx
+++ b/frontend/src/pages/settings/NotifyAboutAutoApprovalsRow.tsx
@@ -1,0 +1,37 @@
+import { Switch } from "@/components/ui/switch";
+
+type Props = {
+  enabled: boolean;
+  disabled: boolean;
+  onCheckedChange: (checked: boolean) => void;
+};
+
+/**
+ * "Notify me about" row for auto-approval execution notifications.
+ * Extracted so Storybook can mirror production markup without mocking hooks.
+ */
+export function NotifyAboutAutoApprovalsRow({
+  enabled,
+  disabled,
+  onCheckedChange,
+}: Props) {
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium">Auto-approval executions</p>
+          <p className="text-xs text-muted-foreground">
+            When an action runs automatically because it matched a standing
+            approval.
+          </p>
+        </div>
+        <Switch
+          checked={enabled}
+          disabled={disabled}
+          aria-label="Auto-approval execution notifications"
+          onCheckedChange={onCheckedChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/NotificationSection.test.tsx
@@ -52,9 +52,14 @@ const profileNoContact: MockProfile = {
   created_at: "2026-01-01T00:00:00Z",
 };
 
+const defaultTypePreferences = [
+  { notification_type: "standing_execution" as const, enabled: true },
+];
+
 function mockApiFetch(
   profile = profileWithContact,
   preferences = allEnabled,
+  typePreferences = defaultTypePreferences,
 ) {
   setupAuthMocks({ authenticated: true });
   mockGet.mockImplementation((url: string) => {
@@ -63,6 +68,9 @@ function mockApiFetch(
     }
     if (url === "/v1/profile/notification-preferences") {
       return Promise.resolve({ data: { preferences } });
+    }
+    if (url === "/v1/profile/notification-type-preferences") {
+      return Promise.resolve({ data: { preferences: typePreferences } });
     }
     return Promise.resolve({ data: null });
   });
@@ -141,8 +149,8 @@ describe("NotificationSection", () => {
       const unchecked = switches.filter(
         (s) => s.getAttribute("data-state") === "unchecked",
       );
-      // email + mobile-push enabled + product updates unchecked
-      expect(checked).toHaveLength(2);
+      // email + mobile-push + standing execution enabled + product updates unchecked
+      expect(checked).toHaveLength(3);
       expect(unchecked).toHaveLength(1);
     });
   });
@@ -357,5 +365,58 @@ describe("NotificationSection", () => {
     // SMS should have a toggle (available=true), not "Coming soon"
     expect(screen.getByRole("switch", { name: /sms notifications/i })).toBeInTheDocument();
     expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
+  });
+
+  it("renders Notify me about and auto-approval toggle", async () => {
+    mockApiFetch();
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Notify me about")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("switch", { name: /auto-approval execution notifications/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls update for notification type when auto-approval toggle is clicked", async () => {
+    mockApiFetch();
+    mockPut.mockImplementation((url: string) => {
+      if (url === "/v1/profile/notification-type-preferences") {
+        return Promise.resolve({
+          data: {
+            preferences: [
+              { notification_type: "standing_execution", enabled: false },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: { preferences: [] } });
+    });
+    const user = userEvent.setup();
+
+    render(<NotificationSection />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /auto-approval execution notifications/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("switch", { name: /auto-approval execution notifications/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalledWith(
+        "/v1/profile/notification-type-preferences",
+        expect.objectContaining({
+          body: {
+            preferences: [{ notification_type: "standing_execution", enabled: false }],
+          },
+        }),
+      );
+    });
   });
 });

--- a/mobile/src/hooks/useNotificationTypePreferences.ts
+++ b/mobile/src/hooks/useNotificationTypePreferences.ts
@@ -1,0 +1,58 @@
+/**
+ * Fetches per-notification-type preferences (shared with web via the same API).
+ */
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+
+export type NotificationTypePreference =
+  components["schemas"]["NotificationTypePreference"];
+
+export const NOTIFICATION_TYPE_PREFS_KEY =
+  "notification-type-preferences" as const;
+
+export function useNotificationTypePreferences() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  tokenRef.current = accessToken;
+
+  const query = useQuery({
+    queryKey: [NOTIFICATION_TYPE_PREFS_KEY, userId ?? ""],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Not authenticated");
+      const { data, error } = await client.GET(
+        "/v1/profile/notification-type-preferences",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(
+            error,
+            "Unable to load notification type preferences.",
+          ),
+        );
+      }
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    preferences: query.data?.preferences ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? (query.error?.message ??
+          "Unable to load notification type preferences.")
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/mobile/src/hooks/useNotificationTypePreferences.ts
+++ b/mobile/src/hooks/useNotificationTypePreferences.ts
@@ -14,6 +14,9 @@ export type NotificationTypePreference =
 export const NOTIFICATION_TYPE_PREFS_KEY =
   "notification-type-preferences" as const;
 
+/** Matches OpenAPI enum and backend `db.NotificationTypeStandingExecution`. */
+export const NOTIFICATION_TYPE_STANDING_EXECUTION = "standing_execution" as const;
+
 export function useNotificationTypePreferences() {
   const { session } = useAuth();
   const accessToken = session?.access_token;

--- a/mobile/src/hooks/useUpdateNotificationTypePreferences.ts
+++ b/mobile/src/hooks/useUpdateNotificationTypePreferences.ts
@@ -1,0 +1,58 @@
+/**
+ * Updates per-notification-type preferences; invalidates the type-preferences cache.
+ */
+import { useRef } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+import { NOTIFICATION_TYPE_PREFS_KEY } from "./useNotificationTypePreferences";
+
+type NotificationTypePreferenceUpdate =
+  components["schemas"]["NotificationTypePreferenceUpdate"];
+
+export function useUpdateNotificationTypePreferences() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(session?.access_token);
+  tokenRef.current = session?.access_token;
+
+  const mutation = useMutation({
+    mutationFn: async (preferences: NotificationTypePreferenceUpdate[]) => {
+      const token = tokenRef.current;
+      if (!token) {
+        throw new Error("Not authenticated");
+      }
+      const { data, error } = await client.PUT(
+        "/v1/profile/notification-type-preferences",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          body: { preferences },
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(
+            error,
+            "Failed to update notification type preferences.",
+          ),
+        );
+      }
+      return data;
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: [NOTIFICATION_TYPE_PREFS_KEY],
+      });
+    },
+  });
+
+  return {
+    updatePreferences: mutation.mutateAsync,
+    isUpdating: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -21,7 +21,10 @@ import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useAuth } from "../../auth/AuthContext";
 import { useNotificationPreferences } from "../../hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "../../hooks/useUpdateNotificationPreferences";
-import { useNotificationTypePreferences } from "../../hooks/useNotificationTypePreferences";
+import {
+  NOTIFICATION_TYPE_STANDING_EXECUTION,
+  useNotificationTypePreferences,
+} from "../../hooks/useNotificationTypePreferences";
 import { useUpdateNotificationTypePreferences } from "../../hooks/useUpdateNotificationTypePreferences";
 import Constants from "expo-constants";
 import { useDeleteAccount } from "../../hooks/useDeleteAccount";
@@ -75,7 +78,7 @@ export default function SettingsScreen(_props: Props) {
   const mobilePushEnabled = mobilePushPref?.enabled ?? true;
 
   const standingPref = typePreferences.find(
-    (p) => p.notification_type === "standing_execution",
+    (p) => p.notification_type === NOTIFICATION_TYPE_STANDING_EXECUTION,
   );
   const standingExecutionEnabled = standingPref?.enabled ?? true;
 
@@ -96,7 +99,7 @@ export default function SettingsScreen(_props: Props) {
     try {
       await updateTypePreferences([
         {
-          notification_type: "standing_execution",
+          notification_type: NOTIFICATION_TYPE_STANDING_EXECUTION,
           enabled: !standingExecutionEnabled,
         },
       ]);

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -21,6 +21,8 @@ import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useAuth } from "../../auth/AuthContext";
 import { useNotificationPreferences } from "../../hooks/useNotificationPreferences";
 import { useUpdateNotificationPreferences } from "../../hooks/useUpdateNotificationPreferences";
+import { useNotificationTypePreferences } from "../../hooks/useNotificationTypePreferences";
+import { useUpdateNotificationTypePreferences } from "../../hooks/useUpdateNotificationTypePreferences";
 import Constants from "expo-constants";
 import { useDeleteAccount } from "../../hooks/useDeleteAccount";
 import { colors } from "../../theme/colors";
@@ -53,8 +55,15 @@ export default function SettingsScreen(_props: Props) {
   const { signOut, user } = useAuth();
   const { preferences, isLoading, error, refetch } =
     useNotificationPreferences();
+  const {
+    preferences: typePreferences,
+    isLoading: isLoadingTypePrefs,
+    error: typePrefsError,
+  } = useNotificationTypePreferences();
   const { updatePreferences, isUpdating } =
     useUpdateNotificationPreferences();
+  const { updatePreferences: updateTypePreferences, isUpdating: isUpdatingType } =
+    useUpdateNotificationTypePreferences();
   const { deleteAccount, isDeleting } = useDeleteAccount();
 
   const contentContainerStyle = useMemo(
@@ -64,6 +73,11 @@ export default function SettingsScreen(_props: Props) {
 
   const mobilePushPref = preferences.find((p) => p.channel === "mobile-push");
   const mobilePushEnabled = mobilePushPref?.enabled ?? true;
+
+  const standingPref = typePreferences.find(
+    (p) => p.notification_type === "standing_execution",
+  );
+  const standingExecutionEnabled = standingPref?.enabled ?? true;
 
   const handleToggleMobilePush = useCallback(async () => {
     try {
@@ -77,6 +91,22 @@ export default function SettingsScreen(_props: Props) {
       );
     }
   }, [mobilePushEnabled, updatePreferences]);
+
+  const handleToggleStandingExecution = useCallback(async () => {
+    try {
+      await updateTypePreferences([
+        {
+          notification_type: "standing_execution",
+          enabled: !standingExecutionEnabled,
+        },
+      ]);
+    } catch {
+      Alert.alert(
+        "Error",
+        "Failed to update notification preference. Please try again.",
+      );
+    }
+  }, [standingExecutionEnabled, updateTypePreferences]);
 
   const handleSignOut = useCallback(() => {
     Alert.alert("Sign out", "Are you sure you want to sign out?", [
@@ -118,7 +148,7 @@ export default function SettingsScreen(_props: Props) {
           Control how you receive approval request notifications on this device.
         </Text>
 
-        {isLoading ? (
+        {isLoading || isLoadingTypePrefs ? (
           <View style={styles.loadingContainer}>
             <ActivityIndicator
               size="small"
@@ -126,9 +156,9 @@ export default function SettingsScreen(_props: Props) {
               testID="prefs-loading"
             />
           </View>
-        ) : error ? (
+        ) : error || typePrefsError ? (
           <View style={styles.errorContainer}>
-            <Text style={styles.errorText}>{error}</Text>
+            <Text style={styles.errorText}>{error ?? typePrefsError}</Text>
             <TouchableOpacity
               style={styles.retryButton}
               accessibilityRole="button"
@@ -160,6 +190,31 @@ export default function SettingsScreen(_props: Props) {
                 accessibilityRole="switch"
                 accessibilityState={{ checked: mobilePushEnabled }}
               />
+            </View>
+            <Text style={styles.subsectionTitle}>Notify me about</Text>
+            <View style={[styles.card, styles.cardSpaced]}>
+              <View style={styles.toggleRow}>
+                <View style={styles.toggleLabel}>
+                  <Text style={styles.toggleTitle}>Auto-approval executions</Text>
+                  <Text style={styles.toggleDescription}>
+                    When an action runs automatically because it matched a
+                    standing approval.
+                  </Text>
+                </View>
+                <Switch
+                  testID="standing-execution-toggle"
+                  value={standingExecutionEnabled}
+                  onValueChange={handleToggleStandingExecution}
+                  disabled={isUpdating || isUpdatingType}
+                  trackColor={{
+                    false: colors.gray300,
+                    true: colors.primary,
+                  }}
+                  accessibilityLabel="Auto-approval execution notifications"
+                  accessibilityRole="switch"
+                  accessibilityState={{ checked: standingExecutionEnabled }}
+                />
+              </View>
             </View>
           </View>
         )}
@@ -314,6 +369,18 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     borderWidth: 1,
     borderColor: colors.gray200,
+  },
+  cardSpaced: {
+    marginTop: 12,
+  },
+  subsectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.gray500,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginTop: 16,
+    marginBottom: 8,
   },
   toggleRow: {
     flexDirection: "row",

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -80,6 +80,31 @@ jest.mock("../../../hooks/useUpdateNotificationPreferences", () => ({
   }),
 }));
 
+const mockTypePreferences = [
+  { notification_type: "standing_execution" as const, enabled: true },
+];
+
+let mockTypePrefsReturn = {
+  preferences: mockTypePreferences,
+  isLoading: false,
+  error: null as string | null,
+  refetch: jest.fn(),
+};
+
+jest.mock("../../../hooks/useNotificationTypePreferences", () => ({
+  useNotificationTypePreferences: () => mockTypePrefsReturn,
+}));
+
+const mockUpdateTypePreferences = jest.fn().mockResolvedValue({});
+
+jest.mock("../../../hooks/useUpdateNotificationTypePreferences", () => ({
+  useUpdateNotificationTypePreferences: () => ({
+    updatePreferences: mockUpdateTypePreferences,
+    isUpdating: false,
+    error: null,
+  }),
+}));
+
 const mockDeleteAccount = jest.fn().mockResolvedValue({});
 
 jest.mock("../../../hooks/useDeleteAccount", () => ({
@@ -131,6 +156,12 @@ describe("SettingsScreen", () => {
     jest.clearAllMocks();
     mockPrefsReturn = {
       preferences: mockPreferences,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    };
+    mockTypePrefsReturn = {
+      preferences: mockTypePreferences,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
@@ -200,6 +231,10 @@ describe("SettingsScreen", () => {
       isLoading: true,
       preferences: [],
     };
+    mockTypePrefsReturn = {
+      ...mockTypePrefsReturn,
+      isLoading: false,
+    };
     await act(async () => {
       renderer = renderScreen();
     });
@@ -213,11 +248,43 @@ describe("SettingsScreen", () => {
       error: "Failed to load",
       preferences: [],
     };
+    mockTypePrefsReturn = {
+      ...mockTypePrefsReturn,
+      error: null,
+    };
     await act(async () => {
       renderer = renderScreen();
     });
     expect(hasText(renderer, "Failed to load")).toBe(true);
     expect(findByTestId(renderer, "mobile-push-toggle")).toHaveLength(0);
+  });
+
+  it("renders auto-approval execution toggle", async () => {
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    expect(hasText(renderer, "Notify me about")).toBe(true);
+    expect(hasText(renderer, "Auto-approval executions")).toBe(true);
+    expect(findByTestId(renderer, "standing-execution-toggle").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls updateTypePreferences when auto-approval toggle is pressed", async () => {
+    await act(async () => {
+      renderer = renderScreen();
+    });
+    const toggle = renderer.root.findAll(
+      (node) =>
+        node.props.testID === "standing-execution-toggle" &&
+        typeof node.props.onValueChange === "function",
+    )[0];
+
+    await act(async () => {
+      toggle?.props.onValueChange(false);
+    });
+
+    expect(mockUpdateTypePreferences).toHaveBeenCalledWith([
+      { notification_type: "standing_execution", enabled: false },
+    ]);
   });
 
   it("renders the sign out button", async () => {

--- a/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/screens/settings/__tests__/SettingsScreen.test.tsx
@@ -92,6 +92,7 @@ let mockTypePrefsReturn = {
 };
 
 jest.mock("../../../hooks/useNotificationTypePreferences", () => ({
+  NOTIFICATION_TYPE_STANDING_EXECUTION: "standing_execution",
   useNotificationTypePreferences: () => mockTypePrefsReturn,
 }));
 

--- a/spec/openapi/components/paths/profiles.yaml
+++ b/spec/openapi/components/paths/profiles.yaml
@@ -126,7 +126,7 @@ profile:
       - All approval history and audit log events
       - All standing approvals and their execution history
       - Subscription and usage data
-      - Notification preferences and push subscriptions
+      - Notification preferences, notification type preferences, and push subscriptions
       - The Supabase authentication user (best-effort)
 
     tags:
@@ -154,6 +154,93 @@ profile:
             example:
               deleted: true
               message: "Account and all associated data have been permanently deleted."
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+notificationTypePreferences:
+  get:
+    operationId: getNotificationTypePreferences
+    summary: Get notification type preferences
+    description: |
+      Returns per-notification-type preferences (e.g. whether to notify about
+      standing approval / auto-approval executions). Types without an explicit
+      row default to enabled.
+
+    tags:
+      - Profiles
+
+    security:
+      - SupabaseSession: []
+
+    responses:
+      '200':
+        description: Notification type preferences retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/profiles.yaml#/NotificationTypePreferencesResponse'
+            example:
+              preferences:
+                - notification_type: "standing_execution"
+                  enabled: true
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+  put:
+    operationId: updateNotificationTypePreferences
+    summary: Update notification type preferences
+    description: |
+      Updates per-notification-type preferences. Accepts an array of
+      notification_type/enabled pairs. Types not included in the request are left
+      unchanged.
+
+    tags:
+      - Profiles
+
+    security:
+      - SupabaseSession: []
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/profiles.yaml#/UpdateNotificationTypePreferencesRequest'
+          example:
+            preferences:
+              - notification_type: "standing_execution"
+                enabled: false
+
+    responses:
+      '200':
+        description: Notification type preferences updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/profiles.yaml#/NotificationTypePreferencesResponse'
 
       '400':
         $ref: '../responses/errors.yaml#/BadRequest'

--- a/spec/openapi/components/schemas/profiles.yaml
+++ b/spec/openapi/components/schemas/profiles.yaml
@@ -137,6 +137,66 @@ UpdateNotificationPreferencesRequest:
       description: Channel preferences to update. Channels not included are unchanged.
       minItems: 1
 
+NotificationTypePreference:
+  type: object
+  description: |
+    Per-notification-type preference (e.g. auto-approval execution notifications).
+    Types without an explicit row default to enabled.
+  required:
+    - notification_type
+    - enabled
+  properties:
+    notification_type:
+      type: string
+      description: Logical notification category
+      enum:
+        - standing_execution
+      example: "standing_execution"
+    enabled:
+      type: boolean
+      description: When false, this notification category is silenced on all channels.
+      example: true
+
+NotificationTypePreferencesResponse:
+  type: object
+  description: All per-type notification preferences for the authenticated user.
+  required:
+    - preferences
+  properties:
+    preferences:
+      type: array
+      items:
+        $ref: '#/NotificationTypePreference'
+
+NotificationTypePreferenceUpdate:
+  type: object
+  description: A notification type preference update (request-only).
+  required:
+    - notification_type
+    - enabled
+  properties:
+    notification_type:
+      type: string
+      enum:
+        - standing_execution
+      example: "standing_execution"
+    enabled:
+      type: boolean
+      example: false
+
+UpdateNotificationTypePreferencesRequest:
+  type: object
+  description: Request body for updating per-type notification preferences.
+  required:
+    - preferences
+  properties:
+    preferences:
+      type: array
+      items:
+        $ref: '#/NotificationTypePreferenceUpdate'
+      description: Type preferences to update. Types not included are unchanged.
+      minItems: 1
+
 DeleteAccountRequest:
   type: object
   description: Request body for deleting the authenticated user's account.

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4679,7 +4679,7 @@ paths:
         - All approval history and audit log events
         - All standing approvals and their execution history
         - Subscription and usage data
-        - Notification preferences and push subscriptions
+        - Notification preferences, notification type preferences, and push subscriptions
         - The Supabase authentication user (best-effort)
       tags:
         - Profiles
@@ -4846,6 +4846,75 @@ paths:
                   details:
                     current_plan: free
                     required_plan: pay_as_you_go
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/profile/notification-type-preferences:
+    get:
+      operationId: getNotificationTypePreferences
+      summary: Get notification type preferences
+      description: |
+        Returns per-notification-type preferences (e.g. whether to notify about
+        standing approval / auto-approval executions). Types without an explicit
+        row default to enabled.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      responses:
+        '200':
+          description: Notification type preferences retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationTypePreferencesResponse'
+              example:
+                preferences:
+                  - notification_type: standing_execution
+                    enabled: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    put:
+      operationId: updateNotificationTypePreferences
+      summary: Update notification type preferences
+      description: |
+        Updates per-notification-type preferences. Accepts an array of
+        notification_type/enabled pairs. Types not included in the request are left
+        unchanged.
+      tags:
+        - Profiles
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateNotificationTypePreferencesRequest'
+            example:
+              preferences:
+                - notification_type: standing_execution
+                  enabled: false
+      responses:
+        '200':
+          description: Notification type preferences updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationTypePreferencesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -11785,6 +11854,62 @@ components:
           type: boolean
           description: Whether notifications should be enabled for this channel
           example: true
+    NotificationTypePreference:
+      type: object
+      description: |
+        Per-notification-type preference (e.g. auto-approval execution notifications).
+        Types without an explicit row default to enabled.
+      required:
+        - notification_type
+        - enabled
+      properties:
+        notification_type:
+          type: string
+          description: Logical notification category
+          enum:
+            - standing_execution
+          example: standing_execution
+        enabled:
+          type: boolean
+          description: When false, this notification category is silenced on all channels.
+          example: true
+    NotificationTypePreferencesResponse:
+      type: object
+      description: All per-type notification preferences for the authenticated user.
+      required:
+        - preferences
+      properties:
+        preferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationTypePreference'
+    NotificationTypePreferenceUpdate:
+      type: object
+      description: A notification type preference update (request-only).
+      required:
+        - notification_type
+        - enabled
+      properties:
+        notification_type:
+          type: string
+          enum:
+            - standing_execution
+          example: standing_execution
+        enabled:
+          type: boolean
+          example: false
+    UpdateNotificationTypePreferencesRequest:
+      type: object
+      description: Request body for updating per-type notification preferences.
+      required:
+        - preferences
+      properties:
+        preferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationTypePreferenceUpdate'
+          description: Type preferences to update. Types not included are unchanged.
+          minItems: 1
     PlanLimits:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -246,6 +246,9 @@ paths:
   /v1/profile/notification-preferences:
     $ref: './components/paths/profiles.yaml#/notificationPreferences'
 
+  /v1/profile/notification-type-preferences:
+    $ref: './components/paths/profiles.yaml#/notificationTypePreferences'
+
   /v1/push-subscriptions:
     $ref: './components/paths/push_subscriptions.yaml#/pushSubscriptions'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #957: users can silence **all** notifications for standing-approval (auto-approval) executions via a per-type preference stored in `notification_type_preferences`, exposed as `GET`/`PUT /v1/profile/notification-type-preferences`. `NotifyStandingApprovalExecution` returns early when `standing_execution` is disabled.

### Developer

- [ ] CI: `make test-backend`, `make test-frontend`, `make mobile-test`, `make build` (Go tests were not run locally in this environment — module/toolchain mismatch; rely on CI)
- [ ] Apply migration in dev/staging before manual QA

### Manual Testing

- [ ] Toggle off on web, trigger an auto-approval, confirm no email/SMS/push
- [ ] Toggle off on mobile, same check; confirm shared state when switching clients
- [ ] With auto-approvals silenced but channels on, trigger a manual approval request and confirm it still notifies
- [ ] New user defaults to notifications on (no row)

Closes #957
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-566ec719-c9a6-46ac-9a1c-d3681e363894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-566ec719-c9a6-46ac-9a1c-d3681e363894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

