### PR TITLE
Phase 4: approval dialog uses _connector_instance_display vs legacy label correctly

### DIFF
--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -125,18 +125,20 @@ export function ReviewApprovalDialog({
   const { denyApproval, isPending: isDenying } = useDenyApproval();
   const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg, isLoading: schemaLoading } =
     useActionSchema(approval.action.type);
-  const connectorInstanceDisplay =
+  const connectorInstanceDisplayStr =
     typeof approval.action === "object" &&
     approval.action !== null &&
     "_connector_instance_display" in approval.action &&
     typeof (approval.action as { _connector_instance_display?: unknown })._connector_instance_display === "string"
       ? (approval.action as { _connector_instance_display: string })._connector_instance_display
-      : typeof approval.action === "object" &&
-          approval.action !== null &&
-          "_connector_instance_label" in approval.action &&
-          typeof (approval.action as { _connector_instance_label?: unknown })._connector_instance_label === "string"
-        ? (approval.action as { _connector_instance_label: string })._connector_instance_label
-        : undefined;
+      : undefined;
+  const connectorInstanceLabelStr =
+    typeof approval.action === "object" &&
+    approval.action !== null &&
+    "_connector_instance_label" in approval.action &&
+    typeof (approval.action as { _connector_instance_label?: unknown })._connector_instance_label === "string"
+      ? (approval.action as { _connector_instance_label: string })._connector_instance_label
+      : undefined;
   const remaining = useCountdown(approval.expires_at);
   const isExpired = remaining <= 0;
   const isBusy = pendingAction !== null || isDenying;
@@ -257,7 +259,8 @@ export function ReviewApprovalDialog({
                     {formatConnectorDisplayName({
                       connectorName,
                       actionType: approval.action.type,
-                      instanceDisplay: connectorInstanceDisplay,
+                      instanceDisplay: connectorInstanceDisplayStr,
+                      instanceLabel: connectorInstanceLabelStr,
                     })}
                   </p>
                 </div>

--- a/frontend/src/pages/dashboard/approvalConnectorLabel.test.ts
+++ b/frontend/src/pages/dashboard/approvalConnectorLabel.test.ts
@@ -32,6 +32,17 @@ describe("formatConnectorDisplayName", () => {
     ).toBe("Slack (Legacy)");
   });
 
+  it("prefers instanceDisplay over instanceLabel when both are present", () => {
+    expect(
+      formatConnectorDisplayName({
+        connectorName: "Slack",
+        actionType: "slack.send_message",
+        instanceDisplay: "New",
+        instanceLabel: "Old",
+      }),
+    ).toBe("Slack (New)");
+  });
+
   it("uses connector name only when no instance label", () => {
     expect(
       formatConnectorDisplayName({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Mobile Phase 4 was already satisfied: `connectorInstanceLabelFromAction` in `mobile/src/screens/approvals/approvalUtils.ts` reads `_connector_instance_display` first and falls back to `_connector_instance_label` (with unit tests).
- The web approval review dialog was collapsing display and label into a single `instanceDisplay` argument, so `formatConnectorDisplayName` could not prefer display when both fields were present. The dialog now passes `instanceDisplay` and `instanceLabel` separately, matching `approvalConnectorLabel.ts` and mobile behavior.
- Added a Vitest case asserting display wins when both are set.

## Related Issue

Part of #974 (Phase 4 — mobile + audit display).

## Test Plan

### Developer

- [x] Unit tests added / updated (`approvalConnectorLabel.test.ts`)
- [x] `make test-frontend` passed
- [x] `make mobile-test` passed (after `npm install` in `mobile/`)
- [x] `cd frontend && npm run build` passed (tsc + vite)
- [ ] `make build` not run (Go build in root requires full toolchain; frontend-only change)

### Manual Testing

- [ ] Open an approval with multi-instance metadata and confirm the subtitle shows the credential display name; spot-check a legacy action that only has `_connector_instance_label`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36e8c2ab-e944-4825-8d29-5c97c3a8b26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36e8c2ab-e944-4825-8d29-5c97c3a8b26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

