### PR TITLE
Email replies Phase 1: backend email_thread + Microsoft send_email_reply

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -304,12 +304,14 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			}
 		}
 
+		contextForStore := mergeEmailThreadFromResourceDetailsIntoContext(req.Context, resourceDetails)
+
 		approval, err := db.InsertApproval(r.Context(), deps.DB, db.InsertApprovalParams{
 			ApprovalID:      approvalID,
 			AgentID:         agent.AgentID,
 			ApproverID:      agent.ApproverID,
 			Action:          req.Action,
-			Context:         req.Context,
+			Context:         contextForStore,
 			ResourceDetails: resourceDetails,
 			ExpiresAt:       expiresAt,
 		}, req.RequestID)

--- a/api/approval_email_thread.go
+++ b/api/approval_email_thread.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// mergeEmailThreadFromResourceDetailsIntoContext copies email_thread from resolved
+// resource_details into context.details.email_thread for approval UI (issue #975).
+// If resource_details is nil or has no email_thread, returns contextJSON unchanged.
+func mergeEmailThreadFromResourceDetailsIntoContext(contextJSON json.RawMessage, resourceDetails []byte) json.RawMessage {
+	if len(resourceDetails) == 0 {
+		return contextJSON
+	}
+	var rd map[string]json.RawMessage
+	if err := json.Unmarshal(resourceDetails, &rd); err != nil {
+		return contextJSON
+	}
+	threadRaw, ok := rd["email_thread"]
+	if !ok || len(threadRaw) == 0 {
+		return contextJSON
+	}
+	var thread connectors.EmailThreadPayload
+	if err := json.Unmarshal(threadRaw, &thread); err != nil {
+		return contextJSON
+	}
+
+	var ctxObj map[string]json.RawMessage
+	if err := json.Unmarshal(contextJSON, &ctxObj); err != nil || ctxObj == nil {
+		return contextJSON
+	}
+	detailsRaw, hasDetails := ctxObj["details"]
+	var detailsObj map[string]json.RawMessage
+	if hasDetails && len(detailsRaw) > 0 {
+		_ = json.Unmarshal(detailsRaw, &detailsObj)
+	}
+	if detailsObj == nil {
+		detailsObj = map[string]json.RawMessage{}
+	}
+	if _, exists := detailsObj["email_thread"]; exists {
+		return contextJSON
+	}
+	detailsObj["email_thread"] = threadRaw
+	mergedDetails, err := json.Marshal(detailsObj)
+	if err != nil {
+		return contextJSON
+	}
+	ctxObj["details"] = mergedDetails
+	out, err := json.Marshal(ctxObj)
+	if err != nil {
+		return contextJSON
+	}
+	// Preserve the 65536-byte cap from the request validator.
+	if len(out) > 65536 {
+		return contextJSON
+	}
+	return out
+}

--- a/api/approval_email_thread_test.go
+++ b/api/approval_email_thread_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestMergeEmailThreadFromResourceDetailsIntoContext(t *testing.T) {
+	ctxIn := []byte(`{"description":"x","details":{"foo":"bar"}}`)
+	rd, _ := json.Marshal(map[string]any{
+		"subject": "S",
+		"email_thread": map[string]any{
+			"subject": "Thr",
+			"messages": []map[string]any{
+				{"from": "a@b.com", "message_id": "1"},
+			},
+		},
+	})
+	out := mergeEmailThreadFromResourceDetailsIntoContext(ctxIn, rd)
+	var parsed map[string]any
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	details := parsed["details"].(map[string]any)
+	et := details["email_thread"].(map[string]any)
+	if et["subject"] != "Thr" {
+		t.Fatalf("email_thread: %+v", et)
+	}
+}
+
+func TestMergeEmailThreadFromResourceDetailsIntoContext_SizeCap(t *testing.T) {
+	// Context stays under 65536; merged output would exceed the cap — merge must no-op.
+	long := strings.Repeat("a", 65380)
+	ctxIn := []byte(`{"description":"` + long + `","details":{}}`)
+	if len(ctxIn) >= 65536 {
+		t.Fatalf("setup: context len %d", len(ctxIn))
+	}
+	thread := connectors.EmailThreadPayload{
+		Subject: "x",
+		Messages: []connectors.EmailThreadMessage{
+			{From: "a", MessageID: "1", BodyText: strings.Repeat("b", 400)},
+		},
+	}
+	b, _ := json.Marshal(map[string]any{"email_thread": thread})
+	out := mergeEmailThreadFromResourceDetailsIntoContext(ctxIn, b)
+	if len(out) > 65536 {
+		t.Fatalf("merged unexpectedly long: %d", len(out))
+	}
+	if string(out) != string(ctxIn) {
+		t.Fatal("expected merge skipped when over size cap")
+	}
+}

--- a/connectors/email_thread.go
+++ b/connectors/email_thread.go
@@ -1,0 +1,83 @@
+package connectors
+
+import (
+	"encoding/json"
+	"unicode/utf8"
+)
+
+// MaxEmailThreadBodyRunes is the per-message body cap (html and text separately)
+// for approval UI payloads. When exceeded, bodies are truncated and Truncated is set.
+const MaxEmailThreadBodyRunes = 20 * 1024
+
+// EmailThreadAttachment is attachment metadata without content (filename + size only).
+type EmailThreadAttachment struct {
+	Filename  string `json:"filename"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// EmailThreadMessage is one message in a normalized email thread for approval UI.
+type EmailThreadMessage struct {
+	From        string                  `json:"from"`
+	To          []string                `json:"to"`
+	Cc          []string                `json:"cc"`
+	Date        string                  `json:"date"`
+	BodyHTML    string                  `json:"body_html"`
+	BodyText    string                  `json:"body_text"`
+	Snippet     string                  `json:"snippet"`
+	MessageID   string                  `json:"message_id"`
+	Truncated   bool                    `json:"truncated"`
+	Attachments []EmailThreadAttachment `json:"attachments,omitempty"`
+}
+
+// EmailThreadPayload is the normalized thread shape stored at context.details.email_thread.
+type EmailThreadPayload struct {
+	Subject  string               `json:"subject"`
+	Messages []EmailThreadMessage `json:"messages"`
+}
+
+// TruncateEmailThreadBodies applies MaxEmailThreadBodyRunes to body_html and body_text,
+// setting truncated when either field is cut. Empty strings are left unchanged.
+func TruncateEmailThreadBodies(m *EmailThreadMessage) {
+	if m == nil {
+		return
+	}
+	if s, cut := truncateAtMaxRunes(m.BodyHTML); cut {
+		m.BodyHTML = s
+		m.Truncated = true
+	}
+	if s, cut := truncateAtMaxRunes(m.BodyText); cut {
+		m.BodyText = s
+		m.Truncated = true
+	}
+}
+
+func truncateAtMaxRunes(s string) (string, bool) {
+	if s == "" {
+		return "", false
+	}
+	if utf8.RuneCountInString(s) <= MaxEmailThreadBodyRunes {
+		return s, false
+	}
+	runes := []rune(s)
+	if len(runes) <= MaxEmailThreadBodyRunes {
+		return s, false
+	}
+	return string(runes[:MaxEmailThreadBodyRunes]), true
+}
+
+// EmailThreadDetailsMap returns resource_details map entries for an email thread.
+// Keys match context.details.email_thread in the OpenAPI contract.
+func EmailThreadDetailsMap(thread *EmailThreadPayload) map[string]any {
+	if thread == nil {
+		return nil
+	}
+	b, err := json.Marshal(thread)
+	if err != nil {
+		return nil
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(b, &asMap); err != nil {
+		return nil
+	}
+	return map[string]any{"email_thread": asMap}
+}

--- a/connectors/email_thread_test.go
+++ b/connectors/email_thread_test.go
@@ -1,0 +1,22 @@
+package connectors
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateEmailThreadBodies(t *testing.T) {
+	long := strings.Repeat("a", MaxEmailThreadBodyRunes+100)
+	m := EmailThreadMessage{BodyHTML: long, BodyText: "short"}
+	TruncateEmailThreadBodies(&m)
+	if utf8.RuneCountInString(m.BodyHTML) != MaxEmailThreadBodyRunes {
+		t.Fatalf("expected html truncated to %d runes, got %d", MaxEmailThreadBodyRunes, utf8.RuneCountInString(m.BodyHTML))
+	}
+	if !m.Truncated {
+		t.Fatal("expected truncated flag")
+	}
+	if m.BodyText != "short" {
+		t.Errorf("short text should be unchanged, got len %d", utf8.RuneCountInString(m.BodyText))
+	}
+}

--- a/connectors/google/gmail_thread.go
+++ b/connectors/google/gmail_thread.go
@@ -143,12 +143,6 @@ func extractHTMLAndPlain(part *gmailMessagePart, depth int) (plain, html string)
 		return plainOut, htmlOut
 	}
 
-	if part.Body.Data != "" && part.MimeType == "text/plain" {
-		return decodeBase64URL(part.Body.Data), ""
-	}
-	if part.Body.Data != "" && part.MimeType == "text/html" {
-		return "", decodeBase64URL(part.Body.Data)
-	}
 	return "", ""
 }
 

--- a/connectors/google/gmail_thread.go
+++ b/connectors/google/gmail_thread.go
@@ -1,0 +1,171 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// gmailThreadAPIResponse is the Gmail threads.get API response (format=full).
+type gmailThreadAPIResponse struct {
+	ID       string             `json:"id"`
+	Messages []gmailFullMessage `json:"messages"`
+}
+
+// buildGmailEmailThread fetches the full thread and returns a normalized email_thread payload.
+func (c *GoogleConnector) buildGmailEmailThread(ctx context.Context, creds connectors.Credentials, threadID string) (*connectors.EmailThreadPayload, error) {
+	if threadID == "" {
+		return nil, fmt.Errorf("missing thread_id")
+	}
+	threadURL := c.gmailBaseURL + "/gmail/v1/users/me/threads/" + url.PathEscape(threadID) + "?format=full"
+	var thr gmailThreadAPIResponse
+	if err := c.doJSON(ctx, creds, http.MethodGet, threadURL, nil, &thr); err != nil {
+		return nil, err
+	}
+	if len(thr.Messages) == 0 {
+		return &connectors.EmailThreadPayload{Subject: "", Messages: nil}, nil
+	}
+
+	// Oldest → newest by internalDate (fallback: preserve API order).
+	msgs := append([]gmailFullMessage(nil), thr.Messages...)
+	sort.Slice(msgs, func(i, j int) bool {
+		ai, _ := strconv.ParseInt(msgs[i].InternalDate, 10, 64)
+		aj, _ := strconv.ParseInt(msgs[j].InternalDate, 10, 64)
+		return ai < aj
+	})
+
+	subject := ""
+	for _, m := range msgs {
+		if s := headerValue(&m.Payload, "Subject"); s != "" {
+			subject = stripHeaderNewlines(s)
+			break
+		}
+	}
+
+	out := make([]connectors.EmailThreadMessage, 0, len(msgs))
+	for _, m := range msgs {
+		em := connectors.EmailThreadMessage{
+			From:      stripHeaderNewlines(headerValue(&m.Payload, "From")),
+			To:        splitAddressList(headerValue(&m.Payload, "To")),
+			Cc:        splitAddressList(headerValue(&m.Payload, "Cc")),
+			Date:      gmailMessageDateRFC3339(&m),
+			Snippet:   m.Snippet,
+			MessageID: m.ID,
+		}
+		plain, html := extractHTMLAndPlain(&m.Payload, 0)
+		em.BodyText = plain
+		em.BodyHTML = html
+		if em.BodyText == "" && em.BodyHTML != "" {
+			em.BodyText = htmlToPlainText(em.BodyHTML)
+		}
+		em.Attachments = gmailAttachmentsToThread(extractAttachments(&m.Payload))
+		connectors.TruncateEmailThreadBodies(&em)
+		out = append(out, em)
+	}
+
+	return &connectors.EmailThreadPayload{
+		Subject:  subject,
+		Messages: out,
+	}, nil
+}
+
+func headerValue(part *gmailMessagePart, name string) string {
+	if part == nil {
+		return ""
+	}
+	lower := strings.ToLower(name)
+	for _, h := range part.Headers {
+		if strings.ToLower(h.Name) == lower {
+			return h.Value
+		}
+	}
+	return ""
+}
+
+func splitAddressList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, stripHeaderNewlines(p))
+		}
+	}
+	return out
+}
+
+func gmailMessageDateRFC3339(m *gmailFullMessage) string {
+	if m.InternalDate != "" {
+		if ms, err := strconv.ParseInt(m.InternalDate, 10, 64); err == nil {
+			return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+		}
+	}
+	if d := headerValue(&m.Payload, "Date"); d != "" {
+		return stripHeaderNewlines(d)
+	}
+	return ""
+}
+
+// extractHTMLAndPlain walks the MIME tree and returns best-effort text/plain and text/html bodies.
+func extractHTMLAndPlain(part *gmailMessagePart, depth int) (plain, html string) {
+	if part == nil || depth > maxMIMEDepth {
+		return "", ""
+	}
+
+	if part.Body.Data != "" && part.MimeType == "text/plain" {
+		return decodeBase64URL(part.Body.Data), ""
+	}
+	if part.Body.Data != "" && part.MimeType == "text/html" {
+		return "", decodeBase64URL(part.Body.Data)
+	}
+
+	if strings.HasPrefix(part.MimeType, "multipart/") {
+		var plainOut, htmlOut string
+		for i := range part.Parts {
+			p, h := extractHTMLAndPlain(&part.Parts[i], depth+1)
+			if p != "" {
+				plainOut = p
+			}
+			if h != "" {
+				htmlOut = h
+			}
+		}
+		return plainOut, htmlOut
+	}
+
+	if part.Body.Data != "" && part.MimeType == "text/plain" {
+		return decodeBase64URL(part.Body.Data), ""
+	}
+	if part.Body.Data != "" && part.MimeType == "text/html" {
+		return "", decodeBase64URL(part.Body.Data)
+	}
+	return "", ""
+}
+
+func gmailAttachmentsToThread(in []gmailAttachmentInfo) []connectors.EmailThreadAttachment {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]connectors.EmailThreadAttachment, 0, len(in))
+	for _, a := range in {
+		fn := a.Filename
+		if fn == "" {
+			fn = "(no filename)"
+		}
+		out = append(out, connectors.EmailThreadAttachment{
+			Filename:  fn,
+			SizeBytes: int64(a.Size),
+		})
+	}
+	return out
+}

--- a/connectors/google/gmail_thread_test.go
+++ b/connectors/google/gmail_thread_test.go
@@ -1,0 +1,133 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func httptestNewJSONServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+}
+
+func TestBuildGmailEmailThread_MultipartAndAttachments(t *testing.T) {
+	threadJSON := `{
+		"id": "th1",
+		"messages": [
+			{
+				"id": "m1",
+				"internalDate": "1000",
+				"snippet": "snip",
+				"payload": {
+					"mimeType": "multipart/alternative",
+					"headers": [
+						{"name": "Subject", "value": "Thread Subj"},
+						{"name": "From", "value": "a@x.com"},
+						{"name": "To", "value": "b@x.com"},
+						{"name": "Cc", "value": "c@x.com"}
+					],
+					"parts": [
+						{
+							"mimeType": "text/plain",
+							"body": {"data": "VGV4dA=="}
+						},
+						{
+							"mimeType": "text/html",
+							"body": {"data": "PHA+SFRNTDwvcD4="}
+						}
+					]
+				}
+			},
+			{
+				"id": "m2",
+				"internalDate": "2000",
+				"snippet": "later",
+				"payload": {
+					"mimeType": "multipart/mixed",
+					"headers": [
+						{"name": "From", "value": "b@x.com"}
+					],
+					"parts": [
+						{
+							"mimeType": "multipart/alternative",
+							"parts": [
+								{"mimeType": "text/plain", "body": {"data": "TGF0ZXI="}}
+							]
+						},
+						{
+							"mimeType": "application/pdf",
+							"filename": "f.pdf",
+							"body": {"attachmentId": "att1", "size": 42}
+						}
+					]
+				}
+			}
+		]
+	}`
+
+	srv := httptestNewJSONServer(t, threadJSON)
+	defer srv.Close()
+
+	c := newGmailForTest(srv.Client(), srv.URL)
+	th, err := c.buildGmailEmailThread(context.Background(), validCreds(), "th1")
+	if err != nil {
+		t.Fatalf("buildGmailEmailThread: %v", err)
+	}
+	if th.Subject != "Thread Subj" {
+		t.Errorf("subject: got %q", th.Subject)
+	}
+	if len(th.Messages) != 2 {
+		t.Fatalf("messages: got %d", len(th.Messages))
+	}
+	if th.Messages[0].MessageID != "m1" || th.Messages[1].MessageID != "m2" {
+		t.Errorf("order: %#v", th.Messages)
+	}
+	if th.Messages[0].BodyText != "Text" {
+		t.Errorf("m1 text: %q", th.Messages[0].BodyText)
+	}
+	if th.Messages[0].BodyHTML != "<p>HTML</p>" {
+		t.Errorf("m1 html: %q", th.Messages[0].BodyHTML)
+	}
+	if len(th.Messages[1].Attachments) != 1 || th.Messages[1].Attachments[0].Filename != "f.pdf" {
+		t.Errorf("attachments: %+v", th.Messages[1].Attachments)
+	}
+}
+
+func TestBuildGmailEmailThread_Truncation(t *testing.T) {
+	longBody := strings.Repeat("z", connectors.MaxEmailThreadBodyRunes+100)
+	plainB64 := base64.StdEncoding.EncodeToString([]byte(longBody))
+	threadJSON := `{
+		"id": "th2",
+		"messages": [{
+			"id": "m1",
+			"internalDate": "1",
+			"payload": {
+				"mimeType": "text/plain",
+				"headers": [{"name": "Subject", "value": "S"}],
+				"body": {"data": "` + plainB64 + `"}
+			}
+		}]
+	}`
+	srv := httptestNewJSONServer(t, threadJSON)
+	defer srv.Close()
+	c := newGmailForTest(srv.Client(), srv.URL)
+	th, err := c.buildGmailEmailThread(context.Background(), validCreds(), "th2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !th.Messages[0].Truncated {
+		t.Fatal("expected truncated")
+	}
+	if len(th.Messages[0].BodyText) != connectors.MaxEmailThreadBodyRunes {
+		t.Fatalf("len %d", len(th.Messages[0].BodyText))
+	}
+}

--- a/connectors/google/read_email.go
+++ b/connectors/google/read_email.go
@@ -73,6 +73,7 @@ type gmailFullMessage struct {
 type gmailMessagePart struct {
 	PartID   string `json:"partId"`
 	MimeType string `json:"mimeType"`
+	Filename string `json:"filename"`
 	Headers  []struct {
 		Name  string `json:"name"`
 		Value string `json:"value"`
@@ -87,17 +88,17 @@ type gmailMessagePart struct {
 
 // emailFullDetail is the shape returned to the agent.
 type emailFullDetail struct {
-	ID          string               `json:"id"`
-	ThreadID    string               `json:"thread_id"`
-	From        string               `json:"from,omitempty"`
-	To          string               `json:"to,omitempty"`
-	Cc          string               `json:"cc,omitempty"`
-	Subject     string               `json:"subject,omitempty"`
-	Date        string               `json:"date,omitempty"`
-	Snippet     string               `json:"snippet,omitempty"`
-	Labels      []string             `json:"labels,omitempty"`
-	ContentType string               `json:"content_type,omitempty"`
-	Body        string               `json:"body,omitempty"`
+	ID          string                `json:"id"`
+	ThreadID    string                `json:"thread_id"`
+	From        string                `json:"from,omitempty"`
+	To          string                `json:"to,omitempty"`
+	Cc          string                `json:"cc,omitempty"`
+	Subject     string                `json:"subject,omitempty"`
+	Date        string                `json:"date,omitempty"`
+	Snippet     string                `json:"snippet,omitempty"`
+	Labels      []string              `json:"labels,omitempty"`
+	ContentType string                `json:"content_type,omitempty"`
+	Body        string                `json:"body,omitempty"`
 	Attachments []gmailAttachmentInfo `json:"attachments,omitempty"`
 }
 
@@ -244,6 +245,9 @@ func collectAttachments(part *gmailMessagePart, out *[]gmailAttachmentInfo, dept
 				}
 			}
 		}
+		if info.Filename == "" && part.Filename != "" {
+			info.Filename = part.Filename
+		}
 		*out = append(*out, info)
 	}
 	for i := range part.Parts {
@@ -282,7 +286,7 @@ func parseFilename(headerValue string) string {
 	return plainName
 }
 
-// decodeRFC5987 decodes a RFC 5987 encoded value like "UTF-8''caf%C3%A9.pdf".
+// decodeRFC5987 decodes a RFC 5987 encoded value like "UTF-8”caf%C3%A9.pdf".
 // Only UTF-8 charset is supported; other charsets (e.g. ISO-8859-1) return ""
 // to avoid producing invalid UTF-8 strings.
 func decodeRFC5987(value string) string {
@@ -309,7 +313,10 @@ func decodeBase64URL(s string) string {
 	if err != nil {
 		b, err = base64.URLEncoding.DecodeString(s)
 		if err != nil {
-			return s // return as-is if decoding fails
+			b, err = base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return s // return as-is if decoding fails
+			}
 		}
 	}
 	return string(b)

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -232,12 +232,34 @@ func (c *GoogleConnector) resolveEmail(ctx context.Context, creds connectors.Cre
 
 func (c *GoogleConnector) resolveEmailReply(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
 	var p struct {
+		ThreadID  string `json:"thread_id"`
 		MessageID string `json:"message_id"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil || p.MessageID == "" {
 		return nil, fmt.Errorf("missing message_id")
 	}
-	return c.fetchEmailMetadata(ctx, creds, p.MessageID)
+	meta, err := c.fetchEmailMetadata(ctx, creds, p.MessageID)
+	if err != nil {
+		return nil, err
+	}
+	if p.ThreadID == "" {
+		return meta, nil
+	}
+	thread, err := c.buildGmailEmailThread(ctx, creds, p.ThreadID)
+	if err != nil {
+		return meta, nil // non-fatal: keep subject/from for display template
+	}
+	extra := connectors.EmailThreadDetailsMap(thread)
+	if extra == nil {
+		return meta, nil
+	}
+	if meta == nil {
+		return extra, nil
+	}
+	for k, v := range extra {
+		meta[k] = v
+	}
+	return meta, nil
 }
 
 func (c *GoogleConnector) fetchEmailMetadata(ctx context.Context, creds connectors.Credentials, messageID string) (map[string]any, error) {

--- a/connectors/google/resolve_resource_details_test.go
+++ b/connectors/google/resolve_resource_details_test.go
@@ -196,16 +196,24 @@ func TestResolveResourceDetails_Email(t *testing.T) {
 func TestResolveResourceDetails_EmailReply(t *testing.T) {
 	srv, conn := testResolveServer(t, map[string]string{
 		"/gmail/v1/users/me/messages/": `{"payload":{"headers":[{"name":"Subject","value":"Re: Budget Discussion"}]}}`,
+		"/gmail/v1/users/me/threads/": `{"id":"th1","messages":[{"id":"msg456","internalDate":"1","payload":{"mimeType":"text/plain","headers":[{"name":"Subject","value":"Re: Budget Discussion"}],"body":{"data":"SGk="}}}]}`,
 	})
 	defer srv.Close()
 
-	params, _ := json.Marshal(map[string]string{"message_id": "msg456"})
+	params, _ := json.Marshal(map[string]string{"thread_id": "th1", "message_id": "msg456"})
 	details, err := conn.ResolveResourceDetails(context.Background(), "google.send_email_reply", params, validCreds())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if details["subject"] != "Re: Budget Discussion" {
 		t.Errorf("expected subject, got %v", details["subject"])
+	}
+	et, ok := details["email_thread"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected email_thread in details, got %T", details["email_thread"])
+	}
+	if et["subject"] != "Re: Budget Discussion" {
+		t.Errorf("email_thread.subject: %v", et["subject"])
 	}
 }
 

--- a/connectors/google/send_email_reply_test.go
+++ b/connectors/google/send_email_reply_test.go
@@ -18,6 +18,23 @@ func replyTestHandler(t *testing.T, threadID, from, subject, messageID string, s
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/threads/") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": threadID,
+				"messages": []map[string]any{
+					{
+						"id": "msg001",
+						"payload": map[string]any{
+							"headers": []map[string]string{
+								{"name": "From", "value": from},
+								{"name": "Subject", "value": subject},
+							},
+						},
+					},
+				},
+			})
+			return
+		}
 		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/messages/") {
 			json.NewEncoder(w).Encode(map[string]any{
 				"id":       "msg001",

--- a/connectors/html_plain.go
+++ b/connectors/html_plain.go
@@ -1,0 +1,21 @@
+package connectors
+
+import (
+	"html"
+	"regexp"
+	"strings"
+)
+
+var htmlTagPattern = regexp.MustCompile(`<[^>]*>`)
+
+// StripHTMLToPlain produces a minimal plain-text fallback from HTML (tags stripped, entities decoded).
+func StripHTMLToPlain(s string) string {
+	s = strings.ReplaceAll(s, "<br>", "\n")
+	s = strings.ReplaceAll(s, "<br/>", "\n")
+	s = strings.ReplaceAll(s, "<br />", "\n")
+	s = strings.ReplaceAll(s, "</p>", "\n")
+	s = strings.ReplaceAll(s, "</div>", "\n")
+	s = htmlTagPattern.ReplaceAllString(s, "")
+	s = html.UnescapeString(s)
+	return strings.TrimSpace(s)
+}

--- a/connectors/microsoft/manifest_templates.go
+++ b/connectors/microsoft/manifest_templates.go
@@ -35,6 +35,13 @@ func microsoftTemplates() []connectors.ManifestTemplate {
 			Description: "Agent can only send emails to recipients matching a specific domain pattern. Set the domain before applying.",
 			Parameters:  json.RawMessage(`{"to":{"$pattern":"*@example.com"},"subject":"*","body":"*"}`),
 		},
+		{
+			ID:          "tpl_microsoft_reply_to_email",
+			ActionType:  "microsoft.send_email_reply",
+			Name:        "Reply to emails",
+			Description: "Agent can reply to existing Outlook messages by message ID.",
+			Parameters:  json.RawMessage(`{"message_id":"*","body":"*"}`),
+		},
 		// --- Calendar read ---
 		{
 			ID:          "tpl_microsoft_list_events",

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -110,11 +110,10 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:      "microsoft.send_email_reply",
-				Name:            "Reply to Email",
-				Description:     "Reply to an existing message in a Microsoft 365 mailbox",
-				RiskLevel:       "medium",
-				DisplayTemplate: "Reply to email {{message_id}}",
+				ActionType:  "microsoft.send_email_reply",
+				Name:        "Reply to Email",
+				Description: "Reply to an existing message in a Microsoft 365 mailbox",
+				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["message_id", "body"],

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -110,6 +110,32 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
+				ActionType:      "microsoft.send_email_reply",
+				Name:            "Reply to Email",
+				Description:     "Reply to an existing message in a Microsoft 365 mailbox",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Reply to email {{message_id}}",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["message_id", "body"],
+					"properties": {
+						"message_id": {
+							"type": "string",
+							"description": "Microsoft Graph message ID of the message to reply to"
+						},
+						"body": {
+							"type": "string",
+							"description": "Reply body. When html is true (default), use valid HTML. When html is false, body is sent as plain text."
+						},
+						"html": {
+							"type": "boolean",
+							"default": true,
+							"description": "When true (default), body is HTML. When false, plain text only."
+						}
+					}
+				}`)),
+			},
+			{
 				ActionType:  "microsoft.list_emails",
 				Name:        "List Emails",
 				Description: "List recent emails from the user's mailbox",
@@ -691,6 +717,7 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 func (c *MicrosoftConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
 		"microsoft.send_email":            &sendEmailAction{conn: c},
+		"microsoft.send_email_reply":      &sendEmailReplyAction{conn: c},
 		"microsoft.list_emails":           &listEmailsAction{conn: c},
 		"microsoft.create_calendar_event": &createCalendarEventAction{conn: c},
 		"microsoft.list_calendar_events":  &listCalendarEventsAction{conn: c},

--- a/connectors/microsoft/microsoft_test.go
+++ b/connectors/microsoft/microsoft_test.go
@@ -21,6 +21,7 @@ func TestMicrosoftConnector_Actions(t *testing.T) {
 
 	expected := []string{
 		"microsoft.send_email",
+		"microsoft.send_email_reply",
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
@@ -111,8 +112,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	if m.Name != "Microsoft" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Microsoft")
 	}
-	if len(m.Actions) != 24 {
-		t.Fatalf("Manifest().Actions has %d items, want 24", len(m.Actions))
+	if len(m.Actions) != 25 {
+		t.Fatalf("Manifest().Actions has %d items, want 25", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -120,6 +121,7 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	}
 	for _, want := range []string{
 		"microsoft.send_email",
+		"microsoft.send_email_reply",
 		"microsoft.list_emails",
 		"microsoft.create_calendar_event",
 		"microsoft.list_calendar_events",
@@ -166,8 +168,8 @@ func TestMicrosoftConnector_Manifest(t *testing.T) {
 	}
 
 	// Validate templates.
-	if len(m.Templates) != 27 {
-		t.Errorf("Manifest().Templates has %d items, want 27", len(m.Templates))
+	if len(m.Templates) != 28 {
+		t.Errorf("Manifest().Templates has %d items, want 28", len(m.Templates))
 	}
 
 	// Validate the manifest passes validation.

--- a/connectors/microsoft/resolve_resource_details.go
+++ b/connectors/microsoft/resolve_resource_details.go
@@ -1,0 +1,49 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// ResolveResourceDetails fetches human-readable metadata for Microsoft action parameters.
+func (c *MicrosoftConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	case "microsoft.send_email_reply":
+		return c.resolveSendEmailReply(ctx, creds, params)
+	default:
+		return nil, nil
+	}
+}
+
+func (c *MicrosoftConnector) resolveSendEmailReply(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		MessageID string `json:"message_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.MessageID == "" {
+		return nil, nil
+	}
+	msg, err := c.fetchGraphMessage(ctx, creds, p.MessageID)
+	if err != nil {
+		return nil, err
+	}
+	details := map[string]any{
+		"subject": stripGraphHeaderNewlines(msg.Subject),
+	}
+	if msg.From != nil {
+		details["from"] = stripGraphHeaderNewlines(msg.From.EmailAddress.Address)
+	}
+	thread, err := c.buildMicrosoftEmailThread(ctx, creds, p.MessageID)
+	if err != nil {
+		return details, nil
+	}
+	extra := connectors.EmailThreadDetailsMap(thread)
+	if extra == nil {
+		return details, nil
+	}
+	for k, v := range extra {
+		details[k] = v
+	}
+	return details, nil
+}

--- a/connectors/microsoft/send_email_reply.go
+++ b/connectors/microsoft/send_email_reply.go
@@ -1,0 +1,75 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// sendEmailReplyAction implements connectors.Action for microsoft.send_email_reply.
+// It replies to an existing message via POST /me/messages/{id}/reply.
+type sendEmailReplyAction struct {
+	conn *MicrosoftConnector
+}
+
+type sendEmailReplyParams struct {
+	MessageID string `json:"message_id"`
+	Body      string `json:"body"`
+	HTML      *bool  `json:"html,omitempty"`
+}
+
+func (p *sendEmailReplyParams) validate() error {
+	if err := validateGraphID("message_id", p.MessageID); err != nil {
+		return err
+	}
+	if p.Body == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: body"}
+	}
+	return nil
+}
+
+// ValidateRequest validates parameters at approval request time.
+func (a *sendEmailReplyAction) ValidateRequest(params json.RawMessage) error {
+	var p sendEmailReplyParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	return p.validate()
+}
+
+type graphReplyRequest struct {
+	Comment string `json:"comment,omitempty"`
+	Message struct {
+		Body graphEmailBody `json:"body"`
+	} `json:"message,omitempty"`
+}
+
+// Execute sends a reply using the Graph reply endpoint.
+func (a *sendEmailReplyAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params sendEmailReplyParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	path := "/me/messages/" + url.PathEscape(params.MessageID) + "/reply"
+	ct := graphBodyContentType(params.HTML)
+	var body graphReplyRequest
+	if ct == "Text" {
+		body.Comment = params.Body
+	} else {
+		body.Message.Body = graphEmailBody{ContentType: "HTML", Content: params.Body}
+	}
+
+	if err := a.conn.doRequest(ctx, http.MethodPost, path, req.Credentials, body, nil); err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]string{"status": "sent"})
+}

--- a/connectors/microsoft/send_email_reply_test.go
+++ b/connectors/microsoft/send_email_reply_test.go
@@ -1,0 +1,78 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestSendEmailReply_HTMLBody(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	var gotBody graphReplyRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendEmailReplyAction{conn: conn}
+	params, _ := json.Marshal(map[string]string{
+		"message_id": "msgA",
+		"body":       "<p>Hi</p>",
+	})
+	_, err := action.Execute(context.Background(), connectors.ActionRequest{
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotPath != "/me/messages/msgA/reply" {
+		t.Errorf("path: %s", gotPath)
+	}
+	if gotBody.Comment != "" {
+		t.Errorf("expected message body for HTML, got comment %q", gotBody.Comment)
+	}
+	if gotBody.Message.Body.ContentType != "HTML" || gotBody.Message.Body.Content != "<p>Hi</p>" {
+		t.Errorf("body: %+v", gotBody.Message.Body)
+	}
+}
+
+func TestSendEmailReply_PlainUsesComment(t *testing.T) {
+	t.Parallel()
+	var gotBody graphReplyRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendEmailReplyAction{conn: conn}
+	htmlFalse := false
+	params, _ := json.Marshal(map[string]any{
+		"message_id": "msgB",
+		"body":       "plain",
+		"html":       htmlFalse,
+	})
+	_, err := action.Execute(context.Background(), connectors.ActionRequest{
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBody.Comment != "plain" {
+		t.Errorf("comment: %q", gotBody.Comment)
+	}
+	if gotBody.Message.Body.Content != "" {
+		t.Errorf("expected empty message.body for plain, got %+v", gotBody.Message.Body)
+	}
+}

--- a/connectors/microsoft/thread.go
+++ b/connectors/microsoft/thread.go
@@ -1,0 +1,162 @@
+package microsoft
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// graphFullMessage is a subset of Graph message fields for thread building and reply context.
+type graphFullMessage struct {
+	ID               string              `json:"id"`
+	Subject          string              `json:"subject"`
+	ConversationID   string              `json:"conversationId"`
+	ReceivedDateTime string              `json:"receivedDateTime"`
+	BodyPreview      string              `json:"bodyPreview"`
+	From             *graphMailAddress   `json:"from,omitempty"`
+	ToRecipients     []*graphMailAddress `json:"toRecipients,omitempty"`
+	CCRecipients     []*graphMailAddress `json:"ccRecipients,omitempty"`
+	Body             graphEmailBody      `json:"body"`
+	Attachments      []graphAttachment   `json:"attachments,omitempty"`
+}
+
+type graphAttachment struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+type graphMessagesPage struct {
+	Value []graphFullMessage `json:"value"`
+}
+
+func addressListFromRecipients(rs []*graphMailAddress) []string {
+	if len(rs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		if r == nil {
+			continue
+		}
+		addr := strings.TrimSpace(r.EmailAddress.Address)
+		if addr != "" {
+			out = append(out, addr)
+		}
+	}
+	return out
+}
+
+func stripGraphHeaderNewlines(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r", ""), "\n", "")
+}
+
+// fetchGraphMessage loads a single message with body and expanded attachments metadata.
+func (c *MicrosoftConnector) fetchGraphMessage(ctx context.Context, creds connectors.Credentials, messageID string) (*graphFullMessage, error) {
+	if err := validateGraphID("message_id", messageID); err != nil {
+		return nil, err
+	}
+	path := "/me/messages/" + url.PathEscape(messageID) +
+		"?$select=" + url.QueryEscape("id,subject,conversationId,receivedDateTime,bodyPreview,from,toRecipients,ccRecipients,body") +
+		"&$expand=" + url.QueryEscape("attachments($select=name,size)")
+	var msg graphFullMessage
+	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// buildMicrosoftEmailThread fetches the anchor message and full conversation ordered oldest→newest.
+func (c *MicrosoftConnector) buildMicrosoftEmailThread(ctx context.Context, creds connectors.Credentials, messageID string) (*connectors.EmailThreadPayload, error) {
+	src, err := c.fetchGraphMessage(ctx, creds, messageID)
+	if err != nil {
+		return nil, err
+	}
+	convID := strings.TrimSpace(src.ConversationID)
+	if convID == "" {
+		return singleMessageThread(src), nil
+	}
+
+	filter := fmt.Sprintf("conversationId eq '%s'", escapeODataString(convID))
+	order := "receivedDateTime asc"
+	selectFields := "id,subject,conversationId,receivedDateTime,bodyPreview,from,toRecipients,ccRecipients,body"
+	path := "/me/messages?$filter=" + url.QueryEscape(filter) +
+		"&$orderby=" + url.QueryEscape(order) +
+		"&$select=" + url.QueryEscape(selectFields) +
+		"&$expand=" + url.QueryEscape("attachments($select=name,size)") +
+		"&$top=100"
+
+	var page graphMessagesPage
+	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &page); err != nil {
+		return singleMessageThread(src), nil
+	}
+	if len(page.Value) == 0 {
+		return singleMessageThread(src), nil
+	}
+
+	subject := stripGraphHeaderNewlines(page.Value[0].Subject)
+	if subject == "" {
+		subject = stripGraphHeaderNewlines(src.Subject)
+	}
+
+	msgs := make([]connectors.EmailThreadMessage, 0, len(page.Value))
+	for _, m := range page.Value {
+		em := graphMessageToThreadMessage(&m)
+		msgs = append(msgs, em)
+	}
+	return &connectors.EmailThreadPayload{Subject: subject, Messages: msgs}, nil
+}
+
+func escapeODataString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+func singleMessageThread(m *graphFullMessage) *connectors.EmailThreadPayload {
+	if m == nil {
+		return &connectors.EmailThreadPayload{}
+	}
+	em := graphMessageToThreadMessage(m)
+	return &connectors.EmailThreadPayload{
+		Subject:  stripGraphHeaderNewlines(m.Subject),
+		Messages: []connectors.EmailThreadMessage{em},
+	}
+}
+
+func graphMessageToThreadMessage(m *graphFullMessage) connectors.EmailThreadMessage {
+	var from string
+	if m.From != nil {
+		from = stripGraphHeaderNewlines(m.From.EmailAddress.Address)
+	}
+	em := connectors.EmailThreadMessage{
+		From:      from,
+		To:        addressListFromRecipients(m.ToRecipients),
+		Cc:        addressListFromRecipients(m.CCRecipients),
+		Date:      stripGraphHeaderNewlines(m.ReceivedDateTime),
+		Snippet:   stripGraphHeaderNewlines(m.BodyPreview),
+		MessageID: m.ID,
+	}
+	ct := strings.ToLower(strings.TrimSpace(m.Body.ContentType))
+	content := m.Body.Content
+	switch ct {
+	case "html":
+		em.BodyHTML = content
+		em.BodyText = connectors.StripHTMLToPlain(content)
+	default:
+		em.BodyText = content
+	}
+	for _, a := range m.Attachments {
+		fn := strings.TrimSpace(a.Name)
+		if fn == "" {
+			fn = "(no filename)"
+		}
+		em.Attachments = append(em.Attachments, connectors.EmailThreadAttachment{
+			Filename:  fn,
+			SizeBytes: a.Size,
+		})
+	}
+	connectors.TruncateEmailThreadBodies(&em)
+	return em
+}

--- a/connectors/microsoft/thread_test.go
+++ b/connectors/microsoft/thread_test.go
@@ -1,0 +1,103 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestGraphMessageToThreadMessage_HTML(t *testing.T) {
+	var from graphMailAddress
+	from.EmailAddress.Address = "a@b.com"
+	var to graphMailAddress
+	to.EmailAddress.Address = "c@d.com"
+	m := &graphFullMessage{
+		ID:               "1",
+		Subject:          "S",
+		ReceivedDateTime: "2020-01-01T00:00:00Z",
+		BodyPreview:      "pv",
+		From:             &from,
+		ToRecipients:     []*graphMailAddress{&to},
+		Body:             graphEmailBody{ContentType: "HTML", Content: "<p>x</p>"},
+	}
+	em := graphMessageToThreadMessage(m)
+	if em.BodyHTML != "<p>x</p>" {
+		t.Fatalf("html: %q", em.BodyHTML)
+	}
+	if em.BodyText == "" {
+		t.Fatal("expected body_text from html")
+	}
+}
+
+func TestBuildMicrosoftEmailThread_Conversation(t *testing.T) {
+	msg1 := `{"id":"m1","subject":"Subj","conversationId":"conv1","receivedDateTime":"2020-01-01T00:00:00Z","bodyPreview":"p1","from":{"emailAddress":{"address":"a@b.com"}},"toRecipients":[{"emailAddress":{"address":"c@d.com"}}],"body":{"contentType":"text","content":"hello"},"attachments":[{"name":"f.txt","size":3}]}`
+	msg2 := `{"id":"m2","subject":"Subj","conversationId":"conv1","receivedDateTime":"2020-01-02T00:00:00Z","bodyPreview":"p2","from":{"emailAddress":{"address":"c@d.com"}},"body":{"contentType":"HTML","content":"<b>late</b>"}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/me/messages/m2" {
+			w.Write([]byte(msg2))
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/me/messages" {
+			w.Write([]byte(`{"value":[` + msg1 + `,` + msg2 + `]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newForTest(srv.Client(), srv.URL)
+	th, err := c.buildMicrosoftEmailThread(context.Background(), validCreds(), "m2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if th.Subject != "Subj" {
+		t.Errorf("subject %q", th.Subject)
+	}
+	if len(th.Messages) != 2 {
+		t.Fatalf("messages %d", len(th.Messages))
+	}
+	if th.Messages[1].BodyHTML != "<b>late</b>" {
+		t.Errorf("last html %q", th.Messages[1].BodyHTML)
+	}
+	if len(th.Messages[0].Attachments) != 1 || th.Messages[0].Attachments[0].Filename != "f.txt" {
+		t.Errorf("att %+v", th.Messages[0].Attachments)
+	}
+}
+
+func TestBuildMicrosoftEmailThread_Truncation(t *testing.T) {
+	long := strings.Repeat("w", connectors.MaxEmailThreadBodyRunes+50)
+	msg := map[string]any{
+		"id": "m1", "subject": "S", "conversationId": "c",
+		"receivedDateTime": "2020-01-01T00:00:00Z",
+		"body":             map[string]string{"contentType": "text", "content": long},
+	}
+	b, _ := json.Marshal(msg)
+	page := `{"value":[` + string(b) + `]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/me/messages/m1" {
+			w.Write(b)
+			return
+		}
+		if r.URL.Path == "/me/messages" {
+			w.Write([]byte(page))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := newForTest(srv.Client(), srv.URL)
+	th, err := c.buildMicrosoftEmailThread(context.Background(), validCreds(), "m1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(th.Messages) != 1 || !th.Messages[0].Truncated {
+		t.Fatalf("trunc: %+v", th.Messages)
+	}
+}

--- a/spec/openapi/components/schemas/shared.yaml
+++ b/spec/openapi/components/schemas/shared.yaml
@@ -107,6 +107,73 @@ Action:
       subject: "Hello World"
       body: "This is a test email."
 
+EmailThreadAttachment:
+  type: object
+  required:
+    - filename
+    - size_bytes
+  properties:
+    filename:
+      type: string
+    size_bytes:
+      type: integer
+      format: int64
+
+EmailThreadMessage:
+  type: object
+  required:
+    - from
+    - to
+    - cc
+    - date
+    - body_html
+    - body_text
+    - snippet
+    - message_id
+    - truncated
+  properties:
+    from:
+      type: string
+    to:
+      type: array
+      items:
+        type: string
+    cc:
+      type: array
+      items:
+        type: string
+    date:
+      type: string
+      description: ISO-8601 timestamp when available
+    body_html:
+      type: string
+    body_text:
+      type: string
+    snippet:
+      type: string
+    message_id:
+      type: string
+    truncated:
+      type: boolean
+      description: True when body_html or body_text was truncated server-side (~20 KB per field)
+    attachments:
+      type: array
+      items:
+        $ref: '#/EmailThreadAttachment'
+
+EmailThread:
+  type: object
+  required:
+    - subject
+    - messages
+  properties:
+    subject:
+      type: string
+    messages:
+      type: array
+      items:
+        $ref: '#/EmailThreadMessage'
+
 ActionContext:
   type: object
   required:
@@ -148,6 +215,10 @@ ActionContext:
         - `recipient_count`: Number of email recipients
         - `estimated_cost`: Estimated cost of a payment action
         - `affected_resources`: List of resources that will be modified
+        - `email_thread`: Full conversation for email reply actions (see EmailThread)
+      properties:
+        email_thread:
+          $ref: '#/EmailThread'
       example:
         recipient_count: 1
         estimated_time: "5 minutes"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -11720,6 +11720,10 @@ components:
             - `recipient_count`: Number of email recipients
             - `estimated_cost`: Estimated cost of a payment action
             - `affected_resources`: List of resources that will be modified
+            - `email_thread`: Full conversation for email reply actions (see EmailThread)
+          properties:
+            email_thread:
+              $ref: '#/components/schemas/EmailThread'
           example:
             recipient_count: 1
             estimated_time: 5 minutes
@@ -11729,6 +11733,70 @@ components:
         details:
           recipient_count: 1
           estimated_time: 5 minutes
+    EmailThread:
+      type: object
+      required:
+        - subject
+        - messages
+      properties:
+        subject:
+          type: string
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmailThreadMessage'
+    EmailThreadMessage:
+      type: object
+      required:
+        - from
+        - to
+        - cc
+        - date
+        - body_html
+        - body_text
+        - snippet
+        - message_id
+        - truncated
+      properties:
+        from:
+          type: string
+        to:
+          type: array
+          items:
+            type: string
+        cc:
+          type: array
+          items:
+            type: string
+        date:
+          type: string
+          description: ISO-8601 timestamp when available
+        body_html:
+          type: string
+        body_text:
+          type: string
+        snippet:
+          type: string
+        message_id:
+          type: string
+        truncated:
+          type: boolean
+          description: True when body_html or body_text was truncated server-side (~20 KB per field)
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmailThreadAttachment'
+    EmailThreadAttachment:
+      type: object
+      required:
+        - filename
+        - size_bytes
+      properties:
+        filename:
+          type: string
+        size_bytes:
+          type: integer
+          format: int64
     AlternativeUrls:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -668,6 +668,12 @@ components:
       $ref: './components/schemas/shared.yaml#/Action'
     ActionContext:
       $ref: './components/schemas/shared.yaml#/ActionContext'
+    EmailThread:
+      $ref: './components/schemas/shared.yaml#/EmailThread'
+    EmailThreadMessage:
+      $ref: './components/schemas/shared.yaml#/EmailThreadMessage'
+    EmailThreadAttachment:
+      $ref: './components/schemas/shared.yaml#/EmailThreadAttachment'
     AlternativeUrls:
       $ref: './components/schemas/shared.yaml#/AlternativeUrls'
     ExecutionStatus:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Gmail:** `ResolveResourceDetails` for `google.send_email_reply` now loads the full thread via `GET .../threads/{id}?format=full`, parses MIME bodies (including multipart), lists attachment filenames/sizes, applies a ~20 KB per-field truncation flag, and exposes `email_thread` in resolved details.
- **Microsoft:** New `microsoft.send_email_reply` action (`POST /me/messages/{id}/reply`), manifest entry, template, and `ResolveResourceDetails` that fetches the anchor message plus the conversation by `conversationId` and maps it to the same normalized shape (HTML → plain text via a shared stripper).
- **API:** When creating an approval, if resolved `resource_details` contains `email_thread`, it is merged into `context.details.email_thread` (skipped if the merged JSON would exceed the existing 64 KiB context limit). OpenAPI documents `EmailThread` / `EmailThreadMessage` / `EmailThreadAttachment` under `ActionContext.details`.

Part of #975

## Test plan

### Claude Code

- [x] `make bundle` — OpenAPI bundle succeeds (run locally).
- [x] `cd frontend && npm run generate:api` — regenerates types from bundle (schema.d.ts is gitignored).
- [x] **Go tests not run in this environment:** local `go test` fails because `go.mod` requires Go 1.25.9 while the sandbox has an older toolchain. CI should run `make test-backend` / full `make test`.

### Human

- [ ] After merge, verify a pending approval for `google.send_email_reply` / `microsoft.send_email_reply` includes `context.details.email_thread` in API responses.
- [ ] Smoke-test Microsoft reply against a real mailbox (Graph permissions already include Mail.Send/Mail.Read).

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea91cab9-f900-4922-9bb0-37cf89203724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea91cab9-f900-4922-9bb0-37cf89203724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


