### PR TITLE
Mobile: email thread preview on approval for email reply actions (#975 phase 3)

### DIFF
--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -36,6 +36,11 @@ import { CountdownBadge } from "./CountdownBadge";
 import { ApprovalActions } from "./ApprovalActions";
 import { KeyValueList, type KeyValueEntry } from "./KeyValueList";
 import { TimelineView, type TimelineEntry } from "./TimelineView";
+import { EmailThreadCard } from "./EmailThreadCard";
+import {
+  isEmailReplyAction,
+  parseEmailThreadDetails,
+} from "./emailThreadUtils";
 
 type Props = NativeStackScreenProps<RootStackParamList, "ApprovalDetail">;
 
@@ -70,10 +75,18 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
     () => Object.entries(parameters).map(([label, value]) => ({ label, value })),
     [parameters],
   );
+  const isEmailReply = isEmailReplyAction(approval.action.type);
+  const emailThread = useMemo(
+    () => parseEmailThreadDetails(approval.context.details),
+    [approval.context.details],
+  );
+
   const contextDetailEntries: KeyValueEntry[] = useMemo(() => {
     const details = safeParams(approval.context.details);
-    return Object.entries(details).map(([label, value]) => ({ label, value }));
-  }, [approval.context.details]);
+    return Object.entries(details)
+      .filter(([label]) => !(isEmailReply && label === "email_thread"))
+      .map(([label, value]) => ({ label, value }));
+  }, [approval.context.details, isEmailReply]);
 
   const isPending = approval.status === "pending" && !isApproved && !isDenied;
   const expired = checkExpired(approval.status, approval.expires_at);
@@ -279,6 +292,12 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
             <View style={styles.cardElevated}>
               <KeyValueList entries={paramEntries} />
             </View>
+          </View>
+        )}
+
+        {isEmailReply && (
+          <View style={styles.sectionMajor}>
+            <EmailThreadCard thread={emailThread} testID="email-thread-card" />
           </View>
         )}
 

--- a/mobile/src/screens/approvals/EmailThreadCard.tsx
+++ b/mobile/src/screens/approvals/EmailThreadCard.tsx
@@ -1,0 +1,304 @@
+/**
+ * Renders normalized `email_thread` for email reply approvals (plain text bodies).
+ * Latest message is expanded; earlier messages live under a collapsible section.
+ */
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { colors } from "../../theme/colors";
+import { formatTimestamp } from "./approvalUtils";
+import type { EmailThread, EmailThreadMessage } from "./emailThreadUtils";
+
+interface EmailThreadCardProps {
+  thread: EmailThread | null;
+  testID?: string;
+}
+
+function formatSizeBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function messageBodyText(m: EmailThreadMessage): string {
+  const trimmed = m.body_text?.trim() ?? "";
+  if (trimmed.length > 0) return m.body_text;
+  const sn = m.snippet?.trim() ?? "";
+  return sn.length > 0 ? m.snippet : "(No message body)";
+}
+
+function TruncationNote({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Show more about truncated message"
+      onPress={() =>
+        Alert.alert(
+          "Message truncated",
+          "This message body was shortened on the server (about 20 KB maximum per field). The full text is not available in this preview.",
+        )
+      }
+      style={styles.truncationLink}
+      testID="email-thread-truncation-note"
+    >
+      <Text style={styles.truncationLinkText}>Show more</Text>
+    </TouchableOpacity>
+  );
+}
+
+function AddressLine({ label, values }: { label: string; values: string[] }) {
+  if (values.length === 0) return null;
+  return (
+    <Text style={styles.metaLine} selectable>
+      <Text style={styles.metaLabel}>{label}: </Text>
+      {values.join(", ")}
+    </Text>
+  );
+}
+
+function AttachmentChips({
+  attachments,
+}: {
+  attachments: NonNullable<EmailThreadMessage["attachments"]>;
+}) {
+  return (
+    <View style={styles.attachRow} accessibilityRole="list">
+      {attachments.map((a) => (
+        <View
+          key={`${a.filename}-${a.size_bytes}`}
+          style={styles.attachChip}
+          accessibilityRole="text"
+          accessibilityLabel={`Attachment ${a.filename}`}
+        >
+          <Text style={styles.attachChipText} numberOfLines={1}>
+            {a.filename}
+            {a.size_bytes > 0 ? ` · ${formatSizeBytes(a.size_bytes)}` : ""}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function MessageBlock({
+  message,
+  testID,
+}: {
+  message: EmailThreadMessage;
+  testID?: string;
+}) {
+  const body = messageBodyText(message);
+  const dateLabel = message.date ? formatTimestamp(message.date) : "—";
+
+  return (
+    <View style={styles.messageBlock} testID={testID}>
+      <Text style={styles.fromLine} selectable numberOfLines={3}>
+        {message.from || "(Unknown sender)"}
+      </Text>
+      <AddressLine label="To" values={message.to} />
+      <AddressLine label="Cc" values={message.cc} />
+      <Text style={styles.dateLine} selectable>
+        {dateLabel}
+      </Text>
+      <Text style={styles.bodyText} selectable>
+        {body}
+      </Text>
+      <TruncationNote visible={message.truncated} />
+      {message.attachments && message.attachments.length > 0 ? (
+        <AttachmentChips attachments={message.attachments} />
+      ) : null}
+    </View>
+  );
+}
+
+export function EmailThreadCard({ thread, testID }: EmailThreadCardProps) {
+  const [earlierOpen, setEarlierOpen] = useState(false);
+
+  const { latest, earlier } = useMemo(() => {
+    const msgs = thread?.messages ?? [];
+    if (msgs.length === 0) {
+      return { latest: null as EmailThreadMessage | null, earlier: [] as EmailThreadMessage[] };
+    }
+    return {
+      latest: msgs[msgs.length - 1] ?? null,
+      earlier: msgs.slice(0, -1),
+    };
+  }, [thread?.messages]);
+
+  const hasThread =
+    (thread?.subject?.trim().length ?? 0) > 0 ||
+    (thread?.messages?.length ?? 0) > 0;
+
+  return (
+    <View style={styles.card} testID={testID}>
+      <Text style={styles.sectionLabel}>Email thread</Text>
+      {!hasThread ? (
+        <Text style={styles.emptyText} testID="email-thread-empty">
+          No conversation loaded for this request.
+        </Text>
+      ) : (
+        <>
+          {thread?.subject ? (
+            <Text style={styles.subject} selectable numberOfLines={4}>
+              {thread.subject}
+            </Text>
+          ) : null}
+
+          {latest ? (
+            <MessageBlock message={latest} testID="email-thread-latest" />
+          ) : null}
+
+          {earlier.length > 0 ? (
+            <View style={styles.earlierSection}>
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityState={{ expanded: earlierOpen }}
+                onPress={() => setEarlierOpen((o) => !o)}
+                style={styles.earlierToggle}
+                testID="email-thread-earlier-toggle"
+              >
+                <Text style={styles.earlierToggleText}>
+                  {earlierOpen ? "▼" : "▶"} Earlier in this thread ({earlier.length})
+                </Text>
+              </TouchableOpacity>
+              {earlierOpen ? (
+                <View style={styles.earlierList} testID="email-thread-earlier-list">
+                  {earlier.map((m, i) => (
+                    <View
+                      key={m.message_id || `earlier-${i}`}
+                      style={styles.earlierItem}
+                    >
+                      <MessageBlock
+                        message={m}
+                        testID={i === 0 ? "email-thread-earlier-first" : undefined}
+                      />
+                    </View>
+                  ))}
+                </View>
+              ) : null}
+            </View>
+          ) : null}
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: colors.gray400,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 12,
+  },
+  subject: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.gray900,
+    marginBottom: 14,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: colors.gray500,
+    lineHeight: 20,
+  },
+  messageBlock: {
+    marginBottom: 0,
+  },
+  fromLine: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.gray900,
+    marginBottom: 6,
+  },
+  metaLine: {
+    fontSize: 13,
+    color: colors.gray700,
+    marginBottom: 4,
+    lineHeight: 18,
+  },
+  metaLabel: {
+    fontWeight: "600",
+    color: colors.gray500,
+  },
+  dateLine: {
+    fontSize: 12,
+    color: colors.gray400,
+    marginBottom: 10,
+  },
+  bodyText: {
+    fontSize: 14,
+    color: colors.gray900,
+    lineHeight: 22,
+  },
+  truncationLink: {
+    alignSelf: "flex-start",
+    marginTop: 8,
+    paddingVertical: 4,
+  },
+  truncationLinkText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.primary,
+  },
+  attachRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 10,
+  },
+  attachChip: {
+    maxWidth: "100%",
+    backgroundColor: colors.gray100,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+  },
+  attachChipText: {
+    fontSize: 12,
+    color: colors.gray700,
+  },
+  earlierSection: {
+    marginTop: 16,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: colors.gray200,
+  },
+  earlierToggle: {
+    paddingVertical: 8,
+  },
+  earlierToggleText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.primary,
+  },
+  earlierList: {
+    marginTop: 4,
+  },
+  earlierItem: {
+    marginBottom: 16,
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray200,
+  },
+});

--- a/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
@@ -166,6 +166,46 @@ describe("ApprovalDetailScreen", () => {
     expect(json).toContain("Welcome");
   });
 
+  it("shows email thread card for google.send_email_reply with thread in context", async () => {
+    const approval = makeApproval({
+      action: {
+        type: "google.send_email_reply",
+        version: "1",
+        parameters: { thread_id: "t1", body: "Reply text" },
+      },
+      context: {
+        description: "Reply to thread",
+        risk_level: "low",
+        details: {
+          email_thread: {
+            subject: "Re: Topic",
+            messages: [
+              {
+                from: "x@y.com",
+                to: ["z@y.com"],
+                cc: [],
+                date: "2026-04-20T12:00:00Z",
+                body_html: "",
+                body_text: "Thread body",
+                snippet: "",
+                message_id: "mid",
+                truncated: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+    const json = JSON.stringify(renderer.toJSON());
+    expect(json).toContain("Email thread");
+    expect(json).toContain("Re: Topic");
+    expect(json).toContain("Thread body");
+    expect(json).not.toContain('"label":"email_thread"');
+  });
+
   it("shows Approved banner for approved status", async () => {
     const approval = makeApproval({
       status: "approved",

--- a/mobile/src/screens/approvals/__tests__/EmailThreadCard.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/EmailThreadCard.test.tsx
@@ -1,0 +1,183 @@
+import React, { createElement } from "react";
+import { Alert } from "react-native";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+import type { components } from "../../../api/schema";
+import { EmailThreadCard } from "../EmailThreadCard";
+
+type EmailThread = components["schemas"]["EmailThread"];
+
+function findByTestId(renderer: ReactTestRenderer, testID: string) {
+  return renderer.root.find(
+    (node) => node.props.testID === testID,
+  );
+}
+
+function hasTestId(renderer: ReactTestRenderer, testID: string) {
+  try {
+    findByTestId(renderer, testID);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("EmailThreadCard", () => {
+  let renderer: ReactTestRenderer;
+
+  afterEach(async () => {
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
+  it("renders subject and latest message body", async () => {
+    const thread: EmailThread = {
+      subject: "Re: Project",
+      messages: [
+        {
+          from: "alice@example.com",
+          to: ["bob@example.com"],
+          cc: [],
+          date: "2026-04-20T15:00:00Z",
+          body_html: "<p>Hi</p>",
+          body_text: "Hi there",
+          snippet: "Hi",
+          message_id: "m1",
+          truncated: false,
+        },
+        {
+          from: "bob@example.com",
+          to: ["alice@example.com"],
+          cc: ["cc@example.com"],
+          date: "2026-04-20T16:00:00Z",
+          body_html: "",
+          body_text: "Latest reply body",
+          snippet: "",
+          message_id: "m2",
+          truncated: false,
+        },
+      ],
+    };
+    await act(async () => {
+      renderer = create(createElement(EmailThreadCard, { thread }));
+    });
+    const json = JSON.stringify(renderer.toJSON());
+    expect(json).toContain("Re: Project");
+    expect(json).toContain("Latest reply body");
+    expect(json).toContain("bob@example.com");
+    expect(json).toContain("Cc");
+    expect(json).toContain("cc@example.com");
+  });
+
+  it("shows empty fallback when thread has no content", async () => {
+    await act(async () => {
+      renderer = create(
+        createElement(EmailThreadCard, { thread: { subject: "", messages: [] } }),
+      );
+    });
+    expect(hasTestId(renderer, "email-thread-empty")).toBe(true);
+  });
+
+  it("shows truncation affordance when truncated is true", async () => {
+    const thread: EmailThread = {
+      subject: "S",
+      messages: [
+        {
+          from: "a@b.com",
+          to: [],
+          cc: [],
+          date: "2026-04-20T12:00:00Z",
+          body_html: "",
+          body_text: "long",
+          snippet: "",
+          message_id: "x",
+          truncated: true,
+        },
+      ],
+    };
+    await act(async () => {
+      renderer = create(createElement(EmailThreadCard, { thread }));
+    });
+    expect(hasTestId(renderer, "email-thread-truncation-note")).toBe(true);
+
+    const alertSpy = jest.spyOn(Alert, "alert");
+    const note = findByTestId(renderer, "email-thread-truncation-note");
+    await act(async () => {
+      note.props.onPress();
+    });
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Message truncated",
+      expect.stringContaining("20 KB"),
+    );
+    alertSpy.mockRestore();
+  });
+
+  it("lists attachment filenames as chips", async () => {
+    const thread: EmailThread = {
+      subject: "With files",
+      messages: [
+        {
+          from: "a@b.com",
+          to: [],
+          cc: [],
+          date: "2026-04-20T12:00:00Z",
+          body_html: "",
+          body_text: "See attached",
+          snippet: "",
+          message_id: "x",
+          truncated: false,
+          attachments: [{ filename: "report.pdf", size_bytes: 2048 }],
+        },
+      ],
+    };
+    await act(async () => {
+      renderer = create(createElement(EmailThreadCard, { thread }));
+    });
+    const json = JSON.stringify(renderer.toJSON());
+    expect(json).toContain("report.pdf");
+    expect(json).toContain("KB");
+  });
+
+  it("expands earlier messages when toggled", async () => {
+    const thread: EmailThread = {
+      subject: "Thread",
+      messages: [
+        {
+          from: "old@example.com",
+          to: [],
+          cc: [],
+          date: "2026-04-20T10:00:00Z",
+          body_html: "",
+          body_text: "First message",
+          snippet: "",
+          message_id: "m0",
+          truncated: false,
+        },
+        {
+          from: "new@example.com",
+          to: [],
+          cc: [],
+          date: "2026-04-20T11:00:00Z",
+          body_html: "",
+          body_text: "Second message",
+          snippet: "",
+          message_id: "m1",
+          truncated: false,
+        },
+      ],
+    };
+    await act(async () => {
+      renderer = create(createElement(EmailThreadCard, { thread }));
+    });
+    const jsonCollapsed = JSON.stringify(renderer.toJSON());
+    expect(jsonCollapsed).not.toContain("First message");
+
+    const toggle = findByTestId(renderer, "email-thread-earlier-toggle");
+    await act(async () => {
+      toggle.props.onPress();
+    });
+    const jsonOpen = JSON.stringify(renderer.toJSON());
+    expect(jsonOpen).toContain("First message");
+    expect(hasTestId(renderer, "email-thread-earlier-list")).toBe(true);
+  });
+});

--- a/mobile/src/screens/approvals/__tests__/emailThreadUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/emailThreadUtils.test.ts
@@ -1,0 +1,40 @@
+import {
+  isEmailReplyAction,
+  parseEmailThreadDetails,
+} from "../emailThreadUtils";
+
+describe("emailThreadUtils", () => {
+  it("identifies google and microsoft send_email_reply actions", () => {
+    expect(isEmailReplyAction("google.send_email_reply")).toBe(true);
+    expect(isEmailReplyAction("microsoft.send_email_reply")).toBe(true);
+    expect(isEmailReplyAction("email.send")).toBe(false);
+  });
+
+  it("parseEmailThreadDetails returns null when email_thread key is absent", () => {
+    expect(parseEmailThreadDetails({ foo: 1 })).toBeNull();
+    expect(parseEmailThreadDetails(undefined)).toBeNull();
+  });
+
+  it("parseEmailThreadDetails coerces partial payloads", () => {
+    const parsed = parseEmailThreadDetails({
+      email_thread: {
+        subject: "Hello",
+        messages: [
+          {
+            from: "a@b.com",
+            attachments: [{ filename: "f.txt", size_bytes: 10 }],
+          },
+        ],
+      },
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.subject).toBe("Hello");
+    expect(parsed!.messages).toHaveLength(1);
+    const m = parsed!.messages[0]!;
+    expect(m.from).toBe("a@b.com");
+    expect(m.to).toEqual([]);
+    expect(m.cc).toEqual([]);
+    expect(m.truncated).toBe(false);
+    expect(m.attachments?.[0]?.filename).toBe("f.txt");
+  });
+});

--- a/mobile/src/screens/approvals/emailThreadUtils.ts
+++ b/mobile/src/screens/approvals/emailThreadUtils.ts
@@ -1,0 +1,82 @@
+/**
+ * Parses `context.details.email_thread` for email reply approvals (issue #975).
+ * Defensive against partial API payloads — coerces to the OpenAPI EmailThread shape.
+ */
+import type { components } from "../../api/schema";
+import { safeParams } from "./approvalUtils";
+
+export type EmailThread = components["schemas"]["EmailThread"];
+export type EmailThreadMessage = components["schemas"]["EmailThreadMessage"];
+
+const EMAIL_REPLY_ACTIONS = new Set([
+  "google.send_email_reply",
+  "microsoft.send_email_reply",
+]);
+
+export function isEmailReplyAction(actionType: string): boolean {
+  return EMAIL_REPLY_ACTIONS.has(actionType);
+}
+
+function stringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string");
+}
+
+function parseAttachments(
+  v: unknown,
+): components["schemas"]["EmailThreadAttachment"][] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: components["schemas"]["EmailThreadAttachment"][] = [];
+  for (const a of v) {
+    if (a == null || typeof a !== "object" || Array.isArray(a)) continue;
+    const o = a as Record<string, unknown>;
+    if (typeof o.filename !== "string") continue;
+    const sz =
+      typeof o.size_bytes === "number" && !Number.isNaN(o.size_bytes)
+        ? o.size_bytes
+        : 0;
+    out.push({ filename: o.filename, size_bytes: sz });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Returns a normalized thread when `email_thread` is present in details.
+ * Returns null when the key is absent (caller may still show an empty-state card for reply actions).
+ */
+export function parseEmailThreadDetails(details: unknown): EmailThread | null {
+  const d = safeParams(details);
+  if (!Object.prototype.hasOwnProperty.call(d, "email_thread")) {
+    return null;
+  }
+  const raw = d.email_thread;
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { subject: "", messages: [] };
+  }
+  const r = raw as Record<string, unknown>;
+  const subject = typeof r.subject === "string" ? r.subject : "";
+  const rawMsgs = r.messages;
+  const messages: EmailThreadMessage[] = [];
+  if (Array.isArray(rawMsgs)) {
+    for (const item of rawMsgs) {
+      if (item == null || typeof item !== "object" || Array.isArray(item)) {
+        continue;
+      }
+      const m = item as Record<string, unknown>;
+      messages.push({
+        from: typeof m.from === "string" ? m.from : "",
+        to: stringArray(m.to),
+        cc: stringArray(m.cc),
+        date: typeof m.date === "string" ? m.date : "",
+        body_html: typeof m.body_html === "string" ? m.body_html : "",
+        body_text: typeof m.body_text === "string" ? m.body_text : "",
+        snippet: typeof m.snippet === "string" ? m.snippet : "",
+        message_id: typeof m.message_id === "string" ? m.message_id : "",
+        truncated:
+          typeof m.truncated === "boolean" ? m.truncated : false,
+        attachments: parseAttachments(m.attachments),
+      });
+    }
+  }
+  return { subject, messages };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `EmailThreadCard` on the approval detail screen for `google.send_email_reply` and `microsoft.send_email_reply`, rendering `context.details.email_thread` (subject, latest message expanded, collapsible earlier messages, attachment filename chips, plain `body_text` with snippet fallback).
- Omits `email_thread` from the generic "Additional Context" key-value list so the thread is not shown twice as raw JSON.
- Adds Jest coverage for the card, parsing helpers, and approval detail wiring.

Refs #975 (Phase 3 only; Phases 1–2 and verification remain elsewhere).

## Related Issue

Refs #975

## Test Plan

### Developer

- [x] Unit tests added / updated
- [ ] `make test` passes locally (not run in this environment; mobile-only change)
- [ ] `make build` succeeds
- [x] Mobile: `cd mobile && npm test -- --ci` passes

### Manual Testing

- [ ] Open a pending approval for an email reply action and confirm subject, messages, and attachments display; expand "Earlier in this thread" for multi-message threads; tap "Show more" on truncated messages.

## Screenshots / Recordings

N/A (not captured in agent environment)

## Notes for Reviewers

- `mobile/src/api/schema.d.ts` is gitignored and generated by `npm run generate:api` in `mobile/`; types use `components["schemas"]["EmailThread"]` from that file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6662e79e-5669-4b1d-a768-6a4ad48cee95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6662e79e-5669-4b1d-a768-6a4ad48cee95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

