### PR TITLE
feat(slack): message lifecycle actions populate slack_context (PR2 / #981)

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -304,7 +304,10 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		contextForStore := mergeEmailThreadFromResourceDetailsIntoContext(req.Context, resourceDetails)
+		contextForStore := mergeSlackContextFromResourceDetailsIntoContext(
+			mergeEmailThreadFromResourceDetailsIntoContext(req.Context, resourceDetails),
+			resourceDetails,
+		)
 
 		approval, err := db.InsertApproval(r.Context(), deps.DB, db.InsertApprovalParams{
 			ApprovalID:      approvalID,

--- a/api/approval_slack_context.go
+++ b/api/approval_slack_context.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"encoding/json"
+)
+
+// mergeSlackContextFromResourceDetailsIntoContext copies slack_context from resolved
+// resource_details into context.details.slack_context for approval UI (issue #981).
+// If resource_details is nil or has no slack_context, returns contextJSON unchanged.
+func mergeSlackContextFromResourceDetailsIntoContext(contextJSON json.RawMessage, resourceDetails []byte) json.RawMessage {
+	if len(resourceDetails) == 0 {
+		return contextJSON
+	}
+	var rd map[string]json.RawMessage
+	if err := json.Unmarshal(resourceDetails, &rd); err != nil {
+		return contextJSON
+	}
+	scRaw, ok := rd["slack_context"]
+	if !ok || len(scRaw) == 0 {
+		return contextJSON
+	}
+
+	var ctxObj map[string]json.RawMessage
+	if err := json.Unmarshal(contextJSON, &ctxObj); err != nil || ctxObj == nil {
+		return contextJSON
+	}
+	detailsRaw, hasDetails := ctxObj["details"]
+	var detailsObj map[string]json.RawMessage
+	if hasDetails && len(detailsRaw) > 0 {
+		_ = json.Unmarshal(detailsRaw, &detailsObj)
+	}
+	if detailsObj == nil {
+		detailsObj = map[string]json.RawMessage{}
+	}
+	if _, exists := detailsObj["slack_context"]; exists {
+		return contextJSON
+	}
+	detailsObj["slack_context"] = scRaw
+	mergedDetails, err := json.Marshal(detailsObj)
+	if err != nil {
+		return contextJSON
+	}
+	ctxObj["details"] = mergedDetails
+	out, err := json.Marshal(ctxObj)
+	if err != nil {
+		return contextJSON
+	}
+	if len(out) > 65536 {
+		return contextJSON
+	}
+	return out
+}

--- a/api/approval_slack_context_test.go
+++ b/api/approval_slack_context_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMergeSlackContextFromResourceDetailsIntoContext(t *testing.T) {
+	ctxIn := []byte(`{"description":"x","details":{"foo":"bar"}}`)
+	rd, _ := json.Marshal(map[string]any{
+		"slack_context": map[string]any{
+			"context_scope": "recent_channel",
+			"channel": map[string]any{
+				"id":        "C1",
+				"permalink": "https://acme.slack.com/archives/C1",
+			},
+		},
+	})
+	out := mergeSlackContextFromResourceDetailsIntoContext(ctxIn, rd)
+	var parsed map[string]any
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	details := parsed["details"].(map[string]any)
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != "recent_channel" {
+		t.Fatalf("slack_context: %+v", sc)
+	}
+}
+
+func TestMergeSlackContextFromResourceDetailsIntoContext_SizeCap(t *testing.T) {
+	long := strings.Repeat("a", 65380)
+	ctxIn := []byte(`{"description":"` + long + `","details":{}}`)
+	if len(ctxIn) >= 65536 {
+		t.Fatalf("setup: context len %d", len(ctxIn))
+	}
+	sc := map[string]any{"context_scope": "metadata_only", "big": strings.Repeat("b", 500)}
+	rd, _ := json.Marshal(map[string]any{"slack_context": sc})
+	out := mergeSlackContextFromResourceDetailsIntoContext(ctxIn, rd)
+	if len(out) > 65536 {
+		t.Fatalf("merged unexpectedly long: %d", len(out))
+	}
+	if string(out) != string(ctxIn) {
+		t.Fatal("expected merge skipped when over size cap")
+	}
+}

--- a/connectors/slack/context/fetch_helpers.go
+++ b/connectors/slack/context/fetch_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
@@ -223,4 +224,87 @@ func FetchDMHistory(ctx context.Context, api SlackAPI, peerUserID string, creds 
 		messages = append(messages, cm)
 	}
 	return SentinelNone, messages, imChannelID, nil
+}
+
+const (
+	surroundBefore = 3
+	surroundAfter  = 3
+)
+
+// MessageWindowAroundResult is the target message plus nearby channel messages (same 24h window as FetchRecentMessages).
+type MessageWindowAroundResult struct {
+	Target ContextMessage
+	// TargetThreadRootTS is set when the target is a thread reply (Slack thread_ts); empty for top-level messages.
+	TargetThreadRootTS string
+	RecentSurrounding  []ContextMessage
+}
+
+// FetchMessageWindowAroundTS loads messages from the last 24h, finds the message with ts,
+// and returns it as Target plus up to surroundBefore/surroundAfter neighbors (oldest first).
+// If the target ts is not in the window, Target.TS is empty and RecentSurrounding is nil.
+func FetchMessageWindowAroundTS(ctx context.Context, api SlackAPI, channelID, targetTS string, creds connectors.Credentials, cache *sessionCache, mcache *MentionCache) (MessageWindowAroundResult, error) {
+	var out MessageWindowAroundResult
+	if err := validateChannelID(channelID); err != nil {
+		return out, err
+	}
+	if strings.TrimSpace(targetTS) == "" {
+		return out, &connectors.ValidationError{Message: "missing message ts for Slack context"}
+	}
+	sess, err := resolveSession(ctx, api, creds, cache)
+	if err != nil {
+		return out, err
+	}
+	cutoff := time.Now().Add(-recentWindowHours * time.Hour).UTC()
+	oldestTS := fmt.Sprintf("%d.%06d", cutoff.Unix(), cutoff.Nanosecond()/1000)
+	body := readChannelHistoryRequest{
+		Channel: channelID,
+		Limit:   100,
+		Oldest:  oldestTS,
+	}
+	var resp messagesResponse
+	if err := api.Post(ctx, "conversations.history", creds, body, &resp); err != nil {
+		return out, err
+	}
+	if !resp.OK {
+		return out, mapSlackErr(resp.Error)
+	}
+	raw := filterMessagesByAge(resp.Messages, cutoff)
+	sortMessagesOldestFirst(raw)
+	idx := -1
+	for i := range raw {
+		if raw[i].TS == targetTS {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return out, nil
+	}
+	targetSlack := raw[idx]
+	tcm, err := messageToContextMessage(ctx, api, creds, sess.TeamDomain, channelID, targetSlack, mcache)
+	if err != nil {
+		return out, err
+	}
+	out.Target = tcm
+	if targetSlack.ThreadTS != "" && targetSlack.ThreadTS != targetSlack.TS {
+		out.TargetThreadRootTS = targetSlack.ThreadTS
+	}
+	start := idx - surroundBefore
+	if start < 0 {
+		start = 0
+	}
+	end := idx + surroundAfter + 1
+	if end > len(raw) {
+		end = len(raw)
+	}
+	window := raw[start:end]
+	out.RecentSurrounding = make([]ContextMessage, 0, len(window))
+	for _, m := range window {
+		cm, err := messageToContextMessage(ctx, api, creds, sess.TeamDomain, channelID, m, mcache)
+		if err != nil {
+			return out, err
+		}
+		out.RecentSurrounding = append(out.RecentSurrounding, cm)
+	}
+	return out, nil
 }

--- a/connectors/slack/context/open_dm.go
+++ b/connectors/slack/context/open_dm.go
@@ -1,0 +1,23 @@
+package context
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// OpenIMChannel opens (or reuses) a DM with the given user and returns the IM channel ID.
+func OpenIMChannel(ctx context.Context, api SlackAPI, userID string, creds connectors.Credentials) (string, error) {
+	if userID == "" {
+		return "", &connectors.ValidationError{Message: "missing user id for DM open"}
+	}
+	openBody := conversationsOpenRequest{Users: userID}
+	var openResp conversationsOpenResponse
+	if err := api.Post(ctx, "conversations.open", creds, openBody, &openResp); err != nil {
+		return "", err
+	}
+	if !openResp.OK {
+		return "", mapSlackErr(openResp.Error)
+	}
+	return openResp.Channel.ID, nil
+}

--- a/connectors/slack/context/session.go
+++ b/connectors/slack/context/session.go
@@ -18,6 +18,9 @@ type sessionCache struct {
 	info *sessionInfo
 }
 
+// SessionCache caches auth.test for a single ResolveResourceDetails / context build.
+type SessionCache = sessionCache
+
 func (c *sessionCache) get() *sessionInfo {
 	if c == nil {
 		return nil

--- a/connectors/slack/context/user.go
+++ b/connectors/slack/context/user.go
@@ -6,6 +6,11 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
+// FetchUserRef loads display fields for a Slack user ID (users.info).
+func FetchUserRef(ctx context.Context, api SlackAPI, creds connectors.Credentials, userID string) (*UserRef, error) {
+	return fetchUserRef(ctx, api, creds, userID)
+}
+
 func fetchUserRef(ctx context.Context, api SlackAPI, creds connectors.Credentials, userID string) (*UserRef, error) {
 	if userID == "" {
 		return nil, nil

--- a/connectors/slack/resolve_resource_details.go
+++ b/connectors/slack/resolve_resource_details.go
@@ -7,20 +7,42 @@ import (
 	"strings"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
+	slackctx "github.com/supersuit-tech/permission-slip/connectors/slack/context"
 )
 
 // ResolveResourceDetails fetches human-readable metadata for resources
 // referenced by opaque IDs in Slack action parameters. For channel-based
 // actions it resolves channel IDs to names; for user-based actions it
-// resolves user IDs to display names. Errors are non-fatal — the caller
+// resolves user IDs to display names. Message-lifecycle actions also
+// populate slack_context (issue #981). Errors are non-fatal — the caller
 // stores the approval without details on failure.
 func (c *SlackConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	var cache slackctx.SessionCache
 	switch actionType {
+	case "slack.send_message":
+		sc, _ := buildSendMessageContext(ctx, c, creds, params, &cache)
+		return mergeLifecycleResourceDetails(ctx, c, creds, actionType, params, sc), nil
+
+	case "slack.schedule_message":
+		sc, _ := buildScheduleMessageContext(ctx, c, creds, params, &cache)
+		return mergeLifecycleResourceDetails(ctx, c, creds, actionType, params, sc), nil
+
+	case "slack.send_dm":
+		sc, _ := buildSendDMContext(ctx, c, creds, params, &cache)
+		return mergeLifecycleResourceDetails(ctx, c, creds, actionType, params, sc), nil
+
+	case "slack.update_message":
+		sc, _ := buildUpdateMessageContext(ctx, c, creds, params, &cache)
+		return mergeLifecycleResourceDetails(ctx, c, creds, actionType, params, sc), nil
+
+	case "slack.delete_message":
+		sc, _ := buildDeleteMessageContext(ctx, c, creds, params, &cache)
+		return mergeLifecycleResourceDetails(ctx, c, creds, actionType, params, sc), nil
+
 	// Channel-based actions
-	case "slack.send_message", "slack.read_channel_messages", "slack.read_thread",
-		"slack.schedule_message", "slack.set_topic", "slack.invite_to_channel",
-		"slack.upload_file", "slack.add_reaction", "slack.update_message",
-		"slack.delete_message",
+	case "slack.read_channel_messages", "slack.read_thread",
+		"slack.set_topic", "slack.invite_to_channel",
+		"slack.upload_file", "slack.add_reaction",
 		"slack.remove_from_channel", "slack.remove_reaction", "slack.pin_message",
 		"slack.unpin_message", "slack.archive_channel", "slack.rename_channel":
 		return c.resolveChannel(ctx, creds, params)
@@ -28,13 +50,44 @@ func (c *SlackConnector) ResolveResourceDetails(ctx context.Context, actionType 
 	case "slack.search_messages":
 		return c.resolveSearchMessagesChannel(ctx, creds, params)
 
-	// User-based actions
-	case "slack.send_dm":
-		return c.resolveUser(ctx, creds, params)
-
 	default:
 		return nil, nil
 	}
+}
+
+func mergeLifecycleResourceDetails(ctx context.Context, c *SlackConnector, creds connectors.Credentials, actionType string, params json.RawMessage, sc *slackctx.SlackContext) map[string]any {
+	out := map[string]any{}
+	switch actionType {
+	case "slack.send_message", "slack.schedule_message", "slack.update_message", "slack.delete_message":
+		if legacy, err := c.resolveChannel(ctx, creds, params); err == nil && legacy != nil {
+			for k, v := range legacy {
+				out[k] = v
+			}
+		}
+	case "slack.send_dm":
+		if legacy, err := c.resolveUser(ctx, creds, params); err == nil && legacy != nil {
+			for k, v := range legacy {
+				out[k] = v
+			}
+		}
+	}
+	if actionType == "slack.schedule_message" {
+		var sp scheduleMessageParams
+		if err := json.Unmarshal(params, &sp); err == nil {
+			if u, err := sp.postAtUnix(); err == nil {
+				out["post_at"] = u
+			}
+		}
+	}
+	if sc != nil {
+		if b, err := json.Marshal(sc); err == nil {
+			var asMap map[string]any
+			if err := json.Unmarshal(b, &asMap); err == nil {
+				out["slack_context"] = asMap
+			}
+		}
+	}
+	return out
 }
 
 // resolveSearchMessagesChannel resolves an optional channel ID for

--- a/connectors/slack/resolve_resource_details_test.go
+++ b/connectors/slack/resolve_resource_details_test.go
@@ -3,9 +3,11 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func testSlackResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *SlackConnector) {
@@ -34,10 +36,9 @@ func TestResolveResourceDetails_Channel(t *testing.T) {
 	defer srv.Close()
 
 	channelActions := []string{
-		"slack.send_message", "slack.read_channel_messages", "slack.read_thread",
-		"slack.schedule_message", "slack.set_topic", "slack.invite_to_channel",
-		"slack.upload_file", "slack.add_reaction", "slack.update_message",
-		"slack.delete_message",
+		"slack.read_channel_messages", "slack.read_thread",
+		"slack.set_topic", "slack.invite_to_channel",
+		"slack.upload_file", "slack.add_reaction",
 		"slack.remove_from_channel", "slack.remove_reaction", "slack.pin_message",
 		"slack.unpin_message", "slack.archive_channel", "slack.rename_channel",
 	}
@@ -58,24 +59,50 @@ func TestResolveResourceDetails_Channel(t *testing.T) {
 func TestResolveResourceDetails_PrivateChannel(t *testing.T) {
 	t.Parallel()
 
-	srv, conn := testSlackResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	ts := fmt.Sprintf("%d.%06d", now.Add(-1*time.Hour).Unix(), 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"ok": true,
-			"channel": map[string]any{
-				"name":       "secret-plans",
-				"is_private": true,
-			},
-		})
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://x.slack.com/", "user_id": "U1"})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id":          "G0AMRGKRTA4",
+					"name":        "secret-plans",
+					"is_private":  true,
+					"topic":       map[string]any{"value": ""},
+					"purpose":     map[string]any{"value": ""},
+					"num_members": 2,
+				},
+			})
+		case "/conversations.history":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"user": "U1", "text": "x", "ts": ts},
+				},
+			})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U1", "name": "a", "profile": map[string]any{}},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
 	}))
 	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
 
-	params, _ := json.Marshal(map[string]string{"channel": "G0AMRGKRTA4"})
+	params, _ := json.Marshal(map[string]string{"channel": "G0AMRGKRTA4", "message": "hi"})
 	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_message", params, validCreds())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Private channels should not get # prefix.
+	// Private channels should not get # prefix on legacy channel_name.
 	if details["channel_name"] != "secret-plans" {
 		t.Errorf("expected channel_name 'secret-plans', got %v", details["channel_name"])
 	}

--- a/connectors/slack/resolve_slack_context.go
+++ b/connectors/slack/resolve_slack_context.go
@@ -31,7 +31,7 @@ func buildSendMessageContext(ctx context.Context, c *SlackConnector, creds conne
 	if p.ThreadTS != "" {
 		parent, replies, truncated, err := slackctx.FetchThread(ctx, c, p.Channel, p.ThreadTS, creds, cache, mcache)
 		if err != nil {
-			if sc, ok := slackctx.HandleRateLimit(err); ok {
+			if _, ok := slackctx.HandleRateLimit(err); ok {
 				out.ContextScope = slackctx.ScopeMetadataOnly
 				return out, nil
 			}
@@ -39,7 +39,7 @@ func buildSendMessageContext(ctx context.Context, c *SlackConnector, creds conne
 		}
 		out.ContextScope = slackctx.ScopeThread
 		out.Thread = &slackctx.ThreadBlock{Parent: &parent, Replies: replies, Truncated: truncated}
-		slackctx.WithLastActivity(out.Channel, append(threadTSToList(parent.TS, replies)...)...)
+		slackctx.WithLastActivity(out.Channel, threadTSToList(parent.TS, replies)...)
 		return out, nil
 	}
 	opts := slackctx.RecentMessagesOpts{}
@@ -48,7 +48,7 @@ func buildSendMessageContext(ctx context.Context, c *SlackConnector, creds conne
 	}
 	recent, err := slackctx.FetchRecentMessages(ctx, c, p.Channel, creds, cache, opts, mcache)
 	if err != nil {
-		if sc, ok := slackctx.HandleRateLimit(err); ok {
+		if _, ok := slackctx.HandleRateLimit(err); ok {
 			out.ContextScope = slackctx.ScopeMetadataOnly
 			return out, nil
 		}
@@ -84,7 +84,7 @@ func buildScheduleMessageContext(ctx context.Context, c *SlackConnector, creds c
 	if p.ThreadTS != "" {
 		parent, replies, truncated, err := slackctx.FetchThread(ctx, c, p.Channel, p.ThreadTS, creds, cache, mcache)
 		if err != nil {
-			if sc, ok := slackctx.HandleRateLimit(err); ok {
+			if _, ok := slackctx.HandleRateLimit(err); ok {
 				out.ContextScope = slackctx.ScopeMetadataOnly
 				return out, nil
 			}
@@ -92,7 +92,7 @@ func buildScheduleMessageContext(ctx context.Context, c *SlackConnector, creds c
 		}
 		out.ContextScope = slackctx.ScopeThread
 		out.Thread = &slackctx.ThreadBlock{Parent: &parent, Replies: replies, Truncated: truncated}
-		slackctx.WithLastActivity(out.Channel, append(threadTSToList(parent.TS, replies)...)...)
+		slackctx.WithLastActivity(out.Channel, threadTSToList(parent.TS, replies)...)
 		return out, nil
 	}
 	opts := slackctx.RecentMessagesOpts{}
@@ -101,7 +101,7 @@ func buildScheduleMessageContext(ctx context.Context, c *SlackConnector, creds c
 	}
 	recent, err := slackctx.FetchRecentMessages(ctx, c, p.Channel, creds, cache, opts, mcache)
 	if err != nil {
-		if sc, ok := slackctx.HandleRateLimit(err); ok {
+		if _, ok := slackctx.HandleRateLimit(err); ok {
 			out.ContextScope = slackctx.ScopeMetadataOnly
 			return out, nil
 		}
@@ -125,15 +125,15 @@ func buildSendDMContext(ctx context.Context, c *SlackConnector, creds connectors
 	mcache := &slackctx.MentionCache{}
 	recipient, err := slackctx.FetchUserRef(ctx, c, creds, p.UserID)
 	if err != nil {
-		if sc, ok := slackctx.HandleRateLimit(err); ok {
-			return sc, nil
+		if rl, ok := slackctx.HandleRateLimit(err); ok {
+			return rl, nil
 		}
 		return nil, err
 	}
 	out := &slackctx.SlackContext{Recipient: recipient}
 	sentinel, msgs, imCh, err := slackctx.FetchDMHistory(ctx, c, p.UserID, creds, cache, mcache)
 	if err != nil {
-		if sc, ok := slackctx.HandleRateLimit(err); ok {
+		if _, ok := slackctx.HandleRateLimit(err); ok {
 			out.ContextScope = slackctx.ScopeMetadataOnly
 			return out, nil
 		}
@@ -221,7 +221,7 @@ func buildMessageTargetContext(ctx context.Context, c *SlackConnector, creds con
 	out := &slackctx.SlackContext{Channel: chMeta}
 	win, err := slackctx.FetchMessageWindowAroundTS(ctx, c, channelID, ts, creds, cache, mcache)
 	if err != nil {
-		if sc, ok := slackctx.HandleRateLimit(err); ok {
+		if _, ok := slackctx.HandleRateLimit(err); ok {
 			out.ContextScope = slackctx.ScopeMetadataOnly
 			return out, nil
 		}
@@ -234,7 +234,7 @@ func buildMessageTargetContext(ctx context.Context, c *SlackConnector, creds con
 	if win.TargetThreadRootTS != "" {
 		parent, replies, truncated, err := slackctx.FetchThread(ctx, c, channelID, win.TargetThreadRootTS, creds, cache, mcache)
 		if err != nil {
-			if sc, ok := slackctx.HandleRateLimit(err); ok {
+			if _, ok := slackctx.HandleRateLimit(err); ok {
 				out.ContextScope = slackctx.ScopeMetadataOnly
 				return out, nil
 			}
@@ -246,7 +246,7 @@ func buildMessageTargetContext(ctx context.Context, c *SlackConnector, creds con
 		if out.TargetMessage == nil {
 			out.TargetMessage = &win.Target
 		}
-		slackctx.WithLastActivity(out.Channel, append(threadTSToList(parent.TS, replies)...)...)
+		slackctx.WithLastActivity(out.Channel, threadTSToList(parent.TS, replies)...)
 		return out, nil
 	}
 	out.ContextScope = slackctx.ScopeRecentChannel

--- a/connectors/slack/resolve_slack_context.go
+++ b/connectors/slack/resolve_slack_context.go
@@ -1,0 +1,286 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	slackctx "github.com/supersuit-tech/permission-slip/connectors/slack/context"
+)
+
+func buildSendMessageContext(ctx context.Context, c *SlackConnector, creds connectors.Credentials, params json.RawMessage, cache *slackctx.SessionCache) (*slackctx.SlackContext, error) {
+	var p sendMessageParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	mcache := &slackctx.MentionCache{}
+	chMeta, err := slackctx.FetchChannelMeta(ctx, c, p.Channel, creds, cache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			if chMeta != nil {
+				sc.Channel = chMeta
+			}
+			return sc, nil
+		}
+		return nil, err
+	}
+	out := &slackctx.SlackContext{Channel: chMeta}
+	if p.ThreadTS != "" {
+		parent, replies, truncated, err := slackctx.FetchThread(ctx, c, p.Channel, p.ThreadTS, creds, cache, mcache)
+		if err != nil {
+			if sc, ok := slackctx.HandleRateLimit(err); ok {
+				out.ContextScope = slackctx.ScopeMetadataOnly
+				return out, nil
+			}
+			return nil, err
+		}
+		out.ContextScope = slackctx.ScopeThread
+		out.Thread = &slackctx.ThreadBlock{Parent: &parent, Replies: replies, Truncated: truncated}
+		slackctx.WithLastActivity(out.Channel, append(threadTSToList(parent.TS, replies)...)...)
+		return out, nil
+	}
+	opts := slackctx.RecentMessagesOpts{}
+	if p.InResponseToTS != "" {
+		opts.AnchorTS = p.InResponseToTS
+	}
+	recent, err := slackctx.FetchRecentMessages(ctx, c, p.Channel, creds, cache, opts, mcache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			out.ContextScope = slackctx.ScopeMetadataOnly
+			return out, nil
+		}
+		return nil, err
+	}
+	out.ContextScope = slackctx.ScopeRecentChannel
+	out.RecentMessages = recent
+	out.ContextWindow = &slackctx.ContextWindow{MessageCount: len(recent), Hours: 24}
+	slackctx.WithLastActivity(out.Channel, tsListFromMessages(recent)...)
+	return out, nil
+}
+
+func buildScheduleMessageContext(ctx context.Context, c *SlackConnector, creds connectors.Credentials, params json.RawMessage, cache *slackctx.SessionCache) (*slackctx.SlackContext, error) {
+	var p scheduleMessageParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	mcache := &slackctx.MentionCache{}
+	chMeta, err := slackctx.FetchChannelMeta(ctx, c, p.Channel, creds, cache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			if chMeta != nil {
+				sc.Channel = chMeta
+			}
+			return sc, nil
+		}
+		return nil, err
+	}
+	out := &slackctx.SlackContext{Channel: chMeta}
+	if p.ThreadTS != "" {
+		parent, replies, truncated, err := slackctx.FetchThread(ctx, c, p.Channel, p.ThreadTS, creds, cache, mcache)
+		if err != nil {
+			if sc, ok := slackctx.HandleRateLimit(err); ok {
+				out.ContextScope = slackctx.ScopeMetadataOnly
+				return out, nil
+			}
+			return nil, err
+		}
+		out.ContextScope = slackctx.ScopeThread
+		out.Thread = &slackctx.ThreadBlock{Parent: &parent, Replies: replies, Truncated: truncated}
+		slackctx.WithLastActivity(out.Channel, append(threadTSToList(parent.TS, replies)...)...)
+		return out, nil
+	}
+	opts := slackctx.RecentMessagesOpts{}
+	if p.InResponseToTS != "" {
+		opts.AnchorTS = p.InResponseToTS
+	}
+	recent, err := slackctx.FetchRecentMessages(ctx, c, p.Channel, creds, cache, opts, mcache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			out.ContextScope = slackctx.ScopeMetadataOnly
+			return out, nil
+		}
+		return nil, err
+	}
+	out.ContextScope = slackctx.ScopeRecentChannel
+	out.RecentMessages = recent
+	out.ContextWindow = &slackctx.ContextWindow{MessageCount: len(recent), Hours: 24}
+	slackctx.WithLastActivity(out.Channel, tsListFromMessages(recent)...)
+	return out, nil
+}
+
+func buildSendDMContext(ctx context.Context, c *SlackConnector, creds connectors.Credentials, params json.RawMessage, cache *slackctx.SessionCache) (*slackctx.SlackContext, error) {
+	var p sendDMParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	mcache := &slackctx.MentionCache{}
+	recipient, err := slackctx.FetchUserRef(ctx, c, creds, p.UserID)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			return sc, nil
+		}
+		return nil, err
+	}
+	out := &slackctx.SlackContext{Recipient: recipient}
+	sentinel, msgs, imCh, err := slackctx.FetchDMHistory(ctx, c, p.UserID, creds, cache, mcache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			out.ContextScope = slackctx.ScopeMetadataOnly
+			return out, nil
+		}
+		return nil, err
+	}
+	switch sentinel {
+	case slackctx.SentinelSelfDM:
+		out.ContextScope = slackctx.ScopeSelfDM
+		imID := imCh
+		if imID == "" {
+			if opened, err := slackctx.OpenIMChannel(ctx, c, p.UserID, creds); err == nil {
+				imID = opened
+			} else if _, ok := slackctx.HandleRateLimit(err); ok {
+				out.ContextScope = slackctx.ScopeMetadataOnly
+				return out, nil
+			}
+		}
+		if imID != "" {
+			if chMeta, err := slackctx.FetchChannelMeta(ctx, c, imID, creds, cache); err == nil {
+				out.Channel = chMeta
+			} else if _, ok := slackctx.HandleRateLimit(err); ok {
+				out.ContextScope = slackctx.ScopeMetadataOnly
+			}
+		}
+		return out, nil
+	case slackctx.SentinelFirstContact:
+		out.ContextScope = slackctx.ScopeFirstContactDM
+		if imCh != "" {
+			if chMeta, err := slackctx.FetchChannelMeta(ctx, c, imCh, creds, cache); err == nil {
+				out.Channel = chMeta
+			} else if _, ok := slackctx.HandleRateLimit(err); ok {
+				out.ContextScope = slackctx.ScopeMetadataOnly
+			}
+		}
+		return out, nil
+	}
+	out.ContextScope = slackctx.ScopeRecentDM
+	out.RecentMessages = msgs
+	out.ContextWindow = &slackctx.ContextWindow{MessageCount: len(msgs), Hours: 24}
+	if imCh != "" {
+		if chMeta, err := slackctx.FetchChannelMeta(ctx, c, imCh, creds, cache); err == nil {
+			slackctx.WithLastActivity(chMeta, tsListFromMessages(msgs)...)
+			out.Channel = chMeta
+		} else if _, ok := slackctx.HandleRateLimit(err); ok {
+			out.ContextScope = slackctx.ScopeMetadataOnly
+		}
+	}
+	return out, nil
+}
+
+func buildUpdateMessageContext(ctx context.Context, c *SlackConnector, creds connectors.Credentials, params json.RawMessage, cache *slackctx.SessionCache) (*slackctx.SlackContext, error) {
+	var p updateMessageParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	return buildMessageTargetContext(ctx, c, creds, p.Channel, p.TS, cache)
+}
+
+func buildDeleteMessageContext(ctx context.Context, c *SlackConnector, creds connectors.Credentials, params json.RawMessage, cache *slackctx.SessionCache) (*slackctx.SlackContext, error) {
+	var p deleteMessageParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	return buildMessageTargetContext(ctx, c, creds, p.Channel, p.TS, cache)
+}
+
+func buildMessageTargetContext(ctx context.Context, c *SlackConnector, creds connectors.Credentials, channelID, ts string, cache *slackctx.SessionCache) (*slackctx.SlackContext, error) {
+	mcache := &slackctx.MentionCache{}
+	chMeta, err := slackctx.FetchChannelMeta(ctx, c, channelID, creds, cache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			if chMeta != nil {
+				sc.Channel = chMeta
+			}
+			return sc, nil
+		}
+		return nil, err
+	}
+	out := &slackctx.SlackContext{Channel: chMeta}
+	win, err := slackctx.FetchMessageWindowAroundTS(ctx, c, channelID, ts, creds, cache, mcache)
+	if err != nil {
+		if sc, ok := slackctx.HandleRateLimit(err); ok {
+			out.ContextScope = slackctx.ScopeMetadataOnly
+			return out, nil
+		}
+		return nil, err
+	}
+	if win.Target.TS == "" {
+		out.ContextScope = slackctx.ScopeMetadataOnly
+		return out, nil
+	}
+	if win.TargetThreadRootTS != "" {
+		parent, replies, truncated, err := slackctx.FetchThread(ctx, c, channelID, win.TargetThreadRootTS, creds, cache, mcache)
+		if err != nil {
+			if sc, ok := slackctx.HandleRateLimit(err); ok {
+				out.ContextScope = slackctx.ScopeMetadataOnly
+				return out, nil
+			}
+			return nil, err
+		}
+		out.ContextScope = slackctx.ScopeThread
+		out.Thread = &slackctx.ThreadBlock{Parent: &parent, Replies: replies, Truncated: truncated}
+		out.TargetMessage = findTargetInThread(parent, replies, ts)
+		if out.TargetMessage == nil {
+			out.TargetMessage = &win.Target
+		}
+		slackctx.WithLastActivity(out.Channel, append(threadTSToList(parent.TS, replies)...)...)
+		return out, nil
+	}
+	out.ContextScope = slackctx.ScopeRecentChannel
+	out.TargetMessage = &win.Target
+	out.RecentMessages = win.RecentSurrounding
+	out.ContextWindow = &slackctx.ContextWindow{MessageCount: len(win.RecentSurrounding), Hours: 24}
+	slackctx.WithLastActivity(out.Channel, tsListFromMessages(win.RecentSurrounding)...)
+	return out, nil
+}
+
+func threadTSToList(parentTS string, replies []slackctx.ContextMessage) []string {
+	out := []string{parentTS}
+	for _, r := range replies {
+		out = append(out, r.TS)
+	}
+	return out
+}
+
+func tsListFromMessages(msgs []slackctx.ContextMessage) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.TS)
+	}
+	return out
+}
+
+func findTargetInThread(parent slackctx.ContextMessage, replies []slackctx.ContextMessage, ts string) *slackctx.ContextMessage {
+	if parent.TS == ts {
+		return &parent
+	}
+	for i := range replies {
+		if replies[i].TS == ts {
+			return &replies[i]
+		}
+	}
+	return nil
+}

--- a/connectors/slack/resolve_slack_context_test.go
+++ b/connectors/slack/resolve_slack_context_test.go
@@ -196,8 +196,9 @@ func TestResolveScheduleMessage_PostAtInResourceDetails(t *testing.T) {
 
 func TestResolveUpdateMessage_ThreadedTarget(t *testing.T) {
 	t.Parallel()
-	rootTS := "50.000000"
-	targetTS := "50.000001"
+	now := time.Now().UTC()
+	rootTS := fmt.Sprintf("%d.%06d", now.Add(-2*time.Hour).Unix(), 0)
+	targetTS := fmt.Sprintf("%d.%06d", now.Add(-1*time.Hour).Unix(), 0)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {

--- a/connectors/slack/resolve_slack_context_test.go
+++ b/connectors/slack/resolve_slack_context_test.go
@@ -1,0 +1,387 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	slackctx "github.com/supersuit-tech/permission-slip/connectors/slack/context"
+)
+
+func testAuthAndChannelServer(t *testing.T, historyMsgs []map[string]any) (*httptest.Server, *SlackConnector) {
+	t.Helper()
+	now := time.Now().UTC()
+	ts1 := fmt.Sprintf("%d.%06d", now.Add(-2*time.Hour).Unix(), 0)
+	ts2 := fmt.Sprintf("%d.%06d", now.Add(-1*time.Hour).Unix(), 0)
+	if len(historyMsgs) == 0 {
+		historyMsgs = []map[string]any{
+			{"user": "U1", "text": "hello <@U2>", "ts": ts1},
+			{"user": "U1", "text": "world", "ts": ts2},
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"url":     "https://acme.slack.com/",
+				"user_id": "U9",
+			})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id":          "C1",
+					"name":        "general",
+					"is_private":  false,
+					"is_im":       false,
+					"is_mpim":     false,
+					"num_members": 3,
+					"topic":       map[string]any{"value": "t"},
+					"purpose":     map[string]any{"value": "p"},
+				},
+			})
+		case "/conversations.history":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"messages": historyMsgs,
+			})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"user": map[string]any{
+					"id":        "U1",
+					"name":      "alice",
+					"real_name": "Alice",
+					"profile": map[string]any{
+						"title":          "",
+						"image_original": "",
+						"image_512":      "",
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return srv, newForTest(srv.Client(), srv.URL)
+}
+
+func TestResolveSendMessage_RecentChannel(t *testing.T) {
+	t.Parallel()
+	srv, conn := testAuthAndChannelServer(t, nil)
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C1",
+		"message": "hi",
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_message", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc, ok := details["slack_context"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing slack_context: %#v", details)
+	}
+	if sc["context_scope"] != string(slackctx.ScopeRecentChannel) {
+		t.Fatalf("scope %v", sc["context_scope"])
+	}
+	if details["channel_name"] != "#general" {
+		t.Fatalf("legacy channel_name: %v", details["channel_name"])
+	}
+}
+
+func TestResolveSendMessage_Thread(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	parentTS := "100.000000"
+	replyTS := fmt.Sprintf("%d.%06d", now.Add(-30*time.Minute).Unix(), 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://acme.slack.com/", "user_id": "U9"})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id": "C1", "name": "general", "is_private": false,
+					"topic": map[string]any{"value": ""}, "purpose": map[string]any{"value": ""},
+				},
+			})
+		case "/conversations.replies":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"user": "U1", "text": "parent", "ts": parentTS},
+					{"user": "U1", "text": "reply", "ts": replyTS},
+				},
+			})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U1", "name": "a", "profile": map[string]any{}},
+			})
+		default:
+			t.Errorf("unexpected %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
+
+	params, _ := json.Marshal(map[string]string{
+		"channel":   "C1",
+		"message":   "hi",
+		"thread_ts": parentTS,
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_message", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != string(slackctx.ScopeThread) {
+		t.Fatalf("got %v", sc["context_scope"])
+	}
+}
+
+func TestResolveSendMessage_RateLimitDegrades(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://x.slack.com/", "user_id": "U1"})
+			return
+		}
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
+	params, _ := json.Marshal(map[string]string{"channel": "C1", "message": "m"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_message", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != string(slackctx.ScopeMetadataOnly) {
+		t.Fatalf("got %#v", sc)
+	}
+}
+
+func TestResolveScheduleMessage_PostAtInResourceDetails(t *testing.T) {
+	t.Parallel()
+	srv, conn := testAuthAndChannelServer(t, nil)
+	defer srv.Close()
+	future := time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339)
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C1",
+		"message": "later",
+		"post_at": future,
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.schedule_message", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := details["post_at"]; !ok {
+		t.Fatalf("expected post_at in details: %#v", details)
+	}
+}
+
+func TestResolveUpdateMessage_ThreadedTarget(t *testing.T) {
+	t.Parallel()
+	rootTS := "50.000000"
+	targetTS := "50.000001"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://acme.slack.com/", "user_id": "U9"})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id": "C1", "name": "general", "is_private": false,
+					"topic": map[string]any{"value": ""}, "purpose": map[string]any{"value": ""},
+				},
+			})
+		case "/conversations.history":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"user": "U1", "text": "root", "ts": rootTS},
+					{"user": "U1", "text": "in thread", "ts": targetTS, "thread_ts": rootTS},
+				},
+			})
+		case "/conversations.replies":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"user": "U1", "text": "root", "ts": rootTS},
+					{"user": "U1", "text": "in thread", "ts": targetTS},
+				},
+			})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U1", "name": "a", "profile": map[string]any{}},
+			})
+		default:
+			t.Errorf("unexpected %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C1",
+		"ts":      targetTS,
+		"message": "edit",
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.update_message", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != string(slackctx.ScopeThread) {
+		t.Fatalf("got %v", sc["context_scope"])
+	}
+}
+
+func TestResolveSendDM_FirstContact(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://acme.slack.com/", "user_id": "U9"})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"user": map[string]any{
+					"id": "UNEW", "name": "newuser", "profile": map[string]any{},
+				},
+			})
+		case "/conversations.open":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": map[string]any{"id": "DNEW"}})
+		case "/conversations.history":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "messages": []any{}})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id": "DNEW", "name": "dm", "is_im": true,
+					"topic": map[string]any{"value": ""}, "purpose": map[string]any{"value": ""},
+				},
+			})
+		default:
+			t.Errorf("unexpected %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
+	params, _ := json.Marshal(map[string]string{"user_id": "UNEW", "message": "hi"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_dm", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != string(slackctx.ScopeFirstContactDM) {
+		t.Fatalf("got %v", sc["context_scope"])
+	}
+}
+
+func TestResolveDeleteMessage_MissingTarget(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	tsOther := fmt.Sprintf("%d.%06d", now.Add(-1*time.Hour).Unix(), 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://acme.slack.com/", "user_id": "U9"})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id": "C1", "name": "general", "is_private": false,
+					"topic": map[string]any{"value": ""}, "purpose": map[string]any{"value": ""},
+				},
+			})
+		case "/conversations.history":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"messages": []map[string]any{
+					{"user": "U1", "text": "other", "ts": tsOther},
+				},
+			})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U1", "name": "a", "profile": map[string]any{}},
+			})
+		default:
+			t.Errorf("unexpected %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
+	params, _ := json.Marshal(map[string]string{
+		"channel": "C1",
+		"ts":      "99.999999",
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.delete_message", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != string(slackctx.ScopeMetadataOnly) {
+		t.Fatalf("got %v", sc["context_scope"])
+	}
+}
+
+func TestResolveSendDM_SelfDM(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth.test":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "url": "https://acme.slack.com/", "user_id": "USELF"})
+		case "/users.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"user": map[string]any{
+					"id": "USELF", "name": "me", "profile": map[string]any{},
+				},
+			})
+		case "/conversations.open":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": map[string]any{"id": "D1"}})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id": "D1", "name": "self", "is_im": true,
+					"topic": map[string]any{"value": ""}, "purpose": map[string]any{"value": ""},
+				},
+			})
+		default:
+			t.Errorf("unexpected %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	conn := newForTest(srv.Client(), srv.URL)
+	params, _ := json.Marshal(map[string]string{"user_id": "USELF", "message": "note"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "slack.send_dm", params, validCreds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := details["slack_context"].(map[string]any)
+	if sc["context_scope"] != string(slackctx.ScopeSelfDM) {
+		t.Fatalf("got %v", sc["context_scope"])
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **PR 2** from [issue #981](https://github.com/supersuit-tech/permission-slip/issues/981): backend approval resolution for **message-lifecycle** Slack actions now builds a normalized `slack_context` (using the existing `connectors/slack/context` helpers) and surfaces it to approvers.

- **`ResolveResourceDetails`** for `slack.send_message`, `slack.schedule_message`, `slack.send_dm`, `slack.update_message`, and `slack.delete_message` merges:
  - Legacy fields (`channel_name` / `user_name`) unchanged for existing UI.
  - `slack_context` (full structured context).
  - `slack.schedule_message`: adds **`post_at`** (Unix seconds) in `resource_details` for UI display.
- **Stored approval context**: `mergeSlackContextFromResourceDetailsIntoContext` copies `slack_context` from resolved `resource_details` into `context.details.slack_context` (same pattern as `email_thread`), with the same **65536-byte** guard as email merge.
- **Helpers**: `FetchMessageWindowAroundTS` for update/delete (target + neighbors in the 24h window); `OpenIMChannel` for self-DM channel metadata; exported `FetchUserRef`.

## Behavior notes

- **Thread**: `thread_ts` on send/schedule → thread scope via `FetchThread`.
- **Anchored / default channel**: `in_response_to_ts` or recent window via `FetchRecentMessages` → `recent_channel`.
- **DMs**: self-DM / first-contact / `recent_dm` per `FetchDMHistory`; self-DM may open IM to attach channel metadata.
- **Update/delete**: window around `ts`; if the target is a thread reply, loads full thread.
- **429**: degrades to `metadata_only` via existing rate-limit handling.

## Test plan

- [ ] CI: `make test-backend` or full `make test` (Go tests were not run locally in this environment).
- [ ] New unit tests: `connectors/slack` (`resolve_slack_context_test.go`, updated `resolve_resource_details_test.go`), `api` (`approval_slack_context_test.go`).

Related to #981 (PR 2 of 5).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-223d7385-9c80-46a9-b4e8-2426dbb9ad71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-223d7385-9c80-46a9-b4e8-2426dbb9ad71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

