### PR TITLE
fix(google): Sheets read batchGet + append column-only range (fix #951, #950)

### DIFF
--- a/connectors/google/sheets_append.go
+++ b/connectors/google/sheets_append.go
@@ -12,10 +12,15 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
-// columnOnlyRange matches ranges like "Sheet1!A:C" or "Sheet1!A:A" where the
-// column range has no row anchors. The Sheets API values.append endpoint does
-// not accept these; callers should pass just the sheet name instead.
-var columnOnlyRange = regexp.MustCompile(`^([^!]+)![A-Za-z]+:[A-Za-z]+$`)
+// columnOnlyRange matches ranges like "Sheet1!A:C" or "Sheet1!A:A" where both
+// sides of the colon are column letters only (no row numbers). The Sheets API
+// values.append endpoint rejects these column-only spans; normalize to the
+// sheet name so append behaves like passing "Sheet1".
+//
+// Whitespace is trimmed first so JSON/parameters with trailing newlines or
+// spaces still normalize (fixes mis-detection where the raw "Sheet1!A:C" was
+// sent through to Google unchanged).
+var columnOnlyRange = regexp.MustCompile(`^([^!]+)!\s*([A-Za-z]+)\s*:\s*([A-Za-z]+)\s*$`)
 
 // sheetsAppendRowsAction implements connectors.Action for google.sheets_append_rows.
 // It appends rows to a sheet via the Google Sheets API
@@ -36,6 +41,7 @@ type sheetsAppendRowsParams struct {
 // sheet name "Sheet1". values.append requires a cell anchor, not a bare column
 // span, so callers who pass "Sheet1!A:C" get the same result as "Sheet1".
 func normalizeAppendRange(r string) string {
+	r = strings.TrimSpace(r)
 	if m := columnOnlyRange.FindStringSubmatch(r); m != nil {
 		return strings.TrimSpace(m[1])
 	}

--- a/connectors/google/sheets_append_test.go
+++ b/connectors/google/sheets_append_test.go
@@ -81,6 +81,28 @@ func TestSheetsAppendRows_Success(t *testing.T) {
 	}
 }
 
+func TestNormalizeAppendRange_ColumnOnlyAndWhitespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Sheet1!A:C", "Sheet1"},
+		{"  Sheet1!A:C  ", "Sheet1"},
+		{"Sheet1! A : C", "Sheet1"},
+		{"Sheet1!A:C\n", "Sheet1"},
+		{"My Sheet!A:C", "My Sheet"},
+		{"Sheet1!A1:C10", "Sheet1!A1:C10"},
+		{"Sheet1", "Sheet1"},
+	}
+	for _, tt := range tests {
+		if got := normalizeAppendRange(tt.in); got != tt.want {
+			t.Errorf("normalizeAppendRange(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestSheetsAppendRows_ColumnOnlyRangeNormalized(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/google/sheets_read.go
+++ b/connectors/google/sheets_read.go
@@ -12,7 +12,12 @@ import (
 
 // sheetsReadRangeAction implements connectors.Action for google.sheets_read_range.
 // It reads cell values from a specified range via the Google Sheets API
-// GET /v4/spreadsheets/{id}/values/{range}.
+// GET /v4/spreadsheets/{id}/values:batchGet?ranges=... .
+//
+// We use values:batchGet with the range in the query string instead of
+// values/{range} in the path. Path-segment encoding turns "!" in A1 ranges into
+// "%21", which breaks some proxies and the read path in production while write
+// (which uses the same encoded segment) can still succeed depending on routing.
 type sheetsReadRangeAction struct {
 	conn *GoogleConnector
 }
@@ -34,11 +39,17 @@ func (p *sheetsReadRangeParams) validate() error {
 	return nil
 }
 
-// sheetsValueRange is the Google Sheets API response for values.get.
+// sheetsValueRange is the Google Sheets API ValueRange resource (values.get and batchGet).
 type sheetsValueRange struct {
-	Range          string     `json:"range"`
-	MajorDimension string    `json:"majorDimension"`
-	Values         [][]any   `json:"values"`
+	Range          string  `json:"range"`
+	MajorDimension string  `json:"majorDimension"`
+	Values         [][]any `json:"values"`
+}
+
+// sheetsBatchGetValuesResponse is the Google Sheets API response for values.batchGet.
+type sheetsBatchGetValuesResponse struct {
+	SpreadsheetID string             `json:"spreadsheetId,omitempty"`
+	ValueRanges   []sheetsValueRange `json:"valueRanges"`
 }
 
 // Execute reads cell values from the specified range in a Google Sheets spreadsheet.
@@ -51,14 +62,19 @@ func (a *sheetsReadRangeAction) Execute(ctx context.Context, req connectors.Acti
 		return nil, err
 	}
 
+	q := url.Values{}
+	q.Set("ranges", params.Range)
 	readURL := a.conn.sheetsBaseURL + "/spreadsheets/" +
-		url.PathEscape(params.SpreadsheetID) + "/values/" +
-		url.PathEscape(params.Range)
+		url.PathEscape(params.SpreadsheetID) + "/values:batchGet?" + q.Encode()
 
-	var resp sheetsValueRange
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, readURL, nil, &resp); err != nil {
-		return nil, err
+	var batchResp sheetsBatchGetValuesResponse
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodGet, readURL, nil, &batchResp); err != nil {
+		return nil, remapInvalidRangeError(ctx, a.conn, req.Credentials, params.SpreadsheetID, params.Range, err)
 	}
+	if len(batchResp.ValueRanges) == 0 {
+		return nil, &connectors.ExternalError{Message: "Google Sheets API returned no value ranges for the requested range"}
+	}
+	resp := batchResp.ValueRanges[0]
 
 	return connectors.JSONResult(map[string]any{
 		"range":  resp.Range,

--- a/connectors/google/sheets_read_test.go
+++ b/connectors/google/sheets_read_test.go
@@ -16,22 +16,27 @@ func TestSheetsReadRange_Success(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/spreadsheets/spreadsheet-123/values/Sheet1!A1:D3" {
+		if r.URL.Path != "/spreadsheets/spreadsheet-123/values:batchGet" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("ranges"); got != "Sheet1!A1:D3" {
+			t.Errorf("unexpected ranges query: %q", got)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer ya29.test-access-token-123" {
 			t.Errorf("unexpected auth header: %s", got)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(sheetsValueRange{
-			Range:          "Sheet1!A1:D3",
-			MajorDimension: "ROWS",
-			Values: [][]any{
-				{"Name", "Age", "City"},
-				{"Alice", 30, "NYC"},
-				{"Bob", 25, "LA"},
-			},
+		json.NewEncoder(w).Encode(sheetsBatchGetValuesResponse{
+			ValueRanges: []sheetsValueRange{{
+				Range:          "Sheet1!A1:D3",
+				MajorDimension: "ROWS",
+				Values: [][]any{
+					{"Name", "Age", "City"},
+					{"Alice", 30, "NYC"},
+					{"Bob", 25, "LA"},
+				},
+			}},
 		})
 	}))
 	defer srv.Close()
@@ -73,8 +78,10 @@ func TestSheetsReadRange_EmptyResult(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(sheetsValueRange{
-			Range: "Sheet1!A1:D3",
+		json.NewEncoder(w).Encode(sheetsBatchGetValuesResponse{
+			ValueRanges: []sheetsValueRange{{
+				Range: "Sheet1!A1:D3",
+			}},
 		})
 	}))
 	defer srv.Close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### #951 — `sheets_read_range` returning 502

`google.sheets_read_range` used `GET .../values/{range}` with `url.PathEscape` on the range. A1 notation turns `!` into `%21` in the path, which some proxies mishandle (502). The read action now uses **`spreadsheets.values.batchGet`** with the range in the **`ranges` query parameter**. Read failures also use **`remapInvalidRangeError`** like writes.

### #950 — `sheets_append_rows` with `Sheet1!A:C` → "Unable to parse range"

Column-only ranges like `Sheet1!A:C` must be normalized to the sheet name for `values.append`. If the range string had **leading/trailing whitespace** or **spaces around `:`**, the regex did not match and the raw range was sent to Google. **`normalizeAppendRange`** now trims the input and matches optional whitespace around the column span.

## Test plan

- [ ] CI `go test ./connectors/google/...`
- Manual #951: `google.sheets_read_range` with `Sheet1!A1:C10` — expect data, not 502.
- Manual #950: `google.sheets_append_rows` with `range` `Sheet1!A:C` — expect append success.

Closes #951
Closes #950
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e45a911-1217-4828-b3d0-ca2c004bb7fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e45a911-1217-4828-b3d0-ca2c004bb7fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

