### PR TITLE
fix(slack): import connectors in list_channels_merged

### DIFF
--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -2,6 +2,8 @@ package slack
 
 import (
 	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
 // listChannelsMerged lists Slack channels for the user OAuth token (xoxp-).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add the missing `github.com/supersuit-tech/permission-slip/connectors` import in `list_channels_merged.go` so `connectors.Credentials` resolves and the Slack package compiles again.

## Related Issue

N/A (CI compile failure from undefined `connectors`).

## Test Plan

### Developer

- [ ] Unit tests added / updated — not required (import-only fix).
- [x] `gofmt -w` and `gofmt -e` on the changed file pass locally.
- [ ] `make test` — not run in this environment (Go module graph / toolchain constraints); CI should validate `make test-backend`.

### Manual Testing

- [ ] N/A

## Notes for Reviewers

Backend tests were not executed locally here; this change only adds the same import pattern used by `list_channels.go` and other Slack connector files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60164907-a6eb-4826-9e3f-b82df1f652fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60164907-a6eb-4826-9e3f-b82df1f652fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

