### PR TITLE
fix(approvals): raise merged approval context cap to 256 KiB (#1004)

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -117,7 +117,7 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action exceeds maximum size"))
 			return
 		}
-		if len(req.Context) > 65536 {
+		if len(req.Context) > maxApprovalContextJSONBytes {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "context exceeds maximum size"))
 			return
 		}

--- a/api/approval_context_limits.go
+++ b/api/approval_context_limits.go
@@ -1,0 +1,6 @@
+package api
+
+// Max merged approval context JSON size (bytes) after enriching from resource_details
+// (e.g. slack_context, email_thread). Must stay in sync with approvals.context DB check
+// and AgentRequestApproval request validation (issue #1004).
+const maxApprovalContextJSONBytes = 262144

--- a/api/approval_email_thread.go
+++ b/api/approval_email_thread.go
@@ -51,8 +51,8 @@ func mergeEmailThreadFromResourceDetailsIntoContext(contextJSON json.RawMessage,
 	if err != nil {
 		return contextJSON
 	}
-	// Preserve the 65536-byte cap from the request validator.
-	if len(out) > 65536 {
+	// Preserve the cap from maxApprovalContextJSONBytes (validator + DB).
+	if len(out) > maxApprovalContextJSONBytes {
 		return contextJSON
 	}
 	return out

--- a/api/approval_email_thread_test.go
+++ b/api/approval_email_thread_test.go
@@ -32,10 +32,10 @@ func TestMergeEmailThreadFromResourceDetailsIntoContext(t *testing.T) {
 }
 
 func TestMergeEmailThreadFromResourceDetailsIntoContext_SizeCap(t *testing.T) {
-	// Context stays under 65536; merged output would exceed the cap — merge must no-op.
-	long := strings.Repeat("a", 65380)
+	// Context stays under maxApprovalContextJSONBytes; merged output would exceed the cap — merge must no-op.
+	long := strings.Repeat("a", maxApprovalContextJSONBytes-200)
 	ctxIn := []byte(`{"description":"` + long + `","details":{}}`)
-	if len(ctxIn) >= 65536 {
+	if len(ctxIn) >= maxApprovalContextJSONBytes {
 		t.Fatalf("setup: context len %d", len(ctxIn))
 	}
 	thread := connectors.EmailThreadPayload{
@@ -46,7 +46,7 @@ func TestMergeEmailThreadFromResourceDetailsIntoContext_SizeCap(t *testing.T) {
 	}
 	b, _ := json.Marshal(map[string]any{"email_thread": thread})
 	out := mergeEmailThreadFromResourceDetailsIntoContext(ctxIn, b)
-	if len(out) > 65536 {
+	if len(out) > maxApprovalContextJSONBytes {
 		t.Fatalf("merged unexpectedly long: %d", len(out))
 	}
 	if string(out) != string(ctxIn) {

--- a/api/approval_slack_context.go
+++ b/api/approval_slack_context.go
@@ -45,7 +45,7 @@ func mergeSlackContextFromResourceDetailsIntoContext(contextJSON json.RawMessage
 	if err != nil {
 		return contextJSON
 	}
-	if len(out) > 65536 {
+	if len(out) > maxApprovalContextJSONBytes {
 		return contextJSON
 	}
 	return out

--- a/api/approval_slack_context_test.go
+++ b/api/approval_slack_context_test.go
@@ -30,15 +30,15 @@ func TestMergeSlackContextFromResourceDetailsIntoContext(t *testing.T) {
 }
 
 func TestMergeSlackContextFromResourceDetailsIntoContext_SizeCap(t *testing.T) {
-	long := strings.Repeat("a", 65380)
+	long := strings.Repeat("a", maxApprovalContextJSONBytes-200)
 	ctxIn := []byte(`{"description":"` + long + `","details":{}}`)
-	if len(ctxIn) >= 65536 {
+	if len(ctxIn) >= maxApprovalContextJSONBytes {
 		t.Fatalf("setup: context len %d", len(ctxIn))
 	}
 	sc := map[string]any{"context_scope": "metadata_only", "big": strings.Repeat("b", 500)}
 	rd, _ := json.Marshal(map[string]any{"slack_context": sc})
 	out := mergeSlackContextFromResourceDetailsIntoContext(ctxIn, rd)
-	if len(out) > 65536 {
+	if len(out) > maxApprovalContextJSONBytes {
 		t.Fatalf("merged unexpectedly long: %d", len(out))
 	}
 	if string(out) != string(ctxIn) {

--- a/db/migrations/20260422004822_widen_approvals_context_to_256kb.sql
+++ b/db/migrations/20260422004822_widen_approvals_context_to_256kb.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- Allow larger approval context JSON after resource_details enrichment (Slack thread preview, etc.).
+-- See issue #1004. action stays at 64 KiB; context raised to 256 KiB to match API + merge caps.
+
+ALTER TABLE approvals DROP CONSTRAINT IF EXISTS approvals_context_check;
+
+ALTER TABLE approvals ADD CONSTRAINT approvals_context_check
+    CHECK (pg_column_size(context) <= 262144);
+
+-- +goose Down
+
+ALTER TABLE approvals DROP CONSTRAINT IF EXISTS approvals_context_check;
+
+ALTER TABLE approvals ADD CONSTRAINT approvals_context_check
+    CHECK (pg_column_size(context) <= 65536);

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -420,7 +420,7 @@ All TEXT primary keys and unbounded text columns have inline CHECK length constr
 
 ### JSONB size constraints
 
-All JSONB columns have `CHECK (pg_column_size(column) <= 65536)` constraints to prevent oversized payloads from bloating storage and indexes. The 64 KB limit applies to: `agents.metadata`, `approvals.action`, `approvals.context`, `connector_actions.parameters_schema`, and `standing_approvals.constraints`. `pg_column_size` measures the actual on-disk JSONB representation, which is more accurate than casting to text.
+Most JSONB columns use `CHECK (pg_column_size(column) <= 65536)` to prevent oversized payloads from bloating storage and indexes. `approvals.context` allows up to 256 KiB so enriched approval payloads (e.g. Slack preview data merged from `resource_details`) can persist. The 64 KB limit still applies to: `agents.metadata`, `approvals.action`, `connector_actions.parameters_schema`, and `standing_approvals.constraints`. `pg_column_size` measures the actual on-disk JSONB representation, which is more accurate than casting to text.
 
 ### pg_cron helper functions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **option 2** from #1004: raise the merged approval `context` JSON budget from 64 KiB to **256 KiB** so `slack_context` (and email thread enrichment) is less likely to be dropped after merge.

## Changes

- Introduced `maxApprovalContextJSONBytes` (`262144`) in `api/approval_context_limits.go` and use it in:
  - `mergeSlackContextFromResourceDetailsIntoContext`
  - `mergeEmailThreadFromResourceDetailsIntoContext`
  - `AgentRequestApproval` validation for `req.Context`
- Migration `20260422004822_widen_approvals_context_to_256kb.sql`: widens `approvals.context` `pg_column_size` check to 262144 bytes; `approvals.action` remains 64 KiB.
- Updated size-cap tests and `docs/database-schema.md`.

## Test plan

- [ ] `make test-backend` (CI) — local sandbox Go toolchain could not run `go test` against this module; formatting verified with `gofmt` on touched files.

Closes #1004
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-312e1c53-b11a-44de-b07f-47e04a0a0b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-312e1c53-b11a-44de-b07f-47e04a0a0b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

