### PR TITLE
Slack: simplify list_channels for user OAuth tokens (#1036)

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -89,7 +89,7 @@ Creates a new Slack channel.
 
 ### `slack.list_channels`
 
-Lists Slack channels visible to the bot. When listing private channel types (`private_channel`, `mpim`, `im`), results are filtered to channels the executing user belongs to.
+Lists Slack channels visible to the **connected user OAuth token** (`xoxp-`). The implementation calls `conversations.list` as the primary source, then merges in rows from `users.conversations` **only** for channel IDs missing from the first response (so human DMs that never appear on `conversations.list` still show up). Rows are filtered with `listChannelEntryMatchesTypes` so a mis-honored `types` parameter on `conversations.list` cannot surface public channels when the caller asked for DMs only ([#1028](https://github.com/supersuit-tech/permission-slip/issues/1028)).
 
 **Risk level:** low
 
@@ -97,7 +97,7 @@ Lists Slack channels visible to the bot. When listing private channel types (`pr
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `types` | string | No | `public_channel,private_channel,mpim,im` | Comma-separated channel types: `public_channel`, `private_channel`, `mpim`, `im`. Defaults to all types when user email is available; falls back to `public_channel` only when no email is set. |
+| `types` | string | No | `public_channel,private_channel,mpim,im` | Comma-separated channel types: `public_channel`, `private_channel`, `mpim`, `im`. Defaults to all types; Slack scopes results to the token owner. |
 | `limit` | integer | No | `100` | Max channels to return (1–1000) |
 | `cursor` | string | No | — | Pagination cursor from a previous response |
 | `exclude_archived` | boolean | No | `true` | Exclude archived channels from results |
@@ -128,9 +128,13 @@ Lists Slack channels visible to the bot. When listing private channel types (`pr
 
 > **Note:** IM channels (DMs) don't have a `name` field. Instead, they include a `user` field with the other participant's Slack user ID.
 
-**Slack API:** `POST /conversations.list` ([docs](https://api.slack.com/methods/conversations.list))
+**Slack API:** `POST /conversations.list`, `POST /users.conversations` ([docs](https://api.slack.com/methods/conversations.list))
 
-**Required bot token scopes:** `channels:read` (public), `groups:read` (private), `im:read` (DMs), `mpim:read` (group DMs)
+**Required user token scopes:** `channels:read` (public), `groups:read` (private), `im:read` (DMs), `mpim:read` (group DMs)
+
+#### Listing vs identity (user tokens)
+
+Each Slack connection stores one **user** access token tied to a single Permission Slip user. Listing does **not** call `users.lookupByEmail` or require the Permission Slip profile email to match Slack; both Web API calls run as the token owner, and Slack enforces membership. Other actions (read, search, unread) may still use email-backed membership checks where the product requires them.
 
 ---
 

--- a/connectors/slack/list_channels.go
+++ b/connectors/slack/list_channels.go
@@ -18,7 +18,6 @@ type listChannelsParams struct {
 	// Types filters by channel type. Comma-separated list of:
 	// public_channel, private_channel, mpim, im.
 	// Defaults to all types: public_channel,private_channel,mpim,im.
-	// Falls back to public_channel if UserEmail is not set (required for private types).
 	Types string `json:"types,omitempty"`
 	// Limit is the max number of channels to return (1-1000, default 100).
 	Limit int `json:"limit,omitempty"`
@@ -87,9 +86,10 @@ type listChannelSummary struct {
 	NumMembers int    `json:"num_members"`
 }
 
-// Execute lists Slack channels visible to the bot, merged with the authorizing
-// user's DMs/group DMs/private channels from users.conversations when a user
-// token is present (so 1:1 DMs where the bot is not a member still appear).
+// Execute lists Slack channels for the authorizing user's OAuth token via
+// conversations.list, with users.conversations merged in to fill gaps (e.g.
+// human DMs missing from conversations.list). Results are filtered to the
+// requested types even when Slack mis-honors the types parameter (#1028).
 func (a *listChannelsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
 	var params listChannelsParams
 	if err := parseAndValidate(req.Parameters, &params); err != nil {

--- a/connectors/slack/list_channels_dm_merge_test.go
+++ b/connectors/slack/list_channels_dm_merge_test.go
@@ -15,11 +15,6 @@ func TestListChannels_MergesHumanDMNotVisibleToBot(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/users.lookupByEmail":
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]string{"id": "U_CALLER"},
-			})
 		case "/users.conversations":
 			if got := r.Header.Get("Authorization"); got != "Bearer xoxp-user" {
 				t.Errorf("users.conversations: expected user token, got %q", got)

--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -2,57 +2,35 @@ package slack
 
 import (
 	"context"
-	"fmt"
-	"strings"
-
-	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
-// listChannelsMerged lists Slack channels using the same merge logic as
-// slack.list_channels (conversations.list + users.conversations when needed).
+// listChannelsMerged lists Slack channels for the user OAuth token (xoxp-).
+// Primary source is conversations.list; responses are filtered with
+// listChannelEntryMatchesTypes to defend against mis-honored types (#1028).
+// When the request includes private types, users.conversations is merged in
+// only to add conversations missing from conversations.list (same token;
+// no email lookup). Slack scopes each call to the token owner.
 func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connectors.Credentials, userEmail string, params listChannelsParams) (*listChannelsResult, error) {
+	_ = userEmail // listing uses token scoping only; email is unused (kept for API stability).
+
 	excludeArchived := true
 	if params.ExcludeArchived != nil {
 		excludeArchived = *params.ExcludeArchived
 	}
 
 	types := params.Types
-	explicitTypes := types != ""
 	if types == "" {
 		types = "public_channel,private_channel,mpim,im"
 	}
 
-	var userChannelIDs map[string]bool
 	var userPrivateMerge []listChannelEntry
 	if channelTypesIncludePrivate(types) {
-		if userEmail == "" {
-			if explicitTypes {
-				return nil, &connectors.ValidationError{
-					Message: "listing private channels, group DMs, or DMs requires your Permission Slip profile to have an email address matching your Slack account",
-				}
-			}
-			types = "public_channel"
-		} else {
-			slackUserID, err := c.lookupSlackUserByEmail(ctx, creds, userEmail)
-			if err != nil {
-				return nil, fmt.Errorf("unable to verify Slack identity: %w", err)
-			}
-			if slackUserID == "" {
-				return nil, &connectors.ValidationError{
-					Message: fmt.Sprintf("no Slack user found matching email %q — ensure your Permission Slip email matches your Slack account", userEmail),
-				}
-			}
-			privateTypes := filterPrivateTypes(types)
-			userPrivateChs, err := c.getUserPrivateConversations(ctx, creds, privateTypes)
-			if err != nil {
-				return nil, fmt.Errorf("fetching user channel memberships: %w", err)
-			}
-			userPrivateMerge = userPrivateChs
-			userChannelIDs = make(map[string]bool, len(userPrivateChs))
-			for _, ch := range userPrivateChs {
-				userChannelIDs[ch.ID] = true
-			}
+		privateTypes := filterPrivateTypes(types)
+		userPrivateChs, err := c.getUserPrivateConversations(ctx, creds, privateTypes)
+		if err != nil {
+			return nil, err
 		}
+		userPrivateMerge = userPrivateChs
 	}
 
 	body := listChannelsRequest{
@@ -79,21 +57,8 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 		Channels: make([]listChannelSummary, 0, len(resp.Channels)+len(userPrivateMerge)),
 	}
 	for _, ch := range resp.Channels {
-		// Defend against conversations.list returning channels outside the
-		// requested types (e.g. bot tokens missing im:read silently return
-		// public channels instead of an error). See issue #1028.
 		if !listChannelEntryMatchesTypes(types, ch) {
 			continue
-		}
-		// When users.conversations returned at least one channel, intersect
-		// private/DM/group IDs with that set so we never surface another user's
-		// DMs from a mis-honored conversations.list. If the merge list is empty,
-		// do not filter — otherwise every DM from conversations.list is dropped
-		// and list_channels looks "DM-less" (#1033).
-		if len(userChannelIDs) > 0 && (ch.IsPrivate || strings.HasPrefix(ch.ID, "D") || strings.HasPrefix(ch.ID, "G")) {
-			if !userChannelIDs[ch.ID] {
-				continue
-			}
 		}
 		seen[ch.ID] = true
 		result.Channels = append(result.Channels, listChannelSummary{

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -112,11 +111,6 @@ func TestListChannels_DefaultTypes(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/users.lookupByEmail":
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]string{"id": "U_CALLER"},
-			})
 		case "/users.conversations":
 			var body usersConversationsRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -198,11 +192,6 @@ func TestListChannels_IMChannels(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/users.lookupByEmail":
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]string{"id": "U_CALLER"},
-			})
 		case "/users.conversations":
 			var body usersConversationsRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -211,13 +200,9 @@ func TestListChannels_IMChannels(t *testing.T) {
 			if body.User != "" {
 				t.Errorf("expected empty user param on users.conversations, got %q", body.User)
 			}
-			// Return the IM channel as one the caller belongs to.
 			json.NewEncoder(w).Encode(map[string]any{
-				"ok": true,
-				"channels": []map[string]any{
-					{"id": "D001"},
-					{"id": "D002"},
-				},
+				"ok":       true,
+				"channels": []map[string]any{},
 			})
 		case "/conversations.list":
 			var body listChannelsRequest
@@ -244,7 +229,6 @@ func TestListChannels_IMChannels(t *testing.T) {
 						"num_members": 0,
 					},
 					{
-						// DM the caller is NOT a member of — should be filtered out.
 						"id":          "D999",
 						"user":        "U_STRANGER",
 						"is_private":  true,
@@ -277,9 +261,9 @@ func TestListChannels_IMChannels(t *testing.T) {
 	if err := json.Unmarshal(result.Data, &data); err != nil {
 		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	// D999 should be filtered out (not in caller's membership set).
-	if len(data.Channels) != 2 {
-		t.Fatalf("expected 2 IM channels, got %d", len(data.Channels))
+	// User-token listing trusts conversations.list for IM rows; no email merge intersection.
+	if len(data.Channels) != 3 {
+		t.Fatalf("expected 3 IM channels, got %d", len(data.Channels))
 	}
 	if data.Channels[0].ID != "D001" {
 		t.Errorf("expected first channel D001, got %q", data.Channels[0].ID)
@@ -418,38 +402,48 @@ func TestListChannels_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestListChannels_DefaultFallbackWithoutEmail(t *testing.T) {
+func TestListChannels_DefaultWithoutEmail(t *testing.T) {
 	t.Parallel()
 
-	// When no types are specified (using the default) and no UserEmail is set,
-	// list_channels should gracefully fall back to public_channel only instead
-	// of returning a ValidationError. This preserves backward compatibility.
+	// Default types include private/DM kinds; user OAuth scopes both calls — no profile email required.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/conversations.list" {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.conversations":
+			var body usersConversationsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode: %v", err)
+			}
+			if body.Types != "private_channel,mpim,im" {
+				t.Errorf("expected users.conversations types 'private_channel,mpim,im', got %q", body.Types)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"channels": []map[string]any{},
+			})
+		case "/conversations.list":
+			var body listChannelsRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode: %v", err)
+			}
+			if body.Types != "public_channel,private_channel,mpim,im" {
+				t.Errorf("expected default types on conversations.list, got %q", body.Types)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "C001", "name": "general", "is_private": false, "num_members": 5},
+				},
+			})
+		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		var body listChannelsRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode: %v", err)
-		}
-		if body.Types != "public_channel" {
-			t.Errorf("expected fallback types 'public_channel', got %q", body.Types)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"ok": true,
-			"channels": []map[string]any{
-				{"id": "C001", "name": "general", "is_private": false, "num_members": 5},
-			},
-		})
 	}))
 	defer srv.Close()
 
 	conn := newForTest(srv.Client(), srv.URL)
 	action := &listChannelsAction{conn: conn}
 
-	// No types param, no UserEmail — should fall back to public_channel.
 	params, _ := json.Marshal(listChannelsParams{})
 
 	result, err := action.Execute(t.Context(), connectors.ActionRequest{
@@ -458,7 +452,7 @@ func TestListChannels_DefaultFallbackWithoutEmail(t *testing.T) {
 		Credentials: validCreds(),
 	})
 	if err != nil {
-		t.Fatalf("expected graceful fallback, got error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	var data listChannelsResult
@@ -484,11 +478,6 @@ func TestListChannels_IMFiltersStrayPublicChannels(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/users.lookupByEmail":
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]string{"id": "U_CALLER"},
-			})
 		case "/users.conversations":
 			var body usersConversationsRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -558,23 +547,46 @@ func TestListChannels_IMFiltersStrayPublicChannels(t *testing.T) {
 func TestListChannels_ExplicitPrivateTypesWithoutEmail(t *testing.T) {
 	t.Parallel()
 
-	// When the caller explicitly requests private types (e.g. types=im) but
-	// has no UserEmail set, list_channels must return a ValidationError —
-	// not silently fall back to public_channel.
-	conn := newForTest(http.DefaultClient, "http://unused")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":       true,
+				"channels": []map[string]any{},
+			})
+		case "/conversations.list":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "D001", "user": "U_X", "is_im": true, "is_private": true, "num_members": 0},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
 	action := &listChannelsAction{conn: conn}
 
 	params, _ := json.Marshal(listChannelsParams{Types: "im"})
 
-	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
 		ActionType:  "slack.list_channels",
 		Parameters:  params,
 		Credentials: validCreds(),
-		// UserEmail intentionally omitted
 	})
-	var valErr *connectors.ValidationError
-	if !errors.As(err, &valErr) {
-		t.Fatalf("expected ValidationError for explicit private types without email, got: %v", err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(data.Channels) != 1 || data.Channels[0].ID != "D001" {
+		t.Fatalf("expected one DM D001, got %+v", data.Channels)
 	}
 }
 
@@ -592,11 +604,6 @@ func TestListChannels_IMReturnsUserDMsWhenConversationsListEmpty(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/users.lookupByEmail":
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]string{"id": "U_CALLER"},
-			})
 		case "/users.conversations":
 			var body usersConversationsRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -669,11 +676,6 @@ func TestListChannels_DMsFromConversationsListWhenUsersConversationsEmpty_issue1
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/users.lookupByEmail":
-			json.NewEncoder(w).Encode(map[string]any{
-				"ok":   true,
-				"user": map[string]string{"id": "U_CALLER"},
-			})
 		case "/users.conversations":
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok":       true,

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -98,7 +98,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:      "slack.list_channels",
 				Name:            "List Channels",
-				Description:     "List Slack channels via conversations.list, merged with the authorizing user's DMs and private conversations from users.conversations when a matching profile email is available. Returns all channel types (public, private, group DMs, DMs) by default when email is set.",
+				Description:     "List Slack channels for the authorizing user's OAuth token via conversations.list, with users.conversations merged to add conversations missing from that list. Defaults to all channel types (public, private, group DMs, DMs).",
 				RiskLevel:       "low",
 				DisplayTemplate: "List Slack channels",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
@@ -108,7 +108,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "string",
 							"default": "public_channel,private_channel,mpim,im",
 							"enum": ["public_channel", "private_channel", "mpim", "im"],
-							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types when a user email is available; falls back to public_channel only when no email is set. im/mpim/private_channel results are filtered to the authorizing user; user-token merge fills in human-only DMs when configured.",
+							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types. Slack scopes results to the token owner; merge adds DMs/private rows missing from conversations.list.",
 							"x-ui": {"label": "Channel types", "widget": "multi-select", "help_text": "public_channel, private_channel, mpim (group DMs), im (direct messages)"}
 						},
 						"limit": {
@@ -863,7 +863,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				ID:               "tpl_slack_list_channels",
 				ActionType:       "slack.list_channels",
 				Name:             "List channels",
-				Description:      "Agent can list channels, including the authorizing user's DMs when profile email matches Slack.",
+				Description:      "Agent can list channels visible to the authorizing user's Slack user token.",
 				Parameters:       json.RawMessage(`{"types":"*","limit":"*","cursor":"*"}`),
 				StandingApproval: neverExpire,
 			},

--- a/frontend/src/api/bundled.yaml
+++ b/frontend/src/api/bundled.yaml
@@ -1685,7 +1685,7 @@ paths:
         Used by the dashboard to populate channel pickers for Slack actions.
 
         Requires session authentication (Supabase JWT). The agent must belong to the current user.
-        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+        Listing uses the connected Slack user OAuth token; channel visibility follows Slack's token scoping (same model as `slack.list_channels`).
       tags:
         - Agents
       security:

--- a/spec/openapi.bundle.yaml
+++ b/spec/openapi.bundle.yaml
@@ -1685,7 +1685,7 @@ paths:
         Used by the dashboard to populate channel pickers for Slack actions.
 
         Requires session authentication (Supabase JWT). The agent must belong to the current user.
-        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+        Listing uses the connected Slack user OAuth token; channel visibility follows Slack's token scoping (same model as `slack.list_channels`).
       tags:
         - Agents
       security:

--- a/spec/openapi/bundled.yaml
+++ b/spec/openapi/bundled.yaml
@@ -1685,7 +1685,7 @@ paths:
         Used by the dashboard to populate channel pickers for Slack actions.
 
         Requires session authentication (Supabase JWT). The agent must belong to the current user.
-        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+        Listing uses the connected Slack user OAuth token; channel visibility follows Slack's token scoping (same model as `slack.list_channels`).
       tags:
         - Agents
       security:

--- a/spec/openapi/components/paths/agent_connectors.yaml
+++ b/spec/openapi/components/paths/agent_connectors.yaml
@@ -480,7 +480,7 @@ agentConnectorChannels:
       Used by the dashboard to populate channel pickers for Slack actions.
 
       Requires session authentication (Supabase JWT). The agent must belong to the current user.
-      Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+      Listing uses the connected Slack user OAuth token; channel visibility follows Slack's token scoping (same model as `slack.list_channels`).
 
     tags:
       - Agents

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -1698,7 +1698,7 @@ paths:
         Used by the dashboard to populate channel pickers for Slack actions.
 
         Requires session authentication (Supabase JWT). The agent must belong to the current user.
-        Private channels and DMs require the user's profile email to match their Slack account (same rules as `slack.list_channels`).
+        Listing uses the connected Slack user OAuth token; channel visibility follows Slack's token scoping (same model as `slack.list_channels`).
       tags:
         - Agents
       security:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1036

## Direction (Option A)

Simplified **user-token-only** channel listing: `conversations.list` is the primary source; `users.conversations` runs when private types are requested and only **adds** channels whose IDs were not already returned. Removed `users.lookupByEmail` and the private/DM **intersection** with the merge set (no more `userEmail` gates for listing).

`listChannelEntryMatchesTypes` remains so mis-honored `types` on `conversations.list` still cannot leak public channels into an `im`-only request (#1028). Regressions for empty `users.conversations` + DMs from `conversations.list` (#1033) and merge-supplied DMs when `conversations.list` is wrong-type-only (#1031 scenario) stay covered by tests.

## Assumptions (from the issue)

- **1:1 OAuth:** Each Slack connection is stored per Permission Slip user; credentials are not shared across users (existing platform model).
- **User token:** Production Slack connections use a user OAuth access token (`xoxp-`); the connector README already documents user-OAuth-only.
- **Listing safety:** For listing, we rely on Slack scoping both `conversations.list` and `users.conversations` to the token owner. The merge is a **correctness** supplement (missing rows), not a cross-user guard. Read/search paths still use their existing membership checks where applicable.

## Docs / API copy

- `connectors/slack/README.md` — `slack.list_channels` section and short “listing vs identity” note.
- `connectors/slack/manifest.go` — action + template descriptions.
- OpenAPI `agentConnectorChannels` description (bundled artifacts + `frontend/src/api/bundled.yaml` kept in sync).

## Test plan

- [ ] `make test-backend` (Go tests including `connectors/slack/...`) — **not run in this agent environment** (full module graph); CI should run them.
- [ ] If desired: spot-check dashboard Slack channel picker still lists expected channels for a connected account.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a25934c-821d-4a58-88b5-dab2b2b6c178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a25934c-821d-4a58-88b5-dab2b2b6c178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

