### PR TITLE
Improve connector instance selection for agents and CLI (#1007)

### DIFF
--- a/api/agent_approvals_instance.go
+++ b/api/agent_approvals_instance.go
@@ -10,6 +10,24 @@ import (
 	"github.com/supersuit-tech/permission-slip/db"
 )
 
+// availableInstanceDetail is one selectable connector instance in error details (JSON).
+type availableInstanceDetail struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+func availableInstancesDetails(instances []db.AgentConnectorInstance) []availableInstanceDetail {
+	out := make([]availableInstanceDetail, 0, len(instances))
+	for _, i := range instances {
+		d := availableInstanceDetail{ID: i.ConnectorInstanceID}
+		if i.DisplayName != "" {
+			d.DisplayName = i.DisplayName
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
 // connectorInstanceResolutionError carries an HTTP error for applyConnectorInstanceToAction.
 type connectorInstanceResolutionError struct {
 	status int
@@ -87,28 +105,35 @@ func applyConnectorInstanceToAction(ctx context.Context, d db.DBTX, agent *db.Ag
 		}
 	} else {
 		if selector == "" {
-			nicknames := make([]string, 0, len(instances))
-			for _, i := range instances {
-				nicknames = append(nicknames, i.DisplayName)
+			def, err := db.GetDefaultAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID)
+			if err != nil {
+				return "", err
 			}
-			resp := BadRequest(ErrConnectorInstanceRequired, "connector_instance is required when multiple instances exist")
-			resp.Error.Details = map[string]any{"available_instances": nicknames}
-			return "", &connectorInstanceResolutionError{status: http.StatusBadRequest, resp: resp}
-		}
-		resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
-		if err != nil {
-			if amb := ambiguousConnectorInstanceErr(err); amb != nil {
-				return "", amb
+			if def != nil {
+				inst = def
+			} else {
+				resp := BadRequest(ErrConnectorInstanceRequired, "connector_instance is required when multiple instances exist and no default is set")
+				resp.Error.Details = map[string]any{
+					"available_instances": availableInstancesDetails(instances),
+				}
+				return "", &connectorInstanceResolutionError{status: http.StatusBadRequest, resp: resp}
 			}
-			return "", err
-		}
-		if resolved == nil {
-			return "", &connectorInstanceResolutionError{
-				status: http.StatusBadRequest,
-				resp:   BadRequest(ErrConnectorInstanceNotFound, "no connector instance matches the given connector_instance"),
+		} else {
+			resolved, err := db.ResolveAgentConnectorInstance(ctx, d, agent.AgentID, agent.ApproverID, connectorID, selector)
+			if err != nil {
+				if amb := ambiguousConnectorInstanceErr(err); amb != nil {
+					return "", amb
+				}
+				return "", err
 			}
+			if resolved == nil {
+				return "", &connectorInstanceResolutionError{
+					status: http.StatusBadRequest,
+					resp:   BadRequest(ErrConnectorInstanceNotFound, "no connector instance matches the given connector_instance"),
+				}
+			}
+			inst = resolved
 		}
-		inst = resolved
 	}
 
 	idRaw, _ := json.Marshal(inst.ConnectorInstanceID)

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -1027,7 +1027,7 @@ func TestAgentRequestApproval_RequestValidatorAllowsValidChannel(t *testing.T) {
 	}
 }
 
-func TestAgentRequestApproval_MultiInstance_RequiresConnectorInstance(t *testing.T) {
+func TestAgentRequestApproval_MultiInstance_UsesDefaultWhenUnset(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -1109,6 +1109,118 @@ func TestAgentRequestApproval_MultiInstance_RequiresConnectorInstance(t *testing
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (default instance), got %d: %s", w.Code, w.Body.String())
+	}
+	var createResp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	appr, err := db.GetApprovalByIDAndAgent(t.Context(), tx, createResp.ApprovalID, agentID)
+	if err != nil || appr == nil {
+		t.Fatalf("get approval: %v", err)
+	}
+	var actionObj map[string]json.RawMessage
+	if err := json.Unmarshal(appr.Action, &actionObj); err != nil {
+		t.Fatalf("unmarshal action: %v", err)
+	}
+	var gotID string
+	_ = json.Unmarshal(actionObj["_connector_instance_id"], &gotID)
+	if gotID != defInst.ConnectorInstanceID {
+		t.Errorf("expected frozen instance %q, got %q", defInst.ConnectorInstanceID, gotID)
+	}
+}
+
+func TestAgentRequestApproval_MultiInstance_NoDefault_RequiresConnectorInstance(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	connID := "mi_test_conn_nd"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	ctx := context.Background()
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
+	})
+	if err != nil {
+		t.Fatalf("second instance: %v", err)
+	}
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "k1"})
+	v1, err := v.CreateSecret(ctx, tx, "c1", credJSON)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID1, uid, connID, "Alpha", v1)
+
+	credJSON2, _ := json.Marshal(map[string]string{"api_key": "k2"})
+	v2, err := v.CreateSecret(ctx, tx, "c2", credJSON2)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID2 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID2, uid, connID, "Beta", v2)
+
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default instance: %v", defInst)
+	}
+	instances, err := db.ListAgentConnectorInstances(ctx, tx, agentID, uid, connID)
+	if err != nil || len(instances) != 2 {
+		t.Fatalf("instances: %v len=%d", err, len(instances))
+	}
+	var secondID string
+	for _, inst := range instances {
+		if inst.ConnectorInstanceID != defInst.ConnectorInstanceID {
+			secondID = inst.ConnectorInstanceID
+			break
+		}
+	}
+	if secondID == "" {
+		t.Fatal("expected two distinct instances")
+	}
+
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID1,
+	}); err != nil {
+		t.Fatalf("bind default: %v", err)
+	}
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: secondID, ApproverID: uid, CredentialID: &credID2,
+	}); err != nil {
+		t.Fatalf("bind second: %v", err)
+	}
+
+	// Clear default flags — simulates legacy or inconsistent data where no instance is marked default.
+	testhelper.MustExec(t, tx, `UPDATE agent_connectors SET is_default = false WHERE agent_id = $1 AND approver_id = $2 AND connector_id = $3`,
+		agentID, uid, connID)
+	if def2, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID); err != nil || def2 != nil {
+		t.Fatalf("expected no default after update, got %v err=%v", def2, err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, connID+".ping"))
+	deps := &Deps{DB: tx, Vault: v, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_mi_need_inst_nd","action":{"type":"` + connID + `.ping","parameters":{}},"context":{"description":"x"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
@@ -1119,19 +1231,117 @@ func TestAgentRequestApproval_MultiInstance_RequiresConnectorInstance(t *testing
 	if errResp.Error.Code != ErrConnectorInstanceRequired {
 		t.Errorf("expected %q, got %q", ErrConnectorInstanceRequired, errResp.Error.Code)
 	}
-	labels, _ := errResp.Error.Details["available_instances"].([]any)
-	if len(labels) != 2 {
+	rawList, _ := errResp.Error.Details["available_instances"].([]any)
+	if len(rawList) != 2 {
 		t.Fatalf("expected 2 available_instances, got %#v", errResp.Error.Details)
 	}
-	got := make(map[string]struct{})
-	for _, x := range labels {
-		s, _ := x.(string)
-		got[s] = struct{}{}
-	}
-	for _, want := range []string{"Alpha", "Beta"} {
-		if _, ok := got[want]; !ok {
-			t.Fatalf("expected available_instances to include %q, got %#v", want, labels)
+	gotIDs := make(map[string]struct{})
+	for _, x := range rawList {
+		m, ok := x.(map[string]any)
+		if !ok {
+			t.Fatalf("expected object entries in available_instances, got %#v", x)
 		}
+		id, _ := m["id"].(string)
+		gotIDs[id] = struct{}{}
+	}
+	if _, ok := gotIDs[defInst.ConnectorInstanceID]; !ok {
+		t.Errorf("missing default id %q in %#v", defInst.ConnectorInstanceID, rawList)
+	}
+	if _, ok := gotIDs[inst2.ConnectorInstanceID]; !ok {
+		t.Errorf("missing second id %q in %#v", inst2.ConnectorInstanceID, rawList)
+	}
+}
+
+func TestAgentRequestApproval_MultiInstance_ExplicitSelector_OverridesDefault(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	connID := "mi_test_conn_ov"
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertConnectorAction(t, tx, connID, connID+".ping", "Ping")
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+	ctx := context.Background()
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: connID,
+	})
+	if err != nil {
+		t.Fatalf("second instance: %v", err)
+	}
+
+	v := vault.NewMockVaultStore()
+	credJSON, _ := json.Marshal(map[string]string{"api_key": "k1"})
+	v1, err := v.CreateSecret(ctx, tx, "c1", credJSON)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID1 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID1, uid, connID, "Alpha", v1)
+
+	credJSON2, _ := json.Marshal(map[string]string{"api_key": "k2"})
+	v2, err := v.CreateSecret(ctx, tx, "c2", credJSON2)
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	credID2 := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertCredentialWithVaultSecretIDAndLabel(t, tx, credID2, uid, connID, "Beta", v2)
+
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default instance: %v", defInst)
+	}
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID1,
+	}); err != nil {
+		t.Fatalf("bind default: %v", err)
+	}
+	if _, err := db.UpsertAgentConnectorCredentialByInstance(ctx, tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "accr_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: inst2.ConnectorInstanceID, ApproverID: uid, CredentialID: &credID2,
+	}); err != nil {
+		t.Fatalf("bind second: %v", err)
+	}
+
+	reg := connectors.NewRegistry()
+	reg.Register(newTestStubConnector(connID, connID+".ping"))
+	deps := &Deps{DB: tx, Vault: v, SupabaseJWTSecret: testJWTSecret, Connectors: reg}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_mi_override","action":{"type":"` + connID + `.ping","parameters":{"connector_instance":"` + inst2.ConnectorInstanceID + `"}},"context":{"description":"x"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var createResp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	appr, err := db.GetApprovalByIDAndAgent(t.Context(), tx, createResp.ApprovalID, agentID)
+	if err != nil || appr == nil {
+		t.Fatalf("get approval: %v", err)
+	}
+	var actionObj map[string]json.RawMessage
+	if err := json.Unmarshal(appr.Action, &actionObj); err != nil {
+		t.Fatalf("unmarshal action: %v", err)
+	}
+	var gotID string
+	_ = json.Unmarshal(actionObj["_connector_instance_id"], &gotID)
+	if gotID != inst2.ConnectorInstanceID {
+		t.Errorf("expected explicit instance %q, got %q", inst2.ConnectorInstanceID, gotID)
+	}
+	if gotID == defInst.ConnectorInstanceID {
+		t.Error("explicit selector should not route to default")
 	}
 }
 

--- a/api/capabilities.go
+++ b/api/capabilities.go
@@ -185,7 +185,7 @@ func buildCapabilitiesResponse(agentID int64, caps *db.AgentCapabilities, baseUR
 				Name:             a.Name,
 				Description:      a.Description,
 				RiskLevel:        a.RiskLevel,
-				ParametersSchema: a.ParametersSchema,
+				ParametersSchema: injectConnectorInstanceIntoParametersSchema(a.ParametersSchema, cc.Instances),
 			}
 
 			// Attach standing approvals for this action type.

--- a/api/capabilities_instance_schema.go
+++ b/api/capabilities_instance_schema.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// injectConnectorInstanceIntoParametersSchema adds an optional connector_instance
+// property (UUID enum + human-readable description) when the agent has multiple
+// instances for this connector. Single-instance connectors leave the schema unchanged.
+func injectConnectorInstanceIntoParametersSchema(schema json.RawMessage, instances []connectorInstanceCapability) json.RawMessage {
+	if len(instances) < 2 {
+		return schema
+	}
+
+	uuids := make([]string, len(instances))
+	descParts := make([]string, 0, len(instances))
+	for i, inst := range instances {
+		uuids[i] = inst.ID
+		label := inst.Display
+		if label == "" {
+			label = "(no display name)"
+		}
+		descParts = append(descParts, fmt.Sprintf("%s — %s", inst.ID, label))
+	}
+	description := strings.Join(descParts, "; ")
+
+	prop := map[string]any{
+		"type":        "string",
+		"format":      "uuid",
+		"enum":        uuids,
+		"description": description,
+	}
+
+	var root map[string]any
+	if len(schema) > 0 && string(schema) != "null" {
+		_ = json.Unmarshal(schema, &root)
+	}
+	if root == nil {
+		root = make(map[string]any)
+	}
+	if _, ok := root["type"]; !ok {
+		root["type"] = "object"
+	}
+
+	props, _ := root["properties"].(map[string]any)
+	if props == nil {
+		props = make(map[string]any)
+		root["properties"] = props
+	}
+	props["connector_instance"] = prop
+
+	out, err := json.Marshal(root)
+	if err != nil {
+		return schema
+	}
+	return out
+}

--- a/api/capabilities_instance_schema_test.go
+++ b/api/capabilities_instance_schema_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInjectConnectorInstanceIntoParametersSchema(t *testing.T) {
+	t.Parallel()
+	base := json.RawMessage(`{"type":"object","properties":{"x":{"type":"string"}}}`)
+	inst := []connectorInstanceCapability{
+		{ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", Display: "A"},
+		{ID: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Display: "B"},
+	}
+	out := injectConnectorInstanceIntoParametersSchema(base, inst)
+	var sch map[string]any
+	if err := json.Unmarshal(out, &sch); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	props, _ := sch["properties"].(map[string]any)
+	ci, _ := props["connector_instance"].(map[string]any)
+	if ci["format"] != "uuid" {
+		t.Errorf("expected format uuid, got %#v", ci["format"])
+	}
+	enum, _ := ci["enum"].([]any)
+	if len(enum) != 2 {
+		t.Fatalf("enum: %#v", enum)
+	}
+}
+
+func TestInjectConnectorInstanceIntoParametersSchema_SingleInstanceNoOp(t *testing.T) {
+	t.Parallel()
+	base := json.RawMessage(`{"type":"object"}`)
+	inst := []connectorInstanceCapability{{ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}}
+	out := injectConnectorInstanceIntoParametersSchema(base, inst)
+	if string(out) != string(base) {
+		t.Errorf("expected unchanged schema, got %s", string(out))
+	}
+}

--- a/api/capabilities_test.go
+++ b/api/capabilities_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
 )
 
@@ -661,5 +663,125 @@ func TestGetCapabilities_InvalidAgentID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetCapabilities_MultiInstance_InjectsConnectorInstanceEnum(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID, privKey := insertRegisteredAgentWithKey(t, tx, uid)
+
+	conn := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, conn)
+	schema := json.RawMessage(`{"type":"object","properties":{"channel":{"type":"string"}}}`)
+	testhelper.InsertConnectorActionFull(t, tx, conn, conn+".post", "Post", testhelper.ConnectorActionOpts{
+		ParametersSchema: schema,
+	})
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn)
+	ctx := context.Background()
+	inst2, err := db.CreateAgentConnectorInstance(ctx, tx, db.CreateAgentConnectorInstanceParams{
+		AgentID: agentID, ApproverID: uid, ConnectorID: conn,
+	})
+	if err != nil {
+		t.Fatalf("second instance: %v", err)
+	}
+	defInst, err := db.GetDefaultAgentConnectorInstance(ctx, tx, agentID, uid, conn)
+	if err != nil || defInst == nil {
+		t.Fatalf("default: %v", defInst)
+	}
+
+	router := NewRouter(&Deps{DB: tx, SupabaseJWTSecret: testJWTSecret})
+	r := capabilitiesRequest(t, agentID, privKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Connectors) != 1 {
+		t.Fatalf("expected 1 connector, got %d", len(resp.Connectors))
+	}
+	a := resp.Connectors[0].Actions[0]
+	var sch map[string]any
+	if err := json.Unmarshal(a.ParametersSchema, &sch); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	props, _ := sch["properties"].(map[string]any)
+	if props == nil {
+		t.Fatal("expected properties in parameters_schema")
+	}
+	ci, ok := props["connector_instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected connector_instance in properties, got %#v", props)
+	}
+	enum, _ := ci["enum"].([]any)
+	if len(enum) != 2 {
+		t.Fatalf("expected enum len 2, got %#v", enum)
+	}
+	gotEnum := make(map[string]struct{})
+	for _, x := range enum {
+		s, _ := x.(string)
+		gotEnum[s] = struct{}{}
+	}
+	if _, ok := gotEnum[defInst.ConnectorInstanceID]; !ok {
+		t.Errorf("enum missing default id %q: %#v", defInst.ConnectorInstanceID, enum)
+	}
+	if _, ok := gotEnum[inst2.ConnectorInstanceID]; !ok {
+		t.Errorf("enum missing second id %q: %#v", inst2.ConnectorInstanceID, enum)
+	}
+	desc, _ := ci["description"].(string)
+	if !strings.Contains(desc, defInst.ConnectorInstanceID) || !strings.Contains(desc, inst2.ConnectorInstanceID) {
+		t.Errorf("description should list both UUIDs: %q", desc)
+	}
+}
+
+func TestGetCapabilities_SingleInstance_OmitsConnectorInstanceInjection(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID, privKey := insertRegisteredAgentWithKey(t, tx, uid)
+
+	conn := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, conn)
+	schema := json.RawMessage(`{"type":"object","properties":{"channel":{"type":"string"}}}`)
+	testhelper.InsertConnectorActionFull(t, tx, conn, conn+".post", "Post", testhelper.ConnectorActionOpts{
+		ParametersSchema: schema,
+	})
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, conn)
+
+	router := NewRouter(&Deps{DB: tx, SupabaseJWTSecret: testJWTSecret})
+	r := capabilitiesRequest(t, agentID, privKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	a := resp.Connectors[0].Actions[0]
+	var sch map[string]any
+	if err := json.Unmarshal(a.ParametersSchema, &sch); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	props, _ := sch["properties"].(map[string]any)
+	if props == nil {
+		t.Fatal("expected properties")
+	}
+	if _, ok := props["connector_instance"]; ok {
+		t.Error("single-instance connector should not inject connector_instance")
 	}
 }

--- a/cli/src/commands/request.ts
+++ b/cli/src/commands/request.ts
@@ -1,5 +1,5 @@
 /**
- * permission-slip request --action <action_id> [--params '{}'] [--server <url>]
+ * permission-slip request --action <action_id> [--instance <name_or_uuid>] [--params '{}'] [--server <url>]
  *
  * Requests approval for an action. If a matching standing approval exists,
  * the action is auto-approved and executed immediately — the result is
@@ -13,12 +13,21 @@ import { resolveAgentId } from "./status.js";
 import { resolveServerUrl, isBuiltInDefaultServerUrl } from "../config/serverUrl.js";
 import { output, type OutputOptions } from "../output.js";
 import { shellQuote } from "../util/shell.js";
+import {
+  mergeParamsWithConnectorInstance,
+  parseAvailableInstances,
+} from "../util/connectorInstance.js";
+import { promptConnectorInstanceChoice } from "../util/promptConnectorInstance.js";
 
 export function requestCommand(program: Command): void {
   program
     .command("request")
     .description("Request approval for an action (auto-approves if a standing approval matches)")
     .requiredOption("--action <action_id>", "Action type (e.g. email.send)")
+    .option(
+      "--instance <name_or_uuid>",
+      "Connector instance (UUID or display name); merged into parameters as connector_instance",
+    )
     .option("--params <json>", "Action parameters as JSON string", "{}")
     .option("--description <text>", "Human-readable description of the action")
     .option("--risk-level <level>", "Risk level: low, medium, high")
@@ -33,6 +42,7 @@ export function requestCommand(program: Command): void {
     .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
     .action(async (opts: {
       action: string;
+      instance?: string;
       params: string;
       description?: string;
       riskLevel?: string;
@@ -53,6 +63,14 @@ export function requestCommand(program: Command): void {
           throw new Error(`--params must be valid JSON. Got: ${opts.params}`);
         }
 
+        // Snapshot before --instance merge so interactive retry can merge a picked UUID into the same base object.
+        const paramsBeforeInstance: unknown = JSON.parse(opts.params);
+
+        const instanceFlag = opts.instance?.trim();
+        if (instanceFlag) {
+          params = mergeParamsWithConnectorInstance(params, instanceFlag);
+        }
+
         const agentId = resolveAgentId(server, opts.agentId);
         const client = new ApiClient({ serverUrl: server, agentId });
 
@@ -64,20 +82,54 @@ export function requestCommand(program: Command): void {
               }
             : undefined;
 
-        const result = await client.requestApproval(
-          opts.action,
-          params,
-          context,
-          { paymentMethodId: opts.paymentMethodId, amountCents: opts.amountCents },
-          opts.requestId,
-        );
+        const send = async (p: unknown) =>
+          client.requestApproval(
+            opts.action,
+            p,
+            context,
+            { paymentMethodId: opts.paymentMethodId, amountCents: opts.amountCents },
+            opts.requestId,
+          );
+
+        const tryRecoverConnectorInstance = async (
+          err: PermissionSlipApiError,
+        ): Promise<Awaited<ReturnType<ApiClient["requestApproval"]>> | null> => {
+          if (err.statusCode !== 400 || err.apiError.code !== "connector_instance_required") {
+            return null;
+          }
+          if (!process.stdin.isTTY || instanceFlag) {
+            return null;
+          }
+          const list = parseAvailableInstances(err.apiError.details);
+          if (list.length === 0) {
+            return null;
+          }
+          const chosen = await promptConnectorInstanceChoice(list);
+          if (!chosen) {
+            return null;
+          }
+          return send(mergeParamsWithConnectorInstance(paramsBeforeInstance, chosen));
+        };
+
+        let result: Awaited<ReturnType<ApiClient["requestApproval"]>>;
+        try {
+          result = await send(params);
+        } catch (firstErr) {
+          if (firstErr instanceof PermissionSlipApiError) {
+            const recovered = await tryRecoverConnectorInstance(firstErr);
+            if (recovered !== null) {
+              result = recovered;
+            } else {
+              throw firstErr;
+            }
+          } else {
+            throw firstErr;
+          }
+        }
 
         if (result.status === "approved") {
-          // Auto-approved via standing approval — action already executed, result is inline.
-          // Include executed flag so external tools know no further action is needed.
           output({ ...result, executed: true }, outputOpts);
         } else {
-          // Pending — tell the user how to check the result.
           output(
             {
               ...result,

--- a/cli/src/util/connectorInstance.ts
+++ b/cli/src/util/connectorInstance.ts
@@ -1,0 +1,65 @@
+/**
+ * Helpers for merging `connector_instance` into action parameters and parsing
+ * `connector_instance_required` error details for interactive recovery.
+ */
+
+export interface AvailableConnectorInstance {
+  id: string;
+  display_name?: string;
+}
+
+export function mergeParamsWithConnectorInstance(
+  params: unknown,
+  instance: string,
+): Record<string, unknown> {
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    throw new Error("--params must be a JSON object when using --instance");
+  }
+  return {
+    ...(params as Record<string, unknown>),
+    connector_instance: instance,
+  };
+}
+
+const uuidRe =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function looksLikeUUID(s: string): boolean {
+  return uuidRe.test(s.trim());
+}
+
+/**
+ * Normalizes `error.details.available_instances` from the API (objects with
+ * id/display_name, or legacy string nicknames only).
+ */
+export function parseAvailableInstances(
+  details: Record<string, unknown> | undefined,
+): AvailableConnectorInstance[] {
+  const raw = details?.["available_instances"];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const out: AvailableConnectorInstance[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      if (looksLikeUUID(item)) {
+        out.push({ id: item.trim() });
+      }
+      continue;
+    }
+    if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+      const o = item as Record<string, unknown>;
+      const id = o["id"];
+      if (typeof id !== "string" || !looksLikeUUID(id)) {
+        continue;
+      }
+      const row: AvailableConnectorInstance = { id: id.trim() };
+      const dn = o["display_name"];
+      if (typeof dn === "string" && dn.length > 0) {
+        row.display_name = dn;
+      }
+      out.push(row);
+    }
+  }
+  return out;
+}

--- a/cli/src/util/promptConnectorInstance.ts
+++ b/cli/src/util/promptConnectorInstance.ts
@@ -1,0 +1,36 @@
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import type { AvailableConnectorInstance } from "./connectorInstance.js";
+
+/**
+ * Prompts for a connector instance when the API returns connector_instance_required.
+ * Returns the selected UUID string, or undefined if the user cancels / invalid input.
+ */
+export async function promptConnectorInstanceChoice(
+  instances: AvailableConnectorInstance[],
+): Promise<string | undefined> {
+  if (instances.length === 0) {
+    return undefined;
+  }
+  const rl = readline.createInterface({ input, output });
+  try {
+    for (let i = 0; i < instances.length; i++) {
+      const inst = instances[i]!;
+      const label =
+        inst.display_name !== undefined && inst.display_name !== ""
+          ? `${inst.display_name} (${inst.id})`
+          : inst.id;
+      output.write(`${i + 1}. ${label}\n`);
+    }
+    const line = await rl.question(
+      `Select connector instance (1-${instances.length}): `,
+    );
+    const n = parseInt(line.trim(), 10);
+    if (!Number.isFinite(n) || n < 1 || n > instances.length) {
+      return undefined;
+    }
+    return instances[n - 1]!.id;
+  } finally {
+    rl.close();
+  }
+}

--- a/cli/tests/connectorInstance.test.ts
+++ b/cli/tests/connectorInstance.test.ts
@@ -1,0 +1,50 @@
+import {
+  mergeParamsWithConnectorInstance,
+  parseAvailableInstances,
+} from "../src/util/connectorInstance.js";
+
+describe("mergeParamsWithConnectorInstance", () => {
+  it("merges connector_instance into a params object", () => {
+    expect(
+      mergeParamsWithConnectorInstance({ channel: "#general" }, "550e8400-e29b-41d4-a716-446655440000"),
+    ).toEqual({
+      channel: "#general",
+      connector_instance: "550e8400-e29b-41d4-a716-446655440000",
+    });
+  });
+
+  it("rejects non-object params", () => {
+    expect(() => mergeParamsWithConnectorInstance([], "x")).toThrow(
+      "--params must be a JSON object when using --instance",
+    );
+  });
+});
+
+describe("parseAvailableInstances", () => {
+  it("parses object-shaped entries", () => {
+    const list = parseAvailableInstances({
+      available_instances: [
+        { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", display_name: "Work" },
+        { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" },
+      ],
+    });
+    expect(list).toEqual([
+      { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", display_name: "Work" },
+      { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" },
+    ]);
+  });
+
+  it("ignores legacy string nicknames (no UUID)", () => {
+    const list = parseAvailableInstances({
+      available_instances: ["Alpha", "Beta"],
+    });
+    expect(list).toEqual([]);
+  });
+
+  it("accepts legacy string UUIDs only", () => {
+    const list = parseAvailableInstances({
+      available_instances: ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"],
+    });
+    expect(list).toEqual([{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }]);
+  });
+});

--- a/spec/openapi/components/schemas/capabilities.yaml
+++ b/spec/openapi/components/schemas/capabilities.yaml
@@ -277,6 +277,13 @@ ActionCapability:
         should validate parameters against this schema before submitting approval
         requests or executing actions.
 
+        When the user has **multiple connector instances** for this connector
+        (multiple workspaces/accounts), the server injects an optional
+        `connector_instance` property: a `string` with `format: uuid`, `enum` listing
+        allowed instance IDs, and a `description` that maps each UUID to its display
+        name. Omit it to use the **default** instance when one is configured; otherwise
+        pass a UUID or nickname from `GET /agents/{id}/capabilities`.
+
         The schema follows standard JSON Schema (draft-07) conventions and includes
         `type`, `required`, `properties`, and validation keywords like `maxLength`,
         `minimum`, `format`, etc.

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -9604,6 +9604,13 @@ components:
             should validate parameters against this schema before submitting approval
             requests or executing actions.
 
+            When the user has **multiple connector instances** for this connector
+            (multiple workspaces/accounts), the server injects an optional
+            `connector_instance` property: a `string` with `format: uuid`, `enum` listing
+            allowed instance IDs, and a `description` that maps each UUID to its display
+            name. Omit it to use the **default** instance when one is configured; otherwise
+            pass a UUID or nickname from `GET /agents/{id}/capabilities`.
+
             The schema follows standard JSON Schema (draft-07) conventions and includes
             `type`, `required`, `properties`, and validation keywords like `maxLength`,
             `minimum`, `format`, etc.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #1007](https://github.com/supersuit-tech/permission-slip/issues/1007): make multi-connector-instance selection reliable for programmatic agents and the CLI.

### Server (`applyConnectorInstanceToAction`)

- When multiple instances exist and `parameters.connector_instance` is omitted, resolve **`GetDefaultAgentConnectorInstance`** and use that row.
- If no default exists (legacy/inconsistent data), return **`connector_instance_required`** with **`available_instances`** as structured objects: `{ "id": "<uuid>", "display_name": "<label>" }` (display omitted when empty).

### Capabilities

- When a connector has **two or more** instances, each action’s **`parameters_schema`** gains an optional **`connector_instance`** property: `format: uuid`, **`enum`** of instance UUIDs, and a **`description`** listing UUID → display name.

### OpenAPI

- Documented the injection behavior on `ActionCapability.parameters_schema` in `spec/openapi/components/schemas/capabilities.yaml` and regenerated **`openapi.bundle.yaml`**.

### CLI (`permission-slip request`)

- **`--instance <name-or-uuid>`** merges **`connector_instance`** into the parsed `--params` object (object params only).
- On **`connector_instance_required`** with a TTY and no `--instance`, **`available_instances`** is parsed and the user gets a **numbered picker**; non-TTY behavior is unchanged (error surfaces as before).

## Behavior change (reviewers)

Requests that used to **400** with `connector_instance_required` when a **default** instance existed will now **succeed** and route to that default. Callers must not rely on that error as a signal when a default is configured.

## Test plan

- **Go**: New/updated tests in `api/agent_approvals_test.go`, `api/capabilities_test.go`, `api/capabilities_instance_schema_test.go`. Full `go test` was **not** run in this environment (module graph / sandbox); CI should validate.
- **CLI**: `cd cli && npm run build && npm test` (passed locally).

Closes #1007
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b631b5f4-fda3-47b5-8326-addbeecea597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b631b5f4-fda3-47b5-8326-addbeecea597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

