### PR TITLE
fix(slack): add missing connectors import in channel_membership

### DIFF
--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -3,6 +3,8 @@ package slack
 import (
 	"context"
 	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
 // usersConversationsRequest is the Slack API request for users.conversations.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`connectors/slack/channel_membership.go` used `connectors.Credentials` in `getUserPrivateConversations` without importing `github.com/supersuit-tech/permission-slip/connectors`, causing `undefined: connectors` and failing backend CI.

## Test plan

- [ ] Confirm `Backend Tests` workflow passes on this PR.
- Local `go test` was not run in this environment (module graph / toolchain constraints); CI is the source of truth for compilation and tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55c83a35-d3fc-4f99-aedc-8b33c7f81b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55c83a35-d3fc-4f99-aedc-8b33c7f81b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

