### PR TITLE
Slack approval context: OpenAPI schema + slack/context helpers (Phase 1 / #981)

### DIFF
--- a/connectors/slack/context/anchor.go
+++ b/connectors/slack/context/anchor.go
@@ -1,0 +1,39 @@
+package context
+
+// sliceAroundAnchor keeps up to maxMsgs messages from msgs (already oldest-first)
+// centered on anchorTS when set. If anchorTS is empty, returns msgs unchanged.
+func sliceAroundAnchor(msgs []slackMessage, anchorTS string, maxMsgs int) []slackMessage {
+	if anchorTS == "" || len(msgs) == 0 {
+		return msgs
+	}
+	as, an, okA := parseSlackTSNs(anchorTS)
+	if !okA {
+		return msgs
+	}
+	bestIdx := -1
+	for i := range msgs {
+		s, n, ok := parseSlackTSNs(msgs[i].TS)
+		if !ok {
+			continue
+		}
+		if s < as || (s == as && n <= an) {
+			bestIdx = i
+		}
+	}
+	if bestIdx < 0 {
+		return msgs
+	}
+	start := bestIdx - (maxMsgs-1)/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxMsgs
+	if end > len(msgs) {
+		end = len(msgs)
+		start = end - maxMsgs
+		if start < 0 {
+			start = 0
+		}
+	}
+	return msgs[start:end]
+}

--- a/connectors/slack/context/anchor_test.go
+++ b/connectors/slack/context/anchor_test.go
@@ -1,0 +1,18 @@
+package context
+
+import "testing"
+
+func TestSliceAroundAnchor(t *testing.T) {
+	t.Parallel()
+	msgs := []slackMessage{
+		{TS: "1.0", Text: "a"},
+		{TS: "2.0", Text: "b"},
+		{TS: "3.0", Text: "c"},
+		{TS: "4.0", Text: "d"},
+		{TS: "5.0", Text: "e"},
+	}
+	got := sliceAroundAnchor(msgs, "3.0", 3)
+	if len(got) != 3 || got[0].TS != "2.0" || got[2].TS != "4.0" {
+		t.Fatalf("got %#v", got)
+	}
+}

--- a/connectors/slack/context/api.go
+++ b/connectors/slack/context/api.go
@@ -1,0 +1,13 @@
+package context
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// SlackAPI is the minimal surface the context helpers need from the Slack connector.
+type SlackAPI interface {
+	Post(ctx context.Context, method string, creds connectors.Credentials, body any, dest any) error
+	Get(ctx context.Context, method string, creds connectors.Credentials, params map[string]string, dest any) error
+}

--- a/connectors/slack/context/channel_meta.go
+++ b/connectors/slack/context/channel_meta.go
@@ -1,0 +1,143 @@
+package context
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// FetchChannelMeta loads channel metadata and a channel-level permalink.
+func FetchChannelMeta(ctx context.Context, api SlackAPI, channelID string, creds connectors.Credentials, cache *sessionCache) (*ChannelMeta, error) {
+	if channelID == "" {
+		return nil, &connectors.ValidationError{Message: "missing channel id for Slack context"}
+	}
+	sess, err := resolveSession(ctx, api, creds, cache)
+	if err != nil {
+		return nil, err
+	}
+	body := conversationsInfoRequest{Channel: channelID}
+	var resp conversationsInfoResponse
+	if err := api.Post(ctx, "conversations.info", creds, body, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, mapSlackErr(resp.Error)
+	}
+	if resp.Channel == nil {
+		return nil, &connectors.ExternalError{StatusCode: 200, Message: "Slack conversations.info returned ok=true but no channel"}
+	}
+	ch := resp.Channel
+	meta := &ChannelMeta{
+		ID:          ch.ID,
+		Name:        ch.Name,
+		IsPrivate:   ch.IsPrivate,
+		IsDM:        ch.IsIM || ch.IsMPIM,
+		Topic:       ch.Topic.Value,
+		Purpose:     ch.Purpose.Value,
+		MemberCount: ch.NumMembers,
+		Permalink:   BuildChannelPermalink(sess.TeamDomain, ch.ID),
+	}
+	return meta, nil
+}
+
+// lastActivityISOFromTS converts a Slack message ts to RFC3339 UTC for last_activity_at.
+func lastActivityISOFromTS(ts string) string {
+	sec, nsec, ok := parseSlackTSNs(ts)
+	if !ok {
+		return ""
+	}
+	t := time.Unix(sec, nsec).UTC()
+	return t.Format(time.RFC3339Nano)
+}
+
+// parseSlackTSNs parses a Slack message timestamp into Unix seconds and nanoseconds.
+func parseSlackTSNs(ts string) (sec int64, nsec int64, ok bool) {
+	if ts == "" {
+		return 0, 0, false
+	}
+	dot := strings.IndexByte(ts, '.')
+	if dot < 0 {
+		s, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil {
+			return 0, 0, false
+		}
+		return s, 0, true
+	}
+	whole := ts[:dot]
+	frac := ts[dot+1:]
+	for i := 0; i < len(whole); i++ {
+		if whole[i] < '0' || whole[i] > '9' {
+			return 0, 0, false
+		}
+	}
+	for i := 0; i < len(frac); i++ {
+		if frac[i] < '0' || frac[i] > '9' {
+			return 0, 0, false
+		}
+	}
+	sec, err := strconv.ParseInt(whole, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	for len(frac) < 6 {
+		frac += "0"
+	}
+	if len(frac) > 6 {
+		frac = frac[:6]
+	}
+	usec, err := strconv.ParseInt(frac, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return sec, usec * 1000, true
+}
+
+// WithLastActivity sets LastActivityAt when empty, using the latest ts among messages.
+func WithLastActivity(meta *ChannelMeta, messageTS ...string) *ChannelMeta {
+	if meta == nil {
+		return nil
+	}
+	if meta.LastActivityAt != "" {
+		return meta
+	}
+	var best string
+	var bestSec int64 = -1
+	var bestNsec int64
+	for _, ts := range messageTS {
+		sec, nsec, ok := parseSlackTSNs(ts)
+		if !ok {
+			continue
+		}
+		if bestSec < 0 || sec > bestSec || (sec == bestSec && nsec > bestNsec) {
+			bestSec, bestNsec = sec, nsec
+			best = ts
+		}
+	}
+	if best != "" {
+		meta.LastActivityAt = lastActivityISOFromTS(best)
+	}
+	return meta
+}
+
+func validateChannelID(channel string) error {
+	if channel == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: channel"}
+	}
+	if len(channel) < 2 {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid channel ID %q: expected a Slack channel ID starting with C, G, or D", channel),
+		}
+	}
+	switch channel[0] {
+	case 'C', 'G', 'D':
+		return nil
+	default:
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid channel ID %q: expected a Slack channel ID starting with C, G, or D", channel),
+		}
+	}
+}

--- a/connectors/slack/context/fetch_helpers.go
+++ b/connectors/slack/context/fetch_helpers.go
@@ -1,0 +1,226 @@
+package context
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+const (
+	recentWindowHours = 24
+	recentCapChannel  = 10
+	recentCapDM       = 10
+	threadCap         = 20
+)
+
+// RecentMessagesOpts configures fetchRecentMessages.
+type RecentMessagesOpts struct {
+	// AnchorTS, when set, biases the window around this message (in_response_to_ts).
+	AnchorTS string
+}
+
+func messageToContextMessage(ctx context.Context, api SlackAPI, creds connectors.Credentials, teamDomain, channelID string, msg slackMessage, mcache *MentionCache) (ContextMessage, error) {
+	text := msg.Text
+	resolved, err := ResolveMentions(ctx, text, api, creds, mcache)
+	if err != nil {
+		return ContextMessage{}, err
+	}
+	body, trunc := TruncateBody(resolved)
+	var uref *UserRef
+	if msg.User != "" {
+		uref, err = fetchUserRef(ctx, api, creds, msg.User)
+		if err != nil {
+			return ContextMessage{}, err
+		}
+	}
+	isBot := msg.BotID != ""
+	cm := ContextMessage{
+		User:      uref,
+		Text:      body,
+		TS:        msg.TS,
+		Permalink: BuildPermalink(teamDomain, channelID, msg.TS),
+		IsBot:     isBot,
+		Truncated: trunc,
+		Files:     ExtractFiles(msg),
+	}
+	return cm, nil
+}
+
+func sortMessagesOldestFirst(msgs []slackMessage) {
+	sort.SliceStable(msgs, func(i, j int) bool {
+		si, ni, okI := parseSlackTSNs(msgs[i].TS)
+		sj, nj, okJ := parseSlackTSNs(msgs[j].TS)
+		if !okI || !okJ {
+			return msgs[i].TS < msgs[j].TS
+		}
+		if si != sj {
+			return si < sj
+		}
+		return ni < nj
+	})
+}
+
+// FetchRecentMessages returns up to 10 messages from the last 24h in a channel,
+// oldest first. Optional AnchorTS narrows the window around that message.
+func FetchRecentMessages(ctx context.Context, api SlackAPI, channelID string, creds connectors.Credentials, cache *sessionCache, opts RecentMessagesOpts, mcache *MentionCache) ([]ContextMessage, error) {
+	if err := validateChannelID(channelID); err != nil {
+		return nil, err
+	}
+	sess, err := resolveSession(ctx, api, creds, cache)
+	if err != nil {
+		return nil, err
+	}
+	cutoff := time.Now().Add(-recentWindowHours * time.Hour).UTC()
+	oldestTS := fmt.Sprintf("%d.%06d", cutoff.Unix(), cutoff.Nanosecond()/1000)
+
+	body := readChannelHistoryRequest{
+		Channel: channelID,
+		Limit:   100,
+		Oldest:  oldestTS,
+	}
+	var resp messagesResponse
+	if err := api.Post(ctx, "conversations.history", creds, body, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, mapSlackErr(resp.Error)
+	}
+	raw := filterMessagesByAge(resp.Messages, cutoff)
+	sortMessagesOldestFirst(raw)
+	raw = sliceAroundAnchor(raw, opts.AnchorTS, recentCapChannel)
+	if len(raw) > recentCapChannel {
+		raw = raw[len(raw)-recentCapChannel:]
+	}
+	out := make([]ContextMessage, 0, len(raw))
+	for _, m := range raw {
+		cm, err := messageToContextMessage(ctx, api, creds, sess.TeamDomain, channelID, m, mcache)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, cm)
+	}
+	return out, nil
+}
+
+func filterMessagesByAge(msgs []slackMessage, cutoff time.Time) []slackMessage {
+	var out []slackMessage
+	for _, m := range msgs {
+		sec, nsec, ok := parseSlackTSNs(m.TS)
+		if !ok {
+			continue
+		}
+		t := time.Unix(sec, nsec).UTC()
+		if !t.Before(cutoff) {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// FetchThread returns the parent message and up to 19 most recent replies (20 total),
+// oldest first for the reply list (parent separate).
+func FetchThread(ctx context.Context, api SlackAPI, channelID, threadTS string, creds connectors.Credentials, cache *sessionCache, mcache *MentionCache) (parent ContextMessage, replies []ContextMessage, truncated bool, err error) {
+	if err := validateChannelID(channelID); err != nil {
+		return ContextMessage{}, nil, false, err
+	}
+	if threadTS == "" {
+		return ContextMessage{}, nil, false, &connectors.ValidationError{Message: "missing thread_ts for Slack thread context"}
+	}
+	sess, err := resolveSession(ctx, api, creds, cache)
+	if err != nil {
+		return ContextMessage{}, nil, false, err
+	}
+	body := readThreadRequest{
+		Channel: channelID,
+		TS:      threadTS,
+		Limit:   1000,
+	}
+	var resp messagesResponse
+	if err := api.Post(ctx, "conversations.replies", creds, body, &resp); err != nil {
+		return ContextMessage{}, nil, false, err
+	}
+	if !resp.OK {
+		return ContextMessage{}, nil, false, mapSlackErr(resp.Error)
+	}
+	if len(resp.Messages) == 0 {
+		return ContextMessage{}, nil, false, &connectors.ExternalError{StatusCode: 200, Message: "Slack thread has no messages"}
+	}
+	sortMessagesOldestFirst(resp.Messages)
+	parentSlack := resp.Messages[0]
+	pmsg, err := messageToContextMessage(ctx, api, creds, sess.TeamDomain, channelID, parentSlack, mcache)
+	if err != nil {
+		return ContextMessage{}, nil, false, err
+	}
+	replySlack := resp.Messages[1:]
+	if len(replySlack) > threadCap-1 {
+		truncated = true
+		replySlack = replySlack[len(replySlack)-(threadCap-1):]
+	}
+	replies = make([]ContextMessage, 0, len(replySlack))
+	for _, m := range replySlack {
+		cm, err := messageToContextMessage(ctx, api, creds, sess.TeamDomain, channelID, m, mcache)
+		if err != nil {
+			return ContextMessage{}, nil, false, err
+		}
+		replies = append(replies, cm)
+	}
+	return pmsg, replies, truncated, nil
+}
+
+// FetchDMHistory loads DM history for an IM channel opened with the given peer user ID.
+// It returns SentinelSelfDM or SentinelFirstContact when those cases apply (no messages).
+func FetchDMHistory(ctx context.Context, api SlackAPI, peerUserID string, creds connectors.Credentials, cache *sessionCache, mcache *MentionCache) (sentinel DMHistorySentinel, messages []ContextMessage, imChannelID string, err error) {
+	if peerUserID == "" {
+		return SentinelNone, nil, "", &connectors.ValidationError{Message: "missing user id for DM context"}
+	}
+	sess, err := resolveSession(ctx, api, creds, cache)
+	if err != nil {
+		return SentinelNone, nil, "", err
+	}
+	if peerUserID == sess.UserID {
+		return SentinelSelfDM, nil, "", nil
+	}
+	openBody := conversationsOpenRequest{Users: peerUserID}
+	var openResp conversationsOpenResponse
+	if err := api.Post(ctx, "conversations.open", creds, openBody, &openResp); err != nil {
+		return SentinelNone, nil, "", err
+	}
+	if !openResp.OK {
+		return SentinelNone, nil, "", mapSlackErr(openResp.Error)
+	}
+	imChannelID = openResp.Channel.ID
+
+	cutoff := time.Now().Add(-recentWindowHours * time.Hour).UTC()
+	oldestTS := fmt.Sprintf("%d.%06d", cutoff.Unix(), cutoff.Nanosecond()/1000)
+	histBody := readChannelHistoryRequest{
+		Channel: imChannelID,
+		Limit:   recentCapDM + 1,
+		Oldest:  oldestTS,
+	}
+	var histResp messagesResponse
+	if err := api.Post(ctx, "conversations.history", creds, histBody, &histResp); err != nil {
+		return SentinelNone, nil, imChannelID, err
+	}
+	if !histResp.OK {
+		return SentinelNone, nil, imChannelID, mapSlackErr(histResp.Error)
+	}
+	raw := filterMessagesByAge(histResp.Messages, cutoff)
+	sortMessagesOldestFirst(raw)
+	if len(raw) == 0 {
+		return SentinelFirstContact, nil, imChannelID, nil
+	}
+	if len(raw) > recentCapDM {
+		raw = raw[len(raw)-recentCapDM:]
+	}
+	for _, m := range raw {
+		cm, err := messageToContextMessage(ctx, api, creds, sess.TeamDomain, imChannelID, m, mcache)
+		if err != nil {
+			return SentinelNone, nil, imChannelID, err
+		}
+		messages = append(messages, cm)
+	}
+	return SentinelNone, messages, imChannelID, nil
+}

--- a/connectors/slack/context/fetch_test.go
+++ b/connectors/slack/context/fetch_test.go
@@ -46,7 +46,7 @@ func TestFetchRecentMessages_WindowAndAnchor(t *testing.T) {
 		}, nil
 	}
 
-	msgs, err := FetchRecentMessages(context.Background(), api, "C1", mockCreds{}, nil, RecentMessagesOpts{AnchorTS: tsMid}, nil)
+	msgs, err := FetchRecentMessages(context.Background(), api, "C1", testSlackCredentials(), nil, RecentMessagesOpts{AnchorTS: tsMid}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestFetchThread_Truncation(t *testing.T) {
 			}{ID: params["user"], Name: "alice"},
 		}, nil
 	}
-	parent, replies, truncated, err := FetchThread(context.Background(), api, "C1", "10.0", mockCreds{}, nil, nil)
+	parent, replies, truncated, err := FetchThread(context.Background(), api, "C1", "10.0", testSlackCredentials(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestFetchDMHistory_SelfAndFirstContact(t *testing.T) {
 	api := newMockAPI()
 	api.authTest.UserID = "U_PEER"
 
-	sent, msgs, ch, err := FetchDMHistory(context.Background(), api, "U_PEER", mockCreds{}, nil, nil)
+	sent, msgs, ch, err := FetchDMHistory(context.Background(), api, "U_PEER", testSlackCredentials(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestFetchDMHistory_SelfAndFirstContact(t *testing.T) {
 	api.postHandlers["conversations.history"] = func(body json.RawMessage) (any, error) {
 		return messagesResponse{slackResponse: slackResponse{OK: true}, Messages: nil}, nil
 	}
-	sent, msgs, ch, err = FetchDMHistory(context.Background(), api, "U_PEER", mockCreds{}, nil, nil)
+	sent, msgs, ch, err = FetchDMHistory(context.Background(), api, "U_PEER", testSlackCredentials(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestHandleRateLimit_FromFetch(t *testing.T) {
 	api.postHandlers["conversations.history"] = func(body json.RawMessage) (any, error) {
 		return nil, &connectors.RateLimitError{Message: "nope"}
 	}
-	_, err := FetchRecentMessages(context.Background(), api, "C1", mockCreds{}, nil, RecentMessagesOpts{}, nil)
+	_, err := FetchRecentMessages(context.Background(), api, "C1", testSlackCredentials(), nil, RecentMessagesOpts{}, nil)
 	sc, ok := HandleRateLimit(err)
 	if !ok || sc.ContextScope != ScopeMetadataOnly {
 		t.Fatalf("HandleRateLimit after fetch: %v %v", sc, ok)

--- a/connectors/slack/context/fetch_test.go
+++ b/connectors/slack/context/fetch_test.go
@@ -1,0 +1,146 @@
+package context
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestFetchRecentMessages_WindowAndAnchor(t *testing.T) {
+	t.Parallel()
+	api := newMockAPI()
+	now := time.Now().UTC()
+	tsOld := fmt.Sprintf("%d.%06d", now.Add(-25*time.Hour).Unix(), 0)
+	tsMid := fmt.Sprintf("%d.%06d", now.Add(-1*time.Hour).Unix(), 0)
+	tsNew := fmt.Sprintf("%d.%06d", now.Add(-30*time.Minute).Unix(), 0)
+
+	api.postHandlers["conversations.history"] = func(body json.RawMessage) (any, error) {
+		return messagesResponse{
+			slackResponse: slackResponse{OK: true},
+			Messages: []slackMessage{
+				{User: "U1", Text: "old", TS: tsOld},
+				{User: "U1", Text: "mid", TS: tsMid},
+				{User: "U1", Text: "new", TS: tsNew},
+			},
+		}, nil
+	}
+	api.getHandlers["users.info"] = func(params map[string]string) (any, error) {
+		return usersInfoResponse{
+			slackResponse: slackResponse{OK: true},
+			User: &struct {
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+				RealName string `json:"real_name"`
+				Profile  struct {
+					DisplayNameNormalized string `json:"display_name_normalized"`
+					RealName              string `json:"real_name"`
+					Title                 string `json:"title"`
+					ImageOriginal         string `json:"image_original"`
+					Image512              string `json:"image_512"`
+				} `json:"profile"`
+			}{ID: params["user"], Name: "alice"},
+		}, nil
+	}
+
+	msgs, err := FetchRecentMessages(context.Background(), api, "C1", mockCreds{}, nil, RecentMessagesOpts{AnchorTS: tsMid}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("len=%d want 2 (old filtered)", len(msgs))
+	}
+	if msgs[0].Text != "mid" || msgs[1].Text != "new" {
+		t.Fatalf("order/content: %#v", msgs)
+	}
+	if msgs[0].Permalink == "" {
+		t.Fatal("expected permalink")
+	}
+}
+
+func TestFetchThread_Truncation(t *testing.T) {
+	t.Parallel()
+	api := newMockAPI()
+	var list []slackMessage
+	list = append(list, slackMessage{User: "U1", Text: "parent", TS: "10.0"})
+	for i := 1; i <= 25; i++ {
+		list = append(list, slackMessage{User: "U1", Text: fmt.Sprintf("r%d", i), TS: fmt.Sprintf("10.%06d", i)})
+	}
+	api.postHandlers["conversations.replies"] = func(body json.RawMessage) (any, error) {
+		return messagesResponse{slackResponse: slackResponse{OK: true}, Messages: list}, nil
+	}
+	api.getHandlers["users.info"] = func(params map[string]string) (any, error) {
+		return usersInfoResponse{
+			slackResponse: slackResponse{OK: true},
+			User: &struct {
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+				RealName string `json:"real_name"`
+				Profile  struct {
+					DisplayNameNormalized string `json:"display_name_normalized"`
+					RealName              string `json:"real_name"`
+					Title                 string `json:"title"`
+					ImageOriginal         string `json:"image_original"`
+					Image512              string `json:"image_512"`
+				} `json:"profile"`
+			}{ID: params["user"], Name: "alice"},
+		}, nil
+	}
+	parent, replies, truncated, err := FetchThread(context.Background(), api, "C1", "10.0", mockCreds{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parent.Text != "parent" {
+		t.Fatalf("parent %q", parent.Text)
+	}
+	if !truncated || len(replies) != 19 {
+		t.Fatalf("truncated=%v len=%d", truncated, len(replies))
+	}
+}
+
+func TestFetchDMHistory_SelfAndFirstContact(t *testing.T) {
+	t.Parallel()
+	api := newMockAPI()
+	api.authTest.UserID = "U_PEER"
+
+	sent, msgs, ch, err := FetchDMHistory(context.Background(), api, "U_PEER", mockCreds{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sent != SentinelSelfDM || msgs != nil || ch != "" {
+		t.Fatalf("self-dm: sent=%v msgs=%v ch=%q", sent, msgs, ch)
+	}
+
+	api.authTest.UserID = "U_SELF"
+	api.postHandlers["conversations.open"] = func(body json.RawMessage) (any, error) {
+		return conversationsOpenResponse{slackResponse: slackResponse{OK: true}, Channel: struct {
+			ID string `json:"id"`
+		}{ID: "D1"}}, nil
+	}
+	api.postHandlers["conversations.history"] = func(body json.RawMessage) (any, error) {
+		return messagesResponse{slackResponse: slackResponse{OK: true}, Messages: nil}, nil
+	}
+	sent, msgs, ch, err = FetchDMHistory(context.Background(), api, "U_PEER", mockCreds{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sent != SentinelFirstContact || len(msgs) != 0 || ch != "D1" {
+		t.Fatalf("first contact: sent=%v len(msgs)=%d ch=%q", sent, len(msgs), ch)
+	}
+}
+
+func TestHandleRateLimit_FromFetch(t *testing.T) {
+	t.Parallel()
+	api := newMockAPI()
+	api.postHandlers["conversations.history"] = func(body json.RawMessage) (any, error) {
+		return nil, &connectors.RateLimitError{Message: "nope"}
+	}
+	_, err := FetchRecentMessages(context.Background(), api, "C1", mockCreds{}, nil, RecentMessagesOpts{}, nil)
+	sc, ok := HandleRateLimit(err)
+	if !ok || sc.ContextScope != ScopeMetadataOnly {
+		t.Fatalf("HandleRateLimit after fetch: %v %v", sc, ok)
+	}
+}

--- a/connectors/slack/context/files_test.go
+++ b/connectors/slack/context/files_test.go
@@ -1,0 +1,17 @@
+package context
+
+import "testing"
+
+func TestExtractFiles(t *testing.T) {
+	t.Parallel()
+	msg := slackMessage{
+		Files: []slackFile{
+			{Name: "a.png", Size: 12},
+			{Name: "", Size: 3},
+		},
+	}
+	fs := ExtractFiles(msg)
+	if len(fs) != 2 || fs[0].Filename != "a.png" || fs[1].Filename != "file" {
+		t.Fatalf("ExtractFiles = %#v", fs)
+	}
+}

--- a/connectors/slack/context/mentions.go
+++ b/connectors/slack/context/mentions.go
@@ -1,0 +1,148 @@
+package context
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// MentionCache stores resolved display strings for a single approval request.
+type MentionCache struct {
+	Users    map[string]string // Slack user ID -> @handle
+	Channels map[string]string // Slack channel ID -> #name
+}
+
+func (m *MentionCache) userKey(id string) string {
+	if m.Users == nil {
+		m.Users = make(map[string]string)
+	}
+	return id
+}
+
+func (m *MentionCache) channelKey(id string) string {
+	if m.Channels == nil {
+		m.Channels = make(map[string]string)
+	}
+	return id
+}
+
+var (
+	reUserMention    = regexp.MustCompile(`<@([UW][A-Z0-9]+)(?:\|([^>]*))?>`)
+	reChannelMention = regexp.MustCompile(`<#(C[A-Z0-9]+)(?:\|([^>]*))?>`)
+	reSubteamLabeled = regexp.MustCompile(`<!subteam\^(S[A-Z0-9]+)\|([^>]+)>`)
+	reSubteamBare    = regexp.MustCompile(`<!subteam\^(S[A-Z0-9]+)>`)
+)
+
+// ResolveMentions replaces Slack mrkdwn mention tokens with human-readable
+// text: users and channels via API (batched with MentionCache), broadcast
+// keywords and labeled subteams without extra calls.
+func ResolveMentions(ctx context.Context, text string, api SlackAPI, creds connectors.Credentials, cache *MentionCache) (string, error) {
+	if text == "" {
+		return "", nil
+	}
+	out := text
+	out = strings.ReplaceAll(out, "<!here>", "@here")
+	out = strings.ReplaceAll(out, "<!channel>", "@channel")
+	out = reSubteamLabeled.ReplaceAllStringFunc(out, func(s string) string {
+		parts := reSubteamLabeled.FindStringSubmatch(s)
+		if len(parts) >= 3 && parts[2] != "" {
+			return "@" + parts[2]
+		}
+		return s
+	})
+	out = reSubteamBare.ReplaceAllString(out, "@subteam")
+
+	userMatches := reUserMention.FindAllStringSubmatch(out, -1)
+	seenUsers := map[string]struct{}{}
+	for _, m := range userMatches {
+		if len(m) >= 2 {
+			seenUsers[m[1]] = struct{}{}
+		}
+	}
+	for uid := range seenUsers {
+		if cache != nil && cache.Users != nil {
+			if _, ok := cache.Users[uid]; ok {
+				continue
+			}
+		}
+		ref, err := fetchUserRef(ctx, api, creds, uid)
+		if err != nil {
+			return "", err
+		}
+		label := "@" + uid
+		if ref != nil && ref.Name != "" {
+			label = "@" + ref.Name
+		}
+		if cache != nil {
+			cache.Users[cache.userKey(uid)] = label
+		}
+	}
+
+	out = reUserMention.ReplaceAllStringFunc(out, func(s string) string {
+		parts := reUserMention.FindStringSubmatch(s)
+		if len(parts) < 2 {
+			return s
+		}
+		uid := parts[1]
+		if len(parts) >= 3 && parts[2] != "" {
+			return "@" + parts[2]
+		}
+		if cache != nil && cache.Users != nil {
+			if lab, ok := cache.Users[uid]; ok {
+				return lab
+			}
+		}
+		return "@" + uid
+	})
+
+	chMatches := reChannelMention.FindAllStringSubmatch(out, -1)
+	seenCh := map[string]struct{}{}
+	for _, m := range chMatches {
+		if len(m) >= 2 {
+			seenCh[m[1]] = struct{}{}
+		}
+	}
+	for cid := range seenCh {
+		if cache != nil && cache.Channels != nil {
+			if _, ok := cache.Channels[cid]; ok {
+				continue
+			}
+		}
+		var resp conversationsInfoResponse
+		body := conversationsInfoRequest{Channel: cid}
+		if err := api.Post(ctx, "conversations.info", creds, body, &resp); err != nil {
+			return "", err
+		}
+		if !resp.OK {
+			return "", mapSlackErr(resp.Error)
+		}
+		label := "#" + cid
+		if resp.Channel != nil && resp.Channel.Name != "" {
+			label = "#" + resp.Channel.Name
+		}
+		if cache != nil {
+			cache.Channels[cache.channelKey(cid)] = label
+		}
+	}
+
+	out = reChannelMention.ReplaceAllStringFunc(out, func(s string) string {
+		parts := reChannelMention.FindStringSubmatch(s)
+		if len(parts) < 2 {
+			return s
+		}
+		cid := parts[1]
+		if len(parts) >= 3 && parts[2] != "" {
+			return "#" + parts[2]
+		}
+		if cache != nil && cache.Channels != nil {
+			if lab, ok := cache.Channels[cid]; ok {
+				return lab
+			}
+		}
+		return "#" + cid
+	})
+
+	return out, nil
+}

--- a/connectors/slack/context/mentions_test.go
+++ b/connectors/slack/context/mentions_test.go
@@ -1,0 +1,68 @@
+package context
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestResolveMentions(t *testing.T) {
+	t.Parallel()
+	api := newMockAPI()
+	api.getHandlers["users.info"] = func(params map[string]string) (any, error) {
+		if params["user"] == "U1" {
+			return usersInfoResponse{
+				slackResponse: slackResponse{OK: true},
+				User: &struct {
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+					RealName string `json:"real_name"`
+					Profile  struct {
+						DisplayNameNormalized string `json:"display_name_normalized"`
+						RealName              string `json:"real_name"`
+						Title                 string `json:"title"`
+						ImageOriginal         string `json:"image_original"`
+						Image512              string `json:"image_512"`
+					} `json:"profile"`
+				}{
+					ID:   "U1",
+					Name: "alice",
+				},
+			}, nil
+		}
+		return usersInfoResponse{slackResponse: slackResponse{OK: false, Error: "user_not_found"}}, nil
+	}
+	api.postHandlers["conversations.info"] = func(body json.RawMessage) (any, error) {
+		var req conversationsInfoRequest
+		_ = json.Unmarshal(body, &req)
+		if req.Channel == "C9" {
+			return conversationsInfoResponse{
+				slackResponse: slackResponse{OK: true},
+				Channel: &struct {
+					ID         string `json:"id"`
+					Name       string `json:"name"`
+					IsPrivate  bool   `json:"is_private"`
+					IsIM       bool   `json:"is_im"`
+					IsMPIM     bool   `json:"is_mpim"`
+					NumMembers int    `json:"num_members"`
+					Topic      struct {
+						Value string `json:"value"`
+					} `json:"topic"`
+					Purpose struct {
+						Value string `json:"value"`
+					} `json:"purpose"`
+				}{ID: "C9", Name: "general"},
+			}, nil
+		}
+		return conversationsInfoResponse{slackResponse: slackResponse{OK: false, Error: "channel_not_found"}}, nil
+	}
+
+	in := "Hi <@U1> in <#C9|ignored> <!here>"
+	out, err := ResolveMentions(context.Background(), in, api, mockCreds{}, &MentionCache{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "Hi @alice in #ignored @here" {
+		t.Fatalf("got %q", out)
+	}
+}

--- a/connectors/slack/context/mentions_test.go
+++ b/connectors/slack/context/mentions_test.go
@@ -58,7 +58,7 @@ func TestResolveMentions(t *testing.T) {
 	}
 
 	in := "Hi <@U1> in <#C9|ignored> <!here>"
-	out, err := ResolveMentions(context.Background(), in, api, mockCreds{}, &MentionCache{})
+	out, err := ResolveMentions(context.Background(), in, api, testSlackCredentials(), &MentionCache{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/connectors/slack/context/mock_api_test.go
+++ b/connectors/slack/context/mock_api_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
-type mockCreds struct{}
-
-func (mockCreds) Get(key string) (string, bool) {
-	if key == "access_token" {
-		return "xoxp-test", true
-	}
-	return "", false
-}
-
 type mockAPI struct {
 	mu sync.Mutex
 
@@ -80,4 +71,8 @@ func copyInto(dest any, src any) error {
 		return err
 	}
 	return json.Unmarshal(b, dest)
+}
+
+func testSlackCredentials() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{"access_token": "xoxp-test"})
 }

--- a/connectors/slack/context/mock_api_test.go
+++ b/connectors/slack/context/mock_api_test.go
@@ -1,0 +1,83 @@
+package context
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type mockCreds struct{}
+
+func (mockCreds) Get(key string) (string, bool) {
+	if key == "access_token" {
+		return "xoxp-test", true
+	}
+	return "", false
+}
+
+type mockAPI struct {
+	mu sync.Mutex
+
+	authTest authTestResponse
+
+	postHandlers map[string]func(body json.RawMessage) (any, error)
+	getHandlers  map[string]func(params map[string]string) (any, error)
+}
+
+func newMockAPI() *mockAPI {
+	return &mockAPI{
+		postHandlers: make(map[string]func(body json.RawMessage) (any, error)),
+		getHandlers:  make(map[string]func(params map[string]string) (any, error)),
+		authTest: authTestResponse{
+			slackResponse: slackResponse{OK: true},
+			URL:           "https://acme.slack.com/",
+			UserID:        "U_SELF",
+		},
+	}
+}
+
+func (m *mockAPI) Post(ctx context.Context, method string, creds connectors.Credentials, body any, dest any) error {
+	_ = ctx
+	_ = creds
+	if method == "auth.test" {
+		return copyInto(dest, m.authTest)
+	}
+	raw, _ := json.Marshal(body)
+	m.mu.Lock()
+	h, ok := m.postHandlers[method]
+	m.mu.Unlock()
+	if !ok {
+		return mapSlackErr("unknown_method")
+	}
+	resp, err := h(raw)
+	if err != nil {
+		return err
+	}
+	return copyInto(dest, resp)
+}
+
+func (m *mockAPI) Get(ctx context.Context, method string, creds connectors.Credentials, params map[string]string, dest any) error {
+	_ = ctx
+	_ = creds
+	m.mu.Lock()
+	h, ok := m.getHandlers[method]
+	m.mu.Unlock()
+	if !ok {
+		return mapSlackErr("unknown_method")
+	}
+	resp, err := h(params)
+	if err != nil {
+		return err
+	}
+	return copyInto(dest, resp)
+}
+
+func copyInto(dest any, src any) error {
+	b, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dest)
+}

--- a/connectors/slack/context/permalink.go
+++ b/connectors/slack/context/permalink.go
@@ -1,0 +1,43 @@
+package context
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildPermalink builds a deterministic Slack message permalink from the team
+// domain (e.g. "acme" from acme.slack.com), channel ID, and message ts.
+// No API call — used for approval context deep links.
+func BuildPermalink(teamDomain, channelID, ts string) string {
+	domain := strings.TrimSpace(teamDomain)
+	domain = strings.TrimSuffix(domain, ".slack.com")
+	domain = strings.TrimSpace(domain)
+	if domain == "" || channelID == "" || ts == "" {
+		return ""
+	}
+	p := permalinkMessagePath(channelID, ts)
+	if p == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://%s.slack.com/archives/%s/%s", domain, channelID, p)
+}
+
+// BuildChannelPermalink builds a channel-level archives URL (no message anchor).
+func BuildChannelPermalink(teamDomain, channelID string) string {
+	domain := strings.TrimSpace(teamDomain)
+	domain = strings.TrimSuffix(domain, ".slack.com")
+	domain = strings.TrimSpace(domain)
+	if domain == "" || channelID == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://%s.slack.com/archives/%s", domain, channelID)
+}
+
+func permalinkMessagePath(channelID, ts string) string {
+	compact := strings.ReplaceAll(ts, ".", "")
+	if len(compact) < 2 {
+		return ""
+	}
+	// Slack permalinks use "p" + ts without the dot between seconds and usec.
+	return "p" + compact
+}

--- a/connectors/slack/context/permalink_test.go
+++ b/connectors/slack/context/permalink_test.go
@@ -1,0 +1,24 @@
+package context
+
+import "testing"
+
+func TestBuildPermalink(t *testing.T) {
+	t.Parallel()
+	got := BuildPermalink("acme", "C123", "1711234567.000100")
+	want := "https://acme.slack.com/archives/C123/p1711234567000100"
+	if got != want {
+		t.Fatalf("BuildPermalink = %q, want %q", got, want)
+	}
+	if BuildPermalink("", "C1", "1.2") != "" {
+		t.Fatal("expected empty for missing domain")
+	}
+}
+
+func TestBuildChannelPermalink(t *testing.T) {
+	t.Parallel()
+	got := BuildChannelPermalink("acme", "C123")
+	want := "https://acme.slack.com/archives/C123"
+	if got != want {
+		t.Fatalf("BuildChannelPermalink = %q, want %q", got, want)
+	}
+}

--- a/connectors/slack/context/rate_limit.go
+++ b/connectors/slack/context/rate_limit.go
@@ -1,0 +1,37 @@
+package context
+
+import (
+	"errors"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// HandleRateLimit returns a metadata-only Slack context when err is or wraps a
+// Slack rate limit (HTTP 429 / RateLimitError / ratelimited). For other errors
+// it returns nil, false.
+func HandleRateLimit(err error) (*SlackContext, bool) {
+	if err == nil {
+		return nil, false
+	}
+	if !connectors.IsRateLimitError(err) {
+		return nil, false
+	}
+	return &SlackContext{
+		ContextScope: ScopeMetadataOnly,
+	}, true
+}
+
+// IsRateLimit reports whether err should trigger metadata-only degradation.
+func IsRateLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	if connectors.IsRateLimitError(err) {
+		return true
+	}
+	var ext *connectors.ExternalError
+	if errors.As(err, &ext) && ext.StatusCode == 429 {
+		return true
+	}
+	return false
+}

--- a/connectors/slack/context/rate_limit_test.go
+++ b/connectors/slack/context/rate_limit_test.go
@@ -1,0 +1,30 @@
+package context
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestHandleRateLimit(t *testing.T) {
+	t.Parallel()
+	sc, ok := HandleRateLimit(&connectors.RateLimitError{Message: "slow"})
+	if !ok || sc == nil || sc.ContextScope != ScopeMetadataOnly {
+		t.Fatalf("HandleRateLimit = %v, %v", sc, ok)
+	}
+	sc, ok = HandleRateLimit(errors.New("other"))
+	if ok || sc != nil {
+		t.Fatalf("expected no degrade: %v %v", sc, ok)
+	}
+}
+
+func TestIsRateLimit(t *testing.T) {
+	t.Parallel()
+	if !IsRateLimit(&connectors.RateLimitError{}) {
+		t.Fatal("expected rate limit")
+	}
+	if IsRateLimit(errors.New("x")) {
+		t.Fatal("expected false")
+	}
+}

--- a/connectors/slack/context/session.go
+++ b/connectors/slack/context/session.go
@@ -1,0 +1,74 @@
+package context
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// sessionInfo holds auth.test data cached for one approval flow.
+type sessionInfo struct {
+	TeamDomain string
+	UserID     string
+}
+
+type sessionCache struct {
+	info *sessionInfo
+}
+
+func (c *sessionCache) get() *sessionInfo {
+	if c == nil {
+		return nil
+	}
+	return c.info
+}
+
+func (c *sessionCache) set(info *sessionInfo) {
+	if c == nil || info == nil {
+		return
+	}
+	c.info = info
+}
+
+// resolveSession calls auth.test once per cache and returns team subdomain and authed user ID.
+func resolveSession(ctx context.Context, api SlackAPI, creds connectors.Credentials, cache *sessionCache) (*sessionInfo, error) {
+	if cache != nil {
+		if s := cache.get(); s != nil && s.TeamDomain != "" && s.UserID != "" {
+			return s, nil
+		}
+	}
+	var resp authTestResponse
+	if err := api.Post(ctx, "auth.test", creds, struct{}{}, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, mapSlackErr(resp.Error)
+	}
+	domain, err := teamDomainFromAuthURL(resp.URL)
+	if err != nil {
+		return nil, err
+	}
+	if resp.UserID == "" {
+		return nil, &connectors.ExternalError{StatusCode: 200, Message: "Slack auth.test returned ok=true but no user_id"}
+	}
+	info := &sessionInfo{TeamDomain: domain, UserID: resp.UserID}
+	if cache != nil {
+		cache.set(info)
+	}
+	return info, nil
+}
+
+func teamDomainFromAuthURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return "", &connectors.ExternalError{StatusCode: 200, Message: "Slack auth.test url could not be parsed"}
+	}
+	host := u.Hostname()
+	host = strings.TrimSuffix(host, ".slack.com")
+	if host == "" {
+		return "", &connectors.ExternalError{StatusCode: 200, Message: "Slack auth.test url missing team subdomain"}
+	}
+	return host, nil
+}

--- a/connectors/slack/context/slack_api.go
+++ b/connectors/slack/context/slack_api.go
@@ -1,0 +1,120 @@
+package context
+
+// slackResponse is the common envelope for Slack Web API responses.
+type slackResponse struct {
+	OK     bool   `json:"ok"`
+	Error  string `json:"error,omitempty"`
+	Needed string `json:"needed,omitempty"`
+}
+
+type paginationMeta struct {
+	NextCursor string `json:"next_cursor"`
+}
+
+// slackMessage is the subset of a Slack message object used for context.
+type slackMessage struct {
+	Type     string      `json:"type"`
+	User     string      `json:"user,omitempty"`
+	BotID    string      `json:"bot_id,omitempty"`
+	Text     string      `json:"text"`
+	TS       string      `json:"ts"`
+	ThreadTS string      `json:"thread_ts,omitempty"`
+	Files    []slackFile `json:"files,omitempty"`
+}
+
+type slackFile struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+type messagesResponse struct {
+	slackResponse
+	Messages []slackMessage  `json:"messages,omitempty"`
+	HasMore  bool            `json:"has_more,omitempty"`
+	Meta     *paginationMeta `json:"response_metadata,omitempty"`
+}
+
+type authTestResponse struct {
+	slackResponse
+	URL    string `json:"url"`
+	UserID string `json:"user_id"`
+}
+
+type conversationsInfoRequest struct {
+	Channel string `json:"channel"`
+}
+
+type conversationsInfoResponse struct {
+	slackResponse
+	Channel *struct {
+		ID         string `json:"id"`
+		Name       string `json:"name"`
+		IsPrivate  bool   `json:"is_private"`
+		IsIM       bool   `json:"is_im"`
+		IsMPIM     bool   `json:"is_mpim"`
+		NumMembers int    `json:"num_members"`
+		Topic      struct {
+			Value string `json:"value"`
+		} `json:"topic"`
+		Purpose struct {
+			Value string `json:"value"`
+		} `json:"purpose"`
+	} `json:"channel,omitempty"`
+}
+
+type usersInfoResponse struct {
+	slackResponse
+	User *struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		RealName string `json:"real_name"`
+		Profile  struct {
+			DisplayNameNormalized string `json:"display_name_normalized"`
+			RealName              string `json:"real_name"`
+			Title                 string `json:"title"`
+			ImageOriginal         string `json:"image_original"`
+			Image512              string `json:"image_512"`
+		} `json:"profile"`
+	} `json:"user,omitempty"`
+}
+
+type conversationsOpenRequest struct {
+	Users string `json:"users"`
+}
+
+type conversationsOpenResponse struct {
+	slackResponse
+	Channel struct {
+		ID string `json:"id"`
+	} `json:"channel"`
+}
+
+type readThreadRequest struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+	Limit   int    `json:"limit,omitempty"`
+}
+
+type readChannelHistoryRequest struct {
+	Channel string `json:"channel"`
+	Limit   int    `json:"limit,omitempty"`
+	Oldest  string `json:"oldest,omitempty"`
+	Latest  string `json:"latest,omitempty"`
+	Cursor  string `json:"cursor,omitempty"`
+}
+
+// ExtractFiles returns filename and size_bytes for each attached file on a message.
+func ExtractFiles(msg slackMessage) []FileMeta {
+	if len(msg.Files) == 0 {
+		return nil
+	}
+	out := make([]FileMeta, 0, len(msg.Files))
+	for _, f := range msg.Files {
+		name := f.Name
+		if name == "" {
+			name = "file"
+		}
+		out = append(out, FileMeta{Filename: name, SizeBytes: f.Size})
+	}
+	return out
+}

--- a/connectors/slack/context/slack_err.go
+++ b/connectors/slack/context/slack_err.go
@@ -1,0 +1,20 @@
+package context
+
+import (
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func mapSlackErr(code string) error {
+	switch code {
+	case "not_authed", "invalid_auth", "token_revoked", "token_expired", "account_inactive":
+		return &connectors.AuthError{Message: fmt.Sprintf("Slack auth error: %s", code)}
+	case "missing_scope":
+		return &connectors.AuthError{Message: "Slack token is missing a required OAuth scope — re-authorize the Slack connection"}
+	case "ratelimited":
+		return &connectors.RateLimitError{Message: "Slack API rate limit exceeded"}
+	default:
+		return &connectors.ExternalError{StatusCode: 200, Message: fmt.Sprintf("Slack API error: %s", code)}
+	}
+}

--- a/connectors/slack/context/truncate.go
+++ b/connectors/slack/context/truncate.go
@@ -1,0 +1,15 @@
+package context
+
+const maxBodyRunes = 4096
+
+// TruncateBody caps message text to 4 KB of UTF-8 / runes (Slack approval context).
+func TruncateBody(text string) (truncated string, wasTruncated bool) {
+	if text == "" {
+		return "", false
+	}
+	runes := []rune(text)
+	if len(runes) <= maxBodyRunes {
+		return text, false
+	}
+	return string(runes[:maxBodyRunes]), true
+}

--- a/connectors/slack/context/truncate_test.go
+++ b/connectors/slack/context/truncate_test.go
@@ -1,0 +1,20 @@
+package context
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateBody(t *testing.T) {
+	t.Parallel()
+	short := "hello"
+	got, tr := TruncateBody(short)
+	if got != short || tr {
+		t.Fatalf("short text: got %q truncated=%v", got, tr)
+	}
+	long := strings.Repeat("x", maxBodyRunes+50)
+	got, tr = TruncateBody(long)
+	if !tr || len([]rune(got)) != maxBodyRunes {
+		t.Fatalf("truncate: rune len=%d truncated=%v", len([]rune(got)), tr)
+	}
+}

--- a/connectors/slack/context/types.go
+++ b/connectors/slack/context/types.go
@@ -1,0 +1,92 @@
+// Package context provides Slack approval-context helpers (thread/channel/DM
+// surroundings) for the Slack connector. Types align with OpenAPI
+// `SlackContext` under ActionContext.details.slack_context.
+package context
+
+// ContextScope matches `SlackContext.context_scope` in the API schema.
+type ContextScope string
+
+const (
+	ScopeThread         ContextScope = "thread"
+	ScopeRecentChannel  ContextScope = "recent_channel"
+	ScopeRecentDM       ContextScope = "recent_dm"
+	ScopeSelfDM         ContextScope = "self_dm"
+	ScopeFirstContactDM ContextScope = "first_contact_dm"
+	ScopeMetadataOnly   ContextScope = "metadata_only"
+)
+
+// SlackContext is the normalized payload for approvers (details.slack_context).
+type SlackContext struct {
+	Channel        *ChannelMeta     `json:"channel,omitempty"`
+	Recipient      *UserRef         `json:"recipient,omitempty"`
+	TargetMessage  *ContextMessage  `json:"target_message,omitempty"`
+	Thread         *ThreadBlock     `json:"thread,omitempty"`
+	RecentMessages []ContextMessage `json:"recent_messages,omitempty"`
+	ContextScope   ContextScope     `json:"context_scope"`
+	ContextWindow  *ContextWindow   `json:"context_window,omitempty"`
+}
+
+// ChannelMeta is channel or conversation metadata.
+type ChannelMeta struct {
+	ID             string `json:"id"`
+	Name           string `json:"name,omitempty"`
+	IsPrivate      bool   `json:"is_private,omitempty"`
+	IsDM           bool   `json:"is_dm,omitempty"`
+	Topic          string `json:"topic,omitempty"`
+	Purpose        string `json:"purpose,omitempty"`
+	MemberCount    int    `json:"member_count,omitempty"`
+	LastActivityAt string `json:"last_activity_at,omitempty"`
+	Permalink      string `json:"permalink"`
+}
+
+// UserRef is a minimal user display object.
+type UserRef struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	RealName  string `json:"real_name,omitempty"`
+	Title     string `json:"title,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+}
+
+// ContextMessage is a single message in context (resolved text + permalink).
+type ContextMessage struct {
+	User      *UserRef   `json:"user,omitempty"`
+	Text      string     `json:"text"`
+	TS        string     `json:"ts"`
+	Permalink string     `json:"permalink"`
+	IsBot     bool       `json:"is_bot,omitempty"`
+	Truncated bool       `json:"truncated,omitempty"`
+	Files     []FileMeta `json:"files,omitempty"`
+}
+
+// FileMeta is attachment metadata only.
+type FileMeta struct {
+	Filename  string `json:"filename"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// ThreadBlock groups a thread parent and replies.
+type ThreadBlock struct {
+	Parent    *ContextMessage  `json:"parent,omitempty"`
+	Replies   []ContextMessage `json:"replies,omitempty"`
+	Truncated bool             `json:"truncated,omitempty"`
+}
+
+// ContextWindow describes the recent-message window (channel or DM).
+type ContextWindow struct {
+	MessageCount int  `json:"message_count,omitempty"`
+	Hours        int  `json:"hours,omitempty"`
+	Truncated    bool `json:"truncated,omitempty"`
+}
+
+// DMHistorySentinel is returned by FetchDMHistory for special DM cases.
+type DMHistorySentinel int
+
+const (
+	// SentinelNone means normal history should be fetched.
+	SentinelNone DMHistorySentinel = iota
+	// SentinelSelfDM is a DM with the authorizing user (note-to-self).
+	SentinelSelfDM
+	// SentinelFirstContact is a DM with no prior messages with the peer.
+	SentinelFirstContact
+)

--- a/connectors/slack/context/user.go
+++ b/connectors/slack/context/user.go
@@ -1,0 +1,42 @@
+package context
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func fetchUserRef(ctx context.Context, api SlackAPI, creds connectors.Credentials, userID string) (*UserRef, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	var resp usersInfoResponse
+	if err := api.Get(ctx, "users.info", creds, map[string]string{"user": userID}, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, mapSlackErr(resp.Error)
+	}
+	if resp.User == nil {
+		return nil, &connectors.ExternalError{StatusCode: 200, Message: "Slack users.info returned ok=true but no user"}
+	}
+	u := resp.User
+	ref := &UserRef{
+		ID:   u.ID,
+		Name: u.Name,
+	}
+	if u.RealName != "" {
+		ref.RealName = u.RealName
+	} else if u.Profile.RealName != "" {
+		ref.RealName = u.Profile.RealName
+	}
+	if u.Profile.Title != "" {
+		ref.Title = u.Profile.Title
+	}
+	if u.Profile.ImageOriginal != "" {
+		ref.AvatarURL = u.Profile.ImageOriginal
+	} else if u.Profile.Image512 != "" {
+		ref.AvatarURL = u.Profile.Image512
+	}
+	return ref, nil
+}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -57,6 +57,16 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "string",
 							"description": "Message text (supports Slack mrkdwn formatting)",
 							"x-ui": {"widget": "textarea", "placeholder": "Enter the message text"}
+						},
+						"thread_ts": {
+							"type": "string",
+							"description": "Optional. Post as a thread reply — Slack message timestamp of the parent message (e.g. 1234567890.123456). Used for approval context (thread view) when set.",
+							"x-ui": {"hidden": true}
+						},
+						"in_response_to_ts": {
+							"type": "string",
+							"description": "Optional. Slack message timestamp to anchor recent-channel context around for approvers. Does not change the Slack API request.",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),
@@ -242,6 +252,16 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 							"format": "date-time",
 							"description": "When the message should be sent in RFC 3339 format (e.g. 2026-03-20T09:00:00Z)",
 							"x-ui": {"label": "Send at", "help_text": "The date and time to deliver the message"}
+						},
+						"thread_ts": {
+							"type": "string",
+							"description": "Optional. Schedule as a thread reply — Slack message timestamp of the parent message. Used for approval context when set.",
+							"x-ui": {"hidden": true}
+						},
+						"in_response_to_ts": {
+							"type": "string",
+							"description": "Optional. Slack message timestamp to anchor recent-channel context around for approvers. Does not change the Slack API request.",
+							"x-ui": {"hidden": true}
 						}
 					}
 				}`)),

--- a/connectors/slack/schedule_message.go
+++ b/connectors/slack/schedule_message.go
@@ -21,6 +21,10 @@ type scheduleMessageParams struct {
 	Channel string       `json:"channel"`
 	Message string       `json:"message"`
 	PostAt  flexDateTime `json:"post_at"`
+	// ThreadTS schedules as a thread reply (chat.scheduleMessage thread_ts). Optional.
+	ThreadTS string `json:"thread_ts,omitempty"`
+	// InResponseToTS anchors approval context only; not sent to Slack (issue #981).
+	InResponseToTS string `json:"in_response_to_ts,omitempty"`
 }
 
 // flexDateTime accepts both a string (RFC 3339, datetime-local) and a legacy
@@ -67,6 +71,16 @@ func (p *scheduleMessageParams) validate() error {
 	}
 	if p.PostAt == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: post_at"}
+	}
+	if p.ThreadTS != "" {
+		if err := validateMessageTS(p.ThreadTS); err != nil {
+			return err
+		}
+	}
+	if p.InResponseToTS != "" {
+		if err := validateMessageTS(p.InResponseToTS); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -141,15 +155,29 @@ func (a *scheduleMessageAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
-	body := scheduleMessageRequest{
-		Channel: params.Channel,
-		Text:    params.Message,
-		PostAt:  postAtUnix,
-	}
-
 	var resp scheduleMessageResponse
-	if err := a.conn.doPost(ctx, "chat.scheduleMessage", req.Credentials, body, &resp); err != nil {
-		return nil, err
+	var postErr error
+	if params.ThreadTS != "" {
+		postErr = a.conn.doPost(ctx, "chat.scheduleMessage", req.Credentials, struct {
+			Channel  string `json:"channel"`
+			Text     string `json:"text"`
+			PostAt   int64  `json:"post_at"`
+			ThreadTS string `json:"thread_ts,omitempty"`
+		}{
+			Channel:  params.Channel,
+			Text:     params.Message,
+			PostAt:   postAtUnix,
+			ThreadTS: params.ThreadTS,
+		}, &resp)
+	} else {
+		postErr = a.conn.doPost(ctx, "chat.scheduleMessage", req.Credentials, scheduleMessageRequest{
+			Channel: params.Channel,
+			Text:    params.Message,
+			PostAt:  postAtUnix,
+		}, &resp)
+	}
+	if postErr != nil {
+		return nil, postErr
 	}
 
 	if !resp.OK {

--- a/connectors/slack/send_message.go
+++ b/connectors/slack/send_message.go
@@ -17,6 +17,10 @@ type sendMessageAction struct {
 type sendMessageParams struct {
 	Channel string `json:"channel"`
 	Message string `json:"message"`
+	// ThreadTS posts in a thread (chat.postMessage thread_ts). Optional.
+	ThreadTS string `json:"thread_ts,omitempty"`
+	// InResponseToTS anchors approval context only; not sent to Slack (issue #981).
+	InResponseToTS string `json:"in_response_to_ts,omitempty"`
 }
 
 func (p *sendMessageParams) validate() error {
@@ -25,6 +29,16 @@ func (p *sendMessageParams) validate() error {
 	}
 	if p.Message == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: message"}
+	}
+	if p.ThreadTS != "" {
+		if err := validateMessageTS(p.ThreadTS); err != nil {
+			return err
+		}
+	}
+	if p.InResponseToTS != "" {
+		if err := validateMessageTS(p.InResponseToTS); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -48,14 +62,26 @@ func (a *sendMessageAction) Execute(ctx context.Context, req connectors.ActionRe
 		return nil, err
 	}
 
-	body := sendMessageRequest{
-		Channel: params.Channel,
-		Text:    params.Message,
-	}
-
 	var resp sendMessageResponse
-	if err := a.conn.doPost(ctx, "chat.postMessage", req.Credentials, body, &resp); err != nil {
-		return nil, err
+	var postErr error
+	if params.ThreadTS != "" {
+		postErr = a.conn.doPost(ctx, "chat.postMessage", req.Credentials, struct {
+			Channel  string `json:"channel"`
+			Text     string `json:"text"`
+			ThreadTS string `json:"thread_ts,omitempty"`
+		}{
+			Channel:  params.Channel,
+			Text:     params.Message,
+			ThreadTS: params.ThreadTS,
+		}, &resp)
+	} else {
+		postErr = a.conn.doPost(ctx, "chat.postMessage", req.Credentials, sendMessageRequest{
+			Channel: params.Channel,
+			Text:    params.Message,
+		}, &resp)
+	}
+	if postErr != nil {
+		return nil, postErr
 	}
 
 	if !resp.OK {

--- a/connectors/slack/send_message_test.go
+++ b/connectors/slack/send_message_test.go
@@ -76,6 +76,49 @@ func TestSendMessage_Success(t *testing.T) {
 	}
 }
 
+func TestSendMessage_WithThreadTS(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Channel  string `json:"channel"`
+			Text     string `json:"text"`
+			ThreadTS string `json:"thread_ts"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.ThreadTS != "111222333.444555" {
+			t.Errorf("expected thread_ts in body, got %q", body.ThreadTS)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"ts":      "999888777.666555",
+			"channel": "C01234567",
+		})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &sendMessageAction{conn: conn}
+
+	params, _ := json.Marshal(sendMessageParams{
+		Channel:  "#general",
+		Message:  "thread reply",
+		ThreadTS: "111222333.444555",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.send_message",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSendMessage_MissingChannel(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -314,6 +314,17 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 	return nil
 }
 
+// Post and Get expose the Slack Web API request lifecycle for helpers in
+// subpackages (e.g. connectors/slack/context). They delegate to doPost/doGet.
+func (c *SlackConnector) Post(ctx context.Context, method string, creds connectors.Credentials, body any, dest any) error {
+	return c.doPost(ctx, method, creds, body, dest)
+}
+
+// Get sends a GET request to a Slack API method with query parameters.
+func (c *SlackConnector) Get(ctx context.Context, method string, creds connectors.Credentials, params map[string]string, dest any) error {
+	return c.doGet(ctx, method, creds, params, dest)
+}
+
 // doGet sends a GET request to a Slack API method with query parameters.
 // Used for endpoints like conversations.info and users.info that only accept
 // application/x-www-form-urlencoded (not JSON body). The params map is

--- a/spec/openapi/components/schemas/shared.yaml
+++ b/spec/openapi/components/schemas/shared.yaml
@@ -148,6 +148,12 @@ ActionContext:
         - `recipient_count`: Number of email recipients
         - `estimated_cost`: Estimated cost of a payment action
         - `affected_resources`: List of resources that will be modified
+        
+        Slack connector actions may include `slack_context` (see `SlackContext`) with
+        channel/thread/DM surroundings for the reviewer.
+      properties:
+        slack_context:
+          $ref: './slack_context.yaml#/SlackContext'
       example:
         recipient_count: 1
         estimated_time: "5 minutes"

--- a/spec/openapi/components/schemas/slack_context.yaml
+++ b/spec/openapi/components/schemas/slack_context.yaml
@@ -1,0 +1,149 @@
+# Slack approval context (connectors/slack) — surfaced under ActionContext.details.slack_context
+
+SlackContextFileMeta:
+  type: object
+  description: File attachment metadata only (no content fetch).
+  required:
+    - filename
+    - size_bytes
+  properties:
+    filename:
+      type: string
+    size_bytes:
+      type: integer
+      format: int64
+
+SlackContextUserRef:
+  type: object
+  description: Minimal Slack user display for approval context.
+  properties:
+    id:
+      type: string
+      description: Slack user ID (e.g. U…).
+    name:
+      type: string
+      description: Slack username / handle.
+    real_name:
+      type: string
+    title:
+      type: string
+    avatar_url:
+      type: string
+      format: uri
+
+SlackContextMessage:
+  type: object
+  description: A Slack message with resolved mentions and a permalink.
+  required:
+    - text
+    - ts
+    - permalink
+  properties:
+    user:
+      $ref: 'slack_context.yaml#/SlackContextUserRef'
+    text:
+      type: string
+      description: Message text with mentions resolved for display.
+    ts:
+      type: string
+      description: Slack message timestamp (e.g. 1711234567.000100).
+    permalink:
+      type: string
+      format: uri
+    is_bot:
+      type: boolean
+    truncated:
+      type: boolean
+      description: True when body was truncated to the per-message cap (4 KB).
+    files:
+      type: array
+      items:
+        $ref: 'slack_context.yaml#/SlackContextFileMeta'
+
+SlackContextChannel:
+  type: object
+  description: Channel or conversation metadata for Slack approval context.
+  required:
+    - id
+    - permalink
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    is_private:
+      type: boolean
+    is_dm:
+      type: boolean
+    topic:
+      type: string
+    purpose:
+      type: string
+    member_count:
+      type: integer
+    last_activity_at:
+      type: string
+      description: ISO-8601 time of the latest message in scope when known.
+    permalink:
+      type: string
+      format: uri
+      description: Opens the channel/conversation in Slack (archives URL).
+
+SlackContextThread:
+  type: object
+  properties:
+    parent:
+      $ref: 'slack_context.yaml#/SlackContextMessage'
+    replies:
+      type: array
+      items:
+        $ref: 'slack_context.yaml#/SlackContextMessage'
+    truncated:
+      type: boolean
+      description: True when the thread was capped (e.g. more than 20 messages).
+
+SlackContextWindow:
+  type: object
+  description: Describes the recent-message window when context_scope is recent_channel or recent_dm.
+  properties:
+    message_count:
+      type: integer
+    hours:
+      type: integer
+      description: Rolling window in hours (e.g. 24).
+    truncated:
+      type: boolean
+
+SlackContext:
+  type: object
+  description: |
+    Normalized Slack surroundings for human approval of Slack connector actions.
+    Populated by the Slack connector under `details.slack_context`. Fields not relevant
+    to the action may be omitted.
+  required:
+    - context_scope
+  properties:
+    channel:
+      $ref: 'slack_context.yaml#/SlackContextChannel'
+    recipient:
+      $ref: 'slack_context.yaml#/SlackContextUserRef'
+      description: DM peer when relevant (e.g. send_dm, invite).
+    target_message:
+      $ref: 'slack_context.yaml#/SlackContextMessage'
+    thread:
+      $ref: 'slack_context.yaml#/SlackContextThread'
+    recent_messages:
+      type: array
+      items:
+        $ref: 'slack_context.yaml#/SlackContextMessage'
+    context_scope:
+      type: string
+      enum:
+        - thread
+        - recent_channel
+        - recent_dm
+        - self_dm
+        - first_contact_dm
+        - metadata_only
+    context_window:
+      $ref: 'slack_context.yaml#/SlackContextWindow'

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -11720,6 +11720,12 @@ components:
             - `recipient_count`: Number of email recipients
             - `estimated_cost`: Estimated cost of a payment action
             - `affected_resources`: List of resources that will be modified
+
+            Slack connector actions may include `slack_context` (see `SlackContext`) with
+            channel/thread/DM surroundings for the reviewer.
+          properties:
+            slack_context:
+              $ref: '#/components/schemas/SlackContext'
           example:
             recipient_count: 1
             estimated_time: 5 minutes
@@ -11729,6 +11735,147 @@ components:
         details:
           recipient_count: 1
           estimated_time: 5 minutes
+    SlackContext:
+      type: object
+      description: |
+        Normalized Slack surroundings for human approval of Slack connector actions.
+        Populated by the Slack connector under `details.slack_context`. Fields not relevant
+        to the action may be omitted.
+      required:
+        - context_scope
+      properties:
+        channel:
+          $ref: '#/components/schemas/SlackContextChannel'
+        recipient:
+          $ref: '#/components/schemas/SlackContextUserRef'
+          description: DM peer when relevant (e.g. send_dm, invite).
+        target_message:
+          $ref: '#/components/schemas/SlackContextMessage'
+        thread:
+          $ref: '#/components/schemas/SlackContextThread'
+        recent_messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlackContextMessage'
+        context_scope:
+          type: string
+          enum:
+            - thread
+            - recent_channel
+            - recent_dm
+            - self_dm
+            - first_contact_dm
+            - metadata_only
+        context_window:
+          $ref: '#/components/schemas/SlackContextWindow'
+    SlackContextChannel:
+      type: object
+      description: Channel or conversation metadata for Slack approval context.
+      required:
+        - id
+        - permalink
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        is_private:
+          type: boolean
+        is_dm:
+          type: boolean
+        topic:
+          type: string
+        purpose:
+          type: string
+        member_count:
+          type: integer
+        last_activity_at:
+          type: string
+          description: ISO-8601 time of the latest message in scope when known.
+        permalink:
+          type: string
+          format: uri
+          description: Opens the channel/conversation in Slack (archives URL).
+    SlackContextWindow:
+      type: object
+      description: Describes the recent-message window when context_scope is recent_channel or recent_dm.
+      properties:
+        message_count:
+          type: integer
+        hours:
+          type: integer
+          description: Rolling window in hours (e.g. 24).
+        truncated:
+          type: boolean
+    SlackContextFileMeta:
+      type: object
+      description: File attachment metadata only (no content fetch).
+      required:
+        - filename
+        - size_bytes
+      properties:
+        filename:
+          type: string
+        size_bytes:
+          type: integer
+          format: int64
+    SlackContextMessage:
+      type: object
+      description: A Slack message with resolved mentions and a permalink.
+      required:
+        - text
+        - ts
+        - permalink
+      properties:
+        user:
+          $ref: '#/components/schemas/SlackContextUserRef'
+        text:
+          type: string
+          description: Message text with mentions resolved for display.
+        ts:
+          type: string
+          description: Slack message timestamp (e.g. 1711234567.000100).
+        permalink:
+          type: string
+          format: uri
+        is_bot:
+          type: boolean
+        truncated:
+          type: boolean
+          description: True when body was truncated to the per-message cap (4 KB).
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlackContextFileMeta'
+    SlackContextThread:
+      type: object
+      properties:
+        parent:
+          $ref: '#/components/schemas/SlackContextMessage'
+        replies:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlackContextMessage'
+        truncated:
+          type: boolean
+          description: True when the thread was capped (e.g. more than 20 messages).
+    SlackContextUserRef:
+      type: object
+      description: Minimal Slack user display for approval context.
+      properties:
+        id:
+          type: string
+          description: Slack user ID (e.g. U…).
+        name:
+          type: string
+          description: Slack username / handle.
+        real_name:
+          type: string
+        title:
+          type: string
+        avatar_url:
+          type: string
+          format: uri
     AlternativeUrls:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -668,6 +668,20 @@ components:
       $ref: './components/schemas/shared.yaml#/Action'
     ActionContext:
       $ref: './components/schemas/shared.yaml#/ActionContext'
+    SlackContext:
+      $ref: './components/schemas/slack_context.yaml#/SlackContext'
+    SlackContextChannel:
+      $ref: './components/schemas/slack_context.yaml#/SlackContextChannel'
+    SlackContextWindow:
+      $ref: './components/schemas/slack_context.yaml#/SlackContextWindow'
+    SlackContextFileMeta:
+      $ref: './components/schemas/slack_context.yaml#/SlackContextFileMeta'
+    SlackContextMessage:
+      $ref: './components/schemas/slack_context.yaml#/SlackContextMessage'
+    SlackContextThread:
+      $ref: './components/schemas/slack_context.yaml#/SlackContextThread'
+    SlackContextUserRef:
+      $ref: './components/schemas/slack_context.yaml#/SlackContextUserRef'
     AlternativeUrls:
       $ref: './components/schemas/shared.yaml#/AlternativeUrls'
     ExecutionStatus:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 1 / Phase 1** from #981: lock the `slack_context` shape in OpenAPI, regenerate the bundled spec, and add `connectors/slack/context` helpers (with unit tests using a mock Slack API) for use in follow-up PRs.

Also wires optional **`thread_ts`** and **`in_response_to_ts`** on `slack.send_message` and `slack.schedule_message` (manifest + execution). `in_response_to_ts` is validated and stored in parameters only — it is **not** sent to Slack; PR2 will use it to anchor context. `thread_ts` is forwarded to `chat.postMessage` / `chat.scheduleMessage` when set.

`SlackConnector` exposes **`Post`** and **`Get`** so the context package can reuse the same HTTP/auth/rate-limit behavior as actions.

## OpenAPI

- New `spec/openapi/components/schemas/slack_context.yaml` and `details.slack_context` under `ActionContext.details` in `shared.yaml`.
- Root `openapi.yaml` registers the new schemas; `openapi.bundle.yaml` updated via Redocly bundle.

Regenerate ignored client types locally: `cd frontend && npm run generate:api` (and `mobile` if needed).

## Test plan

- [x] `cd frontend && npm test` (1020 tests) after regenerating API types from the bundled spec.
- [ ] `go test ./connectors/slack/context/...` — **not run in this environment** (Go toolchain mismatch vs `go.mod`); CI should run full backend tests.

## Part of

#981 — Phase 1 (Foundation) only; does not complete the full issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e833edd-75da-4c71-8771-6b0509dacf8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e833edd-75da-4c71-8771-6b0509dacf8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

