### PR TITLE
feat(db): connector instance schema + backfill (issue #962 phase 1)

### DIFF
--- a/db/agent_connector_credentials.go
+++ b/db/agent_connector_credentials.go
@@ -55,15 +55,15 @@ type UpsertAgentConnectorCredentialParams struct {
 }
 
 // UpsertAgentConnectorCredential creates or replaces the credential binding
-// for an agent+connector pair. The unique index on (agent_id, connector_id)
-// ensures at most one binding per pair.
+// for an agent+connector pair. The unique index on (agent_id, connector_id, connector_instance_id)
+// ensures at most one binding per instance; omitted instance resolves to the default via trigger.
 func UpsertAgentConnectorCredential(ctx context.Context, db DBTX, p UpsertAgentConnectorCredentialParams) (*AgentConnectorCredential, error) {
 	var acc AgentConnectorCredential
 	err := db.QueryRow(ctx, `
 		INSERT INTO agent_connector_credentials
 		    (id, agent_id, connector_id, approver_id, credential_id, oauth_connection_id)
 		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (agent_id, connector_id) DO UPDATE
+		ON CONFLICT (agent_id, connector_id, connector_instance_id) DO UPDATE
 		    SET credential_id = EXCLUDED.credential_id,
 		        oauth_connection_id = EXCLUDED.oauth_connection_id,
 		        approver_id = EXCLUDED.approver_id

--- a/db/agent_connector_credentials_test.go
+++ b/db/agent_connector_credentials_test.go
@@ -1,0 +1,17 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestAgentConnectorCredentialsSchema(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	testhelper.RequireColumns(t, tx, "agent_connector_credentials", []string{
+		"id", "agent_id", "connector_id", "approver_id", "connector_instance_id",
+		"credential_id", "oauth_connection_id", "created_at",
+	})
+}

--- a/db/agent_connectors.go
+++ b/db/agent_connectors.go
@@ -99,7 +99,7 @@ func EnableAgentConnector(ctx context.Context, db DBTX, agentID int64, approverI
 			INSERT INTO agent_connectors (agent_id, approver_id, connector_id)
 			SELECT $1, $2, $3
 			WHERE EXISTS (SELECT 1 FROM agent_check)
-			ON CONFLICT (agent_id, connector_id) DO NOTHING
+			ON CONFLICT (agent_id, connector_id, label) DO NOTHING
 			RETURNING agent_id, connector_id, enabled_at
 		)
 		SELECT agent_id, connector_id, enabled_at FROM inserted
@@ -140,7 +140,7 @@ func DisableAgentConnector(ctx context.Context, db DBTX, agentID int64, approver
 		WITH deleted AS (
 			DELETE FROM agent_connectors
 			WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3
-			RETURNING agent_id, connector_id
+			RETURNING agent_id, connector_id, connector_instance_id
 		), revoked AS (
 			UPDATE standing_approvals
 			SET status = 'revoked', revoked_at = now()
@@ -155,8 +155,8 @@ func DisableAgentConnector(ctx context.Context, db DBTX, agentID int64, approver
 			RETURNING 1
 		)
 		SELECT
-			(SELECT agent_id FROM deleted),
-			(SELECT connector_id FROM deleted),
+			(SELECT agent_id FROM deleted LIMIT 1),
+			(SELECT connector_id FROM deleted LIMIT 1),
 			now(),
 			(SELECT count(*) FROM revoked)`,
 		agentID, approverID, connectorID,

--- a/db/agent_connectors_test.go
+++ b/db/agent_connectors_test.go
@@ -13,7 +13,8 @@ func TestAgentConnectorsSchema(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 
 	testhelper.RequireColumns(t, tx, "agent_connectors", []string{
-		"agent_id", "approver_id", "connector_id", "enabled_at",
+		"agent_id", "approver_id", "connector_id", "connector_instance_id",
+		"label", "is_default", "enabled_at",
 	})
 }
 
@@ -34,7 +35,7 @@ func TestAgentConnectorsDuplicateInsert(t *testing.T) {
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "user_"+uid[:8])
 	testhelper.InsertConnector(t, tx, connID)
 
-	testhelper.RequireUniqueViolation(t, tx, "(agent_id, connector_id)",
+	testhelper.RequireUniqueViolation(t, tx, "(agent_id, connector_id, label)",
 		func() error {
 			testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
 			return nil

--- a/db/migrations/20260420145022_add_connector_instance_id_to_agent_connectors.sql
+++ b/db/migrations/20260420145022_add_connector_instance_id_to_agent_connectors.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+-- Multi-instance connector support: surrogate instance id + label + default flag per (agent, connector).
+-- Backfill: one instance per existing row; label from connectors.name; all rows are default.
+
+ALTER TABLE agent_connectors
+    ADD COLUMN connector_instance_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    ADD COLUMN label text,
+    ADD COLUMN is_default boolean NOT NULL DEFAULT false;
+
+UPDATE agent_connectors ac
+SET label = c.name
+FROM connectors c
+WHERE c.id = ac.connector_id;
+
+ALTER TABLE agent_connectors
+    ALTER COLUMN label SET NOT NULL;
+
+-- Exactly one default instance per (agent_id, connector_id) — every existing row is that default.
+UPDATE agent_connectors SET is_default = true;
+
+CREATE UNIQUE INDEX uq_agent_connectors_agent_connector_label
+    ON agent_connectors (agent_id, connector_id, label);
+
+CREATE UNIQUE INDEX uq_agent_connectors_default_per_pair
+    ON agent_connectors (agent_id, connector_id)
+    WHERE is_default;
+
+-- Back-compat: allow INSERT with only (agent_id, approver_id, connector_id); fill label and default flag.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION trg_agent_connectors_before_insert()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.label IS NULL THEN
+        SELECT name INTO STRICT NEW.label FROM connectors WHERE id = NEW.connector_id;
+    END IF;
+    -- First row for (agent, connector) must be the default instance (column default is false).
+    IF NOT EXISTS (
+        SELECT 1 FROM agent_connectors
+        WHERE agent_id = NEW.agent_id
+          AND connector_id = NEW.connector_id
+          AND is_default
+    ) THEN
+        NEW.is_default := true;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_agent_connectors_before_insert
+    BEFORE INSERT ON agent_connectors
+    FOR EACH ROW
+    EXECUTE FUNCTION trg_agent_connectors_before_insert();
+
+ALTER TABLE agent_connectors DROP CONSTRAINT agent_connectors_pkey;
+
+ALTER TABLE agent_connectors
+    ADD CONSTRAINT agent_connectors_pkey
+    PRIMARY KEY (agent_id, approver_id, connector_id, connector_instance_id);
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS trg_agent_connectors_before_insert ON agent_connectors;
+DROP FUNCTION IF EXISTS trg_agent_connectors_before_insert();
+
+ALTER TABLE agent_connectors DROP CONSTRAINT agent_connectors_pkey;
+
+ALTER TABLE agent_connectors
+    ADD CONSTRAINT agent_connectors_pkey
+    PRIMARY KEY (agent_id, connector_id);
+
+DROP INDEX IF EXISTS uq_agent_connectors_default_per_pair;
+DROP INDEX IF EXISTS uq_agent_connectors_agent_connector_label;
+
+ALTER TABLE agent_connectors
+    DROP COLUMN connector_instance_id,
+    DROP COLUMN label,
+    DROP COLUMN is_default;

--- a/db/migrations/20260420145022_add_connector_instance_id_to_agent_connectors.sql
+++ b/db/migrations/20260420145022_add_connector_instance_id_to_agent_connectors.sql
@@ -31,7 +31,12 @@ CREATE OR REPLACE FUNCTION trg_agent_connectors_before_insert()
 RETURNS trigger AS $$
 BEGIN
     IF NEW.label IS NULL THEN
-        SELECT name INTO STRICT NEW.label FROM connectors WHERE id = NEW.connector_id;
+        SELECT c.name INTO NEW.label FROM connectors c WHERE c.id = NEW.connector_id;
+        IF NEW.label IS NULL THEN
+            -- Match FK violation so API maps to connector_not_found (STRICT would raise P0002 / ErrNoRows).
+            RAISE EXCEPTION 'insert or update on table "agent_connectors" violates foreign key constraint'
+                USING ERRCODE = '23503';
+        END IF;
     END IF;
     -- First row for (agent, connector) must be the default instance (column default is false).
     IF NOT EXISTS (

--- a/db/migrations/20260420145022_add_connector_instance_id_to_agent_connectors.sql
+++ b/db/migrations/20260420145022_add_connector_instance_id_to_agent_connectors.sql
@@ -52,6 +52,10 @@ CREATE TRIGGER trg_agent_connectors_before_insert
     FOR EACH ROW
     EXECUTE FUNCTION trg_agent_connectors_before_insert();
 
+-- agent_connector_credentials references this PK; drop FK before PK swap (re-added in next migration).
+ALTER TABLE agent_connector_credentials
+    DROP CONSTRAINT IF EXISTS agent_connector_credentials_agent_id_connector_id_fkey;
+
 ALTER TABLE agent_connectors DROP CONSTRAINT agent_connectors_pkey;
 
 ALTER TABLE agent_connectors

--- a/db/migrations/20260420145023_agent_connector_credentials_fk_to_instance.sql
+++ b/db/migrations/20260420145023_agent_connector_credentials_fk_to_instance.sql
@@ -14,8 +14,7 @@ WHERE acc.agent_id = ac.agent_id
 ALTER TABLE agent_connector_credentials
     ALTER COLUMN connector_instance_id SET NOT NULL;
 
-ALTER TABLE agent_connector_credentials
-    DROP CONSTRAINT agent_connector_credentials_agent_id_connector_id_fkey;
+-- Legacy FK already dropped in add_connector_instance_id_to_agent_connectors (required before PK swap).
 
 DROP INDEX IF EXISTS idx_agent_connector_credentials_unique;
 

--- a/db/migrations/20260420145023_agent_connector_credentials_fk_to_instance.sql
+++ b/db/migrations/20260420145023_agent_connector_credentials_fk_to_instance.sql
@@ -1,0 +1,74 @@
+-- +goose Up
+-- Bind credentials to a specific connector instance (not just agent+connector).
+
+ALTER TABLE agent_connector_credentials
+    ADD COLUMN connector_instance_id uuid;
+
+UPDATE agent_connector_credentials acc
+SET connector_instance_id = ac.connector_instance_id
+FROM agent_connectors ac
+WHERE acc.agent_id = ac.agent_id
+  AND acc.connector_id = ac.connector_id
+  AND acc.approver_id = ac.approver_id;
+
+ALTER TABLE agent_connector_credentials
+    ALTER COLUMN connector_instance_id SET NOT NULL;
+
+ALTER TABLE agent_connector_credentials
+    DROP CONSTRAINT agent_connector_credentials_agent_id_connector_id_fkey;
+
+DROP INDEX IF EXISTS idx_agent_connector_credentials_unique;
+
+ALTER TABLE agent_connector_credentials
+    ADD CONSTRAINT agent_connector_credentials_agent_instance_fkey
+    FOREIGN KEY (agent_id, approver_id, connector_id, connector_instance_id)
+    REFERENCES agent_connectors (agent_id, approver_id, connector_id, connector_instance_id)
+    ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX idx_agent_connector_credentials_unique
+    ON agent_connector_credentials (agent_id, connector_id, connector_instance_id);
+
+-- Back-compat: INSERT may omit connector_instance_id; resolve to the default instance for the pair.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION trg_agent_connector_credentials_before_insert()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.connector_instance_id IS NULL THEN
+        SELECT connector_instance_id INTO STRICT NEW.connector_instance_id
+        FROM agent_connectors
+        WHERE agent_id = NEW.agent_id
+          AND approver_id = NEW.approver_id
+          AND connector_id = NEW.connector_id
+          AND is_default;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_agent_connector_credentials_before_insert
+    BEFORE INSERT ON agent_connector_credentials
+    FOR EACH ROW
+    EXECUTE FUNCTION trg_agent_connector_credentials_before_insert();
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS trg_agent_connector_credentials_before_insert ON agent_connector_credentials;
+DROP FUNCTION IF EXISTS trg_agent_connector_credentials_before_insert();
+
+DROP INDEX IF EXISTS idx_agent_connector_credentials_unique;
+
+ALTER TABLE agent_connector_credentials
+    DROP CONSTRAINT IF EXISTS agent_connector_credentials_agent_instance_fkey;
+
+CREATE UNIQUE INDEX idx_agent_connector_credentials_unique
+    ON agent_connector_credentials (agent_id, connector_id);
+
+ALTER TABLE agent_connector_credentials
+    ADD CONSTRAINT agent_connector_credentials_agent_id_connector_id_fkey
+    FOREIGN KEY (agent_id, connector_id)
+    REFERENCES agent_connectors (agent_id, connector_id)
+    ON DELETE CASCADE;
+
+ALTER TABLE agent_connector_credentials
+    DROP COLUMN connector_instance_id;

--- a/db/migrations/20260420145024_standing_approvals_add_connector_instance_id.sql
+++ b/db/migrations/20260420145024_standing_approvals_add_connector_instance_id.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- NULL = type-wide standing approval (legacy); non-null = instance-scoped (Phase 4).
+
+ALTER TABLE standing_approvals
+    ADD COLUMN connector_instance_id uuid;
+
+CREATE INDEX idx_standing_approvals_agent_action_status_connector_instance
+    ON standing_approvals (agent_id, action_type, status, connector_instance_id);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_standing_approvals_agent_action_status_connector_instance;
+
+ALTER TABLE standing_approvals
+    DROP COLUMN connector_instance_id;

--- a/db/standing_approvals_test.go
+++ b/db/standing_approvals_test.go
@@ -41,6 +41,7 @@ func TestStandingApprovalsSchema(t *testing.T) {
 		"action_version", "constraints", "status",
 		"starts_at", "expires_at", "created_at",
 		"revoked_at", "expired_at",
+		"connector_instance_id",
 	})
 }
 
@@ -48,6 +49,7 @@ func TestStandingApprovalsIndex(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	testhelper.RequireIndex(t, tx, "standing_approvals", "idx_standing_approvals_agent_action_status")
+	testhelper.RequireIndex(t, tx, "standing_approvals", "idx_standing_approvals_agent_action_status_connector_instance")
 	testhelper.RequireIndex(t, tx, "standing_approvals", "idx_standing_approvals_source_config_active")
 }
 
@@ -181,4 +183,3 @@ func TestStandingApprovalExecutionsCascadeOnProfileDelete(t *testing.T) {
 		"standing_approval_id = '"+saID+"'",
 	)
 }
-

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,6 @@
+-- Local Supabase `db reset` runs this file after goose migrations from `db/migrations`.
+-- Primary dev seed data is applied with `make seed` (`go run ./cmd/seed`), which targets
+-- the same schema. Keep this file valid SQL so reset succeeds; add static reference data here
+-- only when needed for Supabase-only workflows.
+
+SELECT 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** of #962: schema migrations and backfill for multiple connector instances per agent.

- **`agent_connectors`**: `connector_instance_id`, `label`, `is_default`; new PK `(agent_id, approver_id, connector_id, connector_instance_id)`; unique `(agent_id, connector_id, label)`; partial unique default per `(agent_id, connector_id)`. Backfill sets `label` from `connectors.name` and marks existing rows default.
- **`agent_connector_credentials`**: `connector_instance_id` with FK to the new PK; unique `(agent_id, connector_id, connector_instance_id)`; backfill from matching `agent_connectors` rows.
- **`standing_approvals`**: nullable `connector_instance_id` + index `(agent_id, action_type, status, connector_instance_id)`.
- **Triggers** keep legacy `INSERT` shapes working: `agent_connectors` fills `label` / first default; `agent_connector_credentials` resolves omitted `connector_instance_id` to the default instance.
- **`supabase/seed.sql`**: minimal valid seed so `supabase db reset` (configured to load `./seed.sql`) succeeds after migrations.

Application updates (minimal, required for the new constraints): `EnableAgentConnector` / `UpsertAgentConnectorCredential` conflict targets, `DisableAgentConnector` scalar subqueries + extra `RETURNING` column, schema tests.

## Test plan

### Developer

- [ ] `make test-backend` (or CI) — includes `TestMigrationTimestampsUnique`, RLS migration tests, and updated `db` schema tests.
- [ ] Apply migrations on a dev DB with seed data; confirm one default instance per former `(agent, connector)` row and credential rows keyed by that instance.

### Manual Testing

- [ ] `make migrate-up` / `supabase db reset` — migrations apply cleanly.
- [ ] Spot-check: `agent_connectors.label` matches `connectors.name` for seeded rows; `is_default = true` for those rows.

Refs #962 (Phase 1 only — does not complete the full issue).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb19f854-ed5b-4115-9ca7-53bbd6f2afe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb19f854-ed5b-4115-9ca7-53bbd6f2afe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

