### PR TITLE
fix(google): align create/update document body parameter as content

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -462,7 +462,7 @@ The response includes `row_count` and `column_count` from the sheet's grid prope
 
 ### `google.create_document`
 
-Creates a new Google Doc with a title and optional initial body content.
+Creates a new Google Doc with a title and optional initial document body text.
 
 **Risk level:** medium
 
@@ -471,7 +471,8 @@ Creates a new Google Doc with a title and optional initial body content.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `title` | string | Yes | Title of the new Google Doc |
-| `body` | string | No | Optional initial body content (plain text) |
+| `content` | string | No | Optional initial document body (plain text); same field name as `google.update_document` |
+| `body` | string | No | Deprecated — use `content` instead |
 
 **Response:**
 
@@ -535,6 +536,7 @@ Appends or inserts text into an existing Google Doc using the Docs API batchUpda
 |------|------|----------|---------|-------------|
 | `document_id` | string | Yes | — | The ID of the Google Doc to update |
 | `content` | string | Yes | — | Text to insert into the document |
+| `text` | string | — | — | Deprecated — use `content` instead |
 | `index` | integer | No | end | Character index to insert at (1-based). Defaults to end of document. |
 
 **Response:**
@@ -1087,8 +1089,8 @@ The connector ships with constrained templates that demonstrate parameter lockin
 | Append to specific spreadsheet | `sheets_append_rows` | `spreadsheet_id` locked; agent chooses range and values |
 | Read from any spreadsheet | `sheets_read_range` | Nothing — agent controls all parameters |
 | List worksheets in any spreadsheet | `sheets_list_sheets` | Nothing — agent controls spreadsheet |
-| Create documents | `create_document` | Nothing — agent controls title and body |
-| Create empty documents | `create_document` | `body` omitted — title only |
+| Create documents | `create_document` | Nothing — agent controls title and content |
+| Create empty documents | `create_document` | `content` omitted — title only |
 | Read any document | `get_document` | Nothing — agent can read any doc by ID |
 | Edit any document | `update_document` | Nothing — agent controls all parameters |
 | Search documents | `list_documents` | Nothing — agent controls query and count |

--- a/connectors/google/create_document.go
+++ b/connectors/google/create_document.go
@@ -19,8 +19,17 @@ type createDocumentAction struct {
 
 // createDocumentParams is the user-facing parameter schema.
 type createDocumentParams struct {
-	Title string `json:"title"`
-	Body  string `json:"body"`
+	Title   string `json:"title"`
+	Content string `json:"content,omitempty"`
+	// Body is deprecated: prefer Content for the same field as google.update_document.
+	Body string `json:"body,omitempty"`
+}
+
+func (p *createDocumentParams) initialBodyText() string {
+	if p.Content != "" {
+		return p.Content
+	}
+	return p.Body
 }
 
 func (p *createDocumentParams) validate() error {
@@ -62,12 +71,12 @@ func (a *createDocumentAction) Execute(ctx context.Context, req connectors.Actio
 	documentURL := documentEditURL(resp.DocumentID)
 
 	// If body text was provided, insert it via batchUpdate.
-	if params.Body != "" {
+	if text := params.initialBodyText(); text != "" {
 		batchReq := docsBatchUpdateRequest{
 			Requests: []docsRequest{
 				{
 					InsertText: &docsInsertTextRequest{
-						Text:               params.Body,
+						Text:                 text,
 						EndOfSegmentLocation: &docsEndOfSegmentLocation{},
 					},
 				},

--- a/connectors/google/create_document_test.go
+++ b/connectors/google/create_document_test.go
@@ -49,8 +49,8 @@ func TestCreateDocument_Success(t *testing.T) {
 	action := &createDocumentAction{conn: conn}
 
 	params, _ := json.Marshal(createDocumentParams{
-		Title: "My New Doc",
-		Body:  "Hello, world!",
+		Title:   "My New Doc",
+		Content: "Hello, world!",
 	})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -77,6 +77,47 @@ func TestCreateDocument_Success(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Errorf("expected 2 API calls (create + batchUpdate), got %d", calls)
+	}
+}
+
+func TestCreateDocument_DeprecatedBodyAlias(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/documents" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(docsCreateResponse{
+				DocumentID: "doc-alias",
+				Title:      "Alias Doc",
+			})
+		} else if r.URL.Path == "/v1/documents/doc-alias:batchUpdate" {
+			var batch docsBatchUpdateRequest
+			if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			if batch.Requests[0].InsertText == nil || batch.Requests[0].InsertText.Text != "from body" {
+				t.Fatalf("expected InsertText from deprecated body, got %+v", batch.Requests[0].InsertText)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		} else {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &createDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{"title": "Alias Doc", "body": "from body"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.create_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -244,8 +285,8 @@ func TestCreateDocument_BodyInsertionFailure(t *testing.T) {
 	action := &createDocumentAction{conn: conn}
 
 	params, _ := json.Marshal(createDocumentParams{
-		Title: "Partial Doc",
-		Body:  "some text",
+		Title:   "Partial Doc",
+		Content: "some text",
 	})
 
 	// Should succeed with a warning, not error — the document was created.

--- a/connectors/google/manifest.go
+++ b/connectors/google/manifest.go
@@ -329,7 +329,7 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:      "google.create_document",
 				Name:            "Create Document",
-				Description:     "Create a new Google Doc with a title and optional body content",
+				Description:     "Create a new Google Doc with a title and optional document body text",
 				RiskLevel:       "medium",
 				DisplayTemplate: "Create document {{title}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
@@ -341,10 +341,15 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 							"description": "Title of the new Google Doc",
 							"x-ui": {"label": "Title", "placeholder": "Meeting Notes"}
 						},
+						"content": {
+							"type": "string",
+							"description": "Optional initial document body (plain text). Same field as google.update_document.",
+							"x-ui": {"label": "Content", "widget": "textarea"}
+						},
 						"body": {
 							"type": "string",
-							"description": "Optional initial body content (plain text)",
-							"x-ui": {"label": "Body", "widget": "textarea"}
+							"description": "Deprecated: use content instead. Optional initial body (plain text).",
+							"x-ui": {"label": "Body (deprecated)", "widget": "textarea"}
 						}
 					}
 				}`)),
@@ -384,8 +389,13 @@ func (c *GoogleConnector) Manifest() *connectors.ConnectorManifest {
 						},
 						"content": {
 							"type": "string",
-							"description": "Text to insert into the document",
+							"description": "Text to insert into the document (same field name as google.create_document).",
 							"x-ui": {"label": "Content", "widget": "textarea"}
+						},
+						"text": {
+							"type": "string",
+							"description": "Deprecated: use content instead. Text to insert into the document.",
+							"x-ui": {"label": "Text (deprecated)", "widget": "textarea"}
 						},
 						"index": {
 							"type": "integer",

--- a/connectors/google/manifest_templates.go
+++ b/connectors/google/manifest_templates.go
@@ -219,7 +219,7 @@ func googleTemplates() []connectors.ManifestTemplate {
 			ActionType:  "google.create_document",
 			Name:        "Create documents",
 			Description: "Agent can create new Google Docs with any title and body.",
-			Parameters:  json.RawMessage(`{"title":"*","body":"*"}`),
+			Parameters:  json.RawMessage(`{"title":"*","content":"*"}`),
 		},
 		{
 			ID:          "tpl_google_create_document_title_only",

--- a/connectors/google/update_document.go
+++ b/connectors/google/update_document.go
@@ -20,15 +20,24 @@ type updateDocumentAction struct {
 // updateDocumentParams is the user-facing parameter schema.
 type updateDocumentParams struct {
 	DocumentID string `json:"document_id"`
-	Content    string `json:"content"`
-	Index      int    `json:"index"`
+	Content    string `json:"content,omitempty"`
+	// Text is deprecated: prefer Content (aligned with google.create_document).
+	Text  string `json:"text,omitempty"`
+	Index int    `json:"index"`
+}
+
+func (p *updateDocumentParams) insertText() string {
+	if p.Content != "" {
+		return p.Content
+	}
+	return p.Text
 }
 
 func (p *updateDocumentParams) validate() error {
 	if p.DocumentID == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: document_id"}
 	}
-	if p.Content == "" {
+	if p.insertText() == "" {
 		return &connectors.ValidationError{Message: "missing required parameter: content"}
 	}
 	if p.Index < 0 {
@@ -47,15 +56,16 @@ func (a *updateDocumentAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
+	text := params.insertText()
 	var insertReq docsRequest
 	if params.Index > 0 {
 		insertReq.InsertText = &docsInsertTextRequest{
-			Text:     params.Content,
+			Text:     text,
 			Location: &docsLocation{Index: params.Index},
 		}
 	} else {
 		insertReq.InsertText = &docsInsertTextRequest{
-			Text:                 params.Content,
+			Text:                 text,
 			EndOfSegmentLocation: &docsEndOfSegmentLocation{},
 		}
 	}

--- a/connectors/google/update_document_test.go
+++ b/connectors/google/update_document_test.go
@@ -9,6 +9,40 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
+func TestUpdateDocument_DeprecatedTextAlias(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body docsBatchUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if body.Requests[0].InsertText == nil || body.Requests[0].InsertText.Text != "via text" {
+			t.Fatalf("expected text via deprecated alias, got %+v", body.Requests[0].InsertText)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTestDocs(srv.Client(), srv.URL, "")
+	action := &updateDocumentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]string{
+		"document_id": "doc-abc-123",
+		"text":        "via text",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "google.update_document",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestUpdateDocument_SuccessAppend(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
@@ -579,13 +579,13 @@ export const GoogleCreateDocument: Story = {
     riskLevel: "medium",
     displayTemplate: "Create document {{title}}",
     preview: null,
-    parameters: { title: "Q1 Sprint Retrospective", body: "## What went well\n\n- Shipped API v2 on time\n- Zero downtime deployments\n\n## What could improve\n\n- Test coverage on edge cases" },
+    parameters: { title: "Q1 Sprint Retrospective", content: "## What went well\n\n- Shipped API v2 on time\n- Zero downtime deployments\n\n## What could improve\n\n- Test coverage on edge cases" },
     schema: {
       type: "object",
       required: ["title"],
       properties: {
         title: { type: "string", description: "Title of the new Google Doc" },
-        body: { type: "string", description: "Optional initial body content (plain text)" },
+        content: { type: "string", description: "Optional initial document body (plain text); same field as Update Document" },
       },
     },
   },
@@ -627,14 +627,14 @@ export const GoogleUpdateDocument: Story = {
     preview: null,
     parameters: {
       document_id: "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
-      text: "## New Section: Security Considerations\n\nAll API endpoints must validate JWT tokens before processing requests.",
+      content: "## New Section: Security Considerations\n\nAll API endpoints must validate JWT tokens before processing requests.",
     },
     schema: {
       type: "object",
-      required: ["document_id", "text"],
+      required: ["document_id", "content"],
       properties: {
         document_id: { type: "string", description: "The ID of the Google Doc to update" },
-        text: { type: "string", description: "Text to insert into the document" },
+        content: { type: "string", description: "Text to insert into the document" },
         index: { type: "integer", description: "Character index to insert at (1-based)" },
       },
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes inconsistent parameter names for Google Docs actions ([issue #955](https://github.com/supersuit-tech/permission-slip/issues/955)).

- **Canonical field:** `content` is used for the document body text on both `google.create_document` and `google.update_document`.
- **Backward compatibility:** `body` (create) and `text` (update) are still accepted and documented as deprecated.

Manifest schemas, connector README, manifest templates, and Approval Dialog stories are updated so examples match the implementation.

## Test plan

- `gofmt` on changed Go files; `gofmt -e` parse check (full `go test` not run locally — sandbox Go version vs module graph; CI will run backend tests).
- `cd frontend && npm install && npx vitest run src/components/__tests__/ActionPreviewSummary.test.tsx` — passed.

Closes #955
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0259dccc-fda7-4787-af1e-b037b951256c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0259dccc-fda7-4787-af1e-b037b951256c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

