### PR TITLE
Phase 2: Backend connector instance CRUD and API routes

### DIFF
--- a/api/agent_connector_calendars.go
+++ b/api/agent_connector_calendars.go
@@ -72,7 +72,19 @@ func handleListAgentConnectorCalendars(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
+		defaultInst, err := db.GetDefaultAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorCalendars default instance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve connector instance"))
+			return
+		}
+		if defaultInst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not enabled for this agent"))
+			return
+		}
+
+		creds, err := resolveCredentialsForConnectorInstance(r.Context(), deps, agentID, userID, listAction, connectorID, defaultInst.ConnectorInstanceID, reqCreds)
 		if err != nil {
 			if handleConnectorError(w, r, err, connErrCtx) {
 				return

--- a/api/agent_connector_channels.go
+++ b/api/agent_connector_channels.go
@@ -73,7 +73,19 @@ func handleListAgentConnectorChannels(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
+		defaultInst, err := db.GetDefaultAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorChannels default instance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve connector instance"))
+			return
+		}
+		if defaultInst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not enabled for this agent"))
+			return
+		}
+
+		creds, err := resolveCredentialsForConnectorInstance(r.Context(), deps, agentID, userID, listAction, connectorID, defaultInst.ConnectorInstanceID, reqCreds)
 		if err != nil {
 			if handleConnectorError(w, r, err, connErrCtx) {
 				return

--- a/api/agent_connector_credentials.go
+++ b/api/agent_connector_credentials.go
@@ -22,6 +22,53 @@ type agentConnectorCredentialResponse struct {
 	OAuthConnectionID *string `json:"oauth_connection_id,omitempty"`
 }
 
+// validateAssignCredentialRequest checks the assign body and ownership; returns HTTP status and error response if invalid.
+func validateAssignCredentialRequest(w http.ResponseWriter, r *http.Request, deps *Deps, userID, connectorID string, req *assignCredentialRequest) bool {
+	// Exactly one of credential_id or oauth_connection_id must be provided.
+	if (req.CredentialID == nil) == (req.OAuthConnectionID == nil) {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "provide exactly one of credential_id or oauth_connection_id"))
+		return false
+	}
+
+	if req.CredentialID != nil {
+		cred, err := db.GetCredentialByID(r.Context(), deps.DB, *req.CredentialID)
+		if err != nil {
+			log.Printf("[%s] AssignCredential: credential check: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify credential"))
+			return false
+		}
+		if cred == nil || cred.UserID != userID {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Credential not found"))
+			return false
+		}
+		if cred.Service != connectorID {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("credential service %q does not match connector %q", cred.Service, connectorID)))
+			return false
+		}
+	}
+	if req.OAuthConnectionID != nil {
+		conn, err := db.GetOAuthConnectionByID(r.Context(), deps.DB, *req.OAuthConnectionID)
+		if err != nil {
+			log.Printf("[%s] AssignCredential: oauth check: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify OAuth connection"))
+			return false
+		}
+		if conn == nil || conn.UserID != userID {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "OAuth connection not found"))
+			return false
+		}
+		if conn.Provider != connectorID {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("OAuth connection provider %q does not match connector %q", conn.Provider, connectorID)))
+			return false
+		}
+	}
+	return true
+}
+
 func handleAssignAgentConnectorCredential(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID := Profile(r.Context()).ID
@@ -45,48 +92,8 @@ func handleAssignAgentConnectorCredential(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Exactly one of credential_id or oauth_connection_id must be provided.
-		if (req.CredentialID == nil) == (req.OAuthConnectionID == nil) {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "provide exactly one of credential_id or oauth_connection_id"))
+		if !validateAssignCredentialRequest(w, r, deps, userID, connectorID, &req) {
 			return
-		}
-
-		// Validate ownership and service match for static credentials.
-		if req.CredentialID != nil {
-			cred, err := db.GetCredentialByID(r.Context(), deps.DB, *req.CredentialID)
-			if err != nil {
-				log.Printf("[%s] AssignCredential: credential check: %v", TraceID(r.Context()), err)
-				CaptureError(r.Context(), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify credential"))
-				return
-			}
-			if cred == nil || cred.UserID != userID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Credential not found"))
-				return
-			}
-			if cred.Service != connectorID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
-					fmt.Sprintf("credential service %q does not match connector %q", cred.Service, connectorID)))
-				return
-			}
-		}
-		if req.OAuthConnectionID != nil {
-			conn, err := db.GetOAuthConnectionByID(r.Context(), deps.DB, *req.OAuthConnectionID)
-			if err != nil {
-				log.Printf("[%s] AssignCredential: oauth check: %v", TraceID(r.Context()), err)
-				CaptureError(r.Context(), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify OAuth connection"))
-				return
-			}
-			if conn == nil || conn.UserID != userID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "OAuth connection not found"))
-				return
-			}
-			if conn.Provider != connectorID {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
-					fmt.Sprintf("OAuth connection provider %q does not match connector %q", conn.Provider, connectorID)))
-				return
-			}
 		}
 
 		bindingID, err := generatePrefixedID("acc_", 16)

--- a/api/agent_connector_instances.go
+++ b/api/agent_connector_instances.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/supersuit-tech/permission-slip/connectors"
 	"github.com/supersuit-tech/permission-slip/db"
 )
@@ -127,6 +128,10 @@ func handleCreateAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 			Label:       req.Label,
 		})
 		if err != nil {
+			if errors.Is(err, db.ErrAgentConnectorInstanceLabelRequired) || errors.Is(err, db.ErrAgentConnectorInstanceLabelTooLong) {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be 1–256 characters"))
+				return
+			}
 			var acErr *db.AgentConnectorError
 			if errors.As(err, &acErr) {
 				switch acErr.Code {
@@ -135,6 +140,9 @@ func handleCreateAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 					return
 				case db.AgentConnectorErrConnectorNotFound:
 					RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+					return
+				case db.AgentConnectorErrConnectorNotEnabled:
+					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Enable this connector for the agent before adding another instance"))
 					return
 				}
 			}
@@ -159,7 +167,27 @@ func parsePathInstanceID(w http.ResponseWriter, r *http.Request) (string, bool) 
 		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "instance_id is required"))
 		return "", false
 	}
+	if _, err := uuid.Parse(id); err != nil {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "instance_id must be a valid UUID"))
+		return "", false
+	}
 	return id, true
+}
+
+// requireAgentConnectorInstance loads the instance or writes 404/500 and returns nil, false on failure.
+func requireAgentConnectorInstance(w http.ResponseWriter, r *http.Request, deps *Deps, agentID int64, userID, connectorID, instanceID string) (*db.AgentConnectorInstance, bool) {
+	inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+	if err != nil {
+		log.Printf("[%s] GetAgentConnectorInstance: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
+		return nil, false
+	}
+	if inst == nil {
+		RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+		return nil, false
+	}
+	return inst, true
 }
 
 func handleGetAgentConnectorInstance(deps *Deps) http.HandlerFunc {
@@ -182,15 +210,8 @@ func handleGetAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
-		if err != nil {
-			log.Printf("[%s] GetAgentConnectorInstance: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get connector instance"))
-			return
-		}
-		if inst == nil {
-			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+		inst, instOK := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID)
+		if !instOK {
 			return
 		}
 		RespondJSON(w, http.StatusOK, toAgentConnectorInstanceResponse(*inst))
@@ -224,6 +245,10 @@ func handlePatchAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 
 		inst, err := db.RenameAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID, req.Label)
 		if err != nil {
+			if errors.Is(err, db.ErrAgentConnectorInstanceLabelRequired) || errors.Is(err, db.ErrAgentConnectorInstanceLabelTooLong) {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be 1–256 characters"))
+				return
+			}
 			var instErr *db.AgentConnectorInstanceError
 			if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
 				RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
@@ -304,15 +329,7 @@ func handleAssignAgentConnectorInstanceCredential(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
-		if err != nil {
-			log.Printf("[%s] AssignInstanceCredential: get instance: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
-			return
-		}
-		if inst == nil {
-			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+		if _, ok := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID); !ok {
 			return
 		}
 
@@ -377,15 +394,7 @@ func handleRemoveAgentConnectorInstanceCredential(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
-		if err != nil {
-			log.Printf("[%s] RemoveInstanceCredential: get instance: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
-			return
-		}
-		if inst == nil {
-			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+		if _, ok := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID); !ok {
 			return
 		}
 
@@ -424,15 +433,7 @@ func handleGetAgentConnectorInstanceCredential(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
-		if err != nil {
-			log.Printf("[%s] GetInstanceCredential: get instance: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
-			return
-		}
-		if inst == nil {
-			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+		if _, ok := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID); !ok {
 			return
 		}
 
@@ -478,6 +479,10 @@ func handleListAgentConnectorInstanceChannels(deps *Deps) http.HandlerFunc {
 			return
 		}
 		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if _, ok := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID); !ok {
 			return
 		}
 
@@ -569,6 +574,10 @@ func handleListAgentConnectorInstanceCalendars(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		if _, ok := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID); !ok {
+			return
+		}
+
 		if deps.Connectors == nil {
 			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
 			return
@@ -654,6 +663,10 @@ func handleListAgentConnectorInstanceUsers(deps *Deps) http.HandlerFunc {
 			return
 		}
 		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if _, ok := requireAgentConnectorInstance(w, r, deps, agentID, userID, connectorID, instanceID); !ok {
 			return
 		}
 

--- a/api/agent_connector_instances.go
+++ b/api/agent_connector_instances.go
@@ -1,0 +1,725 @@
+package api
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+type agentConnectorInstanceResponse struct {
+	ConnectorInstanceID string    `json:"connector_instance_id"`
+	AgentID             int64     `json:"agent_id"`
+	ConnectorID         string    `json:"connector_id"`
+	Label               string    `json:"label"`
+	IsDefault           bool      `json:"is_default"`
+	EnabledAt           time.Time `json:"enabled_at"`
+}
+
+type agentConnectorInstanceListResponse struct {
+	Data []agentConnectorInstanceResponse `json:"data"`
+}
+
+type createAgentConnectorInstanceRequest struct {
+	Label string `json:"label"`
+}
+
+type patchAgentConnectorInstanceRequest struct {
+	Label string `json:"label"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentConnectorInstanceRoutes)
+}
+
+// RegisterAgentConnectorInstanceRoutes registers multi-instance connector endpoints.
+func RegisterAgentConnectorInstanceRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	base := "/agents/{agent_id}/connectors/{connector_id}/instances"
+	mux.Handle("GET "+base, requireProfile(handleListAgentConnectorInstances(deps)))
+	mux.Handle("POST "+base, requireProfile(handleCreateAgentConnectorInstance(deps)))
+
+	inst := base + "/{instance_id}"
+	mux.Handle("GET "+inst, requireProfile(handleGetAgentConnectorInstance(deps)))
+	mux.Handle("PATCH "+inst, requireProfile(handlePatchAgentConnectorInstance(deps)))
+	mux.Handle("DELETE "+inst, requireProfile(handleDeleteAgentConnectorInstance(deps)))
+
+	mux.Handle("PUT "+inst+"/credential", requireProfile(handleAssignAgentConnectorInstanceCredential(deps)))
+	mux.Handle("DELETE "+inst+"/credential", requireProfile(handleRemoveAgentConnectorInstanceCredential(deps)))
+	mux.Handle("GET "+inst+"/credential", requireProfile(handleGetAgentConnectorInstanceCredential(deps)))
+
+	mux.Handle("GET "+inst+"/channels", requireProfile(handleListAgentConnectorInstanceChannels(deps)))
+	mux.Handle("GET "+inst+"/calendars", requireProfile(handleListAgentConnectorInstanceCalendars(deps)))
+	mux.Handle("GET "+inst+"/users", requireProfile(handleListAgentConnectorInstanceUsers(deps)))
+}
+
+func toAgentConnectorInstanceResponse(inst db.AgentConnectorInstance) agentConnectorInstanceResponse {
+	return agentConnectorInstanceResponse{
+		ConnectorInstanceID: inst.ConnectorInstanceID,
+		AgentID:             inst.AgentID,
+		ConnectorID:         inst.ConnectorID,
+		Label:               inst.Label,
+		IsDefault:           inst.IsDefault,
+		EnabledAt:           inst.EnabledAt,
+	}
+}
+
+func handleListAgentConnectorInstances(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		instances, err := db.ListAgentConnectorInstances(r.Context(), deps.DB, agentID, userID, connectorID)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorInstances: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list connector instances"))
+			return
+		}
+
+		data := make([]agentConnectorInstanceResponse, len(instances))
+		for i, inst := range instances {
+			data[i] = toAgentConnectorInstanceResponse(inst)
+		}
+		RespondJSON(w, http.StatusOK, agentConnectorInstanceListResponse{Data: data})
+	}
+}
+
+func handleCreateAgentConnectorInstance(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		var req createAgentConnectorInstanceRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		inst, err := db.CreateAgentConnectorInstance(r.Context(), deps.DB, db.CreateAgentConnectorInstanceParams{
+			AgentID:     agentID,
+			ApproverID:  userID,
+			ConnectorID: connectorID,
+			Label:       req.Label,
+		})
+		if err != nil {
+			var acErr *db.AgentConnectorError
+			if errors.As(err, &acErr) {
+				switch acErr.Code {
+				case db.AgentConnectorErrAgentNotFound:
+					RespondError(w, r, http.StatusNotFound, NotFound(ErrAgentNotFound, "Agent not found"))
+					return
+				case db.AgentConnectorErrConnectorNotFound:
+					RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+					return
+				}
+			}
+			var instErr *db.AgentConnectorInstanceError
+			if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
+				RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
+				return
+			}
+			log.Printf("[%s] CreateAgentConnectorInstance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create connector instance"))
+			return
+		}
+
+		RespondJSON(w, http.StatusCreated, toAgentConnectorInstanceResponse(*inst))
+	}
+}
+
+func parsePathInstanceID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	id := r.PathValue("instance_id")
+	if id == "" {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "instance_id is required"))
+		return "", false
+	}
+	return id, true
+}
+
+func handleGetAgentConnectorInstance(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] GetAgentConnectorInstance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get connector instance"))
+			return
+		}
+		if inst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			return
+		}
+		RespondJSON(w, http.StatusOK, toAgentConnectorInstanceResponse(*inst))
+	}
+}
+
+func handlePatchAgentConnectorInstance(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		var req patchAgentConnectorInstanceRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		inst, err := db.RenameAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID, req.Label)
+		if err != nil {
+			var instErr *db.AgentConnectorInstanceError
+			if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
+				RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
+				return
+			}
+			log.Printf("[%s] RenameAgentConnectorInstance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to rename connector instance"))
+			return
+		}
+		if inst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			return
+		}
+		RespondJSON(w, http.StatusOK, toAgentConnectorInstanceResponse(*inst))
+	}
+}
+
+func handleDeleteAgentConnectorInstance(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		err := db.DeleteAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			var instErr *db.AgentConnectorInstanceError
+			if errors.As(err, &instErr) {
+				switch instErr.Code {
+				case db.AgentConnectorInstanceErrNotFound:
+					RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+					return
+				case db.AgentConnectorInstanceErrCannotDeleteDefault:
+					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Cannot delete the default connector instance"))
+					return
+				}
+			}
+			log.Printf("[%s] DeleteAgentConnectorInstance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete connector instance"))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func handleAssignAgentConnectorInstanceCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] AssignInstanceCredential: get instance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
+			return
+		}
+		if inst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			return
+		}
+
+		var req assignCredentialRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+		if !validateAssignCredentialRequest(w, r, deps, userID, connectorID, &req) {
+			return
+		}
+
+		bindingID, err := generatePrefixedID("acc_", 16)
+		if err != nil {
+			log.Printf("[%s] AssignInstanceCredential: generate ID: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign credential"))
+			return
+		}
+
+		binding, err := db.UpsertAgentConnectorCredentialByInstance(r.Context(), deps.DB, db.UpsertAgentConnectorCredentialByInstanceParams{
+			ID:                  bindingID,
+			AgentID:             agentID,
+			ConnectorID:         connectorID,
+			ConnectorInstanceID: instanceID,
+			ApproverID:          userID,
+			CredentialID:        req.CredentialID,
+			OAuthConnectionID:   req.OAuthConnectionID,
+		})
+		if err != nil {
+			log.Printf("[%s] AssignInstanceCredential: upsert: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to assign credential"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
+			AgentID:           binding.AgentID,
+			ConnectorID:       binding.ConnectorID,
+			CredentialID:      binding.CredentialID,
+			OAuthConnectionID: binding.OAuthConnectionID,
+		})
+	}
+}
+
+func handleRemoveAgentConnectorInstanceCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] RemoveInstanceCredential: get instance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
+			return
+		}
+		if inst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			return
+		}
+
+		deleted, err := db.DeleteAgentConnectorCredentialByInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] RemoveInstanceCredential: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to remove credential binding"))
+			return
+		}
+		if !deleted {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrCredentialNotFound, "No credential binding found"))
+			return
+		}
+		RespondJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+	}
+}
+
+func handleGetAgentConnectorInstanceCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		inst, err := db.GetAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] GetInstanceCredential: get instance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to verify connector instance"))
+			return
+		}
+		if inst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			return
+		}
+
+		binding, err := db.GetAgentConnectorCredentialByInstance(r.Context(), deps.DB, agentID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] GetInstanceCredential: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get credential binding"))
+			return
+		}
+		if binding == nil {
+			RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
+				AgentID:     agentID,
+				ConnectorID: connectorID,
+			})
+			return
+		}
+		RespondJSON(w, http.StatusOK, agentConnectorCredentialResponse{
+			AgentID:           binding.AgentID,
+			ConnectorID:       binding.ConnectorID,
+			CredentialID:      binding.CredentialID,
+			OAuthConnectionID: binding.OAuthConnectionID,
+		})
+	}
+}
+
+func handleListAgentConnectorInstanceChannels(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+		userEmail := UserEmail(r.Context())
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		lister, ok := conn.(connectors.ChannelLister)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "This connector does not support channel listing"))
+			return
+		}
+
+		listAction := lister.ChannelListCredentialActionType()
+		connErrCtx := ConnectorContext{
+			ConnectorID: connectorID,
+			ActionType:  listAction,
+			AgentID:     agentID,
+		}
+		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorInstanceChannels required creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to look up connector credentials"))
+			return
+		}
+
+		creds, err := resolveCredentialsForConnectorInstance(r.Context(), deps, agentID, userID, listAction, connectorID, instanceID, reqCreds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorInstanceChannels resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorInstanceChannels validate creds: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
+
+		items, err := lister.ListChannels(r.Context(), creds, userEmail)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListChannels (instance): %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list channels"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, channelListResponse{Data: items})
+	}
+}
+
+func handleListAgentConnectorInstanceCalendars(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		lister, ok := conn.(connectors.CalendarLister)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "This connector does not support calendar listing"))
+			return
+		}
+
+		listAction := lister.CalendarListCredentialActionType()
+		connErrCtx := ConnectorContext{
+			ConnectorID: connectorID,
+			ActionType:  listAction,
+			AgentID:     agentID,
+		}
+		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorInstanceCalendars required creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to look up connector credentials"))
+			return
+		}
+
+		creds, err := resolveCredentialsForConnectorInstance(r.Context(), deps, agentID, userID, listAction, connectorID, instanceID, reqCreds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorInstanceCalendars resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorInstanceCalendars validate creds: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
+
+		items, err := lister.ListCalendars(r.Context(), creds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListCalendars (instance): %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list calendars"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, calendarListResponse{Data: items})
+	}
+}
+
+func handleListAgentConnectorInstanceUsers(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := Profile(r.Context()).ID
+
+		agentID, ok := parsePathAgentID(w, r)
+		if !ok {
+			return
+		}
+		connectorID := r.PathValue("connector_id")
+		if connectorID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "connector_id is required"))
+			return
+		}
+		instanceID, ok := parsePathInstanceID(w, r)
+		if !ok {
+			return
+		}
+		if !requireAgentOwnership(w, r, deps, agentID, userID) {
+			return
+		}
+
+		if deps.Connectors == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Connectors are not available"))
+			return
+		}
+
+		conn, ok := deps.Connectors.Get(connectorID)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not found"))
+			return
+		}
+
+		lister, ok := conn.(connectors.UserLister)
+		if !ok {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "This connector does not support user listing"))
+			return
+		}
+
+		listAction := lister.UserListCredentialActionType()
+		connErrCtx := ConnectorContext{
+			ConnectorID: connectorID,
+			ActionType:  listAction,
+			AgentID:     agentID,
+		}
+		reqCreds, err := db.GetRequiredCredentialsByActionType(r.Context(), deps.DB, listAction)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorInstanceUsers required creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to look up connector credentials"))
+			return
+		}
+
+		creds, err := resolveCredentialsForConnectorInstance(r.Context(), deps, agentID, userID, listAction, connectorID, instanceID, reqCreds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorInstanceUsers resolve creds: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve credentials"))
+			return
+		}
+
+		if err := conn.ValidateCredentials(r.Context(), creds); err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListAgentConnectorInstanceUsers validate creds: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
+
+		items, err := lister.ListUsers(r.Context(), creds)
+		if err != nil {
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] ListUsers (instance): %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list users"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, userListResponse{Data: items})
+	}
+}

--- a/api/agent_connector_instances_test.go
+++ b/api/agent_connector_instances_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func decodeInstanceList(t *testing.T, body []byte) agentConnectorInstanceListResponse {
+	t.Helper()
+	var resp agentConnectorInstanceListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal instance list: %v", err)
+	}
+	return resp
+}
+
+func TestListAgentConnectorInstances_Default(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	list := decodeInstanceList(t, w.Body.Bytes())
+	if len(list.Data) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(list.Data))
+	}
+	if !list.Data[0].IsDefault {
+		t.Error("expected default instance")
+	}
+}
+
+func TestCreateAgentConnectorInstance_Second(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Sales"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	r2 := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list: %d %s", w2.Code, w2.Body.String())
+	}
+	list := decodeInstanceList(t, w2.Body.Bytes())
+	if len(list.Data) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(list.Data))
+	}
+}
+
+func TestPatchAgentConnectorInstance_DuplicateLabel409(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r0 := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid)
+	w0 := httptest.NewRecorder()
+	router.ServeHTTP(w0, r0)
+	list := decodeInstanceList(t, w0.Body.Bytes())
+	if len(list.Data) != 1 {
+		t.Fatalf("expected 1 default instance")
+	}
+	defaultLabel := list.Data[0].Label
+
+	// Create second instance
+	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Sales"}`))
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("create second: %d %s", w1.Code, w1.Body.String())
+	}
+	var created agentConnectorInstanceResponse
+	if err := json.Unmarshal(w1.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal created: %v", err)
+	}
+
+	patchPayload, err := json.Marshal(map[string]string{"label": defaultLabel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2 := authenticatedRequestWithBody(t, http.MethodPatch,
+		fmt.Sprintf("/agents/%d/connectors/%s/instances/%s", agentID, connID, created.ConnectorInstanceID), uid, patchPayload)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w2.Code, w2.Body.String())
+	}
+}

--- a/api/agent_connector_instances_test.go
+++ b/api/agent_connector_instances_test.go
@@ -127,3 +127,66 @@ func TestPatchAgentConnectorInstance_DuplicateLabel409(t *testing.T) {
 		t.Fatalf("expected 409, got %d: %s", w2.Code, w2.Body.String())
 	}
 }
+
+func TestGetAgentConnectorInstance_InvalidUUID400(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodGet,
+		fmt.Sprintf("/agents/%d/connectors/%s/instances/not-a-uuid", agentID, connID), uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteAgentConnectorInstance_SecondInstance204(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Extra"}`))
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("create second: %d %s", w1.Code, w1.Body.String())
+	}
+	var created agentConnectorInstanceResponse
+	if err := json.Unmarshal(w1.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	rDel := authenticatedRequest(t, http.MethodDelete,
+		fmt.Sprintf("/agents/%d/connectors/%s/instances/%s", agentID, connID, created.ConnectorInstanceID), uid)
+	wDel := httptest.NewRecorder()
+	router.ServeHTTP(wDel, rDel)
+	if wDel.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", wDel.Code, wDel.Body.String())
+	}
+
+	rList := authenticatedRequest(t, http.MethodGet, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid)
+	wList := httptest.NewRecorder()
+	router.ServeHTTP(wList, rList)
+	list := decodeInstanceList(t, wList.Body.Bytes())
+	if len(list.Data) != 1 {
+		t.Fatalf("after delete expected 1 instance, got %d", len(list.Data))
+	}
+}

--- a/api/agent_connector_users.go
+++ b/api/agent_connector_users.go
@@ -71,7 +71,19 @@ func handleListAgentConnectorUsers(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		creds, err := resolveCredentialsWithFallback(r.Context(), deps, agentID, userID, listAction, connectorID, reqCreds)
+		defaultInst, err := db.GetDefaultAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID)
+		if err != nil {
+			log.Printf("[%s] ListAgentConnectorUsers default instance: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to resolve connector instance"))
+			return
+		}
+		if defaultInst == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorNotFound, "Connector not enabled for this agent"))
+			return
+		}
+
+		creds, err := resolveCredentialsForConnectorInstance(r.Context(), deps, agentID, userID, listAction, connectorID, defaultInst.ConnectorInstanceID, reqCreds)
 		if err != nil {
 			if handleConnectorError(w, r, err, connErrCtx) {
 				return

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -155,25 +155,16 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 			defer db.RollbackTx(r.Context(), tx) //nolint:errcheck // best-effort cleanup
 		}
 
-		// Look up credential binding before disabling — the cascade from
-		// agent_connectors → agent_connector_credentials will remove it.
-		var credBinding *db.AgentConnectorCredential
+		// Look up all credential bindings before disabling — the cascade from
+		// agent_connectors → agent_connector_credentials removes every instance row.
+		var credBindings []db.AgentConnectorCredential
 		if deleteCredentials {
-			defaultInst, instErr := db.GetDefaultAgentConnectorInstance(r.Context(), tx, agentID, userID, connectorID)
-			if instErr != nil {
-				log.Printf("[%s] DisableAgentConnector: get default instance: %v", TraceID(r.Context()), instErr)
-				CaptureError(r.Context(), instErr)
+			credBindings, err = db.ListAgentConnectorCredentialsForAgentConnector(r.Context(), tx, agentID, userID, connectorID)
+			if err != nil {
+				log.Printf("[%s] DisableAgentConnector: list credentials: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
 				return
-			}
-			if defaultInst != nil {
-				credBinding, err = db.GetAgentConnectorCredentialByInstance(r.Context(), tx, agentID, connectorID, defaultInst.ConnectorInstanceID)
-				if err != nil {
-					log.Printf("[%s] DisableAgentConnector: get credential: %v", TraceID(r.Context()), err)
-					CaptureError(r.Context(), err)
-					RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
-					return
-				}
 			}
 		}
 
@@ -191,12 +182,18 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		if deleteCredentials && credBinding != nil && credBinding.CredentialID != nil {
-			if err := deleteCredentialAndVault(r.Context(), tx, *credBinding.CredentialID, userID, deps.Vault); err != nil {
-				log.Printf("[%s] DisableAgentConnector: delete credential: %v", TraceID(r.Context()), err)
-				CaptureError(r.Context(), err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
-				return
+		if deleteCredentials {
+			for i := range credBindings {
+				b := credBindings[i]
+				if b.CredentialID == nil {
+					continue
+				}
+				if err := deleteCredentialAndVault(r.Context(), tx, *b.CredentialID, userID, deps.Vault); err != nil {
+					log.Printf("[%s] DisableAgentConnector: delete credential: %v", TraceID(r.Context()), err)
+					CaptureError(r.Context(), err)
+					RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to delete credential"))
+					return
+				}
 			}
 		}
 

--- a/api/agent_connectors.go
+++ b/api/agent_connectors.go
@@ -159,12 +159,21 @@ func handleDisableAgentConnector(deps *Deps) http.HandlerFunc {
 		// agent_connectors → agent_connector_credentials will remove it.
 		var credBinding *db.AgentConnectorCredential
 		if deleteCredentials {
-			credBinding, err = db.GetAgentConnectorCredential(r.Context(), tx, agentID, connectorID)
-			if err != nil {
-				log.Printf("[%s] DisableAgentConnector: get credential: %v", TraceID(r.Context()), err)
-				CaptureError(r.Context(), err)
+			defaultInst, instErr := db.GetDefaultAgentConnectorInstance(r.Context(), tx, agentID, userID, connectorID)
+			if instErr != nil {
+				log.Printf("[%s] DisableAgentConnector: get default instance: %v", TraceID(r.Context()), instErr)
+				CaptureError(r.Context(), instErr)
 				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
 				return
+			}
+			if defaultInst != nil {
+				credBinding, err = db.GetAgentConnectorCredentialByInstance(r.Context(), tx, agentID, connectorID, defaultInst.ConnectorInstanceID)
+				if err != nil {
+					log.Printf("[%s] DisableAgentConnector: get credential: %v", TraceID(r.Context()), err)
+					CaptureError(r.Context(), err)
+					RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to disable connector"))
+					return
+				}
 			}
 		}
 

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -258,6 +258,27 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 	if err != nil {
 		return connectors.Credentials{}, fmt.Errorf("look up agent connector credential: %w", err)
 	}
+	return resolveCredentialsFromAgentConnectorBinding(ctx, deps, userID, binding)
+}
+
+// resolveCredentialsForConnectorInstance resolves credentials for a specific connector instance (same rules as resolveCredentialsWithFallback).
+func resolveCredentialsForConnectorInstance(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
+	if len(reqCreds) == 0 {
+		return connectors.NewCredentials(nil), nil
+	}
+	if agentID == 0 {
+		return connectors.Credentials{}, &connectors.ValidationError{
+			Message: "no credential assigned — assign a credential to this connector before running actions",
+		}
+	}
+	binding, err := db.GetAgentConnectorCredentialByInstance(ctx, deps.DB, agentID, connectorID, connectorInstanceID)
+	if err != nil {
+		return connectors.Credentials{}, fmt.Errorf("look up agent connector credential: %w", err)
+	}
+	return resolveCredentialsFromAgentConnectorBinding(ctx, deps, userID, binding)
+}
+
+func resolveCredentialsFromAgentConnectorBinding(ctx context.Context, deps *Deps, userID string, binding *db.AgentConnectorCredential) (connectors.Credentials, error) {
 	if binding == nil {
 		return connectors.Credentials{}, &connectors.ValidationError{
 			Message: "no credential assigned — go to the agent's connector settings and assign a credential",

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -57,13 +57,13 @@ const (
 	ErrSMSRequiresPaidPlan          ErrorCode = "sms_requires_paid_plan"
 	ErrChannelNotConfigured         ErrorCode = "channel_not_configured"
 	// OAuth
-	ErrOAuthProviderNotFound       ErrorCode = "oauth_provider_not_found"
-	ErrOAuthProviderUnconfigured   ErrorCode = "oauth_provider_unconfigured"
-	ErrOAuthConnectionNotFound     ErrorCode = "oauth_connection_not_found"
-	ErrOAuthConnectionExists       ErrorCode = "oauth_connection_exists"
-	ErrOAuthStateMismatch          ErrorCode = "oauth_state_mismatch"
-	ErrOAuthExchangeFailed         ErrorCode = "oauth_exchange_failed"
-	ErrOAuthRefreshFailed          ErrorCode = "oauth_refresh_failed"
+	ErrOAuthProviderNotFound     ErrorCode = "oauth_provider_not_found"
+	ErrOAuthProviderUnconfigured ErrorCode = "oauth_provider_unconfigured"
+	ErrOAuthConnectionNotFound   ErrorCode = "oauth_connection_not_found"
+	ErrOAuthConnectionExists     ErrorCode = "oauth_connection_exists"
+	ErrOAuthStateMismatch        ErrorCode = "oauth_state_mismatch"
+	ErrOAuthExchangeFailed       ErrorCode = "oauth_exchange_failed"
+	ErrOAuthRefreshFailed        ErrorCode = "oauth_refresh_failed"
 	// Payment Methods
 	ErrPaymentMethodNotFound ErrorCode = "payment_method_not_found"
 	ErrPaymentMethodRequired ErrorCode = "payment_method_required"
@@ -77,4 +77,7 @@ const (
 
 	// 429 Too Many Requests (quota)
 	ErrMonthlyQuotaExceeded ErrorCode = "monthly_quota_exceeded"
+
+	ErrConnectorInstanceRequired ErrorCode = "connector_instance_required"
+	ErrConnectorInstanceNotFound ErrorCode = "connector_instance_not_found"
 )

--- a/api/standing_approval_match.go
+++ b/api/standing_approval_match.go
@@ -15,7 +15,7 @@ import (
 // response was written (either success or error), false if no standing approval
 // matched and the caller should fall through to the pending approval flow.
 func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps *Deps, agent *db.Agent, actionType string, params json.RawMessage, requestID string, pp *paymentParams) bool {
-	approvals, err := db.FindActiveStandingApprovalsForAgent(r.Context(), deps.DB, agent.AgentID, actionType)
+	approvals, err := db.FindActiveStandingApprovalsForAgent(r.Context(), deps.DB, agent.AgentID, actionType, "")
 	if err != nil {
 		log.Printf("[%s] AutoApprove: find standing approvals: %v", TraceID(r.Context()), err)
 		CaptureError(r.Context(), err)

--- a/db/agent_connector_credentials.go
+++ b/db/agent_connector_credentials.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -12,26 +13,41 @@ import (
 // join table. Each row binds exactly one credential (either a static credential
 // or an OAuth connection) to an agent+connector pair.
 type AgentConnectorCredential struct {
-	ID                string
-	AgentID           int64
-	ConnectorID       string
-	ApproverID        string
-	CredentialID      *string
-	OAuthConnectionID *string
-	CreatedAt         time.Time
+	ID                  string
+	AgentID             int64
+	ConnectorID         string
+	ConnectorInstanceID string
+	ApproverID          string
+	CredentialID        *string
+	OAuthConnectionID   *string
+	CreatedAt           time.Time
 }
 
-// GetAgentConnectorCredential returns the credential binding for an
-// agent+connector pair, or nil if no binding exists.
+// GetAgentConnectorCredential returns the credential binding for the default
+// agent+connector instance, or nil if no binding exists.
+//
+// Deprecated: prefer GetAgentConnectorCredentialByInstance when the instance is known.
 func GetAgentConnectorCredential(ctx context.Context, db DBTX, agentID int64, connectorID string) (*AgentConnectorCredential, error) {
+	defaultInst, err := GetDefaultAgentConnectorInstanceByAgent(ctx, db, agentID, connectorID)
+	if err != nil {
+		return nil, err
+	}
+	if defaultInst == nil {
+		return nil, nil
+	}
+	return GetAgentConnectorCredentialByInstance(ctx, db, agentID, connectorID, defaultInst.ConnectorInstanceID)
+}
+
+// GetAgentConnectorCredentialByInstance returns the credential binding for a specific connector instance.
+func GetAgentConnectorCredentialByInstance(ctx context.Context, db DBTX, agentID int64, connectorID, connectorInstanceID string) (*AgentConnectorCredential, error) {
 	var acc AgentConnectorCredential
 	err := db.QueryRow(ctx, `
-		SELECT id, agent_id, connector_id, approver_id,
+		SELECT id, agent_id, connector_id, connector_instance_id, approver_id,
 		       credential_id, oauth_connection_id, created_at
 		FROM agent_connector_credentials
-		WHERE agent_id = $1 AND connector_id = $2`,
-		agentID, connectorID,
-	).Scan(&acc.ID, &acc.AgentID, &acc.ConnectorID, &acc.ApproverID,
+		WHERE agent_id = $1 AND connector_id = $2 AND connector_instance_id = $3::uuid`,
+		agentID, connectorID, connectorInstanceID,
+	).Scan(&acc.ID, &acc.AgentID, &acc.ConnectorID, &acc.ConnectorInstanceID, &acc.ApproverID,
 		&acc.CredentialID, &acc.OAuthConnectionID, &acc.CreatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -55,23 +71,53 @@ type UpsertAgentConnectorCredentialParams struct {
 }
 
 // UpsertAgentConnectorCredential creates or replaces the credential binding
-// for an agent+connector pair. The unique index on (agent_id, connector_id, connector_instance_id)
-// ensures at most one binding per instance; omitted instance resolves to the default via trigger.
+// for the default agent+connector instance.
 func UpsertAgentConnectorCredential(ctx context.Context, db DBTX, p UpsertAgentConnectorCredentialParams) (*AgentConnectorCredential, error) {
+	defaultInst, err := GetDefaultAgentConnectorInstance(ctx, db, p.AgentID, p.ApproverID, p.ConnectorID)
+	if err != nil {
+		return nil, err
+	}
+	if defaultInst == nil {
+		return nil, fmt.Errorf("connector not enabled for agent: no default instance")
+	}
+	return UpsertAgentConnectorCredentialByInstance(ctx, db, UpsertAgentConnectorCredentialByInstanceParams{
+		ID:                  p.ID,
+		AgentID:             p.AgentID,
+		ConnectorID:         p.ConnectorID,
+		ConnectorInstanceID: defaultInst.ConnectorInstanceID,
+		ApproverID:          p.ApproverID,
+		CredentialID:        p.CredentialID,
+		OAuthConnectionID:   p.OAuthConnectionID,
+	})
+}
+
+// UpsertAgentConnectorCredentialByInstanceParams holds parameters for upserting a credential on a specific instance.
+type UpsertAgentConnectorCredentialByInstanceParams struct {
+	ID                  string
+	AgentID             int64
+	ConnectorID         string
+	ConnectorInstanceID string
+	ApproverID          string
+	CredentialID        *string
+	OAuthConnectionID   *string
+}
+
+// UpsertAgentConnectorCredentialByInstance creates or replaces the credential binding for a specific instance.
+func UpsertAgentConnectorCredentialByInstance(ctx context.Context, db DBTX, p UpsertAgentConnectorCredentialByInstanceParams) (*AgentConnectorCredential, error) {
 	var acc AgentConnectorCredential
 	err := db.QueryRow(ctx, `
 		INSERT INTO agent_connector_credentials
-		    (id, agent_id, connector_id, approver_id, credential_id, oauth_connection_id)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		    (id, agent_id, connector_id, connector_instance_id, approver_id, credential_id, oauth_connection_id)
+		VALUES ($1, $2, $3, $4::uuid, $5, $6, $7)
 		ON CONFLICT (agent_id, connector_id, connector_instance_id) DO UPDATE
 		    SET credential_id = EXCLUDED.credential_id,
 		        oauth_connection_id = EXCLUDED.oauth_connection_id,
 		        approver_id = EXCLUDED.approver_id
-		RETURNING id, agent_id, connector_id, approver_id,
+		RETURNING id, agent_id, connector_id, connector_instance_id, approver_id,
 		          credential_id, oauth_connection_id, created_at`,
-		p.ID, p.AgentID, p.ConnectorID, p.ApproverID,
+		p.ID, p.AgentID, p.ConnectorID, p.ConnectorInstanceID, p.ApproverID,
 		p.CredentialID, p.OAuthConnectionID,
-	).Scan(&acc.ID, &acc.AgentID, &acc.ConnectorID, &acc.ApproverID,
+	).Scan(&acc.ID, &acc.AgentID, &acc.ConnectorID, &acc.ConnectorInstanceID, &acc.ApproverID,
 		&acc.CredentialID, &acc.OAuthConnectionID, &acc.CreatedAt)
 	if err != nil {
 		return nil, err
@@ -79,14 +125,24 @@ func UpsertAgentConnectorCredential(ctx context.Context, db DBTX, p UpsertAgentC
 	return &acc, nil
 }
 
-// DeleteAgentConnectorCredential removes the credential binding for an
-// agent+connector pair. Returns true if a row was deleted, false if no
-// binding existed.
+// DeleteAgentConnectorCredential removes the credential binding for the default instance.
 func DeleteAgentConnectorCredential(ctx context.Context, db DBTX, agentID int64, approverID string, connectorID string) (bool, error) {
+	defaultInst, err := GetDefaultAgentConnectorInstance(ctx, db, agentID, approverID, connectorID)
+	if err != nil {
+		return false, err
+	}
+	if defaultInst == nil {
+		return false, nil
+	}
+	return DeleteAgentConnectorCredentialByInstance(ctx, db, agentID, approverID, connectorID, defaultInst.ConnectorInstanceID)
+}
+
+// DeleteAgentConnectorCredentialByInstance removes the credential binding for a specific instance.
+func DeleteAgentConnectorCredentialByInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID string) (bool, error) {
 	tag, err := db.Exec(ctx, `
 		DELETE FROM agent_connector_credentials
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3`,
-		agentID, approverID, connectorID,
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
+		agentID, approverID, connectorID, connectorInstanceID,
 	)
 	if err != nil {
 		return false, err

--- a/db/agent_connector_credentials.go
+++ b/db/agent_connector_credentials.go
@@ -149,3 +149,30 @@ func DeleteAgentConnectorCredentialByInstance(ctx context.Context, db DBTX, agen
 	}
 	return tag.RowsAffected() > 0, nil
 }
+
+// ListAgentConnectorCredentialsForAgentConnector returns all credential bindings for every
+// instance of this connector on the agent (used when disabling with delete_credentials).
+func ListAgentConnectorCredentialsForAgentConnector(ctx context.Context, db DBTX, agentID int64, approverID, connectorID string) ([]AgentConnectorCredential, error) {
+	rows, err := db.Query(ctx, `
+		SELECT id, agent_id, connector_id, connector_instance_id, approver_id,
+		       credential_id, oauth_connection_id, created_at
+		FROM agent_connector_credentials
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3`,
+		agentID, approverID, connectorID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []AgentConnectorCredential
+	for rows.Next() {
+		var acc AgentConnectorCredential
+		if err := rows.Scan(&acc.ID, &acc.AgentID, &acc.ConnectorID, &acc.ConnectorInstanceID, &acc.ApproverID,
+			&acc.CredentialID, &acc.OAuthConnectionID, &acc.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, acc)
+	}
+	return out, rows.Err()
+}

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -1,0 +1,290 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// AgentConnectorInstance is a row in agent_connectors (one instance of a connector type for an agent).
+type AgentConnectorInstance struct {
+	ConnectorInstanceID string
+	AgentID             int64
+	ConnectorID         string
+	ApproverID          string
+	Label               string
+	IsDefault           bool
+	EnabledAt           time.Time
+}
+
+// AgentConnectorInstanceError is a domain error for connector instance operations.
+type AgentConnectorInstanceError struct {
+	Code AgentConnectorInstanceErrCode
+}
+
+func (e *AgentConnectorInstanceError) Error() string { return string(e.Code) }
+
+// AgentConnectorInstanceErrCode enumerates connector-instance-specific error codes.
+type AgentConnectorInstanceErrCode string
+
+const (
+	AgentConnectorInstanceErrNotFound            AgentConnectorInstanceErrCode = "connector_instance_not_found"
+	AgentConnectorInstanceErrDuplicateLabel      AgentConnectorInstanceErrCode = "duplicate_instance_label"
+	AgentConnectorInstanceErrCannotDeleteDefault AgentConnectorInstanceErrCode = "cannot_delete_default_instance"
+)
+
+// CreateAgentConnectorInstanceParams holds parameters for creating a new instance (non-default row).
+type CreateAgentConnectorInstanceParams struct {
+	AgentID     int64
+	ApproverID  string
+	ConnectorID string
+	Label       string
+}
+
+// CreateAgentConnectorInstance inserts a new agent connector instance with the given label.
+// The first instance for an (agent, connector) pair is the default (enforced by DB trigger);
+// additional instances are non-default.
+func CreateAgentConnectorInstance(ctx context.Context, db DBTX, p CreateAgentConnectorInstanceParams) (*AgentConnectorInstance, error) {
+	label := strings.TrimSpace(p.Label)
+	if label == "" {
+		return nil, errors.New("label is required")
+	}
+
+	var agentOK bool
+	if err := db.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM agents WHERE agent_id = $1 AND approver_id = $2)`,
+		p.AgentID, p.ApproverID,
+	).Scan(&agentOK); err != nil {
+		return nil, err
+	}
+	if !agentOK {
+		return nil, &AgentConnectorError{Code: AgentConnectorErrAgentNotFound}
+	}
+
+	var connOK bool
+	if err := db.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM connectors WHERE id = $1)`,
+		p.ConnectorID,
+	).Scan(&connOK); err != nil {
+		return nil, err
+	}
+	if !connOK {
+		return nil, &AgentConnectorError{Code: AgentConnectorErrConnectorNotFound}
+	}
+
+	row := db.QueryRow(ctx, `
+		INSERT INTO agent_connectors (agent_id, approver_id, connector_id, label, is_default)
+		VALUES ($1, $2, $3, $4, false)
+		RETURNING connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at`,
+		p.AgentID, p.ApproverID, p.ConnectorID, label,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
+			return nil, &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrDuplicateLabel}
+		}
+		return nil, err
+	}
+	return inst, nil
+}
+
+func scanAgentConnectorInstance(row pgx.Row) (*AgentConnectorInstance, error) {
+	var inst AgentConnectorInstance
+	err := row.Scan(
+		&inst.ConnectorInstanceID, &inst.AgentID, &inst.ConnectorID, &inst.ApproverID,
+		&inst.Label, &inst.IsDefault, &inst.EnabledAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &inst, nil
+}
+
+// ListAgentConnectorInstances returns all instances for an agent+connector scoped to the approver.
+func ListAgentConnectorInstances(ctx context.Context, db DBTX, agentID int64, approverID, connectorID string) ([]AgentConnectorInstance, error) {
+	rows, err := db.Query(ctx, `
+		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
+		FROM agent_connectors
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3
+		ORDER BY enabled_at ASC, connector_instance_id ASC`,
+		agentID, approverID, connectorID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []AgentConnectorInstance
+	for rows.Next() {
+		var inst AgentConnectorInstance
+		if err := rows.Scan(
+			&inst.ConnectorInstanceID, &inst.AgentID, &inst.ConnectorID, &inst.ApproverID,
+			&inst.Label, &inst.IsDefault, &inst.EnabledAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, inst)
+	}
+	return out, rows.Err()
+}
+
+// GetAgentConnectorInstance returns a single instance by ID, scoped to agent and approver.
+func GetAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID string) (*AgentConnectorInstance, error) {
+	row := db.QueryRow(ctx, `
+		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
+		FROM agent_connectors
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
+		agentID, approverID, connectorID, connectorInstanceID,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+// GetDefaultAgentConnectorInstance returns the default instance for an (agent, connector) pair.
+func GetDefaultAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID string) (*AgentConnectorInstance, error) {
+	row := db.QueryRow(ctx, `
+		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
+		FROM agent_connectors
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND is_default`,
+		agentID, approverID, connectorID,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+// GetDefaultAgentConnectorInstanceByAgent returns the default instance using only agent_id and connector_id.
+// Each agent has a single approver; this is used when approver_id is not available on the call path.
+func GetDefaultAgentConnectorInstanceByAgent(ctx context.Context, db DBTX, agentID int64, connectorID string) (*AgentConnectorInstance, error) {
+	row := db.QueryRow(ctx, `
+		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
+		FROM agent_connectors
+		WHERE agent_id = $1 AND connector_id = $2 AND is_default`,
+		agentID, connectorID,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
+}
+
+// RenameAgentConnectorInstance updates the label for an instance.
+func RenameAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID, newLabel string) (*AgentConnectorInstance, error) {
+	label := strings.TrimSpace(newLabel)
+	if label == "" {
+		return nil, errors.New("label is required")
+	}
+
+	row := db.QueryRow(ctx, `
+		UPDATE agent_connectors
+		SET label = $5
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid
+		RETURNING connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at`,
+		agentID, approverID, connectorID, connectorInstanceID, label,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
+			return nil, &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrDuplicateLabel}
+		}
+		return nil, err
+	}
+	return inst, nil
+}
+
+// DeleteAgentConnectorInstance removes a non-default instance and revokes instance-scoped standing approvals.
+func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID string) error {
+	var isDefault bool
+	err := db.QueryRow(ctx, `
+		SELECT is_default FROM agent_connectors
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
+		agentID, approverID, connectorID, connectorInstanceID,
+	).Scan(&isDefault)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrNotFound}
+	}
+	if err != nil {
+		return err
+	}
+	if isDefault {
+		return &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrCannotDeleteDefault}
+	}
+
+	_, err = db.Exec(ctx, `
+		UPDATE standing_approvals
+		SET status = 'revoked', revoked_at = now()
+		WHERE agent_id = $1
+		  AND user_id = $2
+		  AND status = 'active'
+		  AND connector_instance_id = $3::uuid`,
+		agentID, approverID, connectorInstanceID,
+	)
+	if err != nil {
+		return err
+	}
+
+	tag, err := db.Exec(ctx, `
+		DELETE FROM agent_connectors
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
+		agentID, approverID, connectorID, connectorInstanceID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrNotFound}
+	}
+	return nil
+}
+
+// ResolveAgentConnectorInstance finds an instance by UUID or by exact label (trimmed).
+func ResolveAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, selector string) (*AgentConnectorInstance, error) {
+	sel := strings.TrimSpace(selector)
+	if sel == "" {
+		return nil, nil
+	}
+
+	if _, err := uuid.Parse(sel); err == nil {
+		return GetAgentConnectorInstance(ctx, db, agentID, approverID, connectorID, sel)
+	}
+
+	row := db.QueryRow(ctx, `
+		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
+		FROM agent_connectors
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND label = $4`,
+		agentID, approverID, connectorID, sel,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
+}

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -5,11 +5,18 @@ import (
 	"errors"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
+
+// ErrAgentConnectorInstanceLabelRequired is returned when label is empty after trim.
+var ErrAgentConnectorInstanceLabelRequired = errors.New("label is required")
+
+// ErrAgentConnectorInstanceLabelTooLong is returned when label exceeds MaxAgentConnectorInstanceLabelLen runes.
+var ErrAgentConnectorInstanceLabelTooLong = errors.New("label exceeds maximum length")
 
 // AgentConnectorInstance is a row in agent_connectors (one instance of a connector type for an agent).
 type AgentConnectorInstance struct {
@@ -38,6 +45,9 @@ const (
 	AgentConnectorInstanceErrCannotDeleteDefault AgentConnectorInstanceErrCode = "cannot_delete_default_instance"
 )
 
+// MaxAgentConnectorInstanceLabelLen is the maximum rune length for instance labels (API + DB).
+const MaxAgentConnectorInstanceLabelLen = 256
+
 // CreateAgentConnectorInstanceParams holds parameters for creating a new instance (non-default row).
 type CreateAgentConnectorInstanceParams struct {
 	AgentID     int64
@@ -52,7 +62,10 @@ type CreateAgentConnectorInstanceParams struct {
 func CreateAgentConnectorInstance(ctx context.Context, db DBTX, p CreateAgentConnectorInstanceParams) (*AgentConnectorInstance, error) {
 	label := strings.TrimSpace(p.Label)
 	if label == "" {
-		return nil, errors.New("label is required")
+		return nil, ErrAgentConnectorInstanceLabelRequired
+	}
+	if utf8.RuneCountInString(label) > MaxAgentConnectorInstanceLabelLen {
+		return nil, ErrAgentConnectorInstanceLabelTooLong
 	}
 
 	var agentOK bool
@@ -75,6 +88,20 @@ func CreateAgentConnectorInstance(ctx context.Context, db DBTX, p CreateAgentCon
 	}
 	if !connOK {
 		return nil, &AgentConnectorError{Code: AgentConnectorErrConnectorNotFound}
+	}
+
+	var enabled bool
+	if err := db.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM agent_connectors
+			WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3
+		)`,
+		p.AgentID, p.ApproverID, p.ConnectorID,
+	).Scan(&enabled); err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, &AgentConnectorError{Code: AgentConnectorErrConnectorNotEnabled}
 	}
 
 	row := db.QueryRow(ctx, `
@@ -193,7 +220,10 @@ func GetDefaultAgentConnectorInstanceByAgent(ctx context.Context, db DBTX, agent
 func RenameAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID, newLabel string) (*AgentConnectorInstance, error) {
 	label := strings.TrimSpace(newLabel)
 	if label == "" {
-		return nil, errors.New("label is required")
+		return nil, ErrAgentConnectorInstanceLabelRequired
+	}
+	if utf8.RuneCountInString(label) > MaxAgentConnectorInstanceLabelLen {
+		return nil, ErrAgentConnectorInstanceLabelTooLong
 	}
 
 	row := db.QueryRow(ctx, `
@@ -219,8 +249,16 @@ func RenameAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, a
 
 // DeleteAgentConnectorInstance removes a non-default instance and revokes instance-scoped standing approvals.
 func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID string) error {
+	tx, owned, err := BeginOrContinue(ctx, db)
+	if err != nil {
+		return err
+	}
+	if owned {
+		defer RollbackTx(ctx, tx) //nolint:errcheck // commit path clears
+	}
+
 	var isDefault bool
-	err := db.QueryRow(ctx, `
+	err = tx.QueryRow(ctx, `
 		SELECT is_default FROM agent_connectors
 		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
 		agentID, approverID, connectorID, connectorInstanceID,
@@ -235,7 +273,7 @@ func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, a
 		return &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrCannotDeleteDefault}
 	}
 
-	_, err = db.Exec(ctx, `
+	_, err = tx.Exec(ctx, `
 		UPDATE standing_approvals
 		SET status = 'revoked', revoked_at = now()
 		WHERE agent_id = $1
@@ -248,7 +286,7 @@ func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, a
 		return err
 	}
 
-	tag, err := db.Exec(ctx, `
+	tag, err := tx.Exec(ctx, `
 		DELETE FROM agent_connectors
 		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
 		agentID, approverID, connectorID, connectorInstanceID,
@@ -258,6 +296,10 @@ func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, a
 	}
 	if tag.RowsAffected() == 0 {
 		return &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrNotFound}
+	}
+
+	if owned {
+		return CommitTx(ctx, tx)
 	}
 	return nil
 }

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -68,6 +68,29 @@ func TestCreateAgentConnectorInstance_SecondInstance(t *testing.T) {
 	}
 }
 
+func TestCreateAgentConnectorInstance_RequiresConnectorEnabled(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	// Connector exists in catalog but is not enabled for the agent.
+
+	_, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID:     agentID,
+		ApproverID:  uid,
+		ConnectorID: connID,
+		Label:       "First",
+	})
+	var acErr *db.AgentConnectorError
+	if !errors.As(err, &acErr) || acErr.Code != db.AgentConnectorErrConnectorNotEnabled {
+		t.Fatalf("expected connector_not_enabled, got %v", err)
+	}
+}
+
 func TestCreateAgentConnectorInstance_DuplicateLabel(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -1,0 +1,210 @@
+package db_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestListAgentConnectorInstances_DefaultOnly(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	instances, err := db.ListAgentConnectorInstances(t.Context(), tx, agentID, uid, connID)
+	if err != nil {
+		t.Fatalf("ListAgentConnectorInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+	if !instances[0].IsDefault {
+		t.Error("expected first instance to be default")
+	}
+	if instances[0].Label == "" {
+		t.Error("expected non-empty label")
+	}
+}
+
+func TestCreateAgentConnectorInstance_SecondInstance(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	inst2, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID:     agentID,
+		ApproverID:  uid,
+		ConnectorID: connID,
+		Label:       "Second",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentConnectorInstance: %v", err)
+	}
+	if inst2.IsDefault {
+		t.Error("second instance should not be default")
+	}
+
+	instances, err := db.ListAgentConnectorInstances(t.Context(), tx, agentID, uid, connID)
+	if err != nil {
+		t.Fatalf("ListAgentConnectorInstances: %v", err)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(instances))
+	}
+}
+
+func TestCreateAgentConnectorInstance_DuplicateLabel(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	defaultInst, err := db.GetDefaultAgentConnectorInstance(t.Context(), tx, agentID, uid, connID)
+	if err != nil || defaultInst == nil {
+		t.Fatalf("default instance: err=%v inst=%v", err, defaultInst)
+	}
+
+	_, err = db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID:     agentID,
+		ApproverID:  uid,
+		ConnectorID: connID,
+		Label:       defaultInst.Label,
+	})
+	var instErr *db.AgentConnectorInstanceError
+	if !errors.As(err, &instErr) || instErr.Code != db.AgentConnectorInstanceErrDuplicateLabel {
+		t.Fatalf("expected duplicate label error, got %v", err)
+	}
+}
+
+func TestFindActiveStandingApprovalsForAgent_FiltersByInstance(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	actionType := "instfilt.action"
+	testhelper.InsertConnectorAction(t, tx, connID, actionType, "Act")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID:     agentID,
+		ApproverID:  uid,
+		ConnectorID: connID,
+		Label:       "Sales",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentConnectorInstance: %v", err)
+	}
+
+	configID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfig(t, tx, configID, agentID, uid, connID, actionType)
+
+	saID := testhelper.GenerateID(t, "sa_")
+	_, err = tx.Exec(ctx,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, source_action_configuration_id, connector_instance_id, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, 'active', $5, $6::uuid, now(), now() + interval '30 days')`,
+		saID, agentID, uid, actionType, configID, inst2.ConnectorInstanceID,
+	)
+	if err != nil {
+		t.Fatalf("insert standing approval: %v", err)
+	}
+
+	all, err := db.FindActiveStandingApprovalsForAgent(ctx, tx, agentID, actionType, "")
+	if err != nil {
+		t.Fatalf("Find (no filter): %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 without instance filter, got %d", len(all))
+	}
+
+	wrong, err := db.FindActiveStandingApprovalsForAgent(ctx, tx, agentID, actionType, "00000000-0000-0000-0000-000000000001")
+	if err != nil {
+		t.Fatalf("Find (wrong instance): %v", err)
+	}
+	if len(wrong) != 0 {
+		t.Fatalf("expected 0 for wrong instance, got %d", len(wrong))
+	}
+
+	match, err := db.FindActiveStandingApprovalsForAgent(ctx, tx, agentID, actionType, inst2.ConnectorInstanceID)
+	if err != nil {
+		t.Fatalf("Find (matching instance): %v", err)
+	}
+	if len(match) != 1 {
+		t.Fatalf("expected 1 for matching instance, got %d", len(match))
+	}
+}
+
+func TestDeleteAgentConnectorInstance_RevokesInstanceScopedStandingApproval(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	actionType := "delinst.action"
+	testhelper.InsertConnectorAction(t, tx, connID, actionType, "Act")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID:     agentID,
+		ApproverID:  uid,
+		ConnectorID: connID,
+		Label:       "ToDelete",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentConnectorInstance: %v", err)
+	}
+
+	configID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfig(t, tx, configID, agentID, uid, connID, actionType)
+
+	saID := testhelper.GenerateID(t, "sa_")
+	_, err = tx.Exec(ctx,
+		`INSERT INTO standing_approvals (standing_approval_id, agent_id, user_id, action_type, status, source_action_configuration_id, connector_instance_id, starts_at, expires_at)
+		 VALUES ($1, $2, $3, $4, 'active', $5, $6::uuid, now(), now() + interval '30 days')`,
+		saID, agentID, uid, actionType, configID, inst2.ConnectorInstanceID,
+	)
+	if err != nil {
+		t.Fatalf("insert standing approval: %v", err)
+	}
+
+	if err := db.DeleteAgentConnectorInstance(ctx, tx, agentID, uid, connID, inst2.ConnectorInstanceID); err != nil {
+		t.Fatalf("DeleteAgentConnectorInstance: %v", err)
+	}
+
+	var status string
+	err = tx.QueryRow(ctx, `SELECT status FROM standing_approvals WHERE standing_approval_id = $1`, saID).Scan(&status)
+	if err != nil {
+		t.Fatalf("query sa: %v", err)
+	}
+	if status != "revoked" {
+		t.Errorf("expected revoked, got %q", status)
+	}
+}

--- a/db/agent_connectors.go
+++ b/db/agent_connectors.go
@@ -34,8 +34,9 @@ func (e *AgentConnectorError) Error() string { return string(e.Code) }
 type AgentConnectorErrCode string
 
 const (
-	AgentConnectorErrAgentNotFound     AgentConnectorErrCode = "agent_not_found"
-	AgentConnectorErrConnectorNotFound AgentConnectorErrCode = "connector_not_found"
+	AgentConnectorErrAgentNotFound       AgentConnectorErrCode = "agent_not_found"
+	AgentConnectorErrConnectorNotFound   AgentConnectorErrCode = "connector_not_found"
+	AgentConnectorErrConnectorNotEnabled AgentConnectorErrCode = "connector_not_enabled"
 )
 
 // ListAgentConnectors returns enabled connectors for an agent, scoped to the approver.

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -19,6 +19,7 @@ type StandingApproval struct {
 	ActionVersion               string
 	Constraints                 []byte // raw JSONB
 	SourceActionConfigurationID *string
+	ConnectorInstanceID         *string // nil = type-wide (legacy); non-nil = instance-scoped
 	Status                      string
 	StartsAt                    time.Time
 	ExpiresAt                   *time.Time // nil means no expiry (until revoked)
@@ -30,7 +31,7 @@ type StandingApproval struct {
 // standingApprovalColumns is the canonical column list for SELECT on the standing_approvals table.
 // Keep in sync with scanStandingApproval.
 const standingApprovalColumns = `standing_approval_id, agent_id, user_id, action_type, action_version,
-	constraints, source_action_configuration_id, status,
+	constraints, source_action_configuration_id, connector_instance_id, status,
 	starts_at, expires_at, created_at, revoked_at, expired_at`
 
 // MaxStandingApprovalListSize is the maximum number of standing approvals returned per page.
@@ -58,7 +59,7 @@ func scanStandingApproval(row pgx.Row) (*StandingApproval, error) {
 	var sa StandingApproval
 	err := row.Scan(
 		&sa.StandingApprovalID, &sa.AgentID, &sa.UserID, &sa.ActionType, &sa.ActionVersion,
-		&sa.Constraints, &sa.SourceActionConfigurationID, &sa.Status,
+		&sa.Constraints, &sa.SourceActionConfigurationID, &sa.ConnectorInstanceID, &sa.Status,
 		&sa.StartsAt, &sa.ExpiresAt, &sa.CreatedAt, &sa.RevokedAt, &sa.ExpiredAt,
 	)
 	if err != nil {
@@ -101,8 +102,8 @@ const (
 	StandingApprovalErrNotFound         = "not_found"
 	StandingApprovalErrAlreadyRevoked   = "already_revoked"
 	StandingApprovalErrNotActive        = "not_active"
-	StandingApprovalErrAgentNotFound     = "agent_not_found"
-	StandingApprovalErrDuplicateRequest  = "duplicate_request"
+	StandingApprovalErrAgentNotFound    = "agent_not_found"
+	StandingApprovalErrDuplicateRequest = "duplicate_request"
 )
 
 // CreateStandingApprovalParams holds the parameters for creating a standing approval.
@@ -114,6 +115,7 @@ type CreateStandingApprovalParams struct {
 	ActionVersion               string
 	Constraints                 []byte // raw JSONB, may be nil
 	SourceActionConfigurationID *string
+	ConnectorInstanceID         *string
 	StartsAt                    time.Time
 	ExpiresAt                   *time.Time // nil means no expiry (until revoked)
 }
@@ -128,12 +130,12 @@ func CreateStandingApproval(ctx context.Context, db DBTX, p CreateStandingApprov
 			SELECT 1 FROM agents WHERE agent_id = $2 AND approver_id = $3
 		)
 		INSERT INTO standing_approvals
-		   (standing_approval_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, status, starts_at, expires_at)
-		 SELECT $1, $2, $3, $4, $5, $6, $7, 'active', $8, $9
+		   (standing_approval_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, connector_instance_id, status, starts_at, expires_at)
+		 SELECT $1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10
 		 WHERE EXISTS (SELECT 1 FROM agent_check)
 		 RETURNING `+standingApprovalColumns,
 		p.StandingApprovalID, p.AgentID, p.UserID, p.ActionType, p.ActionVersion,
-		p.Constraints, p.SourceActionConfigurationID, p.StartsAt, p.ExpiresAt,
+		p.Constraints, p.SourceActionConfigurationID, p.ConnectorInstanceID, p.StartsAt, p.ExpiresAt,
 	)
 	sa, err := scanStandingApproval(row)
 	if err != nil {
@@ -517,7 +519,7 @@ func diagnoseStandingApprovalFailure(ctx context.Context, db DBTX, saID, userID 
 type UpdateStandingApprovalParams struct {
 	StandingApprovalID string
 	UserID             string
-	Constraints        []byte // raw JSONB
+	Constraints        []byte     // raw JSONB
 	ExpiresAt          *time.Time // nil means no expiry (until revoked)
 }
 
@@ -556,22 +558,33 @@ func UpdateStandingApproval(ctx context.Context, db DBTX, p UpdateStandingApprov
 // FindActiveStandingApprovalsForAgent returns all active standing approvals for
 // the given agent and action type, ordered by most recently created first.
 // Exact action_type matches are returned before wildcard ("*") matches.
+// If connectorInstanceID is non-empty, only rows with NULL connector_instance_id
+// (type-wide) or matching connector_instance_id are included.
 // Returns an empty slice if no match is found.
-func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID int64, actionType string) ([]*StandingApproval, error) {
+func FindActiveStandingApprovalsForAgent(ctx context.Context, db DBTX, agentID int64, actionType string, connectorInstanceID string) ([]*StandingApproval, error) {
+	instanceFilter := `1=1`
+	args := []any{agentID, actionType}
+	if connectorInstanceID != "" {
+		instanceFilter = `(connector_instance_id IS NULL OR connector_instance_id = $3::uuid)`
+		args = append(args, connectorInstanceID)
+	}
+
 	rows, err := db.Query(ctx,
 		`SELECT `+standingApprovalColumns+`
 		 FROM (
 		   SELECT `+standingApprovalColumns+`, 1 AS priority FROM standing_approvals
 		   WHERE agent_id = $1 AND action_type = $2 AND status = 'active'
 		     AND starts_at <= now() AND (expires_at IS NULL OR expires_at > now())
+		     AND `+instanceFilter+`
 		   UNION ALL
 		   SELECT `+standingApprovalColumns+`, 2 AS priority FROM standing_approvals
 		   WHERE agent_id = $1 AND action_type = '*' AND action_type != $2 AND status = 'active'
 		     AND starts_at <= now() AND (expires_at IS NULL OR expires_at > now())
+		     AND `+instanceFilter+`
 		 ) combined
 		 ORDER BY priority, created_at DESC, standing_approval_id DESC
 		 LIMIT 100`,
-		agentID, actionType,
+		args...,
 	)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
 	github.com/pressly/goose/v3 v3.26.0
@@ -93,7 +94,6 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/google/flatbuffers v24.12.23+incompatible // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/spec/openapi/components/parameters/common.yaml
+++ b/spec/openapi/components/parameters/common.yaml
@@ -110,6 +110,17 @@ ConnectorId:
     pattern: '^[a-z][a-z0-9_.-]*$'
   example: "gmail"
 
+ConnectorInstanceId:
+  name: instance_id
+  in: path
+  required: true
+  description: |
+    Connector instance UUID (`connector_instance_id` from list/create instance responses).
+  schema:
+    type: string
+    format: uuid
+  example: "550e8400-e29b-41d4-a716-446655440000"
+
 PushSubscriptionId:
   name: subscription_id
   in: path

--- a/spec/openapi/components/paths/agent_connector_instances.yaml
+++ b/spec/openapi/components/paths/agent_connector_instances.yaml
@@ -1,0 +1,335 @@
+agentConnectorInstances:
+  get:
+    operationId: listAgentConnectorInstances
+    summary: List connector instances for an agent
+    description: |
+      Returns all instances of a connector type enabled for the agent (including the default instance).
+
+      Requires session authentication (Supabase JWT).
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+    responses:
+      '200':
+        description: Instances listed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connector_instances.yaml#/AgentConnectorInstanceListResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        description: Agent not found or not owned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+  post:
+    operationId: createAgentConnectorInstance
+    summary: Create an additional connector instance
+    description: |
+      Creates a new labeled instance for this connector type. The first instance for a connector
+      is created when the connector is enabled; this endpoint adds further instances.
+
+      Requires session authentication (Supabase JWT).
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/agent_connector_instances.yaml#/CreateAgentConnectorInstanceRequest'
+    responses:
+      '201':
+        description: Instance created
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connector_instances.yaml#/AgentConnectorInstance'
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        description: Agent or connector not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+      '409':
+        $ref: '../responses/errors.yaml#/Conflict'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+agentConnectorInstanceById:
+  get:
+    operationId: getAgentConnectorInstance
+    summary: Get a connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '200':
+        description: Instance found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connector_instances.yaml#/AgentConnectorInstance'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+  patch:
+    operationId: patchAgentConnectorInstance
+    summary: Rename a connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/agent_connector_instances.yaml#/PatchAgentConnectorInstanceRequest'
+    responses:
+      '200':
+        description: Instance updated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connector_instances.yaml#/AgentConnectorInstance'
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '409':
+        $ref: '../responses/errors.yaml#/Conflict'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+  delete:
+    operationId: deleteAgentConnectorInstance
+    summary: Delete a non-default connector instance
+    description: |
+      Deletes an additional instance. The default instance cannot be deleted; disable the connector type instead.
+
+      Active standing approvals scoped to this instance are revoked.
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '204':
+        description: Instance deleted
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+agentConnectorInstanceCredential:
+  put:
+    operationId: assignAgentConnectorInstanceCredential
+    summary: Assign credential to a connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/agent_connectors.yaml#/AssignCredentialRequest'
+    responses:
+      '200':
+        description: Credential assigned
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorCredentialResponse'
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+  delete:
+    operationId: removeAgentConnectorInstanceCredential
+    summary: Remove credential from a connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '200':
+        description: Binding removed
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  example: removed
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+  get:
+    operationId: getAgentConnectorInstanceCredential
+    summary: Get credential binding for a connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '200':
+        description: Binding (possibly empty)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorCredentialResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+agentConnectorInstanceCalendars:
+  get:
+    operationId: listAgentConnectorInstanceCalendars
+    summary: List calendars for a specific connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '200':
+        description: Calendars listed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorCalendarListResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+agentConnectorInstanceChannels:
+  get:
+    operationId: listAgentConnectorInstanceChannels
+    summary: List channels for a specific connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '200':
+        description: Channels listed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorChannelListResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+agentConnectorInstanceUsers:
+  get:
+    operationId: listAgentConnectorInstanceUsers
+    summary: List users for a specific connector instance
+    tags:
+      - Agents
+    security:
+      - SupabaseSession: []
+    parameters:
+      - $ref: '../parameters/common.yaml#/AgentId'
+      - $ref: '../parameters/common.yaml#/ConnectorId'
+      - $ref: '../parameters/common.yaml#/ConnectorInstanceId'
+    responses:
+      '200':
+        description: Users listed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/agent_connectors.yaml#/AgentConnectorUserListResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -217,12 +217,17 @@ agentConnectorCredential:
     operationId: assignAgentConnectorCredential
     summary: Assign Credential to Agent Connector
     description: |
+      **Deprecated:** targets the **default** connector instance only. Prefer
+      `PUT /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential`
+      for per-instance bindings.
+
       Assign a credential or OAuth connection to an agent-connector pair. This determines
       which credential the agent uses when executing actions through this connector.
 
       Exactly one of `credential_id` or `oauth_connection_id` must be provided.
       If a credential is already assigned, it is replaced (upsert behavior).
 
+    deprecated: true
     tags:
       - Agents
 
@@ -284,9 +289,13 @@ agentConnectorCredential:
     operationId: removeAgentConnectorCredential
     summary: Remove Credential from Agent Connector
     description: |
+      **Deprecated:** removes the binding for the **default** instance only. Prefer
+      `DELETE .../instances/{instance_id}/credential` for per-instance removal.
+
       Remove the credential binding for an agent-connector pair. After removal,
       the agent falls back to user-global credential resolution for this connector.
 
+    deprecated: true
     tags:
       - Agents
 
@@ -329,8 +338,12 @@ agentConnectorCredential:
     operationId: getAgentConnectorCredential
     summary: Get Agent Connector Credential
     description: |
+      **Deprecated:** returns the binding for the **default** instance only. Prefer
+      `GET .../instances/{instance_id}/credential` for a specific instance.
+
       Get the current credential binding for an agent-connector pair.
 
+    deprecated: true
     tags:
       - Agents
 

--- a/spec/openapi/components/schemas/agent_connector_instances.yaml
+++ b/spec/openapi/components/schemas/agent_connector_instances.yaml
@@ -1,0 +1,57 @@
+AgentConnectorInstance:
+  type: object
+  required:
+    - connector_instance_id
+    - agent_id
+    - connector_id
+    - label
+    - is_default
+    - enabled_at
+  properties:
+    connector_instance_id:
+      type: string
+      format: uuid
+      description: Surrogate identifier for this connector instance on the agent.
+    agent_id:
+      type: integer
+      format: int64
+    connector_id:
+      type: string
+      maxLength: 128
+    label:
+      type: string
+      description: Human-readable label unique per agent and connector type.
+    is_default:
+      type: boolean
+      description: True for the default instance used when no instance is specified (legacy routes).
+    enabled_at:
+      type: string
+      format: date-time
+
+AgentConnectorInstanceListResponse:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: '#/AgentConnectorInstance'
+
+CreateAgentConnectorInstanceRequest:
+  type: object
+  required:
+    - label
+  properties:
+    label:
+      type: string
+      description: Display label for the new instance (unique per agent and connector).
+
+PatchAgentConnectorInstanceRequest:
+  type: object
+  required:
+    - label
+  properties:
+    label:
+      type: string
+      description: New display label for the instance.

--- a/spec/openapi/components/schemas/agent_connector_instances.yaml
+++ b/spec/openapi/components/schemas/agent_connector_instances.yaml
@@ -45,6 +45,8 @@ CreateAgentConnectorInstanceRequest:
   properties:
     label:
       type: string
+      minLength: 1
+      maxLength: 256
       description: Display label for the new instance (unique per agent and connector).
 
 PatchAgentConnectorInstanceRequest:
@@ -54,4 +56,6 @@ PatchAgentConnectorInstanceRequest:
   properties:
     label:
       type: string
+      minLength: 1
+      maxLength: 256
       description: New display label for the instance.

--- a/spec/openapi/components/schemas/errors.yaml
+++ b/spec/openapi/components/schemas/errors.yaml
@@ -33,6 +33,7 @@ Error:
         - token_already_used
         - insufficient_scope
         - invalid_parameters
+        - connector_instance_required
         # 404 Not Found
         - agent_not_found
         - approver_not_found
@@ -40,6 +41,7 @@ Error:
         - credential_not_found
         - connector_not_found
         - agent_connector_not_found
+        - connector_instance_not_found
         - credentials_not_found
         - no_matching_standing_approval
         # 403 Forbidden (plan limits)

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1524,11 +1524,16 @@ paths:
       operationId: assignAgentConnectorCredential
       summary: Assign Credential to Agent Connector
       description: |
+        **Deprecated:** targets the **default** connector instance only. Prefer
+        `PUT /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential`
+        for per-instance bindings.
+
         Assign a credential or OAuth connection to an agent-connector pair. This determines
         which credential the agent uses when executing actions through this connector.
 
         Exactly one of `credential_id` or `oauth_connection_id` must be provided.
         If a credential is already assigned, it is replaced (upsert behavior).
+      deprecated: true
       tags:
         - Agents
       security:
@@ -1580,8 +1585,12 @@ paths:
       operationId: removeAgentConnectorCredential
       summary: Remove Credential from Agent Connector
       description: |
+        **Deprecated:** removes the binding for the **default** instance only. Prefer
+        `DELETE .../instances/{instance_id}/credential` for per-instance removal.
+
         Remove the credential binding for an agent-connector pair. After removal,
         the agent falls back to user-global credential resolution for this connector.
+      deprecated: true
       tags:
         - Agents
       security:
@@ -1616,7 +1625,11 @@ paths:
       operationId: getAgentConnectorCredential
       summary: Get Agent Connector Credential
       description: |
+        **Deprecated:** returns the binding for the **default** instance only. Prefer
+        `GET .../instances/{instance_id}/credential` for a specific instance.
+
         Get the current credential binding for an agent-connector pair.
+      deprecated: true
       tags:
         - Agents
       security:
@@ -1751,6 +1764,331 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances:
+    get:
+      operationId: listAgentConnectorInstances
+      summary: List connector instances for an agent
+      description: |
+        Returns all instances of a connector type enabled for the agent (including the default instance).
+
+        Requires session authentication (Supabase JWT).
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      responses:
+        '200':
+          description: Instances listed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorInstanceListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent not found or not owned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      operationId: createAgentConnectorInstance
+      summary: Create an additional connector instance
+      description: |
+        Creates a new labeled instance for this connector type. The first instance for a connector
+        is created when the connector is enabled; this endpoint adds further instances.
+
+        Requires session authentication (Supabase JWT).
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentConnectorInstanceRequest'
+      responses:
+        '201':
+          description: Instance created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorInstance'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Agent or connector not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}:
+    get:
+      operationId: getAgentConnectorInstance
+      summary: Get a connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '200':
+          description: Instance found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorInstance'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      operationId: patchAgentConnectorInstance
+      summary: Rename a connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchAgentConnectorInstanceRequest'
+      responses:
+        '200':
+          description: Instance updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorInstance'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      operationId: deleteAgentConnectorInstance
+      summary: Delete a non-default connector instance
+      description: |
+        Deletes an additional instance. The default instance cannot be deleted; disable the connector type instead.
+
+        Active standing approvals scoped to this instance are revoked.
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '204':
+          description: Instance deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential:
+    put:
+      operationId: assignAgentConnectorInstanceCredential
+      summary: Assign credential to a connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignCredentialRequest'
+      responses:
+        '200':
+          description: Credential assigned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCredentialResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      operationId: removeAgentConnectorInstanceCredential
+      summary: Remove credential from a connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '200':
+          description: Binding removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: removed
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      operationId: getAgentConnectorInstanceCredential
+      summary: Get credential binding for a connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '200':
+          description: Binding (possibly empty)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCredentialResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/calendars:
+    get:
+      operationId: listAgentConnectorInstanceCalendars
+      summary: List calendars for a specific connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '200':
+          description: Calendars listed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorCalendarListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/channels:
+    get:
+      operationId: listAgentConnectorInstanceChannels
+      summary: List channels for a specific connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '200':
+          description: Channels listed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorChannelListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/users:
+    get:
+      operationId: listAgentConnectorInstanceUsers
+      summary: List users for a specific connector instance
+      tags:
+        - Agents
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/AgentId'
+        - $ref: '#/components/parameters/ConnectorId'
+        - $ref: '#/components/parameters/ConnectorInstanceId'
+      responses:
+        '200':
+          description: Users listed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentConnectorUserListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
         '503':
@@ -9555,6 +9893,60 @@ components:
         connector_id: gmail
         disabled_at: '2026-02-18T12:00:00Z'
         revoked_standing_approvals: 2
+    AgentConnectorInstance:
+      type: object
+      required:
+        - connector_instance_id
+        - agent_id
+        - connector_id
+        - label
+        - is_default
+        - enabled_at
+      properties:
+        connector_instance_id:
+          type: string
+          format: uuid
+          description: Surrogate identifier for this connector instance on the agent.
+        agent_id:
+          type: integer
+          format: int64
+        connector_id:
+          type: string
+          maxLength: 128
+        label:
+          type: string
+          description: Human-readable label unique per agent and connector type.
+        is_default:
+          type: boolean
+          description: True for the default instance used when no instance is specified (legacy routes).
+        enabled_at:
+          type: string
+          format: date-time
+    AgentConnectorInstanceListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentConnectorInstance'
+    CreateAgentConnectorInstanceRequest:
+      type: object
+      required:
+        - label
+      properties:
+        label:
+          type: string
+          description: Display label for the new instance (unique per agent and connector).
+    PatchAgentConnectorInstanceRequest:
+      type: object
+      required:
+        - label
+      properties:
+        label:
+          type: string
+          description: New display label for the instance.
     CreateRegistrationInviteRequest:
       type: object
       description: Request to create a registration invite.
@@ -11388,12 +11780,14 @@ components:
             - token_already_used
             - insufficient_scope
             - invalid_parameters
+            - connector_instance_required
             - agent_not_found
             - approver_not_found
             - approval_not_found
             - credential_not_found
             - connector_not_found
             - agent_connector_not_found
+            - connector_instance_not_found
             - credentials_not_found
             - no_matching_standing_approval
             - agent_limit_reached
@@ -12164,6 +12558,16 @@ components:
         maxLength: 128
         pattern: ^[a-z][a-z0-9_.-]*$
       example: gmail
+    ConnectorInstanceId:
+      name: instance_id
+      in: path
+      required: true
+      description: |
+        Connector instance UUID (`connector_instance_id` from list/create instance responses).
+      schema:
+        type: string
+        format: uuid
+      example: 550e8400-e29b-41d4-a716-446655440000
     InviteCode:
       name: invite_code
       in: path

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -9938,6 +9938,8 @@ components:
       properties:
         label:
           type: string
+          minLength: 1
+          maxLength: 256
           description: Display label for the new instance (unique per agent and connector).
     PatchAgentConnectorInstanceRequest:
       type: object
@@ -9946,6 +9948,8 @@ components:
       properties:
         label:
           type: string
+          minLength: 1
+          maxLength: 256
           description: New display label for the instance.
     CreateRegistrationInviteRequest:
       type: object

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -162,6 +162,24 @@ paths:
   /v1/agents/{agent_id}/connectors/{connector_id}/users:
     $ref: './components/paths/agent_connectors.yaml#/agentConnectorUsers'
 
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances:
+    $ref: './components/paths/agent_connector_instances.yaml#/agentConnectorInstances'
+
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}:
+    $ref: './components/paths/agent_connector_instances.yaml#/agentConnectorInstanceById'
+
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential:
+    $ref: './components/paths/agent_connector_instances.yaml#/agentConnectorInstanceCredential'
+
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/calendars:
+    $ref: './components/paths/agent_connector_instances.yaml#/agentConnectorInstanceCalendars'
+
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/channels:
+    $ref: './components/paths/agent_connector_instances.yaml#/agentConnectorInstanceChannels'
+
+  /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/users:
+    $ref: './components/paths/agent_connector_instances.yaml#/agentConnectorInstanceUsers'
+
   /v1/registration-invites:
     $ref: './components/paths/registration_invites.yaml#/createRegistrationInvite'
 
@@ -479,6 +497,14 @@ components:
       $ref: './components/schemas/agent_connectors.yaml#/AgentConnectorResponse'
     DisableAgentConnectorResponse:
       $ref: './components/schemas/agent_connectors.yaml#/DisableAgentConnectorResponse'
+    AgentConnectorInstance:
+      $ref: './components/schemas/agent_connector_instances.yaml#/AgentConnectorInstance'
+    AgentConnectorInstanceListResponse:
+      $ref: './components/schemas/agent_connector_instances.yaml#/AgentConnectorInstanceListResponse'
+    CreateAgentConnectorInstanceRequest:
+      $ref: './components/schemas/agent_connector_instances.yaml#/CreateAgentConnectorInstanceRequest'
+    PatchAgentConnectorInstanceRequest:
+      $ref: './components/schemas/agent_connector_instances.yaml#/PatchAgentConnectorInstanceRequest'
 
     # Registration Invites
     CreateRegistrationInviteRequest:
@@ -668,6 +694,8 @@ components:
       $ref: './components/parameters/common.yaml#/CredentialId'
     ConnectorId:
       $ref: './components/parameters/common.yaml#/ConnectorId'
+    ConnectorInstanceId:
+      $ref: './components/parameters/common.yaml#/ConnectorInstanceId'
     InviteCode:
       $ref: './components/parameters/common.yaml#/InviteCode'
     StandingApprovalId:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 2** of #962: database helpers for connector instances, new REST routes under `/agents/{agent_id}/connectors/{connector_id}/instances`, credential and metadata handlers scoped by `instance_id`, legacy routes targeting the **default** instance, standing approval struct/insert support for `connector_instance_id`, and `FindActiveStandingApprovalsForAgent` filtering when a non-empty instance ID is passed (Phase 4 can thread the resolved instance through).

OpenAPI: new paths and schemas, `ConnectorInstanceId` path parameter, legacy `/credential` operations marked **deprecated** in descriptions, new error codes `connector_instance_required` and `connector_instance_not_found`, bundled spec updated. `google/uuid` is now a direct module dependency for instance selector parsing.

## Test plan

### Developer

- [x] `make bundle` + frontend `tsc -b --noEmit` after spec change
- [x] `make test-frontend` — passed (1008 tests)
- [ ] `go test ./db/...` and `go test ./api/...` — **not run in this environment** (no PostgreSQL on localhost; `go test` also requires toolchain/modules consistent with CI). New tests: `db/agent_connector_instances_test.go`, `api/agent_connector_instances_test.go`.

### Manual Testing

- [ ] Create a second Slack instance via `POST .../instances`; list shows two rows with distinct UUIDs
- [ ] Legacy `GET/PUT/DELETE .../credential` still affects only the default instance when multiple instances exist
- [ ] `PATCH .../instances/{id}` duplicate label returns 409
- [ ] `DELETE` non-default instance removes credential row (cascade) and revokes instance-scoped standing approvals

Refs #962
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cbeaa98-b16c-41dc-8889-48ee9c452248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cbeaa98-b16c-41dc-8889-48ee9c452248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

