### PR TITLE
chore(sentry): downgrade OAuthRefreshError to warning level

### DIFF
--- a/api/sentry.go
+++ b/api/sentry.go
@@ -143,6 +143,14 @@ func CaptureConnectorError(ctx context.Context, err error, cc ConnectorContext) 
 				scope.SetLevel(sentry.LevelWarning)
 			}
 		}
+		// OAuth refresh failures are a user-action-required state, not a
+		// backend failure: the user's token was revoked, expired without a
+		// refresh token, or the connection was force-flipped to needs_reauth
+		// by a scope-change migration. Keep it in Sentry for visibility but
+		// don't page — same rationale as 4xx external errors above.
+		if errorType == "oauth_refresh" {
+			scope.SetLevel(sentry.LevelWarning)
+		}
 		scope.SetFingerprint(fp)
 
 		hub.CaptureException(err)

--- a/api/sentry_test.go
+++ b/api/sentry_test.go
@@ -373,6 +373,39 @@ func TestCaptureConnectorError_5xxExternalErrorStaysError(t *testing.T) {
 	}
 }
 
+func TestCaptureConnectorError_OAuthRefreshIsWarning(t *testing.T) {
+	t.Parallel()
+
+	transport := &sentryTestTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@sentry.example.com/1",
+		Transport: transport,
+	})
+	if err != nil {
+		t.Fatalf("failed to create sentry client: %v", err)
+	}
+
+	hub := sentry.NewHub(client, sentry.NewScope())
+	ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+	CaptureConnectorError(ctx, &connectors.OAuthRefreshError{
+		Provider: "slack",
+		Message:  "OAuth connection for \"slack\" has status \"needs_reauth\" — user must re-authorize",
+	}, ConnectorContext{
+		ConnectorID: "slack",
+		ActionType:  "slack.list_channels",
+		AgentID:     3,
+	})
+
+	events := transport.getEvents()
+	if len(events) == 0 {
+		t.Fatal("expected event to be captured")
+	}
+	if got := events[0].Level; got != sentry.LevelWarning {
+		t.Errorf("level = %q, want %q (oauth_refresh is user-action-required, should not page)", got, sentry.LevelWarning)
+	}
+}
+
 // sentryTestTransport captures events in memory for test assertions.
 // A mutex guards the events slice in case the SDK delivers events from a
 // background goroutine (defensive — our tests are single-goroutine but


### PR DESCRIPTION
## Summary

- `OAuthRefreshError` is a user-action-required state (token revoked, no refresh token, or connection force-flipped to `needs_reauth` by a scope-change migration) — not a backend failure. It shouldn't page via error-level Sentry alert rules.
- Mirror the existing 4xx `ExternalError` rule in `CaptureConnectorError` (`api/sentry.go`): set `sentry.LevelWarning` when `error_type == "oauth_refresh"`. Still captured for visibility; no more paging.
- Adds `TestCaptureConnectorError_OAuthRefreshIsWarning`.

## Context

Triggered by Sentry [PERMISSION-SLIP-GO-R](https://supersuit-technologies.sentry.io/issues/7431758794/): `OAuth token refresh failed for provider "slack": OAuth connection for "slack" has status "needs_reauth"`. Not a refresh-token bug — PR #1013 (merged 2026-04-22 00:20 UTC) intentionally flipped all active Slack connections to `needs_reauth` via migration `20260422001318_slack_granular_search_scopes_reauth.sql` so users re-auth and pick up the new granular `search:read.*` scopes. Affected users' next agent call produced an error-level Sentry event per request, which fired the high-priority alert email.

This change generalizes so future scope-change migrations don't create the same noise.

Follow-up worth checking in the Sentry UI: alert rule `16749461` may need a `level:error` filter added if it currently matches all levels — otherwise the downgrade won't silence the paging.

## Test plan

- [ ] `make test-backend` passes in CI (not runnable locally due to the known sandbox Go 1.25 bigquery toolchain block — `api/sentry.go` and `api/sentry_test.go` are gofmt-clean and parse-clean)
- [ ] After merge and deploy, confirm the next `OAuthRefreshError` event in Sentry shows `level: warning` (not `error`)
- [ ] Confirm the alert rule stops emailing for `error_type:oauth_refresh` events

https://claude.ai/code/session_01EUQifT3cU5rhRfz6d2ubq4