### PR TITLE
Google: document create_spreadsheet and add manifest template (closes #953)

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -22,7 +22,7 @@ The credential `auth_type` is `oauth2` with `oauth_provider` set to `google` (a 
 | `gmail.readonly` | `google.list_emails`, `google.read_email` |
 | `calendar.events` | `google.create_calendar_event`, `google.list_calendar_events`, `google.create_meeting` |
 | `presentations` | `google.create_presentation`, `google.get_presentation`, `google.add_slide` |
-| `spreadsheets` | `google.sheets_read_range`, `google.sheets_write_range`, `google.sheets_append_rows`, `google.sheets_list_sheets` |
+| `spreadsheets` | `google.create_spreadsheet`, `google.sheets_read_range`, `google.sheets_write_range`, `google.sheets_append_rows`, `google.sheets_list_sheets` |
 | `documents` | `google.create_document`, `google.get_document`, `google.update_document` |
 | `chat.spaces.readonly` | `google.list_chat_spaces` |
 | `chat.messages.create` | `google.send_chat_message` |
@@ -457,6 +457,37 @@ Lists all worksheets (tabs) in a Google Sheets spreadsheet.
 **Sheets API:** `GET /v4/spreadsheets/{id}?fields=sheets.properties` ([docs](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get))
 
 The response includes `row_count` and `column_count` from the sheet's grid properties, which can be used to determine sheet dimensions before read/write operations.
+
+---
+
+### `google.create_spreadsheet`
+
+Creates a new Google Sheets spreadsheet (same API family as `google.sheets_read_range` / write / append, but creates an empty file you can pass to those actions).
+
+**Risk level:** medium
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `title` | string | Yes | Title of the new spreadsheet |
+| `sheet_titles` | string[] | No | Optional list of initial worksheet tab names. If omitted, Google defaults to a single `Sheet1` tab. |
+
+**Response:**
+
+```json
+{
+  "spreadsheet_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit",
+  "title": "Q1 Report"
+}
+```
+
+**Sheets API:** `POST /v4/spreadsheets` ([docs](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/create))
+
+**Implementation notes:**
+- Returns `spreadsheet_id` for use with `google.sheets_read_range`, `google.sheets_write_range`, `google.sheets_append_rows`, and `google.sheets_list_sheets`.
+- If the API omits `spreadsheetUrl` in the response, the connector builds an edit URL from `spreadsheet_id`.
 
 ---
 
@@ -1087,6 +1118,7 @@ The connector ships with constrained templates that demonstrate parameter lockin
 | Append to specific spreadsheet | `sheets_append_rows` | `spreadsheet_id` locked; agent chooses range and values |
 | Read from any spreadsheet | `sheets_read_range` | Nothing — agent controls all parameters |
 | List worksheets in any spreadsheet | `sheets_list_sheets` | Nothing — agent controls spreadsheet |
+| Create spreadsheets | `create_spreadsheet` | Nothing — agent controls title and optional tab names |
 | Create documents | `create_document` | Nothing — agent controls title and body |
 | Create empty documents | `create_document` | `body` omitted — title only |
 | Read any document | `get_document` | Nothing — agent can read any doc by ID |
@@ -1131,7 +1163,7 @@ Each action lives in its own file. To add one (e.g., `google.delete_calendar_eve
 ```
 connectors/google/
 ├── google.go                       # GoogleConnector struct, New(), Actions(), doJSON(), doRawGet(), wrapHTTPError(), ValidateCredentials()
-├── manifest.go                     # Manifest() — 28 action schemas and 40+ templates
+├── manifest.go                     # Manifest() — 30 action schemas and 41+ templates
 ├── docs_types.go                   # Shared Docs API types (batchUpdate request) and helpers (documentEditURL)
 ├── email_helpers.go                # buildGmailRaw() — shared RFC 2822 message builder used by send_email and send_email_reply
 ├── send_email.go                   # google.send_email action
@@ -1152,6 +1184,7 @@ connectors/google/
 ├── sheets_append.go                # google.sheets_append_rows action
 ├── sheets_list.go                  # google.sheets_list_sheets action
 ├── sheets_helpers.go               # Shared validation helpers for Sheets actions
+├── create_spreadsheet.go           # google.create_spreadsheet action (Sheets API)
 ├── create_document.go              # google.create_document action
 ├── get_document.go                 # google.get_document action
 ├── update_document.go              # google.update_document action
@@ -1184,6 +1217,7 @@ connectors/google/
 ├── sheets_append_test.go           # Sheets append rows tests
 ├── sheets_list_test.go             # Sheets list worksheets tests
 ├── sheets_helpers_test.go          # Sheets validation helpers tests
+├── create_spreadsheet_test.go      # Create spreadsheet tests
 ├── create_document_test.go         # Create document tests (including partial failure handling)
 ├── get_document_test.go            # Get document tests (including plain text extraction)
 ├── update_document_test.go         # Update document tests (append and insert-at-index)

--- a/connectors/google/manifest_templates.go
+++ b/connectors/google/manifest_templates.go
@@ -271,6 +271,13 @@ func googleTemplates() []connectors.ManifestTemplate {
 			Description: "Locks the spreadsheet; agent chooses the range and rows to append.",
 			Parameters:  json.RawMessage(`{"spreadsheet_id":"SPREADSHEET_ID","range":"*","values":"*"}`),
 		},
+		{
+			ID:          "tpl_google_create_spreadsheet",
+			ActionType:  "google.create_spreadsheet",
+			Name:        "Create spreadsheets",
+			Description: "Agent can create new Google Sheets spreadsheets with any title and optional worksheet tab names.",
+			Parameters:  json.RawMessage(`{"title":"*","sheet_titles":"*"}`),
+		},
 		// --- Slides ---
 		{
 			ID:          "tpl_google_create_presentation",

--- a/docs/creating-connectors.md
+++ b/docs/creating-connectors.md
@@ -1051,7 +1051,7 @@ connectors/
 │   └── *_test.go             # Per-action + connector + response tests
 ├── google/
 │   ├── google.go             # GoogleConnector struct, New(), Actions(), doJSON(), OAuth2 auth
-│   ├── manifest.go           # Manifest() with 27 action schemas and 39+ templates
+│   ├── manifest.go           # Manifest() with 30 action schemas and 41+ templates
 │   ├── email_helpers.go      # buildGmailRaw() shared RFC 2822 builder (send_email + send_email_reply)
 │   ├── send_email.go         # google.send_email action (RFC 2822 + base64url)
 │   ├── list_emails.go        # google.list_emails action (list + metadata fetch)
@@ -1068,6 +1068,7 @@ connectors/
 │   ├── sheets_write.go       # google.sheets_write_range action
 │   ├── sheets_append.go      # google.sheets_append_rows action
 │   ├── sheets_list.go        # google.sheets_list_sheets action
+│   ├── create_spreadsheet.go # google.create_spreadsheet action (Sheets API)
 │   ├── sheets_helpers.go     # Shared validation (row/cell limits, ragged row check)
 │   ├── send_chat_message.go  # google.send_chat_message action (Google Chat API)
 │   ├── list_chat_spaces.go   # google.list_chat_spaces action (Google Chat API)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #953 asked for `google.create_spreadsheet` with required `title`, optional `sheet_titles`, return of the new spreadsheet ID, and documentation next to `create_document` / `create_presentation`.

The connector implementation was already present on `main` (`connectors/google/create_spreadsheet.go`, manifest schema, param validation, tests, and `google.go` registration). This PR completes the **documentation** and adds a **manifest template** so admins can enable the action from templates like other create-* actions.

## Changes

- **`connectors/google/README.md`**: New `google.create_spreadsheet` section (parameters, response, API link, notes), OAuth scope table update, templates table row, file tree entries.
- **`connectors/google/manifest_templates.go`**: `tpl_google_create_spreadsheet` — create spreadsheets with title and optional tab names.
- **`docs/creating-connectors.md`**: File tree line for `create_spreadsheet.go`; refreshed manifest counts.

## Test plan

- [ ] CI `go test ./connectors/google/...` (not run locally: environment Go version does not satisfy `go.mod`).
- [ ] Manual: approve a manifest that includes `google.create_spreadsheet` and verify spreadsheet creation returns `spreadsheet_id` for follow-up sheet actions.

Closes #953
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f0fd3dd-c0de-47cd-a1b8-bd082b3ead5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f0fd3dd-c0de-47cd-a1b8-bd082b3ead5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

