### PR TITLE
Google: resolve Chat space & calendar names in approval summaries (#973 phase 2)

### DIFF
--- a/connectors/display_template_test.go
+++ b/connectors/display_template_test.go
@@ -29,17 +29,23 @@ var templateParamPattern = regexp.MustCompile(`\{\{(\w+)(?::\w+)?\}\}`)
 //     • resolveFile          → file_name, title
 //     • resolveEmail         → subject, from
 //     • resolveSheet         → title, range
+//     • resolveChatSpace     → space_display_name
+//     • resolveCalendar      → calendar_name
+//     • resolvePresentation  → presentation_title (also title)
 var resourceDetailFields = map[string]bool{
 	// Slack (see connectors/slack/resolve_resource_details.go)
 	"channel_name": true,
 	"user_name":    true,
 	// Google (see connectors/google/resolve_resource_details.go)
-	"title":      true,
-	"file_name":  true,
-	"start_time": true,
-	"subject":    true,
-	"from":       true,
-	"range":      true,
+	"title":               true,
+	"presentation_title":  true,
+	"space_display_name":  true,
+	"calendar_name":       true,
+	"file_name":           true,
+	"start_time":          true,
+	"subject":             true,
+	"from":                true,
+	"range":               true,
 }
 
 // TestDisplayTemplateParamsExist validates that every {{param}} reference in a

--- a/connectors/google/chat_space_name.go
+++ b/connectors/google/chat_space_name.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"errors"
+	"strings"
+)
+
+// Sentinel errors for validateChatSpaceName — mapped to user-facing ValidationError
+// messages in sendChatMessageParams.validate and to fmt.Errorf in resolveChatSpace.
+var (
+	errChatSpaceNotPrefixed  = errors.New("chat space: must use spaces/ prefix")
+	errChatSpaceEmptyID      = errors.New("chat space: empty id after prefix")
+	errChatSpaceInvalidChars = errors.New("chat space: invalid characters in id")
+)
+
+// validateChatSpaceName checks that s matches Google Chat space resource names
+// (e.g. spaces/AAAAMpdlehY). Shared by send_chat_message execution and
+// resolveChatSpace so URL-building rules stay in one place.
+func validateChatSpaceName(s string) (spaceID string, err error) {
+	if !strings.HasPrefix(s, "spaces/") {
+		return "", errChatSpaceNotPrefixed
+	}
+	spaceID = strings.TrimPrefix(s, "spaces/")
+	if spaceID == "" {
+		return "", errChatSpaceEmptyID
+	}
+	if strings.ContainsAny(spaceID, "/?#") || strings.Contains(spaceID, "..") {
+		return "", errChatSpaceInvalidChars
+	}
+	return spaceID, nil
+}

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -146,7 +146,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "List Calendar Events",
 				Description:     "List upcoming events from Google Calendar",
 				RiskLevel:       "low",
-				DisplayTemplate: "List calendar events from {{calendar_id}}",
+				DisplayTemplate: "List calendar events from {{calendar_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -463,7 +463,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "Add Slide",
 				Description:     "Add a new slide to an existing Google Slides presentation",
 				RiskLevel:       "medium",
-				DisplayTemplate: "Add {{layout}} slide to presentation",
+				DisplayTemplate: "Add {{layout}} slide to {{presentation_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["presentation_id"],
@@ -499,7 +499,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "Send Chat Message",
 				Description:     "Send a message to a Google Chat space",
 				RiskLevel:       "medium",
-				DisplayTemplate: "Send message to {{space_name}} — {{text}}",
+				DisplayTemplate: "Send message to {{space_display_name}} — {{text}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["space_name", "text"],

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
@@ -19,6 +20,12 @@ func (c *GoogleConnector) ResolveResourceDetails(ctx context.Context, actionType
 	// Calendar
 	case "google.delete_calendar_event", "google.update_calendar_event":
 		return c.resolveCalendarEvent(ctx, creds, params)
+	case "google.list_calendar_events":
+		return c.resolveCalendar(ctx, creds, params)
+
+	// Chat
+	case "google.send_chat_message":
+		return c.resolveChatSpace(ctx, creds, params)
 
 	// Drive
 	case "google.delete_drive_file", "google.get_drive_file":
@@ -188,7 +195,61 @@ func (c *GoogleConnector) resolvePresentation(ctx context.Context, creds connect
 		return nil, err
 	}
 
-	return map[string]any{"title": resp.Title}, nil
+	// Include presentation_title so templates can disambiguate from other "title"
+	// params (e.g. optional slide title on google.add_slide).
+	return map[string]any{
+		"title":              resp.Title,
+		"presentation_title": resp.Title,
+	}, nil
+}
+
+// resolveChatSpace fetches the Chat space display name for approval summaries.
+// API: GET https://chat.googleapis.com/v1/{name}?fields=displayName
+func (c *GoogleConnector) resolveChatSpace(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		SpaceName string `json:"space_name"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.SpaceName == "" {
+		return nil, fmt.Errorf("missing space_name")
+	}
+	if !strings.HasPrefix(p.SpaceName, "spaces/") {
+		return nil, fmt.Errorf("space_name must start with 'spaces/'")
+	}
+	spaceID := strings.TrimPrefix(p.SpaceName, "spaces/")
+	if spaceID == "" || strings.ContainsAny(spaceID, "/?#") || strings.Contains(spaceID, "..") {
+		return nil, fmt.Errorf("invalid space_name")
+	}
+
+	var resp struct {
+		DisplayName string `json:"displayName"`
+	}
+	getURL := c.chatBaseURL + "/v1/" + p.SpaceName + "?fields=displayName"
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+	return map[string]any{"space_display_name": resp.DisplayName}, nil
+}
+
+// resolveCalendar fetches the calendar summary (human-readable name) for a calendar ID.
+func (c *GoogleConnector) resolveCalendar(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		CalendarID string `json:"calendar_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if p.CalendarID == "" {
+		p.CalendarID = "primary"
+	}
+
+	var resp struct {
+		Summary string `json:"summary"`
+	}
+	getURL := c.calendarBaseURL + "/calendars/" + url.PathEscape(p.CalendarID) + "?fields=summary"
+	if err := c.doJSON(ctx, creds, http.MethodGet, getURL, nil, &resp); err != nil {
+		return nil, err
+	}
+	return map[string]any{"calendar_name": resp.Summary}, nil
 }
 
 // ── Gmail ───────────────────────────────────────────────────────────────────

--- a/connectors/google/resolve_resource_details.go
+++ b/connectors/google/resolve_resource_details.go
@@ -3,10 +3,10 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
@@ -212,12 +212,15 @@ func (c *GoogleConnector) resolveChatSpace(ctx context.Context, creds connectors
 	if err := json.Unmarshal(params, &p); err != nil || p.SpaceName == "" {
 		return nil, fmt.Errorf("missing space_name")
 	}
-	if !strings.HasPrefix(p.SpaceName, "spaces/") {
-		return nil, fmt.Errorf("space_name must start with 'spaces/'")
-	}
-	spaceID := strings.TrimPrefix(p.SpaceName, "spaces/")
-	if spaceID == "" || strings.ContainsAny(spaceID, "/?#") || strings.Contains(spaceID, "..") {
-		return nil, fmt.Errorf("invalid space_name")
+	if _, err := validateChatSpaceName(p.SpaceName); err != nil {
+		switch {
+		case errors.Is(err, errChatSpaceNotPrefixed):
+			return nil, fmt.Errorf("space_name must start with 'spaces/'")
+		case errors.Is(err, errChatSpaceEmptyID), errors.Is(err, errChatSpaceInvalidChars):
+			return nil, fmt.Errorf("invalid space_name")
+		default:
+			return nil, err
+		}
 	}
 
 	var resp struct {
@@ -231,12 +234,14 @@ func (c *GoogleConnector) resolveChatSpace(ctx context.Context, creds connectors
 }
 
 // resolveCalendar fetches the calendar summary (human-readable name) for a calendar ID.
+// API: GET {calendarBaseURL}/calendars/{calendarId}?fields=summary (Calendar API v3).
+// When calendar_id is empty, defaults to "primary", matching listCalendarEventsParams.normalize().
 func (c *GoogleConnector) resolveCalendar(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
 	var p struct {
 		CalendarID string `json:"calendar_id"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid calendar params: %w", err)
 	}
 	if p.CalendarID == "" {
 		p.CalendarID = "primary"

--- a/connectors/google/resolve_resource_details_test.go
+++ b/connectors/google/resolve_resource_details_test.go
@@ -32,6 +32,7 @@ func testResolveServer(t *testing.T, routes map[string]string) (*httptest.Server
 		sheetsBaseURL:   srv.URL,
 		docsBaseURL:     srv.URL,
 		driveBaseURL:    srv.URL,
+		chatBaseURL:     srv.URL,
 	}
 	return srv, conn
 }
@@ -159,6 +160,57 @@ func TestResolveResourceDetails_Presentation(t *testing.T) {
 		if details["title"] != "Q1 Review Deck" {
 			t.Errorf("%s: expected title 'Q1 Review Deck', got %v", actionType, details["title"])
 		}
+		if details["presentation_title"] != "Q1 Review Deck" {
+			t.Errorf("%s: expected presentation_title 'Q1 Review Deck', got %v", actionType, details["presentation_title"])
+		}
+	}
+}
+
+func TestResolveResourceDetails_ChatSpace(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/v1/spaces/": `{"displayName":"Dev Team"}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"space_name": "spaces/AAQAohK4ZL0", "text": "Hello"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.send_chat_message", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["space_display_name"] != "Dev Team" {
+		t.Errorf("expected space_display_name 'Dev Team', got %v", details["space_display_name"])
+	}
+}
+
+func TestResolveResourceDetails_CalendarSummary(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/calendars/work%40example.com": `{"summary":"Work Calendar"}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"calendar_id": "work@example.com"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.list_calendar_events", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["calendar_name"] != "Work Calendar" {
+		t.Errorf("expected calendar_name, got %v", details["calendar_name"])
+	}
+}
+
+func TestResolveResourceDetails_CalendarSummary_DefaultPrimary(t *testing.T) {
+	srv, conn := testResolveServer(t, map[string]string{
+		"/calendars/primary": `{"summary":"alice@example.com"}`,
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{})
+	details, err := conn.ResolveResourceDetails(context.Background(), "google.list_calendar_events", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["calendar_name"] != "alice@example.com" {
+		t.Errorf("expected calendar_name for primary, got %v", details["calendar_name"])
 	}
 }
 
@@ -267,5 +319,11 @@ func TestResolveResourceDetails_MissingParams(t *testing.T) {
 	_, err = conn.ResolveResourceDetails(context.Background(), "google.get_presentation", params, validCreds())
 	if err == nil {
 		t.Error("expected error for missing presentation_id")
+	}
+
+	// Missing space_name
+	_, err = conn.ResolveResourceDetails(context.Background(), "google.send_chat_message", params, validCreds())
+	if err == nil {
+		t.Error("expected error for missing space_name")
 	}
 }

--- a/connectors/google/resolve_resource_details_test.go
+++ b/connectors/google/resolve_resource_details_test.go
@@ -166,6 +166,16 @@ func TestResolveResourceDetails_Presentation(t *testing.T) {
 	}
 }
 
+func TestResolveResourceDetails_ChatSpace_Invalid(t *testing.T) {
+	conn := New()
+	for _, spaceName := range []string{"AAA", "spaces/", "spaces/foo/bar", "spaces/..", "spaces/foo?bar"} {
+		params, _ := json.Marshal(map[string]string{"space_name": spaceName})
+		if _, err := conn.ResolveResourceDetails(context.Background(), "google.send_chat_message", params, validCreds()); err == nil {
+			t.Errorf("expected error for space_name=%q", spaceName)
+		}
+	}
+}
+
 func TestResolveResourceDetails_ChatSpace(t *testing.T) {
 	srv, conn := testResolveServer(t, map[string]string{
 		"/v1/spaces/": `{"displayName":"Dev Team"}`,
@@ -184,7 +194,7 @@ func TestResolveResourceDetails_ChatSpace(t *testing.T) {
 
 func TestResolveResourceDetails_CalendarSummary(t *testing.T) {
 	srv, conn := testResolveServer(t, map[string]string{
-		"/calendars/work%40example.com": `{"summary":"Work Calendar"}`,
+		"/calendars/work@example.com": `{"summary":"Work Calendar"}`,
 	})
 	defer srv.Close()
 
@@ -248,7 +258,7 @@ func TestResolveResourceDetails_Email(t *testing.T) {
 func TestResolveResourceDetails_EmailReply(t *testing.T) {
 	srv, conn := testResolveServer(t, map[string]string{
 		"/gmail/v1/users/me/messages/": `{"payload":{"headers":[{"name":"Subject","value":"Re: Budget Discussion"}]}}`,
-		"/gmail/v1/users/me/threads/": `{"id":"th1","messages":[{"id":"msg456","internalDate":"1","payload":{"mimeType":"text/plain","headers":[{"name":"Subject","value":"Re: Budget Discussion"}],"body":{"data":"SGk="}}}]}`,
+		"/gmail/v1/users/me/threads/":  `{"id":"th1","messages":[{"id":"msg456","internalDate":"1","payload":{"mimeType":"text/plain","headers":[{"name":"Subject","value":"Re: Budget Discussion"}],"body":{"data":"SGk="}}}]}`,
 	})
 	defer srv.Close()
 

--- a/connectors/google/send_chat_message.go
+++ b/connectors/google/send_chat_message.go
@@ -3,9 +3,9 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
@@ -28,19 +28,17 @@ func (p *sendChatMessageParams) validate() error {
 	if p.SpaceName == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: space_name"}
 	}
-	// Validate the space_name format to prevent path traversal and URL injection.
-	// Google Chat space names follow the pattern "spaces/{spaceId}" where
-	// spaceId is an alphanumeric identifier (e.g. "spaces/AAAAMpdlehY").
-	if !strings.HasPrefix(p.SpaceName, "spaces/") {
-		return &connectors.ValidationError{Message: "space_name must start with 'spaces/' (e.g. 'spaces/AAAA1234')"}
-	}
-	spaceID := strings.TrimPrefix(p.SpaceName, "spaces/")
-	if spaceID == "" {
-		return &connectors.ValidationError{Message: "space_name must include a space ID after 'spaces/'"}
-	}
-	// Reject characters that could alter URL path or query (/  ?  #  ..)
-	if strings.ContainsAny(spaceID, "/?#") || strings.Contains(spaceID, "..") {
-		return &connectors.ValidationError{Message: "space_name contains invalid characters"}
+	if _, err := validateChatSpaceName(p.SpaceName); err != nil {
+		switch {
+		case errors.Is(err, errChatSpaceNotPrefixed):
+			return &connectors.ValidationError{Message: "space_name must start with 'spaces/' (e.g. 'spaces/AAAA1234')"}
+		case errors.Is(err, errChatSpaceEmptyID):
+			return &connectors.ValidationError{Message: "space_name must include a space ID after 'spaces/'"}
+		case errors.Is(err, errChatSpaceInvalidChars):
+			return &connectors.ValidationError{Message: "space_name contains invalid characters"}
+		default:
+			return &connectors.ValidationError{Message: err.Error()}
+		}
 	}
 	if p.Text == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: text"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 2** of #973 for the Google connector: resolve opaque IDs used in approval `DisplayTemplate` values to human-readable names via `ResolveResourceDetails`.

- **`resolveChatSpace`** — `GET {chatBaseURL}/v1/{space_name}?fields=displayName` → `space_display_name` for `google.send_chat_message`.
- **`resolveCalendar`** — `GET /calendars/{calendarId}?fields=summary` → `calendar_name` for `google.list_calendar_events` (defaults `calendar_id` to `primary` when empty, matching list action behavior).
- **`resolvePresentation`** — also returns `presentation_title` (same value as `title`) so `google.add_slide` can show the deck name without colliding with the optional slide `title` parameter.
- **Templates** — `send_chat_message` uses `{{space_display_name}}`, `list_calendar_events` uses `{{calendar_name}}`, `add_slide` uses `{{presentation_title}}`.
- **`display_template_test.go`** — registers `space_display_name`, `calendar_name`, and `presentation_title`.

## Phase 2 checklist (issue #973)

- [x] Add `resolveChatSpace()` for `google.send_chat_message` — calls `GET https://chat.googleapis.com/v1/{space_name}?fields=displayName`, returns `{"space_display_name": "..."}`
- [x] Update `google.send_chat_message` `DisplayTemplate` (manifest.go:497) from `{{space_name}}` → `{{space_display_name}}`
- [x] Add `resolveCalendar()` for `google.list_calendar_events` — calls `GET /calendar/v3/calendars/{calendarId}?fields=summary`, returns `{"calendar_name": "..."}`
- [x] Update `google.list_calendar_events` `DisplayTemplate` (manifest.go:144) to use `{{calendar_name}}`
- [x] Update `google.add_slide` `DisplayTemplate` (manifest.go:457) to include the resolved `{{title}}` (presentation) so users see which presentation is being modified — implemented as `{{presentation_title}}` to avoid clashing with the optional slide title field
- [x] Add `space_display_name` and `calendar_name` to `connectors/display_template_test.go:32-43` known fields list (also `presentation_title` for the add_slide template)
- [x] Extend `connectors/google/resolve_resource_details_test.go` with cases for the new resolvers

## Test plan

- [ ] `make test-backend` (CI) — **not run locally**: this environment’s Go toolchain cannot resolve the full module graph (see `CLAUDE.md` / sandbox note); please rely on CI for `go test`.
- [ ] `make test-frontend` — not required for these backend-only connector changes
- [ ] `make mobile-test` — not required for these backend-only connector changes

Refs #973
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edf396b7-5dea-4215-af2b-4a6f01063141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edf396b7-5dea-4215-af2b-4a6f01063141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

