### PR TITLE
Surface credential re-auth in the agent credentials checklist

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.stories.tsx
@@ -5,7 +5,7 @@
  * without API calls so Storybook stays offline.
  */
 import type { Meta, StoryObj } from "@storybook/react";
-import { Settings, Star } from "lucide-react";
+import { AlertTriangle, LogIn, Settings, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -92,6 +92,96 @@ export const MultiCredentialChecklist: Story = {
   render: () => (
     <div className="max-w-xl">
       <ConnectorInstancesSectionLayoutMirror />
+    </div>
+  ),
+};
+
+function ConnectorInstancesSectionReauthMirror() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Credentials for this agent</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-900/50 dark:bg-amber-950/40"
+          >
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
+            <p className="text-amber-900 dark:text-amber-200">
+              1 credential needs re-authorization before this agent can use it.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 flex-1 items-start gap-3">
+              <Checkbox id="story-reauth-1" checked className="mt-1" disabled />
+              <div className="min-w-0 flex-1">
+                <label
+                  htmlFor="story-reauth-1"
+                  className="flex cursor-pointer flex-wrap items-center gap-2 font-medium"
+                >
+                  Slack OAuth — Innovation Hub
+                  <Badge
+                    variant="outline"
+                    className="gap-1 border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-300"
+                  >
+                    <AlertTriangle className="size-3" />
+                    Needs re-authorization
+                  </Badge>
+                </label>
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                  Needs re-authorization
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+              <Button type="button" variant="outline" size="sm">
+                <LogIn className="size-3.5" />
+                Re-authorize
+              </Button>
+              <Badge variant="secondary">Default</Badge>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 flex-1 items-start gap-3">
+              <Checkbox id="story-reauth-2" checked className="mt-1" disabled />
+              <div className="min-w-0 flex-1">
+                <label
+                  htmlFor="story-reauth-2"
+                  className="flex cursor-pointer flex-wrap items-center gap-2 font-medium"
+                >
+                  Slack OAuth — supersuit
+                </label>
+                <p className="text-muted-foreground text-xs">Connected 3/2/2026</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+              <Button type="button" variant="outline" size="sm">
+                <Star className="size-3.5" />
+                Make default
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button type="button" variant="outline" size="sm">
+            <Settings className="size-3" />
+            Manage credentials
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export const NeedsReauthorization: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <ConnectorInstancesSectionReauthMirror />
     </div>
   ),
 };

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Loader2, Settings, Star, Trash2 } from "lucide-react";
+import { AlertTriangle, Loader2, LogIn, Settings, Star, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,11 +11,16 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
+import { useAuth } from "@/auth/AuthContext";
 import { useCredentials } from "@/hooks/useCredentials";
 import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
-import { providerLabel } from "@/lib/oauth";
+import {
+  providerLabel,
+  getOAuthAuthorizeUrl,
+  SHOP_REQUIRED_PROVIDERS,
+} from "@/lib/oauth";
 import { serviceLabel } from "@/lib/labels";
 import {
   useAgentConnectorInstances,
@@ -62,6 +67,7 @@ export function ConnectorInstancesSection({
     [connectorId, requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
+  const { session } = useAuth();
 
   useAutoAssignOAuthCredential(agentId, connectorId);
 
@@ -127,8 +133,11 @@ export function ConnectorInstancesSection({
   } = useConnectorInstanceCredentialBindings(agentId, connectorId, instanceIds);
 
   const rows: CredentialRow[] = useMemo(() => {
-    const activeConnections = connections.filter(
-      (c) => c.status === "active" && c.id && c.provider === connectorId,
+    const usableConnections = connections.filter(
+      (c) =>
+        (c.status === "active" || c.status === "needs_reauth") &&
+        c.id &&
+        c.provider === connectorId,
     );
     const scopedCredentials = credentials
       .filter((c) => credentialServiceIds.has(c.service))
@@ -139,7 +148,7 @@ export function ConnectorInstancesSection({
         return la.localeCompare(lb);
       });
 
-    const oauthRows: CredentialRow[] = activeConnections
+    const oauthRows: CredentialRow[] = usableConnections
       .slice()
       .sort((a, b) =>
         (a.display_name ?? a.id).localeCompare(b.display_name ?? b.id),
@@ -158,6 +167,24 @@ export function ConnectorInstancesSection({
 
     return [...oauthRows, ...credRows];
   }, [connections, connectorId, credentials, credentialServiceIds]);
+
+  const oauthScopesByProvider = useMemo(() => {
+    const m = new Map<string, string[] | undefined>();
+    for (const rc of requiredCredentials) {
+      if (rc.auth_type === "oauth2" && rc.oauth_provider) {
+        m.set(rc.oauth_provider, rc.oauth_scopes);
+      }
+    }
+    return m;
+  }, [requiredCredentials]);
+
+  const reauthCount = useMemo(
+    () =>
+      rows.filter(
+        (r) => r.kind === "oauth" && r.connection.status === "needs_reauth",
+      ).length,
+    [rows],
+  );
 
   const instanceByRowKey = useMemo(() => {
     const map = new Map<string, AgentConnectorInstance>();
@@ -333,9 +360,30 @@ export function ConnectorInstancesSection({
 
   function rowMeta(row: CredentialRow): string {
     if (row.kind === "oauth") {
+      if (row.connection.status === "needs_reauth") {
+        return "Needs re-authorization";
+      }
       return `Connected ${new Date(row.connection.connected_at).toLocaleDateString()}`;
     }
     return `Added ${new Date(row.credential.created_at).toLocaleDateString()}`;
+  }
+
+  function handleReauthorize(connection: OAuthConnection) {
+    if (!session?.access_token) return;
+    // Shop-required providers (e.g. shopify) prompt for a shop subdomain —
+    // defer to the Manage credentials dialog, which owns that flow.
+    if (SHOP_REQUIRED_PROVIDERS.has(connection.provider)) {
+      setManageDialogOpen(true);
+      return;
+    }
+    window.location.href = getOAuthAuthorizeUrl(
+      connection.provider,
+      session.access_token,
+      {
+        scopes: oauthScopesByProvider.get(connection.provider),
+        replaceId: connection.id,
+      },
+    );
   }
 
   return (
@@ -369,6 +417,19 @@ export function ConnectorInstancesSection({
                 Failed to load credential links. Refresh the page to retry.
               </p>
             )}
+            {reauthCount > 0 && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-900/50 dark:bg-amber-950/40"
+              >
+                <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
+                <p className="text-amber-900 dark:text-amber-200">
+                  {reauthCount === 1
+                    ? "1 credential needs re-authorization before this agent can use it."
+                    : `${reauthCount} credentials need re-authorization before this agent can use them.`}
+                </p>
+              </div>
+            )}
             {rows.length === 0 && (
               <p className="text-muted-foreground text-sm">
                 No credentials found for this connector. Add one using Manage
@@ -380,6 +441,8 @@ export function ConnectorInstancesSection({
               const enabled = !!inst;
               const isDefault = !!inst?.is_default;
               const showDefaultControls = enabled && enabledInstanceCount > 1;
+              const needsReauth =
+                row.kind === "oauth" && row.connection.status === "needs_reauth";
 
               return (
                 <div
@@ -397,14 +460,39 @@ export function ConnectorInstancesSection({
                     <div className="min-w-0 flex-1">
                       <label
                         htmlFor={`cred-row-${row.rowKey}`}
-                        className="cursor-pointer font-medium"
+                        className="flex cursor-pointer flex-wrap items-center gap-2 font-medium"
                       >
                         {rowLabel(row)}
+                        {needsReauth && (
+                          <Badge
+                            variant="outline"
+                            className="gap-1 border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-300"
+                          >
+                            <AlertTriangle className="size-3" />
+                            Needs re-authorization
+                          </Badge>
+                        )}
                       </label>
-                      <p className="text-muted-foreground text-xs">{rowMeta(row)}</p>
+                      <p
+                        className={`text-xs ${needsReauth ? "text-amber-700 dark:text-amber-300" : "text-muted-foreground"}`}
+                      >
+                        {rowMeta(row)}
+                      </p>
                     </div>
                   </div>
                   <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                    {needsReauth && row.kind === "oauth" && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={busyRow || !session?.access_token}
+                        onClick={() => handleReauthorize(row.connection)}
+                      >
+                        <LogIn className="size-3.5" />
+                        Re-authorize
+                      </Button>
+                    )}
                     {enabled && isDefault && (
                       <Badge variant="secondary">Default</Badge>
                     )}

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
@@ -88,7 +88,10 @@ function normalizeMockPath(path: unknown): string {
 const LIST_INSTANCES_PATH =
   "/v1/agents/{agent_id}/connectors/{connector_id}/instances";
 
-function mockStandardGets(twoInstances = false) {
+function mockStandardGets(
+  twoInstances = false,
+  options?: { secondNeedsReauth?: boolean },
+) {
   mockGet.mockImplementation((path: unknown) => {
     const p = normalizeMockPath(path);
     if (path === LIST_INSTANCES_PATH || (p.includes("/connectors/") && p.endsWith("/instances") && !p.includes("/credential"))) {
@@ -125,7 +128,7 @@ function mockStandardGets(twoInstances = false) {
             {
               id: "oconn_2",
               provider: "slack",
-              status: "active",
+              status: options?.secondNeedsReauth ? "needs_reauth" : "active",
               display_name: "Sales",
               connected_at: "2026-02-12T10:00:00Z",
             },
@@ -316,5 +319,82 @@ describe("ConnectorInstancesSection", () => {
     expect(instDelete?.[1]?.params?.path?.instance_id).toBe(
       secondInstance.connector_instance_id,
     );
+  });
+
+  it("shows needs_reauth credentials in the checklist with a warning and re-authorize button", async () => {
+    mockStandardGets(true, { secondNeedsReauth: true });
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue(
+      bindingsQueryResult(true),
+    );
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    // Row still appears, checkbox reflects the binding (enabled).
+    const salesCheckbox = await screen.findByRole("checkbox", {
+      name: /Slack OAuth — Sales/i,
+    });
+    expect(salesCheckbox).toBeChecked();
+    // Badge next to the row conveys the re-auth state.
+    expect(screen.getAllByText(/Needs re-authorization/i).length).toBeGreaterThan(0);
+    // Re-authorize button is rendered.
+    expect(
+      screen.getByRole("button", { name: /Re-authorize/i }),
+    ).toBeInTheDocument();
+    // Summary banner at the top shows the count.
+    expect(
+      screen.getByText(/1 credential needs re-authorization/i),
+    ).toBeInTheDocument();
+  });
+
+  it("re-authorize button navigates to the OAuth authorize URL with replace param", async () => {
+    mockStandardGets(true, { secondNeedsReauth: true });
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue(
+      bindingsQueryResult(true),
+    );
+    const assignHref = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        set href(url: string) {
+          assignHref(url);
+        },
+        get href() {
+          return "http://localhost/";
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+            oauth_scopes: ["chat:write"],
+          },
+        ]}
+      />,
+    );
+    const button = await screen.findByRole("button", { name: /Re-authorize/i });
+    await user.click(button);
+    expect(assignHref).toHaveBeenCalled();
+    const url = assignHref.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/v1/oauth/slack/authorize");
+    expect(url).toContain("replace=oconn_2");
+    expect(url).toContain("scope=chat%3Awrite");
   });
 });


### PR DESCRIPTION
## Summary

- `needs_reauth` OAuth connections now appear in the "Credentials for this agent" checklist instead of being filtered out, so the user sees a problem exists without opening the Manage credentials dialog.
- Rows that need re-auth render an amber "Needs re-authorization" badge, amber meta text, and an inline **Re-authorize** button that kicks off the same `?replace=<id>` OAuth flow used elsewhere (shop-required providers like Shopify fall back to opening the Manage dialog so the shop-subdomain prompt still runs).
- An amber summary banner is shown at the top of the card whenever any row needs re-auth. The checkbox still reflects the user's binding choice regardless of status so they can enable/disable a broken credential.

## Test plan

- [x] `npx vitest run src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx` — 6/6 pass, including two new cases covering the warning UI and the re-authorize URL.
- [x] `npx vitest run src/pages/agents/` — 223/223 pass.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: load an agent whose connector has a `needs_reauth` connection and confirm the banner, badge, meta text, and Re-authorize button render as expected without opening the Manage dialog.

https://claude.ai/code/session_01XAtipfZpRxhFtk2ndmqEen