### PR TITLE
fix(google): populate add_slide title via separate batchUpdate calls

### DIFF
--- a/connectors/google/add_slide.go
+++ b/connectors/google/add_slide.go
@@ -132,43 +132,56 @@ func (a *addSlideAction) Execute(ctx context.Context, req connectors.ActionReque
 		createReq.InsertionIndex = params.InsertionIndex
 	}
 
-	requests := []slidesBatchRequest{{CreateSlide: createReq}}
-
+	// When a title is provided, map the layout's TITLE placeholder to a known
+	// objectId so we can target it with a follow-up InsertText. The ID must be
+	// unique within the presentation, so we derive it from a nanosecond timestamp.
+	var titleID string
 	if params.Title != "" {
-		// Generate a unique ID per call — the Slides API requires object IDs to
-		// be unique within a presentation, so a fixed constant would fail on any
-		// second titled slide. The Google Slides API applies batchUpdate requests
-		// sequentially, so InsertText safely references the placeholder created
-		// in the preceding CreateSlide request:
-		// https://developers.google.com/slides/api/reference/rest/v1/presentations/batchUpdate
-		titleID := fmt.Sprintf("ps_title_%x", time.Now().UnixNano())
+		titleID = fmt.Sprintf("ps_title_%x", time.Now().UnixNano())
 		createReq.PlaceholderIdMappings = []slidePlaceholderIDMapping{
 			{
 				LayoutPlaceholder: slidePlaceholderRef{Type: "TITLE", Index: 0},
 				ObjectId:          titleID,
 			},
 		}
-		requests = append(requests, slidesBatchRequest{
-			InsertText: &slidesInsertTextReq{
-				ObjectId: titleID,
-				Text:     params.Title,
-			},
-		})
 	}
 
-	body := slidesBatchUpdateRequest{
-		Requests: requests,
-	}
-
-	var resp slidesBatchUpdateResponse
 	batchURL := a.conn.slidesBaseURL + "/v1/presentations/" + url.PathEscape(params.PresentationID) + ":batchUpdate"
-	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, batchURL, body, &resp); err != nil {
+
+	// First batchUpdate: create the slide (and mint the title placeholder ID via
+	// placeholderIdMappings). We deliberately do NOT combine CreateSlide and
+	// InsertText into a single batchUpdate: the Slides API validates the full
+	// request batch before applying any of it, and InsertText targeting a
+	// placeholder that only exists after CreateSlide runs can be silently
+	// dropped. Google's own samples use two separate batchUpdate calls for this
+	// pattern — see
+	// https://developers.google.com/slides/api/samples/slide
+	createBody := slidesBatchUpdateRequest{
+		Requests: []slidesBatchRequest{{CreateSlide: createReq}},
+	}
+	var createResp slidesBatchUpdateResponse
+	if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, batchURL, createBody, &createResp); err != nil {
 		return nil, err
 	}
 
 	slideID := ""
-	if len(resp.Replies) > 0 && resp.Replies[0].CreateSlide != nil {
-		slideID = resp.Replies[0].CreateSlide.ObjectID
+	if len(createResp.Replies) > 0 && createResp.Replies[0].CreateSlide != nil {
+		slideID = createResp.Replies[0].CreateSlide.ObjectID
+	}
+
+	// Second batchUpdate: populate the title placeholder with the user's text.
+	if titleID != "" {
+		textBody := slidesBatchUpdateRequest{
+			Requests: []slidesBatchRequest{{
+				InsertText: &slidesInsertTextReq{
+					ObjectId: titleID,
+					Text:     params.Title,
+				},
+			}},
+		}
+		if err := a.conn.doJSON(ctx, req.Credentials, http.MethodPost, batchURL, textBody, nil); err != nil {
+			return nil, err
+		}
 	}
 
 	return connectors.JSONResult(map[string]string{

--- a/connectors/google/add_slide_test.go
+++ b/connectors/google/add_slide_test.go
@@ -78,47 +78,31 @@ func TestAddSlide_Success(t *testing.T) {
 func TestAddSlide_WithTitle(t *testing.T) {
 	t.Parallel()
 
+	// The Slides API validates the full request batch before applying any of
+	// it, so CreateSlide + InsertText must be sent as two separate batchUpdate
+	// calls. Record each call and assert on both in order.
+	type capturedCall struct {
+		body slidesBatchUpdateRequest
+	}
+	var calls []capturedCall
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body slidesBatchUpdateRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
-		if len(body.Requests) != 2 {
-			t.Fatalf("expected 2 requests (createSlide + insertText), got %d", len(body.Requests))
-		}
-		cs := body.Requests[0].CreateSlide
-		if cs == nil {
-			t.Fatal("expected createSlide in first request")
-		}
-		if len(cs.PlaceholderIdMappings) != 1 {
-			t.Fatalf("expected 1 placeholder mapping, got %d", len(cs.PlaceholderIdMappings))
-		}
-		if cs.PlaceholderIdMappings[0].LayoutPlaceholder.Type != "TITLE" {
-			t.Errorf("expected TITLE placeholder, got %q", cs.PlaceholderIdMappings[0].LayoutPlaceholder.Type)
-		}
-		it := body.Requests[1].InsertText
-		if it == nil {
-			t.Fatal("expected insertText in second request")
-		}
-		if it.Text != "Hello World" {
-			t.Errorf("expected title text 'Hello World', got %q", it.Text)
-		}
-		// The placeholder objectId must be unique per call (not a fixed constant)
-		// and must match between the mapping and the insertText request.
-		mappingID := cs.PlaceholderIdMappings[0].ObjectId
-		if it.ObjectId != mappingID {
-			t.Errorf("insertText objectId %q must match placeholderIdMapping objectId %q", it.ObjectId, mappingID)
-		}
-		if mappingID == "" {
-			t.Error("expected non-empty placeholder objectId")
-		}
+		calls = append(calls, capturedCall{body: body})
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(slidesBatchUpdateResponse{
-			Replies: []slidesBatchReply{
-				{CreateSlide: &createSlideReply{ObjectID: "slide-title-001"}},
-			},
-		})
+		switch len(calls) {
+		case 1:
+			json.NewEncoder(w).Encode(slidesBatchUpdateResponse{
+				Replies: []slidesBatchReply{
+					{CreateSlide: &createSlideReply{ObjectID: "slide-title-001"}},
+				},
+			})
+		default:
+			json.NewEncoder(w).Encode(slidesBatchUpdateResponse{})
+		}
 	}))
 	defer srv.Close()
 
@@ -138,6 +122,46 @@ func TestAddSlide_WithTitle(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 batchUpdate calls (createSlide, then insertText), got %d", len(calls))
+	}
+
+	// First call: CreateSlide with a TITLE placeholder mapping.
+	first := calls[0].body
+	if len(first.Requests) != 1 {
+		t.Fatalf("first call: expected 1 request (createSlide), got %d", len(first.Requests))
+	}
+	cs := first.Requests[0].CreateSlide
+	if cs == nil {
+		t.Fatal("first call: expected createSlide request")
+	}
+	if len(cs.PlaceholderIdMappings) != 1 {
+		t.Fatalf("first call: expected 1 placeholder mapping, got %d", len(cs.PlaceholderIdMappings))
+	}
+	if cs.PlaceholderIdMappings[0].LayoutPlaceholder.Type != "TITLE" {
+		t.Errorf("first call: expected TITLE placeholder, got %q", cs.PlaceholderIdMappings[0].LayoutPlaceholder.Type)
+	}
+	mappingID := cs.PlaceholderIdMappings[0].ObjectId
+	if mappingID == "" {
+		t.Error("first call: expected non-empty placeholder objectId")
+	}
+
+	// Second call: InsertText targeting the mapped placeholder.
+	second := calls[1].body
+	if len(second.Requests) != 1 {
+		t.Fatalf("second call: expected 1 request (insertText), got %d", len(second.Requests))
+	}
+	it := second.Requests[0].InsertText
+	if it == nil {
+		t.Fatal("second call: expected insertText request")
+	}
+	if it.Text != "Hello World" {
+		t.Errorf("second call: expected title text 'Hello World', got %q", it.Text)
+	}
+	if it.ObjectId != mappingID {
+		t.Errorf("second call: insertText objectId %q must match placeholderIdMapping objectId %q", it.ObjectId, mappingID)
 	}
 
 	var data map[string]string

--- a/connectors/google/manifest_templates.go
+++ b/connectors/google/manifest_templates.go
@@ -291,7 +291,7 @@ func googleTemplates() []connectors.ManifestTemplate {
 			ActionType:  "google.add_slide",
 			Name:        "Add slides to presentations",
 			Description: "Agent can add new slides to any Google Slides presentation.",
-			Parameters:  json.RawMessage(`{"presentation_id":"*","layout":"*","insertion_index":"*"}`),
+			Parameters:  json.RawMessage(`{"presentation_id":"*","layout":"*","insertion_index":"*","title":"*"}`),
 		},
 		// --- Chat ---
 		{


### PR DESCRIPTION
## Summary

- Split `google.add_slide`'s title population into **two** `batchUpdate` calls (CreateSlide, then InsertText). The Slides API validates the full request batch before applying any of it, so `InsertText` targeting a placeholder that only exists after `CreateSlide` runs could be silently dropped — leaving the slide correctly laid out but with a blank title. This matches Google's own sample for the pattern: https://developers.google.com/slides/api/samples/slide
- Add `"title":"*"` to the `tpl_google_add_slide` default template parameters so standing approvals created from the template don't reject requests that include a `title` (`ValidateParametersAgainstConfig` rejects any param not declared in the configuration).
- Update `TestAddSlide_WithTitle` to assert the two-call sequence and that the `InsertText` `objectId` matches the `placeholderIdMapping` minted during `CreateSlide`.

## Test plan

- [ ] `make test-backend` (verifies the split-batch flow; cannot run locally in the sandbox — CI will exercise it)
- [ ] Manual smoke: `google.create_presentation` → `google.add_slide` with `{"layout":"TITLE_ONLY","title":"Hello World"}` — the new slide should render "Hello World" in the title placeholder
- [ ] Confirm standing approvals created from `tpl_google_add_slide` accept a `title` parameter without falling through to the pending flow

Closes #954