### PR TITLE
Slack: filter conversations.list results by requested types

### DIFF
--- a/connectors/slack/list_channel_entry_matches_test.go
+++ b/connectors/slack/list_channel_entry_matches_test.go
@@ -83,6 +83,30 @@ func TestListChannelEntryMatchesTypes(t *testing.T) {
 			ch:    listChannelEntry{ID: "C0123", IsPrivate: false},
 			want:  false,
 		},
+		{
+			name:  "public_channel C not private",
+			types: "public_channel",
+			ch:    listChannelEntry{ID: "C0123", IsPrivate: false},
+			want:  true,
+		},
+		{
+			name:  "public_channel C private excluded",
+			types: "public_channel",
+			ch:    listChannelEntry{ID: "C0123", IsPrivate: true},
+			want:  false,
+		},
+		{
+			name:  "public_channel DM excluded",
+			types: "public_channel",
+			ch:    listChannelEntry{ID: "D0123", IsIM: true},
+			want:  false,
+		},
+		{
+			name:  "public_channel MPIM excluded",
+			types: "public_channel",
+			ch:    listChannelEntry{ID: "G0123", IsMPIM: true},
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -132,6 +132,15 @@ func listChannelEntryMatchesTypes(types string, ch listChannelEntry) bool {
 			if ch.IsPrivate && len(ch.ID) > 0 && (ch.ID[0] == 'C' || ch.ID[0] == 'G') {
 				return true
 			}
+		case "public_channel":
+			// Public C-channels only — exclude DMs/MPIMs (which may carry is_private)
+			// and exclude private channels (C or legacy G with is_private=true).
+			if ch.IsIM || ch.IsMPIM {
+				break
+			}
+			if !ch.IsPrivate && len(ch.ID) > 0 && ch.ID[0] == 'C' {
+				return true
+			}
 		}
 	}
 	return false

--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -79,6 +79,12 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 		Channels: make([]listChannelSummary, 0, len(resp.Channels)+len(userPrivateMerge)),
 	}
 	for _, ch := range resp.Channels {
+		// Defend against conversations.list returning channels outside the
+		// requested types (e.g. bot tokens missing im:read silently return
+		// public channels instead of an error). See issue #1028.
+		if !listChannelEntryMatchesTypes(types, ch) {
+			continue
+		}
 		if userChannelIDs != nil && (ch.IsPrivate || strings.HasPrefix(ch.ID, "D") || strings.HasPrefix(ch.ID, "G")) {
 			if !userChannelIDs[ch.ID] {
 				continue

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -460,6 +460,81 @@ func TestListChannels_DefaultFallbackWithoutEmail(t *testing.T) {
 	}
 }
 
+func TestListChannels_IMFiltersStrayPublicChannels(t *testing.T) {
+	t.Parallel()
+
+	// Regression for issue #1028: Slack's conversations.list can return public
+	// channels even when types=im is requested (e.g. when the bot token lacks
+	// im:read scope it silently falls back instead of erroring). The merged
+	// result must still honor the requested types and exclude public channels.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "D001"},
+				},
+			})
+		case "/conversations.list":
+			// Slack mis-honors types=im and returns a public channel alongside the DM.
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{
+						"id":          "C001",
+						"name":        "ihubs-general",
+						"is_private":  false,
+						"num_members": 42,
+					},
+					{
+						"id":          "D001",
+						"user":        "U_OTHER",
+						"is_private":  true,
+						"num_members": 0,
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Channels) != 1 {
+		t.Fatalf("expected 1 channel (DM only), got %d: %+v", len(data.Channels), data.Channels)
+	}
+	if data.Channels[0].ID != "D001" {
+		t.Errorf("expected D001, got %q", data.Channels[0].ID)
+	}
+}
+
 func TestListChannels_ExplicitPrivateTypesWithoutEmail(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `slack.list_channels` was ignoring the `types` parameter. Calls with `types: "im"` or `types: "im,mpim"` returned public channels (e.g. `ihubs-general`) instead of DMs/MPIMs.
- Root cause: the merge loop in `list_channels_merged.go` only applied a *membership* check for private/D/G IDs and trusted Slack's `conversations.list` for type filtering. When the bot token lacks `im:read`/`mpim:read` scopes, Slack silently returns public channels anyway — those C IDs fell straight through to the result.
- Fix: filter `resp.Channels` through `listChannelEntryMatchesTypes(types, ch)` before the membership check, making the caller's `types` request authoritative regardless of what the API returns. Added the missing `public_channel` case to that helper so the default (`public_channel,private_channel,mpim,im`) keeps working.

## Test plan

- [x] New unit cases in `list_channel_entry_matches_test.go` for the `public_channel` branch (positive, private-excluded, DM-excluded, MPIM-excluded).
- [x] New regression test `TestListChannels_IMFiltersStrayPublicChannels` in `list_channels_test.go` — simulates Slack returning a public channel alongside a DM under `types=im` and asserts only the DM survives.
- [ ] `go test ./connectors/slack/ -run 'ListChannel' -v` — **not run locally**: sandbox is on Go 1.24.7 but a transitive dep (`cloud.google.com/go/bigquery`) requires Go 1.25+, per the "Sandbox limitations" note in CLAUDE.md. Relying on CI for the full backend test run.
- [ ] End-to-end repro (for a session with Slack creds): `permission-slip request --action slack.list_channels --params '{"types": "im,mpim"}' --agent-id <id>` should return only DMs/group DMs.

Out of scope: the issue also mentions `slack.search_messages` returning HTTP 502. That's an upstream Slack gateway error, not a connector bug.

Closes #1028