### PR TITLE
feat(frontend): credential checklist for agent connector instances (#974 phase 3)

### DIFF
--- a/frontend/src/hooks/useAgentConnectorInstanceCredential.ts
+++ b/frontend/src/hooks/useAgentConnectorInstanceCredential.ts
@@ -113,6 +113,13 @@ export function useAssignAgentConnectorInstanceCredential() {
           variables.connectorId,
         ],
       });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-credential-bindings",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
     },
   });
 
@@ -177,6 +184,13 @@ export function useRemoveAgentConnectorInstanceCredential() {
       queryClient.invalidateQueries({
         queryKey: [
           "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-credential-bindings",
           variables.agentId,
           variables.connectorId,
         ],

--- a/frontend/src/hooks/useAgentConnectorInstances.ts
+++ b/frontend/src/hooks/useAgentConnectorInstances.ts
@@ -75,6 +75,13 @@ export function useCreateAgentConnectorInstance() {
           variables.connectorId,
         ],
       });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-credential-bindings",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
     },
   });
 
@@ -129,6 +136,13 @@ export function useSetDefaultAgentConnectorInstance() {
       queryClient.invalidateQueries({
         queryKey: [
           "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-credential-bindings",
           variables.agentId,
           variables.connectorId,
         ],
@@ -193,6 +207,13 @@ export function useDeleteAgentConnectorInstance() {
       queryClient.invalidateQueries({
         queryKey: [
           "connector-instance-bindings-summary",
+          variables.agentId,
+          variables.connectorId,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          "connector-instance-credential-bindings",
           variables.agentId,
           variables.connectorId,
         ],

--- a/frontend/src/hooks/useConnectorInstanceCredentialBindings.ts
+++ b/frontend/src/hooks/useConnectorInstanceCredentialBindings.ts
@@ -7,7 +7,8 @@ export type InstanceCredentialBinding =
   components["schemas"]["AgentConnectorCredentialResponse"];
 
 /**
- * Loads credential bindings for each connector instance row (batch GET per instance).
+ * Loads credential bindings for each connector instance row (one GET per instance).
+ * Follow-up: consider a batch endpoint to avoid N+1 when many instances exist.
  */
 export function useConnectorInstanceCredentialBindings(
   agentId: number,

--- a/frontend/src/hooks/useConnectorInstanceCredentialBindings.ts
+++ b/frontend/src/hooks/useConnectorInstanceCredentialBindings.ts
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type InstanceCredentialBinding =
+  components["schemas"]["AgentConnectorCredentialResponse"];
+
+/**
+ * Loads credential bindings for each connector instance row (batch GET per instance).
+ */
+export function useConnectorInstanceCredentialBindings(
+  agentId: number,
+  connectorId: string,
+  instanceIds: string[],
+) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const sortedIds = [...instanceIds].sort().join(",");
+
+  return useQuery({
+    queryKey: [
+      "connector-instance-credential-bindings",
+      agentId,
+      connectorId,
+      sortedIds,
+    ],
+    queryFn: async (): Promise<Map<string, InstanceCredentialBinding | null>> => {
+      if (!accessToken) throw new Error("Missing access token");
+      const out = new Map<string, InstanceCredentialBinding | null>();
+      await Promise.all(
+        instanceIds.map(async (instanceId) => {
+          const { data, error } = await client.GET(
+            "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
+            {
+              headers: { Authorization: `Bearer ${accessToken}` },
+              params: {
+                path: {
+                  agent_id: agentId,
+                  connector_id: connectorId,
+                  instance_id: instanceId,
+                },
+              },
+            },
+          );
+          if (error) throw new Error("Failed to load instance credential binding");
+          out.set(instanceId, data ?? null);
+        }),
+      );
+      return out;
+    },
+    enabled:
+      !!accessToken && agentId > 0 && !!connectorId && instanceIds.length > 0,
+  });
+}

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
@@ -1,13 +1,14 @@
 /**
- * Connector instances layout — Storybook
+ * Connector credentials checklist — Storybook
  *
- * Mirrors the structure of `ConnectorInstancesSection` (cards, default badge,
- * credential row) without API calls so Storybook stays offline.
+ * Mirrors `ConnectorInstancesSection` (checkboxes, default badge, Make default)
+ * without API calls so Storybook stays offline.
  */
 import type { Meta, StoryObj } from "@storybook/react";
-import { Plus, Settings, Star, Trash2, Unplug } from "lucide-react";
+import { Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardHeader,
@@ -15,111 +16,60 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-
-const selectClassName =
-  "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
 
 function ConnectorInstancesSectionLayoutMirror() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Connector instances</CardTitle>
+        <CardTitle>Credentials for this agent</CardTitle>
         <CardDescription>
-          Connect via OAuth (recommended) or use an API key as an alternative.
-          Each instance can use its own credential.
+          Choose which stored credentials this agent may use for Slack. One
+          credential is the default for approvals when no specific instance is
+          selected.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          <div className="rounded-lg border p-4">
-            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 flex-1 items-start gap-3">
+              <Checkbox id="story-oauth-1" checked className="mt-1" disabled />
               <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="font-medium">Engineering</p>
-                  <Badge variant="secondary">Default</Badge>
-                </div>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  Added 3/1/2026, 12:00:00 PM
-                </p>
+                <label htmlFor="story-oauth-1" className="cursor-pointer font-medium">
+                  Slack OAuth — Acme Workspace
+                </label>
+                <p className="text-muted-foreground text-xs">Connected 3/1/2026</p>
               </div>
             </div>
-            <div className="rounded-md border border-dashed p-3">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Label className="text-sm font-medium">Credential</Label>
-                  <Badge
-                    variant="secondary"
-                    className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-                  >
-                    Assigned
-                  </Badge>
-                </div>
-                <p className="text-muted-foreground text-sm">
-                  This instance uses the selected credential or OAuth connection.
-                </p>
-                <Button type="button" variant="ghost" size="sm" className="h-8 px-2">
-                  <Unplug className="size-3.5" />
-                  Disconnect
-                </Button>
-                <select className={selectClassName} defaultValue="oauth:oconn_1">
-                  <option value="oauth:oconn_1">
-                    Slack OAuth — Acme Workspace (connected 3/1/2026)
-                  </option>
-                </select>
-              </div>
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+              <Badge variant="secondary">Default</Badge>
+              <Button type="button" variant="outline" size="sm" disabled>
+                <Star className="size-3.5" />
+                Make default
+              </Button>
             </div>
           </div>
 
-          <div className="rounded-lg border p-4">
-            <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 flex-1 items-start gap-3">
+              <Checkbox id="story-oauth-2" checked className="mt-1" disabled />
               <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="font-medium">Sales</p>
-                </div>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  Added 3/2/2026, 12:00:00 PM
-                </p>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button type="button" variant="outline" size="sm">
-                  <Star className="size-3.5" />
-                  Make default
-                </Button>
-                <Button type="button" variant="outline" size="sm">
-                  <Trash2 className="size-3.5" />
-                  Remove instance
-                </Button>
+                <label htmlFor="story-oauth-2" className="cursor-pointer font-medium">
+                  Slack OAuth — Sales Workspace
+                </label>
+                <p className="text-muted-foreground text-xs">Connected 3/2/2026</p>
               </div>
             </div>
-            <div className="rounded-md border border-dashed p-3">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Label className="text-sm font-medium">Credential</Label>
-                  <Badge variant="destructive">Not set</Badge>
-                </div>
-                <p className="text-muted-foreground text-sm">
-                  Select a credential so this instance can run actions.
-                </p>
-                <select className={selectClassName} defaultValue="">
-                  <option value="">Select a credential…</option>
-                  <option value="oauth:oconn_2">
-                    Slack OAuth — Sales Workspace (connected 3/2/2026)
-                  </option>
-                </select>
-              </div>
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+              <Button type="button" variant="outline" size="sm">
+                <Star className="size-3.5" />
+                Make default
+              </Button>
             </div>
           </div>
-
-          <Button type="button" variant="outline" size="sm" className="w-full sm:w-auto">
-            <Plus className="size-4" />
-            Add another
-          </Button>
         </div>
 
         <div className="mt-4 flex justify-end">
-          <Button variant="outline" size="sm">
-            <Settings className="size-3" />
+          <Button variant="outline" size="sm" type="button">
             Manage credentials
           </Button>
         </div>
@@ -137,7 +87,7 @@ export default meta;
 
 type Story = StoryObj<typeof ConnectorInstancesSectionLayoutMirror>;
 
-export const MultiInstanceLayout: Story = {
+export const MultiCredentialChecklist: Story = {
   render: () => (
     <div className="max-w-xl">
       <ConnectorInstancesSectionLayoutMirror />

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
@@ -5,7 +5,7 @@
  * without API calls so Storybook stays offline.
  */
 import type { Meta, StoryObj } from "@storybook/react";
-import { Star } from "lucide-react";
+import { Settings, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -69,7 +69,8 @@ function ConnectorInstancesSectionLayoutMirror() {
         </div>
 
         <div className="mt-4 flex justify-end">
-          <Button variant="outline" size="sm" type="button">
+          <Button type="button" variant="outline" size="sm">
+            <Settings className="size-3" />
             Manage credentials
           </Button>
         </div>

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -464,6 +464,7 @@ export function ConnectorInstancesSection({
         {showManageButton && (
           <div className="mt-4 flex justify-end">
             <Button
+              type="button"
               variant="outline"
               size="sm"
               onClick={() => setManageDialogOpen(true)}

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Loader2, Settings, Star, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,6 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import { useQueryClient } from "@tanstack/react-query";
 import { useCredentials } from "@/hooks/useCredentials";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
@@ -63,7 +62,6 @@ export function ConnectorInstancesSection({
     [connectorId, requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
-  const queryClient = useQueryClient();
 
   useAutoAssignOAuthCredential(agentId, connectorId);
 
@@ -80,12 +78,6 @@ export function ConnectorInstancesSection({
     useAssignAgentConnectorInstanceCredential();
   const { remove, isPending: removing } =
     useRemoveAgentConnectorInstanceCredential();
-
-  const invalidateConnectorInstanceBindings = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: ["connector-instance-credential-bindings", agentId, connectorId],
-    });
-  }, [queryClient, agentId, connectorId]);
 
   const hasRequiredCredentials = requiredCredentials.length > 0;
   const hasExplicitOAuth = requiredCredentials.some(
@@ -128,8 +120,11 @@ export function ConnectorInstancesSection({
     [instances],
   );
 
-  const { data: bindingByInstance, isLoading: bindingsLoading } =
-    useConnectorInstanceCredentialBindings(agentId, connectorId, instanceIds);
+  const {
+    data: bindingByInstance,
+    isLoading: bindingsLoading,
+    isError: bindingsError,
+  } = useConnectorInstanceCredentialBindings(agentId, connectorId, instanceIds);
 
   const rows: CredentialRow[] = useMemo(() => {
     const activeConnections = connections.filter(
@@ -243,22 +238,23 @@ export function ConnectorInstancesSection({
         credentialId: row.credential.id,
       });
     }
-    invalidateConnectorInstanceBindings();
   }
 
-  async function disableRow(inst: AgentConnectorInstance) {
+  /** Returns true if the instance was fully removed; false if user messaging already ran. */
+  async function disableRow(inst: AgentConnectorInstance): Promise<boolean> {
     const otherWithCredential = instances.filter((i) => {
       if (i.connector_instance_id === inst.connector_instance_id) return false;
       const b = bindingByInstance?.get(i.connector_instance_id);
       return bindingRowKey(b ?? undefined) !== null;
     });
 
+    let transferredDefaultAway = false;
     if (inst.is_default) {
       if (otherWithCredential.length === 0) {
         toast.error(
           "Enable another credential before disabling the default, or pick a different default first.",
         );
-        return;
+        return false;
       }
       const nextDefault = [...otherWithCredential].sort((a, b) =>
         a.connector_instance_id.localeCompare(b.connector_instance_id),
@@ -269,12 +265,37 @@ export function ConnectorInstancesSection({
           connectorId,
           instanceId: nextDefault.connector_instance_id,
         });
+        transferredDefaultAway = true;
       }
     }
 
-    await remove({ agentId, connectorId, instanceId: inst.connector_instance_id });
-    await deleteInstance({ agentId, connectorId, instanceId: inst.connector_instance_id });
-    invalidateConnectorInstanceBindings();
+    try {
+      await remove({ agentId, connectorId, instanceId: inst.connector_instance_id });
+      await deleteInstance({ agentId, connectorId, instanceId: inst.connector_instance_id });
+      return true;
+    } catch (err) {
+      if (transferredDefaultAway) {
+        try {
+          await setDefault({
+            agentId,
+            connectorId,
+            instanceId: inst.connector_instance_id,
+          });
+        } catch {
+          /* best-effort rollback */
+        }
+        toast.error(
+          err instanceof Error
+            ? `${err.message} The default was reverted to this credential — try again or change default manually.`
+            : "Failed to disable credential. The default was reverted — try again or change default manually.",
+        );
+      } else {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to disable credential.",
+        );
+      }
+      return false;
+    }
   }
 
   async function toggleRow(row: CredentialRow, checked: boolean) {
@@ -291,13 +312,9 @@ export function ConnectorInstancesSection({
       return;
     }
     if (!checked && inst) {
-      try {
-        await disableRow(inst);
+      const disabledOk = await disableRow(inst);
+      if (disabledOk) {
         toast.success("Credential disabled for this agent.");
-      } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : "Failed to disable credential.",
-        );
       }
     }
   }
@@ -344,8 +361,13 @@ export function ConnectorInstancesSection({
         )}
         {!isLoading && !error && (
           <div className="space-y-4">
-            {(bindingsLoading || (instanceIds.length > 0 && !bindingByInstance)) && (
+            {bindingsLoading && (
               <p className="text-muted-foreground text-sm">Loading credential links…</p>
+            )}
+            {bindingsError && (
+              <p className="text-destructive text-sm">
+                Failed to load credential links. Refresh the page to retry.
+              </p>
             )}
             {rows.length === 0 && (
               <p className="text-muted-foreground text-sm">
@@ -425,7 +447,7 @@ export function ConnectorInstancesSection({
                         type="button"
                         variant="outline"
                         size="sm"
-                        disabled={busyRow || deleting}
+                        disabled={busyRow}
                         onClick={() => void handleRemoveOrphan(id)}
                       >
                         <Trash2 className="size-3.5" />

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
-import { Loader2, Plus, Settings, Star, Trash2, Unplug } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Loader2, Settings, Star, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardHeader,
@@ -10,15 +11,7 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCredentials } from "@/hooks/useCredentials";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
@@ -33,14 +26,15 @@ import {
   type AgentConnectorInstance,
 } from "@/hooks/useAgentConnectorInstances";
 import {
-  useAgentConnectorInstanceCredential,
   useAssignAgentConnectorInstanceCredential,
   useRemoveAgentConnectorInstanceCredential,
 } from "@/hooks/useAgentConnectorInstanceCredential";
+import { useConnectorInstanceCredentialBindings } from "@/hooks/useConnectorInstanceCredentialBindings";
 import { useAutoAssignOAuthCredential } from "@/hooks/useAutoAssignOAuthCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import type { OAuthConnection } from "@/hooks/useOAuthConnections";
 import { ManageCredentialsDialog } from "./ManageCredentialsDialog";
+import type { InstanceCredentialBinding } from "@/hooks/useConnectorInstanceCredentialBindings";
 
 export interface ConnectorInstancesSectionProps {
   agentId: number;
@@ -48,8 +42,16 @@ export interface ConnectorInstancesSectionProps {
   requiredCredentials: RequiredCredential[];
 }
 
-const selectClassName =
-  "border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm";
+type CredentialRow =
+  | { kind: "oauth"; rowKey: string; connection: OAuthConnection }
+  | { kind: "cred"; rowKey: string; credential: CredentialSummary };
+
+function bindingRowKey(b: InstanceCredentialBinding | null | undefined): string | null {
+  if (!b) return null;
+  if (b.oauth_connection_id) return `oauth:${b.oauth_connection_id}`;
+  if (b.credential_id) return `cred:${b.credential_id}`;
+  return null;
+}
 
 export function ConnectorInstancesSection({
   agentId,
@@ -61,7 +63,7 @@ export function ConnectorInstancesSection({
     [connectorId, requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
-  const [addOpen, setAddOpen] = useState(false);
+  const queryClient = useQueryClient();
 
   useAutoAssignOAuthCredential(agentId, connectorId);
 
@@ -70,6 +72,20 @@ export function ConnectorInstancesSection({
     connectorId,
   );
   const { create, isPending: creating } = useCreateAgentConnectorInstance();
+  const { setDefault, isPending: settingDefault } =
+    useSetDefaultAgentConnectorInstance();
+  const { deleteInstance, isPending: deleting } =
+    useDeleteAgentConnectorInstance();
+  const { assign, isPending: assigning } =
+    useAssignAgentConnectorInstanceCredential();
+  const { remove, isPending: removing } =
+    useRemoveAgentConnectorInstanceCredential();
+
+  const invalidateConnectorInstanceBindings = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: ["connector-instance-credential-bindings", agentId, connectorId],
+    });
+  }, [queryClient, agentId, connectorId]);
 
   const hasRequiredCredentials = requiredCredentials.length > 0;
   const hasExplicitOAuth = requiredCredentials.some(
@@ -87,12 +103,15 @@ export function ConnectorInstancesSection({
     enabled: true,
   });
 
-  const storedByService = new Map<string, CredentialSummary[]>();
-  for (const cred of credentials) {
-    const list = storedByService.get(cred.service) ?? [];
-    list.push(cred);
-    storedByService.set(cred.service, list);
-  }
+  const storedByService = useMemo(() => {
+    const m = new Map<string, CredentialSummary[]>();
+    for (const cred of credentials) {
+      const list = m.get(cred.service) ?? [];
+      list.push(cred);
+      m.set(cred.service, list);
+    }
+    return m;
+  }, [credentials]);
 
   const matchingProvider = providers.find((p) => p.id === connectorId);
   const hasImplicitOAuth = !hasExplicitOAuth && !!matchingProvider;
@@ -104,27 +123,213 @@ export function ConnectorInstancesSection({
     return 0;
   });
 
+  const instanceIds = useMemo(
+    () => instances.map((i) => i.connector_instance_id),
+    [instances],
+  );
+
+  const { data: bindingByInstance, isLoading: bindingsLoading } =
+    useConnectorInstanceCredentialBindings(agentId, connectorId, instanceIds);
+
+  const rows: CredentialRow[] = useMemo(() => {
+    const activeConnections = connections.filter(
+      (c) => c.status === "active" && c.id && c.provider === connectorId,
+    );
+    const scopedCredentials = credentials
+      .filter((c) => credentialServiceIds.has(c.service))
+      .slice()
+      .sort((a, b) => {
+        const la = (a.label ?? a.service).toLowerCase();
+        const lb = (b.label ?? b.service).toLowerCase();
+        return la.localeCompare(lb);
+      });
+
+    const oauthRows: CredentialRow[] = activeConnections
+      .slice()
+      .sort((a, b) =>
+        (a.display_name ?? a.id).localeCompare(b.display_name ?? b.id),
+      )
+      .map((connection) => ({
+        kind: "oauth" as const,
+        rowKey: `oauth:${connection.id}`,
+        connection,
+      }));
+
+    const credRows: CredentialRow[] = scopedCredentials.map((credential) => ({
+      kind: "cred" as const,
+      rowKey: `cred:${credential.id}`,
+      credential,
+    }));
+
+    return [...oauthRows, ...credRows];
+  }, [connections, connectorId, credentials, credentialServiceIds]);
+
+  const instanceByRowKey = useMemo(() => {
+    const map = new Map<string, AgentConnectorInstance>();
+    if (!bindingByInstance) return map;
+    for (const inst of instances) {
+      const b = bindingByInstance.get(inst.connector_instance_id);
+      const key = bindingRowKey(b ?? undefined);
+      if (key) map.set(key, inst);
+    }
+    return map;
+  }, [instances, bindingByInstance]);
+
+  const enabledInstanceCount = useMemo(() => {
+    if (!bindingByInstance) return 0;
+    let n = 0;
+    for (const inst of instances) {
+      const b = bindingByInstance.get(inst.connector_instance_id);
+      if (bindingRowKey(b ?? undefined)) n += 1;
+    }
+    return n;
+  }, [instances, bindingByInstance]);
+
+  const orphanInstanceIds = useMemo(() => {
+    if (!bindingByInstance) return [];
+    const out: string[] = [];
+    for (const inst of instances) {
+      const b = bindingByInstance.get(inst.connector_instance_id);
+      if (!bindingRowKey(b ?? undefined)) out.push(inst.connector_instance_id);
+    }
+    return out;
+  }, [instances, bindingByInstance]);
+
   const anyLoading = credsLoading || connectionsLoading || providersLoading;
   const showManageButton = hasRequiredCredentials || !!matchingProvider;
+  const busyRow =
+    creating || assigning || removing || deleting || settingDefault;
 
-  async function handleAddInstance() {
+  async function handleSetDefault(instanceId: string) {
     try {
-      await create({ agentId, connectorId });
-      toast.success("Connector instance added. Assign a credential to name it.");
-      setAddOpen(false);
+      await setDefault({ agentId, connectorId, instanceId });
+      toast.success("Default credential updated.");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to add instance.");
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update default.",
+      );
     }
+  }
+
+  async function handleRemoveOrphan(instanceId: string) {
+    try {
+      await deleteInstance({ agentId, connectorId, instanceId });
+      toast.success("Unused connector slot removed.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to remove connector slot.",
+      );
+    }
+  }
+
+  async function enableRow(row: CredentialRow) {
+    const created = await create({ agentId, connectorId });
+    const newId = created?.connector_instance_id;
+    if (!newId) {
+      throw new Error("Server did not return a connector instance id");
+    }
+    if (row.kind === "oauth") {
+      await assign({
+        agentId,
+        connectorId,
+        instanceId: newId,
+        oauthConnectionId: row.connection.id,
+      });
+    } else {
+      await assign({
+        agentId,
+        connectorId,
+        instanceId: newId,
+        credentialId: row.credential.id,
+      });
+    }
+    invalidateConnectorInstanceBindings();
+  }
+
+  async function disableRow(inst: AgentConnectorInstance) {
+    const otherWithCredential = instances.filter((i) => {
+      if (i.connector_instance_id === inst.connector_instance_id) return false;
+      const b = bindingByInstance?.get(i.connector_instance_id);
+      return bindingRowKey(b ?? undefined) !== null;
+    });
+
+    if (inst.is_default) {
+      if (otherWithCredential.length === 0) {
+        toast.error(
+          "Enable another credential before disabling the default, or pick a different default first.",
+        );
+        return;
+      }
+      const nextDefault = [...otherWithCredential].sort((a, b) =>
+        a.connector_instance_id.localeCompare(b.connector_instance_id),
+      )[0];
+      if (nextDefault) {
+        await setDefault({
+          agentId,
+          connectorId,
+          instanceId: nextDefault.connector_instance_id,
+        });
+      }
+    }
+
+    await remove({ agentId, connectorId, instanceId: inst.connector_instance_id });
+    await deleteInstance({ agentId, connectorId, instanceId: inst.connector_instance_id });
+    invalidateConnectorInstanceBindings();
+  }
+
+  async function toggleRow(row: CredentialRow, checked: boolean) {
+    const inst = instanceByRowKey.get(row.rowKey);
+    if (checked && !inst) {
+      try {
+        await enableRow(row);
+        toast.success("Credential enabled for this agent.");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to enable credential.",
+        );
+      }
+      return;
+    }
+    if (!checked && inst) {
+      try {
+        await disableRow(inst);
+        toast.success("Credential disabled for this agent.");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to disable credential.",
+        );
+      }
+    }
+  }
+
+  function rowLabel(row: CredentialRow): string {
+    if (row.kind === "oauth") {
+      const conn = row.connection;
+      const base = `${providerLabel(conn.provider)} OAuth`;
+      return conn.display_name ? `${base} — ${conn.display_name}` : base;
+    }
+    const cred = row.credential;
+    return cred.label
+      ? `${cred.label} — ${serviceLabel(cred.service)}`
+      : serviceLabel(cred.service);
+  }
+
+  function rowMeta(row: CredentialRow): string {
+    if (row.kind === "oauth") {
+      return `Connected ${new Date(row.connection.connected_at).toLocaleDateString()}`;
+    }
+    return `Added ${new Date(row.credential.created_at).toLocaleDateString()}`;
   }
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Connector instances</CardTitle>
+        <CardTitle>Credentials for this agent</CardTitle>
         {hasOAuth && hasStatic && (
           <CardDescription>
-            Connect via OAuth (recommended) or use an API key as an
-            alternative. Each instance can use its own credential.
+            Choose which stored credentials this agent may use for{" "}
+            {serviceLabel(connectorId)}. One credential is the default for
+            approvals when no specific instance is selected.
           </CardDescription>
         )}
       </CardHeader>
@@ -139,29 +344,98 @@ export function ConnectorInstancesSection({
         )}
         {!isLoading && !error && (
           <div className="space-y-4">
-            {instances.map((inst) => (
-              <InstanceCard
-                key={inst.connector_instance_id}
-                agentId={agentId}
-                connectorId={connectorId}
-                instance={inst}
-                credentialServiceIds={credentialServiceIds}
-                credentials={credentials}
-                connections={connections}
-                anyLoading={anyLoading}
-              />
-            ))}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="w-full sm:w-auto"
-              onClick={() => setAddOpen(true)}
-              disabled={creating}
-            >
-              <Plus className="size-4" />
-              Add another
-            </Button>
+            {(bindingsLoading || (instanceIds.length > 0 && !bindingByInstance)) && (
+              <p className="text-muted-foreground text-sm">Loading credential links…</p>
+            )}
+            {rows.length === 0 && (
+              <p className="text-muted-foreground text-sm">
+                No credentials found for this connector. Add one using Manage
+                credentials.
+              </p>
+            )}
+            {rows.map((row) => {
+              const inst = instanceByRowKey.get(row.rowKey);
+              const enabled = !!inst;
+              const isDefault = !!inst?.is_default;
+              const showDefaultControls = enabled && enabledInstanceCount > 1;
+
+              return (
+                <div
+                  key={row.rowKey}
+                  className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex min-w-0 flex-1 items-start gap-3">
+                    <Checkbox
+                      id={`cred-row-${row.rowKey}`}
+                      checked={enabled}
+                      disabled={busyRow}
+                      onCheckedChange={(v) => void toggleRow(row, v === true)}
+                      className="mt-1"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <label
+                        htmlFor={`cred-row-${row.rowKey}`}
+                        className="cursor-pointer font-medium"
+                      >
+                        {rowLabel(row)}
+                      </label>
+                      <p className="text-muted-foreground text-xs">{rowMeta(row)}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                    {enabled && isDefault && (
+                      <Badge variant="secondary">Default</Badge>
+                    )}
+                    {enabled && showDefaultControls && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={busyRow || isDefault}
+                        onClick={() =>
+                          inst &&
+                          void handleSetDefault(inst.connector_instance_id)
+                        }
+                      >
+                        <Star className="size-3.5" />
+                        Make default
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {orphanInstanceIds.length > 0 && (
+              <div className="rounded-md border border-dashed p-3">
+                <p className="text-muted-foreground mb-2 text-sm">
+                  These connector slots are not linked to a credential. Remove
+                  them to clean up.
+                </p>
+                <ul className="space-y-2">
+                  {orphanInstanceIds.map((id) => (
+                    <li
+                      key={id}
+                      className="flex items-center justify-between gap-2 text-sm"
+                    >
+                      <span className="text-muted-foreground font-mono text-xs">
+                        {id.slice(0, 8)}…
+                      </span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={busyRow || deleting}
+                        onClick={() => void handleRemoveOrphan(id)}
+                      >
+                        <Trash2 className="size-3.5" />
+                        Remove slot
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         )}
 
@@ -178,28 +452,6 @@ export function ConnectorInstancesSection({
           </div>
         )}
       </CardContent>
-
-      <Dialog open={addOpen} onOpenChange={setAddOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Add connector instance</DialogTitle>
-            <DialogDescription>
-              Creates another slot for this connector. After you add it, assign a
-              credential on that instance&apos;s card in the list (below this dialog)
-              so it has a name in approvals and capabilities.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setAddOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={() => void handleAddInstance()} disabled={creating}>
-              {creating && <Loader2 className="size-4 animate-spin" />}
-              Add
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <ManageCredentialsDialog
         open={manageDialogOpen}
@@ -220,312 +472,5 @@ export function ConnectorInstancesSection({
         oauthError={oauthError}
       />
     </Card>
-  );
-}
-
-function InstanceCard({
-  agentId,
-  connectorId,
-  instance,
-  credentialServiceIds,
-  credentials,
-  connections,
-  anyLoading,
-}: {
-  agentId: number;
-  connectorId: string;
-  instance: AgentConnectorInstance;
-  credentialServiceIds: Set<string>;
-  credentials: CredentialSummary[];
-  connections: OAuthConnection[];
-  anyLoading: boolean;
-}) {
-  const [deleteOpen, setDeleteOpen] = useState(false);
-
-  const { setDefault, isPending: settingDefault } =
-    useSetDefaultAgentConnectorInstance();
-  const { deleteInstance, isPending: deleting } =
-    useDeleteAgentConnectorInstance();
-
-  const isBusy = settingDefault || deleting;
-  const displayName =
-    instance.display?.trim() ||
-    "Unnamed instance — assign a credential";
-
-  async function handleMakeDefault() {
-    try {
-      await setDefault({
-        agentId,
-        connectorId,
-        instanceId: instance.connector_instance_id,
-      });
-      toast.success("Default instance updated.");
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to update default.",
-      );
-    }
-  }
-
-  async function handleDelete() {
-    try {
-      await deleteInstance({
-        agentId,
-        connectorId,
-        instanceId: instance.connector_instance_id,
-      });
-      toast.success("Instance removed.");
-      setDeleteOpen(false);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to remove instance.");
-    }
-  }
-
-  return (
-    <>
-      <div className="rounded-lg border p-4">
-        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="font-medium">{displayName}</p>
-              {instance.is_default && (
-                <Badge variant="secondary">Default</Badge>
-              )}
-            </div>
-            <p className="text-muted-foreground mt-1 text-xs">
-              Added {new Date(instance.enabled_at).toLocaleString()}
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {!instance.is_default && (
-              <>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void handleMakeDefault()}
-                  disabled={isBusy}
-                >
-                  <Star className="size-3.5" />
-                  Make default
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setDeleteOpen(true)}
-                  disabled={isBusy}
-                >
-                  <Trash2 className="size-3.5" />
-                  Remove instance
-                </Button>
-              </>
-            )}
-          </div>
-        </div>
-
-        <InstanceCredentialBinding
-          agentId={agentId}
-          connectorId={connectorId}
-          instanceId={instance.connector_instance_id}
-          credentialServiceIds={credentialServiceIds}
-          credentials={credentials}
-          connections={connections}
-          anyLoading={anyLoading}
-        />
-      </div>
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Remove this instance?</DialogTitle>
-            <DialogDescription>
-              This removes the <strong>{displayName}</strong> instance and its
-              credential binding. Standing approvals scoped to this instance are
-              revoked. The default instance cannot be removed here — disable the
-              connector type instead.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="secondary"
-              onClick={() => setDeleteOpen(false)}
-              disabled={deleting}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => void handleDelete()}
-              disabled={deleting}
-            >
-              {deleting && <Loader2 className="mr-2 size-4 animate-spin" />}
-              Remove
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
-function InstanceCredentialBinding({
-  agentId,
-  connectorId,
-  instanceId,
-  credentialServiceIds,
-  credentials,
-  connections,
-  anyLoading,
-}: {
-  agentId: number;
-  connectorId: string;
-  instanceId: string;
-  credentialServiceIds: Set<string>;
-  credentials: CredentialSummary[];
-  connections: OAuthConnection[];
-  anyLoading: boolean;
-}) {
-  const { binding, isLoading: bindingLoading } = useAgentConnectorInstanceCredential(
-    agentId,
-    connectorId,
-    instanceId,
-  );
-  const { assign, isPending: assigning } =
-    useAssignAgentConnectorInstanceCredential();
-  const { remove, isPending: disconnecting } =
-    useRemoveAgentConnectorInstanceCredential();
-
-  const isLoading = anyLoading || bindingLoading;
-  const isPending = assigning || disconnecting;
-
-  const scopedCredentials = credentials.filter(
-    (c) => credentialServiceIds.has(c.service),
-  );
-  const activeConnections = connections.filter(
-    (c) => c.status === "active" && c.id && c.provider === connectorId,
-  );
-
-  const currentValue = binding?.credential_id
-    ? `cred:${binding.credential_id}`
-    : binding?.oauth_connection_id
-      ? `oauth:${binding.oauth_connection_id}`
-      : "";
-
-  async function handleDisconnect() {
-    if (isPending || !currentValue) return;
-    try {
-      await remove({ agentId, connectorId, instanceId });
-      toast.success("Credential disconnected from this instance.");
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to disconnect credential.",
-      );
-    }
-  }
-
-  async function handleChange(value: string) {
-    if (isPending || !value) return;
-
-    try {
-      if (value.startsWith("oauth:")) {
-        await assign({
-          agentId,
-          connectorId,
-          instanceId,
-          oauthConnectionId: value.slice("oauth:".length),
-        });
-        toast.success("OAuth connection assigned to this instance.");
-      } else if (value.startsWith("cred:")) {
-        await assign({
-          agentId,
-          connectorId,
-          instanceId,
-          credentialId: value.slice("cred:".length),
-        });
-        toast.success("Credential assigned to this instance.");
-      }
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to update credential.",
-      );
-    }
-  }
-
-  if (isLoading) return null;
-
-  if (
-    scopedCredentials.length === 0 &&
-    activeConnections.length === 0 &&
-    !binding
-  ) {
-    return null;
-  }
-
-  return (
-    <div className="rounded-md border border-dashed p-3">
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Label
-            htmlFor={`agent-credential-${instanceId}`}
-            className="text-sm font-medium"
-          >
-            Credential
-          </Label>
-          {currentValue ? (
-            <Badge
-              variant="secondary"
-              className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-            >
-              Assigned
-            </Badge>
-          ) : (
-            <Badge variant="destructive">Not set</Badge>
-          )}
-        </div>
-        <p className="text-muted-foreground text-sm">
-          {currentValue
-            ? "This instance uses the selected credential or OAuth connection."
-            : "Select a credential so this instance can run actions."}
-        </p>
-        {currentValue && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-8 px-2"
-            onClick={() => void handleDisconnect()}
-            disabled={isPending}
-          >
-            <Unplug className="size-3.5" />
-            Disconnect
-          </Button>
-        )}
-        <select
-          id={`agent-credential-${instanceId}`}
-          className={selectClassName}
-          value={currentValue}
-          onChange={(e) => void handleChange(e.target.value)}
-          disabled={isPending}
-        >
-          {!currentValue && <option value="">Select a credential…</option>}
-          {activeConnections.map((conn) => (
-            <option key={`oauth:${conn.id}`} value={`oauth:${conn.id}`}>
-              {providerLabel(conn.provider)} OAuth
-              {conn.display_name ? ` — ${conn.display_name}` : ""} (connected{" "}
-              {new Date(conn.connected_at).toLocaleDateString()})
-            </option>
-          ))}
-          {scopedCredentials.map((cred) => (
-            <option key={`cred:${cred.id}`} value={`cred:${cred.id}`}>
-              {cred.label
-                ? `${cred.label} — ${serviceLabel(cred.service)}`
-                : serviceLabel(cred.service)}{" "}
-              (added {new Date(cred.created_at).toLocaleDateString()})
-            </option>
-          ))}
-        </select>
-      </div>
-    </div>
   );
 }

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
@@ -7,19 +7,26 @@ import {
   mockGet,
   mockPost,
   mockPatch,
+  mockPut,
   mockDelete,
   resetClientMocks,
 } from "../../../../api/__mocks__/client";
 import { ConnectorInstancesSection } from "../ConnectorInstancesSection";
+import type { InstanceCredentialBinding } from "@/hooks/useConnectorInstanceCredentialBindings";
 
 vi.mock("../../../../lib/supabaseClient");
 vi.mock("../../../../api/client");
+
+const mockUseConnectorInstanceCredentialBindings = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/useConnectorInstanceCredentialBindings", () => ({
+  useConnectorInstanceCredentialBindings: mockUseConnectorInstanceCredentialBindings,
+}));
 
 const defaultInstance = {
   connector_instance_id: "11111111-1111-1111-1111-111111111111",
   agent_id: 42,
   connector_id: "slack",
-  display: "Engineering",
+  display: "Acme",
   is_default: true,
   enabled_at: "2026-02-18T10:00:00Z",
 };
@@ -33,19 +40,65 @@ const secondInstance = {
   enabled_at: "2026-02-19T10:00:00Z",
 };
 
+function oauthBinding(oauthId: string): InstanceCredentialBinding {
+  return {
+    agent_id: 42,
+    connector_id: "slack",
+    credential_id: null,
+    oauth_connection_id: oauthId,
+  };
+}
+
+function bindingsQueryResult(twoInstances: boolean) {
+  const m = new Map<string, InstanceCredentialBinding | null>();
+  m.set(defaultInstance.connector_instance_id, oauthBinding("oconn_1"));
+  if (twoInstances) {
+    m.set(secondInstance.connector_instance_id, oauthBinding("oconn_2"));
+  }
+  return {
+    data: m,
+    isLoading: false,
+    isPending: false,
+    isFetching: false,
+    status: "success" as const,
+  };
+}
+
+function normalizeMockPath(path: unknown): string {
+  if (typeof path === "string") {
+    try {
+      if (path.startsWith("http")) {
+        return new URL(path).pathname;
+      }
+    } catch {
+      /* ignore */
+    }
+    return path;
+  }
+  if (path instanceof Request) {
+    try {
+      return new URL(path.url).pathname;
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+const LIST_INSTANCES_PATH =
+  "/v1/agents/{agent_id}/connectors/{connector_id}/instances";
+
 function mockStandardGets(twoInstances = false) {
-  mockGet.mockImplementation((path: string) => {
-    if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/instances") {
+  mockGet.mockImplementation((path: unknown) => {
+    const p = normalizeMockPath(path);
+    if (path === LIST_INSTANCES_PATH || (p.includes("/connectors/") && p.endsWith("/instances") && !p.includes("/credential"))) {
       return Promise.resolve({
         data: {
           data: twoInstances ? [defaultInstance, secondInstance] : [defaultInstance],
         },
       });
     }
-    if (
-      path ===
-      "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential"
-    ) {
+    if (p.endsWith("/credential") && p.includes("/connectors/") && !p.includes("/instances/")) {
       return Promise.resolve({
         data: {
           agent_id: 42,
@@ -55,20 +108,10 @@ function mockStandardGets(twoInstances = false) {
         },
       });
     }
-    if (path === "/v1/agents/{agent_id}/connectors/{connector_id}/credential") {
-      return Promise.resolve({
-        data: {
-          agent_id: 42,
-          connector_id: "slack",
-          credential_id: null,
-          oauth_connection_id: "oconn_1",
-        },
-      });
-    }
-    if (path === "/v1/credentials") {
+    if (p.endsWith("/credentials")) {
       return Promise.resolve({ data: { credentials: [] } });
     }
-    if (path === "/v1/oauth/connections") {
+    if (p.includes("/oauth/connections")) {
       return Promise.resolve({
         data: {
           connections: [
@@ -79,11 +122,18 @@ function mockStandardGets(twoInstances = false) {
               display_name: "Acme",
               connected_at: "2026-02-11T10:00:00Z",
             },
+            {
+              id: "oconn_2",
+              provider: "slack",
+              status: "active",
+              display_name: "Sales",
+              connected_at: "2026-02-12T10:00:00Z",
+            },
           ],
         },
       });
     }
-    if (path === "/v1/oauth/providers") {
+    if (p.includes("/oauth/providers")) {
       return Promise.resolve({ data: { providers: [] } });
     }
     return Promise.resolve({ data: {} });
@@ -95,13 +145,20 @@ describe("ConnectorInstancesSection", () => {
     vi.restoreAllMocks();
     resetClientMocks();
     mockPost.mockResolvedValue({ data: {} });
+    mockPut.mockResolvedValue({ data: {} });
     mockPatch.mockResolvedValue({ data: {} });
     mockDelete.mockResolvedValue({ data: {} });
     setupAuthMocks({ authenticated: true });
+    mockUseConnectorInstanceCredentialBindings.mockImplementation(() =>
+      bindingsQueryResult(false),
+    );
   });
 
-  it("renders instances with default badge", async () => {
+  it("lists credentials with default marked", async () => {
     mockStandardGets(false);
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue(
+      bindingsQueryResult(false),
+    );
     renderWithProviders(
       <ConnectorInstancesSection
         agentId={42}
@@ -116,16 +173,20 @@ describe("ConnectorInstancesSection", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText("Engineering")).toBeInTheDocument();
+      expect(screen.getByText(/Slack OAuth — Acme/)).toBeInTheDocument();
     });
     expect(screen.getByText("Default")).toBeInTheDocument();
   });
 
-  it("creates a new instance when Add another is submitted", async () => {
+  it("enables a credential by creating an instance and assigning it", async () => {
     mockStandardGets(false);
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue(
+      bindingsQueryResult(false),
+    );
     mockPost.mockResolvedValue({
       data: {
         ...secondInstance,
+        is_default: false,
       },
     });
     const user = userEvent.setup();
@@ -143,21 +204,38 @@ describe("ConnectorInstancesSection", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText("Engineering")).toBeInTheDocument();
+      expect(screen.getByText(/Slack OAuth — Acme/)).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("button", { name: /Add another/i }));
-    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    const salesCheckbox = screen.getByRole("checkbox", {
+      name: /Slack OAuth — Sales/i,
+    });
+    await user.click(salesCheckbox);
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalled();
     });
-    const call = mockPost.mock.calls.find(
+    const createCall = mockPost.mock.calls.find(
       (c) => c[0] === "/v1/agents/{agent_id}/connectors/{connector_id}/instances",
     );
-    expect(call?.[1]?.body).toEqual({});
+    expect(createCall?.[1]?.body).toEqual({});
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalled();
+    });
+    const putCall = mockPut.mock.calls.find(
+      (c) =>
+        c[0] ===
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
+    );
+    expect(putCall?.[1]?.body).toEqual({
+      credential_id: undefined,
+      oauth_connection_id: "oconn_2",
+    });
   });
 
   it("sets default instance via PATCH", async () => {
     mockStandardGets(true);
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue(
+      bindingsQueryResult(true),
+    );
     const user = userEvent.setup();
     renderWithProviders(
       <ConnectorInstancesSection
@@ -173,9 +251,14 @@ describe("ConnectorInstancesSection", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText("Sales")).toBeInTheDocument();
+      expect(screen.getByText(/Slack OAuth — Sales/)).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("button", { name: /Make default/i }));
+    const makeDefaultButtons = screen.getAllByRole("button", {
+      name: /Make default/i,
+    });
+    const salesMakeDefault = makeDefaultButtons.find((b) => !b.hasAttribute("disabled"));
+    expect(salesMakeDefault).toBeTruthy();
+    await user.click(salesMakeDefault!);
     await waitFor(() => {
       expect(mockPatch).toHaveBeenCalled();
     });
@@ -188,8 +271,11 @@ describe("ConnectorInstancesSection", () => {
     expect(call?.[1]?.params?.path?.instance_id).toBe(secondInstance.connector_instance_id);
   });
 
-  it("removes non-default instance via DELETE", async () => {
+  it("disables a non-default credential by removing binding and deleting instance", async () => {
     mockStandardGets(true);
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue(
+      bindingsQueryResult(true),
+    );
     const user = userEvent.setup();
     renderWithProviders(
       <ConnectorInstancesSection
@@ -205,18 +291,30 @@ describe("ConnectorInstancesSection", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText("Sales")).toBeInTheDocument();
+      expect(screen.getByText(/Slack OAuth — Sales/)).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("button", { name: /Remove instance/i }));
-    await user.click(screen.getByRole("button", { name: /^Remove$/i }));
+    const salesCheckbox = screen.getByRole("checkbox", {
+      name: /Slack OAuth — Sales/i,
+    });
+    await user.click(salesCheckbox);
     await waitFor(() => {
       expect(mockDelete).toHaveBeenCalled();
     });
-    const call = mockDelete.mock.calls.find(
+    const credDelete = mockDelete.mock.calls.find(
+      (c) =>
+        c[0] ===
+        "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}/credential",
+    );
+    expect(credDelete?.[1]?.params?.path?.instance_id).toBe(
+      secondInstance.connector_instance_id,
+    );
+    const instDelete = mockDelete.mock.calls.find(
       (c) =>
         c[0] ===
         "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
     );
-    expect(call?.[1]?.params?.path?.instance_id).toBe(secondInstance.connector_instance_id);
+    expect(instDelete?.[1]?.params?.path?.instance_id).toBe(
+      secondInstance.connector_instance_id,
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #974](https://github.com/supersuit-tech/permission-slip/issues/974) **phase 3 (frontend)**: the per-agent connector area is now a **credentials checklist**—one row per OAuth connection or API key for that connector type, with a checkbox for “allowed for this agent,” a **Default** badge on the default instance, and **Make default** (star) when multiple credentials are enabled.

- Removed the “Add another” dialog and the old per-instance card flow (dropdown assign, separate instance chrome).
- **Enable:** `POST` new instance + `PUT` credential on that instance.
- **Disable (non-default):** `DELETE` credential binding then `DELETE` instance.
- **Disable default:** requires another enabled credential first; if the user unchecks the default while others exist, the code **PATCH**es another instance as default, then removes binding + deletes the instance.
- Added `useConnectorInstanceCredentialBindings` to batch-load per-instance bindings and wired **query invalidation** from existing instance/credential mutations.
- `approvalConnectorLabel.ts` / `formatConnectorDisplayName()` already preferred `_connector_instance_display` with legacy `_connector_instance_label` fallback—no change needed.
- Regenerated API types (`npm run generate:api`); OpenAPI already matched the no-label model.
- Updated Storybook mirror and unit tests.

## Test plan

- [x] `make test-frontend`
- [x] `cd frontend && npm run build` (tsc + vite)

Backend `go test` was not run in this environment (see repo sandbox notes); frontend-only change.

Refs #974
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-807cc659-0964-4da4-9e0c-07fd43d280c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-807cc659-0964-4da4-9e0c-07fd43d280c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

