### PR TITLE
feat(settings): add System theme option in Profile

### DIFF
--- a/frontend/src/components/ThemeContext.tsx
+++ b/frontend/src/components/ThemeContext.tsx
@@ -2,63 +2,89 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useState,
   type ReactNode,
 } from "react";
 
-type Theme = "light" | "dark";
+type ResolvedTheme = "light" | "dark";
+export type ThemePreference = "light" | "dark" | "system";
 
 interface ThemeState {
-  theme: Theme;
-  toggleTheme: () => void;
+  theme: ResolvedTheme;
+  preference: ThemePreference;
+  setPreference: (preference: ThemePreference) => void;
 }
 
 const ThemeContext = createContext<ThemeState | undefined>(undefined);
 
 const STORAGE_KEY = "permission-slip-theme";
+const SYSTEM_QUERY = "(prefers-color-scheme: dark)";
 
-function getSystemTheme(): Theme {
-  return window.matchMedia?.("(prefers-color-scheme: dark)")?.matches
-    ? "dark"
-    : "light";
+function getSystemTheme(): ResolvedTheme {
+  return window.matchMedia?.(SYSTEM_QUERY)?.matches ? "dark" : "light";
 }
 
-function getInitialTheme(): Theme {
+function getInitialPreference(): ThemePreference {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
   } catch {
     // Storage may be disabled (private mode, quota exceeded, etc.)
   }
-  return getSystemTheme();
+  return "system";
 }
 
-function applyTheme(theme: Theme) {
+function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  return preference === "system" ? getSystemTheme() : preference;
+}
+
+function applyTheme(theme: ResolvedTheme) {
   document.documentElement.classList.toggle("dark", theme === "dark");
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  const [preference, setPreferenceState] = useState<ThemePreference>(
+    getInitialPreference,
+  );
+  const [theme, setTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(getInitialPreference()),
+  );
 
   useLayoutEffect(() => {
-    applyTheme(theme);
-  }, [theme]);
+    const resolved = resolveTheme(preference);
+    setTheme(resolved);
+    applyTheme(resolved);
+  }, [preference]);
 
-  const toggleTheme = useCallback(() => {
-    setTheme((prev) => {
-      const next = prev === "light" ? "dark" : "light";
-      try {
-        localStorage.setItem(STORAGE_KEY, next);
-      } catch {
-        // Storage may be unavailable; toggle still works for the session.
-      }
-      return next;
-    });
+  // When the user picked "system", follow OS changes in real time.
+  useEffect(() => {
+    if (preference !== "system") return;
+    const mql = window.matchMedia?.(SYSTEM_QUERY);
+    if (!mql) return;
+    const handler = (event: MediaQueryListEvent) => {
+      const next: ResolvedTheme = event.matches ? "dark" : "light";
+      setTheme(next);
+      applyTheme(next);
+    };
+    mql.addEventListener?.("change", handler);
+    return () => mql.removeEventListener?.("change", handler);
+  }, [preference]);
+
+  const setPreference = useCallback((next: ThemePreference) => {
+    setPreferenceState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Storage may be unavailable; preference still applies for the session.
+    }
   }, []);
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, preference, setPreference }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -4,20 +4,17 @@ import {
   User,
   Shield,
   CreditCard,
-  Moon,
   LifeBuoy,
 } from "lucide-react";
 import { useAuth } from "@/auth/AuthContext";
 import { useProfile } from "@/hooks/useProfile";
 import { useSignOut } from "@/hooks/useSignOut";
-import { useTheme } from "@/components/ThemeContext";
 import { isSaas } from "@/lib/saas";
 import { Avatar } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuCheckboxItem,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -27,7 +24,6 @@ import {
 export function UserMenu() {
   const { user } = useAuth();
   const { profile } = useProfile();
-  const { theme, toggleTheme } = useTheme();
   const handleSignOut = useSignOut();
   const navigate = useNavigate();
 
@@ -80,14 +76,6 @@ export function UserMenu() {
               </DropdownMenuItem>
             </>
           )}
-          <DropdownMenuSeparator />
-          <DropdownMenuCheckboxItem
-            checked={theme === "dark"}
-            onCheckedChange={toggleTheme}
-          >
-            <Moon />
-            <span>Dark Mode</span>
-          </DropdownMenuCheckboxItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleSignOut} variant="destructive">
             <LogOut />

--- a/frontend/src/components/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/components/__tests__/ThemeContext.test.tsx
@@ -1,15 +1,18 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { ThemeProvider, useTheme } from "../ThemeContext";
 
 function TestComponent() {
-  const { theme, toggleTheme } = useTheme();
+  const { theme, preference, setPreference } = useTheme();
   return (
     <div>
       <span data-testid="theme">{theme}</span>
-      <button onClick={toggleTheme}>Toggle</button>
+      <span data-testid="preference">{preference}</span>
+      <button onClick={() => setPreference("light")}>Pick Light</button>
+      <button onClick={() => setPreference("dark")}>Pick Dark</button>
+      <button onClick={() => setPreference("system")}>Pick System</button>
     </div>
   );
 }
@@ -22,12 +25,37 @@ function renderWithTheme() {
   );
 }
 
-function mockMatchMedia(prefersDark: boolean) {
+type Listener = (event: MediaQueryListEvent) => void;
+
+interface FakeMediaQueryList {
+  matches: boolean;
+  addEventListener: (type: "change", listener: Listener) => void;
+  removeEventListener: (type: "change", listener: Listener) => void;
+  emit: (matches: boolean) => void;
+}
+
+function mockMatchMedia(prefersDark: boolean): FakeMediaQueryList {
+  const listeners = new Set<Listener>();
+  const mql: FakeMediaQueryList = {
+    matches: prefersDark,
+    addEventListener: (_type, listener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_type, listener) => {
+      listeners.delete(listener);
+    },
+    emit: (matches: boolean) => {
+      mql.matches = matches;
+      const event = { matches } as MediaQueryListEvent;
+      listeners.forEach((l) => l(event));
+    },
+  };
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     configurable: true,
-    value: vi.fn().mockReturnValue({ matches: prefersDark }),
+    value: vi.fn().mockReturnValue(mql),
   });
+  return mql;
 }
 
 describe("ThemeContext", () => {
@@ -41,65 +69,132 @@ describe("ThemeContext", () => {
     document.documentElement.classList.remove("dark");
   });
 
-  it("defaults to light when no stored preference and system prefers light", () => {
+  it("defaults preference to system when nothing is stored", () => {
     renderWithTheme();
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
     expect(screen.getByTestId("theme")).toHaveTextContent("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
-  it("defaults to dark when system prefers dark", () => {
+  it("resolves to dark when system prefers dark and preference is system", () => {
     mockMatchMedia(true);
     renderWithTheme();
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
     expect(screen.getByTestId("theme")).toHaveTextContent("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it("does not persist system-derived theme on initial mount", () => {
+  it("does not persist the system-derived theme on initial mount", () => {
     mockMatchMedia(true);
     renderWithTheme();
-    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
     expect(localStorage.getItem("permission-slip-theme")).toBeNull();
   });
 
-  it("uses stored preference over system preference", () => {
-    localStorage.setItem("permission-slip-theme", "dark");
+  it("uses stored light preference over system preference", () => {
+    mockMatchMedia(true);
+    localStorage.setItem("permission-slip-theme", "light");
     renderWithTheme();
-    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-  });
-
-  it("toggles from light to dark", async () => {
-    renderWithTheme();
+    expect(screen.getByTestId("preference")).toHaveTextContent("light");
     expect(screen.getByTestId("theme")).toHaveTextContent("light");
-
-    await userEvent.click(screen.getByText("Toggle"));
-
-    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-    expect(localStorage.getItem("permission-slip-theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
-  it("toggles from dark to light", async () => {
+  it("uses stored dark preference over system preference", () => {
     localStorage.setItem("permission-slip-theme", "dark");
+    renderWithTheme();
+    expect(screen.getByTestId("preference")).toHaveTextContent("dark");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("stores and applies an explicit light preference", async () => {
+    mockMatchMedia(true);
     renderWithTheme();
     expect(screen.getByTestId("theme")).toHaveTextContent("dark");
 
-    await userEvent.click(screen.getByText("Toggle"));
+    await userEvent.click(screen.getByText("Pick Light"));
 
+    expect(screen.getByTestId("preference")).toHaveTextContent("light");
     expect(screen.getByTestId("theme")).toHaveTextContent("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
     expect(localStorage.getItem("permission-slip-theme")).toBe("light");
   });
 
-  it("falls back to system preference when localStorage throws", () => {
+  it("stores and applies an explicit dark preference", async () => {
+    renderWithTheme();
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+
+    await userEvent.click(screen.getByText("Pick Dark"));
+
+    expect(screen.getByTestId("preference")).toHaveTextContent("dark");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("permission-slip-theme")).toBe("dark");
+  });
+
+  it("follows OS changes in real time when preference is system", async () => {
+    const mql = mockMatchMedia(false);
+    renderWithTheme();
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+
+    act(() => mql.emit(true));
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    act(() => mql.emit(false));
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("ignores OS changes when an explicit preference is set", async () => {
+    const mql = mockMatchMedia(false);
+    renderWithTheme();
+
+    await userEvent.click(screen.getByText("Pick Light"));
+    act(() => mql.emit(true));
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("switching back to system re-resolves from the OS", async () => {
+    mockMatchMedia(true);
+    localStorage.setItem("permission-slip-theme", "light");
+    renderWithTheme();
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+
+    await userEvent.click(screen.getByText("Pick System"));
+
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("permission-slip-theme")).toBe("system");
+  });
+
+  it("falls back to system preference when localStorage throws on read", () => {
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new Error("storage disabled");
     });
     mockMatchMedia(true);
     renderWithTheme();
+    expect(screen.getByTestId("preference")).toHaveTextContent("system");
     expect(screen.getByTestId("theme")).toHaveTextContent("dark");
     vi.restoreAllMocks();
     mockMatchMedia(false);
+  });
+
+  it("still applies the preference when localStorage throws on write", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    renderWithTheme();
+
+    await userEvent.click(screen.getByText("Pick Dark"));
+
+    expect(screen.getByTestId("preference")).toHaveTextContent("dark");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    vi.restoreAllMocks();
   });
 
   it("throws when useTheme is used outside ThemeProvider", () => {

--- a/frontend/src/components/__tests__/UserMenu.test.tsx
+++ b/frontend/src/components/__tests__/UserMenu.test.tsx
@@ -76,21 +76,13 @@ describe("UserMenu", () => {
     expect(screen.getByText("Profile")).toBeInTheDocument();
     expect(screen.getByText("Security")).toBeInTheDocument();
     expect(screen.getByText("Billing")).toBeInTheDocument();
-    expect(screen.getByText("Dark Mode")).toBeInTheDocument();
     expect(screen.getByText("Sign Out")).toBeInTheDocument();
   });
 
-  it("toggles dark mode when clicked", async () => {
+  it("does not show a theme toggle (moved to Profile)", async () => {
     renderWithProviders(<UserMenu />);
     await userEvent.click(screen.getByLabelText("User menu"));
-    const checkbox = screen.getByRole("menuitemcheckbox", { name: /dark mode/i });
-    expect(checkbox).not.toBeChecked();
-
-    await userEvent.click(checkbox);
-
-    // Re-open the menu to check updated state
-    await userEvent.click(screen.getByLabelText("User menu"));
-    expect(screen.getByRole("menuitemcheckbox", { name: /dark mode/i })).toBeChecked();
+    expect(screen.queryByText(/dark mode/i)).not.toBeInTheDocument();
   });
 
   it("calls signOut when Sign Out is clicked", async () => {

--- a/frontend/src/pages/settings/AppearanceSection.tsx
+++ b/frontend/src/pages/settings/AppearanceSection.tsx
@@ -1,0 +1,46 @@
+import { Palette } from "lucide-react";
+import { useTheme, type ThemePreference } from "@/components/ThemeContext";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const OPTIONS: { label: string; value: ThemePreference }[] = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+  { label: "System", value: "system" },
+];
+
+export function AppearanceSection() {
+  const { preference, setPreference } = useTheme();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Palette className="text-muted-foreground size-5" />
+          <CardTitle>Appearance</CardTitle>
+        </div>
+        <CardDescription>
+          Choose how Permission Slip looks. &ldquo;System&rdquo; matches your
+          device&rsquo;s current theme.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Theme</p>
+          <SegmentedControl
+            options={OPTIONS}
+            value={preference}
+            onChange={setPreference}
+            ariaLabel="Theme"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/settings/ProfilePage.tsx
+++ b/frontend/src/pages/settings/ProfilePage.tsx
@@ -1,11 +1,13 @@
 import { AccountSection } from "./AccountSection";
 import { NotificationSection } from "./NotificationSection";
+import { AppearanceSection } from "./AppearanceSection";
 
 export function ProfilePage() {
   return (
     <>
       <AccountSection />
       <NotificationSection />
+      <AppearanceSection />
     </>
   );
 }

--- a/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -6,6 +6,7 @@ import { setupAuthMocks, mockMfa } from "../../../auth/__tests__/fixtures";
 import { mockGet, resetClientMocks } from "../../../api/__mocks__/client";
 import { AuthProvider } from "../../../auth/AuthContext";
 import { CookieConsentProvider } from "../../../components/CookieConsentContext";
+import { ThemeProvider } from "../../../components/ThemeContext";
 import { SettingsLayout } from "../SettingsLayout";
 
 vi.mock("../../../lib/supabaseClient");
@@ -73,13 +74,15 @@ function renderSettingsAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <QueryClientProvider client={queryClient}>
-        <CookieConsentProvider>
-          <AuthProvider>
-            <Routes>
-              <Route path="/settings/*" element={<SettingsLayout />} />
-            </Routes>
-          </AuthProvider>
-        </CookieConsentProvider>
+        <ThemeProvider>
+          <CookieConsentProvider>
+            <AuthProvider>
+              <Routes>
+                <Route path="/settings/*" element={<SettingsLayout />} />
+              </Routes>
+            </AuthProvider>
+          </CookieConsentProvider>
+        </ThemeProvider>
       </QueryClientProvider>
     </MemoryRouter>,
   );


### PR DESCRIPTION
## Summary

- Move the dark/light mode toggle out of the user dropdown menu and into a new **Appearance** card on the Profile settings page.
- The selector now offers **Light / Dark / System** as a segmented control. "System" tracks the OS theme live via a `matchMedia` listener, so flipping the OS theme updates the app immediately.
- Existing users who previously toggled to light or dark keep their stored preference (both values are still valid). The default for new sessions becomes `system`, which resolves to the same OS-derived value the old code already used at first paint, so the visible default behavior is unchanged.

## Implementation notes

- `ThemeContext` now distinguishes a stored `preference` (`light | dark | system`) from a resolved `theme` (`light | dark`) applied to `<html>`. Public API is `{ theme, preference, setPreference }` — `toggleTheme` is gone since the UI is no longer a binary toggle.
- New `AppearanceSection` reuses the existing `SegmentedControl` UI primitive.
- `UserMenu` no longer imports `useTheme` or the `Moon` icon and no longer renders the dark mode checkbox item.
- Updated `ThemeContext.test.tsx`, `UserMenu.test.tsx`, and `SettingsPage.test.tsx` (the last needed `ThemeProvider` because `ProfilePage` now consumes the theme context).

## Test plan

- [x] `npx vitest run` — full frontend suite (1068 tests) passes
- [x] `npm run build` — clean TypeScript compile + production build
- [ ] Manual: open `/settings/profile`, confirm Appearance card shows current preference selected; switching options updates the app theme immediately and persists across reload
- [ ] Manual: with preference set to **System**, toggle OS dark mode and confirm the app follows in real time
- [ ] Manual: confirm the dark mode toggle is gone from the user dropdown menu

https://claude.ai/code/session_01YbkdKWSjUMzS5deJXTmpG5