### PR TITLE
Phase 3: Connector instances dashboard UI (issue #962)

### DIFF
--- a/api/agent_connector_instances.go
+++ b/api/agent_connector_instances.go
@@ -29,7 +29,8 @@ type createAgentConnectorInstanceRequest struct {
 }
 
 type patchAgentConnectorInstanceRequest struct {
-	Label string `json:"label"`
+	Label     *string `json:"label,omitempty"`
+	IsDefault *bool   `json:"is_default,omitempty"`
 }
 
 func init() {
@@ -242,25 +243,59 @@ func handlePatchAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 		if !DecodeJSONOrReject(w, r, &req) {
 			return
 		}
-
-		inst, err := db.RenameAgentConnectorInstance(r.Context(), deps.DB, agentID, userID, connectorID, instanceID, req.Label)
-		if err != nil {
-			if errors.Is(err, db.ErrAgentConnectorInstanceLabelRequired) || errors.Is(err, db.ErrAgentConnectorInstanceLabelTooLong) {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be 1–256 characters"))
-				return
-			}
-			var instErr *db.AgentConnectorInstanceError
-			if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
-				RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
-				return
-			}
-			log.Printf("[%s] RenameAgentConnectorInstance: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to rename connector instance"))
+		if req.Label == nil && req.IsDefault == nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Provide label and/or is_default"))
 			return
 		}
+		if req.IsDefault != nil && !*req.IsDefault {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "is_default may only be set to true"))
+			return
+		}
+
+		ctx := r.Context()
+		var inst *db.AgentConnectorInstance
+
+		if req.Label != nil {
+			var err error
+			inst, err = db.RenameAgentConnectorInstance(ctx, deps.DB, agentID, userID, connectorID, instanceID, *req.Label)
+			if err != nil {
+				if errors.Is(err, db.ErrAgentConnectorInstanceLabelRequired) || errors.Is(err, db.ErrAgentConnectorInstanceLabelTooLong) {
+					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be 1–256 characters"))
+					return
+				}
+				var instErr *db.AgentConnectorInstanceError
+				if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
+					RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
+					return
+				}
+				log.Printf("[%s] RenameAgentConnectorInstance: %v", TraceID(ctx), err)
+				CaptureError(ctx, err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to rename connector instance"))
+				return
+			}
+			if inst == nil {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+				return
+			}
+		}
+
+		if req.IsDefault != nil && *req.IsDefault {
+			def, err := db.SetDefaultAgentConnectorInstance(ctx, deps.DB, agentID, userID, connectorID, instanceID)
+			if err != nil {
+				log.Printf("[%s] SetDefaultAgentConnectorInstance: %v", TraceID(ctx), err)
+				CaptureError(ctx, err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update default connector instance"))
+				return
+			}
+			if def == nil {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+				return
+			}
+			inst = def
+		}
+
 		if inst == nil {
-			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update connector instance"))
 			return
 		}
 		RespondJSON(w, http.StatusOK, toAgentConnectorInstanceResponse(*inst))

--- a/api/agent_connector_instances_test.go
+++ b/api/agent_connector_instances_test.go
@@ -81,6 +81,50 @@ func TestCreateAgentConnectorInstance_Second(t *testing.T) {
 	}
 }
 
+func TestPatchAgentConnectorInstance_SetDefault(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Sales"}`))
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("create second: %d %s", w1.Code, w1.Body.String())
+	}
+	var created agentConnectorInstanceResponse
+	if err := json.Unmarshal(w1.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal created: %v", err)
+	}
+
+	patchPayload, err := json.Marshal(map[string]bool{"is_default": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2 := authenticatedRequestWithBody(t, http.MethodPatch,
+		fmt.Sprintf("/agents/%d/connectors/%s/instances/%s", agentID, connID, created.ConnectorInstanceID), uid, patchPayload)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var patched agentConnectorInstanceResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("unmarshal patched: %v", err)
+	}
+	if !patched.IsDefault {
+		t.Error("expected patched instance to be default")
+	}
+}
+
 func TestPatchAgentConnectorInstance_DuplicateLabel409(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -216,6 +216,52 @@ func GetDefaultAgentConnectorInstanceByAgent(ctx context.Context, db DBTX, agent
 	return inst, nil
 }
 
+// SetDefaultAgentConnectorInstance marks the given instance as the default for
+// (agent, connector) and clears is_default on sibling instances.
+func SetDefaultAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID string) (*AgentConnectorInstance, error) {
+	tx, owned, err := BeginOrContinue(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if owned {
+		defer RollbackTx(ctx, tx) //nolint:errcheck // commit path clears
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE agent_connectors
+		SET is_default = false
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3
+		  AND is_default
+		  AND connector_instance_id <> $4::uuid`,
+		agentID, approverID, connectorID, connectorInstanceID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	row := tx.QueryRow(ctx, `
+		UPDATE agent_connectors
+		SET is_default = true
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid
+		RETURNING connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at`,
+		agentID, approverID, connectorID, connectorInstanceID,
+	)
+	inst, err := scanAgentConnectorInstance(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if owned {
+		if err := CommitTx(ctx, tx); err != nil {
+			return nil, err
+		}
+	}
+	return inst, nil
+}
+
 // RenameAgentConnectorInstance updates the label for an instance.
 func RenameAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID, newLabel string) (*AgentConnectorInstance, error) {
 	label := strings.TrimSpace(newLabel)

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -91,6 +91,56 @@ func TestCreateAgentConnectorInstance_RequiresConnectorEnabled(t *testing.T) {
 	}
 }
 
+func TestSetDefaultAgentConnectorInstance_SwitchesDefault(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID:     agentID,
+		ApproverID:  uid,
+		ConnectorID: connID,
+		Label:       "Sales",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentConnectorInstance: %v", err)
+	}
+
+	def1, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || def1 == nil {
+		t.Fatalf("default before: err=%v inst=%v", err, def1)
+	}
+	if !def1.IsDefault {
+		t.Error("expected def1 is_default")
+	}
+	if def1.ConnectorInstanceID == inst2.ConnectorInstanceID {
+		t.Fatal("second instance should not start as default")
+	}
+
+	updated, err := db.SetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID, inst2.ConnectorInstanceID)
+	if err != nil {
+		t.Fatalf("SetDefaultAgentConnectorInstance: %v", err)
+	}
+	if updated == nil || !updated.IsDefault {
+		t.Fatalf("expected updated default: %+v", updated)
+	}
+
+	def2, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || def2 == nil {
+		t.Fatalf("default after: err=%v inst=%v", err, def2)
+	}
+	if def2.ConnectorInstanceID != inst2.ConnectorInstanceID {
+		t.Fatalf("expected Sales instance default, got %s", def2.ConnectorInstanceID)
+	}
+}
+
 func TestCreateAgentConnectorInstance_DuplicateLabel(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/frontend/src/hooks/__tests__/useAgentConnectorInstances.test.tsx
+++ b/frontend/src/hooks/__tests__/useAgentConnectorInstances.test.tsx
@@ -1,0 +1,169 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../test-helpers";
+import {
+  mockGet,
+  mockPost,
+  mockPatch,
+  mockDelete,
+  resetClientMocks,
+} from "../../api/__mocks__/client";
+import {
+  useAgentConnectorInstances,
+  useCreateAgentConnectorInstance,
+  useRenameAgentConnectorInstance,
+  useSetDefaultAgentConnectorInstance,
+  useDeleteAgentConnectorInstance,
+} from "../useAgentConnectorInstances";
+
+vi.mock("../../lib/supabaseClient");
+vi.mock("../../api/client");
+
+describe("useAgentConnectorInstances", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("lists instances", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            connector_instance_id: "11111111-1111-1111-1111-111111111111",
+            agent_id: 1,
+            connector_id: "slack",
+            label: "Main",
+            is_default: true,
+            enabled_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(
+      () => useAgentConnectorInstances(1, "slack"),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.instances).toHaveLength(1);
+    });
+    expect(result.current.instances[0]?.label).toBe("Main");
+    expect(mockGet).toHaveBeenCalledWith(
+      "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
+      expect.objectContaining({
+        params: { path: { agent_id: 1, connector_id: "slack" } },
+      }),
+    );
+  });
+
+  it("create posts label", async () => {
+    mockPost.mockResolvedValue({ data: {} });
+    const { result } = renderHook(() => useCreateAgentConnectorInstance(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.create({
+        agentId: 1,
+        connectorId: "slack",
+        label: "Sales",
+      });
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
+      expect.objectContaining({
+        body: { label: "Sales" },
+        params: { path: { agent_id: 1, connector_id: "slack" } },
+      }),
+    );
+  });
+
+  it("setDefault patches is_default", async () => {
+    mockPatch.mockResolvedValue({ data: {} });
+    const { result } = renderHook(
+      () => useSetDefaultAgentConnectorInstance(),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.setDefault({
+        agentId: 1,
+        connectorId: "slack",
+        instanceId: "22222222-2222-2222-2222-222222222222",
+      });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith(
+      "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+      expect.objectContaining({
+        body: { is_default: true },
+        params: {
+          path: {
+            agent_id: 1,
+            connector_id: "slack",
+            instance_id: "22222222-2222-2222-2222-222222222222",
+          },
+        },
+      }),
+    );
+  });
+
+  it("rename patches label", async () => {
+    mockPatch.mockResolvedValue({ data: {} });
+    const { result } = renderHook(() => useRenameAgentConnectorInstance(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.rename({
+        agentId: 1,
+        connectorId: "slack",
+        instanceId: "11111111-1111-1111-1111-111111111111",
+        label: "Renamed",
+      });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith(
+      "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+      expect.objectContaining({
+        body: { label: "Renamed" },
+      }),
+    );
+  });
+
+  it("deleteInstance calls DELETE", async () => {
+    mockDelete.mockResolvedValue({ data: {} });
+    const { result } = renderHook(() => useDeleteAgentConnectorInstance(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.deleteInstance({
+        agentId: 1,
+        connectorId: "slack",
+        instanceId: "22222222-2222-2222-2222-222222222222",
+      });
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+      expect.objectContaining({
+        params: {
+          path: {
+            agent_id: 1,
+            connector_id: "slack",
+            instance_id: "22222222-2222-2222-2222-222222222222",
+          },
+        },
+      }),
+    );
+  });
+});

--- a/frontend/src/hooks/useAgentConnectorInstanceCredential.ts
+++ b/frontend/src/hooks/useAgentConnectorInstanceCredential.ts
@@ -3,45 +3,49 @@ import { useAuth } from "@/auth/AuthContext";
 import client from "@/api/client";
 import type { components } from "@/api/schema";
 
-export type AgentConnectorCredential =
+export type AgentConnectorCredentialResponse =
   components["schemas"]["AgentConnectorCredentialResponse"];
 
-export function useAgentConnectorCredential(
+export function useAgentConnectorInstanceCredential(
   agentId: number,
   connectorId: string,
+  instanceId: string,
 ) {
   const { session } = useAuth();
   const accessToken = session?.access_token;
 
   const query = useQuery({
-    queryKey: ["agent-connector-credential", agentId, connectorId],
+    queryKey: ["agent-connector-instance-credential", agentId, connectorId, instanceId],
     queryFn: async () => {
       if (!accessToken) throw new Error("Missing access token");
       const { data, error } = await client.GET(
-        "/v1/agents/{agent_id}/connectors/{connector_id}/credential",
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
         {
           headers: { Authorization: `Bearer ${accessToken}` },
-          params: { path: { agent_id: agentId, connector_id: connectorId } },
+          params: {
+            path: {
+              agent_id: agentId,
+              connector_id: connectorId,
+              instance_id: instanceId,
+            },
+          },
         },
       );
       if (error) throw new Error("Failed to load credential binding");
       return data;
     },
-    enabled: !!accessToken && agentId > 0 && !!connectorId,
+    enabled: !!accessToken && agentId > 0 && !!connectorId && !!instanceId,
   });
 
   return {
     binding: query.data ?? null,
     isLoading: query.isLoading,
-    /** True while the first credential binding fetch is in flight (avoids UI flash). */
     isCredentialBindingPending: query.isPending,
-    error: query.isError
-      ? "Unable to load credential binding."
-      : null,
+    error: query.isError ? "Unable to load credential binding." : null,
   };
 }
 
-export function useAssignAgentConnectorCredential() {
+export function useAssignAgentConnectorInstanceCredential() {
   const { session } = useAuth();
   const accessToken = session?.access_token;
   const queryClient = useQueryClient();
@@ -50,20 +54,28 @@ export function useAssignAgentConnectorCredential() {
     mutationFn: async ({
       agentId,
       connectorId,
+      instanceId,
       credentialId,
       oauthConnectionId,
     }: {
       agentId: number;
       connectorId: string;
+      instanceId: string;
       credentialId?: string;
       oauthConnectionId?: string;
     }) => {
       if (!accessToken) throw new Error("Missing access token");
       const { data, error } = await client.PUT(
-        "/v1/agents/{agent_id}/connectors/{connector_id}/credential",
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
         {
           headers: { Authorization: `Bearer ${accessToken}` },
-          params: { path: { agent_id: agentId, connector_id: connectorId } },
+          params: {
+            path: {
+              agent_id: agentId,
+              connector_id: connectorId,
+              instance_id: instanceId,
+            },
+          },
           body: {
             credential_id: credentialId,
             oauth_connection_id: oauthConnectionId,
@@ -81,9 +93,10 @@ export function useAssignAgentConnectorCredential() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: [
-          "agent-connector-credential",
+          "agent-connector-instance-credential",
           variables.agentId,
           variables.connectorId,
+          variables.instanceId,
         ],
       });
       queryClient.invalidateQueries({
@@ -109,7 +122,7 @@ export function useAssignAgentConnectorCredential() {
   };
 }
 
-export function useRemoveAgentConnectorCredential() {
+export function useRemoveAgentConnectorInstanceCredential() {
   const { session } = useAuth();
   const accessToken = session?.access_token;
   const queryClient = useQueryClient();
@@ -118,16 +131,24 @@ export function useRemoveAgentConnectorCredential() {
     mutationFn: async ({
       agentId,
       connectorId,
+      instanceId,
     }: {
       agentId: number;
       connectorId: string;
+      instanceId: string;
     }) => {
       if (!accessToken) throw new Error("Missing access token");
-      const { data, error } = await client.DELETE(
-        "/v1/agents/{agent_id}/connectors/{connector_id}/credential",
+      const { error } = await client.DELETE(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
         {
           headers: { Authorization: `Bearer ${accessToken}` },
-          params: { path: { agent_id: agentId, connector_id: connectorId } },
+          params: {
+            path: {
+              agent_id: agentId,
+              connector_id: connectorId,
+              instance_id: instanceId,
+            },
+          },
         },
       );
       if (error) {
@@ -136,14 +157,14 @@ export function useRemoveAgentConnectorCredential() {
           "Failed to remove credential";
         throw new Error(msg);
       }
-      return data;
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: [
-          "agent-connector-credential",
+          "agent-connector-instance-credential",
           variables.agentId,
           variables.connectorId,
+          variables.instanceId,
         ],
       });
       queryClient.invalidateQueries({

--- a/frontend/src/hooks/useAgentConnectorInstances.ts
+++ b/frontend/src/hooks/useAgentConnectorInstances.ts
@@ -1,0 +1,277 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type AgentConnectorInstance = components["schemas"]["AgentConnectorInstance"];
+
+export function useAgentConnectorInstances(agentId: number, connectorId: string) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const query = useQuery({
+    queryKey: ["agent-connector-instances", agentId, connectorId],
+    queryFn: async () => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.GET(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { path: { agent_id: agentId, connector_id: connectorId } },
+        },
+      );
+      if (error) throw new Error("Failed to load connector instances");
+      return data?.data ?? [];
+    },
+    enabled: !!accessToken && agentId > 0 && !!connectorId,
+  });
+
+  return {
+    instances: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.isError ? "Unable to load connector instances." : null,
+    refetch: query.refetch,
+  };
+}
+
+export function useCreateAgentConnectorInstance() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      agentId,
+      connectorId,
+      label,
+    }: {
+      agentId: number;
+      connectorId: string;
+      label: string;
+    }) => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.POST(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { path: { agent_id: agentId, connector_id: connectorId } },
+          body: { label },
+        },
+      );
+      if (error) {
+        const msg =
+          (error as { error?: { message?: string } }).error?.message ??
+          "Failed to create instance";
+        throw new Error(msg);
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-connector-instances", variables.agentId, variables.connectorId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+    },
+  });
+
+  return {
+    create: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export function useRenameAgentConnectorInstance() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      agentId,
+      connectorId,
+      instanceId,
+      label,
+    }: {
+      agentId: number;
+      connectorId: string;
+      instanceId: string;
+      label: string;
+    }) => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.PATCH(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: {
+            path: {
+              agent_id: agentId,
+              connector_id: connectorId,
+              instance_id: instanceId,
+            },
+          },
+          body: { label },
+        },
+      );
+      if (error) {
+        const msg =
+          (error as { error?: { message?: string } }).error?.message ??
+          "Failed to rename instance";
+        throw new Error(msg);
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-connector-instances", variables.agentId, variables.connectorId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "agent-connector-instance-credential",
+          variables.agentId,
+          variables.connectorId,
+          variables.instanceId,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+    },
+  });
+
+  return {
+    rename: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export function useSetDefaultAgentConnectorInstance() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      agentId,
+      connectorId,
+      instanceId,
+    }: {
+      agentId: number;
+      connectorId: string;
+      instanceId: string;
+    }) => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data, error } = await client.PATCH(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: {
+            path: {
+              agent_id: agentId,
+              connector_id: connectorId,
+              instance_id: instanceId,
+            },
+          },
+          body: { is_default: true },
+        },
+      );
+      if (error) {
+        const msg =
+          (error as { error?: { message?: string } }).error?.message ??
+          "Failed to set default instance";
+        throw new Error(msg);
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-connector-instances", variables.agentId, variables.connectorId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+    },
+  });
+
+  return {
+    setDefault: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export function useDeleteAgentConnectorInstance() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      agentId,
+      connectorId,
+      instanceId,
+    }: {
+      agentId: number;
+      connectorId: string;
+      instanceId: string;
+    }) => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { error } = await client.DELETE(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: {
+            path: {
+              agent_id: agentId,
+              connector_id: connectorId,
+              instance_id: instanceId,
+            },
+          },
+        },
+      );
+      if (error) {
+        const msg =
+          (error as { error?: { message?: string } }).error?.message ??
+          "Failed to delete instance";
+        throw new Error(msg);
+      }
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-connector-instances", variables.agentId, variables.connectorId],
+      });
+      queryClient.removeQueries({
+        queryKey: [
+          "agent-connector-instance-credential",
+          variables.agentId,
+          variables.connectorId,
+          variables.instanceId,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+    },
+  });
+
+  return {
+    deleteInstance: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/hooks/useConnectorInstanceBindingsSummary.ts
+++ b/frontend/src/hooks/useConnectorInstanceBindingsSummary.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+
+export interface ConnectorInstanceBindingsSummary {
+  instanceCount: number;
+  oauthConnectionIds: string[];
+  hasApiKeyCredential: boolean;
+}
+
+/**
+ * Loads connector instances and each instance's credential binding for danger-zone
+ * copy and OAuth disconnect-on-remove.
+ */
+export function useConnectorInstanceBindingsSummary(
+  agentId: number,
+  connectorId: string,
+) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  return useQuery({
+    queryKey: ["connector-instance-bindings-summary", agentId, connectorId],
+    queryFn: async (): Promise<ConnectorInstanceBindingsSummary> => {
+      if (!accessToken) throw new Error("Missing access token");
+      const { data: listData, error: listErr } = await client.GET(
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params: { path: { agent_id: agentId, connector_id: connectorId } },
+        },
+      );
+      if (listErr) throw new Error("Failed to list instances");
+      const instances = listData?.data ?? [];
+      const oauthIds: string[] = [];
+      let hasApiKeyCredential = false;
+
+      await Promise.all(
+        instances.map(async (inst) => {
+          const { data: credData, error: credErr } = await client.GET(
+            "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
+            {
+              headers: { Authorization: `Bearer ${accessToken}` },
+              params: {
+                path: {
+                  agent_id: agentId,
+                  connector_id: connectorId,
+                  instance_id: inst.connector_instance_id,
+                },
+              },
+            },
+          );
+          if (credErr || !credData) return;
+          if (credData.oauth_connection_id) {
+            oauthIds.push(credData.oauth_connection_id);
+          }
+          if (credData.credential_id) {
+            hasApiKeyCredential = true;
+          }
+        }),
+      );
+
+      return {
+        instanceCount: instances.length,
+        oauthConnectionIds: [...new Set(oauthIds)],
+        hasApiKeyCredential,
+      };
+    },
+    enabled: !!accessToken && agentId > 0 && !!connectorId,
+  });
+}

--- a/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorConfigPage.tsx
@@ -6,11 +6,10 @@ import { useAgent } from "@/hooks/useAgent";
 import { useActionConfigs } from "@/hooks/useActionConfigs";
 import { useConnectorDetail } from "@/hooks/useConnectorDetail";
 import { useAgentConnectors } from "@/hooks/useAgentConnectors";
-import { useAgentConnectorCredential } from "@/hooks/useAgentConnectorCredential";
 import { ConnectorOverviewSection } from "./ConnectorOverviewSection";
 import { ConnectorActionsDialog } from "./ConnectorActionsDialog";
 import { ActionConfigurationsSection } from "./ActionConfigurationsSection";
-import { ConnectorCredentialsSection } from "./ConnectorCredentialsSection";
+import { ConnectorInstancesSection } from "./ConnectorInstancesSection";
 import { DisableConnectorSection } from "./DisableConnectorSection";
 
 export function ConnectorConfigPage() {
@@ -46,11 +45,6 @@ export function ConnectorConfigPage() {
     error: configsError,
     refetch: refetchConfigs,
   } = useActionConfigs(agentId);
-
-  const { binding: credentialBinding } = useAgentConnectorCredential(
-    agentId,
-    connectorId ?? "",
-  );
 
   const connectorConfigs = configs.filter((c) => c.connector_id === connectorId);
 
@@ -163,7 +157,7 @@ export function ConnectorConfigPage() {
         error={configsError}
         onConfigsChanged={() => void refetchConfigs()}
       />
-      <ConnectorCredentialsSection
+      <ConnectorInstancesSection
         agentId={agentId}
         connectorId={connectorId}
         requiredCredentials={connector.required_credentials}
@@ -177,8 +171,6 @@ export function ConnectorConfigPage() {
             (c) => c.auth_type === "oauth2" && c.oauth_provider,
           )?.oauth_provider
         }
-        oauthConnectionId={credentialBinding?.oauth_connection_id ?? undefined}
-        hasApiKeyCredential={!!credentialBinding?.credential_id}
       />
     </div>
   );

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
@@ -1,0 +1,160 @@
+/**
+ * Connector instances layout — Storybook
+ *
+ * Mirrors the structure of `ConnectorInstancesSection` (cards, default badge,
+ * credential row) without API calls so Storybook stays offline.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { Check, Pencil, Plus, Settings, Star, Trash2, Unplug } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const selectClassName =
+  "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
+
+function ConnectorInstancesSectionLayoutMirror() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Connector instances</CardTitle>
+        <CardDescription>
+          Connect via OAuth (recommended) or use an API key as an alternative.
+          Each instance can use its own credential.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="rounded-lg border p-4">
+            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium">Engineering</p>
+                  <Badge variant="secondary">Default</Badge>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    aria-label="Rename instance"
+                  >
+                    <Pencil className="size-3.5" />
+                  </Button>
+                </div>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Added 3/1/2026, 12:00:00 PM
+                </p>
+              </div>
+            </div>
+            <div className="rounded-md border border-dashed p-3">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Label className="text-sm font-medium">Credential</Label>
+                  <Badge
+                    variant="secondary"
+                    className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                  >
+                    Assigned
+                  </Badge>
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  This instance uses the selected credential or OAuth connection.
+                </p>
+                <Button type="button" variant="ghost" size="sm" className="h-8 px-2">
+                  <Unplug className="size-3.5" />
+                  Disconnect
+                </Button>
+                <select className={selectClassName} defaultValue="oauth:oconn_1">
+                  <option value="oauth:oconn_1">
+                    Slack OAuth — Acme Workspace (connected 3/1/2026)
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border p-4">
+            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input defaultValue="Sales" className="max-w-md" />
+                  <Button type="button" size="sm" variant="secondary">
+                    <Check className="size-4" />
+                    Save
+                  </Button>
+                </div>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Added 3/2/2026, 12:00:00 PM
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" variant="outline" size="sm">
+                  <Star className="size-3.5" />
+                  Make default
+                </Button>
+                <Button type="button" variant="outline" size="sm">
+                  <Trash2 className="size-3.5" />
+                  Remove instance
+                </Button>
+              </div>
+            </div>
+            <div className="rounded-md border border-dashed p-3">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Label className="text-sm font-medium">Credential</Label>
+                  <Badge variant="destructive">Not set</Badge>
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  Select a credential so this instance can run actions.
+                </p>
+                <select className={selectClassName} defaultValue="">
+                  <option value="">Select a credential…</option>
+                  <option value="oauth:oconn_2">
+                    Slack OAuth — Sales Workspace (connected 3/2/2026)
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <Button type="button" variant="outline" size="sm" className="w-full sm:w-auto">
+            <Plus className="size-4" />
+            Add another
+          </Button>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button variant="outline" size="sm">
+            <Settings className="size-3" />
+            Manage credentials
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+const meta: Meta<typeof ConnectorInstancesSectionLayoutMirror> = {
+  title: "Agents/ConnectorInstancesSection",
+  component: ConnectorInstancesSectionLayoutMirror,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ConnectorInstancesSectionLayoutMirror>;
+
+export const MultiInstanceLayout: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <ConnectorInstancesSectionLayoutMirror />
+    </div>
+  ),
+};

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -1,0 +1,626 @@
+import { useMemo, useState } from "react";
+import {
+  Check,
+  Loader2,
+  Pencil,
+  Plus,
+  Settings,
+  Star,
+  Trash2,
+  Unplug,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCredentials } from "@/hooks/useCredentials";
+import type { CredentialSummary } from "@/hooks/useCredentials";
+import { useOAuthConnections } from "@/hooks/useOAuthConnections";
+import { useOAuthProviders } from "@/hooks/useOAuthProviders";
+import { providerLabel } from "@/lib/oauth";
+import { serviceLabel } from "@/lib/labels";
+import {
+  useAgentConnectorInstances,
+  useCreateAgentConnectorInstance,
+  useRenameAgentConnectorInstance,
+  useDeleteAgentConnectorInstance,
+  useSetDefaultAgentConnectorInstance,
+  type AgentConnectorInstance,
+} from "@/hooks/useAgentConnectorInstances";
+import {
+  useAgentConnectorInstanceCredential,
+  useAssignAgentConnectorInstanceCredential,
+  useRemoveAgentConnectorInstanceCredential,
+} from "@/hooks/useAgentConnectorInstanceCredential";
+import { useAutoAssignOAuthCredential } from "@/hooks/useAutoAssignOAuthCredential";
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import type { OAuthConnection } from "@/hooks/useOAuthConnections";
+import { ManageCredentialsDialog } from "./ManageCredentialsDialog";
+
+export interface ConnectorInstancesSectionProps {
+  agentId: number;
+  connectorId: string;
+  requiredCredentials: RequiredCredential[];
+}
+
+const selectClassName =
+  "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
+
+export function ConnectorInstancesSection({
+  agentId,
+  connectorId,
+  requiredCredentials,
+}: ConnectorInstancesSectionProps) {
+  const credentialServiceIds = useMemo(
+    () => new Set([connectorId, ...requiredCredentials.map((rc) => rc.service)]),
+    [connectorId, requiredCredentials],
+  );
+  const [manageDialogOpen, setManageDialogOpen] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const [newLabel, setNewLabel] = useState("");
+
+  useAutoAssignOAuthCredential(agentId, connectorId);
+
+  const { instances, isLoading, error } = useAgentConnectorInstances(
+    agentId,
+    connectorId,
+  );
+  const { create, isPending: creating } = useCreateAgentConnectorInstance();
+
+  const hasRequiredCredentials = requiredCredentials.length > 0;
+  const hasExplicitOAuth = requiredCredentials.some(
+    (c) => c.auth_type === "oauth2",
+  );
+  const hasStatic = requiredCredentials.some((c) => c.auth_type !== "oauth2");
+  const { credentials, isLoading: credsLoading, error: credsError } =
+    useCredentials({ enabled: hasStatic });
+  const {
+    connections,
+    isLoading: connectionsLoading,
+    error: oauthError,
+  } = useOAuthConnections({ enabled: true });
+  const { providers, isLoading: providersLoading } = useOAuthProviders({
+    enabled: true,
+  });
+
+  const storedByService = new Map<string, CredentialSummary[]>();
+  for (const cred of credentials) {
+    const list = storedByService.get(cred.service) ?? [];
+    list.push(cred);
+    storedByService.set(cred.service, list);
+  }
+
+  const matchingProvider = providers.find((p) => p.id === connectorId);
+  const hasImplicitOAuth = !hasExplicitOAuth && !!matchingProvider;
+  const hasOAuth = hasExplicitOAuth || hasImplicitOAuth;
+
+  const sorted = [...requiredCredentials].sort((a, b) => {
+    if (a.auth_type === "oauth2" && b.auth_type !== "oauth2") return -1;
+    if (a.auth_type !== "oauth2" && b.auth_type === "oauth2") return 1;
+    return 0;
+  });
+
+  const anyLoading = credsLoading || connectionsLoading || providersLoading;
+  const showManageButton = hasRequiredCredentials || !!matchingProvider;
+
+  async function handleAddInstance() {
+    const label = newLabel.trim();
+    if (!label) {
+      toast.error("Enter a label for the new instance.");
+      return;
+    }
+    try {
+      await create({ agentId, connectorId, label });
+      toast.success("Connector instance added.");
+      setNewLabel("");
+      setAddOpen(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to add instance.");
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Connector instances</CardTitle>
+        {hasOAuth && hasStatic && (
+          <CardDescription>
+            Connect via OAuth (recommended) or use an API key as an
+            alternative. Each instance can use its own credential.
+          </CardDescription>
+        )}
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="flex items-center justify-center py-6" role="status">
+            <Loader2 className="text-muted-foreground size-6 animate-spin" />
+          </div>
+        )}
+        {!isLoading && error && (
+          <p className="text-destructive text-sm">{error}</p>
+        )}
+        {!isLoading && !error && (
+          <div className="space-y-4">
+            {instances.map((inst) => (
+              <InstanceCard
+                key={inst.connector_instance_id}
+                agentId={agentId}
+                connectorId={connectorId}
+                instance={inst}
+                credentialServiceIds={credentialServiceIds}
+                credentials={credentials}
+                connections={connections}
+                anyLoading={anyLoading}
+              />
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => setAddOpen(true)}
+              disabled={creating}
+            >
+              <Plus className="size-4" />
+              Add another
+            </Button>
+          </div>
+        )}
+
+        {showManageButton && (
+          <div className="mt-4 flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setManageDialogOpen(true)}
+            >
+              <Settings className="size-3" />
+              Manage credentials
+            </Button>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add connector instance</DialogTitle>
+            <DialogDescription>
+              Choose a unique label (for example a Slack workspace name). You
+              can connect a credential after the instance is created.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="new-instance-label">Label</Label>
+            <Input
+              id="new-instance-label"
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              placeholder="e.g. Engineering Slack"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleAddInstance();
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setAddOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleAddInstance()} disabled={creating}>
+              {creating && <Loader2 className="size-4 animate-spin" />}
+              Add
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ManageCredentialsDialog
+        open={manageDialogOpen}
+        onOpenChange={setManageDialogOpen}
+        agentId={agentId}
+        connectorId={connectorId}
+        connectorLabel={serviceLabel(connectorId)}
+        hasRequiredCredentials={hasRequiredCredentials}
+        hasImplicitOAuth={hasImplicitOAuth}
+        hasOAuth={hasOAuth}
+        sorted={sorted}
+        connections={connections}
+        providers={providers}
+        storedByService={storedByService}
+        matchingProvider={matchingProvider}
+        anyLoading={anyLoading}
+        error={credsError}
+        oauthError={oauthError}
+      />
+    </Card>
+  );
+}
+
+function InstanceCard({
+  agentId,
+  connectorId,
+  instance,
+  credentialServiceIds,
+  credentials,
+  connections,
+  anyLoading,
+}: {
+  agentId: number;
+  connectorId: string;
+  instance: AgentConnectorInstance;
+  credentialServiceIds: Set<string>;
+  credentials: CredentialSummary[];
+  connections: OAuthConnection[];
+  anyLoading: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [labelDraft, setLabelDraft] = useState(instance.label);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const { rename, isPending: renaming } = useRenameAgentConnectorInstance();
+  const { setDefault, isPending: settingDefault } =
+    useSetDefaultAgentConnectorInstance();
+  const { deleteInstance, isPending: deleting } =
+    useDeleteAgentConnectorInstance();
+
+  const isBusy = renaming || settingDefault || deleting;
+
+  async function commitRename() {
+    const next = labelDraft.trim();
+    if (!next || next === instance.label) {
+      setLabelDraft(instance.label);
+      setEditing(false);
+      return;
+    }
+    try {
+      await rename({
+        agentId,
+        connectorId,
+        instanceId: instance.connector_instance_id,
+        label: next,
+      });
+      toast.success("Instance renamed.");
+      setEditing(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to rename.");
+      setLabelDraft(instance.label);
+      setEditing(false);
+    }
+  }
+
+  async function handleMakeDefault() {
+    try {
+      await setDefault({
+        agentId,
+        connectorId,
+        instanceId: instance.connector_instance_id,
+      });
+      toast.success("Default instance updated.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update default.",
+      );
+    }
+  }
+
+  async function handleDelete() {
+    try {
+      await deleteInstance({
+        agentId,
+        connectorId,
+        instanceId: instance.connector_instance_id,
+      });
+      toast.success("Instance removed.");
+      setDeleteOpen(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove instance.");
+    }
+  }
+
+  return (
+    <>
+      <div className="rounded-lg border p-4">
+        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 flex-1">
+            {editing ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  value={labelDraft}
+                  onChange={(e) => setLabelDraft(e.target.value)}
+                  className="max-w-md"
+                  disabled={renaming}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void commitRename();
+                    if (e.key === "Escape") {
+                      setLabelDraft(instance.label);
+                      setEditing(false);
+                    }
+                  }}
+                  autoFocus
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => void commitRename()}
+                  disabled={renaming}
+                >
+                  <Check className="size-4" />
+                  Save
+                </Button>
+              </div>
+            ) : (
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="font-medium">{instance.label}</p>
+                {instance.is_default && (
+                  <Badge variant="secondary">Default</Badge>
+                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                  onClick={() => {
+                    setLabelDraft(instance.label);
+                    setEditing(true);
+                  }}
+                  disabled={isBusy}
+                  aria-label="Rename instance"
+                >
+                  <Pencil className="size-3.5" />
+                </Button>
+              </div>
+            )}
+            <p className="text-muted-foreground mt-1 text-xs">
+              Added {new Date(instance.enabled_at).toLocaleString()}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {!instance.is_default && (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleMakeDefault()}
+                  disabled={isBusy}
+                >
+                  <Star className="size-3.5" />
+                  Make default
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setDeleteOpen(true)}
+                  disabled={isBusy}
+                >
+                  <Trash2 className="size-3.5" />
+                  Remove instance
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <InstanceCredentialBinding
+          agentId={agentId}
+          connectorId={connectorId}
+          instanceId={instance.connector_instance_id}
+          credentialServiceIds={credentialServiceIds}
+          credentials={credentials}
+          connections={connections}
+          anyLoading={anyLoading}
+        />
+      </div>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove this instance?</DialogTitle>
+            <DialogDescription>
+              This removes the <strong>{instance.label}</strong> instance and its
+              credential binding. Standing approvals scoped to this instance are
+              revoked. The default instance cannot be removed here — disable the
+              connector type instead.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="secondary"
+              onClick={() => setDeleteOpen(false)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void handleDelete()}
+              disabled={deleting}
+            >
+              {deleting && <Loader2 className="mr-2 size-4 animate-spin" />}
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function InstanceCredentialBinding({
+  agentId,
+  connectorId,
+  instanceId,
+  credentialServiceIds,
+  credentials,
+  connections,
+  anyLoading,
+}: {
+  agentId: number;
+  connectorId: string;
+  instanceId: string;
+  credentialServiceIds: Set<string>;
+  credentials: CredentialSummary[];
+  connections: OAuthConnection[];
+  anyLoading: boolean;
+}) {
+  const { binding, isLoading: bindingLoading } = useAgentConnectorInstanceCredential(
+    agentId,
+    connectorId,
+    instanceId,
+  );
+  const { assign, isPending: assigning } =
+    useAssignAgentConnectorInstanceCredential();
+  const { remove, isPending: disconnecting } =
+    useRemoveAgentConnectorInstanceCredential();
+
+  const isLoading = anyLoading || bindingLoading;
+  const isPending = assigning || disconnecting;
+
+  const scopedCredentials = credentials.filter(
+    (c) => credentialServiceIds.has(c.service),
+  );
+  const activeConnections = connections.filter(
+    (c) => c.status === "active" && c.id && c.provider === connectorId,
+  );
+
+  const currentValue = binding?.credential_id
+    ? `cred:${binding.credential_id}`
+    : binding?.oauth_connection_id
+      ? `oauth:${binding.oauth_connection_id}`
+      : "";
+
+  async function handleDisconnect() {
+    if (isPending || !currentValue) return;
+    try {
+      await remove({ agentId, connectorId, instanceId });
+      toast.success("Credential disconnected from this instance.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to disconnect credential.",
+      );
+    }
+  }
+
+  async function handleChange(value: string) {
+    if (isPending || !value) return;
+
+    try {
+      if (value.startsWith("oauth:")) {
+        await assign({
+          agentId,
+          connectorId,
+          instanceId,
+          oauthConnectionId: value.slice("oauth:".length),
+        });
+        toast.success("OAuth connection assigned to this instance.");
+      } else if (value.startsWith("cred:")) {
+        await assign({
+          agentId,
+          connectorId,
+          instanceId,
+          credentialId: value.slice("cred:".length),
+        });
+        toast.success("Credential assigned to this instance.");
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update credential.",
+      );
+    }
+  }
+
+  if (isLoading) return null;
+
+  if (
+    scopedCredentials.length === 0 &&
+    activeConnections.length === 0 &&
+    !binding
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border border-dashed p-3">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Label
+            htmlFor={`agent-credential-${instanceId}`}
+            className="text-sm font-medium"
+          >
+            Credential
+          </Label>
+          {currentValue ? (
+            <Badge
+              variant="secondary"
+              className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+            >
+              Assigned
+            </Badge>
+          ) : (
+            <Badge variant="destructive">Not set</Badge>
+          )}
+        </div>
+        <p className="text-muted-foreground text-sm">
+          {currentValue
+            ? "This instance uses the selected credential or OAuth connection."
+            : "Select a credential so this instance can run actions."}
+        </p>
+        {currentValue && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2"
+            onClick={() => void handleDisconnect()}
+            disabled={isPending}
+          >
+            <Unplug className="size-3.5" />
+            Disconnect
+          </Button>
+        )}
+        <select
+          id={`agent-credential-${instanceId}`}
+          className={selectClassName}
+          value={currentValue}
+          onChange={(e) => void handleChange(e.target.value)}
+          disabled={isPending}
+        >
+          {!currentValue && <option value="">Select a credential…</option>}
+          {activeConnections.map((conn) => (
+            <option key={`oauth:${conn.id}`} value={`oauth:${conn.id}`}>
+              {providerLabel(conn.provider)} OAuth
+              {conn.display_name ? ` — ${conn.display_name}` : ""} (connected{" "}
+              {new Date(conn.connected_at).toLocaleDateString()})
+            </option>
+          ))}
+          {scopedCredentials.map((cred) => (
+            <option key={`cred:${cred.id}`} value={`cred:${cred.id}`}>
+              {cred.label
+                ? `${cred.label} — ${serviceLabel(cred.service)}`
+                : serviceLabel(cred.service)}{" "}
+              (added {new Date(cred.created_at).toLocaleDateString()})
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
+++ b/frontend/src/pages/agents/connectors/DisableConnectorSection.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { useDisableAgentConnector } from "@/hooks/useDisableAgentConnector";
 import { useDisconnectOAuth } from "@/hooks/useDisconnectOAuth";
+import { useConnectorInstanceBindingsSummary } from "@/hooks/useConnectorInstanceBindingsSummary";
 import { providerLabel } from "@/lib/labels";
 
 interface DisableConnectorSectionProps {
@@ -28,23 +29,9 @@ interface DisableConnectorSectionProps {
   /**
    * OAuth provider ID (e.g. "github") from the connector spec.
    * When set, the "Remove" option is shown and its description mentions
-   * disconnecting OAuth. Does NOT drive the actual disconnect call —
-   * see `oauthConnectionId` for that.
+   * disconnecting OAuth.
    */
   oauthProvider?: string;
-  /**
-   * The specific OAuth connection ID currently bound to this connector
-   * (e.g. "oconn_abc123"). Passed to `useDisconnectOAuth` on Remove so
-   * the correct connection is disconnected. If undefined, the OAuth
-   * disconnect step is skipped silently.
-   */
-  oauthConnectionId?: string;
-  /**
-   * True when an API key credential is assigned to this connector.
-   * When true (and `oauthProvider` is not set), the "Remove" option is
-   * shown so the user can permanently delete the saved API key.
-   */
-  hasApiKeyCredential?: boolean;
 }
 
 export function DisableConnectorSection({
@@ -52,8 +39,6 @@ export function DisableConnectorSection({
   connectorId,
   connectorName,
   oauthProvider,
-  oauthConnectionId,
-  hasApiKeyCredential = false,
 }: DisableConnectorSectionProps) {
   const [disableConfirmOpen, setDisableConfirmOpen] = useState(false);
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
@@ -62,6 +47,14 @@ export function DisableConnectorSection({
     useDisableAgentConnector();
   const { disconnect } = useDisconnectOAuth();
   const navigate = useNavigate();
+
+  const { data: bindingsSummary } = useConnectorInstanceBindingsSummary(
+    agentId,
+    connectorId,
+  );
+  const instanceCount = bindingsSummary?.instanceCount ?? 1;
+  const oauthConnectionIds = bindingsSummary?.oauthConnectionIds ?? [];
+  const hasApiKeyCredential = bindingsSummary?.hasApiKeyCredential ?? false;
 
   async function handleDisable() {
     try {
@@ -84,10 +77,13 @@ export function DisableConnectorSection({
   async function handleRemove() {
     setIsRemoving(true);
     try {
-      // Step 1: disable the connector and delete any API key credentials.
       let disableResult: Awaited<ReturnType<typeof disableConnector>>;
       try {
-        disableResult = await disableConnector({ agentId, connectorId, deleteCredentials: true });
+        disableResult = await disableConnector({
+          agentId,
+          connectorId,
+          deleteCredentials: true,
+        });
       } catch {
         toast.error("Failed to disable connector");
         return;
@@ -99,17 +95,23 @@ export function DisableConnectorSection({
           ? ` ${revoked} standing approval${revoked === 1 ? "" : "s"} revoked.`
           : "";
 
-      // Step 2: disconnect OAuth (best-effort — connector is already disabled).
-      // oauthConnectionId is the specific connection to disconnect; skip if not bound.
-      if (oauthConnectionId) {
-        try {
-          await disconnect(oauthConnectionId);
-          toast.success(
-            `Connector removed and OAuth disconnected.${revokedSuffix}`,
-          );
-        } catch {
+      if (oauthProvider && oauthConnectionIds.length > 0) {
+        let anyFailed = false;
+        for (const id of oauthConnectionIds) {
+          try {
+            await disconnect(id);
+          } catch {
+            anyFailed = true;
+          }
+        }
+        if (anyFailed) {
           toast.warning(
-            `Connector disabled and API keys deleted, but OAuth disconnect failed.${revokedSuffix} You can disconnect manually from Settings.`,
+            `Connector disabled.${revokedSuffix} Some OAuth connections could not be disconnected — you can remove them from Settings.`,
+          );
+        } else {
+          const n = oauthConnectionIds.length;
+          toast.success(
+            `Connector removed and ${n} OAuth connection${n === 1 ? "" : "s"} disconnected.${revokedSuffix}`,
           );
         }
       } else {
@@ -122,6 +124,11 @@ export function DisableConnectorSection({
       setIsRemoving(false);
     }
   }
+
+  const instanceWarning =
+    instanceCount > 1
+      ? ` This will remove all ${instanceCount} configured instances for this connector type on this agent.`
+      : "";
 
   return (
     <>
@@ -161,10 +168,13 @@ export function DisableConnectorSection({
                   <p className="text-muted-foreground text-sm">
                     {oauthProvider ? (
                       <>
-                        Disable the connector, disconnect the{" "}
-                        {providerLabel(oauthProvider)} OAuth connection, and
-                        permanently delete any saved API keys. You will need to
-                        re-authorize and re-add credentials when re-enabling.
+                        Disable the connector, disconnect{" "}
+                        {oauthConnectionIds.length > 1
+                          ? "all linked OAuth connections"
+                          : `the ${providerLabel(oauthProvider)} OAuth connection`}
+                        , and permanently delete any saved API keys. You will
+                        need to re-authorize and re-add credentials when
+                        re-enabling.
                       </>
                     ) : (
                       <>
@@ -190,7 +200,6 @@ export function DisableConnectorSection({
         </CardContent>
       </Card>
 
-      {/* Disable confirmation */}
       <Dialog open={disableConfirmOpen} onOpenChange={setDisableConfirmOpen}>
         <DialogContent>
           <DialogHeader>
@@ -199,6 +208,7 @@ export function DisableConnectorSection({
               This will disable the <strong>{connectorName}</strong> connector
               for this agent. Any active standing approvals for actions from
               this connector will be automatically revoked.
+              {instanceWarning}
               {oauthProvider && " Your OAuth connection is preserved."}
             </DialogDescription>
           </DialogHeader>
@@ -222,7 +232,6 @@ export function DisableConnectorSection({
         </DialogContent>
       </Dialog>
 
-      {/* Remove confirmation */}
       <Dialog open={removeConfirmOpen} onOpenChange={(open) => !isRemoving && setRemoveConfirmOpen(open)}>
         <DialogContent>
           <DialogHeader>
@@ -231,18 +240,34 @@ export function DisableConnectorSection({
               {oauthProvider ? (
                 <>
                   This will disable the <strong>{connectorName}</strong>{" "}
-                  connector, disconnect the{" "}
-                  <strong>{providerLabel(oauthProvider)}</strong> OAuth
-                  connection, and permanently delete any saved API keys.
-                  Standing approvals will be revoked. You will need to
-                  re-authorize and re-add credentials when re-enabling.
+                  connector
+                  {instanceWarning}
+                  {", "}
+                  disconnect{" "}
+                  {oauthConnectionIds.length > 1 ? (
+                    <>
+                      <strong>{oauthConnectionIds.length}</strong> OAuth
+                      connections ({providerLabel(oauthProvider)})
+                    </>
+                  ) : (
+                    <>
+                      the <strong>{providerLabel(oauthProvider)}</strong> OAuth
+                      connection
+                    </>
+                  )}
+                  , and permanently delete any saved API keys. Standing
+                  approvals will be revoked. You will need to re-authorize and
+                  re-add credentials when re-enabling.
                 </>
               ) : (
                 <>
                   This will disable the <strong>{connectorName}</strong>{" "}
-                  connector and permanently delete the saved API key. Standing
-                  approvals will be revoked. You will need to re-add credentials
-                  when re-enabling.
+                  connector
+                  {instanceWarning}
+                  {" "}
+                  and permanently delete the saved API key. Standing approvals
+                  will be revoked. You will need to re-add credentials when
+                  re-enabling.
                 </>
               )}
             </DialogDescription>

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorConfigPage.test.tsx
@@ -7,7 +7,13 @@ import { AuthProvider } from "../../../../auth/AuthContext";
 import { ThemeProvider } from "../../../../components/ThemeContext";
 import { Toaster } from "../../../../components/ui/sonner";
 import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
-import { mockGet, resetClientMocks } from "../../../../api/__mocks__/client";
+import {
+  mockGet,
+  mockPost,
+  mockPatch,
+  mockDelete,
+  resetClientMocks,
+} from "../../../../api/__mocks__/client";
 import { ConnectorConfigPage } from "../ConnectorConfigPage";
 
 vi.mock("../../../../lib/supabaseClient");
@@ -114,6 +120,9 @@ describe("ConnectorConfigPage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     resetClientMocks();
+    mockPost.mockResolvedValue({ data: {} });
+    mockPatch.mockResolvedValue({ data: {} });
+    mockDelete.mockResolvedValue({ data: {} });
     setupAuthMocks({ authenticated: true });
   });
 
@@ -140,9 +149,43 @@ describe("ConnectorConfigPage", () => {
       if (path === "/v1/action-configurations") {
         return Promise.resolve({ data: mockActionConfigsResponse });
       }
+      if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/instances") {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                connector_instance_id: "00000000-0000-0000-0000-000000000001",
+                agent_id: 42,
+                connector_id: "github",
+                label: "GitHub",
+                is_default: true,
+                enabled_at: "2026-02-18T10:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      if (
+        path ===
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential"
+      ) {
+        return Promise.resolve({
+          data: {
+            agent_id: 42,
+            connector_id: "github",
+            credential_id: "cred_123",
+            oauth_connection_id: null,
+          },
+        });
+      }
       if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
         return Promise.resolve({
-          data: { agent_id: 42, connector_id: "github", credential_id: "cred_123", oauth_connection_id: null },
+          data: {
+            agent_id: 42,
+            connector_id: "github",
+            credential_id: "cred_123",
+            oauth_connection_id: null,
+          },
         });
       }
       if (path === "/v1/oauth/connections") {
@@ -250,9 +293,43 @@ describe("ConnectorConfigPage", () => {
       if (path === "/v1/credentials") {
         return Promise.resolve({ data: { credentials: [] } });
       }
+      if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/instances") {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                connector_instance_id: "00000000-0000-0000-0000-000000000001",
+                agent_id: 42,
+                connector_id: "github",
+                label: "GitHub",
+                is_default: true,
+                enabled_at: "2026-02-18T10:00:00Z",
+              },
+            ],
+          },
+        });
+      }
+      if (
+        path ===
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential"
+      ) {
+        return Promise.resolve({
+          data: {
+            agent_id: 42,
+            connector_id: "github",
+            credential_id: null,
+            oauth_connection_id: null,
+          },
+        });
+      }
       if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
         return Promise.resolve({
-          data: { agent_id: 42, connector_id: "github", credential_id: null, oauth_connection_id: null },
+          data: {
+            agent_id: 42,
+            connector_id: "github",
+            credential_id: null,
+            oauth_connection_id: null,
+          },
         });
       }
       if (path === "/v1/oauth/connections") {

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
@@ -1,0 +1,223 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderWithProviders } from "../../../../test-helpers";
+import { setupAuthMocks } from "../../../../auth/__tests__/fixtures";
+import {
+  mockGet,
+  mockPost,
+  mockPatch,
+  mockDelete,
+  resetClientMocks,
+} from "../../../../api/__mocks__/client";
+import { ConnectorInstancesSection } from "../ConnectorInstancesSection";
+
+vi.mock("../../../../lib/supabaseClient");
+vi.mock("../../../../api/client");
+
+const defaultInstance = {
+  connector_instance_id: "11111111-1111-1111-1111-111111111111",
+  agent_id: 42,
+  connector_id: "slack",
+  label: "Engineering",
+  is_default: true,
+  enabled_at: "2026-02-18T10:00:00Z",
+};
+
+const secondInstance = {
+  connector_instance_id: "22222222-2222-2222-2222-222222222222",
+  agent_id: 42,
+  connector_id: "slack",
+  label: "Sales",
+  is_default: false,
+  enabled_at: "2026-02-19T10:00:00Z",
+};
+
+function mockStandardGets(twoInstances = false) {
+  mockGet.mockImplementation((path: string) => {
+    if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/instances") {
+      return Promise.resolve({
+        data: {
+          data: twoInstances ? [defaultInstance, secondInstance] : [defaultInstance],
+        },
+      });
+    }
+    if (
+      path ===
+      "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential"
+    ) {
+      return Promise.resolve({
+        data: {
+          agent_id: 42,
+          connector_id: "slack",
+          credential_id: null,
+          oauth_connection_id: "oconn_1",
+        },
+      });
+    }
+    if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
+      return Promise.resolve({
+        data: {
+          agent_id: 42,
+          connector_id: "slack",
+          credential_id: null,
+          oauth_connection_id: "oconn_1",
+        },
+      });
+    }
+    if (path === "/v1/credentials") {
+      return Promise.resolve({ data: { credentials: [] } });
+    }
+    if (path === "/v1/oauth/connections") {
+      return Promise.resolve({
+        data: {
+          connections: [
+            {
+              id: "oconn_1",
+              provider: "slack",
+              status: "active",
+              display_name: "Acme",
+              connected_at: "2026-02-11T10:00:00Z",
+            },
+          ],
+        },
+      });
+    }
+    if (path === "/v1/oauth/providers") {
+      return Promise.resolve({ data: { providers: [] } });
+    }
+    return Promise.resolve({ data: {} });
+  });
+}
+
+describe("ConnectorInstancesSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    mockPost.mockResolvedValue({ data: {} });
+    mockPatch.mockResolvedValue({ data: {} });
+    mockDelete.mockResolvedValue({ data: {} });
+    setupAuthMocks({ authenticated: true });
+  });
+
+  it("renders instances with default badge", async () => {
+    mockStandardGets(false);
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Default")).toBeInTheDocument();
+  });
+
+  it("creates a new instance when Add another is submitted", async () => {
+    mockStandardGets(false);
+    mockPost.mockResolvedValue({
+      data: {
+        ...secondInstance,
+      },
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Add another/i }));
+    await user.type(screen.getByLabelText(/Label/i), "Sales");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+    const call = mockPost.mock.calls.find(
+      (c) => c[0] === "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
+    );
+    expect(call?.[1]?.body).toEqual({ label: "Sales" });
+  });
+
+  it("sets default instance via PATCH", async () => {
+    mockStandardGets(true);
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Sales")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Make default/i }));
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalled();
+    });
+    const call = mockPatch.mock.calls.find(
+      (c) =>
+        c[0] ===
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+    );
+    expect(call?.[1]?.body).toEqual({ is_default: true });
+    expect(call?.[1]?.params?.path?.instance_id).toBe(secondInstance.connector_instance_id);
+  });
+
+  it("removes non-default instance via DELETE", async () => {
+    mockStandardGets(true);
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Sales")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Remove instance/i }));
+    await user.click(screen.getByRole("button", { name: /^Remove$/i }));
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalled();
+    });
+    const call = mockDelete.mock.calls.find(
+      (c) =>
+        c[0] ===
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+    );
+    expect(call?.[1]?.params?.path?.instance_id).toBe(secondInstance.connector_instance_id);
+  });
+});

--- a/spec/openapi/components/schemas/agent_connector_instances.yaml
+++ b/spec/openapi/components/schemas/agent_connector_instances.yaml
@@ -51,11 +51,15 @@ CreateAgentConnectorInstanceRequest:
 
 PatchAgentConnectorInstanceRequest:
   type: object
-  required:
-    - label
+  description: >-
+    At least one of `label` or `is_default` must be provided.
+    When `is_default` is true, this instance becomes the default for the agent and connector type.
   properties:
     label:
       type: string
       minLength: 1
       maxLength: 256
       description: New display label for the instance.
+    is_default:
+      type: boolean
+      description: When true, marks this instance as the default (only value accepted; omit to leave default unchanged).

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -9943,14 +9943,16 @@ components:
           description: Display label for the new instance (unique per agent and connector).
     PatchAgentConnectorInstanceRequest:
       type: object
-      required:
-        - label
+      description: At least one of `label` or `is_default` must be provided. When `is_default` is true, this instance becomes the default for the agent and connector type.
       properties:
         label:
           type: string
           minLength: 1
           maxLength: 256
           description: New display label for the instance.
+        is_default:
+          type: boolean
+          description: When true, marks this instance as the default (only value accepted; omit to leave default unchanged).
     CreateRegistrationInviteRequest:
       type: object
       description: Request to create a registration invite.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements **Phase 3 — Frontend UI** from #962: multi-instance connector management on the agent connector config page, plus backend support needed for **Make default** (`PATCH` with `is_default: true`).

### Summary

- New `ConnectorInstancesSection` lists instances as cards with inline rename, per-instance credential dropdown (same patterns as the former single-instance UI), **Make default**, **Disconnect** (clears binding), **Remove instance** (non-default), and **Add another**.
- `ConnectorConfigPage` renders the new section instead of `ConnectorCredentialsSection`.
- `DisableConnectorSection` loads instance + credential bindings to show how many instances will be removed and disconnects all linked OAuth connections on **Remove** when applicable.
- **API/DB**: `SetDefaultAgentConnectorInstance` + extended `PATCH .../instances/{instance_id}` (optional `label` and/or `is_default`). OpenAPI `PatchAgentConnectorInstanceRequest` updated; bundle regenerated.

### Developer

- [x] Frontend hooks and UI; tests (`make test-frontend` passed locally)
- [x] OpenAPI + bundle updated for PATCH body
- [ ] CI `go test` / full repo checks (sandbox cannot run Go module graph; rely on CI)

### Manual Testing

- [ ] Add a second instance, assign distinct OAuth per instance, set default, rename, disconnect, remove non-default instance
- [ ] Disable connector with multiple instances: confirm copy mentions count and OAuth disconnect behavior
- [ ] Single-instance agents: one card, familiar credential row

Ref #962
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be8b9c07-a693-4045-9901-c2862b939b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be8b9c07-a693-4045-9901-c2862b939b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

