### PR TITLE
feat(mobile): Slack context preview on approval detail screen

### DIFF
--- a/mobile/src/components/previews/SlackContextPreview.tsx
+++ b/mobile/src/components/previews/SlackContextPreview.tsx
@@ -60,7 +60,8 @@ export function SlackContextPreview({ slackContext }: Props) {
         <RecipientCard recipient={recipient} />
       )}
 
-      {target_message && (
+      {target_message &&
+        !(context_scope === "thread" && thread?.parent?.ts === target_message.ts) && (
         <View style={styles.section} testID="target-message-section">
           <Text style={styles.sectionLabel}>Target message</Text>
           <MessageCard message={target_message} />

--- a/mobile/src/components/previews/SlackContextPreview.tsx
+++ b/mobile/src/components/previews/SlackContextPreview.tsx
@@ -74,6 +74,7 @@ export function SlackContextPreview({ slackContext }: Props) {
       {recent_messages && recent_messages.length > 0 && (
         <RecentMessagesSection
           messages={recent_messages}
+          contextScope={context_scope}
           contextWindow={context_window}
         />
       )}
@@ -260,14 +261,16 @@ function ThreadSection({ thread }: { thread: SlackContextThread }) {
 
 function RecentMessagesSection({
   messages,
+  contextScope,
   contextWindow,
 }: {
   messages: SlackContextMessage[];
+  contextScope: SlackContext["context_scope"];
   contextWindow?: SlackContextWindow;
 }) {
   const [expanded, setExpanded] = useState(false);
 
-  const label = buildRecentLabel(messages.length, contextWindow);
+  const label = buildRecentLabel(messages.length, contextScope, contextWindow);
 
   return (
     <View style={styles.section} testID="recent-messages-section">
@@ -383,10 +386,12 @@ function getAvatarColors(name: string): { bg: string; text: string } {
 
 function buildRecentLabel(
   count: number,
+  contextScope: SlackContext["context_scope"],
   contextWindow?: SlackContextWindow,
 ): string {
   const hours = contextWindow?.hours ?? 24;
-  return `Channel activity in the last ${hours}h (${count} message${count !== 1 ? "s" : ""})`;
+  const prefix = contextScope === "recent_dm" ? "DM activity" : "Channel activity";
+  return `${prefix} in the last ${hours}h (${count} message${count !== 1 ? "s" : ""})`;
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile/src/components/previews/SlackContextPreview.tsx
+++ b/mobile/src/components/previews/SlackContextPreview.tsx
@@ -1,0 +1,651 @@
+import { useState } from "react";
+import {
+  Linking,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import type { components } from "../../api/schema";
+import { slackMrkdwnToPlaintext } from "../../lib/slackMrkdwn";
+import { colors } from "../../theme/colors";
+
+type SlackContext = components["schemas"]["SlackContext"];
+type SlackContextMessage = components["schemas"]["SlackContextMessage"];
+type SlackContextChannel = components["schemas"]["SlackContextChannel"];
+type SlackContextUserRef = components["schemas"]["SlackContextUserRef"];
+type SlackContextFileMeta = components["schemas"]["SlackContextFileMeta"];
+type SlackContextThread = components["schemas"]["SlackContextThread"];
+type SlackContextWindow = components["schemas"]["SlackContextWindow"];
+
+interface Props {
+  slackContext: SlackContext;
+}
+
+export function SlackContextPreview({ slackContext }: Props) {
+  const {
+    context_scope,
+    channel,
+    recipient,
+    target_message,
+    thread,
+    recent_messages,
+    context_window,
+  } = slackContext;
+
+  return (
+    <View testID="slack-context-preview">
+      {channel && <ChannelHeader channel={channel} />}
+
+      {context_scope === "self_dm" && (
+        <ScopeBadge
+          text="Note to self"
+          testID="badge-self-dm"
+        />
+      )}
+      {context_scope === "first_contact_dm" && (
+        <ScopeBadge
+          text="No prior messages with this user"
+          testID="badge-first-contact"
+        />
+      )}
+      {context_scope === "metadata_only" && (
+        <ScopeBadge
+          text="Context unavailable — open in Slack"
+          testID="badge-metadata-only"
+        />
+      )}
+
+      {recipient && context_scope !== "self_dm" && (
+        <RecipientCard recipient={recipient} />
+      )}
+
+      {target_message && (
+        <View style={styles.section} testID="target-message-section">
+          <Text style={styles.sectionLabel}>Target message</Text>
+          <MessageCard message={target_message} />
+        </View>
+      )}
+
+      {context_scope === "thread" && thread && (
+        <ThreadSection thread={thread} />
+      )}
+
+      {recent_messages && recent_messages.length > 0 && (
+        <RecentMessagesSection
+          messages={recent_messages}
+          contextWindow={context_window}
+        />
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Channel header
+// ---------------------------------------------------------------------------
+
+function ChannelHeader({ channel }: { channel: SlackContextChannel }) {
+  const label = channel.is_dm
+    ? "Direct message"
+    : channel.name
+      ? `#${channel.name}`
+      : channel.id;
+
+  return (
+    <View style={styles.channelHeader} testID="channel-header">
+      <View style={styles.channelTitleRow}>
+        <Text style={styles.channelName} numberOfLines={1}>
+          {label}
+        </Text>
+        {channel.is_private && !channel.is_dm && (
+          <View style={styles.privateBadge} testID="private-badge">
+            <Text style={styles.privateBadgeText}>Private</Text>
+          </View>
+        )}
+        <TouchableOpacity
+          onPress={() => openUrl(channel.permalink)}
+          accessibilityLabel="Open in Slack"
+          accessibilityRole="link"
+          testID="open-in-slack"
+        >
+          <Text style={styles.openInSlack}>Open in Slack ↗</Text>
+        </TouchableOpacity>
+      </View>
+
+      {channel.topic ? (
+        <Text style={styles.channelMeta} numberOfLines={2} testID="channel-topic">
+          {channel.topic}
+        </Text>
+      ) : channel.purpose ? (
+        <Text style={styles.channelMeta} numberOfLines={2} testID="channel-purpose">
+          {channel.purpose}
+        </Text>
+      ) : null}
+
+      {channel.member_count != null && (
+        <Text style={styles.memberCount} testID="member-count">
+          {channel.member_count.toLocaleString()} members
+        </Text>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recipient card (DMs)
+// ---------------------------------------------------------------------------
+
+function RecipientCard({ recipient }: { recipient: SlackContextUserRef }) {
+  const displayName = recipient.real_name ?? recipient.name ?? recipient.id ?? "Unknown";
+  const initials = getInitials(displayName);
+  const avatarColors = getAvatarColors(displayName);
+
+  return (
+    <View style={styles.section} testID="recipient-card">
+      <Text style={styles.sectionLabel}>Recipient</Text>
+      <View style={styles.card}>
+        <View style={[styles.avatar, { backgroundColor: avatarColors.bg }]}>
+          <Text style={[styles.avatarText, { color: avatarColors.text }]}>
+            {initials}
+          </Text>
+        </View>
+        <View style={styles.recipientInfo}>
+          <Text style={styles.recipientName}>{displayName}</Text>
+          {recipient.title ? (
+            <Text style={styles.recipientTitle}>{recipient.title}</Text>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Message card
+// ---------------------------------------------------------------------------
+
+function MessageCard({ message }: { message: SlackContextMessage }) {
+  const authorName =
+    message.user?.real_name ?? message.user?.name ?? (message.is_bot ? "Bot" : "Unknown");
+  const plainText = slackMrkdwnToPlaintext(message.text);
+  const timestamp = formatSlackTs(message.ts);
+  const initials = getInitials(authorName);
+  const avatarColors = getAvatarColors(authorName);
+
+  return (
+    <View style={styles.messageCard} testID="message-card">
+      <View style={styles.messageHeader}>
+        <View style={[styles.avatarSmall, { backgroundColor: avatarColors.bg }]}>
+          <Text style={[styles.avatarTextSmall, { color: avatarColors.text }]}>
+            {initials}
+          </Text>
+        </View>
+        <View style={styles.messageAuthorBlock}>
+          <View style={styles.messageAuthorRow}>
+            <Text style={styles.messageAuthor}>{authorName}</Text>
+            {message.is_bot && (
+              <View style={styles.botBadge} testID="bot-badge">
+                <Text style={styles.botBadgeText}>Bot</Text>
+              </View>
+            )}
+          </View>
+          <Text style={styles.messageTs}>{timestamp}</Text>
+        </View>
+        <TouchableOpacity
+          onPress={() => openUrl(message.permalink)}
+          accessibilityLabel="Open message in Slack"
+          accessibilityRole="link"
+          testID="message-permalink"
+        >
+          <Text style={styles.permalinkLink}>↗</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Text style={styles.messageText} testID="message-text">
+        {plainText}
+        {message.truncated && (
+          <Text style={styles.truncatedNote}> [truncated]</Text>
+        )}
+      </Text>
+
+      {message.files && message.files.length > 0 && (
+        <View style={styles.fileList} testID="file-list">
+          {message.files.map((f, i) => (
+            <FileRow key={i} file={f} />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Thread section
+// ---------------------------------------------------------------------------
+
+function ThreadSection({ thread }: { thread: SlackContextThread }) {
+  return (
+    <View style={styles.section} testID="thread-section">
+      <Text style={styles.sectionLabel}>Thread</Text>
+      {thread.parent && (
+        <View style={styles.threadParent}>
+          <MessageCard message={thread.parent} />
+        </View>
+      )}
+      {thread.replies && thread.replies.length > 0 && (
+        <View style={styles.replies} testID="thread-replies">
+          {thread.replies.map((reply, i) => (
+            <View key={i} style={styles.replyRow}>
+              <View style={styles.replyConnector} />
+              <View style={styles.replyContent}>
+                <MessageCard message={reply} />
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+      {thread.truncated && (
+        <Text style={styles.truncatedNote} testID="thread-truncated">
+          Thread truncated — open in Slack to see all messages
+        </Text>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recent messages accordion
+// ---------------------------------------------------------------------------
+
+function RecentMessagesSection({
+  messages,
+  contextWindow,
+}: {
+  messages: SlackContextMessage[];
+  contextWindow?: SlackContextWindow;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const label = buildRecentLabel(messages.length, contextWindow);
+
+  return (
+    <View style={styles.section} testID="recent-messages-section">
+      <TouchableOpacity
+        style={styles.accordionHeader}
+        onPress={() => setExpanded((v) => !v)}
+        accessibilityRole="button"
+        accessibilityLabel={expanded ? "Collapse recent activity" : "Expand recent activity"}
+        testID="recent-messages-toggle"
+      >
+        <Text style={styles.sectionLabel}>{label}</Text>
+        <Text style={styles.accordionChevron}>{expanded ? "▲" : "▼"}</Text>
+      </TouchableOpacity>
+
+      {expanded && (
+        <View testID="recent-messages-list">
+          {messages.map((msg, i) => (
+            <View key={i} style={i > 0 ? styles.messageSeparator : undefined}>
+              <MessageCard message={msg} />
+            </View>
+          ))}
+          {contextWindow?.truncated && (
+            <Text style={styles.truncatedNote} testID="recent-truncated">
+              More messages available — open in Slack
+            </Text>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// File row
+// ---------------------------------------------------------------------------
+
+function FileRow({ file }: { file: SlackContextFileMeta }) {
+  return (
+    <View style={styles.fileRow} testID="file-row">
+      <Text style={styles.fileName} numberOfLines={1}>
+        {file.filename}
+      </Text>
+      <Text style={styles.fileSize}>{formatBytes(file.size_bytes)}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scope badge (empty states)
+// ---------------------------------------------------------------------------
+
+function ScopeBadge({ text, testID }: { text: string; testID: string }) {
+  return (
+    <View style={styles.scopeBadge} testID={testID}>
+      <Text style={styles.scopeBadgeText}>{text}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function openUrl(url: string) {
+  Linking.openURL(url).catch(() => undefined);
+}
+
+function formatSlackTs(ts: string): string {
+  const ms = parseFloat(ts) * 1000;
+  if (isNaN(ms)) return ts;
+  return new Date(ms).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  if (words.length === 1) return (words[0]?.charAt(0) ?? "?").toUpperCase();
+  return (
+    (words[0]?.charAt(0) ?? "") + (words[words.length - 1]?.charAt(0) ?? "")
+  ).toUpperCase();
+}
+
+const AVATAR_COLORS = [
+  { bg: "#DBEAFE", text: "#1E40AF" },
+  { bg: colors.approvedBg, text: colors.approvedText },
+  { bg: "#EDE9FE", text: "#5B21B6" },
+  { bg: "#FCE7F3", text: "#9D174D" },
+  { bg: colors.pendingBg, text: colors.pendingText },
+  { bg: "#CFFAFE", text: "#155E75" },
+  { bg: "#FFEDD5", text: "#9A3412" },
+  { bg: "#FFE4E6", text: "#9F1239" },
+] as const;
+
+function getAvatarColors(name: string): { bg: string; text: string } {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % AVATAR_COLORS.length;
+  const entry = AVATAR_COLORS[index]!;
+  return { bg: entry.bg, text: entry.text };
+}
+
+function buildRecentLabel(
+  count: number,
+  contextWindow?: SlackContextWindow,
+): string {
+  const hours = contextWindow?.hours ?? 24;
+  return `Channel activity in the last ${hours}h (${count} message${count !== 1 ? "s" : ""})`;
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  // Section wrapper
+  section: {
+    marginTop: 12,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: colors.gray400,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 6,
+  },
+
+  // Channel header
+  channelHeader: {
+    backgroundColor: colors.white,
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 4,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 1,
+  },
+  channelTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    flexWrap: "wrap",
+  },
+  channelName: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: colors.gray900,
+    flex: 1,
+  },
+  privateBadge: {
+    backgroundColor: colors.gray100,
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  privateBadgeText: {
+    fontSize: 11,
+    color: colors.gray500,
+    fontWeight: "600",
+  },
+  openInSlack: {
+    fontSize: 12,
+    color: colors.primary,
+    fontWeight: "600",
+  },
+  channelMeta: {
+    fontSize: 13,
+    color: colors.gray500,
+    marginTop: 4,
+    lineHeight: 18,
+  },
+  memberCount: {
+    fontSize: 12,
+    color: colors.gray400,
+    marginTop: 4,
+  },
+
+  // Recipient card
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 10,
+    padding: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 1,
+  },
+  avatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarText: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  recipientInfo: {
+    flex: 1,
+  },
+  recipientName: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.gray900,
+  },
+  recipientTitle: {
+    fontSize: 12,
+    color: colors.gray500,
+    marginTop: 2,
+  },
+
+  // Message card
+  messageCard: {
+    backgroundColor: colors.white,
+    borderRadius: 10,
+    padding: 12,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 1,
+  },
+  messageHeader: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    marginBottom: 8,
+  },
+  avatarSmall: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  avatarTextSmall: {
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  messageAuthorBlock: {
+    flex: 1,
+  },
+  messageAuthorRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    flexWrap: "wrap",
+  },
+  messageAuthor: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.gray900,
+  },
+  botBadge: {
+    backgroundColor: colors.gray100,
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+  },
+  botBadgeText: {
+    fontSize: 10,
+    color: colors.gray500,
+    fontWeight: "600",
+  },
+  messageTs: {
+    fontSize: 11,
+    color: colors.gray400,
+    marginTop: 1,
+  },
+  permalinkLink: {
+    fontSize: 14,
+    color: colors.primary,
+    paddingLeft: 4,
+  },
+  messageText: {
+    fontSize: 13,
+    color: colors.gray700,
+    lineHeight: 19,
+  },
+  truncatedNote: {
+    fontSize: 11,
+    color: colors.gray400,
+    fontStyle: "italic",
+    marginTop: 4,
+  },
+  fileList: {
+    marginTop: 8,
+    gap: 4,
+  },
+  fileRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: colors.gray50,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+  },
+  fileName: {
+    fontSize: 12,
+    color: colors.gray700,
+    flex: 1,
+  },
+  fileSize: {
+    fontSize: 11,
+    color: colors.gray400,
+    marginLeft: 8,
+  },
+
+  // Thread
+  threadParent: {
+    marginBottom: 8,
+  },
+  replies: {
+    gap: 6,
+  },
+  replyRow: {
+    flexDirection: "row",
+    gap: 0,
+  },
+  replyConnector: {
+    width: 2,
+    backgroundColor: colors.gray200,
+    borderRadius: 1,
+    marginRight: 10,
+    marginLeft: 13,
+  },
+  replyContent: {
+    flex: 1,
+  },
+
+  // Accordion
+  accordionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 2,
+  },
+  accordionChevron: {
+    fontSize: 10,
+    color: colors.gray400,
+  },
+  messageSeparator: {
+    marginTop: 8,
+  },
+
+  // Scope badges
+  scopeBadge: {
+    backgroundColor: colors.gray100,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginTop: 4,
+  },
+  scopeBadgeText: {
+    fontSize: 13,
+    color: colors.gray500,
+    fontWeight: "500",
+    textAlign: "center",
+  },
+});

--- a/mobile/src/components/previews/__tests__/SlackContextPreview.test.tsx
+++ b/mobile/src/components/previews/__tests__/SlackContextPreview.test.tsx
@@ -1,0 +1,396 @@
+import React, { createElement } from "react";
+import { Linking } from "react-native";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+import { SlackContextPreview } from "../SlackContextPreview";
+import type { components } from "../../../api/schema";
+
+type SlackContext = components["schemas"]["SlackContext"];
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CHANNEL: components["schemas"]["SlackContextChannel"] = {
+  id: "C001",
+  name: "general",
+  is_private: false,
+  is_dm: false,
+  topic: "Company-wide announcements",
+  member_count: 120,
+  permalink: "https://slack.com/archives/C001",
+};
+
+const USER_REF: components["schemas"]["SlackContextUserRef"] = {
+  id: "U001",
+  name: "alice",
+  real_name: "Alice Example",
+  title: "Engineer",
+};
+
+const MESSAGE: components["schemas"]["SlackContextMessage"] = {
+  user: USER_REF,
+  text: "Hello *world*",
+  ts: "1711234567.000100",
+  permalink: "https://slack.com/archives/C001/p1711234567000100",
+  is_bot: false,
+  truncated: false,
+  files: [],
+};
+
+const BOT_MESSAGE: components["schemas"]["SlackContextMessage"] = {
+  ...MESSAGE,
+  is_bot: true,
+  text: "Deployment started",
+};
+
+const MESSAGE_WITH_FILES: components["schemas"]["SlackContextMessage"] = {
+  ...MESSAGE,
+  files: [
+    { filename: "report.pdf", size_bytes: 204800 },
+    { filename: "data.csv", size_bytes: 512 },
+  ],
+};
+
+const TRUNCATED_MESSAGE: components["schemas"]["SlackContextMessage"] = {
+  ...MESSAGE,
+  truncated: true,
+  text: "Very long message...",
+};
+
+function makeContext(overrides: Partial<SlackContext>): SlackContext {
+  return {
+    context_scope: "recent_channel",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function render(ctx: SlackContext): ReactTestRenderer {
+  return create(createElement(SlackContextPreview, { slackContext: ctx }));
+}
+
+function hasTestId(r: ReactTestRenderer, id: string): boolean {
+  return r.root.findAll((n) => n.props.testID === id).length > 0;
+}
+
+function findByTestId(r: ReactTestRenderer, id: string) {
+  return r.root.findAll((n) => n.props.testID === id)[0];
+}
+
+function textContent(r: ReactTestRenderer): string {
+  return JSON.stringify(r.toJSON());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SlackContextPreview", () => {
+  let renderer: ReactTestRenderer;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
+  // --- channel header ---
+
+  it("renders channel name", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ channel: CHANNEL }));
+    });
+    expect(textContent(renderer)).toContain("#general");
+  });
+
+  it("renders channel topic", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ channel: CHANNEL }));
+    });
+    expect(hasTestId(renderer, "channel-topic")).toBe(true);
+    expect(textContent(renderer)).toContain("Company-wide announcements");
+  });
+
+  it("renders member count", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ channel: CHANNEL }));
+    });
+    expect(hasTestId(renderer, "member-count")).toBe(true);
+    expect(textContent(renderer)).toContain("120");
+  });
+
+  it("renders private badge for private channels", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          channel: { ...CHANNEL, is_private: true },
+        }),
+      );
+    });
+    expect(hasTestId(renderer, "private-badge")).toBe(true);
+  });
+
+  it("does not render private badge for public channels", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ channel: CHANNEL }));
+    });
+    expect(hasTestId(renderer, "private-badge")).toBe(false);
+  });
+
+  it("open-in-slack link fires Linking.openURL", async () => {
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+    await act(async () => {
+      renderer = render(makeContext({ channel: CHANNEL }));
+    });
+
+    const link = findByTestId(renderer, "open-in-slack");
+    await act(async () => {
+      link?.props.onPress();
+    });
+
+    expect(openURL).toHaveBeenCalledWith("https://slack.com/archives/C001");
+  });
+
+  // --- scope badges ---
+
+  it("renders self-dm badge for self_dm scope", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ context_scope: "self_dm" }));
+    });
+    expect(hasTestId(renderer, "badge-self-dm")).toBe(true);
+    expect(textContent(renderer)).toContain("Note to self");
+  });
+
+  it("renders first-contact badge for first_contact_dm scope", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ context_scope: "first_contact_dm" }));
+    });
+    expect(hasTestId(renderer, "badge-first-contact")).toBe(true);
+    expect(textContent(renderer)).toContain("No prior messages with this user");
+  });
+
+  it("renders metadata-only badge for metadata_only scope", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ context_scope: "metadata_only" }));
+    });
+    expect(hasTestId(renderer, "badge-metadata-only")).toBe(true);
+    expect(textContent(renderer)).toContain("Context unavailable");
+  });
+
+  // --- recipient card ---
+
+  it("renders recipient card for DM scope", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({ context_scope: "recent_dm", recipient: USER_REF }),
+      );
+    });
+    expect(hasTestId(renderer, "recipient-card")).toBe(true);
+    expect(textContent(renderer)).toContain("Alice Example");
+  });
+
+  it("does not render recipient card for self_dm scope", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({ context_scope: "self_dm", recipient: USER_REF }),
+      );
+    });
+    expect(hasTestId(renderer, "recipient-card")).toBe(false);
+  });
+
+  it("renders recipient title when available", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({ context_scope: "recent_dm", recipient: USER_REF }),
+      );
+    });
+    expect(textContent(renderer)).toContain("Engineer");
+  });
+
+  // --- target message ---
+
+  it("renders target message section", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ target_message: MESSAGE }));
+    });
+    expect(hasTestId(renderer, "target-message-section")).toBe(true);
+  });
+
+  it("strips mrkdwn from message text", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ target_message: MESSAGE }));
+    });
+    // "Hello *world*" → "Hello world"
+    expect(textContent(renderer)).toContain("Hello world");
+    expect(textContent(renderer)).not.toContain("*world*");
+  });
+
+  it("renders bot badge for bot messages", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ target_message: BOT_MESSAGE }));
+    });
+    expect(hasTestId(renderer, "bot-badge")).toBe(true);
+  });
+
+  it("renders file attachments with name and size", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ target_message: MESSAGE_WITH_FILES }));
+    });
+    expect(hasTestId(renderer, "file-list")).toBe(true);
+    expect(textContent(renderer)).toContain("report.pdf");
+    expect(textContent(renderer)).toContain("200 KB");
+    expect(textContent(renderer)).toContain("data.csv");
+    expect(textContent(renderer)).toContain("512 B");
+  });
+
+  it("shows truncated indicator for truncated messages", async () => {
+    await act(async () => {
+      renderer = render(makeContext({ target_message: TRUNCATED_MESSAGE }));
+    });
+    expect(textContent(renderer)).toContain("[truncated]");
+  });
+
+  it("message permalink fires Linking.openURL", async () => {
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+    await act(async () => {
+      renderer = render(makeContext({ target_message: MESSAGE }));
+    });
+
+    const link = findByTestId(renderer, "message-permalink");
+    await act(async () => {
+      link?.props.onPress();
+    });
+
+    expect(openURL).toHaveBeenCalledWith(MESSAGE.permalink);
+  });
+
+  // --- thread scope ---
+
+  it("renders thread section for thread scope", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          context_scope: "thread",
+          thread: { parent: MESSAGE, replies: [BOT_MESSAGE], truncated: false },
+        }),
+      );
+    });
+    expect(hasTestId(renderer, "thread-section")).toBe(true);
+    expect(hasTestId(renderer, "thread-replies")).toBe(true);
+  });
+
+  it("shows thread-truncated notice when thread is truncated", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          context_scope: "thread",
+          thread: { parent: MESSAGE, replies: [], truncated: true },
+        }),
+      );
+    });
+    expect(hasTestId(renderer, "thread-truncated")).toBe(true);
+  });
+
+  it("does not render thread section when scope is not thread", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          context_scope: "recent_channel",
+          thread: { parent: MESSAGE, replies: [] },
+        }),
+      );
+    });
+    expect(hasTestId(renderer, "thread-section")).toBe(false);
+  });
+
+  // --- recent messages accordion ---
+
+  it("renders recent-messages section when messages present", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({ recent_messages: [MESSAGE, BOT_MESSAGE] }),
+      );
+    });
+    expect(hasTestId(renderer, "recent-messages-section")).toBe(true);
+  });
+
+  it("recent messages are collapsed by default", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({ recent_messages: [MESSAGE] }),
+      );
+    });
+    expect(hasTestId(renderer, "recent-messages-list")).toBe(false);
+  });
+
+  it("expands recent messages on toggle press", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({ recent_messages: [MESSAGE] }),
+      );
+    });
+
+    const toggle = findByTestId(renderer, "recent-messages-toggle");
+    await act(async () => {
+      toggle?.props.onPress();
+    });
+
+    expect(hasTestId(renderer, "recent-messages-list")).toBe(true);
+  });
+
+  it("shows label with message count and hours", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          recent_messages: [MESSAGE, BOT_MESSAGE],
+          context_window: { message_count: 2, hours: 24 },
+        }),
+      );
+    });
+    expect(textContent(renderer)).toContain("last 24h");
+    expect(textContent(renderer)).toContain("2 messages");
+  });
+
+  // --- missing fields ---
+
+  it("renders without crashing when only context_scope is set", async () => {
+    await act(async () => {
+      renderer = render(makeContext({}));
+    });
+    expect(renderer.toJSON()).toBeTruthy();
+    expect(hasTestId(renderer, "slack-context-preview")).toBe(true);
+  });
+
+  it("renders without crashing when channel has no name", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          channel: { id: "C999", permalink: "https://slack.com/archives/C999" },
+        }),
+      );
+    });
+    expect(renderer.toJSON()).toBeTruthy();
+    expect(textContent(renderer)).toContain("C999");
+  });
+
+  it("renders without crashing when message has no user", async () => {
+    const msg: components["schemas"]["SlackContextMessage"] = {
+      text: "Anonymous message",
+      ts: "1711234567.000000",
+      permalink: "https://slack.com/archives/C001/p1",
+    };
+    await act(async () => {
+      renderer = render(makeContext({ target_message: msg }));
+    });
+    expect(textContent(renderer)).toContain("Anonymous message");
+  });
+});

--- a/mobile/src/components/previews/__tests__/SlackContextPreview.test.tsx
+++ b/mobile/src/components/previews/__tests__/SlackContextPreview.test.tsx
@@ -347,17 +347,33 @@ describe("SlackContextPreview", () => {
     expect(hasTestId(renderer, "recent-messages-list")).toBe(true);
   });
 
-  it("shows label with message count and hours", async () => {
+  it("shows channel label with message count and hours", async () => {
     await act(async () => {
       renderer = render(
         makeContext({
+          context_scope: "recent_channel",
           recent_messages: [MESSAGE, BOT_MESSAGE],
           context_window: { message_count: 2, hours: 24 },
         }),
       );
     });
+    expect(textContent(renderer)).toContain("Channel activity");
     expect(textContent(renderer)).toContain("last 24h");
     expect(textContent(renderer)).toContain("2 messages");
+  });
+
+  it("shows DM label for recent_dm scope", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          context_scope: "recent_dm",
+          recent_messages: [MESSAGE],
+          context_window: { message_count: 1, hours: 24 },
+        }),
+      );
+    });
+    expect(textContent(renderer)).toContain("DM activity");
+    expect(textContent(renderer)).not.toContain("Channel activity");
   });
 
   // --- missing fields ---

--- a/mobile/src/components/previews/__tests__/SlackContextPreview.test.tsx
+++ b/mobile/src/components/previews/__tests__/SlackContextPreview.test.tsx
@@ -312,6 +312,39 @@ describe("SlackContextPreview", () => {
     expect(hasTestId(renderer, "thread-section")).toBe(false);
   });
 
+  it("hides target-message block when it duplicates thread.parent (same ts)", async () => {
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          context_scope: "thread",
+          target_message: MESSAGE,
+          thread: { parent: MESSAGE, replies: [BOT_MESSAGE] },
+        }),
+      );
+    });
+    // thread-section shows the parent — standalone target-message block should be absent
+    expect(hasTestId(renderer, "thread-section")).toBe(true);
+    const targetSections = renderer.root.findAll(
+      (n) => n.props.testID === "target-message-section",
+    );
+    expect(targetSections.length).toBe(0);
+  });
+
+  it("shows target-message block when it differs from thread.parent ts", async () => {
+    const differentTarget: typeof MESSAGE = { ...MESSAGE, ts: "1711234000.000000" };
+    await act(async () => {
+      renderer = render(
+        makeContext({
+          context_scope: "thread",
+          target_message: differentTarget,
+          thread: { parent: MESSAGE, replies: [] },
+        }),
+      );
+    });
+    expect(hasTestId(renderer, "target-message-section")).toBe(true);
+    expect(hasTestId(renderer, "thread-section")).toBe(true);
+  });
+
   // --- recent messages accordion ---
 
   it("renders recent-messages section when messages present", async () => {

--- a/mobile/src/lib/__tests__/slackMrkdwn.test.ts
+++ b/mobile/src/lib/__tests__/slackMrkdwn.test.ts
@@ -1,0 +1,67 @@
+import { slackMrkdwnToPlaintext } from "../slackMrkdwn";
+
+describe("slackMrkdwnToPlaintext", () => {
+  it("returns plain text unchanged", () => {
+    expect(slackMrkdwnToPlaintext("Hello world")).toBe("Hello world");
+  });
+
+  it("strips bold syntax", () => {
+    expect(slackMrkdwnToPlaintext("This is *bold* text")).toBe("This is bold text");
+  });
+
+  it("strips italic syntax", () => {
+    expect(slackMrkdwnToPlaintext("This is _italic_ text")).toBe("This is italic text");
+  });
+
+  it("strips strikethrough syntax", () => {
+    expect(slackMrkdwnToPlaintext("This is ~struck~ text")).toBe("This is struck text");
+  });
+
+  it("strips inline code backticks", () => {
+    expect(slackMrkdwnToPlaintext("Use `npm install`")).toBe("Use npm install");
+  });
+
+  it("strips code block backticks", () => {
+    expect(slackMrkdwnToPlaintext("```const x = 1;```")).toBe("const x = 1;");
+  });
+
+  it("strips blockquote prefix", () => {
+    expect(slackMrkdwnToPlaintext("> quoted text")).toBe("quoted text");
+  });
+
+  it("converts named link to display text", () => {
+    expect(slackMrkdwnToPlaintext("<https://example.com|click here>")).toBe("click here");
+  });
+
+  it("unwraps plain URL angle brackets", () => {
+    expect(slackMrkdwnToPlaintext("<https://example.com>")).toBe("https://example.com");
+  });
+
+  it("converts <!here> to @here", () => {
+    expect(slackMrkdwnToPlaintext("<!here> please review")).toBe("@here please review");
+  });
+
+  it("converts <!channel> to @channel", () => {
+    expect(slackMrkdwnToPlaintext("Heads up <!channel>")).toBe("Heads up @channel");
+  });
+
+  it("converts <!everyone> to @everyone", () => {
+    expect(slackMrkdwnToPlaintext("<!everyone> announcement")).toBe("@everyone announcement");
+  });
+
+  it("handles already-resolved mentions as plain text", () => {
+    // Backend resolves <@U123> → @alice before the payload reaches the client
+    expect(slackMrkdwnToPlaintext("Hey @alice, check this")).toBe(
+      "Hey @alice, check this",
+    );
+  });
+
+  it("handles multiline text", () => {
+    const input = "*First* line\n> Quoted\n_Second_ line";
+    expect(slackMrkdwnToPlaintext(input)).toBe("First line\nQuoted\nSecond line");
+  });
+
+  it("handles empty string", () => {
+    expect(slackMrkdwnToPlaintext("")).toBe("");
+  });
+});

--- a/mobile/src/lib/slackMrkdwn.ts
+++ b/mobile/src/lib/slackMrkdwn.ts
@@ -1,0 +1,31 @@
+/**
+ * Converts Slack mrkdwn to plain text for mobile display.
+ *
+ * The backend resolves `<@U123>` mentions and `<#C123|name>` channels
+ * server-side before the payload reaches the client. This helper strips
+ * remaining mrkdwn formatting syntax so the text reads naturally on mobile.
+ */
+export function slackMrkdwnToPlaintext(text: string): string {
+  return text
+    // Code blocks: ```text``` → text (before inline code)
+    .replace(/```([\s\S]*?)```/g, (_, code: string) => code.trim())
+    // Named links / channel refs: <URL|display> → display
+    .replace(/<[^|>]+\|([^>]+)>/g, "$1")
+    // Special broadcasts: <!here>, <!channel>, <!everyone>
+    .replace(/<!here>/g, "@here")
+    .replace(/<!channel>/g, "@channel")
+    .replace(/<!everyone>/g, "@everyone")
+    // Remaining angle-bracket refs (URLs, unresolved user IDs): <X> → X
+    .replace(/<([^>]+)>/g, "$1")
+    // Bold: *text* → text
+    .replace(/\*([^*\n]+)\*/g, "$1")
+    // Italic: _text_ → text
+    .replace(/_([^_\n]+)_/g, "$1")
+    // Strikethrough: ~text~ → text
+    .replace(/~([^~\n]+)~/g, "$1")
+    // Inline code: `text` → text
+    .replace(/`([^`\n]+)`/g, "$1")
+    // Blockquotes: strip leading ">" (with optional space)
+    .replace(/^> ?/gm, "")
+    .trim();
+}

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -36,6 +36,8 @@ import { CountdownBadge } from "./CountdownBadge";
 import { ApprovalActions } from "./ApprovalActions";
 import { KeyValueList, type KeyValueEntry } from "./KeyValueList";
 import { TimelineView, type TimelineEntry } from "./TimelineView";
+import { SlackContextPreview } from "../../components/previews/SlackContextPreview";
+import type { components } from "../../api/schema";
 
 type Props = NativeStackScreenProps<RootStackParamList, "ApprovalDetail">;
 
@@ -70,9 +72,16 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
     () => Object.entries(parameters).map(([label, value]) => ({ label, value })),
     [parameters],
   );
+  const slackContext = useMemo(() => {
+    const details = approval.context.details as { slack_context?: components["schemas"]["SlackContext"] } | undefined;
+    return details?.slack_context ?? null;
+  }, [approval.context.details]);
+
   const contextDetailEntries: KeyValueEntry[] = useMemo(() => {
     const details = safeParams(approval.context.details);
-    return Object.entries(details).map(([label, value]) => ({ label, value }));
+    // Exclude slack_context — rendered by SlackContextPreview below
+    const { slack_context: _sc, ...rest } = details;
+    return Object.entries(rest).map(([label, value]) => ({ label, value }));
   }, [approval.context.details]);
 
   const isPending = approval.status === "pending" && !isApproved && !isDenied;
@@ -279,6 +288,14 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
             <View style={styles.cardElevated}>
               <KeyValueList entries={paramEntries} />
             </View>
+          </View>
+        )}
+
+        {/* Slack context — rich preview for Slack connector actions */}
+        {slackContext && (
+          <View style={styles.sectionMajor}>
+            <Text style={styles.sectionLabel}>Slack Context</Text>
+            <SlackContextPreview slackContext={slackContext} />
           </View>
         )}
 


### PR DESCRIPTION
## Summary

- Adds `slackMrkdwn.ts` — strips Slack mrkdwn (bold, italic, strike, code, blockquotes, links, `<!here>`/`<!channel>`) to plain text for mobile display.
- Adds `SlackContextPreview.tsx` — native React Native component that renders all six `context_scope` variants: `thread`, `recent_channel`, `recent_dm`, `self_dm`, `first_contact_dm`, `metadata_only`. Includes channel header with "Open in Slack" deep link, recipient card, target message card, thread view with visual connector, collapsible recent-activity accordion, empty-state scope badges, file attachment metadata, and per-message permalinks via `Linking.openURL`.
- Wires `SlackContextPreview` into `ApprovalDetailScreen.tsx` — rendered when `context.details.slack_context` is present; `slack_context` is excluded from the generic `KeyValueList` fallback to avoid double rendering.

Covers all 12 Slack actions from #981: `send_message`, `send_dm`, `schedule_message`, `update_message`, `delete_message`, `add_reaction`, `remove_reaction`, `pin_message`, `unpin_message`, `archive_channel`, `invite_to_channel`, `remove_from_channel`.

## Test plan

- [x] 43 new unit/component tests pass (`make mobile-test` / `npm test -- --ci`)
  - `slackMrkdwn.test.ts` — 15 cases covering all formatting rules
  - `SlackContextPreview.test.tsx` — 28 cases covering every scope, missing fields, mrkdwn stripping, file size formatting, accordion expand/collapse, deep link callbacks
- [x] Full mobile suite (276 tests) still passes with zero regressions
- [x] Zero new TypeScript errors introduced (`npx tsc --noEmit` output unchanged)
- [ ] End-to-end visual verification deferred until PR 2+3 (backend) land and real Slack context is populated in approval payloads

Closes #981

https://claude.ai/code/session_01LuP7QLNxvEqiEB8W81VpxP