### PR TITLE
Microsoft: approval display templates + Graph resource resolvers (Phase 4, #973)

### DIFF
--- a/connectors/display_template_test.go
+++ b/connectors/display_template_test.go
@@ -22,13 +22,17 @@ var templateParamPattern = regexp.MustCompile(`\{\{(\w+)(?::\w+)?\}\}`)
 // When adding a new connector that implements ResourceDetailResolver, add its
 // returned keys here. Source files for each connector's resolver:
 //   - Slack: connectors/slack/resolve_resource_details.go
-//     • resolveChannel → channel_name
-//     • resolveUser    → user_name
+//   - resolveChannel → channel_name
+//   - resolveUser    → user_name
 //   - Google: connectors/google/resolve_resource_details.go
-//     • resolveCalendarEvent → title, start_time
-//     • resolveFile          → file_name, title
-//     • resolveEmail         → subject, from
-//     • resolveSheet         → title, range
+//   - resolveCalendarEvent → title, start_time
+//   - resolveFile          → file_name, title
+//   - resolveEmail         → subject, from
+//   - resolveSheet         → title, range
+//   - Microsoft: connectors/microsoft/resolve_resource_details.go
+//   - drive item → file_name (shared key with Google)
+//   - document / presentation / workbook → document_title, presentation_title, workbook_title
+//   - calendar / team / channel → calendar_name, team_name, channel_name (channel_name shared with Slack)
 var resourceDetailFields = map[string]bool{
 	// Slack (see connectors/slack/resolve_resource_details.go)
 	"channel_name": true,
@@ -40,6 +44,12 @@ var resourceDetailFields = map[string]bool{
 	"subject":    true,
 	"from":       true,
 	"range":      true,
+	// Microsoft (see connectors/microsoft/resolve_resource_details.go)
+	"document_title":     true,
+	"presentation_title": true,
+	"workbook_title":     true,
+	"calendar_name":      true,
+	"team_name":          true,
 }
 
 // TestDisplayTemplateParamsExist validates that every {{param}} reference in a

--- a/connectors/display_template_test.go
+++ b/connectors/display_template_test.go
@@ -22,21 +22,21 @@ var templateParamPattern = regexp.MustCompile(`\{\{(\w+)(?::\w+)?\}\}`)
 // When adding a new connector that implements ResourceDetailResolver, add its
 // returned keys here. Source files for each connector's resolver:
 //   - Slack: connectors/slack/resolve_resource_details.go
-//   - resolveChannel → channel_name
-//   - resolveUser    → user_name
+//     • resolveChannel → channel_name
+//     • resolveUser    → user_name
 //   - Google: connectors/google/resolve_resource_details.go
-//   - resolveCalendarEvent → title, start_time
-//   - resolveFile          → file_name, title
-//   - resolveEmail         → subject, from
-//   - resolveSheet         → title, range
+//     • resolveCalendarEvent → title, start_time
+//     • resolveFile          → file_name, title
+//     • resolveEmail         → subject, from
+//     • resolveSheet         → title, range
 //   - GitHub: connectors/github/resolve_resource_details.go
-//   - resolveWorkflow → workflow_name
-//   - resolveWebhook  → webhook_url, webhook_events
+//     • resolveWorkflow → workflow_name
+//     • resolveWebhook  → webhook_url, webhook_events
 //   - Microsoft: connectors/microsoft/resolve_resource_details.go
-//   - drive item → file_name (shared key with Google)
-//   - document / presentation / workbook → document_title, presentation_title, workbook_title
-//   - calendar / team / channel → calendar_name, team_name, channel_name (channel_name shared with Slack)
-//   - send_email_reply → subject, from, email_thread (via EmailThreadDetailsMap)
+//     • drive item → file_name (shared key with Google)
+//     • document / presentation / workbook → document_title, presentation_title, workbook_title
+//     • calendar / team / channel → calendar_name, team_name, channel_name (channel_name shared with Slack)
+//     • send_email_reply → subject, from, email_thread (via EmailThreadDetailsMap)
 var resourceDetailFields = map[string]bool{
 	// Slack (see connectors/slack/resolve_resource_details.go)
 	"channel_name": true,

--- a/connectors/microsoft/microsoft.go
+++ b/connectors/microsoft/microsoft.go
@@ -75,10 +75,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{
-				ActionType:  "microsoft.send_email",
-				Name:        "Send Email",
-				Description: "Send an email using Microsoft 365",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.send_email",
+				Name:            "Send Email",
+				Description:     "Send an email using Microsoft 365",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Send email to {{to}} — {{subject}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["to", "subject", "body"],
@@ -110,10 +111,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_emails",
-				Name:        "List Emails",
-				Description: "List recent emails from the user's mailbox",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_emails",
+				Name:            "List Emails",
+				Description:     "List recent emails from the user's mailbox",
+				RiskLevel:       "low",
+				DisplayTemplate: "List emails in {{folder}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -133,10 +135,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.create_calendar_event",
-				Name:        "Create Calendar Event",
-				Description: "Create a new event on the user's calendar",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.create_calendar_event",
+				Name:            "Create Calendar Event",
+				Description:     "Create a new event on the user's calendar",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Create event {{subject}} on {{start:datetime}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["subject", "start", "end"],
@@ -193,10 +196,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_calendar_events",
-				Name:        "List Calendar Events",
-				Description: "List upcoming events from the user's calendar",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_calendar_events",
+				Name:            "List Calendar Events",
+				Description:     "List upcoming events from the user's calendar",
+				RiskLevel:       "low",
+				DisplayTemplate: "List calendar events in {{calendar_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -224,10 +228,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_drive_files",
-				Name:        "List Drive Files",
-				Description: "List files and folders in OneDrive",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_drive_files",
+				Name:            "List Drive Files",
+				Description:     "List files and folders in OneDrive",
+				RiskLevel:       "low",
+				DisplayTemplate: "List OneDrive files in {{folder_path}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -246,10 +251,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.get_drive_file",
-				Name:        "Get Drive File",
-				Description: "Get file metadata and optionally download text content from OneDrive",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.get_drive_file",
+				Name:            "Get Drive File",
+				Description:     "Get file metadata and optionally download text content from OneDrive",
+				RiskLevel:       "low",
+				DisplayTemplate: "Get OneDrive file {{file_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id"],
@@ -267,10 +273,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.upload_drive_file",
-				Name:        "Upload Drive File",
-				Description: "Upload or create a file in OneDrive",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.upload_drive_file",
+				Name:            "Upload Drive File",
+				Description:     "Upload or create a file in OneDrive",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Upload {{file_path}} to OneDrive",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["file_path"],
@@ -293,10 +300,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.delete_drive_file",
-				Name:        "Delete Drive File",
-				Description: "Move a file to the OneDrive recycle bin (recoverable)",
-				RiskLevel:   "high",
+				ActionType:      "microsoft.delete_drive_file",
+				Name:            "Delete Drive File",
+				Description:     "Move a file to the OneDrive recycle bin (recoverable)",
+				RiskLevel:       "high",
+				DisplayTemplate: "Delete OneDrive file {{file_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id"],
@@ -309,10 +317,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.create_document",
-				Name:        "Create Document",
-				Description: "Create a new Word document in OneDrive",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.create_document",
+				Name:            "Create Document",
+				Description:     "Create a new Word document in OneDrive",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Create Word doc {{filename}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["filename"],
@@ -335,10 +344,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.get_document",
-				Name:        "Get Document",
-				Description: "Get metadata of a Word document from OneDrive",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.get_document",
+				Name:            "Get Document",
+				Description:     "Get metadata of a Word document from OneDrive",
+				RiskLevel:       "low",
+				DisplayTemplate: "Get document {{document_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id"],
@@ -351,10 +361,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.update_document",
-				Name:        "Update Document",
-				Description: "Update the content of a Word document in OneDrive",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.update_document",
+				Name:            "Update Document",
+				Description:     "Update the content of a Word document in OneDrive",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Update document {{document_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id", "content"],
@@ -371,10 +382,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_documents",
-				Name:        "List Documents",
-				Description: "List Word documents from OneDrive",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_documents",
+				Name:            "List Documents",
+				Description:     "List Word documents from OneDrive",
+				RiskLevel:       "low",
+				DisplayTemplate: "List documents in {{folder_path}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -394,10 +406,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_teams",
-				Name:        "List Teams",
-				Description: "List Microsoft Teams the user is a member of",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_teams",
+				Name:            "List Teams",
+				Description:     "List Microsoft Teams the user is a member of",
+				RiskLevel:       "low",
+				DisplayTemplate: "List Microsoft Teams",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -412,10 +425,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_channels",
-				Name:        "List Channels",
-				Description: "List channels in a Microsoft Teams team",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_channels",
+				Name:            "List Channels",
+				Description:     "List channels in a Microsoft Teams team",
+				RiskLevel:       "low",
+				DisplayTemplate: "List channels in {{team_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["team_id"],
@@ -428,10 +442,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.send_channel_message",
-				Name:        "Send Channel Message",
-				Description: "Send a message to a Microsoft Teams channel",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.send_channel_message",
+				Name:            "Send Channel Message",
+				Description:     "Send a message to a Microsoft Teams channel",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Send message to {{team_name}} / {{channel_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["team_id", "channel_id", "message"],
@@ -461,10 +476,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_channel_messages",
-				Name:        "List Channel Messages",
-				Description: "List recent messages from a Microsoft Teams channel",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_channel_messages",
+				Name:            "List Channel Messages",
+				Description:     "List recent messages from a Microsoft Teams channel",
+				RiskLevel:       "low",
+				DisplayTemplate: "Read messages in {{team_name}} / {{channel_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["team_id", "channel_id"],
@@ -488,10 +504,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.create_presentation",
-				Name:        "Create Presentation",
-				Description: "Create a new PowerPoint presentation in OneDrive",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.create_presentation",
+				Name:            "Create Presentation",
+				Description:     "Create a new PowerPoint presentation in OneDrive",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Create presentation {{filename}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["filename"],
@@ -508,10 +525,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.list_presentations",
-				Name:        "List Presentations",
-				Description: "Search for PowerPoint presentations in OneDrive",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.list_presentations",
+				Name:            "List Presentations",
+				Description:     "Search for PowerPoint presentations in OneDrive",
+				RiskLevel:       "low",
+				DisplayTemplate: "List presentations in {{folder_path}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -530,10 +548,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.get_presentation",
-				Name:        "Get Presentation",
-				Description: "Get metadata about a specific PowerPoint presentation",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.get_presentation",
+				Name:            "Get Presentation",
+				Description:     "Get metadata about a specific PowerPoint presentation",
+				RiskLevel:       "low",
+				DisplayTemplate: "Get presentation {{presentation_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id"],
@@ -546,10 +565,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.create_spreadsheet",
-				Name:        "Create Spreadsheet",
-				Description: "Create a new Excel spreadsheet in OneDrive",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.create_spreadsheet",
+				Name:            "Create Spreadsheet",
+				Description:     "Create a new Excel spreadsheet in OneDrive",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Create Excel workbook {{filename}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["filename"],
@@ -566,10 +586,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.excel_list_worksheets",
-				Name:        "List Excel Worksheets",
-				Description: "List all worksheets in an Excel workbook stored in OneDrive",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.excel_list_worksheets",
+				Name:            "List Excel Worksheets",
+				Description:     "List all worksheets in an Excel workbook stored in OneDrive",
+				RiskLevel:       "low",
+				DisplayTemplate: "List worksheets in {{workbook_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id"],
@@ -582,10 +603,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.excel_read_range",
-				Name:        "Read Excel Range",
-				Description: "Read cell values from a worksheet range in an Excel workbook",
-				RiskLevel:   "low",
+				ActionType:      "microsoft.excel_read_range",
+				Name:            "Read Excel Range",
+				Description:     "Read cell values from a worksheet range in an Excel workbook",
+				RiskLevel:       "low",
+				DisplayTemplate: "Read {{range}} from {{workbook_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id", "sheet_name", "range"],
@@ -606,10 +628,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.excel_write_range",
-				Name:        "Write Excel Range",
-				Description: "Write cell values to a worksheet range in an Excel workbook",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.excel_write_range",
+				Name:            "Write Excel Range",
+				Description:     "Write cell values to a worksheet range in an Excel workbook",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Write to {{range}} in {{workbook_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id", "sheet_name", "range", "values"],
@@ -638,10 +661,11 @@ func (c *MicrosoftConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "microsoft.excel_append_rows",
-				Name:        "Append Excel Rows",
-				Description: "Append rows to a named table in an Excel workbook",
-				RiskLevel:   "medium",
+				ActionType:      "microsoft.excel_append_rows",
+				Name:            "Append Excel Rows",
+				Description:     "Append rows to a named table in an Excel workbook",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Append rows to {{workbook_title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["item_id", "table_name", "values"],

--- a/connectors/microsoft/resolve_resource_details.go
+++ b/connectors/microsoft/resolve_resource_details.go
@@ -20,20 +20,20 @@ func (c *MicrosoftConnector) ResolveResourceDetails(ctx context.Context, actionT
 
 	// OneDrive item (file name)
 	case "microsoft.get_drive_file", "microsoft.delete_drive_file":
-		return c.resolveDriveItemName(ctx, creds, params)
+		return c.resolveDriveItemAs(ctx, creds, params, "file_name")
 
 	// Word document title (drive item name)
 	case "microsoft.get_document", "microsoft.update_document":
-		return c.resolveDocumentTitle(ctx, creds, params)
+		return c.resolveDriveItemAs(ctx, creds, params, "document_title")
 
 	// PowerPoint presentation title
 	case "microsoft.get_presentation":
-		return c.resolvePresentationTitle(ctx, creds, params)
+		return c.resolveDriveItemAs(ctx, creds, params, "presentation_title")
 
 	// Excel workbook title
 	case "microsoft.excel_list_worksheets", "microsoft.excel_read_range",
 		"microsoft.excel_write_range", "microsoft.excel_append_rows":
-		return c.resolveWorkbookTitle(ctx, creds, params)
+		return c.resolveDriveItemAs(ctx, creds, params, "workbook_title")
 
 	// Calendar display name
 	case "microsoft.list_calendar_events":
@@ -83,7 +83,7 @@ func (c *MicrosoftConnector) resolveSendEmailReply(ctx context.Context, creds co
 	return details, nil
 }
 
-func (c *MicrosoftConnector) resolveDriveItemName(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+func (c *MicrosoftConnector) resolveDriveItemAs(ctx context.Context, creds connectors.Credentials, params json.RawMessage, resultKey string) (map[string]any, error) {
 	var p struct {
 		ItemID string `json:"item_id"`
 	}
@@ -97,58 +97,7 @@ func (c *MicrosoftConnector) resolveDriveItemName(ctx context.Context, creds con
 	if name == "" {
 		return nil, nil
 	}
-	return map[string]any{"file_name": name}, nil
-}
-
-func (c *MicrosoftConnector) resolveDocumentTitle(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
-	var p struct {
-		ItemID string `json:"item_id"`
-	}
-	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
-		return nil, fmt.Errorf("missing item_id")
-	}
-	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
-	if err != nil {
-		return nil, err
-	}
-	if name == "" {
-		return nil, nil
-	}
-	return map[string]any{"document_title": name}, nil
-}
-
-func (c *MicrosoftConnector) resolvePresentationTitle(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
-	var p struct {
-		ItemID string `json:"item_id"`
-	}
-	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
-		return nil, fmt.Errorf("missing item_id")
-	}
-	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
-	if err != nil {
-		return nil, err
-	}
-	if name == "" {
-		return nil, nil
-	}
-	return map[string]any{"presentation_title": name}, nil
-}
-
-func (c *MicrosoftConnector) resolveWorkbookTitle(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
-	var p struct {
-		ItemID string `json:"item_id"`
-	}
-	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
-		return nil, fmt.Errorf("missing item_id")
-	}
-	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
-	if err != nil {
-		return nil, err
-	}
-	if name == "" {
-		return nil, nil
-	}
-	return map[string]any{"workbook_title": name}, nil
+	return map[string]any{resultKey: name}, nil
 }
 
 func (c *MicrosoftConnector) fetchDriveItemName(ctx context.Context, creds connectors.Credentials, itemID string) (string, error) {
@@ -167,7 +116,7 @@ func (c *MicrosoftConnector) resolveCalendarName(ctx context.Context, creds conn
 		CalendarID string `json:"calendar_id"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, fmt.Errorf("invalid parameters")
+		return nil, fmt.Errorf("unmarshal calendar params: %w", err)
 	}
 	var path string
 	if p.CalendarID == "" {

--- a/connectors/microsoft/resolve_resource_details.go
+++ b/connectors/microsoft/resolve_resource_details.go
@@ -1,0 +1,217 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// ResolveResourceDetails fetches human-readable metadata for resources
+// referenced by opaque IDs in Microsoft Graph action parameters. Errors are
+// non-fatal — the caller stores the approval without details on failure.
+func (c *MicrosoftConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	// OneDrive item (file name)
+	case "microsoft.get_drive_file", "microsoft.delete_drive_file":
+		return c.resolveDriveItemName(ctx, creds, params)
+
+	// Word document title (drive item name)
+	case "microsoft.get_document", "microsoft.update_document":
+		return c.resolveDocumentTitle(ctx, creds, params)
+
+	// PowerPoint presentation title
+	case "microsoft.get_presentation":
+		return c.resolvePresentationTitle(ctx, creds, params)
+
+	// Excel workbook title
+	case "microsoft.excel_list_worksheets", "microsoft.excel_read_range",
+		"microsoft.excel_write_range", "microsoft.excel_append_rows":
+		return c.resolveWorkbookTitle(ctx, creds, params)
+
+	// Calendar display name
+	case "microsoft.list_calendar_events":
+		return c.resolveCalendarName(ctx, creds, params)
+
+	// Team display name
+	case "microsoft.list_channels":
+		return c.resolveTeamName(ctx, creds, params)
+
+	// Team + channel display names
+	case "microsoft.send_channel_message", "microsoft.list_channel_messages":
+		return c.resolveTeamAndChannel(ctx, creds, params)
+
+	default:
+		return nil, nil
+	}
+}
+
+func (c *MicrosoftConnector) resolveDriveItemName(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		ItemID string `json:"item_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
+		return nil, fmt.Errorf("missing item_id")
+	}
+	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return map[string]any{"file_name": name}, nil
+}
+
+func (c *MicrosoftConnector) resolveDocumentTitle(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		ItemID string `json:"item_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
+		return nil, fmt.Errorf("missing item_id")
+	}
+	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return map[string]any{"document_title": name}, nil
+}
+
+func (c *MicrosoftConnector) resolvePresentationTitle(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		ItemID string `json:"item_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
+		return nil, fmt.Errorf("missing item_id")
+	}
+	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return map[string]any{"presentation_title": name}, nil
+}
+
+func (c *MicrosoftConnector) resolveWorkbookTitle(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		ItemID string `json:"item_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.ItemID == "" {
+		return nil, fmt.Errorf("missing item_id")
+	}
+	name, err := c.fetchDriveItemName(ctx, creds, p.ItemID)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return map[string]any{"workbook_title": name}, nil
+}
+
+func (c *MicrosoftConnector) fetchDriveItemName(ctx context.Context, creds connectors.Credentials, itemID string) (string, error) {
+	path := "/me/drive/items/" + url.PathEscape(itemID) + "?$select=name"
+	var resp struct {
+		Name string `json:"name"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+func (c *MicrosoftConnector) resolveCalendarName(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		CalendarID string `json:"calendar_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, fmt.Errorf("invalid parameters")
+	}
+	var path string
+	if p.CalendarID == "" {
+		path = "/me/calendar?$select=name"
+	} else {
+		path = "/me/calendars/" + url.PathEscape(p.CalendarID) + "?$select=name"
+	}
+	var resp struct {
+		Name string `json:"name"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Name == "" {
+		return nil, nil
+	}
+	return map[string]any{"calendar_name": resp.Name}, nil
+}
+
+func (c *MicrosoftConnector) resolveTeamName(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		TeamID string `json:"team_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.TeamID == "" {
+		return nil, fmt.Errorf("missing team_id")
+	}
+	name, err := c.fetchTeamDisplayName(ctx, creds, p.TeamID)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return map[string]any{"team_name": name}, nil
+}
+
+func (c *MicrosoftConnector) fetchTeamDisplayName(ctx context.Context, creds connectors.Credentials, teamID string) (string, error) {
+	path := "/teams/" + url.PathEscape(teamID) + "?$select=displayName"
+	var resp struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, creds, nil, &resp); err != nil {
+		return "", err
+	}
+	return resp.DisplayName, nil
+}
+
+func (c *MicrosoftConnector) resolveTeamAndChannel(ctx context.Context, creds connectors.Credentials, params json.RawMessage) (map[string]any, error) {
+	var p struct {
+		TeamID    string `json:"team_id"`
+		ChannelID string `json:"channel_id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.TeamID == "" || p.ChannelID == "" {
+		return nil, fmt.Errorf("missing team_id or channel_id")
+	}
+	teamName, err := c.fetchTeamDisplayName(ctx, creds, p.TeamID)
+	if err != nil {
+		return nil, err
+	}
+	chPath := "/teams/" + url.PathEscape(p.TeamID) + "/channels/" + url.PathEscape(p.ChannelID) + "?$select=displayName"
+	var chResp struct {
+		DisplayName string `json:"displayName"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, chPath, creds, nil, &chResp); err != nil {
+		return nil, err
+	}
+	details := map[string]any{}
+	if teamName != "" {
+		details["team_name"] = teamName
+	}
+	if chResp.DisplayName != "" {
+		details["channel_name"] = chResp.DisplayName
+	}
+	if len(details) == 0 {
+		return nil, nil
+	}
+	return details, nil
+}
+
+// Compile-time check that MicrosoftConnector implements ResourceDetailResolver.
+var _ connectors.ResourceDetailResolver = (*MicrosoftConnector)(nil)

--- a/connectors/microsoft/resolve_resource_details_test.go
+++ b/connectors/microsoft/resolve_resource_details_test.go
@@ -1,0 +1,194 @@
+package microsoft
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func testResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *MicrosoftConnector) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	conn := newForTest(srv.Client(), srv.URL)
+	return srv, conn
+}
+
+func validCreds() connectors.Credentials {
+	return connectors.CredentialsFromMap(map[string]string{"access_token": "test-token"})
+}
+
+func TestResolveResourceDetails_DriveItem(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/me/drive/items/item123" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"report.txt"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"item_id": "item123"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.get_drive_file", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["file_name"] != "report.txt" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_DocumentTitle(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Notes.docx"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"item_id": "doc1"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.update_document", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["document_title"] != "Notes.docx" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_PresentationTitle(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Deck.pptx"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"item_id": "pres1"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.get_presentation", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["presentation_title"] != "Deck.pptx" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_WorkbookTitle(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Book.xlsx"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"item_id": "wb1"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.excel_read_range", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["workbook_title"] != "Book.xlsx" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_CalendarName_Default(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/me/calendar" {
+			t.Errorf("expected /me/calendar, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Calendar"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.list_calendar_events", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["calendar_name"] != "Calendar" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_CalendarName_Specific(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/me/calendars/cal-abc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Work"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"calendar_id": "cal-abc"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.list_calendar_events", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["calendar_name"] != "Work" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_TeamName(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"displayName":"Engineering"}`))
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"team_id": "team1"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.list_channels", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["team_name"] != "Engineering" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_TeamAndChannel(t *testing.T) {
+	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/teams/t1":
+			_, _ = w.Write([]byte(`{"displayName":"Sales"}`))
+		case "/teams/t1/channels/ch1":
+			_, _ = w.Write([]byte(`{"displayName":"General"}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"team_id": "t1", "channel_id": "ch1"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.send_channel_message", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details["team_name"] != "Sales" || details["channel_name"] != "General" {
+		t.Fatalf("got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_UnknownAction(t *testing.T) {
+	conn := New()
+	details, err := conn.ResolveResourceDetails(context.Background(), "microsoft.send_email", []byte(`{}`), validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != nil {
+		t.Fatalf("expected nil, got %#v", details)
+	}
+}
+
+func TestResolveResourceDetails_MissingItemID(t *testing.T) {
+	conn := New()
+	_, err := conn.ResolveResourceDetails(context.Background(), "microsoft.get_drive_file", []byte(`{}`), validCreds())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/connectors/microsoft/resolve_resource_details_test.go
+++ b/connectors/microsoft/resolve_resource_details_test.go
@@ -17,10 +17,6 @@ func testResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server
 	return srv, conn
 }
 
-func validCreds() connectors.Credentials {
-	return connectors.CredentialsFromMap(map[string]string{"access_token": "test-token"})
-}
-
 func TestResolveResourceDetails_DriveItem(t *testing.T) {
 	srv, conn := testResolveServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/me/drive/items/item123" {

--- a/connectors/microsoft/resolve_resource_details_test.go
+++ b/connectors/microsoft/resolve_resource_details_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
 func testResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *MicrosoftConnector) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 4** of #973 for the Microsoft connector: `DisplayTemplate` on every Microsoft action, `ResolveResourceDetails` for opaque Graph IDs, and known-field registration in `display_template_test.go` (4a + 4b + 4c together).

### Phase 4a — Display templates (`connectors/microsoft/microsoft.go`)

- [x] `microsoft.send_email` → `"Send email to {{to}} — {{subject}}"`
- [x] `microsoft.list_emails` → `"List emails in {{folder}}"`
- [x] `microsoft.create_calendar_event` → `"Create event {{subject}} on {{start:datetime}}"`
- [x] `microsoft.list_calendar_events` → `"List calendar events in {{calendar_name}}"` (resolver)
- [x] `microsoft.list_drive_files` → `"List OneDrive files in {{folder_path}}"`
- [x] `microsoft.get_drive_file` → `"Get OneDrive file {{file_name}}"` (resolver)
- [x] `microsoft.upload_drive_file` → `"Upload {{file_path}} to OneDrive"`
- [x] `microsoft.delete_drive_file` → `"Delete OneDrive file {{file_name}}"` (resolver)
- [x] `microsoft.create_document` → `"Create Word doc {{filename}}"`
- [x] `microsoft.get_document` → `"Get document {{document_title}}"` (resolver)
- [x] `microsoft.update_document` → `"Update document {{document_title}}"` (resolver)
- [x] `microsoft.list_documents` → `"List documents in {{folder_path}}"`
- [x] `microsoft.list_teams` → `"List Microsoft Teams"`
- [x] `microsoft.list_channels` → `"List channels in {{team_name}}"` (resolver)
- [x] `microsoft.send_channel_message` → `"Send message to {{team_name}} / {{channel_name}}"` (resolver)
- [x] `microsoft.list_channel_messages` → `"Read messages in {{team_name}} / {{channel_name}}"` (resolver)
- [x] `microsoft.create_presentation` → `"Create presentation {{filename}}"`
- [x] `microsoft.list_presentations` → `"List presentations in {{folder_path}}"`
- [x] `microsoft.get_presentation` → `"Get presentation {{presentation_title}}"` (resolver)
- [x] `microsoft.create_spreadsheet` → `"Create Excel workbook {{filename}}"`
- [x] `microsoft.excel_list_worksheets` → `"List worksheets in {{workbook_title}}"` (resolver)
- [x] `microsoft.excel_read_range` → `"Read {{range}} from {{workbook_title}}"` (resolver)
- [x] `microsoft.excel_write_range` → `"Write to {{range}} in {{workbook_title}}"` (resolver)
- [x] `microsoft.excel_append_rows` → `"Append rows to {{workbook_title}}"` (resolver)

### Phase 4b — Resolver (`connectors/microsoft/resolve_resource_details.go`)

- [x] Implement `ResourceDetailResolver` on `MicrosoftConnector`
- [x] `resolveDriveItem` (OneDrive `item_id`) → `file_name` — `get_drive_file`, `delete_drive_file`
- [x] `resolveDocument` (`item_id`) → `document_title` — `get_document`, `update_document`
- [x] `resolvePresentation` (`item_id`) → `presentation_title` — `get_presentation`
- [x] `resolveWorkbook` (`item_id`) → `workbook_title` — Excel actions
- [x] `resolveCalendar` (`calendar_id`) → `calendar_name` — `list_calendar_events` (uses `/me/calendar` when ID empty)
- [x] `resolveTeam` (`team_id`) → `team_name` — `list_channels`
- [x] `resolveChannel` (`team_id` + `channel_id`) → `team_name`, `channel_name` — `send_channel_message`, `list_channel_messages`
- [x] Wired via method on connector (same pattern as Slack/Google; API discovers `ResourceDetailResolver`)
- [x] `connectors/microsoft/resolve_resource_details_test.go` covering each resolver path

### Phase 4c — Known fields (`connectors/display_template_test.go`)

- [x] `file_name`, `document_title`, `presentation_title`, `workbook_title`, `calendar_name`, `team_name`, `channel_name` (Slack already registered `channel_name`)

## Test plan

- [ ] `make test-backend` (not run in this agent environment: local Go/toolchain cannot resolve the full module graph; CI should run the full suite)
- [ ] `make test-frontend`
- [ ] `make mobile-test`

Part of #973.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e12d70-f5ac-469e-8b3c-63b97cdfa827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e12d70-f5ac-469e-8b3c-63b97cdfa827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

