### PR TITLE
Slack: reject legacy bot tokens for DM listings

### DIFF
--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -33,6 +33,9 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 			}
 			types = "public_channel"
 		} else {
+			if err := c.requireUserOAuthToken(creds, "slack.list_channels for private channels, group DMs, or DMs"); err != nil {
+				return nil, err
+			}
 			slackUserID, err := c.lookupSlackUserByEmail(ctx, creds, userEmail)
 			if err != nil {
 				return nil, fmt.Errorf("unable to verify Slack identity: %w", err)

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -232,22 +232,22 @@ func TestListChannels_IMChannels(t *testing.T) {
 				"ok": true,
 				"channels": []map[string]any{
 					{
-						"id":         "D001",
-						"user":       "U_OTHER",
-						"is_private": true,
+						"id":          "D001",
+						"user":        "U_OTHER",
+						"is_private":  true,
 						"num_members": 0,
 					},
 					{
-						"id":         "D002",
-						"user":       "U_ANOTHER",
-						"is_private": true,
+						"id":          "D002",
+						"user":        "U_ANOTHER",
+						"is_private":  true,
 						"num_members": 0,
 					},
 					{
 						// DM the caller is NOT a member of — should be filtered out.
-						"id":         "D999",
-						"user":       "U_STRANGER",
-						"is_private": true,
+						"id":          "D999",
+						"user":        "U_STRANGER",
+						"is_private":  true,
 						"num_members": 0,
 					},
 				},
@@ -470,6 +470,30 @@ func TestListChannels_DefaultFallbackWithoutEmail(t *testing.T) {
 	}
 	if data.Channels[0].ID != "C001" {
 		t.Errorf("expected channel C001, got %q", data.Channels[0].ID)
+	}
+}
+
+func TestListChannels_PrivateTypesRequireUserToken(t *testing.T) {
+	t.Parallel()
+
+	conn := newForTest(http.DefaultClient, "http://unused")
+	action := &listChannelsAction{conn: conn}
+
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType: "slack.list_channels",
+		Parameters: params,
+		Credentials: connectors.NewCredentials(map[string]string{
+			"access_token": "xoxb-legacy-bot-token",
+		}),
+		UserEmail: "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected error for bot token on private channel listing")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
 	}
 }
 

--- a/connectors/slack/list_unread.go
+++ b/connectors/slack/list_unread.go
@@ -40,6 +40,10 @@ func (a *listUnreadAction) Execute(ctx context.Context, req connectors.ActionReq
 		return nil, err
 	}
 
+	if err := a.conn.requireUserOAuthToken(req.Credentials, "slack.list_unread"); err != nil {
+		return nil, err
+	}
+
 	if req.UserEmail == "" {
 		return nil, &connectors.ValidationError{
 			Message: "listing unread conversations requires your Permission Slip profile to have an email address matching your Slack account",

--- a/connectors/slack/list_unread_test.go
+++ b/connectors/slack/list_unread_test.go
@@ -30,6 +30,32 @@ func TestListUnread_NoEmail(t *testing.T) {
 	}
 }
 
+func TestListUnread_RequiresUserOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	conn := newForTest(http.DefaultClient, "http://unused.example")
+	action := &listUnreadAction{conn: conn}
+	legacyBotCreds := connectors.NewCredentials(map[string]string{
+		"access_token": "xoxb-legacy-bot-token",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: legacyBotCreds,
+		UserEmail:   "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected auth error for legacy bot token")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "reconnect Slack") {
+		t.Fatalf("expected reconnect guidance, got %v", err)
+	}
+}
+
 func TestListUnread_NoUnreads(t *testing.T) {
 	t.Parallel()
 

--- a/connectors/slack/token_type.go
+++ b/connectors/slack/token_type.go
@@ -1,0 +1,32 @@
+package slack
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// Slack token rotation can wrap the token type in an xoxe prefix. Match on the
+// embedded token family so legacy bot tokens (xoxb-) are rejected for actions
+// that must act as the authorizing user.
+func looksLikeSlackUserToken(token string) bool {
+	return strings.HasPrefix(token, "xoxp-") || strings.Contains(token, "xoxp-")
+}
+
+func looksLikeSlackBotToken(token string) bool {
+	return strings.HasPrefix(token, "xoxb-") || strings.Contains(token, "xoxb-")
+}
+
+func (c *SlackConnector) requireUserOAuthToken(creds connectors.Credentials, action string) error {
+	token, err := c.getToken(creds)
+	if err != nil {
+		return err
+	}
+	if looksLikeSlackBotToken(token) && !looksLikeSlackUserToken(token) {
+		return &connectors.AuthError{
+			Message: fmt.Sprintf("%s requires a Slack user OAuth token (xoxp-), but this connection is still using a legacy bot token — reconnect Slack", action),
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Detect legacy Slack bot-token connections before `slack.list_channels` tries to enumerate private channels, MPIMs, or DMs, and return a reconnect/re-auth error instead of a misleading empty result.
- Apply the same user-token requirement to `slack.list_unread`, which also relies on `users.conversations` for the authorizing user's private conversation set.
- Add regression coverage for the bot-token failure mode while preserving the existing public-channel fallback when no profile email is present.

## Related Issue

Closes #1033

## Test Plan

### Developer

- [x] Unit tests added / updated
- [ ] `make test` passes locally *(sandbox could not resolve uncached Go modules with `GOPROXY=off`)*
- [ ] `make build` succeeds *(same backend module-resolution limitation in this sandbox)*
- [x] `gofmt -l` clean and `gofmt -e` parse checks passed on changed files

### Manual Testing

- [ ] Reconnect a legacy Slack OAuth connection, then verify `slack.list_channels` with `types=im` returns DMs instead of empty results
- [ ] Verify `slack.list_unread` lists the authorizing user's conversations after reconnecting the Slack connection

## Notes for Reviewers

- The underlying issue appears to be legacy Slack OAuth credentials that still store an `xoxb-` bot token. Those tokens can still hit `conversations.list`, but any path that depends on `users.conversations` is scoped to the bot rather than the human, which explains the empty DM results.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-655ac985-c628-444b-90ae-0b409fb33242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-655ac985-c628-444b-90ae-0b409fb33242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

