### PR TITLE
Phase 1: drop agent_connectors.label (migration + DB/API alignment)

### DIFF
--- a/api/agent_approvals_instance.go
+++ b/api/agent_approvals_instance.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -71,6 +72,9 @@ func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Ag
 		} else {
 			resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
 			if err != nil {
+				if amb := ambiguousConnectorInstanceErr(err); amb != nil {
+					return "", amb
+				}
 				return "", err
 			}
 			if resolved == nil || resolved.ConnectorInstanceID != only.ConnectorInstanceID {
@@ -93,6 +97,9 @@ func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Ag
 		}
 		resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
 		if err != nil {
+			if amb := ambiguousConnectorInstanceErr(err); amb != nil {
+				return "", amb
+			}
 			return "", err
 		}
 		if resolved == nil {
@@ -109,4 +116,15 @@ func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Ag
 	displayRaw, _ := json.Marshal(inst.DisplayName)
 	actionObj["_connector_instance_display"] = displayRaw
 	return inst.ConnectorInstanceID, nil
+}
+
+func ambiguousConnectorInstanceErr(err error) *connectorInstanceResolutionError {
+	var instErr *db.AgentConnectorInstanceError
+	if !errors.As(err, &instErr) || instErr.Code != db.AgentConnectorInstanceErrAmbiguousDisplay {
+		return nil
+	}
+	resp := BadRequest(ErrConnectorInstanceAmbiguous,
+		"multiple connector instances match this display name; use connector_instance with a UUID from GET /agents/{id}/capabilities")
+	resp.Error.Details = map[string]any{"matching_instance_ids": instErr.AmbiguousInstanceIDs}
+	return &connectorInstanceResolutionError{status: http.StatusBadRequest, resp: resp}
 }

--- a/api/agent_approvals_instance.go
+++ b/api/agent_approvals_instance.go
@@ -20,7 +20,7 @@ func (e *connectorInstanceResolutionError) Error() string {
 }
 
 // applyConnectorInstanceToAction removes parameters.connector_instance, resolves the target
-// instance for the action's connector, and sets _connector_instance_id and _connector_instance_label
+// instance for the action's connector, and sets _connector_instance_id and _connector_instance_display
 // on the action object. Returns the resolved instance UUID for credential routing (empty if the
 // connector has no enabled instances on the agent — downstream "no credential" handling applies).
 func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Agent, actionType string, actionObj map[string]json.RawMessage) (connectorInstanceID string, err error) {
@@ -83,12 +83,12 @@ func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Ag
 		}
 	} else {
 		if selector == "" {
-			labels := make([]string, 0, len(instances))
+			nicknames := make([]string, 0, len(instances))
 			for _, i := range instances {
-				labels = append(labels, i.Label)
+				nicknames = append(nicknames, i.DisplayName)
 			}
 			resp := BadRequest(ErrConnectorInstanceRequired, "connector_instance is required when multiple instances exist")
-			resp.Error.Details = map[string]any{"available_instances": labels}
+			resp.Error.Details = map[string]any{"available_instances": nicknames}
 			return "", &connectorInstanceResolutionError{status: http.StatusBadRequest, resp: resp}
 		}
 		resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
@@ -106,7 +106,7 @@ func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Ag
 
 	idRaw, _ := json.Marshal(inst.ConnectorInstanceID)
 	actionObj["_connector_instance_id"] = idRaw
-	labelRaw, _ := json.Marshal(inst.Label)
-	actionObj["_connector_instance_label"] = labelRaw
+	displayRaw, _ := json.Marshal(inst.DisplayName)
+	actionObj["_connector_instance_display"] = displayRaw
 	return inst.ConnectorInstanceID, nil
 }

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors/slack"
 	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
+	"github.com/supersuit-tech/permission-slip/vault"
 )
 
 // testDepsForDB creates a Deps suitable for tests that only need a DB and JWT secret.
@@ -1042,15 +1043,65 @@ func TestAgentRequestApproval_MultiInstance_RequiresConnectorInstance(t *testing
 	testhelper.InsertConnector(t, tx, connID)
 	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-	if _, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
-		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Beta",
+	ctx := context.Background()
+	if _, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
 	}); err != nil {
 		t.Fatalf("second instance: %v", err)
 	}
 
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "k1"})
+	v1, err := v.CreateSecret(ctx, tx, "c1", credJSON)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID1, uid, connID, "Alpha", v1)
+
+	credJSON2, _ := json.Marshal(map[string]string{"api_key": "k2"})
+	v2, err := v.CreateSecret(ctx, tx, "c2", credJSON2)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID2 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID2, uid, connID, "Beta", v2)
+
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default instance: %v", defInst)
+	}
+	instances, err := db.ListAgentConnectorInstances(ctx, tx, agentID, uid, connID)
+	if err != nil || len(instances) != 2 {
+		t.Fatalf("instances: %v len=%d", err, len(instances))
+	}
+	var secondID string
+	for _, inst := range instances {
+		if inst.ConnectorInstanceID != defInst.ConnectorInstanceID {
+			secondID = inst.ConnectorInstanceID
+			break
+		}
+	}
+	if secondID == "" {
+		t.Fatal("expected two distinct instances")
+	}
+
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID1,
+	}); err != nil {
+		t.Fatalf("bind default: %v", err)
+	}
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: secondID, ApproverID: uid, CredentialID: &credID2,
+	}); err != nil {
+		t.Fatalf("bind second: %v", err)
+	}
+
 	reg := connectors.NewRegistry()
 	reg.Register(newTestStubConnector(connID, connID+".ping"))
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	deps := &Deps{DB: tx, Vault: v, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
 	router := NewRouter(deps)
 
 	reqBody := `{"request_id":"req_mi_need_inst","action":{"type":"` + connID + `.ping","parameters":{}},"context":{"description":"x"}}`
@@ -1072,6 +1123,16 @@ func TestAgentRequestApproval_MultiInstance_RequiresConnectorInstance(t *testing
 	if len(labels) != 2 {
 		t.Fatalf("expected 2 available_instances, got %#v", errResp.Error.Details)
 	}
+	got := make(map[string]struct{})
+	for _, x := range labels {
+		s, _ := x.(string)
+		got[s] = struct{}{}
+	}
+	for _, want := range []string{"Alpha", "Beta"} {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("expected available_instances to include %q, got %#v", want, labels)
+		}
+	}
 }
 
 func TestAgentRequestApproval_MultiInstance_WithLabel_FreezesInstanceOnAction(t *testing.T) {
@@ -1090,16 +1151,51 @@ func TestAgentRequestApproval_MultiInstance_WithLabel_FreezesInstanceOnAction(t 
 	testhelper.InsertConnector(t, tx, connID)
 	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-	inst2, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
-		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Sales",
+	ctx := context.Background()
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
 	})
 	if err != nil {
 		t.Fatalf("second instance: %v", err)
 	}
 
+	v := vault.NewMockVaultStore()
+	credJSON1, _ := json.Marshal(map[string]string{"api_key": "k1"})
+	v1, err := v.CreateSecret(ctx, tx, "c1", credJSON1)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID1, uid, connID, "Alpha", v1)
+
+	credJSON2, _ := json.Marshal(map[string]string{"api_key": "k2"})
+	v2, err := v.CreateSecret(ctx, tx, "c2", credJSON2)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID2 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID2, uid, connID, "Sales", v2)
+
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default instance: %v", defInst)
+	}
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID1,
+	}); err != nil {
+		t.Fatalf("bind default: %v", err)
+	}
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: inst2.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID2,
+	}); err != nil {
+		t.Fatalf("bind sales: %v", err)
+	}
+
 	reg := connectors.NewRegistry()
 	reg.Register(newTestStubConnector(connID, connID+".ping"))
-	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	deps := &Deps{DB: tx, Vault: v, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
 	router := NewRouter(deps)
 
 	reqBody := `{"request_id":"req_mi_label","action":{"type":"` + connID + `.ping","parameters":{"connector_instance":"Sales"}},"context":{"description":"x"}}`

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -1218,14 +1218,14 @@ func TestAgentRequestApproval_MultiInstance_WithLabel_FreezesInstanceOnAction(t 
 	if err := json.Unmarshal(appr.Action, &actionObj); err != nil {
 		t.Fatalf("unmarshal action: %v", err)
 	}
-	var gotID, gotLabel string
+	var gotID, gotDisplay string
 	_ = json.Unmarshal(actionObj["_connector_instance_id"], &gotID)
-	_ = json.Unmarshal(actionObj["_connector_instance_label"], &gotLabel)
+	_ = json.Unmarshal(actionObj["_connector_instance_display"], &gotDisplay)
 	if gotID != inst2.ConnectorInstanceID {
 		t.Errorf("connector_instance_id: want %q got %q", inst2.ConnectorInstanceID, gotID)
 	}
-	if gotLabel != "Sales" {
-		t.Errorf("connector_instance_label: want Sales got %q", gotLabel)
+	if gotDisplay != "Sales" {
+		t.Errorf("connector_instance_display: want Sales got %q", gotDisplay)
 	}
 	if raw, ok := actionObj["parameters"]; ok {
 		var params map[string]json.RawMessage

--- a/api/agent_connector_instances.go
+++ b/api/agent_connector_instances.go
@@ -15,7 +15,7 @@ type agentConnectorInstanceResponse struct {
 	ConnectorInstanceID string    `json:"connector_instance_id"`
 	AgentID             int64     `json:"agent_id"`
 	ConnectorID         string    `json:"connector_id"`
-	Label               string    `json:"label"`
+	Label               string    `json:"label,omitempty"`
 	IsDefault           bool      `json:"is_default"`
 	EnabledAt           time.Time `json:"enabled_at"`
 }
@@ -24,13 +24,10 @@ type agentConnectorInstanceListResponse struct {
 	Data []agentConnectorInstanceResponse `json:"data"`
 }
 
-type createAgentConnectorInstanceRequest struct {
-	Label string `json:"label"`
-}
+type createAgentConnectorInstanceRequest struct{}
 
 type patchAgentConnectorInstanceRequest struct {
-	Label     *string `json:"label,omitempty"`
-	IsDefault *bool   `json:"is_default,omitempty"`
+	IsDefault *bool `json:"is_default,omitempty"`
 }
 
 func init() {
@@ -126,13 +123,8 @@ func handleCreateAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 			AgentID:     agentID,
 			ApproverID:  userID,
 			ConnectorID: connectorID,
-			Label:       req.Label,
 		})
 		if err != nil {
-			if errors.Is(err, db.ErrAgentConnectorInstanceLabelRequired) || errors.Is(err, db.ErrAgentConnectorInstanceLabelTooLong) {
-				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be 1–256 characters"))
-				return
-			}
 			var acErr *db.AgentConnectorError
 			if errors.As(err, &acErr) {
 				switch acErr.Code {
@@ -146,11 +138,6 @@ func handleCreateAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Enable this connector for the agent before adding another instance"))
 					return
 				}
-			}
-			var instErr *db.AgentConnectorInstanceError
-			if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
-				RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
-				return
 			}
 			log.Printf("[%s] CreateAgentConnectorInstance: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)
@@ -243,62 +230,28 @@ func handlePatchAgentConnectorInstance(deps *Deps) http.HandlerFunc {
 		if !DecodeJSONOrReject(w, r, &req) {
 			return
 		}
-		if req.Label == nil && req.IsDefault == nil {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Provide label and/or is_default"))
+		if req.IsDefault == nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Provide is_default"))
 			return
 		}
-		if req.IsDefault != nil && !*req.IsDefault {
+		if !*req.IsDefault {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "is_default may only be set to true"))
 			return
 		}
 
 		ctx := r.Context()
-		var inst *db.AgentConnectorInstance
-
-		if req.Label != nil {
-			var err error
-			inst, err = db.RenameAgentConnectorInstance(ctx, deps.DB, agentID, userID, connectorID, instanceID, *req.Label)
-			if err != nil {
-				if errors.Is(err, db.ErrAgentConnectorInstanceLabelRequired) || errors.Is(err, db.ErrAgentConnectorInstanceLabelTooLong) {
-					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be 1–256 characters"))
-					return
-				}
-				var instErr *db.AgentConnectorInstanceError
-				if errors.As(err, &instErr) && instErr.Code == db.AgentConnectorInstanceErrDuplicateLabel {
-					RespondError(w, r, http.StatusConflict, Conflict(ErrConstraintViolation, "An instance with this label already exists"))
-					return
-				}
-				log.Printf("[%s] RenameAgentConnectorInstance: %v", TraceID(ctx), err)
-				CaptureError(ctx, err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to rename connector instance"))
-				return
-			}
-			if inst == nil {
-				RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
-				return
-			}
-		}
-
-		if req.IsDefault != nil && *req.IsDefault {
-			def, err := db.SetDefaultAgentConnectorInstance(ctx, deps.DB, agentID, userID, connectorID, instanceID)
-			if err != nil {
-				log.Printf("[%s] SetDefaultAgentConnectorInstance: %v", TraceID(ctx), err)
-				CaptureError(ctx, err)
-				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update default connector instance"))
-				return
-			}
-			if def == nil {
-				RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
-				return
-			}
-			inst = def
-		}
-
-		if inst == nil {
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update connector instance"))
+		def, err := db.SetDefaultAgentConnectorInstance(ctx, deps.DB, agentID, userID, connectorID, instanceID)
+		if err != nil {
+			log.Printf("[%s] SetDefaultAgentConnectorInstance: %v", TraceID(ctx), err)
+			CaptureError(ctx, err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update default connector instance"))
 			return
 		}
-		RespondJSON(w, http.StatusOK, toAgentConnectorInstanceResponse(*inst))
+		if def == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrConnectorInstanceNotFound, "Connector instance not found"))
+			return
+		}
+		RespondJSON(w, http.StatusOK, toAgentConnectorInstanceResponse(*def))
 	}
 }
 

--- a/api/agent_connector_instances.go
+++ b/api/agent_connector_instances.go
@@ -15,7 +15,7 @@ type agentConnectorInstanceResponse struct {
 	ConnectorInstanceID string    `json:"connector_instance_id"`
 	AgentID             int64     `json:"agent_id"`
 	ConnectorID         string    `json:"connector_id"`
-	Label               string    `json:"label,omitempty"`
+	Display             string    `json:"display,omitempty"`
 	IsDefault           bool      `json:"is_default"`
 	EnabledAt           time.Time `json:"enabled_at"`
 }
@@ -60,7 +60,7 @@ func toAgentConnectorInstanceResponse(inst db.AgentConnectorInstance) agentConne
 		ConnectorInstanceID: inst.ConnectorInstanceID,
 		AgentID:             inst.AgentID,
 		ConnectorID:         inst.ConnectorID,
-		Label:               inst.Label,
+		Display:             inst.DisplayName,
 		IsDefault:           inst.IsDefault,
 		EnabledAt:           inst.EnabledAt,
 	}

--- a/api/agent_connector_instances_test.go
+++ b/api/agent_connector_instances_test.go
@@ -61,7 +61,7 @@ func TestCreateAgentConnectorInstance_Second(t *testing.T) {
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	r := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Sales"}`))
+	r := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{}`))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -94,7 +94,7 @@ func TestPatchAgentConnectorInstance_SetDefault(t *testing.T) {
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Sales"}`))
+	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{}`))
 	w1 := httptest.NewRecorder()
 	router.ServeHTTP(w1, r1)
 	if w1.Code != http.StatusCreated {
@@ -125,7 +125,7 @@ func TestPatchAgentConnectorInstance_SetDefault(t *testing.T) {
 	}
 }
 
-func TestPatchAgentConnectorInstance_DuplicateLabel409(t *testing.T) {
+func TestPatchAgentConnectorInstance_RequiresIsDefault(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -145,30 +145,17 @@ func TestPatchAgentConnectorInstance_DuplicateLabel409(t *testing.T) {
 	if len(list.Data) != 1 {
 		t.Fatalf("expected 1 default instance")
 	}
-	defaultLabel := list.Data[0].Label
 
-	// Create second instance
-	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Sales"}`))
-	w1 := httptest.NewRecorder()
-	router.ServeHTTP(w1, r1)
-	if w1.Code != http.StatusCreated {
-		t.Fatalf("create second: %d %s", w1.Code, w1.Body.String())
-	}
-	var created agentConnectorInstanceResponse
-	if err := json.Unmarshal(w1.Body.Bytes(), &created); err != nil {
-		t.Fatalf("unmarshal created: %v", err)
-	}
-
-	patchPayload, err := json.Marshal(map[string]string{"label": defaultLabel})
+	patchPayload, err := json.Marshal(map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	r2 := authenticatedRequestWithBody(t, http.MethodPatch,
-		fmt.Sprintf("/agents/%d/connectors/%s/instances/%s", agentID, connID, created.ConnectorInstanceID), uid, patchPayload)
+		fmt.Sprintf("/agents/%d/connectors/%s/instances/%s", agentID, connID, list.Data[0].ConnectorInstanceID), uid, patchPayload)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, r2)
-	if w2.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w2.Code, w2.Body.String())
+	if w2.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w2.Code, w2.Body.String())
 	}
 }
 
@@ -207,7 +194,7 @@ func TestDeleteAgentConnectorInstance_SecondInstance204(t *testing.T) {
 	deps := &Deps{DB: tx, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{"label":"Extra"}`))
+	r1 := authenticatedRequestWithBody(t, http.MethodPost, fmt.Sprintf("/agents/%d/connectors/%s/instances", agentID, connID), uid, []byte(`{}`))
 	w1 := httptest.NewRecorder()
 	router.ServeHTTP(w1, r1)
 	if w1.Code != http.StatusCreated {

--- a/api/approval_flow_multi_instance_test.go
+++ b/api/approval_flow_multi_instance_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -31,8 +32,9 @@ func TestApprovalFlow_MultiInstance_UsesCorrectCredentialOnApprove(t *testing.T)
 	testhelper.InsertConnectorRequiredCredential(t, tx, connID, connID, "api_key")
 
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-	instSales, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
-		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Sales",
+	ctx := context.Background()
+	instSales, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
 	})
 	if err != nil {
 		t.Fatalf("create instance: %v", err)
@@ -55,7 +57,19 @@ func TestApprovalFlow_MultiInstance_UsesCorrectCredentialOnApprove(t *testing.T)
 	credID2 := testhelper.GenerateID(t, "cred_")
 	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID2, uid, connID, "sales", v2)
 
-	_, err = db.UpsertAgentConnectorCredentialByInstance(t.Context(), tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default instance: %v", defInst)
+	}
+	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID1,
+	})
+	if err != nil {
+		t.Fatalf("bind default: %v", err)
+	}
+
+	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
 		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
 		ConnectorInstanceID: instSales.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID2,
 	})
@@ -74,7 +88,7 @@ func TestApprovalFlow_MultiInstance_UsesCorrectCredentialOnApprove(t *testing.T)
 	deps := &Deps{DB: tx, Vault: v, Connectors: reg, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	reqBody := `{"request_id":"req_flow_mi","action":{"type":"` + connID + `.ping","parameters":{"connector_instance":"Sales"}},"context":{"description":"x"}}`
+	reqBody := `{"request_id":"req_flow_mi","action":{"type":"` + connID + `.ping","parameters":{"connector_instance":"sales"}},"context":{"description":"x"}}`
 	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)

--- a/api/audit_helpers.go
+++ b/api/audit_helpers.go
@@ -266,6 +266,12 @@ func redactActionToTypeWithConnectorInstance(raw []byte) []byte {
 			out["_connector_instance_id"] = s
 		}
 	}
+	if v, ok := obj["_connector_instance_display"]; ok {
+		var s string
+		if json.Unmarshal(v, &s) == nil && s != "" {
+			out["_connector_instance_display"] = s
+		}
+	}
 	if v, ok := obj["_connector_instance_label"]; ok {
 		var s string
 		if json.Unmarshal(v, &s) == nil && s != "" {

--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -20,7 +20,7 @@ type capabilitiesResponse struct {
 
 type connectorInstanceCapability struct {
 	ID               string `json:"id"`
-	Label            string `json:"label"`
+	Display          string `json:"display,omitempty"`
 	CredentialsReady bool   `json:"credentials_ready"`
 }
 
@@ -171,7 +171,7 @@ func buildCapabilitiesResponse(agentID int64, caps *db.AgentCapabilities, baseUR
 		for _, inst := range instancesByConnector[c.ID] {
 			cc.Instances = append(cc.Instances, connectorInstanceCapability{
 				ID:               inst.ConnectorInstanceID,
-				Label:            inst.Label,
+				Display:          inst.DisplayName,
 				CredentialsReady: inst.CredentialsReady,
 			})
 		}

--- a/api/connector_execution_test.go
+++ b/api/connector_execution_test.go
@@ -887,7 +887,7 @@ func TestExecuteConnectorAction_UsesConnectorInstanceIDWhenProvided(t *testing.T
 	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
 	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
 	inst, err := db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
-		AgentID: agentID, ApproverID: uid, ConnectorID: connID, Label: "Other",
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
 	})
 	if err != nil {
 		t.Fatalf("create instance: %v", err)

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -79,6 +79,7 @@ const (
 	// 429 Too Many Requests (quota)
 	ErrMonthlyQuotaExceeded ErrorCode = "monthly_quota_exceeded"
 
-	ErrConnectorInstanceRequired ErrorCode = "connector_instance_required"
-	ErrConnectorInstanceNotFound ErrorCode = "connector_instance_not_found"
+	ErrConnectorInstanceRequired  ErrorCode = "connector_instance_required"
+	ErrConnectorInstanceNotFound  ErrorCode = "connector_instance_not_found"
+	ErrConnectorInstanceAmbiguous ErrorCode = "connector_instance_ambiguous"
 )

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -4,21 +4,13 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"time"
-	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// ErrAgentConnectorInstanceLabelRequired is returned when label is empty after trim.
-var ErrAgentConnectorInstanceLabelRequired = errors.New("label is required")
-
-// ErrAgentConnectorInstanceLabelTooLong is returned when label exceeds MaxAgentConnectorInstanceLabelLen runes.
-var ErrAgentConnectorInstanceLabelTooLong = errors.New("label exceeds maximum length")
-
 // AgentConnectorInstance is a row in agent_connectors (one instance of a connector type for an agent).
+// Label is a display string derived from the bound credential (API key label or OAuth workspace name).
 type AgentConnectorInstance struct {
 	ConnectorInstanceID string
 	AgentID             int64
@@ -41,33 +33,35 @@ type AgentConnectorInstanceErrCode string
 
 const (
 	AgentConnectorInstanceErrNotFound            AgentConnectorInstanceErrCode = "connector_instance_not_found"
-	AgentConnectorInstanceErrDuplicateLabel      AgentConnectorInstanceErrCode = "duplicate_instance_label"
 	AgentConnectorInstanceErrCannotDeleteDefault AgentConnectorInstanceErrCode = "cannot_delete_default_instance"
 )
 
-// MaxAgentConnectorInstanceLabelLen is the maximum rune length for instance labels (API + DB).
-const MaxAgentConnectorInstanceLabelLen = 256
+// agentConnectorInstanceSelect is the standard SELECT for an agent_connectors row with display label
+// from the assigned credential (static API key label or OAuth extra_data name).
+const agentConnectorInstanceSelect = `
+	SELECT ac.connector_instance_id, ac.agent_id, ac.connector_id, ac.approver_id,
+	       COALESCE(cr.label, oc.extra_data->>'name', '') AS label,
+	       ac.is_default, ac.enabled_at
+	FROM agent_connectors ac
+	LEFT JOIN agent_connector_credentials acc
+	       ON acc.agent_id = ac.agent_id
+	      AND acc.connector_id = ac.connector_id
+	      AND acc.approver_id = ac.approver_id
+	      AND acc.connector_instance_id = ac.connector_instance_id
+	LEFT JOIN credentials cr ON cr.id = acc.credential_id
+	LEFT JOIN oauth_connections oc ON oc.id = acc.oauth_connection_id`
 
 // CreateAgentConnectorInstanceParams holds parameters for creating a new instance (non-default row).
 type CreateAgentConnectorInstanceParams struct {
 	AgentID     int64
 	ApproverID  string
 	ConnectorID string
-	Label       string
 }
 
-// CreateAgentConnectorInstance inserts a new agent connector instance with the given label.
+// CreateAgentConnectorInstance inserts a new agent connector instance.
 // The first instance for an (agent, connector) pair is the default (enforced by DB trigger);
 // additional instances are non-default.
 func CreateAgentConnectorInstance(ctx context.Context, db DBTX, p CreateAgentConnectorInstanceParams) (*AgentConnectorInstance, error) {
-	label := strings.TrimSpace(p.Label)
-	if label == "" {
-		return nil, ErrAgentConnectorInstanceLabelRequired
-	}
-	if utf8.RuneCountInString(label) > MaxAgentConnectorInstanceLabelLen {
-		return nil, ErrAgentConnectorInstanceLabelTooLong
-	}
-
 	var agentOK bool
 	if err := db.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM agents WHERE agent_id = $1 AND approver_id = $2)`,
@@ -104,21 +98,17 @@ func CreateAgentConnectorInstance(ctx context.Context, db DBTX, p CreateAgentCon
 		return nil, &AgentConnectorError{Code: AgentConnectorErrConnectorNotEnabled}
 	}
 
-	row := db.QueryRow(ctx, `
-		INSERT INTO agent_connectors (agent_id, approver_id, connector_id, label, is_default)
-		VALUES ($1, $2, $3, $4, false)
-		RETURNING connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at`,
-		p.AgentID, p.ApproverID, p.ConnectorID, label,
-	)
-	inst, err := scanAgentConnectorInstance(row)
+	var newID string
+	err := db.QueryRow(ctx, `
+		INSERT INTO agent_connectors (agent_id, approver_id, connector_id, is_default)
+		VALUES ($1, $2, $3, false)
+		RETURNING connector_instance_id::text`,
+		p.AgentID, p.ApproverID, p.ConnectorID,
+	).Scan(&newID)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
-			return nil, &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrDuplicateLabel}
-		}
 		return nil, err
 	}
-	return inst, nil
+	return GetAgentConnectorInstance(ctx, db, p.AgentID, p.ApproverID, p.ConnectorID, newID)
 }
 
 func scanAgentConnectorInstance(row pgx.Row) (*AgentConnectorInstance, error) {
@@ -135,11 +125,9 @@ func scanAgentConnectorInstance(row pgx.Row) (*AgentConnectorInstance, error) {
 
 // ListAgentConnectorInstances returns all instances for an agent+connector scoped to the approver.
 func ListAgentConnectorInstances(ctx context.Context, db DBTX, agentID int64, approverID, connectorID string) ([]AgentConnectorInstance, error) {
-	rows, err := db.Query(ctx, `
-		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
-		FROM agent_connectors
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3
-		ORDER BY enabled_at ASC, connector_instance_id ASC`,
+	rows, err := db.Query(ctx, agentConnectorInstanceSelect+`
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3
+		ORDER BY ac.enabled_at ASC, ac.connector_instance_id ASC`,
 		agentID, approverID, connectorID,
 	)
 	if err != nil {
@@ -149,24 +137,19 @@ func ListAgentConnectorInstances(ctx context.Context, db DBTX, agentID int64, ap
 
 	var out []AgentConnectorInstance
 	for rows.Next() {
-		var inst AgentConnectorInstance
-		if err := rows.Scan(
-			&inst.ConnectorInstanceID, &inst.AgentID, &inst.ConnectorID, &inst.ApproverID,
-			&inst.Label, &inst.IsDefault, &inst.EnabledAt,
-		); err != nil {
+		inst, err := scanAgentConnectorInstance(rows)
+		if err != nil {
 			return nil, err
 		}
-		out = append(out, inst)
+		out = append(out, *inst)
 	}
 	return out, rows.Err()
 }
 
 // GetAgentConnectorInstance returns a single instance by ID, scoped to agent and approver.
 func GetAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID string) (*AgentConnectorInstance, error) {
-	row := db.QueryRow(ctx, `
-		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
-		FROM agent_connectors
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
+	row := db.QueryRow(ctx, agentConnectorInstanceSelect+`
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3 AND ac.connector_instance_id = $4::uuid`,
 		agentID, approverID, connectorID, connectorInstanceID,
 	)
 	inst, err := scanAgentConnectorInstance(row)
@@ -181,10 +164,8 @@ func GetAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, appr
 
 // GetDefaultAgentConnectorInstance returns the default instance for an (agent, connector) pair.
 func GetDefaultAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID string) (*AgentConnectorInstance, error) {
-	row := db.QueryRow(ctx, `
-		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
-		FROM agent_connectors
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND is_default`,
+	row := db.QueryRow(ctx, agentConnectorInstanceSelect+`
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3 AND ac.is_default`,
 		agentID, approverID, connectorID,
 	)
 	inst, err := scanAgentConnectorInstance(row)
@@ -200,10 +181,8 @@ func GetDefaultAgentConnectorInstance(ctx context.Context, db DBTX, agentID int6
 // GetDefaultAgentConnectorInstanceByAgent returns the default instance using only agent_id and connector_id.
 // Each agent has a single approver; this is used when approver_id is not available on the call path.
 func GetDefaultAgentConnectorInstanceByAgent(ctx context.Context, db DBTX, agentID int64, connectorID string) (*AgentConnectorInstance, error) {
-	row := db.QueryRow(ctx, `
-		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
-		FROM agent_connectors
-		WHERE agent_id = $1 AND connector_id = $2 AND is_default`,
+	row := db.QueryRow(ctx, agentConnectorInstanceSelect+`
+		WHERE ac.agent_id = $1 AND ac.connector_id = $2 AND ac.is_default`,
 		agentID, connectorID,
 	)
 	inst, err := scanAgentConnectorInstance(row)
@@ -239,19 +218,20 @@ func SetDefaultAgentConnectorInstance(ctx context.Context, db DBTX, agentID int6
 		return nil, err
 	}
 
-	row := tx.QueryRow(ctx, `
+	tag, err := tx.Exec(ctx, `
 		UPDATE agent_connectors
 		SET is_default = true
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid
-		RETURNING connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at`,
+		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid`,
 		agentID, approverID, connectorID, connectorInstanceID,
 	)
-	inst, err := scanAgentConnectorInstance(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
+	}
+	if tag.RowsAffected() == 0 {
+		if owned {
+			_ = RollbackTx(ctx, tx)
+		}
+		return nil, nil
 	}
 
 	if owned {
@@ -259,38 +239,7 @@ func SetDefaultAgentConnectorInstance(ctx context.Context, db DBTX, agentID int6
 			return nil, err
 		}
 	}
-	return inst, nil
-}
-
-// RenameAgentConnectorInstance updates the label for an instance.
-func RenameAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, connectorInstanceID, newLabel string) (*AgentConnectorInstance, error) {
-	label := strings.TrimSpace(newLabel)
-	if label == "" {
-		return nil, ErrAgentConnectorInstanceLabelRequired
-	}
-	if utf8.RuneCountInString(label) > MaxAgentConnectorInstanceLabelLen {
-		return nil, ErrAgentConnectorInstanceLabelTooLong
-	}
-
-	row := db.QueryRow(ctx, `
-		UPDATE agent_connectors
-		SET label = $5
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND connector_instance_id = $4::uuid
-		RETURNING connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at`,
-		agentID, approverID, connectorID, connectorInstanceID, label,
-	)
-	inst, err := scanAgentConnectorInstance(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
-			return nil, &AgentConnectorInstanceError{Code: AgentConnectorInstanceErrDuplicateLabel}
-		}
-		return nil, err
-	}
-	return inst, nil
+	return GetAgentConnectorInstance(ctx, db, agentID, approverID, connectorID, connectorInstanceID)
 }
 
 // DeleteAgentConnectorInstance removes a non-default instance and revokes instance-scoped standing approvals.
@@ -350,7 +299,7 @@ func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, a
 	return nil
 }
 
-// ResolveAgentConnectorInstance finds an instance by UUID or by exact label (trimmed).
+// ResolveAgentConnectorInstance finds an instance by UUID or by credential display name (trimmed).
 func ResolveAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, selector string) (*AgentConnectorInstance, error) {
 	sel := strings.TrimSpace(selector)
 	if sel == "" {
@@ -361,10 +310,9 @@ func ResolveAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, 
 		return GetAgentConnectorInstance(ctx, db, agentID, approverID, connectorID, sel)
 	}
 
-	row := db.QueryRow(ctx, `
-		SELECT connector_instance_id, agent_id, connector_id, approver_id, label, is_default, enabled_at
-		FROM agent_connectors
-		WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3 AND label = $4`,
+	row := db.QueryRow(ctx, agentConnectorInstanceSelect+`
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3
+		  AND COALESCE(cr.label, oc.extra_data->>'name', '') = $4`,
 		agentID, approverID, connectorID, sel,
 	)
 	inst, err := scanAgentConnectorInstance(row)

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -23,7 +24,8 @@ type AgentConnectorInstance struct {
 
 // AgentConnectorInstanceError is a domain error for connector instance operations.
 type AgentConnectorInstanceError struct {
-	Code AgentConnectorInstanceErrCode
+	Code                 AgentConnectorInstanceErrCode
+	AmbiguousInstanceIDs []string // set when Code == AgentConnectorInstanceErrAmbiguousDisplay
 }
 
 func (e *AgentConnectorInstanceError) Error() string { return string(e.Code) }
@@ -34,6 +36,7 @@ type AgentConnectorInstanceErrCode string
 const (
 	AgentConnectorInstanceErrNotFound            AgentConnectorInstanceErrCode = "connector_instance_not_found"
 	AgentConnectorInstanceErrCannotDeleteDefault AgentConnectorInstanceErrCode = "cannot_delete_default_instance"
+	AgentConnectorInstanceErrAmbiguousDisplay    AgentConnectorInstanceErrCode = "connector_instance_ambiguous_display"
 )
 
 // agentConnectorInstanceSelect is the standard SELECT for an agent_connectors row with display name
@@ -300,6 +303,8 @@ func DeleteAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, a
 }
 
 // ResolveAgentConnectorInstance finds an instance by UUID or by credential display name (trimmed).
+// If multiple instances share the same display string, returns AgentConnectorInstanceError with
+// Code AgentConnectorInstanceErrAmbiguousDisplay (caller should surface HTTP 400 with matching UUIDs).
 func ResolveAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, approverID, connectorID, selector string) (*AgentConnectorInstance, error) {
 	sel := strings.TrimSpace(selector)
 	if sel == "" {
@@ -310,17 +315,40 @@ func ResolveAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, 
 		return GetAgentConnectorInstance(ctx, db, agentID, approverID, connectorID, sel)
 	}
 
-	row := db.QueryRow(ctx, agentConnectorInstanceSelect+`
+	rows, err := db.Query(ctx, agentConnectorInstanceSelect+`
 		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3
-		  AND COALESCE(cr.label, oc.extra_data->>'name', '') = $4`,
+		  AND COALESCE(cr.label, oc.extra_data->>'name', '') = $4
+		ORDER BY ac.connector_instance_id ASC`,
 		agentID, approverID, connectorID, sel,
 	)
-	inst, err := scanAgentConnectorInstance(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}
-	return inst, nil
+	defer rows.Close()
+
+	var list []*AgentConnectorInstance
+	for rows.Next() {
+		inst, err := scanAgentConnectorInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, inst)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	if len(list) > 1 {
+		ids := make([]string, len(list))
+		for i, inst := range list {
+			ids[i] = inst.ConnectorInstanceID
+		}
+		return nil, &AgentConnectorInstanceError{
+			Code:                 AgentConnectorInstanceErrAmbiguousDisplay,
+			AmbiguousInstanceIDs: ids,
+		}
+	}
+	return list[0], nil
 }

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -10,13 +10,13 @@ import (
 )
 
 // AgentConnectorInstance is a row in agent_connectors (one instance of a connector type for an agent).
-// Label is a display string derived from the bound credential (API key label or OAuth workspace name).
+// DisplayName is derived from the bound credential (API key label or OAuth workspace name in extra_data).
 type AgentConnectorInstance struct {
 	ConnectorInstanceID string
 	AgentID             int64
 	ConnectorID         string
 	ApproverID          string
-	Label               string
+	DisplayName         string
 	IsDefault           bool
 	EnabledAt           time.Time
 }
@@ -36,11 +36,11 @@ const (
 	AgentConnectorInstanceErrCannotDeleteDefault AgentConnectorInstanceErrCode = "cannot_delete_default_instance"
 )
 
-// agentConnectorInstanceSelect is the standard SELECT for an agent_connectors row with display label
+// agentConnectorInstanceSelect is the standard SELECT for an agent_connectors row with display name
 // from the assigned credential (static API key label or OAuth extra_data name).
 const agentConnectorInstanceSelect = `
 	SELECT ac.connector_instance_id, ac.agent_id, ac.connector_id, ac.approver_id,
-	       COALESCE(cr.label, oc.extra_data->>'name', '') AS label,
+	       COALESCE(cr.label, oc.extra_data->>'name', '') AS display_name,
 	       ac.is_default, ac.enabled_at
 	FROM agent_connectors ac
 	LEFT JOIN agent_connector_credentials acc
@@ -115,7 +115,7 @@ func scanAgentConnectorInstance(row pgx.Row) (*AgentConnectorInstance, error) {
 	var inst AgentConnectorInstance
 	err := row.Scan(
 		&inst.ConnectorInstanceID, &inst.AgentID, &inst.ConnectorID, &inst.ApproverID,
-		&inst.Label, &inst.IsDefault, &inst.EnabledAt,
+		&inst.DisplayName, &inst.IsDefault, &inst.EnabledAt,
 	)
 	if err != nil {
 		return nil, err

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -135,6 +135,60 @@ func TestSetDefaultAgentConnectorInstance_SwitchesDefault(t *testing.T) {
 	}
 }
 
+func TestResolveAgentConnectorInstance_AmbiguousDisplay(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	ctx := context.Background()
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentConnectorInstance: %v", err)
+	}
+
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default: %v", defInst)
+	}
+
+	cred1 := testhelper.GenerateID(t, "cred_")
+	cred2 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, cred1, uid, connID, "Same", "00000000-0000-0000-0000-0000000000a1")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, cred2, uid, connID, "Same", "00000000-0000-0000-0000-0000000000a2")
+
+	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "acc_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &cred1,
+	})
+	if err != nil {
+		t.Fatalf("bind default: %v", err)
+	}
+	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "acc_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: inst2.ConnectorInstanceID, ApproverID: uid, CredentialID: &cred2,
+	})
+	if err != nil {
+		t.Fatalf("bind second: %v", err)
+	}
+
+	_, err = db.ResolveAgentConnectorInstance(ctx, tx, agentID, uid, connID, "Same")
+	var instErr *db.AgentConnectorInstanceError
+	if !errors.As(err, &instErr) || instErr.Code != db.AgentConnectorInstanceErrAmbiguousDisplay {
+		t.Fatalf("expected ambiguous display error, got %v", err)
+	}
+	if len(instErr.AmbiguousInstanceIDs) != 2 {
+		t.Fatalf("expected 2 ids, got %v", instErr.AmbiguousInstanceIDs)
+	}
+}
+
 func TestFindActiveStandingApprovalsForAgent_FiltersByInstance(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -30,9 +30,6 @@ func TestListAgentConnectorInstances_DefaultOnly(t *testing.T) {
 	if !instances[0].IsDefault {
 		t.Error("expected first instance to be default")
 	}
-	if instances[0].Label == "" {
-		t.Error("expected non-empty label")
-	}
 }
 
 func TestCreateAgentConnectorInstance_SecondInstance(t *testing.T) {
@@ -50,7 +47,6 @@ func TestCreateAgentConnectorInstance_SecondInstance(t *testing.T) {
 		AgentID:     agentID,
 		ApproverID:  uid,
 		ConnectorID: connID,
-		Label:       "Second",
 	})
 	if err != nil {
 		t.Fatalf("CreateAgentConnectorInstance: %v", err)
@@ -83,7 +79,6 @@ func TestCreateAgentConnectorInstance_RequiresConnectorEnabled(t *testing.T) {
 		AgentID:     agentID,
 		ApproverID:  uid,
 		ConnectorID: connID,
-		Label:       "First",
 	})
 	var acErr *db.AgentConnectorError
 	if !errors.As(err, &acErr) || acErr.Code != db.AgentConnectorErrConnectorNotEnabled {
@@ -107,7 +102,6 @@ func TestSetDefaultAgentConnectorInstance_SwitchesDefault(t *testing.T) {
 		AgentID:     agentID,
 		ApproverID:  uid,
 		ConnectorID: connID,
-		Label:       "Sales",
 	})
 	if err != nil {
 		t.Fatalf("CreateAgentConnectorInstance: %v", err)
@@ -137,35 +131,7 @@ func TestSetDefaultAgentConnectorInstance_SwitchesDefault(t *testing.T) {
 		t.Fatalf("default after: err=%v inst=%v", err, def2)
 	}
 	if def2.ConnectorInstanceID != inst2.ConnectorInstanceID {
-		t.Fatalf("expected Sales instance default, got %s", def2.ConnectorInstanceID)
-	}
-}
-
-func TestCreateAgentConnectorInstance_DuplicateLabel(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-
-	uid := testhelper.GenerateUID(t)
-	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
-
-	connID := testhelper.GenerateID(t, "conn_")
-	testhelper.InsertConnector(t, tx, connID)
-	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-
-	defaultInst, err := db.GetDefaultAgentConnectorInstance(t.Context(), tx, agentID, uid, connID)
-	if err != nil || defaultInst == nil {
-		t.Fatalf("default instance: err=%v inst=%v", err, defaultInst)
-	}
-
-	_, err = db.CreateAgentConnectorInstance(t.Context(), tx, db.CreateAgentConnectorInstanceParams{
-		AgentID:     agentID,
-		ApproverID:  uid,
-		ConnectorID: connID,
-		Label:       defaultInst.Label,
-	})
-	var instErr *db.AgentConnectorInstanceError
-	if !errors.As(err, &instErr) || instErr.Code != db.AgentConnectorInstanceErrDuplicateLabel {
-		t.Fatalf("expected duplicate label error, got %v", err)
+		t.Fatalf("expected second instance to become default, got %s", def2.ConnectorInstanceID)
 	}
 }
 
@@ -187,7 +153,6 @@ func TestFindActiveStandingApprovalsForAgent_FiltersByInstance(t *testing.T) {
 		AgentID:     agentID,
 		ApproverID:  uid,
 		ConnectorID: connID,
-		Label:       "Sales",
 	})
 	if err != nil {
 		t.Fatalf("CreateAgentConnectorInstance: %v", err)
@@ -249,7 +214,6 @@ func TestDeleteAgentConnectorInstance_RevokesInstanceScopedStandingApproval(t *t
 		AgentID:     agentID,
 		ApproverID:  uid,
 		ConnectorID: connID,
-		Label:       "ToDelete",
 	})
 	if err != nil {
 		t.Fatalf("CreateAgentConnectorInstance: %v", err)

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -164,8 +164,14 @@ func TestResolveAgentConnectorInstance_AmbiguousDisplay(t *testing.T) {
 	oauth1 := testhelper.GenerateID(t, "oauth_")
 	oauth2 := testhelper.GenerateID(t, "oauth_")
 	sharedName, _ := json.Marshal(map[string]string{"name": "SharedOAuthName"})
-	testhelper.InsertOAuthConnectionFull(t, tx, oauth1, uid, "test_oauth", testhelper.OAuthConnectionOpts{ExtraData: sharedName})
-	testhelper.InsertOAuthConnectionFull(t, tx, oauth2, uid, "test_oauth", testhelper.OAuthConnectionOpts{ExtraData: sharedName})
+	testhelper.InsertOAuthConnectionFull(t, tx, oauth1, uid, "test_oauth", testhelper.OAuthConnectionOpts{
+		Scopes:    []string{},
+		ExtraData: sharedName,
+	})
+	testhelper.InsertOAuthConnectionFull(t, tx, oauth2, uid, "test_oauth", testhelper.OAuthConnectionOpts{
+		Scopes:    []string{},
+		ExtraData: sharedName,
+	})
 
 	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
 		ID: testhelper.GenerateID(t, "acc_"), AgentID: agentID, ConnectorID: connID,

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -159,27 +160,29 @@ func TestResolveAgentConnectorInstance_AmbiguousDisplay(t *testing.T) {
 		t.Fatalf("default: %v", defInst)
 	}
 
-	cred1 := testhelper.GenerateID(t, "cred_")
-	cred2 := testhelper.GenerateID(t, "cred_")
-	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, cred1, uid, connID, "Same", "00000000-0000-0000-0000-0000000000a1")
-	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, cred2, uid, connID, "Same", "00000000-0000-0000-0000-0000000000a2")
+	// Two OAuth connections with the same extra_data->>'name' (credentials cannot duplicate label per user+service).
+	oauth1 := testhelper.GenerateID(t, "oauth_")
+	oauth2 := testhelper.GenerateID(t, "oauth_")
+	sharedName, _ := json.Marshal(map[string]string{"name": "SharedOAuthName"})
+	testhelper.InsertOAuthConnectionFull(t, tx, oauth1, uid, "test_oauth", testhelper.OAuthConnectionOpts{ExtraData: sharedName})
+	testhelper.InsertOAuthConnectionFull(t, tx, oauth2, uid, "test_oauth", testhelper.OAuthConnectionOpts{ExtraData: sharedName})
 
 	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
 		ID: testhelper.GenerateID(t, "acc_"), AgentID: agentID, ConnectorID: connID,
-		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &cred1,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, OAuthConnectionID: &oauth1,
 	})
 	if err != nil {
 		t.Fatalf("bind default: %v", err)
 	}
 	_, err = db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
 		ID: testhelper.GenerateID(t, "acc_"), AgentID: agentID, ConnectorID: connID,
-		ConnectorInstanceID: inst2.ConnectorInstanceID, ApproverID: uid, CredentialID: &cred2,
+		ConnectorInstanceID: inst2.ConnectorInstanceID, ApproverID: uid, OAuthConnectionID: &oauth2,
 	})
 	if err != nil {
 		t.Fatalf("bind second: %v", err)
 	}
 
-	_, err = db.ResolveAgentConnectorInstance(ctx, tx, agentID, uid, connID, "Same")
+	_, err = db.ResolveAgentConnectorInstance(ctx, tx, agentID, uid, connID, "SharedOAuthName")
 	var instErr *db.AgentConnectorInstanceError
 	if !errors.As(err, &instErr) || instErr.Code != db.AgentConnectorInstanceErrAmbiguousDisplay {
 		t.Fatalf("expected ambiguous display error, got %v", err)

--- a/db/agent_connectors.go
+++ b/db/agent_connectors.go
@@ -100,14 +100,17 @@ func EnableAgentConnector(ctx context.Context, db DBTX, agentID int64, approverI
 			INSERT INTO agent_connectors (agent_id, approver_id, connector_id)
 			SELECT $1, $2, $3
 			WHERE EXISTS (SELECT 1 FROM agent_check)
-			ON CONFLICT (agent_id, connector_id, label) DO NOTHING
+			  AND NOT EXISTS (
+			      SELECT 1 FROM agent_connectors ac0
+			      WHERE ac0.agent_id = $1 AND ac0.approver_id = $2 AND ac0.connector_id = $3
+			  )
 			RETURNING agent_id, connector_id, enabled_at
 		)
 		SELECT agent_id, connector_id, enabled_at FROM inserted
 		UNION ALL
 		SELECT ac.agent_id, ac.connector_id, ac.enabled_at
 		FROM agent_connectors ac
-		WHERE ac.agent_id = $1 AND ac.connector_id = $3
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3
 		  AND NOT EXISTS (SELECT 1 FROM inserted)
 		  AND EXISTS (SELECT 1 FROM agent_check)`,
 		agentID, approverID, connectorID,

--- a/db/agent_connectors.go
+++ b/db/agent_connectors.go
@@ -86,6 +86,22 @@ func ListAgentConnectors(ctx context.Context, db DBTX, agentID int64, approverID
 	return result, rows.Err()
 }
 
+func readEnabledAgentConnectorRow(ctx context.Context, db DBTX, agentID int64, approverID, connectorID string) (*AgentConnectorRow, error) {
+	var row AgentConnectorRow
+	err := db.QueryRow(ctx, `
+		SELECT ac.agent_id, ac.connector_id, ac.enabled_at
+		FROM agent_connectors ac
+		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3
+		ORDER BY ac.is_default DESC, ac.enabled_at ASC
+		LIMIT 1`,
+		agentID, approverID, connectorID,
+	).Scan(&row.AgentID, &row.ConnectorID, &row.EnabledAt)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
 // EnableAgentConnector idempotently enables a connector for an agent.
 // The INSERT is guarded by an agent ownership check: if the agent does not
 // belong to the approver, no row is inserted and AgentConnectorErrAgentNotFound
@@ -104,6 +120,7 @@ func EnableAgentConnector(ctx context.Context, db DBTX, agentID int64, approverI
 			      SELECT 1 FROM agent_connectors ac0
 			      WHERE ac0.agent_id = $1 AND ac0.approver_id = $2 AND ac0.connector_id = $3
 			  )
+			ON CONFLICT (agent_id, connector_id) WHERE (is_default) DO NOTHING
 			RETURNING agent_id, connector_id, enabled_at
 		)
 		SELECT agent_id, connector_id, enabled_at FROM inserted
@@ -122,6 +139,10 @@ func EnableAgentConnector(ctx context.Context, db DBTX, agentID int64, approverI
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == PgCodeForeignKeyViolation {
 			return nil, &AgentConnectorError{Code: AgentConnectorErrConnectorNotFound}
+		}
+		if errors.As(err, &pgErr) && pgErr.Code == PgCodeUniqueViolation {
+			// Concurrent enable: retry read of existing row (idempotent success).
+			return readEnabledAgentConnectorRow(ctx, db, agentID, approverID, connectorID)
 		}
 		return nil, err
 	}

--- a/db/agent_connectors_query_test.go
+++ b/db/agent_connectors_query_test.go
@@ -149,6 +149,17 @@ func TestEnableAgentConnector_Idempotent(t *testing.T) {
 	if !row1.EnabledAt.Equal(row2.EnabledAt) {
 		t.Errorf("expected same enabled_at on idempotent enable, got %v and %v", row1.EnabledAt, row2.EnabledAt)
 	}
+
+	var n int
+	if err := tx.QueryRow(t.Context(),
+		`SELECT count(*) FROM agent_connectors WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3`,
+		agentID, uid, connID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 agent_connectors row, got %d", n)
+	}
 }
 
 // ── DisableAgentConnector ───────────────────────────────────────────────────

--- a/db/agent_connectors_test.go
+++ b/db/agent_connectors_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
 )
 

--- a/db/agent_connectors_test.go
+++ b/db/agent_connectors_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
 )
 
@@ -14,7 +15,7 @@ func TestAgentConnectorsSchema(t *testing.T) {
 
 	testhelper.RequireColumns(t, tx, "agent_connectors", []string{
 		"agent_id", "approver_id", "connector_id", "connector_instance_id",
-		"label", "is_default", "enabled_at",
+		"is_default", "enabled_at",
 	})
 }
 
@@ -25,7 +26,7 @@ func TestAgentConnectorsIndex(t *testing.T) {
 	testhelper.RequireIndex(t, tx, "agent_connectors", "idx_agent_connectors_connector")
 }
 
-func TestAgentConnectorsDuplicateInsert(t *testing.T) {
+func TestEnableAgentConnector_Idempotent(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 
@@ -35,18 +36,28 @@ func TestAgentConnectorsDuplicateInsert(t *testing.T) {
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "user_"+uid[:8])
 	testhelper.InsertConnector(t, tx, connID)
 
-	testhelper.RequireUniqueViolation(t, tx, "(agent_id, connector_id, label)",
-		func() error {
-			testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
-			return nil
-		},
-		func() error {
-			_, err := tx.Exec(context.Background(),
-				`INSERT INTO agent_connectors (agent_id, approver_id, connector_id) VALUES ($1, $2, $3)`,
-				agentID, uid, connID)
-			return err
-		},
-	)
+	row1, err := db.EnableAgentConnector(t.Context(), tx, agentID, uid, connID)
+	if err != nil {
+		t.Fatalf("EnableAgentConnector first: %v", err)
+	}
+	row2, err := db.EnableAgentConnector(t.Context(), tx, agentID, uid, connID)
+	if err != nil {
+		t.Fatalf("EnableAgentConnector second: %v", err)
+	}
+	if row1.EnabledAt != row2.EnabledAt {
+		t.Fatalf("expected same row on idempotent enable, got %v vs %v", row1.EnabledAt, row2.EnabledAt)
+	}
+
+	var n int
+	if err := tx.QueryRow(t.Context(),
+		`SELECT count(*) FROM agent_connectors WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3`,
+		agentID, uid, connID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 agent_connectors row, got %d", n)
+	}
 }
 
 func TestAgentConnectorsCascadeOnAgentDelete(t *testing.T) {

--- a/db/agent_connectors_test.go
+++ b/db/agent_connectors_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -24,40 +23,6 @@ func TestAgentConnectorsIndex(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 
 	testhelper.RequireIndex(t, tx, "agent_connectors", "idx_agent_connectors_connector")
-}
-
-func TestEnableAgentConnector_Idempotent(t *testing.T) {
-	t.Parallel()
-	tx := testhelper.SetupTestDB(t)
-
-	uid := testhelper.GenerateUID(t)
-	connID := testhelper.GenerateID(t, "conn_")
-
-	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "user_"+uid[:8])
-	testhelper.InsertConnector(t, tx, connID)
-
-	row1, err := db.EnableAgentConnector(t.Context(), tx, agentID, uid, connID)
-	if err != nil {
-		t.Fatalf("EnableAgentConnector first: %v", err)
-	}
-	row2, err := db.EnableAgentConnector(t.Context(), tx, agentID, uid, connID)
-	if err != nil {
-		t.Fatalf("EnableAgentConnector second: %v", err)
-	}
-	if row1.EnabledAt != row2.EnabledAt {
-		t.Fatalf("expected same row on idempotent enable, got %v vs %v", row1.EnabledAt, row2.EnabledAt)
-	}
-
-	var n int
-	if err := tx.QueryRow(t.Context(),
-		`SELECT count(*) FROM agent_connectors WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3`,
-		agentID, uid, connID,
-	).Scan(&n); err != nil {
-		t.Fatalf("count: %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("expected 1 agent_connectors row, got %d", n)
-	}
 }
 
 func TestAgentConnectorsCascadeOnAgentDelete(t *testing.T) {

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -147,7 +147,8 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 
 	// 1b. Per-instance credential readiness (one row per agent_connectors instance).
 	instRows, err := db.Query(ctx, `
-		SELECT ac.connector_id, ac.connector_instance_id::text, ac.label,
+		SELECT ac.connector_id, ac.connector_instance_id::text,
+		       COALESCE(cr.label, oc.extra_data->>'name', ''),
 		       NOT EXISTS (
 		           SELECT 1 FROM connector_required_credentials crc
 		           WHERE crc.connector_id = ac.connector_id
@@ -177,6 +178,13 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 		             )
 		       ) AS credentials_ready
 		FROM agent_connectors ac
+		LEFT JOIN agent_connector_credentials acc
+		       ON acc.agent_id = ac.agent_id
+		      AND acc.connector_id = ac.connector_id
+		      AND acc.approver_id = ac.approver_id
+		      AND acc.connector_instance_id = ac.connector_instance_id
+		LEFT JOIN credentials cr ON cr.id = acc.credential_id
+		LEFT JOIN oauth_connections oc ON oc.id = acc.oauth_connection_id
 		WHERE ac.agent_id = $1 AND ac.approver_id = $2
 		ORDER BY ac.connector_id, ac.enabled_at ASC, ac.connector_instance_id ASC`,
 		agentID, approverID,

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -31,7 +31,7 @@ type CapabilityConnector struct {
 type CapabilityConnectorInstance struct {
 	ConnectorID         string
 	ConnectorInstanceID string
-	Label               string
+	DisplayName         string
 	CredentialsReady    bool
 }
 
@@ -196,7 +196,7 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 
 	for instRows.Next() {
 		var ci CapabilityConnectorInstance
-		if err := instRows.Scan(&ci.ConnectorID, &ci.ConnectorInstanceID, &ci.Label, &ci.CredentialsReady); err != nil {
+		if err := instRows.Scan(&ci.ConnectorID, &ci.ConnectorInstanceID, &ci.DisplayName, &ci.CredentialsReady); err != nil {
 			return nil, err
 		}
 		caps.ConnectorInstances = append(caps.ConnectorInstances, ci)

--- a/db/migrations/20260421134629_drop_agent_connectors_label.sql
+++ b/db/migrations/20260421134629_drop_agent_connectors_label.sql
@@ -1,0 +1,80 @@
+-- +goose Up
+-- Remove redundant per-instance label; display names come from credentials (issue #974 phase 1).
+
+DROP TRIGGER IF EXISTS trg_agent_connectors_before_insert ON agent_connectors;
+DROP FUNCTION IF EXISTS trg_agent_connectors_before_insert();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION trg_agent_connectors_before_insert()
+RETURNS trigger AS $$
+BEGIN
+    -- First row for (agent, connector) must be the default instance (column default is false).
+    IF NOT EXISTS (
+        SELECT 1 FROM agent_connectors
+        WHERE agent_id = NEW.agent_id
+          AND connector_id = NEW.connector_id
+          AND is_default
+    ) THEN
+        NEW.is_default := true;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_agent_connectors_before_insert
+    BEFORE INSERT ON agent_connectors
+    FOR EACH ROW
+    EXECUTE FUNCTION trg_agent_connectors_before_insert();
+
+DROP INDEX IF EXISTS uq_agent_connectors_agent_connector_label;
+
+ALTER TABLE agent_connectors DROP COLUMN label;
+
+-- +goose Down
+
+ALTER TABLE agent_connectors
+    ADD COLUMN label text;
+
+UPDATE agent_connectors ac
+SET label = c.name
+FROM connectors c
+WHERE c.id = ac.connector_id;
+
+ALTER TABLE agent_connectors
+    ALTER COLUMN label SET NOT NULL;
+
+CREATE UNIQUE INDEX uq_agent_connectors_agent_connector_label
+    ON agent_connectors (agent_id, connector_id, label);
+
+DROP TRIGGER IF EXISTS trg_agent_connectors_before_insert ON agent_connectors;
+DROP FUNCTION IF EXISTS trg_agent_connectors_before_insert();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION trg_agent_connectors_before_insert()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.label IS NULL THEN
+        SELECT c.name INTO NEW.label FROM connectors c WHERE c.id = NEW.connector_id;
+        IF NEW.label IS NULL THEN
+            RAISE EXCEPTION 'insert or update on table "agent_connectors" violates foreign key constraint'
+                USING ERRCODE = '23503';
+        END IF;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM agent_connectors
+        WHERE agent_id = NEW.agent_id
+          AND connector_id = NEW.connector_id
+          AND is_default
+    ) THEN
+        NEW.is_default := true;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_agent_connectors_before_insert
+    BEFORE INSERT ON agent_connectors
+    FOR EACH ROW
+    EXECUTE FUNCTION trg_agent_connectors_before_insert();

--- a/db/migrations/20260421134629_drop_agent_connectors_label.sql
+++ b/db/migrations/20260421134629_drop_agent_connectors_label.sql
@@ -37,7 +37,10 @@ ALTER TABLE agent_connectors
     ADD COLUMN label text;
 
 UPDATE agent_connectors ac
-SET label = c.name
+SET label = CASE
+        WHEN ac.is_default THEN c.name
+        ELSE c.name || ' (' || substr(ac.connector_instance_id::text, 1, 8) || ')'
+    END
 FROM connectors c
 WHERE c.id = ac.connector_id;
 

--- a/frontend/src/hooks/__tests__/useAgentConnectorInstances.test.tsx
+++ b/frontend/src/hooks/__tests__/useAgentConnectorInstances.test.tsx
@@ -12,7 +12,6 @@ import {
 import {
   useAgentConnectorInstances,
   useCreateAgentConnectorInstance,
-  useRenameAgentConnectorInstance,
   useSetDefaultAgentConnectorInstance,
   useDeleteAgentConnectorInstance,
 } from "../useAgentConnectorInstances";
@@ -38,7 +37,7 @@ describe("useAgentConnectorInstances", () => {
             connector_instance_id: "11111111-1111-1111-1111-111111111111",
             agent_id: 1,
             connector_id: "slack",
-            label: "Main",
+            display: "Main",
             is_default: true,
             enabled_at: "2026-01-01T00:00:00Z",
           },
@@ -54,7 +53,7 @@ describe("useAgentConnectorInstances", () => {
     await waitFor(() => {
       expect(result.current.instances).toHaveLength(1);
     });
-    expect(result.current.instances[0]?.label).toBe("Main");
+    expect(result.current.instances[0]?.display).toBe("Main");
     expect(mockGet).toHaveBeenCalledWith(
       "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
       expect.objectContaining({
@@ -63,7 +62,7 @@ describe("useAgentConnectorInstances", () => {
     );
   });
 
-  it("create posts label", async () => {
+  it("create posts empty body", async () => {
     mockPost.mockResolvedValue({ data: {} });
     const { result } = renderHook(() => useCreateAgentConnectorInstance(), {
       wrapper,
@@ -73,14 +72,13 @@ describe("useAgentConnectorInstances", () => {
       await result.current.create({
         agentId: 1,
         connectorId: "slack",
-        label: "Sales",
       });
     });
 
     expect(mockPost).toHaveBeenCalledWith(
       "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
       expect.objectContaining({
-        body: { label: "Sales" },
+        body: {},
         params: { path: { agent_id: 1, connector_id: "slack" } },
       }),
     );
@@ -112,29 +110,6 @@ describe("useAgentConnectorInstances", () => {
             instance_id: "22222222-2222-2222-2222-222222222222",
           },
         },
-      }),
-    );
-  });
-
-  it("rename patches label", async () => {
-    mockPatch.mockResolvedValue({ data: {} });
-    const { result } = renderHook(() => useRenameAgentConnectorInstance(), {
-      wrapper,
-    });
-
-    await act(async () => {
-      await result.current.rename({
-        agentId: 1,
-        connectorId: "slack",
-        instanceId: "11111111-1111-1111-1111-111111111111",
-        label: "Renamed",
-      });
-    });
-
-    expect(mockPatch).toHaveBeenCalledWith(
-      "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
-      expect.objectContaining({
-        body: { label: "Renamed" },
       }),
     );
   });

--- a/frontend/src/hooks/useAgentConnectorInstances.ts
+++ b/frontend/src/hooks/useAgentConnectorInstances.ts
@@ -43,11 +43,9 @@ export function useCreateAgentConnectorInstance() {
     mutationFn: async ({
       agentId,
       connectorId,
-      label,
     }: {
       agentId: number;
       connectorId: string;
-      label: string;
     }) => {
       if (!accessToken) throw new Error("Missing access token");
       const { data, error } = await client.POST(
@@ -55,7 +53,7 @@ export function useCreateAgentConnectorInstance() {
         {
           headers: { Authorization: `Bearer ${accessToken}` },
           params: { path: { agent_id: agentId, connector_id: connectorId } },
-          body: { label },
+          body: {},
         },
       );
       if (error) {
@@ -82,74 +80,6 @@ export function useCreateAgentConnectorInstance() {
 
   return {
     create: mutation.mutateAsync,
-    isPending: mutation.isPending,
-  };
-}
-
-export function useRenameAgentConnectorInstance() {
-  const { session } = useAuth();
-  const accessToken = session?.access_token;
-  const queryClient = useQueryClient();
-
-  const mutation = useMutation({
-    mutationFn: async ({
-      agentId,
-      connectorId,
-      instanceId,
-      label,
-    }: {
-      agentId: number;
-      connectorId: string;
-      instanceId: string;
-      label: string;
-    }) => {
-      if (!accessToken) throw new Error("Missing access token");
-      const { data, error } = await client.PATCH(
-        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
-        {
-          headers: { Authorization: `Bearer ${accessToken}` },
-          params: {
-            path: {
-              agent_id: agentId,
-              connector_id: connectorId,
-              instance_id: instanceId,
-            },
-          },
-          body: { label },
-        },
-      );
-      if (error) {
-        const msg =
-          (error as { error?: { message?: string } }).error?.message ??
-          "Failed to rename instance";
-        throw new Error(msg);
-      }
-      return data;
-    },
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ["agent-connector-instances", variables.agentId, variables.connectorId],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [
-          "agent-connector-instance-credential",
-          variables.agentId,
-          variables.connectorId,
-          variables.instanceId,
-        ],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [
-          "connector-instance-bindings-summary",
-          variables.agentId,
-          variables.connectorId,
-        ],
-      });
-    },
-  });
-
-  return {
-    rename: mutation.mutateAsync,
     isPending: mutation.isPending,
   };
 }

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
@@ -5,7 +5,7 @@
  * credential row) without API calls so Storybook stays offline.
  */
 import type { Meta, StoryObj } from "@storybook/react";
-import { Check, Pencil, Plus, Settings, Star, Trash2, Unplug } from "lucide-react";
+import { Plus, Settings, Star, Trash2, Unplug } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -15,7 +15,6 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 const selectClassName =
@@ -39,15 +38,6 @@ function ConnectorInstancesSectionLayoutMirror() {
                 <div className="flex flex-wrap items-center gap-2">
                   <p className="font-medium">Engineering</p>
                   <Badge variant="secondary">Default</Badge>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8"
-                    aria-label="Rename instance"
-                  >
-                    <Pencil className="size-3.5" />
-                  </Button>
                 </div>
                 <p className="text-muted-foreground mt-1 text-xs">
                   Added 3/1/2026, 12:00:00 PM
@@ -85,11 +75,7 @@ function ConnectorInstancesSectionLayoutMirror() {
             <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <Input defaultValue="Sales" className="max-w-md" />
-                  <Button type="button" size="sm" variant="secondary">
-                    <Check className="size-4" />
-                    Save
-                  </Button>
+                  <p className="font-medium">Sales</p>
                 </div>
                 <p className="text-muted-foreground mt-1 text-xs">
                   Added 3/2/2026, 12:00:00 PM

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -1,14 +1,5 @@
 import { useMemo, useState } from "react";
-import {
-  Check,
-  Loader2,
-  Pencil,
-  Plus,
-  Settings,
-  Star,
-  Trash2,
-  Unplug,
-} from "lucide-react";
+import { Loader2, Plus, Settings, Star, Trash2, Unplug } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -19,7 +10,6 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Dialog,
@@ -38,7 +28,6 @@ import { serviceLabel } from "@/lib/labels";
 import {
   useAgentConnectorInstances,
   useCreateAgentConnectorInstance,
-  useRenameAgentConnectorInstance,
   useDeleteAgentConnectorInstance,
   useSetDefaultAgentConnectorInstance,
   type AgentConnectorInstance,
@@ -73,7 +62,6 @@ export function ConnectorInstancesSection({
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
-  const [newLabel, setNewLabel] = useState("");
 
   useAutoAssignOAuthCredential(agentId, connectorId);
 
@@ -120,15 +108,9 @@ export function ConnectorInstancesSection({
   const showManageButton = hasRequiredCredentials || !!matchingProvider;
 
   async function handleAddInstance() {
-    const label = newLabel.trim();
-    if (!label) {
-      toast.error("Enter a label for the new instance.");
-      return;
-    }
     try {
-      await create({ agentId, connectorId, label });
-      toast.success("Connector instance added.");
-      setNewLabel("");
+      await create({ agentId, connectorId });
+      toast.success("Connector instance added. Assign a credential to name it.");
       setAddOpen(false);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to add instance.");
@@ -202,22 +184,10 @@ export function ConnectorInstancesSection({
           <DialogHeader>
             <DialogTitle>Add connector instance</DialogTitle>
             <DialogDescription>
-              Choose a unique label (for example a Slack workspace name). You
-              can connect a credential after the instance is created.
+              Creates another slot for this connector. Assign a credential below
+              to set how it appears in approvals and capabilities.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="new-instance-label">Label</Label>
-            <Input
-              id="new-instance-label"
-              value={newLabel}
-              onChange={(e) => setNewLabel(e.target.value)}
-              placeholder="e.g. Engineering Slack"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void handleAddInstance();
-              }}
-            />
-          </div>
           <DialogFooter>
             <Button variant="secondary" onClick={() => setAddOpen(false)}>
               Cancel
@@ -269,40 +239,17 @@ function InstanceCard({
   connections: OAuthConnection[];
   anyLoading: boolean;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [labelDraft, setLabelDraft] = useState(instance.label);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  const { rename, isPending: renaming } = useRenameAgentConnectorInstance();
   const { setDefault, isPending: settingDefault } =
     useSetDefaultAgentConnectorInstance();
   const { deleteInstance, isPending: deleting } =
     useDeleteAgentConnectorInstance();
 
-  const isBusy = renaming || settingDefault || deleting;
-
-  async function commitRename() {
-    const next = labelDraft.trim();
-    if (!next || next === instance.label) {
-      setLabelDraft(instance.label);
-      setEditing(false);
-      return;
-    }
-    try {
-      await rename({
-        agentId,
-        connectorId,
-        instanceId: instance.connector_instance_id,
-        label: next,
-      });
-      toast.success("Instance renamed.");
-      setEditing(false);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to rename.");
-      setLabelDraft(instance.label);
-      setEditing(false);
-    }
-  }
+  const isBusy = settingDefault || deleting;
+  const displayName =
+    instance.display?.trim() ||
+    `Instance ${instance.connector_instance_id.slice(0, 8)}…`;
 
   async function handleMakeDefault() {
     try {
@@ -338,55 +285,12 @@ function InstanceCard({
       <div className="rounded-lg border p-4">
         <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex-1">
-            {editing ? (
-              <div className="flex flex-wrap items-center gap-2">
-                <Input
-                  value={labelDraft}
-                  onChange={(e) => setLabelDraft(e.target.value)}
-                  className="max-w-md"
-                  disabled={renaming}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") void commitRename();
-                    if (e.key === "Escape") {
-                      setLabelDraft(instance.label);
-                      setEditing(false);
-                    }
-                  }}
-                  autoFocus
-                />
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => void commitRename()}
-                  disabled={renaming}
-                >
-                  <Check className="size-4" />
-                  Save
-                </Button>
-              </div>
-            ) : (
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="font-medium">{instance.label}</p>
-                {instance.is_default && (
-                  <Badge variant="secondary">Default</Badge>
-                )}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-8"
-                  onClick={() => {
-                    setLabelDraft(instance.label);
-                    setEditing(true);
-                  }}
-                  disabled={isBusy}
-                  aria-label="Rename instance"
-                >
-                  <Pencil className="size-3.5" />
-                </Button>
-              </div>
-            )}
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="font-medium">{displayName}</p>
+              {instance.is_default && (
+                <Badge variant="secondary">Default</Badge>
+              )}
+            </div>
             <p className="text-muted-foreground mt-1 text-xs">
               Added {new Date(instance.enabled_at).toLocaleString()}
             </p>
@@ -435,7 +339,7 @@ function InstanceCard({
           <DialogHeader>
             <DialogTitle>Remove this instance?</DialogTitle>
             <DialogDescription>
-              This removes the <strong>{instance.label}</strong> instance and its
+              This removes the <strong>{displayName}</strong> instance and its
               credential binding. Standing approvals scoped to this instance are
               revoked. The default instance cannot be removed here — disable the
               connector type instead.

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -184,8 +184,9 @@ export function ConnectorInstancesSection({
           <DialogHeader>
             <DialogTitle>Add connector instance</DialogTitle>
             <DialogDescription>
-              Creates another slot for this connector. Assign a credential below
-              to set how it appears in approvals and capabilities.
+              Creates another slot for this connector. After you add it, assign a
+              credential on that instance&apos;s card in the list (below this dialog)
+              so it has a name in approvals and capabilities.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -249,7 +250,7 @@ function InstanceCard({
   const isBusy = settingDefault || deleting;
   const displayName =
     instance.display?.trim() ||
-    `Instance ${instance.connector_instance_id.slice(0, 8)}…`;
+    "Unnamed instance — assign a credential";
 
   async function handleMakeDefault() {
     try {

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
@@ -19,7 +19,7 @@ const defaultInstance = {
   connector_instance_id: "11111111-1111-1111-1111-111111111111",
   agent_id: 42,
   connector_id: "slack",
-  label: "Engineering",
+  display: "Engineering",
   is_default: true,
   enabled_at: "2026-02-18T10:00:00Z",
 };
@@ -28,7 +28,7 @@ const secondInstance = {
   connector_instance_id: "22222222-2222-2222-2222-222222222222",
   agent_id: 42,
   connector_id: "slack",
-  label: "Sales",
+  display: "Sales",
   is_default: false,
   enabled_at: "2026-02-19T10:00:00Z",
 };
@@ -146,7 +146,6 @@ describe("ConnectorInstancesSection", () => {
       expect(screen.getByText("Engineering")).toBeInTheDocument();
     });
     await user.click(screen.getByRole("button", { name: /Add another/i }));
-    await user.type(screen.getByLabelText(/Label/i), "Sales");
     await user.click(screen.getByRole("button", { name: /^Add$/i }));
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalled();
@@ -154,7 +153,7 @@ describe("ConnectorInstancesSection", () => {
     const call = mockPost.mock.calls.find(
       (c) => c[0] === "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
     );
-    expect(call?.[1]?.body).toEqual({ label: "Sales" });
+    expect(call?.[1]?.body).toEqual({});
   });
 
   it("sets default instance via PATCH", async () => {

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -125,13 +125,18 @@ export function ReviewApprovalDialog({
   const { denyApproval, isPending: isDenying } = useDenyApproval();
   const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg, isLoading: schemaLoading } =
     useActionSchema(approval.action.type);
-  const connectorInstanceLabel =
+  const connectorInstanceDisplay =
     typeof approval.action === "object" &&
     approval.action !== null &&
-    "_connector_instance_label" in approval.action &&
-    typeof (approval.action as { _connector_instance_label?: unknown })._connector_instance_label === "string"
-      ? (approval.action as { _connector_instance_label: string })._connector_instance_label
-      : undefined;
+    "_connector_instance_display" in approval.action &&
+    typeof (approval.action as { _connector_instance_display?: unknown })._connector_instance_display === "string"
+      ? (approval.action as { _connector_instance_display: string })._connector_instance_display
+      : typeof approval.action === "object" &&
+          approval.action !== null &&
+          "_connector_instance_label" in approval.action &&
+          typeof (approval.action as { _connector_instance_label?: unknown })._connector_instance_label === "string"
+        ? (approval.action as { _connector_instance_label: string })._connector_instance_label
+        : undefined;
   const remaining = useCountdown(approval.expires_at);
   const isExpired = remaining <= 0;
   const isBusy = pendingAction !== null || isDenying;
@@ -252,7 +257,7 @@ export function ReviewApprovalDialog({
                     {formatConnectorDisplayName({
                       connectorName,
                       actionType: approval.action.type,
-                      instanceLabel: connectorInstanceLabel,
+                      instanceDisplay: connectorInstanceDisplay,
                     })}
                   </p>
                 </div>

--- a/frontend/src/pages/dashboard/approvalConnectorLabel.test.ts
+++ b/frontend/src/pages/dashboard/approvalConnectorLabel.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { formatConnectorDisplayName } from "./approvalConnectorLabel";
 
 describe("formatConnectorDisplayName", () => {
-  it("appends instance label in parentheses when present", () => {
+  it("appends instance display in parentheses when present", () => {
     expect(
       formatConnectorDisplayName({
         connectorName: "Slack",
         actionType: "slack.send_message",
-        instanceLabel: "Engineering",
+        instanceDisplay: "Engineering",
       }),
     ).toBe("Slack (Engineering)");
   });
@@ -17,9 +17,19 @@ describe("formatConnectorDisplayName", () => {
       formatConnectorDisplayName({
         connectorName: null,
         actionType: "slack.send_message",
-        instanceLabel: "Engineering",
+        instanceDisplay: "Engineering",
       }),
     ).toBe("Slack (Engineering)");
+  });
+
+  it("falls back to legacy instanceLabel when display is absent", () => {
+    expect(
+      formatConnectorDisplayName({
+        connectorName: "Slack",
+        actionType: "slack.send_message",
+        instanceLabel: "Legacy",
+      }),
+    ).toBe("Slack (Legacy)");
   });
 
   it("uses connector name only when no instance label", () => {

--- a/frontend/src/pages/dashboard/approvalConnectorLabel.ts
+++ b/frontend/src/pages/dashboard/approvalConnectorLabel.ts
@@ -7,16 +7,19 @@ function humanizeConnectorPrefix(actionType: string): string {
 }
 
 /**
- * Connector line for approval UI: "Slack (Engineering)" when a multi-instance label is frozen on the action.
+ * Connector line for approval UI: "Slack (Engineering)" when a multi-instance display name is frozen on the action.
+ * Prefer `instanceDisplay` (new `_connector_instance_display`); fall back to `instanceLabel` for legacy actions.
  */
 export function formatConnectorDisplayName(args: {
   connectorName: string | null | undefined;
   actionType: string;
+  instanceDisplay?: string | null;
   instanceLabel?: string | null;
 }): string {
   const base =
     args.connectorName?.trim() || humanizeConnectorPrefix(args.actionType);
-  const inst = args.instanceLabel?.trim();
+  const inst =
+    args.instanceDisplay?.trim() || args.instanceLabel?.trim();
   if (inst) {
     return `${base} (${inst})`;
   }

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -82,7 +82,10 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const summary = buildActionSummary(approval.action.type, parameters, undefined, approval.resource_details as Record<string, unknown> | undefined);
   const actionName = humanizeActionType(approval.action.type);
   const instanceLabel = connectorInstanceLabelFromAction(
-    approval.action as { _connector_instance_label?: unknown },
+    approval.action as {
+      _connector_instance_display?: unknown;
+      _connector_instance_label?: unknown;
+    },
   );
   const connectorDisplayName = instanceLabel
     ? `${humanizeConnectorPrefix(approval.action.type)} (${instanceLabel})`

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -287,12 +287,29 @@ describe("humanizeConnectorPrefix", () => {
 });
 
 describe("connectorInstanceLabelFromAction", () => {
-  it("returns the label when present", () => {
+  it("returns display when present", () => {
     expect(
       connectorInstanceLabelFromAction({
-        _connector_instance_label: "Engineering",
+        _connector_instance_display: "Engineering",
       }),
     ).toBe("Engineering");
+  });
+
+  it("returns legacy label when display is absent", () => {
+    expect(
+      connectorInstanceLabelFromAction({
+        _connector_instance_label: "Legacy",
+      }),
+    ).toBe("Legacy");
+  });
+
+  it("prefers display over legacy label", () => {
+    expect(
+      connectorInstanceLabelFromAction({
+        _connector_instance_display: "New",
+        _connector_instance_label: "Old",
+      }),
+    ).toBe("New");
   });
 
   it("returns undefined when absent", () => {

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -74,10 +74,13 @@ export function humanizeConnectorPrefix(actionType: string): string {
   return prefix.charAt(0).toUpperCase() + prefix.slice(1);
 }
 
-/** Reads frozen multi-instance label from stored action JSON, if present. */
+/** Reads frozen multi-instance display from stored action JSON, if present (legacy: `_connector_instance_label`). */
 export function connectorInstanceLabelFromAction(action: {
+  _connector_instance_display?: unknown;
   _connector_instance_label?: unknown;
 }): string | undefined {
+  const d = action._connector_instance_display;
+  if (typeof d === "string" && d.trim() !== "") return d;
   const v = action._connector_instance_label;
   if (typeof v === "string" && v.trim() !== "") return v;
   return undefined;

--- a/spec/openapi/components/paths/agent_connector_instances.yaml
+++ b/spec/openapi/components/paths/agent_connector_instances.yaml
@@ -35,8 +35,9 @@ agentConnectorInstances:
     operationId: createAgentConnectorInstance
     summary: Create an additional connector instance
     description: |
-      Creates a new labeled instance for this connector type. The first instance for a connector
-      is created when the connector is enabled; this endpoint adds further instances.
+      Creates an additional instance row for this connector type. The first instance is created
+      when the connector is enabled; this endpoint adds further instances. Assign a credential to
+      the instance to set its display name.
 
       Requires session authentication (Supabase JWT).
     tags:
@@ -69,8 +70,6 @@ agentConnectorInstances:
           application/json:
             schema:
               $ref: '../schemas/errors.yaml#/ErrorResponse'
-      '409':
-        $ref: '../responses/errors.yaml#/Conflict'
       '500':
         $ref: '../responses/errors.yaml#/InternalServerError'
 
@@ -102,7 +101,7 @@ agentConnectorInstanceById:
 
   patch:
     operationId: patchAgentConnectorInstance
-    summary: Rename a connector instance
+    summary: Set default connector instance
     tags:
       - Agents
     security:
@@ -130,8 +129,6 @@ agentConnectorInstanceById:
         $ref: '../responses/errors.yaml#/Unauthorized'
       '404':
         $ref: '../responses/errors.yaml#/NotFound'
-      '409':
-        $ref: '../responses/errors.yaml#/Conflict'
       '500':
         $ref: '../responses/errors.yaml#/InternalServerError'
 

--- a/spec/openapi/components/schemas/agent_connector_instances.yaml
+++ b/spec/openapi/components/schemas/agent_connector_instances.yaml
@@ -4,7 +4,6 @@ AgentConnectorInstance:
     - connector_instance_id
     - agent_id
     - connector_id
-    - label
     - is_default
     - enabled_at
   properties:
@@ -18,9 +17,11 @@ AgentConnectorInstance:
     connector_id:
       type: string
       maxLength: 128
-    label:
+    display:
       type: string
-      description: Human-readable label unique per agent and connector type.
+      description: >-
+        Human-readable name from the credential bound to this instance (API key nickname or OAuth
+        workspace/team name). Omitted when no credential is assigned yet.
     is_default:
       type: boolean
       description: True for the default instance used when no instance is specified (legacy routes).
@@ -40,26 +41,18 @@ AgentConnectorInstanceListResponse:
 
 CreateAgentConnectorInstanceRequest:
   type: object
-  required:
-    - label
-  properties:
-    label:
-      type: string
-      minLength: 1
-      maxLength: 256
-      description: Display label for the new instance (unique per agent and connector).
+  description: >-
+    Creates an additional instance row for this connector type. Display names come from the
+    credential assigned per instance, not from this request.
 
 PatchAgentConnectorInstanceRequest:
   type: object
   description: >-
-    At least one of `label` or `is_default` must be provided.
-    When `is_default` is true, this instance becomes the default for the agent and connector type.
+    `is_default` must be provided and set to `true` to mark this instance as the default for the
+    agent and connector type.
+  required:
+    - is_default
   properties:
-    label:
-      type: string
-      minLength: 1
-      maxLength: 256
-      description: New display label for the instance.
     is_default:
       type: boolean
-      description: When true, marks this instance as the default (only value accepted; omit to leave default unchanged).
+      description: Must be `true` — marks this instance as the default.

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -249,7 +249,7 @@ ApprovalSummary:
     action:
       description: |
         Same as `Action`, plus optional frozen connector instance fields when the
-        request targeted a specific instance (`_connector_instance_id`, `_connector_instance_label`).
+        request targeted a specific instance (`_connector_instance_id`, `_connector_instance_display`).
       allOf:
         - $ref: './shared.yaml#/Action'
         - type: object
@@ -258,9 +258,11 @@ ApprovalSummary:
               type: string
               format: uuid
               description: Frozen UUID of the connector instance for this approval (if any).
-            _connector_instance_label:
+            _connector_instance_display:
               type: string
-              description: Human-readable instance label at request time (if any).
+              description: >-
+                Snapshot of the credential display name at request time (if any). Legacy actions may
+                still expose `_connector_instance_label` instead.
     context:
       $ref: './shared.yaml#/ActionContext'
     status:

--- a/spec/openapi/components/schemas/capabilities.yaml
+++ b/spec/openapi/components/schemas/capabilities.yaml
@@ -116,16 +116,18 @@ ConnectorInstanceCapability:
   type: object
   required:
     - id
-    - label
     - credentials_ready
   properties:
     id:
       type: string
       format: uuid
       description: Instance identifier (also accepted as `connector_instance`).
-    label:
+    display:
       type: string
-      description: Human-readable label for this instance (shown in UIs and accepted as `connector_instance`).
+      description: >-
+        Credential nickname / workspace name for this instance (from the bound credential). Omitted
+        when unset. Use `id` or this value as `action.parameters.connector_instance` when multiple
+        instances exist.
     credentials_ready:
       type: boolean
       description: Whether this specific instance has required credentials bound.
@@ -193,7 +195,7 @@ ConnectorCapability:
         $ref: '#/ConnectorInstanceCapability'
       description: |
         Enabled connector instances for this agent (one row per workspace/account binding).
-        Use `label` or `id` as `action.parameters.connector_instance` when multiple instances exist.
+        Use `display` (credential nickname) or `id` as `action.parameters.connector_instance` when multiple instances exist.
 
     actions:
       type: array

--- a/spec/openapi/components/schemas/errors.yaml
+++ b/spec/openapi/components/schemas/errors.yaml
@@ -21,6 +21,7 @@ Error:
         - unsupported_action_version
         - agent_id_mismatch
         - invalid_public_key
+        - connector_instance_ambiguous
         # 401 Unauthorized
         - invalid_signature
         - timestamp_expired

--- a/spec/openapi/components/schemas/shared.yaml
+++ b/spec/openapi/components/schemas/shared.yaml
@@ -85,11 +85,11 @@ Action:
 
         **Multi-instance connectors**: When an agent has more than one instance of the
         same connector (e.g. two Slack workspaces), include `connector_instance` in this
-        object with the instance label or UUID from `GET /agents/{id}/capabilities`
+        object with the instance UUID or credential nickname from `GET /agents/{id}/capabilities`
         (`connectors[].instances[]`). Omit it when only one instance exists — the server
         auto-selects. The field is stripped before schema validation and does not appear on
         stored approvals; resolved routing is frozen as `_connector_instance_id` and
-        `_connector_instance_label` on the action object in responses.
+        `_connector_instance_display` on the action object in responses.
       example:
         from: "alice@example.com"
         to:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1804,8 +1804,9 @@ paths:
       operationId: createAgentConnectorInstance
       summary: Create an additional connector instance
       description: |
-        Creates a new labeled instance for this connector type. The first instance for a connector
-        is created when the connector is enabled; this endpoint adds further instances.
+        Creates an additional instance row for this connector type. The first instance is created
+        when the connector is enabled; this endpoint adds further instances. Assign a credential to
+        the instance to set its display name.
 
         Requires session authentication (Supabase JWT).
       tags:
@@ -1838,8 +1839,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}:
@@ -1869,7 +1868,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     patch:
       operationId: patchAgentConnectorInstance
-      summary: Rename a connector instance
+      summary: Set default connector instance
       tags:
         - Agents
       security:
@@ -1897,8 +1896,6 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
@@ -7322,7 +7319,7 @@ components:
         action:
           description: |
             Same as `Action`, plus optional frozen connector instance fields when the
-            request targeted a specific instance (`_connector_instance_id`, `_connector_instance_label`).
+            request targeted a specific instance (`_connector_instance_id`, `_connector_instance_display`).
           allOf:
             - $ref: '#/components/schemas/Action'
             - type: object
@@ -7331,9 +7328,9 @@ components:
                   type: string
                   format: uuid
                   description: Frozen UUID of the connector instance for this approval (if any).
-                _connector_instance_label:
+                _connector_instance_display:
                   type: string
-                  description: Human-readable instance label at request time (if any).
+                  description: Snapshot of the credential display name at request time (if any). Legacy actions may still expose `_connector_instance_label` instead.
         context:
           $ref: '#/components/schemas/ActionContext'
         status:
@@ -9532,7 +9529,7 @@ components:
             $ref: '#/components/schemas/ConnectorInstanceCapability'
           description: |
             Enabled connector instances for this agent (one row per workspace/account binding).
-            Use `label` or `id` as `action.parameters.connector_instance` when multiple instances exist.
+            Use `display` (credential nickname) or `id` as `action.parameters.connector_instance` when multiple instances exist.
         actions:
           type: array
           items:
@@ -9926,7 +9923,6 @@ components:
         - connector_instance_id
         - agent_id
         - connector_id
-        - label
         - is_default
         - enabled_at
       properties:
@@ -9940,9 +9936,9 @@ components:
         connector_id:
           type: string
           maxLength: 128
-        label:
+        display:
           type: string
-          description: Human-readable label unique per agent and connector type.
+          description: Human-readable name from the credential bound to this instance (API key nickname or OAuth workspace/team name). Omitted when no credential is assigned yet.
         is_default:
           type: boolean
           description: True for the default instance used when no instance is specified (legacy routes).
@@ -9960,26 +9956,16 @@ components:
             $ref: '#/components/schemas/AgentConnectorInstance'
     CreateAgentConnectorInstanceRequest:
       type: object
-      required:
-        - label
-      properties:
-        label:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: Display label for the new instance (unique per agent and connector).
+      description: Creates an additional instance row for this connector type. Display names come from the credential assigned per instance, not from this request.
     PatchAgentConnectorInstanceRequest:
       type: object
-      description: At least one of `label` or `is_default` must be provided. When `is_default` is true, this instance becomes the default for the agent and connector type.
+      description: '`is_default` must be provided and set to `true` to mark this instance as the default for the agent and connector type.'
+      required:
+        - is_default
       properties:
-        label:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: New display label for the instance.
         is_default:
           type: boolean
-          description: When true, marks this instance as the default (only value accepted; omit to leave default unchanged).
+          description: Must be `true` — marks this instance as the default.
     CreateRegistrationInviteRequest:
       type: object
       description: Request to create a registration invite.
@@ -11661,11 +11647,11 @@ components:
 
             **Multi-instance connectors**: When an agent has more than one instance of the
             same connector (e.g. two Slack workspaces), include `connector_instance` in this
-            object with the instance label or UUID from `GET /agents/{id}/capabilities`
+            object with the instance UUID or credential nickname from `GET /agents/{id}/capabilities`
             (`connectors[].instances[]`). Omit it when only one instance exists — the server
             auto-selects. The field is stripped before schema validation and does not appear on
             stored approvals; resolved routing is frozen as `_connector_instance_id` and
-            `_connector_instance_label` on the action object in responses.
+            `_connector_instance_display` on the action object in responses.
           example:
             from: alice@example.com
             to:
@@ -11957,16 +11943,15 @@ components:
       type: object
       required:
         - id
-        - label
         - credentials_ready
       properties:
         id:
           type: string
           format: uuid
           description: Instance identifier (also accepted as `connector_instance`).
-        label:
+        display:
           type: string
-          description: Human-readable label for this instance (shown in UIs and accepted as `connector_instance`).
+          description: Credential nickname / workspace name for this instance (from the bound credential). Omitted when unset. Use `id` or this value as `action.parameters.connector_instance` when multiple instances exist.
         credentials_ready:
           type: boolean
           description: Whether this specific instance has required credentials bound.

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -11797,6 +11797,7 @@ components:
             - unsupported_action_version
             - agent_id_mismatch
             - invalid_public_key
+            - connector_instance_ambiguous
             - invalid_signature
             - timestamp_expired
             - invalid_code


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #974](https://github.com/supersuit-tech/permission-slip/issues/974) **Phases 1–2**:

### Phase 1 (database)
- Migration `20260421134629_drop_agent_connectors_label.sql`: drop `label`, unique index on label, replace insert trigger (first-row default only).
- `EnableAgentConnector` idempotent without label unique constraint.
- Instance display derived from credential binding (API + DB).

### Phase 2 (backend + spec)
- `AgentConnectorInstance` / JSON: `display` (from credential nickname / OAuth name); struct field `DisplayName` in Go.
- Capabilities `connectors[].instances[]`: `display` instead of `label`.
- Approvals: freeze `_connector_instance_display` on action JSON (legacy `_connector_instance_label` still in audit redaction for old rows).
- `available_instances` error detail uses credential display strings.
- OpenAPI updated + `openapi.bundle.yaml` regenerated (`make bundle`).

### Clients (required for spec + compile)
- **Frontend:** connector instances UI — add instance without label, remove rename; approval dialog reads `_connector_instance_display` with fallback to `_connector_instance_label`.
- **Mobile:** `connectorInstanceLabelFromAction` prefers `_connector_instance_display`.

Ref #974

## Test plan

- [ ] CI: `make test-backend`, `make test-frontend`, `make mobile-test`
- Local agent: frontend vitest (connector hooks + section + approvalConnectorLabel); mobile jest (approvalUtils) — passed
- Backend `go test` not run locally (toolchain constraint in agent env)

## Risks / notes

- PATCH connector instance only supports `is_default` (no rename).
- Empty credential binding → empty `display` (omitempty in JSON).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f53cbe6-8fa6-4f64-b0c4-e9791215155a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f53cbe6-8fa6-4f64-b0c4-e9791215155a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

