### PR TITLE
fix(connectors): default Google/Microsoft outbound email to HTML

### DIFF
--- a/api/profiles_test.go
+++ b/api/profiles_test.go
@@ -36,9 +36,10 @@ func TestGetProfile_Unauthenticated(t *testing.T) {
 
 func TestGetProfile_TraceIDPresent(t *testing.T) {
 	t.Parallel()
-	// Verify trace ID middleware runs before session auth
+	// Verify trace ID middleware runs before session auth. NewRouter omits
+	// TraceIDMiddleware (main.go wraps the full mux); mirror production here.
 	deps := &Deps{SupabaseJWTSecret: testJWTSecret}
-	router := NewRouter(deps)
+	router := TraceIDMiddleware(NewRouter(deps))
 
 	r := httptest.NewRequest(http.MethodGet, "/profile", nil)
 	w := httptest.NewRecorder()

--- a/connectors/google/email_helpers.go
+++ b/connectors/google/email_helpers.go
@@ -1,17 +1,56 @@
 package google
 
 import (
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
+	"html"
+	"regexp"
 	"strings"
 )
 
-// buildGmailRaw constructs a plain-text RFC 2822 email message and returns
-// it as a base64url-encoded string suitable for the Gmail API's raw field.
+var tagPattern = regexp.MustCompile(`<[^>]*>`)
+
+// emailHTMLDefault returns true when html is nil (default HTML) or *html is true.
+func emailHTMLDefault(html *bool) bool {
+	if html == nil {
+		return true
+	}
+	return *html
+}
+
+// htmlToPlainText produces a minimal plain-text fallback from HTML for the
+// text/plain MIME part (tags stripped, entities decoded).
+func htmlToPlainText(s string) string {
+	s = strings.ReplaceAll(s, "<br>", "\n")
+	s = strings.ReplaceAll(s, "<br/>", "\n")
+	s = strings.ReplaceAll(s, "<br />", "\n")
+	s = strings.ReplaceAll(s, "</p>", "\n")
+	s = strings.ReplaceAll(s, "</div>", "\n")
+	s = tagPattern.ReplaceAllString(s, "")
+	s = html.UnescapeString(s)
+	return strings.TrimSpace(s)
+}
+
+func randomMimeBoundary() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Extremely unlikely; use a fixed fallback (still unique enough for one message).
+		return "ps_mime_fallback_boundary"
+	}
+	return "ps_mime_" + hex.EncodeToString(b[:])
+}
+
+// buildGmailRaw constructs an RFC 2822 email message and returns it as a
+// base64url-encoded string suitable for the Gmail API's raw field.
+//
+// When html is true, the message is multipart/alternative with text/plain and
+// text/html parts. When html is false, a single text/plain part is used.
 //
 // Callers are responsible for sanitizing header values before passing them in.
 // extraHeaders are written between Subject and Content-Type, in the order given;
 // entries with an empty value are skipped.
-func buildGmailRaw(to, subject, body string, extraHeaders [][2]string) string {
+func buildGmailRaw(to, subject, body string, html bool, extraHeaders [][2]string) string {
 	var msg strings.Builder
 	msg.WriteString("To: " + to + "\r\n")
 	msg.WriteString("Subject: " + subject + "\r\n")
@@ -20,8 +59,30 @@ func buildGmailRaw(to, subject, body string, extraHeaders [][2]string) string {
 			msg.WriteString(h[0] + ": " + h[1] + "\r\n")
 		}
 	}
-	msg.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
-	msg.WriteString("\r\n")
-	msg.WriteString(body)
+	if html {
+		boundary := randomMimeBoundary()
+		plain := htmlToPlainText(body)
+		if plain == "" {
+			plain = " "
+		}
+		msg.WriteString("MIME-Version: 1.0\r\n")
+		msg.WriteString("Content-Type: multipart/alternative; boundary=\"" + boundary + "\"\r\n")
+		msg.WriteString("\r\n")
+		msg.WriteString("--" + boundary + "\r\n")
+		msg.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
+		msg.WriteString("\r\n")
+		msg.WriteString(plain)
+		msg.WriteString("\r\n")
+		msg.WriteString("--" + boundary + "\r\n")
+		msg.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
+		msg.WriteString("\r\n")
+		msg.WriteString(body)
+		msg.WriteString("\r\n")
+		msg.WriteString("--" + boundary + "--\r\n")
+	} else {
+		msg.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
+		msg.WriteString("\r\n")
+		msg.WriteString(body)
+	}
 	return base64.RawURLEncoding.EncodeToString([]byte(msg.String()))
 }

--- a/connectors/google/email_helpers_test.go
+++ b/connectors/google/email_helpers_test.go
@@ -1,0 +1,67 @@
+package google
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestBuildGmailRaw_HTMLMultipartStructure(t *testing.T) {
+	t.Parallel()
+
+	htmlBody := "<p>Hello <strong>world</strong></p>"
+	raw := buildGmailRaw("a@b.com", "Subj", htmlBody, true, nil)
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	msg := string(decoded)
+	if !strings.Contains(msg, "MIME-Version: 1.0\r\n") {
+		t.Error("expected MIME-Version header")
+	}
+	if !strings.Contains(msg, "Content-Type: multipart/alternative; boundary=") {
+		t.Error("expected multipart/alternative")
+	}
+	if !strings.Contains(msg, "Content-Type: text/plain; charset=\"UTF-8\"") {
+		t.Error("expected text/plain part")
+	}
+	if !strings.Contains(msg, "Content-Type: text/html; charset=\"UTF-8\"") {
+		t.Error("expected text/html part")
+	}
+	if !strings.Contains(msg, htmlBody) {
+		t.Error("expected HTML body in message")
+	}
+	if !strings.Contains(msg, "Hello world") {
+		t.Error("expected plain fallback to strip tags")
+	}
+}
+
+func TestBuildGmailRaw_PlaintextOnly(t *testing.T) {
+	t.Parallel()
+
+	body := "Line1\nLine2"
+	raw := buildGmailRaw("x@y.com", "S", body, false, nil)
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	msg := string(decoded)
+	if strings.Contains(msg, "multipart/alternative") {
+		t.Error("did not expect multipart for plaintext mode")
+	}
+	if !strings.Contains(msg, "Content-Type: text/plain; charset=\"UTF-8\"") {
+		t.Error("expected single text/plain")
+	}
+	if !strings.HasSuffix(strings.TrimSpace(msg), body) {
+		t.Errorf("body not at end: %q", msg)
+	}
+}
+
+func TestHtmlToPlainText(t *testing.T) {
+	t.Parallel()
+
+	got := htmlToPlainText("<p>a &amp; b</p>")
+	if got != "a & b" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -47,8 +47,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Email body (plain text)",
+							"description": "Email body. When html is true (default), use valid HTML (e.g. <p>, <br>, <strong>). When html is false, body is sent as plain text and tags are not interpreted.",
 							"x-ui": {"label": "Body", "widget": "textarea"}
+						},
+						"html": {
+							"type": "boolean",
+							"default": true,
+							"description": "When true (default), body must be valid HTML. When false, body is sent as plain text only."
 						}
 					}
 				}`)),
@@ -912,8 +917,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Reply body (plain text)",
+							"description": "Reply body. When html is true (default), use valid HTML (e.g. <p>, <br>, <strong>). When html is false, body is sent as plain text and tags are not interpreted.",
 							"x-ui": {"label": "Reply", "widget": "textarea"}
+						},
+						"html": {
+							"type": "boolean",
+							"default": true,
+							"description": "When true (default), body must be valid HTML. When false, body is sent as plain text only."
 						}
 					}
 				}`)),

--- a/connectors/google/send_email.go
+++ b/connectors/google/send_email.go
@@ -21,6 +21,7 @@ type sendEmailParams struct {
 	To      string `json:"to"`
 	Subject string `json:"subject"`
 	Body    string `json:"body"`
+	HTML    *bool  `json:"html,omitempty"`
 }
 
 func (p *sendEmailParams) validate() error {
@@ -70,7 +71,7 @@ func (a *sendEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 		return nil, err
 	}
 
-	raw := buildGmailRaw(params.To, params.Subject, params.Body, nil)
+	raw := buildGmailRaw(params.To, params.Subject, params.Body, emailHTMLDefault(params.HTML), nil)
 
 	body := gmailSendRequest{Raw: raw}
 	var resp gmailSendResponse

--- a/connectors/google/send_email_reply.go
+++ b/connectors/google/send_email_reply.go
@@ -23,6 +23,7 @@ type sendEmailReplyParams struct {
 	ThreadID  string `json:"thread_id"`
 	MessageID string `json:"message_id"`
 	Body      string `json:"body"`
+	HTML      *bool  `json:"html,omitempty"`
 }
 
 func (p *sendEmailReplyParams) validate() error {
@@ -105,7 +106,7 @@ func (a *sendEmailReplyAction) Execute(ctx context.Context, req connectors.Actio
 	}
 
 	// Build and encode the RFC 2822 reply using the shared helper.
-	raw := buildGmailRaw(origFrom, replySubject, params.Body, [][2]string{
+	raw := buildGmailRaw(origFrom, replySubject, params.Body, emailHTMLDefault(params.HTML), [][2]string{
 		{"In-Reply-To", origMessageID},
 		{"References", origMessageID},
 	})

--- a/connectors/google/send_email_reply_test.go
+++ b/connectors/google/send_email_reply_test.go
@@ -124,8 +124,12 @@ func TestSendEmailReply_SubjectPrefixed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode raw: %v", err)
 	}
-	if !strings.Contains(string(raw), "Subject: Re: Existing Thread\r\n") {
-		t.Errorf("expected exact Subject header in raw message, got:\n%s", string(raw))
+	rawStr := string(raw)
+	if !strings.Contains(rawStr, "Subject: Re: Existing Thread\r\n") {
+		t.Errorf("expected exact Subject header in raw message, got:\n%s", rawStr)
+	}
+	if !strings.Contains(rawStr, "multipart/alternative") {
+		t.Error("expected multipart for default html reply")
 	}
 }
 
@@ -223,6 +227,42 @@ func TestSendEmailReply_MissingThreadID(t *testing.T) {
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSendEmailReply_HTMLFalsePlaintext(t *testing.T) {
+	var sent gmailSendReplyRequest
+	srv := httptest.NewServer(replyTestHandler(t,
+		"threadPlain", "sender@example.com", "Sub", "<mid@x.com>", &sent,
+	))
+	defer srv.Close()
+
+	conn := newGmailForTest(srv.Client(), srv.URL)
+	action := &sendEmailReplyAction{conn: conn}
+	htmlFalse := false
+	params, _ := json.Marshal(map[string]any{
+		"thread_id":  "threadPlain",
+		"message_id": "msgPlain",
+		"body":       "<b>not html</b>",
+		"html":       htmlFalse,
+	})
+	_, err := action.Execute(context.Background(), connectors.ActionRequest{
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(sent.Raw)
+	if err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	rawStr := string(raw)
+	if strings.Contains(rawStr, "multipart/alternative") {
+		t.Error("expected single part for html=false reply")
+	}
+	if !strings.Contains(rawStr, "<b>not html</b>") {
+		t.Error("expected literal angle brackets in plaintext reply body")
 	}
 }
 

--- a/connectors/google/send_email_test.go
+++ b/connectors/google/send_email_test.go
@@ -49,8 +49,11 @@ func TestSendEmail_Success(t *testing.T) {
 		if !strings.Contains(msg, "Subject: Test Subject") {
 			t.Error("decoded message missing Subject header")
 		}
-		if !strings.Contains(msg, "Hello, world!") {
-			t.Error("decoded message missing body text")
+		if !strings.Contains(msg, "<p>Hello, world!</p>") {
+			t.Error("decoded message missing HTML body")
+		}
+		if !strings.Contains(msg, "multipart/alternative") {
+			t.Error("expected multipart/alternative for default html mode")
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -67,7 +70,7 @@ func TestSendEmail_Success(t *testing.T) {
 	params, _ := json.Marshal(sendEmailParams{
 		To:      "user@example.com",
 		Subject: "Test Subject",
-		Body:    "Hello, world!",
+		Body:    "<p>Hello, world!</p>",
 	})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -278,6 +281,52 @@ func TestSendEmail_HeaderInjectionSubject(t *testing.T) {
 	}
 	if !connectors.IsValidationError(err) {
 		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestSendEmail_HTMLFalsePlaintext(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body gmailSendRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		decoded, err := base64.RawURLEncoding.DecodeString(body.Raw)
+		if err != nil {
+			t.Fatalf("decode raw: %v", err)
+		}
+		msg := string(decoded)
+		if strings.Contains(msg, "multipart/alternative") {
+			t.Error("expected single part for html=false")
+		}
+		if !strings.Contains(msg, "Content-Type: text/plain; charset=\"UTF-8\"") {
+			t.Error("expected text/plain only")
+		}
+		if !strings.Contains(msg, "<p>tags as text</p>") {
+			t.Error("expected literal tags in plaintext body")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(gmailSendResponse{ID: "m1", ThreadID: "t1"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL, "", "")
+	action := &sendEmailAction{conn: conn}
+	htmlFalse := false
+	params, _ := json.Marshal(sendEmailParams{
+		To:      "user@example.com",
+		Subject: "S",
+		Body:    "<p>tags as text</p>",
+		HTML:    &htmlFalse,
+	})
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/connectors/microsoft/README.md
+++ b/connectors/microsoft/README.md
@@ -32,7 +32,8 @@ Sends an email via Microsoft 365.
 |------|------|----------|---------|-------------|
 | `to` | string[] | Yes | — | Recipient email addresses |
 | `subject` | string | Yes | — | Email subject line |
-| `body` | string | Yes | — | Email body (HTML or plain text — auto-detected) |
+| `body` | string | Yes | — | Email body; format follows `html` |
+| `html` | boolean | No | `true` | When true, body is HTML; when false, plain text |
 | `cc` | string[] | No | — | CC recipient email addresses |
 
 **Response:**
@@ -141,7 +142,7 @@ Lists channels in a Microsoft Teams team.
 
 ### `microsoft.send_channel_message`
 
-Sends a message to a Microsoft Teams channel. Supports plain text and HTML (auto-detected). Optionally replies to an existing message thread.
+Sends a message to a Microsoft Teams channel. Body format is controlled by `html` (default HTML). Optionally replies to an existing message thread.
 
 **Risk level:** medium
 
@@ -151,7 +152,8 @@ Sends a message to a Microsoft Teams channel. Supports plain text and HTML (auto
 |------|------|----------|---------|-------------|
 | `team_id` | string | Yes | — | The ID of the team |
 | `channel_id` | string | Yes | — | The ID of the channel to post to |
-| `message` | string | Yes | — | Message content (HTML or plain text — auto-detected) |
+| `message` | string | Yes | — | Message content; format follows `html` |
+| `html` | boolean | No | `true` | When true, message is HTML; when false, plain text |
 | `reply_to_message_id` | string | No | — | Message ID to reply to (creates a threaded reply) |
 
 **Response:**
@@ -214,7 +216,8 @@ Creates a new event on the user's calendar.
 | `start` | string | Yes | — | Start date/time in ISO 8601 format (e.g., `2024-01-15T09:00:00`) |
 | `end` | string | Yes | — | End date/time in ISO 8601 format (e.g., `2024-01-15T10:00:00`) |
 | `time_zone` | string | No | `"UTC"` | Time zone (e.g., `America/New_York`) |
-| `body` | string | No | — | Event body/description (HTML supported) |
+| `body` | string | No | — | Event body/description; format follows `html` |
+| `html` | boolean | No | `true` | When true, body is HTML; when false, plain text |
 | `attendees` | string[] | No | — | Attendee email addresses |
 | `location` | string | No | — | Event location |
 

--- a/connectors/microsoft/create_calendar_event.go
+++ b/connectors/microsoft/create_calendar_event.go
@@ -34,6 +34,7 @@ type createCalendarEventParams struct {
 	End        string   `json:"end"`
 	TimeZone   string   `json:"time_zone"`
 	Body       string   `json:"body,omitempty"`
+	HTML       *bool    `json:"html,omitempty"`
 	Attendees  []string `json:"attendees,omitempty"`
 	Location   string   `json:"location,omitempty"`
 }
@@ -107,7 +108,7 @@ func (a *createCalendarEventAction) Execute(ctx context.Context, req connectors.
 
 	if params.Body != "" {
 		graphReq.Body = &graphEmailBody{
-			ContentType: "HTML",
+			ContentType: graphBodyContentType(params.HTML),
 			Content:     params.Body,
 		}
 	}

--- a/connectors/microsoft/create_calendar_event_test.go
+++ b/connectors/microsoft/create_calendar_event_test.go
@@ -112,6 +112,101 @@ func TestCreateCalendarEvent_WithCalendarID(t *testing.T) {
 	}
 }
 
+func TestCreateCalendarEvent_BodyDefaultHTML(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body graphEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Body == nil {
+			t.Fatal("expected event body")
+		}
+		if body.Body.ContentType != "HTML" {
+			t.Errorf("expected default body ContentType HTML, got %q", body.Body.ContentType)
+		}
+		if body.Body.Content != "Agenda line one" {
+			t.Errorf("unexpected body content: %q", body.Body.Content)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "event-body",
+			"subject": "S",
+			"start":   map[string]string{"dateTime": "2024-01-15T09:00:00", "timeZone": "UTC"},
+			"end":     map[string]string{"dateTime": "2024-01-15T10:00:00", "timeZone": "UTC"},
+			"webLink": "https://example.com",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		Subject: "S",
+		Start:   "2024-01-15T09:00:00",
+		End:     "2024-01-15T10:00:00",
+		Body:    "Agenda line one",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateCalendarEvent_BodyPlainText(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body graphEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Body == nil {
+			t.Fatal("expected event body")
+		}
+		if body.Body.ContentType != "Text" {
+			t.Errorf("expected body ContentType Text, got %q", body.Body.ContentType)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "event-txt",
+			"subject": "S",
+			"start":   map[string]string{"dateTime": "2024-01-15T09:00:00", "timeZone": "UTC"},
+			"end":     map[string]string{"dateTime": "2024-01-15T10:00:00", "timeZone": "UTC"},
+			"webLink": "https://example.com",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &createCalendarEventAction{conn: conn}
+	htmlFalse := false
+
+	params, _ := json.Marshal(createCalendarEventParams{
+		Subject: "S",
+		Start:   "2024-01-15T09:00:00",
+		End:     "2024-01-15T10:00:00",
+		Body:    "<p>not html</p>",
+		HTML:    &htmlFalse,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.create_calendar_event",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCreateCalendarEvent_WithAttendees(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/microsoft/manifest_templates.go
+++ b/connectors/microsoft/manifest_templates.go
@@ -49,7 +49,7 @@ func microsoftTemplates() []connectors.ManifestTemplate {
 			ActionType:  "microsoft.create_calendar_event",
 			Name:        "Create calendar events",
 			Description: "Agent can create events on the calendar with any details.",
-			Parameters:  json.RawMessage(`{"subject":"*","start":"*","end":"*","time_zone":"*","body":"*","attendees":"*","location":"*","calendar_id":""}`),
+			Parameters:  json.RawMessage(`{"subject":"*","start":"*","end":"*","time_zone":"*","body":"*","attendees":"*","location":"*","calendar_id":"","html":"*"}`),
 		},
 		// --- OneDrive read ---
 		{
@@ -209,7 +209,7 @@ func microsoftTemplates() []connectors.ManifestTemplate {
 			ActionType:  "microsoft.send_channel_message",
 			Name:        "Send channel messages",
 			Description: "Agent can send messages to any Teams channel.",
-			Parameters:  json.RawMessage(`{"team_id":"*","channel_id":"*","message":"*","reply_to_message_id":"*"}`),
+			Parameters:  json.RawMessage(`{"team_id":"*","channel_id":"*","message":"*","reply_to_message_id":"*","html":"*"}`),
 		},
 	}
 }

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -160,7 +160,12 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Event body/description (HTML supported)"
+							"description": "Event body/description. When html is true (default), use valid HTML. When false, plain text only."
+						},
+						"html": {
+							"type": "boolean",
+							"default": true,
+							"description": "When true (default), body is HTML. When false, body is plain text only."
 						},
 						"attendees": {
 							"type": "array",
@@ -441,7 +446,12 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"message": {
 							"type": "string",
-							"description": "Message content (HTML or plain text — auto-detected)"
+							"description": "Message content. When html is true (default), use valid HTML. When false, plain text only."
+						},
+						"html": {
+							"type": "boolean",
+							"default": true,
+							"description": "When true (default), message is HTML. When false, plain text only."
 						},
 						"reply_to_message_id": {
 							"type": "string",

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -4,9 +4,9 @@
 package microsoft
 
 import (
-	_ "embed"
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,6 +62,7 @@ func (c *MicrosoftConnector) ID() string { return "microsoft" }
 
 // Manifest returns the connector's metadata manifest. Used by the server to
 // auto-seed DB rows on startup, replacing manual seed.go files.
+//
 //go:embed logo.svg
 var logoSVG string
 
@@ -93,12 +94,17 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"body": {
 							"type": "string",
-							"description": "Email body (HTML or plain text — auto-detected)"
+							"description": "Email body. When html is true (default), use valid HTML (e.g. <p>, <br>, <strong>). When html is false, body is sent as plain text and tags are not interpreted."
 						},
 						"cc": {
 							"type": "array",
 							"items": {"type": "string"},
 							"description": "CC recipient email addresses"
+						},
+						"html": {
+							"type": "boolean",
+							"default": true,
+							"description": "When true (default), body must be valid HTML. When false, body is sent as plain text only."
 						}
 					}
 				}`)),
@@ -213,7 +219,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-			ActionType:  "microsoft.list_drive_files",
+				ActionType:  "microsoft.list_drive_files",
 				Name:        "List Drive Files",
 				Description: "List files and folders in OneDrive",
 				RiskLevel:   "low",

--- a/connectors/microsoft/send_channel_message.go
+++ b/connectors/microsoft/send_channel_message.go
@@ -21,6 +21,7 @@ type sendChannelMessageParams struct {
 	ChannelID        string `json:"channel_id"`
 	Message          string `json:"message"`
 	ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
+	HTML             *bool  `json:"html,omitempty"`
 }
 
 func (p *sendChannelMessageParams) validate() error {
@@ -69,7 +70,7 @@ func (a *sendChannelMessageAction) Execute(ctx context.Context, req connectors.A
 
 	graphReq := graphChannelMessageRequest{
 		Body: graphChannelMessageBody{
-			ContentType: detectContentType(params.Message),
+			ContentType: graphBodyContentType(params.HTML),
 			Content:     params.Message,
 		},
 	}

--- a/connectors/microsoft/send_channel_message_test.go
+++ b/connectors/microsoft/send_channel_message_test.go
@@ -33,8 +33,8 @@ func TestSendChannelMessage_Success(t *testing.T) {
 		if body.Body.Content != "Hello Teams!" {
 			t.Errorf("expected message 'Hello Teams!', got %q", body.Body.Content)
 		}
-		if body.Body.ContentType != "Text" {
-			t.Errorf("expected content type 'Text', got %q", body.Body.ContentType)
+		if body.Body.ContentType != "HTML" {
+			t.Errorf("expected default content type 'HTML', got %q", body.Body.ContentType)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -76,7 +76,7 @@ func TestSendChannelMessage_Success(t *testing.T) {
 	}
 }
 
-func TestSendChannelMessage_HTMLContent(t *testing.T) {
+func TestSendChannelMessage_HTMLExplicitTrue(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +85,7 @@ func TestSendChannelMessage_HTMLContent(t *testing.T) {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
 		if body.Body.ContentType != "HTML" {
-			t.Errorf("expected content type 'HTML' for HTML body, got %q", body.Body.ContentType)
+			t.Errorf("expected content type 'HTML', got %q", body.Body.ContentType)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -99,11 +99,58 @@ func TestSendChannelMessage_HTMLContent(t *testing.T) {
 
 	conn := newForTest(srv.Client(), srv.URL)
 	action := &sendChannelMessageAction{conn: conn}
+	htmlTrue := true
 
 	params, _ := json.Marshal(sendChannelMessageParams{
 		TeamID:    "team-1",
 		ChannelID: "channel-1",
-		Message:   "<p>Hello <strong>Teams</strong></p>",
+		Message:   "plain prose, no brackets",
+		HTML:      &htmlTrue,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.send_channel_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendChannelMessage_HTMLFalsePlainText(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body graphChannelMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Body.ContentType != "Text" {
+			t.Errorf("expected content type 'Text', got %q", body.Body.ContentType)
+		}
+		if body.Body.Content != "<p>literal</p>" {
+			t.Errorf("expected literal message, got %q", body.Body.Content)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":              "msg-plain",
+			"createdDateTime": "2024-01-15T10:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendChannelMessageAction{conn: conn}
+	htmlFalse := false
+
+	params, _ := json.Marshal(sendChannelMessageParams{
+		TeamID:    "team-1",
+		ChannelID: "channel-1",
+		Message:   "<p>literal</p>",
+		HTML:      &htmlFalse,
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -316,9 +363,9 @@ func TestSendChannelMessage_PathTraversalInReplyID(t *testing.T) {
 	action := &sendChannelMessageAction{conn: conn}
 
 	params, _ := json.Marshal(map[string]string{
-		"team_id":              "team-1",
-		"channel_id":           "channel-1",
-		"message":              "Hello",
+		"team_id":             "team-1",
+		"channel_id":          "channel-1",
+		"message":             "Hello",
 		"reply_to_message_id": "../../me/sendMail",
 	})
 

--- a/connectors/microsoft/send_email.go
+++ b/connectors/microsoft/send_email.go
@@ -86,7 +86,7 @@ func (a *sendEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	var graphReq graphSendMailRequest
 	graphReq.Message.Subject = params.Subject
 	graphReq.Message.Body = graphEmailBody{
-		ContentType: sendMailGraphContentType(params.HTML),
+		ContentType: graphBodyContentType(params.HTML),
 		Content:     params.Body,
 	}
 	graphReq.Message.ToRecipients = toGraphRecipients(params.To)

--- a/connectors/microsoft/send_email.go
+++ b/connectors/microsoft/send_email.go
@@ -21,6 +21,7 @@ type sendEmailParams struct {
 	Subject string   `json:"subject"`
 	Body    string   `json:"body"`
 	CC      []string `json:"cc,omitempty"`
+	HTML    *bool    `json:"html,omitempty"`
 }
 
 func (p *sendEmailParams) validate() error {
@@ -85,7 +86,7 @@ func (a *sendEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	var graphReq graphSendMailRequest
 	graphReq.Message.Subject = params.Subject
 	graphReq.Message.Body = graphEmailBody{
-		ContentType: detectContentType(params.Body),
+		ContentType: sendMailGraphContentType(params.HTML),
 		Content:     params.Body,
 	}
 	graphReq.Message.ToRecipients = toGraphRecipients(params.To)

--- a/connectors/microsoft/send_email_test.go
+++ b/connectors/microsoft/send_email_test.go
@@ -30,6 +30,9 @@ func TestSendEmail_Success(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
+		if body.Message.Body.ContentType != "HTML" {
+			t.Errorf("expected default HTML content type, got %q", body.Message.Body.ContentType)
+		}
 		if body.Message.Subject != "Test Subject" {
 			t.Errorf("expected subject 'Test Subject', got %q", body.Message.Subject)
 		}
@@ -308,11 +311,49 @@ func TestSendEmail_PlainTextBody(t *testing.T) {
 
 	conn := newForTest(srv.Client(), srv.URL)
 	action := &sendEmailAction{conn: conn}
+	htmlFalse := false
 
 	params, _ := json.Marshal(sendEmailParams{
 		To:      []string{"user@example.com"},
 		Subject: "Test",
 		Body:    "Just plain text, no HTML here.",
+		HTML:    &htmlFalse,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "microsoft.send_email",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendEmail_HTMLExplicitTrue(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body graphSendMailRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Message.Body.ContentType != "HTML" {
+			t.Errorf("expected content type 'HTML', got %q", body.Message.Body.ContentType)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendEmailAction{conn: conn}
+	htmlTrue := true
+
+	params, _ := json.Marshal(sendEmailParams{
+		To:      []string{"user@example.com"},
+		Subject: "Test",
+		Body:    "minimal",
+		HTML:    &htmlTrue,
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -346,7 +387,7 @@ func TestSendEmail_HTMLBody(t *testing.T) {
 	params, _ := json.Marshal(sendEmailParams{
 		To:      []string{"user@example.com"},
 		Subject: "Test",
-		Body:    "<p>Hello <strong>world</strong></p>",
+		Body:    "No angle brackets — still HTML mode by default.",
 	})
 
 	_, err := action.Execute(t.Context(), connectors.ActionRequest{

--- a/connectors/microsoft/validation.go
+++ b/connectors/microsoft/validation.go
@@ -53,6 +53,15 @@ func detectContentType(body string) string {
 	return "Text"
 }
 
+// sendMailGraphContentType maps the explicit html flag to Microsoft Graph
+// sendMail body contentType. Nil defaults to HTML (issue #971).
+func sendMailGraphContentType(html *bool) string {
+	if html != nil && !*html {
+		return "Text"
+	}
+	return "HTML"
+}
+
 // validateFolderPath checks a OneDrive folder path for traversal sequences and
 // URL-significant characters that could manipulate the Graph API request.
 // Slashes are allowed since folder paths are naturally slash-separated.

--- a/connectors/microsoft/validation.go
+++ b/connectors/microsoft/validation.go
@@ -45,17 +45,10 @@ func validateItemID(id string) error {
 	return validateGraphID("item_id", id)
 }
 
-// detectContentType returns "HTML" if the body contains HTML tags, otherwise "Text".
-func detectContentType(body string) string {
-	if strings.Contains(body, "<") && strings.Contains(body, ">") {
-		return "HTML"
-	}
-	return "Text"
-}
-
-// sendMailGraphContentType maps the explicit html flag to Microsoft Graph
-// sendMail body contentType. Nil defaults to HTML (issue #971).
-func sendMailGraphContentType(html *bool) string {
+// graphBodyContentType maps the explicit html flag to Microsoft Graph
+// body contentType (sendMail, Teams messages, event body, etc.). Nil defaults
+// to HTML so Markdown-ish content without angle brackets still renders as HTML.
+func graphBodyContentType(html *bool) string {
 	if html != nil && !*html {
 		return "Text"
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub #971: outbound Gmail and Microsoft Graph emails now default to HTML rendering instead of plaintext or brittle tag sniffing.

- **Gmail (`google.send_email`, `google.send_email_reply`)**: Optional `html` (`*bool`, default when omitted: **true**). When HTML mode is on, messages are `multipart/alternative` with `text/html` plus a generated `text/plain` fallback (tags stripped, entities decoded). When `html: false`, behavior matches the previous single `text/plain` path.
- **Microsoft (`microsoft.send_email`)**: Same `html` flag. Graph `body.contentType` is **`HTML`** or **`Text`** from that flag only (default **HTML**).

**Parity (this update):** `microsoft.send_channel_message` and `microsoft.create_calendar_event` now use the same explicit `html` parameter and shared `graphBodyContentType` helper. The `<…>` tag heuristic (`detectContentType`) is removed.

Connector manifests and `connectors/microsoft/README.md` document the parameters.

## Tests

- `go test ./connectors/google/... ./connectors/microsoft/...`
- `go test ./connectors/...`

( Full `make test-backend` not run in this environment; CI should cover the rest. )

Closes #971
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26ef83ec-76eb-4fe2-89d8-09a234c6b493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26ef83ec-76eb-4fe2-89d8-09a234c6b493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

