### PR TITLE
Slack: omit user param on users.conversations for user tokens

### DIFF
--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -232,8 +232,11 @@ func describeChannelType(channelID string) string {
 }
 
 // usersConversationsRequest is the Slack API request for users.conversations.
+// Leave User empty on user-token (xoxp-) calls so Slack returns the token
+// owner's own conversations. Passing the token owner's own ID triggers the
+// "browse another user" path and can silently return empty — see #1031.
 type usersConversationsRequest struct {
-	User   string `json:"user"`
+	User   string `json:"user,omitempty"`
 	Types  string `json:"types,omitempty"`
 	Limit  int    `json:"limit,omitempty"`
 	Cursor string `json:"cursor,omitempty"`
@@ -248,17 +251,16 @@ type usersConversationsResponse struct {
 // maxUserConversationPages limits pagination when fetching a user's channel list.
 const maxUserConversationPages = 50
 
-// getUserPrivateConversations returns conversation objects for the given Slack user
-// and types via users.conversations. This uses the user token (xoxp-), which only
-// returns conversations the token owner belongs to. A bot token with the `user`
-// parameter would require admin.conversations:read scope — we intentionally
-// use the user token to avoid that requirement.
-func (c *SlackConnector) getUserPrivateConversations(ctx context.Context, creds connectors.Credentials, slackUserID, types string) ([]listChannelEntry, error) {
+// getUserPrivateConversations returns the token owner's conversations for the
+// requested types via users.conversations. The Slack user token (xoxp-)
+// implicitly scopes the response to the caller, so we must NOT pass a `user`
+// parameter — doing so switches Slack to the admin-style "browse another
+// user" path and returns empty for non-admin tokens (#1031).
+func (c *SlackConnector) getUserPrivateConversations(ctx context.Context, creds connectors.Credentials, types string) ([]listChannelEntry, error) {
 	var out []listChannelEntry
 	cursor := ""
 	for page := 0; page < maxUserConversationPages; page++ {
 		body := usersConversationsRequest{
-			User:   slackUserID,
 			Types:  types,
 			Limit:  200,
 			Cursor: cursor,

--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -43,7 +43,7 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 				}
 			}
 			privateTypes := filterPrivateTypes(types)
-			userPrivateChs, err := c.getUserPrivateConversations(ctx, creds, slackUserID, privateTypes)
+			userPrivateChs, err := c.getUserPrivateConversations(ctx, creds, privateTypes)
 			if err != nil {
 				return nil, fmt.Errorf("fetching user channel memberships: %w", err)
 			}

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -126,6 +126,12 @@ func TestListChannels_DefaultTypes(t *testing.T) {
 			if body.Types != "private_channel,mpim,im" {
 				t.Errorf("expected types 'private_channel,mpim,im' for users.conversations, got %q", body.Types)
 			}
+			// User must be empty on user-token calls. Passing the token
+			// owner's own ID flips Slack to the admin "browse another
+			// user" path and returns empty (#1031).
+			if body.User != "" {
+				t.Errorf("expected empty user param on users.conversations, got %q", body.User)
+			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,
 				"channels": []map[string]any{
@@ -198,6 +204,13 @@ func TestListChannels_IMChannels(t *testing.T) {
 				"user": map[string]string{"id": "U_CALLER"},
 			})
 		case "/users.conversations":
+			var body usersConversationsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode users.conversations body: %v", err)
+			}
+			if body.User != "" {
+				t.Errorf("expected empty user param on users.conversations, got %q", body.User)
+			}
 			// Return the IM channel as one the caller belongs to.
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,
@@ -477,6 +490,13 @@ func TestListChannels_IMFiltersStrayPublicChannels(t *testing.T) {
 				"user": map[string]string{"id": "U_CALLER"},
 			})
 		case "/users.conversations":
+			var body usersConversationsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode users.conversations body: %v", err)
+			}
+			if body.User != "" {
+				t.Errorf("expected empty user param on users.conversations, got %q", body.User)
+			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,
 				"channels": []map[string]any{
@@ -555,5 +575,85 @@ func TestListChannels_ExplicitPrivateTypesWithoutEmail(t *testing.T) {
 	var valErr *connectors.ValidationError
 	if !errors.As(err, &valErr) {
 		t.Fatalf("expected ValidationError for explicit private types without email, got: %v", err)
+	}
+}
+
+func TestListChannels_IMReturnsUserDMsWhenConversationsListEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Regression for issue #1031. Before the fix, getUserPrivateConversations
+	// passed `user: slackUserID` to users.conversations. With a non-admin user
+	// token that flips Slack into the "browse another user" path and returns
+	// empty, leaving only conversations.list (which silently falls back to
+	// public channels for types=im) — and #1029 now filters those out. Result:
+	// empty, even though the caller has DMs. The fix is to omit `user` on
+	// user-token calls so Slack returns the token owner's conversations.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			var body usersConversationsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode users.conversations body: %v", err)
+			}
+			if body.User != "" {
+				t.Errorf("user param must be omitted on user-token calls, got %q", body.User)
+			}
+			if body.Types != "im" {
+				t.Errorf("expected users.conversations types=im, got %q", body.Types)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "D_PETER", "user": "U_PETER", "is_private": true},
+				},
+			})
+		case "/conversations.list":
+			// Simulate a token whose conversations.list scope falls back to
+			// public channels when types=im is requested.
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "C001", "name": "ihubs-general", "is_private": false, "num_members": 42},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Channels) != 1 {
+		t.Fatalf("expected 1 DM, got %d: %+v", len(data.Channels), data.Channels)
+	}
+	if data.Channels[0].ID != "D_PETER" {
+		t.Errorf("expected D_PETER, got %q", data.Channels[0].ID)
+	}
+	if data.Channels[0].User != "U_PETER" {
+		t.Errorf("expected user U_PETER, got %q", data.Channels[0].User)
 	}
 }

--- a/connectors/slack/list_unread.go
+++ b/connectors/slack/list_unread.go
@@ -60,8 +60,10 @@ func (a *listUnreadAction) Execute(ctx context.Context, req connectors.ActionReq
 	var entries []unreadChannelEntry
 	cursor := ""
 	for page := 0; page < maxUserConversationPages; page++ {
+		// Omit User: the xoxp- user token implicitly scopes users.conversations
+		// to the token owner. Passing the owner's own ID triggers the admin
+		// "browse another user" path and returns empty (#1031).
 		body := usersConversationsRequest{
-			User:   slackUserID,
 			Types:  types,
 			Limit:  200,
 			Cursor: cursor,

--- a/connectors/slack/list_unread_test.go
+++ b/connectors/slack/list_unread_test.go
@@ -351,6 +351,10 @@ func TestListUnread_PaginatesUsersConversations(t *testing.T) {
 		case "/users.conversations":
 			var body usersConversationsRequest
 			_ = json.NewDecoder(r.Body).Decode(&body)
+			// User must be omitted on user-token calls (#1031).
+			if body.User != "" {
+				t.Errorf("expected empty user param on users.conversations, got %q", body.User)
+			}
 			page++
 			if page == 1 {
 				json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
## Summary

Fixes #1031. `slack.list_channels` with `types=im` (or `types=im,mpim`) was returning an empty array in production even when the caller had DMs.

### Why yesterday's fix exposed this

PR #1029 (for #1028) added a filter in `list_channels_merged.go` so that stray public channels from `conversations.list` are dropped when the caller asked for `types=im`. That filter is correct — but it revealed a pre-existing bug: the DM list coming from `users.conversations` had been empty in production the whole time. Before #1029 the stray public channels leaked through, which is what #1028 reported. After #1029 they're filtered, leaving nothing.

### Root cause

`getUserPrivateConversations` (and the parallel call in `list_unread`) passed `user: slackUserID` in the `users.conversations` request body. With a non-admin user token (`xoxp-`), that flips Slack into the admin-style "browse another user" path and silently returns empty — even when the target ID is the token owner. PR #761 originally intended to omit this field ("Slack documents user-token calls as returning the caller's conversations"), and the code comment at `channel_membership.go:253-255` still reflected that intent. The parameter crept back in at some point and wasn't caught by tests.

### Fix

- Drop the `User` field from the request body in `getUserPrivateConversations` and `list_unread`.
- Mark `User` as `omitempty` on `usersConversationsRequest`.
- Drop the now-unused `slackUserID` arg from `getUserPrivateConversations` (identity validation stays in the caller).
- Add invariant assertions (`body.User == ""`) to every existing test handler that decodes `users.conversations` bodies so this can't regress silently.
- Add `TestListChannels_IMReturnsUserDMsWhenConversationsListEmpty` — a direct regression for the reported scenario (users.conversations returns the DM, conversations.list falls back to public channels, merged result must be the DM).

## Test plan

- [ ] CI: `go test ./connectors/slack/...` — the sandbox can't run Go tests (Go 1.25+ transitive dep vs. 1.24.7 toolchain — see CLAUDE.md "Sandbox limitations"), relying on CI.
- [ ] Post-merge manual repro against the reporter's workspace:
  ```
  npx tsx src/index.ts request \
    --action slack.list_channels \
    --params '{"types":"im","connector_instance":"617eab67-bfa7-4f51-a26a-96e4b89ef455"}' \
    --agent-id 3 --pretty
  ```
  Expected: the DM with Peter Denbeigh appears.
- [ ] Also verify `slack.list_unread` still returns the user's unread channels (same call site was fixed).

Closes #1031