### PR TITLE
GitHub: resolve workflow & webhook IDs for approval summaries (issue #973 phase 3)

### DIFF
--- a/connectors/display_template_test.go
+++ b/connectors/display_template_test.go
@@ -29,6 +29,9 @@ var templateParamPattern = regexp.MustCompile(`\{\{(\w+)(?::\w+)?\}\}`)
 //     • resolveFile          → file_name, title
 //     • resolveEmail         → subject, from
 //     • resolveSheet         → title, range
+//   - GitHub: connectors/github/resolve_resource_details.go
+//     • resolveWorkflow → workflow_name
+//     • resolveWebhook  → webhook_url, webhook_events
 var resourceDetailFields = map[string]bool{
 	// Slack (see connectors/slack/resolve_resource_details.go)
 	"channel_name": true,
@@ -40,6 +43,10 @@ var resourceDetailFields = map[string]bool{
 	"subject":    true,
 	"from":       true,
 	"range":      true,
+	// GitHub (see connectors/github/resolve_resource_details.go)
+	"workflow_name":  true,
+	"webhook_url":    true,
+	"webhook_events": true,
 }
 
 // TestDisplayTemplateParamsExist validates that every {{param}} reference in a

--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -593,7 +593,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "Trigger Workflow",
 				Description:     "Trigger a GitHub Actions workflow dispatch event",
 				RiskLevel:       "medium",
-				DisplayTemplate: "Trigger workflow {{workflow_id}} in {{owner}}/{{repo}}",
+				DisplayTemplate: "Trigger workflow {{workflow_name}} in {{owner}}/{{repo}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["owner", "repo", "workflow_id", "ref"],
@@ -1267,7 +1267,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "Delete Webhook",
 				Description:     "Delete a repository webhook by numeric hook ID",
 				RiskLevel:       "high",
-				DisplayTemplate: "Delete webhook {{hook_id}} in {{owner}}/{{repo}}",
+				DisplayTemplate: "Delete webhook {{webhook_url}} in {{owner}}/{{repo}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["owner", "repo", "hook_id"],

--- a/connectors/github/resolve_resource_details.go
+++ b/connectors/github/resolve_resource_details.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+var _ connectors.ResourceDetailResolver = (*GitHubConnector)(nil)
+
+// ResolveResourceDetails fetches human-readable metadata for resources
+// referenced by opaque IDs in GitHub action parameters. Errors are non-fatal —
+// the caller stores the approval without details on failure.
+func (c *GitHubConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	case "github.trigger_workflow":
+		return c.resolveWorkflow(ctx, creds, params)
+	case "github.delete_webhook":
+		return c.resolveWebhook(ctx, creds, params)
+	default:
+		return nil, nil
+	}
+}
+
+func (c *GitHubConnector) resolveWorkflow(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		Owner      string `json:"owner"`
+		Repo       string `json:"repo"`
+		WorkflowID string `json:"workflow_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return nil, err
+	}
+	if p.WorkflowID == "" {
+		return nil, fmt.Errorf("missing workflow_id")
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/actions/workflows/%s",
+		url.PathEscape(p.Owner), url.PathEscape(p.Repo), url.PathEscape(p.WorkflowID))
+
+	var resp struct {
+		Name string `json:"name"`
+	}
+	if err := c.do(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(resp.Name) == "" {
+		return nil, nil
+	}
+	return map[string]any{"workflow_name": resp.Name}, nil
+}
+
+func (c *GitHubConnector) resolveWebhook(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		Owner  string `json:"owner"`
+		Repo   string `json:"repo"`
+		HookID int    `json:"hook_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("parse params: %w", err)
+	}
+	if err := requireOwnerRepo(p.Owner, p.Repo); err != nil {
+		return nil, err
+	}
+	if err := requirePositiveInt(p.HookID, "hook_id"); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/hooks/%d",
+		url.PathEscape(p.Owner), url.PathEscape(p.Repo), p.HookID)
+
+	var resp struct {
+		Config struct {
+			URL string `json:"url"`
+		} `json:"config"`
+		Events []string `json:"events"`
+	}
+	if err := c.do(ctx, creds, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	out := map[string]any{}
+	if u := strings.TrimSpace(resp.Config.URL); u != "" {
+		out["webhook_url"] = u
+	}
+	if len(resp.Events) > 0 {
+		out["webhook_events"] = strings.Join(resp.Events, ", ")
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}

--- a/connectors/github/resolve_resource_details_test.go
+++ b/connectors/github/resolve_resource_details_test.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testGitHubResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *GitHubConnector) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	conn := newForTest(srv.Client(), srv.URL)
+	return srv, conn
+}
+
+func TestResolveResourceDetails_Workflow(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		want := "/repos/acme/app/actions/workflows/deploy.yml"
+		if r.URL.Path != want {
+			t.Errorf("expected path %q, got %q", want, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"name": "Deploy to production"})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{
+		"owner":       "acme",
+		"repo":        "app",
+		"workflow_id": "deploy.yml",
+		"ref":         "main",
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "github.trigger_workflow", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["workflow_name"] != "Deploy to production" {
+		t.Errorf("expected workflow_name, got %v", details["workflow_name"])
+	}
+}
+
+func TestResolveResourceDetails_Webhook(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		want := "/repos/acme/app/hooks/42"
+		if r.URL.Path != want {
+			t.Errorf("expected path %q, got %q", want, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"config": map[string]string{"url": "https://example.com/webhook"},
+			"events": []string{"push", "pull_request"},
+		})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"owner":   "acme",
+		"repo":    "app",
+		"hook_id": 42,
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "github.delete_webhook", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["webhook_url"] != "https://example.com/webhook" {
+		t.Errorf("expected webhook_url, got %v", details["webhook_url"])
+	}
+	if details["webhook_events"] != "push, pull_request" {
+		t.Errorf("expected webhook_events, got %v", details["webhook_events"])
+	}
+}
+
+func TestResolveResourceDetails_UnknownAction(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	params, _ := json.Marshal(map[string]string{"owner": "a", "repo": "b"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "github.create_issue", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != nil {
+		t.Errorf("expected nil details for unhandled action, got %v", details)
+	}
+}
+
+func TestResolveResourceDetails_WorkflowMissingID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	params, _ := json.Marshal(map[string]string{"owner": "a", "repo": "b", "ref": "main"})
+	_, err := conn.ResolveResourceDetails(context.Background(), "github.trigger_workflow", params, validCreds())
+	if err == nil {
+		t.Fatal("expected error for missing workflow_id")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements **Phase 3** of #973: add `ResourceDetailResolver` for the GitHub connector so approval summaries show human-readable workflow names and webhook URLs instead of raw IDs.

## Summary

- New `connectors/github/resolve_resource_details.go`: `github.trigger_workflow` → GET `/repos/{owner}/{repo}/actions/workflows/{workflow_id}` → `workflow_name`; `github.delete_webhook` → GET `/repos/{owner}/{repo}/hooks/{hook_id}` → `webhook_url`, `webhook_events` (comma-separated).
- Updated display templates in `manifest.go` to use `{{workflow_name}}` and `{{webhook_url}}`.
- Registered `workflow_name`, `webhook_url`, and `webhook_events` in `connectors/display_template_test.go`.
- Added `resolve_resource_details_test.go` with httptest coverage.

`GitHubConnector` now satisfies `connectors.ResourceDetailResolver` (same pattern as Slack/Google); agent approvals already pick this up via type assertion in `api/agent_approvals.go`.

## Phase 3 checklist (issue #973)

- [x] Create `connectors/github/resolve_resource_details.go` implementing the `ResourceDetailResolver` interface (follow Slack/Google pattern)
- [x] Implement `resolveWorkflow()` for `github.trigger_workflow` — `GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}` → `{"workflow_name": "..."}`
- [x] Implement `resolveWebhook()` for `github.delete_webhook` — `GET /repos/{owner}/{repo}/hooks/{hook_id}` → `{"webhook_url": "...", "webhook_events": "push, pull_request"}`
- [x] Update `github.trigger_workflow` `DisplayTemplate` (manifest.go:596) to use `{{workflow_name}}`
- [x] Update `github.delete_webhook` `DisplayTemplate` (manifest.go:1270) to use `{{webhook_url}}`
- [x] Add `workflow_name`, `webhook_url`, `webhook_events` to known fields in `display_template_test.go`
- [x] Create `connectors/github/resolve_resource_details_test.go` with coverage for both resolvers
- [x] Wire the resolver into the connector's registration so `ResolveResourceDetails` is called (check how Slack/Google expose it via the connector struct)

Refs #973 (partial — phases 1, 2, and 4 are separate PRs).

## Test plan

- [ ] `make test-backend` (not run in this environment: local Go toolchain is older than `go.mod`; CI should run the full suite)
- [x] `gofmt -e` on new/edited Go files
- [ ] `make test-frontend` / `make mobile-test` (no frontend/mobile changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b73b006-55cb-4010-8785-52c52ba4d34a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b73b006-55cb-4010-8785-52c52ba4d34a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

