### PR TITLE
feat(web): email thread preview on reply approvals (#975 phase 2)

### DIFF
--- a/frontend/src/components/previews/EmailThreadPreview.stories.tsx
+++ b/frontend/src/components/previews/EmailThreadPreview.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { EmailThreadPreview, type EmailThread } from "./EmailThreadPreview";
+
+const meta: Meta<typeof EmailThreadPreview> = {
+  title: "Previews/EmailThreadPreview",
+  component: EmailThreadPreview,
+  parameters: { layout: "centered" },
+  decorators: [(Story) => <div className="w-[560px]"><Story /></div>],
+};
+export default meta;
+type Story = StoryObj<typeof EmailThreadPreview>;
+
+const sampleThread: EmailThread = {
+  subject: "Re: Q2 roadmap — engineering sync",
+  messages: [
+    {
+      from: "dana@example.com",
+      to: ["team@example.com"],
+      cc: [],
+      date: "2026-04-18T09:15:00Z",
+      body_html: "<p>Hi team — here is a <strong>draft</strong> of the Q2 roadmap.</p>",
+      body_text: "Hi team — here is a draft of the Q2 roadmap.",
+      snippet: "Hi team — here is a draft",
+      message_id: "msg-1",
+      truncated: false,
+      attachments: [{ filename: "roadmap-draft.pdf", size_bytes: 245_760 }],
+    },
+    {
+      from: "eli@example.com",
+      to: ["dana@example.com"],
+      cc: ["team@example.com"],
+      date: "2026-04-19T14:22:00Z",
+      body_html:
+        "<p>Thanks Dana. Can we <em>slot</em> the API hardening work before the dashboard launch?</p>",
+      body_text:
+        "Thanks Dana. Can we slot the API hardening work before the dashboard launch?",
+      snippet: "Thanks Dana. Can we slot",
+      message_id: "msg-2",
+      truncated: false,
+    },
+    {
+      from: "dana@example.com",
+      to: ["eli@example.com"],
+      cc: ["team@example.com"],
+      date: "2026-04-20T08:01:00Z",
+      body_html:
+        "<p>Yes — I moved hardening to sprint 3. We should be good for an April 28 cut.</p>",
+      body_text: "Yes — I moved hardening to sprint 3. We should be good for an April 28 cut.",
+      snippet: "Yes — I moved hardening",
+      message_id: "msg-3",
+      truncated: true,
+      attachments: [{ filename: "sprint-board.png", size_bytes: 89_012 }],
+    },
+  ],
+};
+
+export const FullThread: Story = {
+  args: {
+    thread: sampleThread,
+  },
+};
+
+export const SingleMessage: Story = {
+  args: {
+    thread: {
+      subject: "Hello",
+      messages: [
+        {
+          from: "support@vendor.com",
+          to: ["you@company.com"],
+          cc: [],
+          date: "2026-04-20T10:00:00Z",
+          body_html: "<p>Your ticket <a href=\"https://example.invalid/t/1\">#42</a> was updated.</p>",
+          body_text: "Your ticket #42 was updated.",
+          snippet: "Your ticket #42",
+          message_id: "solo",
+          truncated: false,
+        },
+      ],
+    },
+  },
+};
+
+export const EmptyThread: Story = {
+  args: {
+    thread: { subject: "(no messages)", messages: [] },
+  },
+};

--- a/frontend/src/components/previews/EmailThreadPreview.tsx
+++ b/frontend/src/components/previews/EmailThreadPreview.tsx
@@ -1,0 +1,339 @@
+import { useId, useState } from "react";
+import DOMPurify, { type Config as DOMPurifyConfig } from "dompurify";
+import { Paperclip } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { components } from "@/api/schema";
+import { cn } from "@/lib/utils";
+
+export type EmailThread = components["schemas"]["EmailThread"];
+export type EmailThreadMessage = components["schemas"]["EmailThreadMessage"];
+
+/** Action types that include normalized `context.details.email_thread` (issue #975). */
+export const EMAIL_REPLY_ACTION_TYPES = new Set([
+  "google.send_email_reply",
+  "microsoft.send_email_reply",
+]);
+
+/**
+ * Loose runtime parse for `context.details` so we never trust JSON shape alone.
+ */
+export function parseEmailThreadFromDetails(details: unknown): EmailThread | null {
+  if (!details || typeof details !== "object") return null;
+  const d = details as Record<string, unknown>;
+  const raw = d.email_thread;
+  if (!raw || typeof raw !== "object") return null;
+  const t = raw as Record<string, unknown>;
+  if (typeof t.subject !== "string" || !Array.isArray(t.messages)) return null;
+  const messages: EmailThreadMessage[] = [];
+  for (const m of t.messages) {
+    if (!m || typeof m !== "object") return null;
+    const msg = m as Record<string, unknown>;
+    if (
+      typeof msg.from !== "string" ||
+      !Array.isArray(msg.to) ||
+      !msg.to.every((x) => typeof x === "string") ||
+      !Array.isArray(msg.cc) ||
+      !msg.cc.every((x) => typeof x === "string") ||
+      typeof msg.date !== "string" ||
+      typeof msg.body_html !== "string" ||
+      typeof msg.body_text !== "string" ||
+      typeof msg.snippet !== "string" ||
+      typeof msg.message_id !== "string" ||
+      typeof msg.truncated !== "boolean"
+    ) {
+      return null;
+    }
+    const attachmentsRaw = msg.attachments;
+    let attachments: EmailThreadMessage["attachments"];
+    if (attachmentsRaw !== undefined) {
+      if (!Array.isArray(attachmentsRaw)) return null;
+      attachments = [];
+      for (const a of attachmentsRaw) {
+        if (!a || typeof a !== "object") return null;
+        const att = a as Record<string, unknown>;
+        if (typeof att.filename !== "string" || typeof att.size_bytes !== "number") return null;
+        attachments.push({ filename: att.filename, size_bytes: att.size_bytes });
+      }
+    }
+    messages.push({
+      from: msg.from,
+      to: msg.to as string[],
+      cc: msg.cc as string[],
+      date: msg.date,
+      body_html: msg.body_html,
+      body_text: msg.body_text,
+      snippet: msg.snippet,
+      message_id: msg.message_id,
+      truncated: msg.truncated,
+      attachments,
+    });
+  }
+  return { subject: t.subject, messages };
+}
+
+// DOMPurify Config type expects mutable string[] fields.
+const EMAIL_HTML_SANITIZER_CONFIG: DOMPurifyConfig = {
+  USE_PROFILES: { html: true },
+  FORBID_TAGS: [
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "base",
+    "link",
+    "meta",
+    "form",
+    "input",
+    "button",
+    "textarea",
+    "select",
+    "option",
+  ],
+  FORBID_ATTR: [
+    "onabort",
+    "onblur",
+    "onchange",
+    "onclick",
+    "onclose",
+    "oncontextmenu",
+    "ondblclick",
+    "onerror",
+    "onfocus",
+    "oninput",
+    "oninvalid",
+    "onkeydown",
+    "onkeypress",
+    "onkeyup",
+    "onload",
+    "onmousedown",
+    "onmouseenter",
+    "onmouseleave",
+    "onmousemove",
+    "onmouseout",
+    "onmouseover",
+    "onmouseup",
+    "onreset",
+    "onscroll",
+    "onselect",
+    "onsubmit",
+    "onunload",
+  ],
+};
+
+function sanitizeEmailHtmlFragment(html: string): string {
+  return DOMPurify.sanitize(html, EMAIL_HTML_SANITIZER_CONFIG);
+}
+
+function buildIframeSrcDoc(sanitizedBody: string): string {
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+    body { margin: 0; padding: 8px 10px; font-family: system-ui, sans-serif; font-size: 13px; line-height: 1.45; color: #0f172a; word-wrap: break-word; overflow-wrap: anywhere; }
+    img { max-width: 100%; height: auto; }
+    pre { white-space: pre-wrap; word-break: break-word; }
+  </style></head><body>${sanitizedBody}</body></html>`;
+}
+
+function formatListLine(label: string, values: string[]): string | null {
+  if (values.length === 0) return null;
+  return `${label}: ${values.join(", ")}`;
+}
+
+function MessageMeta({
+  message,
+  headingId,
+}: {
+  message: EmailThreadMessage;
+  headingId: string;
+}) {
+  const toLine = formatListLine("To", message.to);
+  const ccLine = formatListLine("Cc", message.cc);
+  return (
+    <div className="space-y-1 border-b border-border/60 pb-2 text-xs">
+      <p id={headingId} className="font-semibold text-foreground">
+        {message.from}
+      </p>
+      <p className="text-muted-foreground">
+        <time dateTime={message.date}>{message.date}</time>
+      </p>
+      {toLine && <p className="text-muted-foreground">{toLine}</p>}
+      {ccLine && <p className="text-muted-foreground">{ccLine}</p>}
+    </div>
+  );
+}
+
+function TruncationNote({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) {
+  return (
+    <div className="mt-2 rounded-md border border-amber-200/80 bg-amber-50/80 px-3 py-2 text-xs text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+      {expanded ? (
+        <>
+          <p>
+            The message body was shortened on the server (about 20 KB per field) so the approval
+            screen stays responsive. The full original text is only in your mailbox.
+          </p>
+          <button
+            type="button"
+            className="mt-1 font-medium text-amber-900 underline underline-offset-2 hover:text-amber-950 dark:text-amber-200 dark:hover:text-amber-50"
+            onClick={onToggle}
+          >
+            Show less
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="inline">This message was truncated server-side.</p>{" "}
+          <button
+            type="button"
+            className="font-medium text-amber-900 underline underline-offset-2 hover:text-amber-950 dark:text-amber-200 dark:hover:text-amber-50"
+            onClick={onToggle}
+          >
+            Show more
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function MessageBody({
+  message,
+}: {
+  message: EmailThreadMessage;
+}) {
+  const [truncNoteOpen, setTruncNoteOpen] = useState(false);
+  const html = message.body_html.trim();
+  const text = message.body_text.trim();
+  const useHtml = html.length > 0;
+  const sanitized = useHtml ? sanitizeEmailHtmlFragment(html) : "";
+  const srcDoc = useHtml ? buildIframeSrcDoc(sanitized) : "";
+
+  return (
+    <div className="space-y-2 pt-2">
+      {useHtml ? (
+        <iframe
+          title="Email message body"
+          className="w-full min-h-[160px] rounded-md border border-border bg-white dark:bg-slate-950"
+          sandbox=""
+          srcDoc={srcDoc}
+        />
+      ) : (
+        <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed">
+          {text || "(No body)"}
+        </pre>
+      )}
+      {message.truncated && (
+        <TruncationNote expanded={truncNoteOpen} onToggle={() => setTruncNoteOpen((v) => !v)} />
+      )}
+    </div>
+  );
+}
+
+function AttachmentChips({
+  attachments,
+}: {
+  attachments: NonNullable<EmailThreadMessage["attachments"]>;
+}) {
+  if (attachments.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 pt-2">
+      <Paperclip className="text-muted-foreground size-3.5 shrink-0" aria-hidden="true" />
+      {attachments.map((a) => (
+        <Badge
+          key={`${a.filename}-${a.size_bytes}`}
+          variant="outline"
+          className="max-w-full truncate font-normal"
+        >
+          {a.filename}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function MessageBlock({ message }: { message: EmailThreadMessage }) {
+  const headingId = useId();
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="rounded-lg border border-border/80 bg-muted/20 p-3"
+    >
+      <MessageMeta message={message} headingId={headingId} />
+      <MessageBody message={message} />
+      {message.attachments && message.attachments.length > 0 && (
+        <AttachmentChips attachments={message.attachments} />
+      )}
+    </section>
+  );
+}
+
+export interface EmailThreadPreviewProps {
+  thread: EmailThread | null;
+  className?: string;
+}
+
+/**
+ * Renders normalized email thread context for approval of reply actions.
+ * HTML bodies are sanitized with DOMPurify and shown in a sandboxed iframe (no scripts in approval DOM).
+ */
+export function EmailThreadPreview({ thread, className }: EmailThreadPreviewProps) {
+  if (!thread || !Array.isArray(thread.messages) || thread.messages.length === 0) {
+    return (
+      <div
+        className={cn(
+          "rounded-xl border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        No conversation history was included with this request.
+      </div>
+    );
+  }
+
+  const messages = thread.messages;
+  const latest = messages[messages.length - 1];
+  if (!latest) {
+    return (
+      <div
+        className={cn(
+          "rounded-xl border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        No conversation history was included with this request.
+      </div>
+    );
+  }
+  const earlier = messages.length > 1 ? messages.slice(0, -1) : [];
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div>
+        <h3 className="text-base font-semibold leading-snug">{thread.subject || "(No subject)"}</h3>
+        <p className="text-muted-foreground mt-1 text-xs">Conversation (oldest to newest)</p>
+      </div>
+
+      {earlier.length > 0 && (
+        <details className="group rounded-lg border border-border bg-card">
+          <summary className="cursor-pointer list-none px-3 py-2 text-sm font-medium marker:content-none [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex w-full items-center justify-between gap-2">
+              <span>Earlier in this thread</span>
+              <span className="text-muted-foreground text-xs font-normal">
+                {earlier.length} message{earlier.length === 1 ? "" : "s"}
+              </span>
+            </span>
+          </summary>
+          <div className="space-y-3 border-t border-border px-3 py-3">
+            {earlier.map((m, i) => (
+              <MessageBlock key={m.message_id || `earlier-${i}`} message={m} />
+            ))}
+          </div>
+        </details>
+      )}
+
+      <div>
+        <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+          Latest in thread
+        </p>
+        <MessageBlock message={latest} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/previews/__tests__/EmailThreadPreview.test.tsx
+++ b/frontend/src/components/previews/__tests__/EmailThreadPreview.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import {
+  EmailThreadPreview,
+  parseEmailThreadFromDetails,
+  type EmailThread,
+} from "../EmailThreadPreview";
+
+function makeMessage(
+  overrides: Partial<EmailThread["messages"][number]> = {},
+): EmailThread["messages"][number] {
+  return {
+    from: "alice@example.com",
+    to: ["bob@example.com"],
+    cc: [],
+    date: "2026-04-20T12:00:00Z",
+    body_html: "<p>Hello</p>",
+    body_text: "Hello",
+    snippet: "Hello",
+    message_id: "m1",
+    truncated: false,
+    ...overrides,
+  };
+}
+
+describe("parseEmailThreadFromDetails", () => {
+  it("returns null for invalid shapes", () => {
+    expect(parseEmailThreadFromDetails(null)).toBeNull();
+    expect(parseEmailThreadFromDetails({})).toBeNull();
+    expect(parseEmailThreadFromDetails({ email_thread: "x" })).toBeNull();
+  });
+
+  it("parses a valid email_thread object", () => {
+    const thread: EmailThread = {
+      subject: "Re: Plan",
+      messages: [makeMessage({ message_id: "a" }), makeMessage({ message_id: "b", from: "bob@example.com" })],
+    };
+    const parsed = parseEmailThreadFromDetails({ email_thread: thread });
+    expect(parsed).toEqual(thread);
+  });
+});
+
+describe("EmailThreadPreview", () => {
+  it("renders subject and messages", () => {
+    const thread: EmailThread = {
+      subject: "Project update",
+      messages: [
+        makeMessage({
+          message_id: "1",
+          from: "alice@example.com",
+          body_html: "<p>First</p>",
+          body_text: "First",
+        }),
+        makeMessage({
+          message_id: "2",
+          from: "bob@example.com",
+          body_html: "<p>Second</p>",
+          body_text: "Second",
+        }),
+      ],
+    };
+    render(<EmailThreadPreview thread={thread} />);
+    expect(screen.getByText("Project update")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+  });
+
+  it("shows empty-thread fallback when messages is empty", () => {
+    render(<EmailThreadPreview thread={{ subject: "X", messages: [] }} />);
+    expect(
+      screen.getByText("No conversation history was included with this request."),
+    ).toBeInTheDocument();
+  });
+
+  it("strips script tags from HTML via sanitization (iframe srcdoc)", () => {
+    const thread: EmailThread = {
+      subject: "Unsafe",
+      messages: [
+        makeMessage({
+          message_id: "1",
+          body_html: '<p>Hi</p><script>document.body.dataset.x="bad"</script>',
+          body_text: "Hi",
+        }),
+      ],
+    };
+    const { container } = render(<EmailThreadPreview thread={thread} />);
+    const iframe = container.querySelector("iframe[title='Email message body']");
+    expect(iframe).toBeTruthy();
+    const srcdoc = iframe?.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).not.toContain("<script");
+    expect(srcdoc).toContain("<p>Hi</p>");
+  });
+
+  it("expands truncation note when Show more is clicked", async () => {
+    const user = userEvent.setup();
+    const thread: EmailThread = {
+      subject: "Trunc",
+      messages: [
+        makeMessage({
+          message_id: "1",
+          truncated: true,
+          body_html: "<p>Body</p>",
+          body_text: "Body",
+        }),
+      ],
+    };
+    render(<EmailThreadPreview thread={thread} />);
+    expect(screen.getByText(/truncated server-side/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /show more/i }));
+    expect(
+      screen.getByText(/shortened on the server/i),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles earlier messages in details", async () => {
+    const user = userEvent.setup();
+    const thread: EmailThread = {
+      subject: "Thread",
+      messages: [
+        makeMessage({
+          message_id: "old",
+          from: "old@example.com",
+          body_html: "<p>Old</p>",
+          body_text: "Old",
+        }),
+        makeMessage({
+          message_id: "new",
+          from: "new@example.com",
+          body_html: "<p>New</p>",
+          body_text: "New",
+        }),
+      ],
+    };
+    const { container } = render(<EmailThreadPreview thread={thread} />);
+    const detailsEl = container.querySelector("details");
+    expect(detailsEl).toBeTruthy();
+    if (!detailsEl) throw new Error("expected details");
+    expect(detailsEl.open).toBe(false);
+    await user.click(screen.getByText("Earlier in this thread"));
+    expect(detailsEl.open).toBe(true);
+    expect(within(detailsEl).getByText("old@example.com")).toBeVisible();
+    expect(screen.getByText("new@example.com")).toBeVisible();
+  });
+});

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -21,6 +21,11 @@ import { useAgents } from "@/hooks/useAgents";
 import { useStandingApprovals } from "@/hooks/useStandingApprovals";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { ActionPreviewCard } from "@/components/previews/ActionPreviewCard";
+import {
+  EmailThreadPreview,
+  EMAIL_REPLY_ACTION_TYPES,
+  parseEmailThreadFromDetails,
+} from "@/components/previews/EmailThreadPreview";
 import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import {
   useCountdown,
@@ -156,6 +161,12 @@ export function ReviewApprovalDialog({
     [standingApprovals, approval.agent_id, approval.action.type],
   );
   const showAlwaysAllow = hasParams && !standingApprovalsLoading && !hasExistingStandingApproval;
+
+  const emailThread = useMemo(
+    () => parseEmailThreadFromDetails(approval.context.details),
+    [approval.context.details],
+  );
+  const showEmailThreadPreview = EMAIL_REPLY_ACTION_TYPES.has(approval.action.type);
 
   // Auto-close dialog after successful approval (never while the nested standing-approval
   // wizard is open — a render with isApproved true before autoCloseBlocked flips true
@@ -348,15 +359,22 @@ export function ReviewApprovalDialog({
                   <Skeleton className="h-3 w-full" />
                 </div>
               ) : (
-                <ActionPreviewCard
-                  preview={preview}
-                  parameters={params}
-                  actionType={approval.action.type}
-                  schema={schema}
-                  actionName={actionName}
-                  displayTemplate={displayTemplate}
-                  resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
-                />
+                <>
+                  {showEmailThreadPreview && (
+                    <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
+                      <EmailThreadPreview thread={emailThread} />
+                    </div>
+                  )}
+                  <ActionPreviewCard
+                    preview={preview}
+                    parameters={params}
+                    actionType={approval.action.type}
+                    schema={schema}
+                    actionName={actionName}
+                    displayTemplate={displayTemplate}
+                    resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
+                  />
+                </>
               )}
             </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 2 (Web UI)** for [issue #975](https://github.com/supersuit-tech/permission-slip/issues/975): show normalized `context.details.email_thread` on the dashboard approval dialog for `google.send_email_reply` and `microsoft.send_email_reply`.

- New `EmailThreadPreview` component: subject, latest message expanded, earlier messages in a collapsible **Earlier in this thread** section, attachment filename chips (no download), server-side truncation note with **Show more** / **Show less**.
- HTML bodies are sanitized with DOMPurify and rendered in a **sandboxed** `<iframe srcDoc>` (empty sandbox — no scripts/plugins) so content stays out of the approval document.
- Runtime parsing/validation of `email_thread` so malformed API data does not break the dialog.

## Test plan

- [x] `make test-frontend`
- [x] `cd frontend && npm run build`
- [ ] Manual: open a pending email-reply approval and confirm thread + reply preview both appear.

Refs #975
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe84d2d2-1f60-4406-83b1-63c8db60008d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe84d2d2-1f60-4406-83b1-63c8db60008d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

