### PR TITLE
fix(slack): restore DMs in list_channels when users.conversations is empty

### DIFF
--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -85,7 +85,12 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 		if !listChannelEntryMatchesTypes(types, ch) {
 			continue
 		}
-		if userChannelIDs != nil && (ch.IsPrivate || strings.HasPrefix(ch.ID, "D") || strings.HasPrefix(ch.ID, "G")) {
+		// When users.conversations returned at least one channel, intersect
+		// private/DM/group IDs with that set so we never surface another user's
+		// DMs from a mis-honored conversations.list. If the merge list is empty,
+		// do not filter — otherwise every DM from conversations.list is dropped
+		// and list_channels looks "DM-less" (#1033).
+		if len(userChannelIDs) > 0 && (ch.IsPrivate || strings.HasPrefix(ch.ID, "D") || strings.HasPrefix(ch.ID, "G")) {
 			if !userChannelIDs[ch.ID] {
 				continue
 			}

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -232,22 +232,22 @@ func TestListChannels_IMChannels(t *testing.T) {
 				"ok": true,
 				"channels": []map[string]any{
 					{
-						"id":         "D001",
-						"user":       "U_OTHER",
-						"is_private": true,
+						"id":          "D001",
+						"user":        "U_OTHER",
+						"is_private":  true,
 						"num_members": 0,
 					},
 					{
-						"id":         "D002",
-						"user":       "U_ANOTHER",
-						"is_private": true,
+						"id":          "D002",
+						"user":        "U_ANOTHER",
+						"is_private":  true,
 						"num_members": 0,
 					},
 					{
 						// DM the caller is NOT a member of — should be filtered out.
-						"id":         "D999",
-						"user":       "U_STRANGER",
-						"is_private": true,
+						"id":          "D999",
+						"user":        "U_STRANGER",
+						"is_private":  true,
 						"num_members": 0,
 					},
 				},
@@ -655,5 +655,74 @@ func TestListChannels_IMReturnsUserDMsWhenConversationsListEmpty(t *testing.T) {
 	}
 	if data.Channels[0].User != "U_PETER" {
 		t.Errorf("expected user U_PETER, got %q", data.Channels[0].User)
+	}
+}
+
+func TestListChannels_DMsFromConversationsListWhenUsersConversationsEmpty_issue1033(t *testing.T) {
+	t.Parallel()
+
+	// Regression #1033: userChannelIDs was built from users.conversations even
+	// when that response was empty. A non-nil empty map made the merge loop
+	// drop every D/G/private row from conversations.list, so default listings
+	// showed only public channels and types=im returned [].
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"channels": []map[string]any{},
+			})
+		case "/conversations.list":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{
+						"id":          "D001",
+						"user":        "U_COLLEAGUE",
+						"is_im":       true,
+						"is_private":  true,
+						"num_members": 0,
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Channels) != 1 {
+		t.Fatalf("expected 1 DM from conversations.list, got %d: %+v", len(data.Channels), data.Channels)
+	}
+	if data.Channels[0].ID != "D001" {
+		t.Errorf("expected D001, got %q", data.Channels[0].ID)
+	}
+	if data.Channels[0].User != "U_COLLEAGUE" {
+		t.Errorf("expected user U_COLLEAGUE, got %q", data.Channels[0].User)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [issue #1033](https://github.com/supersuit-tech/permission-slip/issues/1033).

After resolving the Slack user via email, `list_channels` builds `userChannelIDs` from `users.conversations`. When that API returned **zero** channels, we still allocated a non-nil empty map. The merge loop treated `userChannelIDs != nil` as “apply membership filter,” which dropped **every** `D`/`G`/private row from `conversations.list`. Users then saw only public channels by default and `types=im` returned `[]`, even when DMs were present in `conversations.list`.

We now apply the intersection filter only when `len(userChannelIDs) > 0`, preserving the safety property when the merge set is populated, and falling back to type-filtered `conversations.list` when the merge set is empty.

## Test plan

- [ ] `go test ./connectors/slack -run TestListChannels -count=1` (CI — local agent Go toolchain cannot run full module tests here)
- Added `TestListChannels_DMsFromConversationsListWhenUsersConversationsEmpty_issue1033`.

Closes #1033
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e83f7254-5b47-433c-8f4d-06991109f0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e83f7254-5b47-433c-8f4d-06991109f0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

