### PR TITLE
Add HTTP panic recovery middleware (JSON 500, Sentry, trace_id)

### DIFF
--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -36,6 +36,7 @@ const (
 	ErrApprovalExpired              ErrorCode = "approval_expired"
 	ErrRateLimited                  ErrorCode = "rate_limited"
 	ErrInternalError                ErrorCode = "internal_error"
+	ErrInternalPanic                ErrorCode = "internal_panic"
 	ErrUpstreamError                ErrorCode = "upstream_error"
 	ErrActionConfigNotFound         ErrorCode = "action_config_not_found"
 	ErrActionConfigTemplateNotFound ErrorCode = "action_config_template_not_found"

--- a/api/recover_middleware.go
+++ b/api/recover_middleware.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+)
+
+// panicCaptureError is swapped in tests to verify Sentry reporting.
+var panicCaptureError = CaptureError
+
+// PanicRecoverMiddleware recovers from panics in downstream handlers and
+// writes a structured JSON 500 response. It must run inside sentryhttp.Handler
+// (so a Sentry hub exists) but before the inner handler chain so panics are
+// handled before sentry-go's recover fires.
+//
+// If the response writer has already sent headers, it only logs and reports
+// to Sentry — it does not write a second response.
+func PanicRecoverMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw := &panicRecoverWriter{ResponseWriter: w}
+		defer func() {
+			v := recover()
+			if v == nil {
+				return
+			}
+			traceID := TraceID(r.Context())
+			stack := debug.Stack()
+			slog.ErrorContext(r.Context(), "http handler panic",
+				slog.Any("panic", v),
+				slog.String("trace_id", traceID),
+				slog.String("stack", string(stack)),
+			)
+			panicCaptureError(r.Context(), fmt.Errorf("panic: %v\n%s", v, stack))
+			if rw.wroteHeader {
+				return
+			}
+			resp := newErrorResponse(ErrInternalPanic, "An unexpected error occurred. Please try again later.", false)
+			RespondError(rw, r, http.StatusInternalServerError, resp)
+		}()
+		next.ServeHTTP(rw, r)
+	})
+}
+
+type panicRecoverWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (pr *panicRecoverWriter) WriteHeader(code int) {
+	if !pr.wroteHeader {
+		pr.wroteHeader = true
+	}
+	pr.ResponseWriter.WriteHeader(code)
+}
+
+func (pr *panicRecoverWriter) Write(b []byte) (int, error) {
+	if !pr.wroteHeader {
+		// First Write sends implicit 200 OK and commits headers.
+		pr.wroteHeader = true
+	}
+	return pr.ResponseWriter.Write(b)
+}

--- a/api/recover_middleware_test.go
+++ b/api/recover_middleware_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPanicRecoverMiddleware_ReturnsStructured500(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("super-secret-panic-detail-do-not-leak")
+	})
+
+	var sentryCalled bool
+	oldCapture := panicCaptureError
+	panicCaptureError = func(_ context.Context, _ error) {
+		sentryCalled = true
+	}
+	t.Cleanup(func() { panicCaptureError = oldCapture })
+
+	handler := TraceIDMiddleware(PanicRecoverMiddleware(inner))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if !sentryCalled {
+		t.Error("expected CaptureError to be invoked")
+	}
+
+	var parsed ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if parsed.Error.Code != ErrInternalPanic {
+		t.Errorf("error.code = %q, want %q", parsed.Error.Code, ErrInternalPanic)
+	}
+	if parsed.Error.Retryable {
+		t.Error("expected retryable false")
+	}
+	if parsed.Error.TraceID == "" {
+		t.Error("expected non-empty trace_id on error")
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "super-secret-panic-detail-do-not-leak") {
+		t.Error("panic value leaked into response body")
+	}
+}
+
+func TestPanicRecoverMiddleware_NoSecondWriteAfterImplicit200(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+		panic("after implicit headers")
+	})
+
+	var sentryCalled bool
+	oldCapture := panicCaptureError
+	panicCaptureError = func(_ context.Context, _ error) {
+		sentryCalled = true
+	}
+	t.Cleanup(func() { panicCaptureError = oldCapture })
+
+	handler := TraceIDMiddleware(PanicRecoverMiddleware(inner))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !sentryCalled {
+		t.Error("expected CaptureError to be invoked")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (implicit from Write)", rec.Code)
+	}
+	if strings.TrimSpace(rec.Body.String()) != "ok" {
+		t.Errorf("body = %q, want ok", rec.Body.String())
+	}
+}
+
+func TestPanicRecoverMiddleware_NoSecondWriteAfterHeaders(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		panic("after headers")
+	})
+
+	var sentryCalled bool
+	oldCapture := panicCaptureError
+	panicCaptureError = func(_ context.Context, _ error) {
+		sentryCalled = true
+	}
+	t.Cleanup(func() { panicCaptureError = oldCapture })
+
+	handler := TraceIDMiddleware(PanicRecoverMiddleware(inner))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !sentryCalled {
+		t.Error("expected CaptureError to be invoked")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (no overwrite after headers)", rec.Code)
+	}
+	if strings.TrimSpace(rec.Body.String()) != "" {
+		t.Errorf("expected empty body after panic with headers sent, got %q", rec.Body.String())
+	}
+}
+
+func TestPanicRecoverMiddleware_PassThrough(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler := TraceIDMiddleware(PanicRecoverMiddleware(inner))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+}

--- a/api/router.go
+++ b/api/router.go
@@ -47,8 +47,9 @@ type Deps struct {
 }
 
 // NewRouter returns an http.Handler that serves all /api/v1/ routes.
-// The returned handler includes the TraceIDMiddleware, RequestLoggerMiddleware,
-// and RateLimitMiddleware.
+// The returned handler includes RequestLoggerMiddleware, RateLimitMiddleware,
+// sentryhttp, PanicRecoverMiddleware, and SentryTraceIDMiddleware. Trace IDs
+// are set by TraceIDMiddleware in main.go (wrapping the entire server).
 //
 // Rate limiting is scoped to /api/v1/ intentionally. Endpoints outside this
 // router (/api/health for load-balancer probes, /invite/ for user-facing
@@ -76,17 +77,17 @@ func NewRouter(deps *Deps) http.Handler {
 		handler = RequestLoggerMiddleware(deps.Logger, deps.TrustedProxyHeader)(handler)
 	}
 	// Middleware execution order (outermost → innermost):
-	//   TraceIDMiddleware → sentryhttp.Handler → SentryTraceIDMiddleware → ...
+	//   sentryhttp.Handler → PanicRecoverMiddleware → SentryTraceIDMiddleware → mux
 	//
-	// TraceID generates the trace ID first, sentryhttp puts a Sentry hub in
-	// context, then SentryTraceIDMiddleware tags the hub with the trace ID.
-	// sentryhttp also captures panics with full stack traces. Repanic: true
-	// re-panics so net/http or an upstream supervisor can also observe them.
+	// sentryhttp puts a Sentry hub in context. PanicRecoverMiddleware runs
+	// inside sentryhttp's defer order so it recovers before sentry-go's
+	// recover, writes JSON 500 + CaptureError, and does not re-panic.
+	// Repanic is false so the panic does not propagate after our recovery.
 	sentryHandler := sentryhttp.New(sentryhttp.Options{
-		Repanic: true,
+		Repanic: false,
 	})
 	handler = SentryTraceIDMiddleware(handler)
+	handler = PanicRecoverMiddleware(handler)
 	handler = sentryHandler.Handle(handler)
-	handler = TraceIDMiddleware(handler)
 	return handler
 }

--- a/main.go
+++ b/main.go
@@ -501,6 +501,10 @@ func main() {
 	}
 	handler = api.SecurityHeadersMiddleware(sentryCSPEndpoint, extraConnectSrc, extraScriptSrc)(handler)
 
+	// Trace ID + panic recovery wrap the entire server (API, webhooks, SPA).
+	// TraceID must be outermost so panics on any route get trace_id in logs/JSON.
+	handler = api.TraceIDMiddleware(api.PanicRecoverMiddleware(handler))
+
 	srv := &http.Server{
 		Addr:    ":" + port,
 		Handler: handler,

--- a/spec/openapi/components/schemas/errors.yaml
+++ b/spec/openapi/components/schemas/errors.yaml
@@ -71,6 +71,7 @@ Error:
         - monthly_quota_exceeded
         # 500 Internal Server Error
         - internal_error
+        - internal_panic
         # 502 Bad Gateway
         - upstream_error
         # 503 Service Unavailable

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -11850,6 +11850,7 @@ components:
             - rate_limited
             - monthly_quota_exceeded
             - internal_error
+            - internal_panic
             - upstream_error
             - service_unavailable
             - billing_not_enabled


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements [issue #969](https://github.com/supersuit-tech/permission-slip/issues/969): panic recovery for HTTP handlers so clients get a structured JSON 500 with `trace_id` and `error.code: internal_panic` instead of a bare upstream 502.

- **`api/recover_middleware.go`**: `PanicRecoverMiddleware` recovers panics, logs with `slog` (panic value + stack + `trace_id`), reports via `CaptureError`, and responds with `RespondError` using new `ErrInternalPanic`. Skips writing a body if headers were already sent (including implicit 200 from `Write()`).
- **`api/router.go`**: Chains `PanicRecoverMiddleware` **inside** `sentryhttp` (before inner handlers) with `Repanic: false` so our recovery runs before sentry-go’s defer and we avoid double-report/re-panic behavior.
- **`main.go`**: Wraps the entire mux with `TraceIDMiddleware` + `PanicRecoverMiddleware` so non-`/api/v1` routes (webhooks, invite, health, SPA) also get trace IDs and JSON panic responses.
- **OpenAPI**: Added `internal_panic` to the error `code` enum; rebundled `spec/openapi/openapi.bundle.yaml`.

## Test plan
- [ ] `go test ./api/...` (full backend suite) — **not run locally**: workspace Go is older than `go.mod` (1.25.9); CI should run tests.
- [x] `gofmt -e` on changed Go files; manual review of middleware order.
- [ ] After merge, optional: `make test` in an environment matching `go.mod`.

Closes #969
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4164762-0c3a-4bac-8178-c0a37835c339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4164762-0c3a-4bac-8178-c0a37835c339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

