### PR TITLE
Remove 'connector slot' UI; auto-delete orphan instances silently

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { AlertTriangle, Loader2, LogIn, Settings, Star, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Loader2, LogIn, Settings, Star } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -233,16 +233,16 @@ export function ConnectorInstancesSection({
     }
   }
 
-  async function handleRemoveOrphan(instanceId: string) {
-    try {
-      await deleteInstance({ agentId, connectorId, instanceId });
-      toast.success("Unused connector slot removed.");
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to remove connector slot.",
-      );
+  const cleaningUpRef = useRef(new Set<string>());
+  useEffect(() => {
+    for (const id of orphanInstanceIds) {
+      if (cleaningUpRef.current.has(id)) continue;
+      cleaningUpRef.current.add(id);
+      deleteInstance({ agentId, connectorId, instanceId: id }).finally(() => {
+        cleaningUpRef.current.delete(id);
+      });
     }
-  }
+  }, [orphanInstanceIds, agentId, connectorId, deleteInstance]);
 
   async function enableRow(row: CredentialRow) {
     const created = await create({ agentId, connectorId });
@@ -515,37 +515,6 @@ export function ConnectorInstancesSection({
                 </div>
               );
             })}
-
-            {orphanInstanceIds.length > 0 && (
-              <div className="rounded-md border border-dashed p-3">
-                <p className="text-muted-foreground mb-2 text-sm">
-                  These connector slots are not linked to a credential. Remove
-                  them to clean up.
-                </p>
-                <ul className="space-y-2">
-                  {orphanInstanceIds.map((id) => (
-                    <li
-                      key={id}
-                      className="flex items-center justify-between gap-2 text-sm"
-                    >
-                      <span className="text-muted-foreground font-mono text-xs">
-                        {id.slice(0, 8)}…
-                      </span>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={busyRow}
-                        onClick={() => void handleRemoveOrphan(id)}
-                      >
-                        <Trash2 className="size-3.5" />
-                        Remove slot
-                      </Button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
           </div>
         )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The connector config page (`/agents/:id/connectors/slack`) showed a confusing "connector slots" section when orphan connector instances existed — instances with no credential bound. This exposed raw UUIDs and internal jargon ("slot") that means nothing to users.

**Before:** A dashed-border section appeared with text like *"These connector slots are not linked to a credential. Remove them to clean up."* and a truncated UUID with a "Remove slot" button.

**After:** Orphan instances are silently auto-deleted in the background via a `useEffect`. Users never see them.

## What changed

- **Removed** the orphan instance UI block (dashed border, UUID list, "Remove slot" buttons)
- **Removed** the `handleRemoveOrphan` function and "slot" toast messages
- **Added** a `useEffect` + `useRef` guard that automatically deletes orphan instances when detected, deduplicating concurrent cleanup attempts
- **Removed** unused `Trash2` icon import

## Why the underlying abstraction stays

The "connector instance" data model (the `agent_connectors` row with a UUID) is still needed — it's what enables multi-credential support per connector type (e.g. two Slack workspaces). The change is purely about removing the user-facing "slot" concept and auto-cleaning garbage state instead of asking users to do it.

## Test plan

- All 6 `ConnectorInstancesSection` tests pass
- Full frontend suite: 110 files, 1070 tests pass
- Backend not modified — no backend tests needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5eff8677-c5c0-426e-bfca-7dbac375551b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eff8677-c5c0-426e-bfca-7dbac375551b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

