### PR TITLE
Phase 4: Tool-call connector instance routing

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -18,13 +18,13 @@ import (
 // ── Request/response types ─────────────────────────────────────────────────
 
 type agentRequestApprovalRequest struct {
-	RequestID       string                 `json:"request_id" validate:"required"`
-	Action          json.RawMessage        `json:"action" validate:"required"`
-	Context         json.RawMessage        `json:"context" validate:"required"`
-	ExpiresIn       *int                   `json:"expires_in,omitempty" validate:"omitempty,gte=60,lte=86400"`
+	RequestID       string                  `json:"request_id" validate:"required"`
+	Action          json.RawMessage         `json:"action" validate:"required"`
+	Context         json.RawMessage         `json:"context" validate:"required"`
+	ExpiresIn       *int                    `json:"expires_in,omitempty" validate:"omitempty,gte=60,lte=86400"`
 	Configuration   *agentApprovalConfigRef `json:"configuration,omitempty"`
-	PaymentMethodID string                 `json:"payment_method_id,omitempty"`
-	AmountCents     *int                   `json:"amount_cents,omitempty"`
+	PaymentMethodID string                  `json:"payment_method_id,omitempty"`
+	AmountCents     *int                    `json:"amount_cents,omitempty"`
 }
 
 type agentApprovalConfigRef struct {
@@ -204,6 +204,23 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		// Multi-instance routing: resolve optional parameters.connector_instance, freeze UUID+label on action, strip from parameters.
+		connectorInstanceID, err := applyConnectorInstanceToAction(r.Context(), deps.DB, agent, actionType, actionObj)
+		if err != nil {
+			var ciErr *connectorInstanceResolutionError
+			if errors.As(err, &ciErr) {
+				RespondError(w, r, ciErr.status, ciErr.resp)
+				return
+			}
+			log.Printf("[%s] applyConnectorInstanceToAction: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to process action"))
+			return
+		}
+		if updated, mErr := json.Marshal(actionObj); mErr == nil {
+			req.Action = updated
+		}
+
 		// Validate action parameters against the connector's parameters_schema.
 		// Runs after alias normalization so canonical keys are checked.
 		// Fail-open: skipped if the action has no schema.
@@ -233,7 +250,7 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 		// approval matches this agent + action type + parameters. If so,
 		// execute immediately and return the result — no human review needed.
 		pp := &paymentParams{PaymentMethodID: req.PaymentMethodID, AmountCents: req.AmountCents}
-		if handled := tryStandingApprovalAutoApprove(w, r, deps, agent, actionType, actionParams, req.RequestID, pp); handled {
+		if handled := tryStandingApprovalAutoApprove(w, r, deps, agent, actionType, actionParams, req.RequestID, pp, connectorInstanceID); handled {
 			return
 		}
 
@@ -272,7 +289,7 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 				if conn, ok := deps.Connectors.Get(cid[0]); ok {
 					if resolver, ok := conn.(connectors.ResourceDetailResolver); ok {
 						resolveCtx, resolveCancel := context.WithTimeout(r.Context(), 5*time.Second)
-						details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0]))
+						details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0], connectorInstanceID))
 						resolveCancel()
 						if resolveErr != nil {
 							log.Printf("[%s] ResolveResourceDetails: %v", TraceID(r.Context()), resolveErr)
@@ -432,12 +449,12 @@ var handleAgentApprovalError = handleApprovalError
 // ResourceDetailResolver call. It mirrors the credential resolution logic from
 // connector execution but returns empty credentials on any failure (since
 // resource detail resolution is non-fatal).
-func resolveCredentialsForResolver(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID string) connectors.Credentials {
+func resolveCredentialsForResolver(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string) connectors.Credentials {
 	reqCreds, err := db.GetRequiredCredentialsByActionType(ctx, deps.DB, actionType)
 	if err != nil || len(reqCreds) == 0 {
 		return connectors.NewCredentials(nil)
 	}
-	creds, err := resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, reqCreds)
+	creds, err := resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
 	if err != nil {
 		return connectors.NewCredentials(nil)
 	}
@@ -456,7 +473,7 @@ func emitApprovalRequestAuditEvent(ctx context.Context, d db.DBTX, userID string
 		SourceID:    appr.ApprovalID,
 		SourceType:  "approval",
 		AgentMeta:   agentMeta,
-		Action:      redactActionToType(appr.Action),
+		Action:      redactActionToTypeWithConnectorInstance(appr.Action),
 		ConnectorID: connectorIDFromActionType(actionTypeFromJSON(appr.Action)),
 	}, true)
 }

--- a/api/agent_approvals_instance.go
+++ b/api/agent_approvals_instance.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+// connectorInstanceResolutionError carries an HTTP error for applyConnectorInstanceToAction.
+type connectorInstanceResolutionError struct {
+	status int
+	resp   ErrorResponse
+}
+
+func (e *connectorInstanceResolutionError) Error() string {
+	return e.resp.Error.Message
+}
+
+// applyConnectorInstanceToAction removes parameters.connector_instance, resolves the target
+// instance for the action's connector, and sets _connector_instance_id and _connector_instance_label
+// on the action object. Returns the resolved instance UUID for credential routing (empty if the
+// connector has no enabled instances on the agent — downstream "no credential" handling applies).
+func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Agent, actionType string, actionObj map[string]json.RawMessage) (connectorInstanceID string, err error) {
+	parts := strings.SplitN(actionType, ".", 2)
+	if len(parts) != 2 {
+		return "", nil
+	}
+	connectorID := parts[0]
+
+	var paramsObj map[string]json.RawMessage
+	if raw, ok := actionObj["parameters"]; ok && len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &paramsObj); err != nil {
+			return "", err
+		}
+	}
+
+	var selector string
+	if paramsObj != nil {
+		if raw, ok := paramsObj["connector_instance"]; ok {
+			_ = json.Unmarshal(raw, &selector)
+			selector = strings.TrimSpace(selector)
+			delete(paramsObj, "connector_instance")
+			if len(paramsObj) == 0 {
+				delete(actionObj, "parameters")
+			} else {
+				b, mErr := json.Marshal(paramsObj)
+				if mErr != nil {
+					return "", mErr
+				}
+				actionObj["parameters"] = b
+			}
+		}
+	}
+
+	instances, err := db.ListAgentConnectorInstances(ctx, d, agent.AgentID, agent.ApproverID, connectorID)
+	if err != nil {
+		return "", err
+	}
+	if len(instances) == 0 {
+		return "", nil
+	}
+
+	var inst *db.AgentConnectorInstance
+	if len(instances) == 1 {
+		only := &instances[0]
+		if selector == "" {
+			inst = only
+		} else {
+			resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
+			if err != nil {
+				return "", err
+			}
+			if resolved == nil || resolved.ConnectorInstanceID != only.ConnectorInstanceID {
+				return "", &connectorInstanceResolutionError{
+					status: http.StatusBadRequest,
+					resp:   BadRequest(ErrConnectorInstanceNotFound, "no connector instance matches the given connector_instance"),
+				}
+			}
+			inst = resolved
+		}
+	} else {
+		if selector == "" {
+			labels := make([]string, 0, len(instances))
+			for _, i := range instances {
+				labels = append(labels, i.Label)
+			}
+			resp := BadRequest(ErrConnectorInstanceRequired, "connector_instance is required when multiple instances exist")
+			resp.Error.Details = map[string]any{"available_instances": labels}
+			return "", &connectorInstanceResolutionError{status: http.StatusBadRequest, resp: resp}
+		}
+		resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
+		if err != nil {
+			return "", err
+		}
+		if resolved == nil {
+			return "", &connectorInstanceResolutionError{
+				status: http.StatusBadRequest,
+				resp:   BadRequest(ErrConnectorInstanceNotFound, "no connector instance matches the given connector_instance"),
+			}
+		}
+		inst = resolved
+	}
+
+	idRaw, _ := json.Marshal(inst.ConnectorInstanceID)
+	actionObj["_connector_instance_id"] = idRaw
+	labelRaw, _ := json.Marshal(inst.Label)
+	actionObj["_connector_instance_label"] = labelRaw
+	return inst.ConnectorInstanceID, nil
+}

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -1025,3 +1025,117 @@ func TestAgentRequestApproval_RequestValidatorAllowsValidChannel(t *testing.T) {
 		t.Fatalf("expected 200 for valid channel ID, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestAgentRequestApproval_MultiInstance_RequiresConnectorInstance(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	connID := "mi_test_conn"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	if _, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Beta",
+	}); err != nil {
+		t.Fatalf("second instance: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, connID+".ping"))
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_mi_need_inst","action":{"type":"` + connID + `.ping","parameters":{}},"context":{"description":"x"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error.Code != ErrConnectorInstanceRequired {
+		t.Errorf("expected %q, got %q", ErrConnectorInstanceRequired, errResp.Error.Code)
+	}
+	labels, _ := errResp.Error.Details["available_instances"].([]any)
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 available_instances, got %#v", errResp.Error.Details)
+	}
+}
+
+func TestAgentRequestApproval_MultiInstance_WithLabel_FreezesInstanceOnAction(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	connID := "mi_test_conn2"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	inst2, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Sales",
+	})
+	if err != nil {
+		t.Fatalf("second instance: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, connID+".ping"))
+	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_mi_label","action":{"type":"` + connID + `.ping","parameters":{"connector_instance":"Sales"}},"context":{"description":"x"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var createResp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	appr, err := db.GetApprovalByIDAndAgent(t.Context(), tx, createResp.ApprovalID, agentID)
+	if err != nil || appr == nil {
+		t.Fatalf("get approval: %v", err)
+	}
+	var actionObj map[string]json.RawMessage
+	if err := json.Unmarshal(appr.Action, &actionObj); err != nil {
+		t.Fatalf("unmarshal action: %v", err)
+	}
+	var gotID, gotLabel string
+	_ = json.Unmarshal(actionObj["_connector_instance_id"], &gotID)
+	_ = json.Unmarshal(actionObj["_connector_instance_label"], &gotLabel)
+	if gotID != inst2.ConnectorInstanceID {
+		t.Errorf("connector_instance_id: want %q got %q", inst2.ConnectorInstanceID, gotID)
+	}
+	if gotLabel != "Sales" {
+		t.Errorf("connector_instance_label: want Sales got %q", gotLabel)
+	}
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal(actionObj["parameters"], &params); err != nil {
+		t.Fatalf("parameters: %v", err)
+	}
+	if _, ok := params["connector_instance"]; ok {
+		t.Error("connector_instance should be stripped from parameters")
+	}
+}

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -1131,11 +1131,13 @@ func TestAgentRequestApproval_MultiInstance_WithLabel_FreezesInstanceOnAction(t 
 	if gotLabel != "Sales" {
 		t.Errorf("connector_instance_label: want Sales got %q", gotLabel)
 	}
-	var params map[string]json.RawMessage
-	if err := json.Unmarshal(actionObj["parameters"], &params); err != nil {
-		t.Fatalf("parameters: %v", err)
-	}
-	if _, ok := params["connector_instance"]; ok {
-		t.Error("connector_instance should be stripped from parameters")
+	if raw, ok := actionObj["parameters"]; ok {
+		var params map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &params); err != nil {
+			t.Fatalf("parameters: %v", err)
+		}
+		if _, ok := params["connector_instance"]; ok {
+			t.Error("connector_instance should be stripped from parameters")
+		}
 	}
 }

--- a/api/approval_flow_multi_instance_test.go
+++ b/api/approval_flow_multi_instance_test.go
@@ -45,7 +45,7 @@ func TestApprovalFlow_MultiInstance_UsesCorrectCredentialOnApprove(t *testing.T)
 		t.Fatalf("vault: %v", err)
 	}
 	credID1 := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID1, uid, connID, v1)
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID1, uid, connID, "default", v1)
 
 	credJSON2, _ := json.Marshal(map[string]string{"api_key": "token-sales"})
 	v2, err := v.CreateSecret(t.Context(), tx, "c2", credJSON2)
@@ -53,7 +53,7 @@ func TestApprovalFlow_MultiInstance_UsesCorrectCredentialOnApprove(t *testing.T)
 		t.Fatalf("vault: %v", err)
 	}
 	credID2 := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID2, uid, connID, v2)
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID2, uid, connID, "sales", v2)
 
 	_, err = db.UpsertAgentConnectorCredentialByInstance(t.Context(), tx, db.UpsertAgentConnectorCredentialByInstanceParams{
 		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,

--- a/api/approval_flow_multi_instance_test.go
+++ b/api/approval_flow_multi_instance_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 

--- a/api/approval_flow_multi_instance_test.go
+++ b/api/approval_flow_multi_instance_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+	"github.com/supersuit-tech/permission-slip/vault"
+)
+
+// End-to-end: two connector instances with distinct static credentials; approval execution uses the instance from the frozen action JSON.
+func TestApprovalFlow_MultiInstance_UsesCorrectCredentialOnApprove(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	connID := "flow_mi"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
+
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	instSales, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Sales",
+	})
+	if err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	v := vault.NewMockVaultStore()
+	credJSON1, _ := json.Marshal(map[string]string{"api_key": "token-eng"})
+	v1, err := v.CreateSecret(t.Context(), tx, "c1", credJSON1)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID1, uid, connID, v1)
+
+	credJSON2, _ := json.Marshal(map[string]string{"api_key": "token-sales"})
+	v2, err := v.CreateSecret(t.Context(), tx, "c2", credJSON2)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID2 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID2, uid, connID, v2)
+
+	_, err = db.UpsertAgentConnectorCredentialByInstance(t.Context(), tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: instSales.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID2,
+	})
+	if err != nil {
+		t.Fatalf("bind sales: %v", err)
+	}
+
+	var captured connectors.Credentials
+	reg := connectors.NewRegistry()
+	reg.Register(&credCapturingConnector{
+		id:      connID,
+		actions: []string{connID + ".ping"},
+		onExec:  func(c connectors.Credentials) { captured = c },
+	})
+
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_flow_mi","action":{"type":"` + connID + `.ping","parameters":{"connector_instance":"Sales"}},"context":{"description":"x"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("request approval: %d %s", w.Code, w.Body.String())
+	}
+	var createResp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	r2 := authenticatedRequest(t, http.MethodPost, "/approvals/"+createResp.ApprovalID+"/approve", uid)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("approve: %d %s", w2.Code, w2.Body.String())
+	}
+
+	tok, ok := captured.Get("api_key")
+	if !ok {
+		t.Fatal("expected api_key in executed credentials")
+	}
+	if tok != "token-sales" {
+		t.Errorf("wrong OAuth/static credential used: got %q want token-sales", tok)
+	}
+}

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -251,7 +251,17 @@ func executeApprovalAction(ctx context.Context, deps *Deps, userID string, appr 
 		_ = json.Unmarshal(appr.Action, &actionObj)
 	}
 
-	result, execErr := executeConnectorAction(ctx, deps, appr.AgentID, userID, actionType, actionObj.Parameters, nil)
+	var connectorInstanceID string
+	if len(appr.Action) > 0 {
+		var raw map[string]json.RawMessage
+		if json.Unmarshal(appr.Action, &raw) == nil {
+			if v, ok := raw["_connector_instance_id"]; ok {
+				_ = json.Unmarshal(v, &connectorInstanceID)
+			}
+		}
+	}
+
+	result, execErr := executeConnectorAction(ctx, deps, appr.AgentID, userID, actionType, actionObj.Parameters, nil, connectorInstanceID)
 
 	var execStatus string
 	var resultJSON json.RawMessage

--- a/api/audit_helpers.go
+++ b/api/audit_helpers.go
@@ -240,3 +240,38 @@ func redactActionToType(raw []byte) []byte {
 	redacted, _ := json.Marshal(map[string]string{"type": obj.Type})
 	return redacted
 }
+
+// redactActionToTypeWithConnectorInstance is like redactActionToType but preserves
+// frozen multi-instance routing fields for audit visibility (no parameters).
+func redactActionToTypeWithConnectorInstance(raw []byte) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil {
+		return redactActionToType(raw)
+	}
+	typeRaw, ok := obj["type"]
+	if !ok {
+		return redactActionToType(raw)
+	}
+	var actionType string
+	if json.Unmarshal(typeRaw, &actionType) != nil || actionType == "" {
+		return redactActionToType(raw)
+	}
+	out := map[string]any{"type": actionType}
+	if v, ok := obj["_connector_instance_id"]; ok {
+		var s string
+		if json.Unmarshal(v, &s) == nil && s != "" {
+			out["_connector_instance_id"] = s
+		}
+	}
+	if v, ok := obj["_connector_instance_label"]; ok {
+		var s string
+		if json.Unmarshal(v, &s) == nil && s != "" {
+			out["_connector_instance_label"] = s
+		}
+	}
+	redacted, _ := json.Marshal(out)
+	return redacted
+}

--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -13,28 +13,35 @@ import (
 // ── Response types ──────────────────────────────────────────────────────────
 
 type capabilitiesResponse struct {
-	AgentID    int64                    `json:"agent_id"`
-	Approver   *approverInfo            `json:"approver,omitempty"`
-	Connectors []connectorCapability    `json:"connectors"`
+	AgentID    int64                 `json:"agent_id"`
+	Approver   *approverInfo         `json:"approver,omitempty"`
+	Connectors []connectorCapability `json:"connectors"`
+}
+
+type connectorInstanceCapability struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	CredentialsReady bool   `json:"credentials_ready"`
 }
 
 type connectorCapability struct {
-	ID                  string              `json:"id"`
-	Name                string              `json:"name"`
-	Description         *string             `json:"description,omitempty"`
-	CredentialsReady    bool                `json:"credentials_ready"`
-	CredentialsSetupURL *string             `json:"credentials_setup_url,omitempty"`
-	Actions             []actionCapability  `json:"actions"`
+	ID                  string                        `json:"id"`
+	Name                string                        `json:"name"`
+	Description         *string                       `json:"description,omitempty"`
+	CredentialsReady    bool                          `json:"credentials_ready"`
+	CredentialsSetupURL *string                       `json:"credentials_setup_url,omitempty"`
+	Instances           []connectorInstanceCapability `json:"instances,omitempty"`
+	Actions             []actionCapability            `json:"actions"`
 }
 
 type actionCapability struct {
-	ActionType           string                        `json:"action_type"`
-	Name                 string                        `json:"name"`
-	Description          *string                       `json:"description,omitempty"`
-	RiskLevel            *string                       `json:"risk_level,omitempty"`
-	ParametersSchema     json.RawMessage               `json:"parameters_schema,omitempty"`
-	StandingApprovals    []standingApprovalCapability   `json:"standing_approvals"`
-	ActionConfigurations []actionConfigCapability       `json:"action_configurations"`
+	ActionType           string                       `json:"action_type"`
+	Name                 string                       `json:"name"`
+	Description          *string                      `json:"description,omitempty"`
+	RiskLevel            *string                      `json:"risk_level,omitempty"`
+	ParametersSchema     json.RawMessage              `json:"parameters_schema,omitempty"`
+	StandingApprovals    []standingApprovalCapability `json:"standing_approvals"`
+	ActionConfigurations []actionConfigCapability     `json:"action_configurations"`
 }
 
 type actionConfigCapability struct {
@@ -46,9 +53,10 @@ type actionConfigCapability struct {
 }
 
 type standingApprovalCapability struct {
-	StandingApprovalID string          `json:"standing_approval_id"`
-	Constraints        json.RawMessage `json:"constraints"`
-	ExpiresAt          *time.Time      `json:"expires_at"`
+	StandingApprovalID  string          `json:"standing_approval_id"`
+	Constraints         json.RawMessage `json:"constraints"`
+	ExpiresAt           *time.Time      `json:"expires_at"`
+	ConnectorInstanceID *string         `json:"connector_instance_id,omitempty"`
 }
 
 // ── Route registration ──────────────────────────────────────────────────────
@@ -130,6 +138,11 @@ func buildCapabilitiesResponse(agentID int64, caps *db.AgentCapabilities, baseUR
 		saByAction[sa.ActionType] = append(saByAction[sa.ActionType], sa)
 	}
 
+	instancesByConnector := make(map[string][]db.CapabilityConnectorInstance)
+	for _, inst := range caps.ConnectorInstances {
+		instancesByConnector[inst.ConnectorID] = append(instancesByConnector[inst.ConnectorID], inst)
+	}
+
 	// Index action configurations by connector+action_type composite key.
 	// Unlike standing approvals (which lack ConnectorID), action configs
 	// are connector-scoped and must not bleed across connectors that share
@@ -155,6 +168,14 @@ func buildCapabilitiesResponse(agentID int64, caps *db.AgentCapabilities, baseUR
 			cc.CredentialsSetupURL = &url
 		}
 
+		for _, inst := range instancesByConnector[c.ID] {
+			cc.Instances = append(cc.Instances, connectorInstanceCapability{
+				ID:               inst.ConnectorInstanceID,
+				Label:            inst.Label,
+				CredentialsReady: inst.CredentialsReady,
+			})
+		}
+
 		// Build actions for this connector.
 		dbActions := actionsByConnector[c.ID]
 		actions := make([]actionCapability, 0, len(dbActions))
@@ -172,9 +193,10 @@ func buildCapabilitiesResponse(agentID int64, caps *db.AgentCapabilities, baseUR
 			sas := make([]standingApprovalCapability, 0, len(dbSAs))
 			for _, sa := range dbSAs {
 				sas = append(sas, standingApprovalCapability{
-					StandingApprovalID: sa.StandingApprovalID,
-					Constraints:        sa.Constraints,
-					ExpiresAt:          sa.ExpiresAt,
+					StandingApprovalID:  sa.StandingApprovalID,
+					Constraints:         sa.Constraints,
+					ExpiresAt:           sa.ExpiresAt,
+					ConnectorInstanceID: sa.ConnectorInstanceID,
 				})
 			}
 			acap.StandingApprovals = sas

--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -31,7 +31,7 @@ type paymentParams struct {
 // validates the payment method and enforces spending limits before execution,
 // then records the transaction only after the connector succeeds. This ensures
 // failed executions don't count against the user's spending limits.
-func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, userID, actionType string, parameters json.RawMessage, pp *paymentParams) (*connectors.ActionResult, error) {
+func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, userID, actionType string, parameters json.RawMessage, pp *paymentParams, connectorInstanceID string) (*connectors.ActionResult, error) {
 	if deps.Connectors == nil {
 		return nil, nil
 	}
@@ -52,7 +52,7 @@ func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, user
 	connectorID := strings.SplitN(actionType, ".", 2)[0]
 
 	var creds connectors.Credentials
-	creds, err = resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, reqCreds)
+	creds, err = resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,9 @@ func validatePaymentMethod(ctx context.Context, deps *Deps, userID string, pp *p
 // It requires an explicit credential binding on the agent — no auto-resolve.
 // If no binding exists, it returns a validation error prompting the user to
 // assign a credential in the agent's connector settings.
-func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
+// connectorInstanceID selects which agent connector instance to use. Empty string
+// selects the default instance (backward compatible with single-instance agents).
+func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
 	if len(reqCreds) == 0 {
 		return connectors.NewCredentials(nil), nil
 	}
@@ -254,7 +256,13 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 		}
 	}
 
-	binding, err := db.GetAgentConnectorCredential(ctx, deps.DB, agentID, connectorID)
+	var binding *db.AgentConnectorCredential
+	var err error
+	if connectorInstanceID != "" {
+		binding, err = db.GetAgentConnectorCredentialByInstance(ctx, deps.DB, agentID, connectorID, connectorInstanceID)
+	} else {
+		binding, err = db.GetAgentConnectorCredential(ctx, deps.DB, agentID, connectorID)
+	}
 	if err != nil {
 		return connectors.Credentials{}, fmt.Errorf("look up agent connector credential: %w", err)
 	}
@@ -263,19 +271,7 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 
 // resolveCredentialsForConnectorInstance resolves credentials for a specific connector instance (same rules as resolveCredentialsWithFallback).
 func resolveCredentialsForConnectorInstance(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
-	if len(reqCreds) == 0 {
-		return connectors.NewCredentials(nil), nil
-	}
-	if agentID == 0 {
-		return connectors.Credentials{}, &connectors.ValidationError{
-			Message: "no credential assigned — assign a credential to this connector before running actions",
-		}
-	}
-	binding, err := db.GetAgentConnectorCredentialByInstance(ctx, deps.DB, agentID, connectorID, connectorInstanceID)
-	if err != nil {
-		return connectors.Credentials{}, fmt.Errorf("look up agent connector credential: %w", err)
-	}
-	return resolveCredentialsFromAgentConnectorBinding(ctx, deps, userID, binding)
+	return resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
 }
 
 func resolveCredentialsFromAgentConnectorBinding(ctx context.Context, deps *Deps, userID string, binding *db.AgentConnectorCredential) (connectors.Credentials, error) {

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -245,7 +245,7 @@ func TestExecuteConnectorAction_OAuthPath_Success(t *testing.T) {
 		t.Fatalf("update tokens: %v", err)
 	}
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestExecuteConnectorAction_OAuthPath_NoConnection_NoBinding(t *testing.T) {
 		// No Connection — no binding will be created either.
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error when no credential binding exists")
 	}
@@ -295,7 +295,7 @@ func TestExecuteConnectorAction_OAuth_NoBinding_ReturnsError(t *testing.T) {
 	})
 
 	// Without a binding, execution should fail even though the connector exists.
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error when no credential binding exists")
 	}
@@ -319,7 +319,7 @@ func TestExecuteConnectorAction_OAuth_NeedsReauth(t *testing.T) {
 		Connection:  &testhelper.OAuthConnectionOpts{Status: "needs_reauth"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testnotion.search", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error for needs_reauth status")
 	}
@@ -335,7 +335,7 @@ func TestExecuteConnectorAction_OAuthPath_NeedsReauth(t *testing.T) {
 		Connection: &testhelper.OAuthConnectionOpts{Status: "needs_reauth"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error for needs_reauth connection")
 	}
@@ -352,7 +352,7 @@ func TestExecuteConnectorAction_OAuthPath_RevokedConnection(t *testing.T) {
 		Connection: &testhelper.OAuthConnectionOpts{Status: "revoked"},
 	})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.list_emails", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.list_emails", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error for revoked connection")
 	}
@@ -366,7 +366,7 @@ func TestExecuteConnectorAction_OAuthPath_NoVault(t *testing.T) {
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{NoVault: true})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error when vault is nil")
 	}
@@ -377,7 +377,7 @@ func TestExecuteConnectorAction_OAuthPath_NoOAuthRegistry(t *testing.T) {
 
 	f := setupOAuthExecutionTest(t, oauthExecOpts{NoOAuthRegistry: true})
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error when OAuth registry is nil")
 	}
@@ -396,7 +396,7 @@ func TestExecuteConnectorAction_OAuthPath_ExpiredTokenNoRefreshToken(t *testing.
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, &pastExpiry)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error for expired token without refresh token")
 	}
@@ -429,7 +429,7 @@ func TestExecuteConnectorAction_OAuthPath_NonExpiredTokenSkipsRefresh(t *testing
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, &farFuture)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -460,7 +460,7 @@ func TestExecuteConnectorAction_OAuthPath_NilTokenExpirySkipsRefresh(t *testing.
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, nil)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestExecuteConnectorAction_OAuthPath_NilExpiryNilOAuthRegistrySucceeds(t *t
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, nil, nil)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error with nil OAuthProviders and nil expiry: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestExecuteConnectorAction_OAuthPath_RefreshesExpiredToken(t *testing.T) {
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, &refreshVaultID, &pastExpiry)
 
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -620,7 +620,7 @@ func TestExecuteConnectorAction_OAuthPath_RefreshFailsTokenRevoked(t *testing.T)
 	conn, _ := db.GetOAuthConnectionByProvider(t.Context(), f.TX, f.UserID, "google")
 	_ = db.UpdateOAuthConnectionTokens(t.Context(), f.TX, conn.ID, f.UserID, accessVaultID, &refreshVaultID, &pastExpiry)
 
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, "testgoogle.send_email", json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error when refresh token is revoked")
 	}
@@ -658,7 +658,7 @@ func TestResolveCredentialsWithFallback_NoAgentID_ReturnsError(t *testing.T) {
 		t.Fatalf("get creds: %v", err)
 	}
 
-	_, err = resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".do_thing", connID, reqCreds)
+	_, err = resolveCredentialsWithFallback(t.Context(), deps, 0, uid, connID+".do_thing", connID, "", reqCreds)
 	if err == nil {
 		t.Fatal("expected error when agentID is 0")
 	}
@@ -690,7 +690,7 @@ func TestResolveCredentialsWithFallback_NoBinding_ReturnsError(t *testing.T) {
 		t.Fatalf("get creds: %v", err)
 	}
 
-	_, err = resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, reqCreds)
+	_, err = resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, "", reqCreds)
 	if err == nil {
 		t.Fatal("expected error when no credential binding exists")
 	}
@@ -738,7 +738,7 @@ func TestResolveCredentialsWithFallback_WithStaticBinding_Works(t *testing.T) {
 		t.Fatalf("get creds: %v", err)
 	}
 
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, reqCreds)
+	creds, err := resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, "", reqCreds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -801,7 +801,7 @@ func TestResolveCredentialsWithFallback_WithOAuthBinding_Works(t *testing.T) {
 		t.Fatalf("get creds: %v", err)
 	}
 
-	creds, err := resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, reqCreds)
+	creds, err := resolveCredentialsWithFallback(t.Context(), deps, agentID, uid, connID+".do_thing", connID, "", reqCreds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -856,7 +856,7 @@ func TestExecuteConnectorAction_StaticPath_WithBinding(t *testing.T) {
 
 	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
 
-	result, err := executeConnectorAction(t.Context(), deps, agentID, uid, "testslack.send_message", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), deps, agentID, uid, "testslack.send_message", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -873,13 +873,77 @@ func TestExecuteConnectorAction_StaticPath_WithBinding(t *testing.T) {
 	}
 }
 
+func TestExecuteConnectorAction_UsesConnectorInstanceIDWhenProvided(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	connID := "testslack2"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, "testslack2.send_message", "Send Message")
+	testhelper.InsertConnectorRequiredCredential(t, tx, connID, "slack", "api_key")
+
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	inst, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Other",
+	})
+	if err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "xoxb-instance-token"})
+	vaultID, err := v.CreateSecret(t.Context(), tx, "cred", credJSON)
+	if err != nil {
+		t.Fatalf("vault create: %v", err)
+	}
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, "slack", vaultID)
+
+	_, err = db.UpsertAgentConnectorCredentialByInstance(t.Context(), tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: inst.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID,
+	})
+	if err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	var capturedCreds connectors.Credentials
+	reg := connectors.NewRegistry()
+	reg.Register(&credCapturingConnector{
+		id:      connID,
+		actions: []string{"testslack2.send_message"},
+		onExec:  func(creds connectors.Credentials) { capturedCreds = creds },
+	})
+
+	deps := &Deps{DB: tx, Vault: v, Connectors: reg}
+
+	result, err := executeConnectorAction(t.Context(), deps, agentID, uid, "testslack2.send_message", json.RawMessage(`{}`), nil, inst.ConnectorInstanceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	tok, ok := capturedCreds.Get("api_key")
+	if !ok {
+		t.Fatal("expected api_key in credentials")
+	}
+	if tok != "xoxb-instance-token" {
+		t.Errorf("expected api_key %q, got %q", "xoxb-instance-token", tok)
+	}
+}
+
 // ── executeConnectorAction: edge cases ──────────────────────────────────────
 
 func TestExecuteConnectorAction_NilConnectorRegistry(t *testing.T) {
 	t.Parallel()
 
 	deps := &Deps{Connectors: nil}
-	result, err := executeConnectorAction(context.Background(), deps, 0, "any-user", "any.action", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(context.Background(), deps, 0, "any-user", "any.action", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -895,7 +959,7 @@ func TestExecuteConnectorAction_UnknownAction(t *testing.T) {
 	reg.Register(newTestStubConnector("github", "github.create_issue"))
 
 	deps := &Deps{Connectors: reg}
-	result, err := executeConnectorAction(context.Background(), deps, 0, "any-user", "unknown.action", json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(context.Background(), deps, 0, "any-user", "unknown.action", json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("expected nil error for unknown action, got %v", err)
 	}
@@ -1317,7 +1381,7 @@ func TestExecuteConnectorAction_PaymentMethod_Success(t *testing.T) {
 	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1355,7 +1419,7 @@ func TestExecuteConnectorAction_PaymentMethod_MissingRequired(t *testing.T) {
 	f := setupPaymentExecTest(t, paymentExecOpts{})
 
 	// No payment params provided.
-	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
+	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), nil, "")
 	if err == nil {
 		t.Fatal("expected error when payment_method_id is missing")
 	}
@@ -1381,7 +1445,7 @@ func TestExecuteConnectorAction_PaymentMethod_PerTxLimitExceeded(t *testing.T) {
 	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected error when per-transaction limit is exceeded")
 	}
@@ -1429,7 +1493,7 @@ func TestExecuteConnectorAction_PaymentMethod_MonthlyLimitExceeded(t *testing.T)
 	_, err = executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: pmID,
 		AmountCents:     &amount,
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected error when monthly limit is exceeded")
 	}
@@ -1465,7 +1529,7 @@ func TestExecuteConnectorAction_PaymentMethod_NotFound(t *testing.T) {
 	_, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), &paymentParams{
 		PaymentMethodID: "00000000-0000-0000-0000-000000000099",
 		AmountCents:     &amount,
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected error for nonexistent payment method")
 	}
@@ -1484,7 +1548,7 @@ func TestExecuteConnectorAction_NoPaymentMethod_WhenNotRequired(t *testing.T) {
 	f := setupPaymentExecTest(t, paymentExecOpts{RequiresPayment: &noPayment})
 
 	// No payment params — should succeed because action doesn't require payment.
-	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), nil)
+	result, err := executeConnectorAction(t.Context(), f.Deps, f.AgentID, f.UserID, f.ActionType, json.RawMessage(`{}`), nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/standing_approval_match.go
+++ b/api/standing_approval_match.go
@@ -14,8 +14,8 @@ import (
 // is executed immediately and the result is written to w. Returns true if the
 // response was written (either success or error), false if no standing approval
 // matched and the caller should fall through to the pending approval flow.
-func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps *Deps, agent *db.Agent, actionType string, params json.RawMessage, requestID string, pp *paymentParams) bool {
-	approvals, err := db.FindActiveStandingApprovalsForAgent(r.Context(), deps.DB, agent.AgentID, actionType, "")
+func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps *Deps, agent *db.Agent, actionType string, params json.RawMessage, requestID string, pp *paymentParams, connectorInstanceID string) bool {
+	approvals, err := db.FindActiveStandingApprovalsForAgent(r.Context(), deps.DB, agent.AgentID, actionType, connectorInstanceID)
 	if err != nil {
 		log.Printf("[%s] AutoApprove: find standing approvals: %v", TraceID(r.Context()), err)
 		CaptureError(r.Context(), err)
@@ -92,7 +92,7 @@ func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps
 	// the record remains even though no action succeeded. This is intentional: reversing
 	// the atomic CTE would require a compensating transaction and could mask abuse (an agent
 	// retrying indefinitely to bypass rate limits).
-	result, execErr := executeConnectorAction(r.Context(), deps, exec.AgentID, exec.UserID, actionType, params, pp)
+	result, execErr := executeConnectorAction(r.Context(), deps, exec.AgentID, exec.UserID, actionType, params, pp, connectorInstanceID)
 
 	// Emit audit event (best-effort).
 	emitStandingApprovalAuditEvent(r.Context(), deps.DB, exec.UserID, exec.AgentID, sa.StandingApprovalID, exec.ActionType, exec.AgentMeta, execErr)

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -472,7 +472,11 @@ func handleExecuteStandingApproval(deps *Deps) http.HandlerFunc {
 		// Attempt connector execution. If no connector is registered for this
 		// action type, the existing behavior (record execution, emit audit event)
 		// still works — execution just returns no external result (graceful degradation).
-		result, execErr := executeConnectorAction(r.Context(), deps, exec.AgentID, profile.ID, exec.ActionType, req.Parameters, nil)
+		var connectorInstanceID string
+		if exec.ConnectorInstanceID != nil {
+			connectorInstanceID = *exec.ConnectorInstanceID
+		}
+		result, execErr := executeConnectorAction(r.Context(), deps, exec.AgentID, profile.ID, exec.ActionType, req.Parameters, nil, connectorInstanceID)
 
 		// Always emit the audit event with the actual execution result (best-effort).
 		emitStandingApprovalAuditEvent(r.Context(), deps.DB, profile.ID, exec.AgentID, saID, exec.ActionType, exec.AgentMeta, execErr)

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"time"
 )
@@ -11,10 +12,11 @@ import (
 // ActionCapability, StandingApprovalCapability, and CapabilityActionConfig
 // structs from these rows.
 type AgentCapabilities struct {
-	Connectors        []CapabilityConnector
-	Actions           []CapabilityAction
-	StandingApprovals []CapabilityStandingApproval
-	ActionConfigs     []CapabilityActionConfig
+	Connectors         []CapabilityConnector
+	ConnectorInstances []CapabilityConnectorInstance
+	Actions            []CapabilityAction
+	StandingApprovals  []CapabilityStandingApproval
+	ActionConfigs      []CapabilityActionConfig
 }
 
 // CapabilityConnector represents an enabled connector with credential readiness.
@@ -23,6 +25,14 @@ type CapabilityConnector struct {
 	Name             string
 	Description      *string
 	CredentialsReady bool
+}
+
+// CapabilityConnectorInstance is one agent connector instance with per-instance credential readiness.
+type CapabilityConnectorInstance struct {
+	ConnectorID         string
+	ConnectorInstanceID string
+	Label               string
+	CredentialsReady    bool
 }
 
 // CapabilityAction represents an action available through an enabled connector.
@@ -49,10 +59,11 @@ type CapabilityActionConfig struct {
 
 // CapabilityStandingApproval represents an active, non-expired standing approval.
 type CapabilityStandingApproval struct {
-	StandingApprovalID string
-	ActionType         string
-	Constraints        json.RawMessage // raw JSONB
-	ExpiresAt          *time.Time
+	StandingApprovalID  string
+	ActionType          string
+	Constraints         json.RawMessage // raw JSONB
+	ExpiresAt           *time.Time
+	ConnectorInstanceID *string
 }
 
 // GetAgentCapabilities retrieves all data needed for the capabilities endpoint:
@@ -76,35 +87,38 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 	// Connectors with no connector_required_credentials rows are always ready.
 	connRows, err := db.Query(ctx, `
 		SELECT c.id, c.name, c.description,
-		       NOT EXISTS (
-		           SELECT 1 FROM connector_required_credentials crc
-		           WHERE crc.connector_id = c.id
-		             AND NOT (
-		                 (crc.auth_type <> 'oauth2' AND EXISTS (
-		                     SELECT 1 FROM agent_connector_credentials acc
-		                     INNER JOIN credentials cr ON cr.id = acc.credential_id
-		                     WHERE acc.agent_id = ac.agent_id
-		                       AND acc.connector_id = c.id
-		                       AND acc.approver_id = ac.approver_id
-		                       AND cr.user_id = ac.approver_id
-		                       AND (cr.service = crc.service OR cr.service = c.id)
-		                 ))
-		                 OR (crc.auth_type = 'oauth2' AND EXISTS (
-		                     SELECT 1 FROM agent_connector_credentials acc
-		                     INNER JOIN oauth_connections oc ON oc.id = acc.oauth_connection_id
-		                     WHERE acc.agent_id = ac.agent_id
-		                       AND acc.connector_id = c.id
-		                       AND acc.approver_id = ac.approver_id
-		                       AND oc.user_id = ac.approver_id
-		                       AND oc.provider = crc.oauth_provider
-		                       AND oc.status = 'active'
-		                       AND crc.oauth_scopes <@ oc.scopes
-		                 ))
-		             )
+		       BOOL_OR(
+		           NOT EXISTS (
+		               SELECT 1 FROM connector_required_credentials crc
+		               WHERE crc.connector_id = c.id
+		                 AND NOT (
+		                     (crc.auth_type <> 'oauth2' AND EXISTS (
+		                         SELECT 1 FROM agent_connector_credentials acc
+		                         INNER JOIN credentials cr ON cr.id = acc.credential_id
+		                         WHERE acc.agent_id = ac.agent_id
+		                           AND acc.connector_id = c.id
+		                           AND acc.approver_id = ac.approver_id
+		                           AND cr.user_id = ac.approver_id
+		                           AND (cr.service = crc.service OR cr.service = c.id)
+		                     ))
+		                     OR (crc.auth_type = 'oauth2' AND EXISTS (
+		                         SELECT 1 FROM agent_connector_credentials acc
+		                         INNER JOIN oauth_connections oc ON oc.id = acc.oauth_connection_id
+		                         WHERE acc.agent_id = ac.agent_id
+		                           AND acc.connector_id = c.id
+		                           AND acc.approver_id = ac.approver_id
+		                           AND oc.user_id = ac.approver_id
+		                           AND oc.provider = crc.oauth_provider
+		                           AND oc.status = 'active'
+		                           AND crc.oauth_scopes <@ oc.scopes
+		                     ))
+		                 )
+		           )
 		       ) AS credentials_ready
 		FROM agent_connectors ac
 		JOIN connectors c ON c.id = ac.connector_id
 		WHERE ac.agent_id = $1 AND ac.approver_id = $2
+		GROUP BY c.id, c.name, c.description
 		ORDER BY c.id`,
 		agentID, approverID,
 	)
@@ -129,6 +143,58 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 	// Short-circuit: no connectors means no actions or standing approvals.
 	if len(connectorIDs) == 0 {
 		return caps, nil
+	}
+
+	// 1b. Per-instance credential readiness (one row per agent_connectors instance).
+	instRows, err := db.Query(ctx, `
+		SELECT ac.connector_id, ac.connector_instance_id::text, ac.label,
+		       NOT EXISTS (
+		           SELECT 1 FROM connector_required_credentials crc
+		           WHERE crc.connector_id = ac.connector_id
+		             AND NOT (
+		                 (crc.auth_type <> 'oauth2' AND EXISTS (
+		                     SELECT 1 FROM agent_connector_credentials acc
+		                     INNER JOIN credentials cr ON cr.id = acc.credential_id
+		                     WHERE acc.agent_id = ac.agent_id
+		                       AND acc.connector_id = ac.connector_id
+		                       AND acc.connector_instance_id = ac.connector_instance_id
+		                       AND acc.approver_id = ac.approver_id
+		                       AND cr.user_id = ac.approver_id
+		                       AND (cr.service = crc.service OR cr.service = ac.connector_id)
+		                 ))
+		                 OR (crc.auth_type = 'oauth2' AND EXISTS (
+		                     SELECT 1 FROM agent_connector_credentials acc
+		                     INNER JOIN oauth_connections oc ON oc.id = acc.oauth_connection_id
+		                     WHERE acc.agent_id = ac.agent_id
+		                       AND acc.connector_id = ac.connector_id
+		                       AND acc.connector_instance_id = ac.connector_instance_id
+		                       AND acc.approver_id = ac.approver_id
+		                       AND oc.user_id = ac.approver_id
+		                       AND oc.provider = crc.oauth_provider
+		                       AND oc.status = 'active'
+		                       AND crc.oauth_scopes <@ oc.scopes
+		                 ))
+		             )
+		       ) AS credentials_ready
+		FROM agent_connectors ac
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2
+		ORDER BY ac.connector_id, ac.enabled_at ASC, ac.connector_instance_id ASC`,
+		agentID, approverID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer instRows.Close()
+
+	for instRows.Next() {
+		var ci CapabilityConnectorInstance
+		if err := instRows.Scan(&ci.ConnectorID, &ci.ConnectorInstanceID, &ci.Label, &ci.CredentialsReady); err != nil {
+			return nil, err
+		}
+		caps.ConnectorInstances = append(caps.ConnectorInstances, ci)
+	}
+	if err := instRows.Err(); err != nil {
+		return nil, err
 	}
 
 	// 2. Actions for enabled connectors.
@@ -159,7 +225,7 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 	// 3. Active, non-expired standing approvals for this agent.
 	saRows, err := db.Query(ctx, `
 		SELECT sa.standing_approval_id, sa.action_type, sa.constraints,
-		       sa.expires_at
+		       sa.expires_at, sa.connector_instance_id::text
 		FROM standing_approvals sa
 		WHERE sa.agent_id = $1
 		  AND sa.user_id = $2
@@ -176,8 +242,13 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 
 	for saRows.Next() {
 		var sa CapabilityStandingApproval
-		if err := saRows.Scan(&sa.StandingApprovalID, &sa.ActionType, &sa.Constraints, &sa.ExpiresAt); err != nil {
+		var instID sql.NullString
+		if err := saRows.Scan(&sa.StandingApprovalID, &sa.ActionType, &sa.Constraints, &sa.ExpiresAt, &instID); err != nil {
 			return nil, err
+		}
+		if instID.Valid {
+			s := instID.String
+			sa.ConnectorInstanceID = &s
 		}
 		caps.StandingApprovals = append(caps.StandingApprovals, sa)
 	}

--- a/db/standing_approvals.go
+++ b/db/standing_approvals.go
@@ -452,14 +452,15 @@ func RevokeStandingApproval(ctx context.Context, db DBTX, saID, userID string) (
 // AgentID, UserID, ActionType, and AgentMeta are derived from related rows
 // (not stored on the executions table) and populated via JOIN in queries.
 type StandingApprovalExecution struct {
-	ExecutionID        int64
-	StandingApprovalID string
-	AgentID            int64
-	UserID             string
-	ActionType         string
-	AgentMeta          []byte // raw JSONB from agents.metadata, may be nil
-	Parameters         []byte // raw JSONB, may be nil
-	ExecutedAt         time.Time
+	ExecutionID         int64
+	StandingApprovalID  string
+	AgentID             int64
+	UserID              string
+	ActionType          string
+	ConnectorInstanceID *string // from standing_approvals.connector_instance_id; nil = type-wide
+	AgentMeta           []byte  // raw JSONB from agents.metadata, may be nil
+	Parameters          []byte  // raw JSONB, may be nil
+	ExecutedAt          time.Time
 }
 
 // RecordStandingApprovalExecution inserts an execution record after locking the
@@ -471,7 +472,7 @@ func RecordStandingApprovalExecution(ctx context.Context, db DBTX, standingAppro
 
 	err := db.QueryRow(ctx,
 		`WITH locked AS (
-			SELECT standing_approval_id, agent_id, user_id, action_type
+			SELECT standing_approval_id, agent_id, user_id, action_type, connector_instance_id
 			FROM standing_approvals
 			WHERE standing_approval_id = $1 AND user_id = $2 AND status = 'active'
 			  AND (expires_at IS NULL OR expires_at > now())
@@ -484,12 +485,12 @@ func RecordStandingApprovalExecution(ctx context.Context, db DBTX, standingAppro
 			RETURNING id, standing_approval_id, parameters, executed_at
 		)
 		SELECT ins.id, ins.standing_approval_id, locked.agent_id, locked.user_id::text,
-		       locked.action_type, a.metadata, ins.parameters, ins.executed_at
+		       locked.action_type, locked.connector_instance_id, a.metadata, ins.parameters, ins.executed_at
 		FROM ins
 		JOIN locked ON locked.standing_approval_id = ins.standing_approval_id
 		LEFT JOIN agents a ON a.agent_id = locked.agent_id`,
 		standingApprovalID, userID, parameters,
-	).Scan(&e.ExecutionID, &e.StandingApprovalID, &e.AgentID, &e.UserID, &e.ActionType, &e.AgentMeta, &e.Parameters, &e.ExecutedAt)
+	).Scan(&e.ExecutionID, &e.StandingApprovalID, &e.AgentID, &e.UserID, &e.ActionType, &e.ConnectorInstanceID, &e.AgentMeta, &e.Parameters, &e.ExecutedAt)
 	if err == nil {
 		return &e, nil
 	}
@@ -618,7 +619,7 @@ func RecordStandingApprovalExecutionByAgent(ctx context.Context, db DBTX, standi
 
 	err := db.QueryRow(ctx,
 		`WITH locked AS (
-			SELECT standing_approval_id, agent_id, user_id, action_type
+			SELECT standing_approval_id, agent_id, user_id, action_type, connector_instance_id
 			FROM standing_approvals
 			WHERE standing_approval_id = $1
 			  AND agent_id = $2
@@ -634,13 +635,13 @@ func RecordStandingApprovalExecutionByAgent(ctx context.Context, db DBTX, standi
 			RETURNING id, standing_approval_id, parameters, executed_at
 		)
 		SELECT ins.id, ins.standing_approval_id, locked.agent_id, locked.user_id::text,
-		       locked.action_type, a.metadata, ins.parameters, ins.executed_at
+		       locked.action_type, locked.connector_instance_id, a.metadata, ins.parameters, ins.executed_at
 		FROM ins
 		JOIN locked ON locked.standing_approval_id = ins.standing_approval_id
 		LEFT JOIN agents a ON a.agent_id = locked.agent_id`,
 		standingApprovalID, agentID, parameters, requestID,
 	).Scan(&e.ExecutionID, &e.StandingApprovalID, &e.AgentID, &e.UserID, &e.ActionType,
-		&e.AgentMeta, &e.Parameters, &e.ExecutedAt)
+		&e.ConnectorInstanceID, &e.AgentMeta, &e.Parameters, &e.ExecutedAt)
 	if err == nil {
 		return &e, nil
 	}

--- a/db/testhelper/fixtures_credentials.go
+++ b/db/testhelper/fixtures_credentials.go
@@ -32,3 +32,12 @@ func InsertCredentialWithVaultSecretID(t *testing.T, d db.DBTX, credID, userID, 
 		`INSERT INTO credentials (id, user_id, service, vault_secret_id) VALUES ($1, $2, $3, $4)`,
 		credID, userID, service, vaultSecretID)
 }
+
+// InsertCredentialWithVaultSecretIDAndLabel creates a credential with vault secret and a disambiguating label
+// (required when the same user has multiple credentials for the same service).
+func InsertCredentialWithVaultSecretIDAndLabel(t *testing.T, d db.DBTX, credID, userID, service, label, vaultSecretID string) {
+	t.Helper()
+	mustExec(t, d,
+		`INSERT INTO credentials (id, user_id, service, label, vault_secret_id) VALUES ($1, $2, $3, $4, $5)`,
+		credID, userID, service, label, vaultSecretID)
+}

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -28,6 +28,7 @@ import {
   urgencyColor,
   RiskBadge,
 } from "./approval-components";
+import { formatConnectorDisplayName } from "./approvalConnectorLabel";
 
 /** Auto-close delay (ms) after a successful approval. */
 const SUCCESS_AUTO_CLOSE_MS = 3_000;
@@ -124,6 +125,13 @@ export function ReviewApprovalDialog({
   const { denyApproval, isPending: isDenying } = useDenyApproval();
   const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg, isLoading: schemaLoading } =
     useActionSchema(approval.action.type);
+  const connectorInstanceLabel =
+    typeof approval.action === "object" &&
+    approval.action !== null &&
+    "_connector_instance_label" in approval.action &&
+    typeof (approval.action as { _connector_instance_label?: unknown })._connector_instance_label === "string"
+      ? (approval.action as { _connector_instance_label: string })._connector_instance_label
+      : undefined;
   const remaining = useCountdown(approval.expires_at);
   const isExpired = remaining <= 0;
   const isBusy = pendingAction !== null || isDenying;
@@ -240,11 +248,13 @@ export function ReviewApprovalDialog({
                   <DialogTitle className="truncate text-base">
                     {actionName ?? approval.action.type}
                   </DialogTitle>
-                  {connectorName && (
-                    <p className="text-muted-foreground text-sm">
-                      {connectorName}
-                    </p>
-                  )}
+                  <p className="text-muted-foreground text-sm">
+                    {formatConnectorDisplayName({
+                      connectorName,
+                      actionType: approval.action.type,
+                      instanceLabel: connectorInstanceLabel,
+                    })}
+                  </p>
                 </div>
               </>
             )}

--- a/frontend/src/pages/dashboard/approvalConnectorLabel.test.ts
+++ b/frontend/src/pages/dashboard/approvalConnectorLabel.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { formatConnectorDisplayName } from "./approvalConnectorLabel";
+
+describe("formatConnectorDisplayName", () => {
+  it("appends instance label in parentheses when present", () => {
+    expect(
+      formatConnectorDisplayName({
+        connectorName: "Slack",
+        actionType: "slack.send_message",
+        instanceLabel: "Engineering",
+      }),
+    ).toBe("Slack (Engineering)");
+  });
+
+  it("falls back to connector prefix when connectorName is missing", () => {
+    expect(
+      formatConnectorDisplayName({
+        connectorName: null,
+        actionType: "slack.send_message",
+        instanceLabel: "Engineering",
+      }),
+    ).toBe("Slack (Engineering)");
+  });
+
+  it("uses connector name only when no instance label", () => {
+    expect(
+      formatConnectorDisplayName({
+        connectorName: "Slack",
+        actionType: "slack.send_message",
+        instanceLabel: undefined,
+      }),
+    ).toBe("Slack");
+  });
+});

--- a/frontend/src/pages/dashboard/approvalConnectorLabel.ts
+++ b/frontend/src/pages/dashboard/approvalConnectorLabel.ts
@@ -1,0 +1,24 @@
+/** First segment of an action type, title-cased (e.g. slack.send_message → Slack). */
+function humanizeConnectorPrefix(actionType: string): string {
+  const dot = actionType.indexOf(".");
+  const prefix = dot > 0 ? actionType.slice(0, dot) : actionType;
+  if (!prefix) return actionType;
+  return prefix.charAt(0).toUpperCase() + prefix.slice(1);
+}
+
+/**
+ * Connector line for approval UI: "Slack (Engineering)" when a multi-instance label is frozen on the action.
+ */
+export function formatConnectorDisplayName(args: {
+  connectorName: string | null | undefined;
+  actionType: string;
+  instanceLabel?: string | null;
+}): string {
+  const base =
+    args.connectorName?.trim() || humanizeConnectorPrefix(args.actionType);
+  const inst = args.instanceLabel?.trim();
+  if (inst) {
+    return `${base} (${inst})`;
+  }
+  return base;
+}

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -23,6 +23,8 @@ import { useDenyApproval } from "../../hooks/useDenyApproval";
 import { colors } from "../../theme/colors";
 import {
   humanizeActionType,
+  humanizeConnectorPrefix,
+  connectorInstanceLabelFromAction,
   buildActionSummary,
   safeParams,
   isExpired as checkExpired,
@@ -79,6 +81,12 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
 
   const summary = buildActionSummary(approval.action.type, parameters, undefined, approval.resource_details as Record<string, unknown> | undefined);
   const actionName = humanizeActionType(approval.action.type);
+  const instanceLabel = connectorInstanceLabelFromAction(
+    approval.action as { _connector_instance_label?: unknown },
+  );
+  const connectorDisplayName = instanceLabel
+    ? `${humanizeConnectorPrefix(approval.action.type)} (${instanceLabel})`
+    : null;
 
   // Derive display status for the hero header
   const displayStatus = useMemo(() => {
@@ -215,6 +223,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
         <HeroHeader
           actionName={actionName}
           actionType={approval.action.type}
+          connectorDisplayName={connectorDisplayName}
           actionVersion={approval.action.version}
           summary={summary}
           riskLevel={approval.context.risk_level}

--- a/mobile/src/screens/approvals/HeroHeader.tsx
+++ b/mobile/src/screens/approvals/HeroHeader.tsx
@@ -11,6 +11,8 @@ import { getAvatarColors, formatTimestamp } from "./approvalUtils";
 interface HeroHeaderProps {
   actionName: string;
   actionType: string;
+  /** e.g. "Slack (Engineering)" when a connector instance is targeted */
+  connectorDisplayName?: string | null;
   actionVersion?: string;
   summary: string;
   riskLevel?: "low" | "medium" | "high" | null;
@@ -28,6 +30,7 @@ interface HeroHeaderProps {
 export function HeroHeader({
   actionName,
   actionType,
+  connectorDisplayName,
   actionVersion,
   summary,
   riskLevel,
@@ -55,6 +58,9 @@ export function HeroHeader({
             {actionType}
             {actionVersion ? `  v${actionVersion}` : ""}
           </Text>
+          {connectorDisplayName ? (
+            <Text style={styles.connectorLine}>{connectorDisplayName}</Text>
+          ) : null}
         </View>
         {showStatus && <StatusPill status={displayStatus} />}
       </View>
@@ -133,6 +139,12 @@ const styles = StyleSheet.create({
     color: colors.gray400,
     fontFamily: "monospace",
     marginTop: 4,
+  },
+  connectorLine: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.gray700,
+    marginTop: 6,
   },
   summary: {
     fontSize: 15,

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -2,6 +2,8 @@ import {
   secondsUntil,
   formatCountdown,
   humanizeActionType,
+  humanizeConnectorPrefix,
+  connectorInstanceLabelFromAction,
   buildActionSummary,
   formatRelativeTime,
   formatLastUpdated,
@@ -275,5 +277,25 @@ describe("formatTimestamp", () => {
 
   it("returns input string for invalid date", () => {
     expect(formatTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("humanizeConnectorPrefix", () => {
+  it("title-cases the first segment", () => {
+    expect(humanizeConnectorPrefix("slack.send_message")).toBe("Slack");
+  });
+});
+
+describe("connectorInstanceLabelFromAction", () => {
+  it("returns the label when present", () => {
+    expect(
+      connectorInstanceLabelFromAction({
+        _connector_instance_label: "Engineering",
+      }),
+    ).toBe("Engineering");
+  });
+
+  it("returns undefined when absent", () => {
+    expect(connectorInstanceLabelFromAction({})).toBeUndefined();
   });
 });

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -66,6 +66,23 @@ export function humanizeActionType(actionType: string): string {
   return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
+/** First segment of an action type, title-cased (e.g. slack.send_message → Slack). */
+export function humanizeConnectorPrefix(actionType: string): string {
+  const dot = actionType.indexOf(".");
+  const prefix = dot > 0 ? actionType.slice(0, dot) : actionType;
+  if (!prefix) return actionType;
+  return prefix.charAt(0).toUpperCase() + prefix.slice(1);
+}
+
+/** Reads frozen multi-instance label from stored action JSON, if present. */
+export function connectorInstanceLabelFromAction(action: {
+  _connector_instance_label?: unknown;
+}): string | undefined {
+  const v = action._connector_instance_label;
+  if (typeof v === "string" && v.trim() !== "") return v;
+  return undefined;
+}
+
 /** Builds a plain-text summary for an action, similar to the web frontend. */
 export function buildActionSummary(
   actionType: string,

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -247,7 +247,20 @@ ApprovalSummary:
       description: Agent that requested the approval
       example: 42
     action:
-      $ref: './shared.yaml#/Action'
+      description: |
+        Same as `Action`, plus optional frozen connector instance fields when the
+        request targeted a specific instance (`_connector_instance_id`, `_connector_instance_label`).
+      allOf:
+        - $ref: './shared.yaml#/Action'
+        - type: object
+          properties:
+            _connector_instance_id:
+              type: string
+              format: uuid
+              description: Frozen UUID of the connector instance for this approval (if any).
+            _connector_instance_label:
+              type: string
+              description: Human-readable instance label at request time (if any).
     context:
       $ref: './shared.yaml#/ActionContext'
     status:

--- a/spec/openapi/components/schemas/capabilities.yaml
+++ b/spec/openapi/components/schemas/capabilities.yaml
@@ -112,6 +112,24 @@ AgentCapabilitiesResponse:
             standing_approvals: []
             action_configurations: []
 
+ConnectorInstanceCapability:
+  type: object
+  required:
+    - id
+    - label
+    - credentials_ready
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Instance identifier (also accepted as `connector_instance`).
+    label:
+      type: string
+      description: Human-readable label for this instance (shown in UIs and accepted as `connector_instance`).
+    credentials_ready:
+      type: boolean
+      description: Whether this specific instance has required credentials bound.
+
 ConnectorCapability:
   type: object
   required:
@@ -168,6 +186,14 @@ ConnectorCapability:
         `credentials_ready` is `false`. The agent can present this URL to the
         user to prompt credential setup.
       example: "https://app.permissionslip.dev/connect/stripe"
+
+    instances:
+      type: array
+      items:
+        $ref: '#/ConnectorInstanceCapability'
+      description: |
+        Enabled connector instances for this agent (one row per workspace/account binding).
+        Use `label` or `id` as `action.parameters.connector_instance` when multiple instances exist.
 
     actions:
       type: array
@@ -380,6 +406,14 @@ StandingApprovalCapability:
         the standing approval is inactive and the agent must use one-off
         approval or the user must create a new standing approval.
       example: "2026-05-15T00:00:00Z"
+
+    connector_instance_id:
+      type: string
+      format: uuid
+      nullable: true
+      description: |
+        When set, this standing approval applies only to that connector instance.
+        Omitted or null means type-wide (legacy) and matches any instance.
 
   example:
     standing_approval_id: "sa_def456"

--- a/spec/openapi/components/schemas/shared.yaml
+++ b/spec/openapi/components/schemas/shared.yaml
@@ -82,6 +82,14 @@ Action:
 
         **Security**: Permission Slip verifies that request parameters match the stored
         params_hash before executing actions.
+
+        **Multi-instance connectors**: When an agent has more than one instance of the
+        same connector (e.g. two Slack workspaces), include `connector_instance` in this
+        object with the instance label or UUID from `GET /agents/{id}/capabilities`
+        (`connectors[].instances[]`). Omit it when only one instance exists — the server
+        auto-selects. The field is stripped before schema validation and does not appear on
+        stored approvals; resolved routing is frozen as `_connector_instance_id` and
+        `_connector_instance_label` on the action object in responses.
       example:
         from: "alice@example.com"
         to:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -7320,7 +7320,20 @@ components:
           description: Agent that requested the approval
           example: 42
         action:
-          $ref: '#/components/schemas/Action'
+          description: |
+            Same as `Action`, plus optional frozen connector instance fields when the
+            request targeted a specific instance (`_connector_instance_id`, `_connector_instance_label`).
+          allOf:
+            - $ref: '#/components/schemas/Action'
+            - type: object
+              properties:
+                _connector_instance_id:
+                  type: string
+                  format: uuid
+                  description: Frozen UUID of the connector instance for this approval (if any).
+                _connector_instance_label:
+                  type: string
+                  description: Human-readable instance label at request time (if any).
         context:
           $ref: '#/components/schemas/ActionContext'
         status:
@@ -9513,6 +9526,13 @@ components:
             `credentials_ready` is `false`. The agent can present this URL to the
             user to prompt credential setup.
           example: https://app.permissionslip.dev/connect/stripe
+        instances:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectorInstanceCapability'
+          description: |
+            Enabled connector instances for this agent (one row per workspace/account binding).
+            Use `label` or `id` as `action.parameters.connector_instance` when multiple instances exist.
         actions:
           type: array
           items:
@@ -9712,6 +9732,13 @@ components:
             the standing approval is inactive and the agent must use one-off
             approval or the user must create a new standing approval.
           example: '2026-05-15T00:00:00Z'
+        connector_instance_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            When set, this standing approval applies only to that connector instance.
+            Omitted or null means type-wide (legacy) and matches any instance.
       example:
         standing_approval_id: sa_def456
         constraints:
@@ -11631,6 +11658,14 @@ components:
 
             **Security**: Permission Slip verifies that request parameters match the stored
             params_hash before executing actions.
+
+            **Multi-instance connectors**: When an agent has more than one instance of the
+            same connector (e.g. two Slack workspaces), include `connector_instance` in this
+            object with the instance label or UUID from `GET /agents/{id}/capabilities`
+            (`connectors[].instances[]`). Omit it when only one instance exists — the server
+            auto-selects. The field is stripped before schema validation and does not appear on
+            stored approvals; resolved routing is frozen as `_connector_instance_id` and
+            `_connector_instance_label` on the action object in responses.
           example:
             from: alice@example.com
             to:
@@ -11917,6 +11952,23 @@ components:
             next page. Only present when `has_more` is true. Do not construct
             or parse cursor values — they may change format without notice.
           example: 2026-02-11T13:15:00.123456Z,42
+    ConnectorInstanceCapability:
+      type: object
+      required:
+        - id
+        - label
+        - credentials_ready
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Instance identifier (also accepted as `connector_instance`).
+        label:
+          type: string
+          description: Human-readable label for this instance (shown in UIs and accepted as `connector_instance`).
+        credentials_ready:
+          type: boolean
+          description: Whether this specific instance has required credentials bound.
     AgentConnectorCredentialResponse:
       type: object
       required:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub issue #962 Phase 4: agents can target a specific connector instance via `action.parameters.connector_instance` (label or UUID). The server strips it before schema validation, freezes `_connector_instance_id` / `_connector_instance_label` on the stored action JSON, and routes credentials + standing-approval matching accordingly.

Also extends capabilities with per-instance rows (`instances[]`), threads instance scope through execution paths, enriches approval-request audit metadata, and updates web + mobile approval UIs to show `Connector (Label)` when a frozen label exists.

## Test plan

- [x] `cd frontend && npx vitest run src/pages/dashboard/approvalConnectorLabel.test.ts`
- [x] `cd mobile && npm test -- --ci src/screens/approvals/__tests__/approvalUtils.test.ts`
- [ ] Backend: `make test-backend` — **not run in this environment** (local Go version mismatch vs `go.mod`; CI should run full suite)

Closes #962
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e6ab8f7-c0d0-4bbe-8fc4-be0ffa6e989a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e6ab8f7-c0d0-4bbe-8fc4-be0ffa6e989a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

