### PR TITLE
GitHub resolver follow-ups: template fallbacks, errors, tests (#987)

### DIFF
--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -593,7 +593,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "Trigger Workflow",
 				Description:     "Trigger a GitHub Actions workflow dispatch event",
 				RiskLevel:       "medium",
-				DisplayTemplate: "Trigger workflow {{workflow_name}} in {{owner}}/{{repo}}",
+				DisplayTemplate: "Trigger workflow {{workflow_name}} ({{workflow_id}}) in {{owner}}/{{repo}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["owner", "repo", "workflow_id", "ref"],
@@ -1267,7 +1267,7 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 				Name:            "Delete Webhook",
 				Description:     "Delete a repository webhook by numeric hook ID",
 				RiskLevel:       "high",
-				DisplayTemplate: "Delete webhook {{webhook_url}} in {{owner}}/{{repo}}",
+				DisplayTemplate: "Delete webhook {{webhook_url}} (#{{hook_id}}) in {{owner}}/{{repo}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["owner", "repo", "hook_id"],

--- a/connectors/github/resolve_resource_details.go
+++ b/connectors/github/resolve_resource_details.go
@@ -40,7 +40,7 @@ func (c *GitHubConnector) resolveWorkflow(ctx context.Context, creds connectors.
 		return nil, err
 	}
 	if p.WorkflowID == "" {
-		return nil, fmt.Errorf("missing workflow_id")
+		return nil, &connectors.ValidationError{Message: "missing required parameter: workflow_id"}
 	}
 
 	path := fmt.Sprintf("/repos/%s/%s/actions/workflows/%s",
@@ -91,8 +91,12 @@ func (c *GitHubConnector) resolveWebhook(ctx context.Context, creds connectors.C
 	if u := strings.TrimSpace(resp.Config.URL); u != "" {
 		out["webhook_url"] = u
 	}
-	if len(resp.Events) > 0 {
-		out["webhook_events"] = strings.Join(resp.Events, ", ")
+	if n := len(resp.Events); n > 0 {
+		if n <= 3 {
+			out["webhook_events"] = strings.Join(resp.Events, ", ")
+		} else {
+			out["webhook_events"] = fmt.Sprintf("%s, +%d more", strings.Join(resp.Events[:3], ", "), n-3)
+		}
 	}
 	if len(out) == 0 {
 		return nil, nil

--- a/connectors/github/resolve_resource_details_test.go
+++ b/connectors/github/resolve_resource_details_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
 func testGitHubResolveServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *GitHubConnector) {
@@ -104,5 +106,111 @@ func TestResolveResourceDetails_WorkflowMissingID(t *testing.T) {
 	_, err := conn.ResolveResourceDetails(context.Background(), "github.trigger_workflow", params, validCreds())
 	if err == nil {
 		t.Fatal("expected error for missing workflow_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestResolveResourceDetails_Workflow_EmptyName(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"name": "   "})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{
+		"owner": "acme", "repo": "app", "workflow_id": "deploy.yml", "ref": "main",
+	})
+	details, err := conn.ResolveResourceDetails(context.Background(), "github.trigger_workflow", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != nil {
+		t.Errorf("expected nil details for empty workflow name, got %v", details)
+	}
+}
+
+func TestResolveResourceDetails_Webhook_EmptyURLAndEvents(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"config": map[string]string{}, "events": []string{}})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{"owner": "acme", "repo": "app", "hook_id": 42})
+	details, err := conn.ResolveResourceDetails(context.Background(), "github.delete_webhook", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details != nil {
+		t.Errorf("expected nil details when webhook has no URL and no events, got %v", details)
+	}
+}
+
+func TestResolveResourceDetails_Webhook_ManyEventsTruncated(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"config": map[string]string{"url": "https://example.com/h"},
+			"events": []string{"push", "pull_request", "issues", "workflow_dispatch", "release"},
+		})
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{"owner": "acme", "repo": "app", "hook_id": 1})
+	details, err := conn.ResolveResourceDetails(context.Background(), "github.delete_webhook", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "push, pull_request, issues, +2 more"
+	if details["webhook_events"] != want {
+		t.Errorf("webhook_events: want %q, got %v", want, details["webhook_events"])
+	}
+}
+
+func TestResolveResourceDetails_Workflow_APIError(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{
+		"owner": "acme", "repo": "app", "workflow_id": "missing.yml", "ref": "main",
+	})
+	_, err := conn.ResolveResourceDetails(context.Background(), "github.trigger_workflow", params, validCreds())
+	if err == nil {
+		t.Fatal("expected error for 404 API response")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError for 404, got %T: %v", err, err)
+	}
+}
+
+func TestResolveResourceDetails_Webhook_APIError(t *testing.T) {
+	t.Parallel()
+
+	srv, conn := testGitHubResolveServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"Server Error"}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{"owner": "acme", "repo": "app", "hook_id": 99})
+	_, err := conn.ResolveResourceDetails(context.Background(), "github.delete_webhook", params, validCreds())
+	if err == nil {
+		t.Fatal("expected error for 500 API response")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Fatalf("expected ExternalError for 500, got %T: %v", err, err)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Restored stable identifiers in display templates for `github.trigger_workflow` and `github.delete_webhook` by always interpolating `workflow_id` and `hook_id` from parameters, so approvers still see which resource is targeted when `ResolveResourceDetails` returns no details.
- Aligned missing `workflow_id` in the resolver with `connectors.ValidationError`, and capped `webhook_events` to three events plus a "+N more" suffix when GitHub returns a long list.
- Expanded `resolve_resource_details_test.go` with coverage for empty-name / empty-webhook graceful `(nil, nil)` paths, truncated events, 404 (workflow), and 500 (webhook) API responses.

Closes #987

## Test plan

### Claude Code

- [x] `gofmt` on touched Go files
- [x] `make test-backend` / `go test ./connectors/github/...` (deferred to CI: agent environment Go version is below `go.mod` minimum)

### OpenClaw

- [ ] Confirm approval UI strings for trigger workflow and delete webhook with and without resolved details look acceptable (including the double-parens case when `workflow_name` is present).

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2881e202-090d-47de-9676-21d1173d1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2881e202-090d-47de-9676-21d1173d1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

