### PR TITLE
Clarify multi-task issue organization: one PR per phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ The OpenAPI spec (`spec/openapi/`) is the single source of truth for all API typ
 - When creating issues, default to using checklists (`- [ ]`) instead of bullet points for work items that can be completed independently. This makes it easy to track progress directly in the issue.
 - When you encounter an issue with a checklist that is out of date (items completed but not checked off, missing items, irrelevant items), update the checklist to reflect the current state.
 - **Never assume issue scope.** If you can't access an issue (e.g., a link doesn't work or returns an error), try fetching it with the `gh` CLI (`GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh issue view <number>`). If you still can't access it, ask the user for the issue details — do not guess or infer what the issue is about.
-- **Organize multi-task issues into phases.** When an issue has multiple tasks, group them into sequential phases where each phase depends on the previous one completing. Within each phase, mark which tasks can run in parallel vs. which must be sequential. Use checklists within each phase for trackability.
+- **Organize multi-task issues into phases, one PR per phase.** When an issue has multiple tasks, group them into sequential phases where each phase depends on the previous one completing. Each phase should be scoped to ship as its own PR — sized so it can be reviewed and merged independently before the next phase begins. Within each phase, mark which tasks can run in parallel vs. which must be sequential. Use checklists within each phase for trackability, and reference the phase's PR in the issue as it opens/merges.
 
 ## Go Toolchain Setup
 


### PR DESCRIPTION
## Summary

- Updated guidance on organizing multi-task issues to explicitly require one PR per phase
- Clarified that each phase should be scoped to ship independently and be reviewable/mergeable before the next phase begins
- Added guidance to reference the phase's PR in the issue as it opens/merges for better traceability

## Related Issue

N/A

## Test Plan

No testing needed — this is a documentation update to the contributor guidelines.

## Notes for Reviewers

This change reinforces the principle of keeping PRs focused and reviewable by tying the phase-based organization of issues directly to PR scope. It helps prevent large, hard-to-review PRs by making it explicit that each phase should be its own PR.

https://claude.ai/code/session_011zaAAMwFH373ZcnqsQpDt8