### PR TITLE
Slack: list_unread and mark_read for agent unread state (#1010)

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -172,6 +172,30 @@ Reads recent messages from a Slack channel. For private channels, DMs, and group
 
 **Required bot token scopes:** `channels:history` (public), `groups:history` (private)
 
+#### Unread messages (user token)
+
+To answer “do I have unread Slack messages?” or load only unread content, use this flow (no extra OAuth scopes beyond the connector’s user token):
+
+1. Call **`slack.list_unread`** — returns conversations where `unread_count` &gt; 0, with `last_read_ts` and a short `latest_message_preview` when Slack provides `latest`.
+2. For a given conversation, call **`slack.read_channel_messages`** with **`oldest` = `last_read_ts`** from that row (Slack accepts the same timestamp format as in `list_unread`). That limits history to messages after the user’s read cursor instead of guessing from “recent” history alone.
+3. Optionally **`slack.mark_read`** with **`channel_id`** and an explicit **`ts`** — the Slack message timestamp of the last message you surfaced to the user. **`ts` is required** (there is no default) so the agent cannot clear unreads it never showed.
+
+---
+
+### `slack.list_unread`
+
+Lists conversations where the authorizing user has unread messages. Uses `users.conversations` to enumerate conversations, then `conversations.info` per channel for `last_read`, `unread_count_display`, and `latest`. Requires a Permission Slip profile email that matches the Slack account (same identity model as other private/DM flows).
+
+**Slack API:** `POST /users.conversations`, `GET /conversations.info`
+
+---
+
+### `slack.mark_read`
+
+Sets the read cursor for a conversation (`conversations.mark`). **`channel_id`** and **`ts`** are both required.
+
+**Slack API:** `POST /conversations.mark`
+
 ---
 
 ### `slack.read_thread`
@@ -664,6 +688,9 @@ connectors/slack/
 ├── create_channel.go               # slack.create_channel action
 ├── list_channels.go                # slack.list_channels action
 ├── read_channel_messages.go        # slack.read_channel_messages action
+├── conversation_info.go            # conversations.info helper (unread + shared)
+├── list_unread.go                  # slack.list_unread action
+├── mark_read.go                    # slack.mark_read action
 ├── read_thread.go                  # slack.read_thread action
 ├── schedule_message.go             # slack.schedule_message action
 ├── set_topic.go                    # slack.set_topic action

--- a/connectors/slack/conversation_info.go
+++ b/connectors/slack/conversation_info.go
@@ -1,0 +1,82 @@
+package slack
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// conversationInfoChannel is the subset of conversations.channel used for
+// unread state and display (conversations.info).
+type conversationInfoChannel struct {
+	ID                 string        `json:"id"`
+	Name               string        `json:"name"`
+	User               string        `json:"user"`
+	IsPrivate          bool          `json:"is_private"`
+	IsIM               bool          `json:"is_im"`
+	IsMPIM             bool          `json:"is_mpim"`
+	LastRead           string        `json:"last_read"`
+	UnreadCountDisplay int           `json:"unread_count_display"`
+	Latest             *slackMessage `json:"latest"`
+}
+
+type conversationInfoResponse struct {
+	slackResponse
+	Channel conversationInfoChannel `json:"channel"`
+}
+
+// fetchConversationInfo loads a single channel via GET conversations.info.
+func (c *SlackConnector) fetchConversationInfo(ctx context.Context, creds connectors.Credentials, channelID string) (*conversationInfoChannel, error) {
+	var resp conversationInfoResponse
+	if err := c.doGet(ctx, "conversations.info", creds, map[string]string{"channel": channelID}, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, resp.asError()
+	}
+	return &resp.Channel, nil
+}
+
+const maxLatestPreviewRunes = 200
+
+func channelDisplayName(ch *conversationInfoChannel) string {
+	if ch == nil {
+		return ""
+	}
+	if ch.Name != "" {
+		return ch.Name
+	}
+	if ch.IsIM && ch.User != "" {
+		return ch.User
+	}
+	return ""
+}
+
+func channelTypeLabel(ch *conversationInfoChannel) string {
+	if ch == nil {
+		return "unknown"
+	}
+	switch {
+	case ch.IsIM:
+		return "im"
+	case ch.IsMPIM:
+		return "mpim"
+	case ch.IsPrivate:
+		return "private_channel"
+	default:
+		return "public_channel"
+	}
+}
+
+func truncatePreviewText(s string) string {
+	if s == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= maxLatestPreviewRunes {
+		return strings.TrimSpace(s)
+	}
+	runes := []rune(s)
+	return strings.TrimSpace(string(runes[:maxLatestPreviewRunes])) + "…"
+}

--- a/connectors/slack/list_unread.go
+++ b/connectors/slack/list_unread.go
@@ -1,0 +1,128 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// listUnreadAction implements slack.list_unread.
+type listUnreadAction struct {
+	conn *SlackConnector
+}
+
+type listUnreadParams struct{}
+
+func (p *listUnreadParams) validate() error { return nil }
+
+type latestMessagePreview struct {
+	Text string `json:"text,omitempty"`
+	User string `json:"user,omitempty"`
+	TS   string `json:"ts,omitempty"`
+}
+
+type unreadChannelEntry struct {
+	ChannelID            string                `json:"channel_id"`
+	ChannelName          string                `json:"channel_name,omitempty"`
+	ChannelType          string                `json:"channel_type"`
+	UnreadCount          int                   `json:"unread_count"`
+	LastReadTS           string                `json:"last_read_ts,omitempty"`
+	LatestMessagePreview *latestMessagePreview `json:"latest_message_preview,omitempty"`
+}
+
+type listUnreadResult struct {
+	UnreadChannels []unreadChannelEntry `json:"unread_channels"`
+}
+
+func (a *listUnreadAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params listUnreadParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	if req.UserEmail == "" {
+		return nil, &connectors.ValidationError{
+			Message: "listing unread conversations requires your Permission Slip profile to have an email address matching your Slack account",
+		}
+	}
+
+	slackUserID, err := a.conn.lookupSlackUserByEmail(ctx, req.Credentials, req.UserEmail)
+	if err != nil {
+		return nil, err
+	}
+	if slackUserID == "" {
+		return nil, &connectors.ValidationError{
+			Message: "no Slack user found matching your email — ensure your Permission Slip email matches your Slack account",
+		}
+	}
+
+	types := "public_channel,private_channel,mpim,im"
+	var entries []unreadChannelEntry
+	cursor := ""
+	for page := 0; page < maxUserConversationPages; page++ {
+		body := usersConversationsRequest{
+			User:   slackUserID,
+			Types:  types,
+			Limit:  200,
+			Cursor: cursor,
+		}
+		var resp usersConversationsResponse
+		if err := a.conn.doPost(ctx, "users.conversations", req.Credentials, body, &resp); err != nil {
+			return nil, err
+		}
+		if !resp.OK {
+			return nil, resp.asError()
+		}
+
+		for _, ch := range resp.Channels {
+			info, err := a.conn.fetchConversationInfo(ctx, req.Credentials, ch.ID)
+			if err != nil {
+				return nil, err
+			}
+			if info.UnreadCountDisplay <= 0 {
+				continue
+			}
+			var previewPtr *latestMessagePreview
+			if info.Latest != nil {
+				p := latestMessagePreview{
+					Text: truncatePreviewText(info.Latest.Text),
+					User: info.Latest.User,
+					TS:   info.Latest.TS,
+				}
+				if info.Latest.BotID != "" && p.User == "" {
+					p.User = info.Latest.BotID
+				}
+				previewPtr = &p
+			}
+			name := channelDisplayName(info)
+			if name == "" {
+				name = channelDisplayNameFromListEntry(ch)
+			}
+			entries = append(entries, unreadChannelEntry{
+				ChannelID:            info.ID,
+				ChannelName:          name,
+				ChannelType:          channelTypeLabel(info),
+				UnreadCount:          info.UnreadCountDisplay,
+				LastReadTS:           info.LastRead,
+				LatestMessagePreview: previewPtr,
+			})
+		}
+
+		if resp.Meta == nil || resp.Meta.NextCursor == "" {
+			break
+		}
+		cursor = resp.Meta.NextCursor
+	}
+
+	return connectors.JSONResult(listUnreadResult{UnreadChannels: entries})
+}
+
+func channelDisplayNameFromListEntry(ch listChannelEntry) string {
+	if ch.Name != "" {
+		return ch.Name
+	}
+	if ch.IsIM && ch.User != "" {
+		return ch.User
+	}
+	return ""
+}

--- a/connectors/slack/list_unread_test.go
+++ b/connectors/slack/list_unread_test.go
@@ -1,0 +1,405 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestListUnread_NoEmail(t *testing.T) {
+	t.Parallel()
+
+	conn := newForTest(http.DefaultClient, "http://unused.example")
+	action := &listUnreadAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing user email")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestListUnread_NoUnreads(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U111"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "C1", "name": "general"},
+				},
+			})
+		case "/conversations.info":
+			q := r.URL.Query().Get("channel")
+			if q != "C1" {
+				t.Errorf("expected channel C1, got %q", q)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id":                   "C1",
+					"name":                 "general",
+					"is_private":           false,
+					"unread_count_display": 0,
+					"last_read":            "1.0",
+					"latest":               map[string]any{"text": "hi", "user": "U2", "ts": "2.0"},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out listUnreadResult
+	if err := json.Unmarshal(res.Data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.UnreadChannels) != 0 {
+		t.Fatalf("expected no unreads, got %+v", out.UnreadChannels)
+	}
+}
+
+func TestListUnread_MixedTypes_WithPreview(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U111"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "Cpub", "name": "announce"},
+					{"id": "Ddm", "is_im": true, "user": "U222"},
+					{"id": "Ggrp", "is_mpim": true, "name": "mpim-name"},
+				},
+			})
+		case "/conversations.info":
+			ch := r.URL.Query().Get("channel")
+			switch ch {
+			case "Cpub":
+				json.NewEncoder(w).Encode(map[string]any{
+					"ok": true,
+					"channel": map[string]any{
+						"id":                   "Cpub",
+						"name":                 "announce",
+						"is_private":           false,
+						"unread_count_display": 2,
+						"last_read":            "100.0",
+						"latest": map[string]any{
+							"text": strings.Repeat("a", 250),
+							"user": "U9",
+							"ts":   "200.0",
+						},
+					},
+				})
+			case "Ddm":
+				json.NewEncoder(w).Encode(map[string]any{
+					"ok": true,
+					"channel": map[string]any{
+						"id":                   "Ddm",
+						"is_im":                true,
+						"user":                 "U222",
+						"unread_count_display": 1,
+						"last_read":            "1.0",
+						"latest": map[string]any{
+							"text": "dm hello",
+							"user": "U222",
+							"ts":   "2.0",
+						},
+					},
+				})
+			case "Ggrp":
+				json.NewEncoder(w).Encode(map[string]any{
+					"ok": true,
+					"channel": map[string]any{
+						"id":                   "Ggrp",
+						"is_mpim":              true,
+						"name":                 "mpim-name",
+						"unread_count_display": 3,
+						"last_read":            "3.0",
+						"latest": map[string]any{
+							"text": "group ping",
+							"user": "U3",
+							"ts":   "4.0",
+						},
+					},
+				})
+			default:
+				t.Fatalf("unexpected channel %q", ch)
+			}
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out listUnreadResult
+	if err := json.Unmarshal(res.Data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.UnreadChannels) != 3 {
+		t.Fatalf("expected 3 unreads, got %d", len(out.UnreadChannels))
+	}
+	// Find Cpub and check truncation
+	var pub *unreadChannelEntry
+	for i := range out.UnreadChannels {
+		if out.UnreadChannels[i].ChannelID == "Cpub" {
+			pub = &out.UnreadChannels[i]
+			break
+		}
+	}
+	if pub == nil {
+		t.Fatal("missing Cpub entry")
+	}
+	if pub.ChannelType != "public_channel" {
+		t.Errorf("Cpub type: got %q", pub.ChannelType)
+	}
+	if pub.LatestMessagePreview == nil {
+		t.Fatal("missing preview")
+	}
+	if got := len([]rune(pub.LatestMessagePreview.Text)); got != 201 { // 200 runes + ellipsis
+		t.Errorf("expected truncated text length 201 runes, got %d", got)
+	}
+}
+
+func TestListUnread_EmptyChannelList(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "user": map[string]any{"id": "U1"}})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "channels": []any{}})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "a@b.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out listUnreadResult
+	_ = json.Unmarshal(res.Data, &out)
+	if len(out.UnreadChannels) != 0 {
+		t.Fatalf("expected empty, got %d", len(out.UnreadChannels))
+	}
+}
+
+func TestListUnread_MissingLatestOmitsPreview(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "user": map[string]any{"id": "U1"}})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"channels": []map[string]any{{"id": "C1", "name": "x"}},
+			})
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id":                   "C1",
+					"name":                 "x",
+					"unread_count_display": 1,
+					"last_read":            "1.0",
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "a@b.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out listUnreadResult
+	_ = json.Unmarshal(res.Data, &out)
+	if len(out.UnreadChannels) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(out.UnreadChannels))
+	}
+	if out.UnreadChannels[0].LatestMessagePreview != nil {
+		t.Fatal("expected nil latest_message_preview")
+	}
+}
+
+func TestListUnread_RateLimitOnInfo(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "user": map[string]any{"id": "U1"}})
+		case "/users.conversations":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"channels": []map[string]any{{"id": "C1"}},
+			})
+		case "/conversations.info":
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Header().Set("Retry-After", "2")
+			json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "ratelimited"})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "a@b.com",
+	})
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Fatalf("expected RateLimitError, got %T: %v", err, err)
+	}
+}
+
+func TestListUnread_PaginatesUsersConversations(t *testing.T) {
+	t.Parallel()
+
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "user": map[string]any{"id": "U1"}})
+		case "/users.conversations":
+			var body usersConversationsRequest
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			page++
+			if page == 1 {
+				json.NewEncoder(w).Encode(map[string]any{
+					"ok":                true,
+					"channels":          []map[string]any{{"id": "C1"}},
+					"response_metadata": map[string]any{"next_cursor": "c2"},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"channels": []map[string]any{{"id": "C2"}},
+			})
+		case "/conversations.info":
+			ch := r.URL.Query().Get("channel")
+			unread := 0
+			if ch == "C2" {
+				unread = 1
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channel": map[string]any{
+					"id": ch, "name": ch,
+					"unread_count_display": unread,
+					"last_read":            "1.0",
+					"latest":               map[string]any{"text": "x", "user": "U1", "ts": "2.0"},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "a@b.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out listUnreadResult
+	_ = json.Unmarshal(res.Data, &out)
+	if len(out.UnreadChannels) != 1 || out.UnreadChannels[0].ChannelID != "C2" {
+		t.Fatalf("expected single unread on C2, got %+v", out.UnreadChannels)
+	}
+}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -134,7 +134,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:      "slack.read_channel_messages",
 				Name:            "Read Channel Messages",
-				Description:     "Read recent messages from a Slack channel, DM (D…), or group DM (G…).",
+				Description:     "Read recent messages from a Slack channel, DM (D…), or group DM (G…). To fetch only unread messages, call slack.list_unread first and pass oldest = last_read_ts from that result (do not rely on blind recent history).",
 				RiskLevel:       "low",
 				DisplayTemplate: "Read messages from {{channel_name}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
@@ -785,6 +785,46 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 					}
 				}`)),
 			},
+			{
+				ActionType:      "slack.list_unread",
+				Name:            "List Unread",
+				Description:     "List Slack conversations where the authorizing user has unread messages (users.conversations + conversations.info per channel). Use slack.read_channel_messages with oldest = last_read_ts from an entry to load only unread messages; optionally clear read state with slack.mark_read using the ts of the last message you surfaced (required parameter).",
+				RiskLevel:       "low",
+				DisplayTemplate: "List unread Slack conversations",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {}
+				}`)),
+			},
+			{
+				ActionType:      "slack.mark_read",
+				Name:            "Mark Read",
+				Description:     "Set the read cursor for a conversation (conversations.mark). Requires channel_id and ts — pass the Slack message timestamp of the last message you showed the user (no default).",
+				RiskLevel:       "low",
+				DisplayTemplate: "Mark Slack conversation read",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["channel_id", "ts"],
+					"properties": {
+						"channel_id": {
+							"type": "string",
+							"description": "Channel ID (C…, D…, or G…)",
+							"x-ui": {
+								"widget": "remote-select",
+								"remote_select_options_path": "/v1/agents/{agent_id}/connectors/{connector_id}/channels",
+								"remote_select_id_key": "id",
+								"remote_select_label_key": "display_label",
+								"remote_select_fallback_placeholder": "Channel ID (e.g. C01234567)"
+							}
+						},
+						"ts": {
+							"type": "string",
+							"description": "Slack message timestamp to mark as read (e.g. 1234567890.123456) — required; use the ts of the last message you surfaced",
+							"x-ui": {"hidden": true}
+						}
+					}
+				}`)),
+			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
@@ -1001,6 +1041,22 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				Name:             "Unpin messages",
 				Description:      "Agent can unpin messages in channels.",
 				Parameters:       json.RawMessage(`{"channel":"*","ts":"*"}`),
+				StandingApproval: neverExpire,
+			},
+			{
+				ID:               "tpl_slack_list_unread",
+				ActionType:       "slack.list_unread",
+				Name:             "List unread conversations",
+				Description:      "Agent can list conversations with unread messages for the authorizing user.",
+				Parameters:       json.RawMessage(`{}`),
+				StandingApproval: neverExpire,
+			},
+			{
+				ID:               "tpl_slack_mark_read",
+				ActionType:       "slack.mark_read",
+				Name:             "Mark conversations read",
+				Description:      "Agent can mark a conversation read at an explicit message timestamp.",
+				Parameters:       json.RawMessage(`{"channel_id":"*","ts":"*"}`),
 				StandingApproval: neverExpire,
 			},
 		},

--- a/connectors/slack/mark_read.go
+++ b/connectors/slack/mark_read.go
@@ -1,0 +1,54 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// markReadAction implements slack.mark_read (conversations.mark).
+type markReadAction struct {
+	conn *SlackConnector
+}
+
+type markReadParams struct {
+	ChannelID string `json:"channel_id"`
+	TS        string `json:"ts"`
+}
+
+type markReadRequest struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+}
+
+func (p *markReadParams) validate() error {
+	if err := validateChannelID(p.ChannelID); err != nil {
+		return err
+	}
+	return validateMessageTS(p.TS)
+}
+
+func (a *markReadAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params markReadParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	if err := a.conn.verifyChannelAccess(ctx, req.Credentials, params.ChannelID, req.UserEmail); err != nil {
+		return nil, err
+	}
+
+	body := markReadRequest{
+		Channel: params.ChannelID,
+		TS:      params.TS,
+	}
+	var resp slackResponse
+	if err := a.conn.doPost(ctx, "conversations.mark", req.Credentials, body, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, resp.asError()
+	}
+
+	return connectors.JSONResult(map[string]any{"ok": true})
+}

--- a/connectors/slack/mark_read_test.go
+++ b/connectors/slack/mark_read_test.go
@@ -1,0 +1,186 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestMarkRead_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/conversations.info":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"channel": map[string]any{"id": "C01234567", "is_private": false},
+			})
+		case "/conversations.mark":
+			var body markReadRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if body.Channel != "C01234567" || body.TS != "1678900000.000100" {
+				t.Errorf("unexpected body %+v", body)
+			}
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &markReadAction{conn: conn}
+
+	params, _ := json.Marshal(markReadParams{
+		ChannelID: "C01234567",
+		TS:        "1678900000.000100",
+	})
+
+	res, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.mark_read",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(res.Data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["ok"] != true {
+		t.Fatalf("expected ok true, got %+v", out)
+	}
+}
+
+func TestMarkRead_MissingTS(t *testing.T) {
+	t.Parallel()
+
+	conn := newForTest(http.DefaultClient, "http://unused.example")
+	action := &markReadAction{conn: conn}
+
+	params, _ := json.Marshal(markReadParams{
+		ChannelID: "C01234567",
+		TS:        "",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.mark_read",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestMarkRead_InvalidChannelID(t *testing.T) {
+	t.Parallel()
+
+	conn := newForTest(http.DefaultClient, "http://unused.example")
+	action := &markReadAction{conn: conn}
+
+	params, _ := json.Marshal(markReadParams{
+		ChannelID: "not-a-channel-id",
+		TS:        "1678900000.000100",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.mark_read",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestMarkRead_ChannelNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/conversations.info" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "channel_not_found"})
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &markReadAction{conn: conn}
+
+	params, _ := json.Marshal(markReadParams{
+		ChannelID: "C01234567",
+		TS:        "1678900000.000100",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.mark_read",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMarkRead_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.info":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"channel": map[string]any{"id": "C01234567", "is_private": false},
+			})
+		case "/conversations.mark":
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "ratelimited"})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &markReadAction{conn: conn}
+
+	params, _ := json.Marshal(markReadParams{
+		ChannelID: "C01234567",
+		TS:        "1678900000.000100",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.mark_read",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	if !connectors.IsRateLimitError(err) {
+		t.Fatalf("expected RateLimitError, got %T: %v", err, err)
+	}
+}

--- a/connectors/slack/param_validate.go
+++ b/connectors/slack/param_validate.go
@@ -42,6 +42,8 @@ var paramValidators = map[string]connectors.ParamValidatorFunc{
 	"slack.remove_reaction":       makeParamValidator[removeReactionParams](),
 	"slack.rename_channel":        makeParamValidator[renameChannelParams](),
 	"slack.unpin_message":         makeParamValidator[unpinMessageParams](),
+	"slack.list_unread":           makeParamValidator[listUnreadParams](),
+	"slack.mark_read":             makeParamValidator[markReadParams](),
 }
 
 func makeParamValidator[T any, PT interface {

--- a/connectors/slack/resolve_resource_details.go
+++ b/connectors/slack/resolve_resource_details.go
@@ -63,6 +63,17 @@ func (c *SlackConnector) ResolveResourceDetails(ctx context.Context, actionType 
 	case "slack.search_messages":
 		return c.resolveSearchMessagesChannel(ctx, creds, params)
 
+	case "slack.mark_read":
+		var p markReadParams
+		if err := json.Unmarshal(params, &p); err != nil || p.ChannelID == "" {
+			return nil, nil
+		}
+		channelOnly, err := json.Marshal(map[string]string{"channel": p.ChannelID})
+		if err != nil {
+			return nil, err
+		}
+		return c.resolveChannel(ctx, creds, channelOnly)
+
 	default:
 		return nil, nil
 	}

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -117,6 +117,8 @@ func (c *SlackConnector) Actions() map[string]connectors.Action {
 		"slack.get_user_profile":      &getUserProfileAction{conn: c},
 		"slack.pin_message":           &pinMessageAction{conn: c},
 		"slack.unpin_message":         &unpinMessageAction{conn: c},
+		"slack.list_unread":           &listUnreadAction{conn: c},
+		"slack.mark_read":             &markReadAction{conn: c},
 	}
 }
 

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -46,6 +46,8 @@ func TestSlackConnector_Actions(t *testing.T) {
 		"slack.get_user_profile",
 		"slack.pin_message",
 		"slack.unpin_message",
+		"slack.list_unread",
+		"slack.mark_read",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -113,8 +115,8 @@ func TestSlackConnector_Manifest(t *testing.T) {
 	if m.Name != "Slack" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Slack")
 	}
-	if len(m.Actions) != 22 {
-		t.Fatalf("Manifest().Actions has %d items, want 22", len(m.Actions))
+	if len(m.Actions) != 24 {
+		t.Fatalf("Manifest().Actions has %d items, want 24", len(m.Actions))
 	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
@@ -129,6 +131,7 @@ func TestSlackConnector_Manifest(t *testing.T) {
 		"slack.list_users", "slack.search_messages",
 		"slack.archive_channel", "slack.rename_channel", "slack.remove_from_channel",
 		"slack.get_user_profile", "slack.pin_message", "slack.unpin_message",
+		"slack.list_unread", "slack.mark_read",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub issue #1010: expose Slack per-user unread state to agents without new OAuth scopes.

- **`slack.list_unread`** — Paginates `users.conversations` (types `public_channel,private_channel,mpim,im`), calls `conversations.info` per channel via shared `fetchConversationInfo`, keeps rows where `unread_count_display > 0`, returns `channel_id`, `channel_name`, `channel_type`, `unread_count`, `last_read_ts`, and optional `latest_message_preview` (`text` truncated to 200 runes, `user`/`ts`).
- **`slack.mark_read`** — `conversations.mark` with required `channel_id` and `ts` (validated); runs existing `verifyChannelAccess` before marking.
- **Manifest** — New actions + standing-approval templates; **`slack.read_channel_messages`** description updated to steer agents toward `list_unread` + `oldest=last_read_ts` instead of blind history.
- **README** — Short agent workflow for unreads / read / mark.
- **`ResolveResourceDetails`** — Resolves `channel_name` for `slack.mark_read` from `channel_id`.

## Test plan

- [ ] `make test-backend` / `go test ./connectors/slack/...` on CI (local agent environment could not run the full Go test suite due to toolchain constraints).
- [ ] Manual: CLI — “do I have unread Slack messages?” uses `list_unread` + `read_channel_messages` with `oldest`.
- [ ] Manual: `mark_read` with explicit `ts` then `list_unread` drops the channel; `mark_read` without `ts` returns validation error.

Closes #1010
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f1d4d30-4164-4503-ab29-968050c38f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f1d4d30-4164-4503-ab29-968050c38f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

