### PR TITLE
feat(web): Slack context preview on approval dialog (PR 4 / #981)

### DIFF
--- a/frontend/src/components/previews/SlackContextPreview.stories.tsx
+++ b/frontend/src/components/previews/SlackContextPreview.stories.tsx
@@ -1,0 +1,288 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SlackContextPreview } from "./SlackContextPreview";
+import type { components } from "@/api/schema";
+
+type SlackContext = components["schemas"]["SlackContext"];
+
+const meta: Meta<typeof SlackContextPreview> = {
+  title: "Previews/SlackContextPreview",
+  component: SlackContextPreview,
+  parameters: { layout: "centered" },
+  decorators: [(Story) => <div className="w-[520px]"><Story /></div>],
+};
+export default meta;
+type Story = StoryObj<typeof SlackContextPreview>;
+
+const aliceUser: components["schemas"]["SlackContextUserRef"] = {
+  id: "U001",
+  name: "alice",
+  real_name: "Alice Chen",
+  title: "Staff Engineer",
+};
+
+const bobUser: components["schemas"]["SlackContextUserRef"] = {
+  id: "U002",
+  name: "bob",
+  real_name: "Bob Smith",
+};
+
+const deployBotUser: components["schemas"]["SlackContextUserRef"] = {
+  id: "U003",
+  name: "deploybot",
+  real_name: "Deploy Bot",
+};
+
+const generalChannel: components["schemas"]["SlackContextChannel"] = {
+  id: "C001",
+  name: "general",
+  is_private: false,
+  is_dm: false,
+  topic: "Company-wide announcements and discussions",
+  member_count: 142,
+  permalink: "https://example.slack.com/archives/C001",
+};
+
+const engineeringChannel: components["schemas"]["SlackContextChannel"] = {
+  id: "C002",
+  name: "engineering",
+  is_private: true,
+  is_dm: false,
+  topic: "Engineering team sync",
+  purpose: "Discuss technical work and coordinate eng efforts",
+  member_count: 18,
+  permalink: "https://example.slack.com/archives/C002",
+};
+
+const dmChannel: components["schemas"]["SlackContextChannel"] = {
+  id: "D001",
+  is_dm: true,
+  is_private: true,
+  permalink: "https://example.slack.com/archives/D001",
+};
+
+function makeMessage(
+  text: string,
+  user: components["schemas"]["SlackContextUserRef"],
+  tsOffset = 0,
+  extras?: Partial<components["schemas"]["SlackContextMessage"]>,
+): components["schemas"]["SlackContextMessage"] {
+  return {
+    text,
+    user,
+    ts: String(1711200000 + tsOffset),
+    permalink: `https://example.slack.com/archives/C001/p${1711200000 + tsOffset}`,
+    ...extras,
+  };
+}
+
+export const RecentChannel: Story = {
+  name: "Recent channel activity (send_message)",
+  args: {
+    slackContext: {
+      context_scope: "recent_channel",
+      channel: generalChannel,
+      recent_messages: [
+        makeMessage("Anyone have the Q1 numbers ready?", bobUser, 0),
+        makeMessage(
+          "Just sent them over to @alice — *check your DMs*!",
+          aliceUser,
+          120,
+        ),
+        makeMessage(
+          "Deploy to staging finished. All health checks ✅",
+          deployBotUser,
+          240,
+          { is_bot: true },
+        ),
+        makeMessage(
+          "Heads up: standup moved to 10am tomorrow.",
+          bobUser,
+          360,
+        ),
+      ],
+      context_window: { message_count: 4, hours: 24, truncated: false },
+    } satisfies SlackContext,
+  },
+};
+
+export const ThreadReply: Story = {
+  name: "Thread reply (send_message with thread_ts)",
+  args: {
+    slackContext: {
+      context_scope: "thread",
+      channel: engineeringChannel,
+      thread: {
+        parent: makeMessage(
+          "Shipping v2.4.1 today. Release notes in Notion. Let me know if you see anything weird.",
+          aliceUser,
+          0,
+        ),
+        replies: [
+          makeMessage("LGTM — I reviewed the diff this morning.", bobUser, 300),
+          makeMessage(
+            "Can we also bump the mobile version in this release?",
+            { id: "U004", name: "charlie", real_name: "Charlie Davis" },
+            600,
+          ),
+        ],
+        truncated: false,
+      },
+    } satisfies SlackContext,
+  },
+};
+
+export const UpdateMessage: Story = {
+  name: "Update/delete target message",
+  args: {
+    slackContext: {
+      context_scope: "recent_channel",
+      channel: generalChannel,
+      target_message: makeMessage(
+        "Reminder: *all-hands meeting* Friday at 3pm PST. Link: <https://meet.example.com/all-hands|Join meeting>",
+        aliceUser,
+        0,
+        {
+          files: [
+            { filename: "agenda.pdf", size_bytes: 24576 },
+            { filename: "slides.pptx", size_bytes: 1048576 },
+          ],
+        },
+      ),
+      recent_messages: [
+        makeMessage("Thanks for the reminder!", bobUser, 180),
+        makeMessage("Will the recording be posted afterwards?", aliceUser, 360),
+      ],
+      context_window: { message_count: 2, hours: 24, truncated: false },
+    } satisfies SlackContext,
+  },
+};
+
+export const DirectMessage: Story = {
+  name: "DM history (send_dm)",
+  args: {
+    slackContext: {
+      context_scope: "recent_dm",
+      channel: dmChannel,
+      recipient: aliceUser,
+      recent_messages: [
+        makeMessage("Hey, did you get a chance to review the PR?", bobUser, 0),
+        makeMessage(
+          "Not yet, been slammed with the infra migration. Will do it tonight.",
+          aliceUser,
+          600,
+        ),
+        makeMessage("No rush, just wanted to check in!", bobUser, 900),
+      ],
+      context_window: { message_count: 3, hours: 24, truncated: false },
+    } satisfies SlackContext,
+  },
+};
+
+export const SelfDm: Story = {
+  name: "Self-DM (Note to self)",
+  args: {
+    slackContext: {
+      context_scope: "self_dm",
+      channel: dmChannel,
+    } satisfies SlackContext,
+  },
+};
+
+export const FirstContactDm: Story = {
+  name: "First-contact DM (no prior messages)",
+  args: {
+    slackContext: {
+      context_scope: "first_contact_dm",
+      channel: dmChannel,
+      recipient: {
+        id: "U999",
+        name: "newjoinee",
+        real_name: "Taylor Newcomer",
+        title: "Product Manager",
+      },
+    } satisfies SlackContext,
+  },
+};
+
+export const MetadataOnly: Story = {
+  name: "Rate-limit degrade (metadata_only)",
+  args: {
+    slackContext: {
+      context_scope: "metadata_only",
+      channel: {
+        id: "C003",
+        name: "incidents",
+        is_private: true,
+        is_dm: false,
+        member_count: 7,
+        permalink: "https://example.slack.com/archives/C003",
+      },
+    } satisfies SlackContext,
+  },
+};
+
+export const ArchiveChannel: Story = {
+  name: "Archive channel (channel metadata emphasis)",
+  args: {
+    slackContext: {
+      context_scope: "recent_channel",
+      channel: {
+        id: "C004",
+        name: "old-project-2024",
+        is_private: false,
+        is_dm: false,
+        topic: "Project Nighthawk — wrapped up Jan 2025",
+        member_count: 31,
+        last_activity_at: "2025-01-15T14:23:00Z",
+        permalink: "https://example.slack.com/archives/C004",
+      },
+      recent_messages: [
+        makeMessage("Wrapping up — all tasks closed. Archiving this channel.", aliceUser, 0),
+      ],
+      context_window: { message_count: 1, hours: 24, truncated: false },
+    } satisfies SlackContext,
+  },
+};
+
+export const TruncatedThread: Story = {
+  name: "Large thread (truncated)",
+  args: {
+    slackContext: {
+      context_scope: "thread",
+      channel: generalChannel,
+      thread: {
+        parent: makeMessage(
+          "Big announcement: we're migrating to a new CI/CD pipeline next week. Detailed docs in Confluence.",
+          aliceUser,
+          0,
+        ),
+        replies: Array.from({ length: 5 }, (_, i) =>
+          makeMessage(
+            `Reply ${i + 1}: ${["Exciting!", "Will our custom scripts still work?", "Who's the DRI for this?", "Is there a rollback plan?", "Will there be a dry run first?"][i]}`,
+            [aliceUser, bobUser, deployBotUser][i % 3] ?? aliceUser,
+            300 * (i + 1),
+          ),
+        ),
+        truncated: true,
+      },
+    } satisfies SlackContext,
+  },
+};
+
+export const MrkdwnFormatting: Story = {
+  name: "Mrkdwn formatting showcase",
+  args: {
+    slackContext: {
+      context_scope: "recent_channel",
+      channel: generalChannel,
+      recent_messages: [
+        makeMessage(
+          "*Bold text*, _italic_, ~strikethrough~, and `inline code`.\n>Quoted text from someone else.\n```\nconst x = 42;\n```\nLink: <https://example.com|Example site>",
+          aliceUser,
+          0,
+        ),
+      ],
+      context_window: { message_count: 1, hours: 24, truncated: false },
+    } satisfies SlackContext,
+  },
+};

--- a/frontend/src/components/previews/SlackContextPreview.tsx
+++ b/frontend/src/components/previews/SlackContextPreview.tsx
@@ -1,0 +1,366 @@
+import { useState } from "react";
+import {
+  Hash,
+  Lock,
+  AtSign,
+  ExternalLink,
+  Paperclip,
+  Bot,
+  ChevronRight,
+  Users,
+} from "lucide-react";
+import type { components } from "@/api/schema";
+import { slackMrkdwnToHtml } from "@/lib/slackMrkdwn";
+import { getInitials } from "@/components/ui/avatar";
+
+type SlackContext = components["schemas"]["SlackContext"];
+type SlackContextMessage = components["schemas"]["SlackContextMessage"];
+type SlackContextChannel = components["schemas"]["SlackContextChannel"];
+type SlackContextUserRef = components["schemas"]["SlackContextUserRef"];
+type SlackContextFileMeta = components["schemas"]["SlackContextFileMeta"];
+
+interface SlackContextPreviewProps {
+  slackContext: SlackContext;
+}
+
+function formatSlackTs(ts: string): string {
+  const seconds = parseFloat(ts);
+  if (isNaN(seconds)) return ts;
+  return new Date(seconds * 1000).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function UserAvatar({ user }: { user: SlackContextUserRef }) {
+  const displayName = user.real_name ?? user.name ?? "?";
+  const initials = getInitials(displayName);
+  if (user.avatar_url) {
+    return (
+      <img
+        src={user.avatar_url}
+        alt={displayName}
+        className="size-6 rounded-full object-cover"
+      />
+    );
+  }
+  return (
+    <span
+      className="flex size-6 shrink-0 items-center justify-center rounded-full bg-violet-100 text-[10px] font-semibold text-violet-700 dark:bg-violet-900/40 dark:text-violet-300"
+      aria-hidden="true"
+    >
+      {initials}
+    </span>
+  );
+}
+
+function FileList({ files }: { files: SlackContextFileMeta[] }) {
+  if (files.length === 0) return null;
+  return (
+    <div className="mt-1.5 flex flex-wrap gap-1.5">
+      {files.map((f, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center gap-1 rounded border bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground"
+        >
+          <Paperclip className="size-3 shrink-0" aria-hidden="true" />
+          {f.filename}
+          <span className="opacity-60">({formatBytes(f.size_bytes)})</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function MessageCard({
+  message,
+  compact = false,
+}: {
+  message: SlackContextMessage;
+  compact?: boolean;
+}) {
+  const html = slackMrkdwnToHtml(message.text);
+  return (
+    <div className={`flex gap-2 ${compact ? "py-1.5" : "py-2"}`}>
+      {message.user ? (
+        <UserAvatar user={message.user} />
+      ) : (
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground">
+          <Bot className="size-3.5" aria-hidden="true" />
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-1.5 flex-wrap">
+          <span className="text-xs font-semibold">
+            {message.user?.real_name ?? message.user?.name ?? "Bot"}
+          </span>
+          {message.is_bot && (
+            <span className="rounded bg-muted px-1 py-0 text-[10px] text-muted-foreground">
+              APP
+            </span>
+          )}
+          <span className="text-[11px] text-muted-foreground">
+            {formatSlackTs(message.ts)}
+          </span>
+          <a
+            href={message.permalink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-0.5"
+            aria-label="View message in Slack"
+          >
+            <ExternalLink className="size-2.5" aria-hidden="true" />
+          </a>
+        </div>
+        {message.truncated && (
+          <p className="mb-0.5 text-[11px] text-amber-600 dark:text-amber-400">
+            Message truncated
+          </p>
+        )}
+        <div
+          className="slack-message-body text-sm leading-relaxed [&_blockquote]:border-l-2 [&_blockquote]:border-muted-foreground/40 [&_blockquote]:pl-2 [&_blockquote]:text-muted-foreground [&_code]:rounded [&_code]:bg-muted/70 [&_code]:px-1 [&_code]:py-0 [&_code]:text-xs [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-muted/70 [&_pre]:p-2 [&_pre]:text-xs"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+        {message.files && message.files.length > 0 && (
+          <FileList files={message.files} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChannelHeader({ channel }: { channel: SlackContextChannel }) {
+  const Icon = channel.is_dm
+    ? AtSign
+    : channel.is_private
+      ? Lock
+      : Hash;
+
+  return (
+    <div className="mb-3 flex items-start justify-between gap-2">
+      <div className="flex items-start gap-2 min-w-0">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-violet-50 ring-1 ring-violet-200 dark:bg-violet-950 dark:ring-violet-800">
+          <Icon
+            className="size-4 text-violet-600 dark:text-violet-400"
+            aria-hidden="true"
+          />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-sm font-semibold truncate">
+              {channel.is_dm ? "" : channel.is_private ? "" : "#"}
+              {channel.name ?? channel.id}
+            </span>
+            {channel.is_private && !channel.is_dm && (
+              <span className="rounded-full bg-muted px-1.5 py-0 text-[10px] text-muted-foreground">
+                Private
+              </span>
+            )}
+          </div>
+          {(channel.topic || channel.purpose) && (
+            <p className="text-xs text-muted-foreground truncate mt-0.5">
+              {channel.topic || channel.purpose}
+            </p>
+          )}
+          {channel.member_count !== undefined && !channel.is_dm && (
+            <p className="mt-0.5 flex items-center gap-1 text-[11px] text-muted-foreground">
+              <Users className="size-3" aria-hidden="true" />
+              {channel.member_count.toLocaleString()} members
+            </p>
+          )}
+        </div>
+      </div>
+      <a
+        href={channel.permalink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="Open channel in Slack"
+      >
+        <ExternalLink className="size-3.5" aria-hidden="true" />
+        Open in Slack
+      </a>
+    </div>
+  );
+}
+
+function RecipientCard({ user }: { user: SlackContextUserRef }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-muted/40 px-3 py-2 mb-3">
+      <UserAvatar user={user} />
+      <div className="min-w-0">
+        <p className="text-xs font-semibold truncate">
+          {user.real_name ?? user.name}
+        </p>
+        {user.title && (
+          <p className="text-[11px] text-muted-foreground truncate">
+            {user.title}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ThreadSection({
+  thread,
+}: {
+  thread: NonNullable<SlackContext["thread"]>;
+}) {
+  const replyCount = thread.replies?.length ?? 0;
+  return (
+    <div>
+      {thread.parent && (
+        <div className="border-b pb-2">
+          <p className="mb-1 text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+            Original message
+          </p>
+          <MessageCard message={thread.parent} />
+        </div>
+      )}
+      {replyCount > 0 && (
+        <div className="pt-2">
+          <p className="mb-1 text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+            {replyCount} {replyCount === 1 ? "reply" : "replies"}
+            {thread.truncated && " (showing most recent)"}
+          </p>
+          <div className="divide-y">
+            {(thread.replies ?? []).map((msg, i) => (
+              <MessageCard key={i} message={msg} compact />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RecentActivitySection({
+  messages,
+  contextWindow,
+  label,
+}: {
+  messages: SlackContextMessage[];
+  contextWindow?: SlackContext["context_window"];
+  label: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const count = contextWindow?.message_count ?? messages.length;
+  const hours = contextWindow?.hours ?? 24;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 text-left text-xs font-medium text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+        aria-expanded={open}
+      >
+        <ChevronRight
+          className="size-3.5 shrink-0 transition-transform duration-150"
+          style={{ transform: open ? "rotate(90deg)" : "rotate(0deg)" }}
+          aria-hidden="true"
+        />
+        {label} — last {hours}h ({count} {count === 1 ? "message" : "messages"})
+        {contextWindow?.truncated && " · truncated"}
+      </button>
+      {open && messages.length > 0 && (
+        <div className="mt-2 divide-y border rounded-lg px-3 bg-muted/20">
+          {messages.map((msg, i) => (
+            <MessageCard key={i} message={msg} compact />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SlackContextPreview({ slackContext }: SlackContextPreviewProps) {
+  const {
+    context_scope,
+    channel,
+    recipient,
+    target_message,
+    thread,
+    recent_messages,
+    context_window,
+  } = slackContext;
+
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
+      {channel && <ChannelHeader channel={channel} />}
+
+      {context_scope === "self_dm" && (
+        <div className="flex items-center justify-center rounded-lg bg-muted/50 px-3 py-3 text-sm text-muted-foreground">
+          Note to self
+        </div>
+      )}
+
+      {context_scope === "first_contact_dm" && (
+        <div className="flex items-center justify-center rounded-lg bg-muted/50 px-3 py-3 text-sm text-muted-foreground">
+          No prior messages with this user
+        </div>
+      )}
+
+      {context_scope === "metadata_only" && (
+        <div className="flex items-center justify-between rounded-lg bg-muted/50 px-3 py-3">
+          <span className="text-sm text-muted-foreground">
+            Context unavailable
+          </span>
+          {channel && (
+            <a
+              href={channel.permalink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <ExternalLink className="size-3" aria-hidden="true" />
+              Open in Slack
+            </a>
+          )}
+        </div>
+      )}
+
+      {recipient &&
+        (context_scope === "recent_dm" ||
+          context_scope === "first_contact_dm") && (
+          <RecipientCard user={recipient} />
+        )}
+
+      {target_message && (
+        <div className="mb-3">
+          <p className="mb-1 text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+            Target message
+          </p>
+          <div className="rounded-lg border bg-muted/20 px-3">
+            <MessageCard message={target_message} />
+          </div>
+        </div>
+      )}
+
+      {context_scope === "thread" && thread && (
+        <ThreadSection thread={thread} />
+      )}
+
+      {(context_scope === "recent_channel" || context_scope === "recent_dm") &&
+        recent_messages &&
+        recent_messages.length > 0 && (
+          <RecentActivitySection
+            messages={recent_messages}
+            contextWindow={context_window}
+            label={
+              context_scope === "recent_dm" ? "DM history" : "Channel activity"
+            }
+          />
+        )}
+    </div>
+  );
+}

--- a/frontend/src/components/previews/__tests__/SlackContextPreview.test.tsx
+++ b/frontend/src/components/previews/__tests__/SlackContextPreview.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { SlackContextPreview } from "../SlackContextPreview";
+import type { components } from "@/api/schema";
+
+type SlackContext = components["schemas"]["SlackContext"];
+type SlackContextMessage = components["schemas"]["SlackContextMessage"];
+type SlackContextUserRef = components["schemas"]["SlackContextUserRef"];
+
+const aliceUser: SlackContextUserRef = {
+  id: "U001",
+  name: "alice",
+  real_name: "Alice Chen",
+  title: "Engineer",
+};
+
+const bobUser: SlackContextUserRef = {
+  id: "U002",
+  name: "bob",
+  real_name: "Bob Smith",
+};
+
+function makeMessage(
+  text: string,
+  user: SlackContextUserRef,
+  ts = "1711200000",
+): SlackContextMessage {
+  return {
+    text,
+    user,
+    ts,
+    permalink: `https://example.slack.com/archives/C001/p${ts}`,
+  };
+}
+
+const publicChannel: components["schemas"]["SlackContextChannel"] = {
+  id: "C001",
+  name: "general",
+  is_private: false,
+  is_dm: false,
+  topic: "Company updates",
+  member_count: 50,
+  permalink: "https://example.slack.com/archives/C001",
+};
+
+describe("SlackContextPreview", () => {
+  it("renders channel name and member count", () => {
+    render(
+      <SlackContextPreview
+        slackContext={{
+          context_scope: "recent_channel",
+          channel: publicChannel,
+          recent_messages: [],
+        }}
+      />,
+    );
+    expect(screen.getByText(/general/)).toBeInTheDocument();
+    expect(screen.getByText(/50/)).toBeInTheDocument();
+  });
+
+  it("renders Open in Slack link with rel=noopener noreferrer", () => {
+    render(
+      <SlackContextPreview
+        slackContext={{
+          context_scope: "recent_channel",
+          channel: publicChannel,
+          recent_messages: [],
+        }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /open.*slack/i });
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://example.slack.com/archives/C001",
+    );
+  });
+
+  it('shows "Note to self" badge for self_dm scope', () => {
+    render(
+      <SlackContextPreview
+        slackContext={{ context_scope: "self_dm" } as SlackContext}
+      />,
+    );
+    expect(screen.getByText("Note to self")).toBeInTheDocument();
+  });
+
+  it('shows "No prior messages" badge for first_contact_dm scope', () => {
+    render(
+      <SlackContextPreview
+        slackContext={{
+          context_scope: "first_contact_dm",
+          recipient: aliceUser,
+        } as SlackContext}
+      />,
+    );
+    expect(
+      screen.getByText(/no prior messages/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Context unavailable" badge for metadata_only scope', () => {
+    render(
+      <SlackContextPreview
+        slackContext={{
+          context_scope: "metadata_only",
+          channel: publicChannel,
+        } as SlackContext}
+      />,
+    );
+    expect(screen.getByText(/context unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders recent activity toggle for recent_channel scope", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      recent_messages: [makeMessage("Hello team!", aliceUser)],
+      context_window: { message_count: 1, hours: 24 },
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    // Accordion toggle is visible; messages are inside it (expanded in separate test)
+    expect(
+      screen.getByRole("button", { name: /channel activity/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 message/)).toBeInTheDocument();
+  });
+
+  it("recent activity accordion is collapsed by default", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      recent_messages: [makeMessage("Hidden message", aliceUser)],
+      context_window: { message_count: 1, hours: 24 },
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    // The toggle button should exist
+    expect(
+      screen.getByRole("button", { name: /channel activity/i }),
+    ).toBeInTheDocument();
+    // But the message should not be visible yet (accordion collapsed)
+    expect(screen.queryByText("Hidden message")).not.toBeInTheDocument();
+  });
+
+  it("expands recent activity accordion on click", async () => {
+    const user = userEvent.setup();
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      recent_messages: [makeMessage("Expanded message", aliceUser)],
+      context_window: { message_count: 1, hours: 24 },
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    await user.click(screen.getByRole("button", { name: /channel activity/i }));
+    expect(screen.getByText("Expanded message")).toBeInTheDocument();
+  });
+
+  it("renders thread section with parent and replies for thread scope", () => {
+    const ctx: SlackContext = {
+      context_scope: "thread",
+      channel: publicChannel,
+      thread: {
+        parent: makeMessage("Parent message", aliceUser, "1711200000"),
+        replies: [makeMessage("Reply here", bobUser, "1711200300")],
+        truncated: false,
+      },
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    expect(screen.getByText("Parent message")).toBeInTheDocument();
+    expect(screen.getByText("Reply here")).toBeInTheDocument();
+    expect(screen.getByText(/original message/i)).toBeInTheDocument();
+  });
+
+  it("renders target message section when present", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      target_message: makeMessage("Target text here", aliceUser),
+      recent_messages: [],
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    expect(screen.getByText(/target message/i)).toBeInTheDocument();
+    expect(screen.getByText(/Target text here/)).toBeInTheDocument();
+  });
+
+  it("renders recipient card for recent_dm scope", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_dm",
+      recipient: aliceUser,
+      recent_messages: [],
+      context_window: { message_count: 0, hours: 24 },
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    expect(screen.getByText("Alice Chen")).toBeInTheDocument();
+    expect(screen.getByText("Engineer")).toBeInTheDocument();
+  });
+
+  it("renders file attachments on messages", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      target_message: {
+        ...makeMessage("Has files", aliceUser),
+        files: [{ filename: "report.pdf", size_bytes: 102400 }],
+      },
+      recent_messages: [],
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+    expect(screen.getByText(/100 KB/)).toBeInTheDocument();
+  });
+
+  it("renders mrkdwn bold text", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      target_message: makeMessage("*Bold words*", aliceUser),
+      recent_messages: [],
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    const strong = document.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong?.textContent).toBe("Bold words");
+  });
+
+  it("message permalinks have rel=noopener noreferrer", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      target_message: makeMessage("A message", aliceUser),
+      recent_messages: [],
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    const links = document.querySelectorAll("a[rel='noopener noreferrer']");
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it("handles missing optional fields gracefully", () => {
+    render(
+      <SlackContextPreview
+        slackContext={{ context_scope: "metadata_only" } as SlackContext}
+      />,
+    );
+    expect(screen.getByText(/context unavailable/i)).toBeInTheDocument();
+  });
+
+  it("shows Private badge for private channels", () => {
+    render(
+      <SlackContextPreview
+        slackContext={{
+          context_scope: "metadata_only",
+          channel: {
+            id: "C999",
+            name: "secret-team",
+            is_private: true,
+            is_dm: false,
+            permalink: "https://example.slack.com/archives/C999",
+          },
+        } as SlackContext}
+      />,
+    );
+    expect(screen.getByText("Private")).toBeInTheDocument();
+  });
+
+  it("shows truncated warning on truncated messages", () => {
+    const ctx: SlackContext = {
+      context_scope: "recent_channel",
+      channel: publicChannel,
+      target_message: {
+        ...makeMessage("Truncated body", aliceUser),
+        truncated: true,
+      },
+      recent_messages: [],
+    };
+    render(<SlackContextPreview slackContext={ctx} />);
+    expect(screen.getByText(/message truncated/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/__tests__/slackMrkdwn.test.ts
+++ b/frontend/src/lib/__tests__/slackMrkdwn.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { slackMrkdwnToHtml } from "../slackMrkdwn";
+
+describe("slackMrkdwnToHtml", () => {
+  it("converts bold *text*", () => {
+    expect(slackMrkdwnToHtml("*hello*")).toContain("<strong>hello</strong>");
+  });
+
+  it("converts italic _text_", () => {
+    expect(slackMrkdwnToHtml("_hello_")).toContain("<em>hello</em>");
+  });
+
+  it("converts strikethrough ~text~", () => {
+    expect(slackMrkdwnToHtml("~hello~")).toContain("<s>hello</s>");
+  });
+
+  it("converts inline code `text`", () => {
+    expect(slackMrkdwnToHtml("`code`")).toContain("<code>code</code>");
+  });
+
+  it("converts triple-backtick code blocks", () => {
+    const result = slackMrkdwnToHtml("```const x = 1;```");
+    expect(result).toContain("<pre>");
+    expect(result).toContain("<code>");
+    expect(result).toContain("const x = 1;");
+  });
+
+  it("converts Slack link <url>", () => {
+    const result = slackMrkdwnToHtml("<https://example.com>");
+    expect(result).toContain('href="https://example.com"');
+    expect(result).toContain('rel="noopener noreferrer"');
+    expect(result).toContain('target="_blank"');
+  });
+
+  it("converts Slack link <url|label>", () => {
+    const result = slackMrkdwnToHtml("<https://example.com|Click here>");
+    expect(result).toContain('href="https://example.com"');
+    expect(result).toContain("Click here");
+  });
+
+  it("links have rel=noopener noreferrer", () => {
+    const result = slackMrkdwnToHtml("<https://example.com|link>");
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it("converts blockquote lines starting with >", () => {
+    const result = slackMrkdwnToHtml(">quoted text");
+    expect(result).toContain("<blockquote>");
+    expect(result).toContain("quoted text");
+  });
+
+  it("converts newlines to <br>", () => {
+    const result = slackMrkdwnToHtml("line1\nline2");
+    expect(result).toContain("<br>");
+  });
+
+  it("sanitizes script tags", () => {
+    const result = slackMrkdwnToHtml("<script>alert(1)</script>hello");
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("hello");
+  });
+
+  it("sanitizes event handler attributes", () => {
+    const result = slackMrkdwnToHtml(
+      "<a href='https://x.com' onclick='alert(1)'>x</a>",
+    );
+    expect(result).not.toContain("onclick");
+  });
+
+  it("does not double-process content inside code blocks", () => {
+    const result = slackMrkdwnToHtml("```*not bold*```");
+    expect(result).toContain("*not bold*");
+    expect(result).not.toContain("<strong>");
+  });
+
+  it("handles already-resolved mentions as plain text", () => {
+    const result = slackMrkdwnToHtml("@alice and #general");
+    expect(result).toContain("@alice");
+    expect(result).toContain("#general");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(slackMrkdwnToHtml("")).toBe("");
+  });
+});

--- a/frontend/src/lib/slackMrkdwn.ts
+++ b/frontend/src/lib/slackMrkdwn.ts
@@ -1,0 +1,75 @@
+import DOMPurify from "dompurify";
+
+const SANITIZE_CONFIG = {
+  ALLOWED_TAGS: ["br", "strong", "em", "s", "code", "pre", "blockquote", "a"],
+  ALLOWED_ATTR: ["href", "rel", "target"],
+};
+
+/**
+ * Converts Slack mrkdwn to sanitized HTML.
+ *
+ * Assumes the backend has already resolved <@U123> → @alice and
+ * <#C123|name> → #name. Handles: *bold*, _italic_, ~strike~, `code`,
+ * ```code blocks```, >blockquotes, <url|label> links, and \n → <br>.
+ *
+ * Code spans are extracted first and protected from mrkdwn processing via
+ * null-byte placeholders, then restored before sanitization.
+ *
+ * Output must be rendered via dangerouslySetInnerHTML — DOMPurify is applied
+ * as the final step.
+ */
+export function slackMrkdwnToHtml(text: string): string {
+  const protected_: string[] = [];
+
+  let html = text;
+
+  // Slack link format: <url> and <url|label>
+  html = html.replace(
+    /<(https?:\/\/[^|>\s]+)(?:\|([^>]*))?>/g,
+    (_, url: string, label?: string) =>
+      `<a href="${url}" target="_blank" rel="noopener noreferrer">${label ?? url}</a>`,
+  );
+
+  // Extract code blocks (triple backtick) — protect from further formatting
+  html = html.replace(/```([\s\S]*?)```/g, (_, code: string) => {
+    const idx = protected_.length;
+    protected_.push(`<pre><code>${code}</code></pre>`);
+    return `\x00P${idx}\x00`;
+  });
+
+  // Extract inline code — protect from further formatting
+  html = html.replace(/`([^`\n]+)`/g, (_, code: string) => {
+    const idx = protected_.length;
+    protected_.push(`<code>${code}</code>`);
+    return `\x00P${idx}\x00`;
+  });
+
+  // Bold *text*
+  html = html.replace(
+    /\*([^*\n]+)\*/g,
+    (_, t: string) => `<strong>${t}</strong>`,
+  );
+
+  // Italic _text_
+  html = html.replace(/_([^_\n]+)_/g, (_, t: string) => `<em>${t}</em>`);
+
+  // Strikethrough ~text~
+  html = html.replace(/~([^~\n]+)~/g, (_, t: string) => `<s>${t}</s>`);
+
+  // Blockquotes — lines starting with >
+  html = html.replace(
+    /^>(.+)$/gm,
+    (_, content: string) => `<blockquote>${content}</blockquote>`,
+  );
+
+  // Restore protected code spans
+  html = html.replace(
+    /\x00P(\d+)\x00/g,
+    (_, idx: string) => protected_[Number(idx)] ?? "",
+  );
+
+  // Newlines → <br>
+  html = html.replace(/\n/g, "<br>");
+
+  return DOMPurify.sanitize(html, SANITIZE_CONFIG);
+}

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -21,6 +21,8 @@ import { useAgents } from "@/hooks/useAgents";
 import { useStandingApprovals } from "@/hooks/useStandingApprovals";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { ActionPreviewCard } from "@/components/previews/ActionPreviewCard";
+import { SlackContextPreview } from "@/components/previews/SlackContextPreview";
+import type { components } from "@/api/schema";
 import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import {
   useCountdown,
@@ -348,15 +350,24 @@ export function ReviewApprovalDialog({
                   <Skeleton className="h-3 w-full" />
                 </div>
               ) : (
-                <ActionPreviewCard
-                  preview={preview}
-                  parameters={params}
-                  actionType={approval.action.type}
-                  schema={schema}
-                  actionName={actionName}
-                  displayTemplate={displayTemplate}
-                  resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
-                />
+                <>
+                  <ActionPreviewCard
+                    preview={preview}
+                    parameters={params}
+                    actionType={approval.action.type}
+                    schema={schema}
+                    actionName={actionName}
+                    displayTemplate={displayTemplate}
+                    resourceDetails={approval.resource_details as Record<string, unknown> | undefined}
+                  />
+                  {(() => {
+                    const slackCtx = (approval.context.details as Record<string, unknown> | undefined)
+                      ?.slack_context as components["schemas"]["SlackContext"] | undefined;
+                    return slackCtx ? (
+                      <SlackContextPreview slackContext={slackCtx} />
+                    ) : null;
+                  })()}
+                </>
               )}
             </div>
 


### PR DESCRIPTION
## Summary

- Adds `slackMrkdwn.ts` helper converting Slack mrkdwn to sanitized HTML (bold, italic, strike, code, blockquotes, `<url|label>` links). Code spans are protected via placeholders so mrkdwn formatting doesn't re-process their content. DOMPurify sanitizes the final output.
- Adds `SlackContextPreview` component rendering all six `context_scope` variants: channel header, recipient card (DMs), target message, thread section with parent+replies, recent activity accordion (collapsed by default), and empty-state badges for `self_dm` / `first_contact_dm` / `metadata_only`.
- Wires `SlackContextPreview` into `ReviewApprovalDialog` — displayed below the action preview card whenever `context.details.slack_context` is present, covering all 12 Slack action types automatically.
- 9 Storybook stories covering every scope variant plus mrkdwn formatting showcase.
- 32 new tests (15 mrkdwn unit tests + 17 component tests). All 1053 frontend tests pass.

**Note:** Full end-to-end verification requires PR 2 + PR 3 to merge first (backend populates `slack_context`). The component is ready and renders correctly against the locked schema from PR 1.

## Test plan

- [ ] All 1053 frontend tests pass (`cd frontend && npm test`)
- [ ] Storybook renders all 9 story variants without errors (`npm run storybook`)
- [ ] After PR 2+3 merge: approve a `send_message` in a channel — verify recent window accordion renders
- [ ] After PR 2+3 merge: approve a `send_message` with `thread_ts` — verify thread renders with parent + replies
- [ ] After PR 2+3 merge: approve a `send_dm` to a new user — verify first-contact badge renders
- [ ] After PR 2+3 merge: approve a `send_dm` to self — verify "Note to self" badge
- [ ] After PR 2+3 merge: force a 429 from Slack — verify `metadata_only` "Context unavailable" renders
- [ ] Verify all links have `rel="noopener noreferrer"`
- [ ] Verify mrkdwn renders correctly (bold, italic, links)

Closes #981 (PR 4 of 5)

https://claude.ai/code/session_01C4Un38UZEZ14umXevvEtCu