### PR TITLE
slack: verify DM membership before read_channel_messages / read_thread

### DIFF
--- a/connectors/slack/dm_read_guard.go
+++ b/connectors/slack/dm_read_guard.go
@@ -1,0 +1,110 @@
+package slack
+
+import (
+	"context"
+	neturl "net/url"
+	"slices"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// ensureUserCanReadDMChannel verifies that the Permission Slip user (identified
+// by email) is a member of the Slack DM channel before history/replies calls.
+// Slack scopes conversations.history to participants; this check fails fast
+// with a clear error when the token owner is not the same person as the
+// Permission Slip caller (e.g. delegated tokens). For non-D channels or when no
+// email is provided, this is a no-op.
+func (c *SlackConnector) ensureUserCanReadDMChannel(ctx context.Context, creds connectors.Credentials, channelID, permissionSlipUserEmail string) error {
+	if len(channelID) == 0 || channelID[0] != 'D' {
+		return nil
+	}
+	email := strings.TrimSpace(permissionSlipUserEmail)
+	if email == "" {
+		return nil
+	}
+
+	slackUserID, err := c.lookupSlackUserIDByEmail(ctx, creds, email)
+	if err != nil {
+		return err
+	}
+	member, err := c.slackUserIsConversationMember(ctx, creds, channelID, slackUserID)
+	if err != nil {
+		return err
+	}
+	if !member {
+		return &connectors.AuthError{
+			Message: "Slack user for this Permission Slip account is not a member of this DM; re-authorize Slack as the user who should read this conversation, or open the correct DM channel ID.",
+		}
+	}
+	return nil
+}
+
+type usersLookupByEmailResponse struct {
+	slackResponse
+	User *struct {
+		ID string `json:"id"`
+	} `json:"user,omitempty"`
+}
+
+func (c *SlackConnector) lookupSlackUserIDByEmail(ctx context.Context, creds connectors.Credentials, email string) (string, error) {
+	token, err := c.getToken(creds)
+	if err != nil {
+		return "", err
+	}
+	q := neturl.Values{}
+	q.Set("email", email)
+	fullURL := c.baseURL + "/users.lookupByEmail?" + q.Encode()
+
+	var resp usersLookupByEmailResponse
+	if err := c.doGetURL(ctx, fullURL, token, &resp); err != nil {
+		return "", err
+	}
+	if !resp.OK {
+		return "", resp.asError()
+	}
+	if resp.User == nil || resp.User.ID == "" {
+		return "", &connectors.ExternalError{StatusCode: 200, Message: "Slack users.lookupByEmail returned ok=true but no user id"}
+	}
+	return resp.User.ID, nil
+}
+
+type conversationsMembersRequest struct {
+	Channel string `json:"channel"`
+	Limit   int    `json:"limit,omitempty"`
+	Cursor  string `json:"cursor,omitempty"`
+}
+
+type conversationsMembersResponse struct {
+	slackResponse
+	Members []string        `json:"members,omitempty"`
+	Meta    *paginationMeta `json:"response_metadata,omitempty"`
+}
+
+const maxConversationMemberPages = 50
+
+func (c *SlackConnector) slackUserIsConversationMember(ctx context.Context, creds connectors.Credentials, channelID, slackUserID string) (bool, error) {
+	cursor := ""
+	for page := 0; page < maxConversationMemberPages; page++ {
+		body := conversationsMembersRequest{
+			Channel: channelID,
+			Limit:   200,
+			Cursor:  cursor,
+		}
+		var resp conversationsMembersResponse
+		if err := c.doPost(ctx, "conversations.members", creds, body, &resp); err != nil {
+			return false, err
+		}
+		if !resp.OK {
+			return false, resp.asError()
+		}
+		if slices.Contains(resp.Members, slackUserID) {
+			return true, nil
+		}
+		if resp.Meta == nil || resp.Meta.NextCursor == "" {
+			return false, nil
+		}
+		cursor = resp.Meta.NextCursor
+	}
+	return false, nil
+}

--- a/connectors/slack/read_channel_messages.go
+++ b/connectors/slack/read_channel_messages.go
@@ -74,6 +74,10 @@ func (a *readChannelMessagesAction) Execute(ctx context.Context, req connectors.
 		body.Limit = 20
 	}
 
+	if err := a.conn.ensureUserCanReadDMChannel(ctx, req.Credentials, params.Channel, req.UserEmail); err != nil {
+		return nil, err
+	}
+
 	var resp messagesResponse
 	if err := a.conn.doPost(ctx, "conversations.history", req.Credentials, body, &resp); err != nil {
 		return nil, err

--- a/connectors/slack/read_thread.go
+++ b/connectors/slack/read_thread.go
@@ -60,6 +60,10 @@ func (a *readThreadAction) Execute(ctx context.Context, req connectors.ActionReq
 		body.Limit = 50
 	}
 
+	if err := a.conn.ensureUserCanReadDMChannel(ctx, req.Credentials, params.Channel, req.UserEmail); err != nil {
+		return nil, err
+	}
+
 	var resp messagesResponse
 	if err := a.conn.doPost(ctx, "conversations.replies", req.Credentials, body, &resp); err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI was failing on `TestReadChannelMessages_DMUsesAccessTokenForMembersAndHistory` because `slack.read_channel_messages` only called `conversations.history` and never hit `users.lookupByEmail` or `conversations.members`.

For **D-channel** reads when **`UserEmail`** is set (Permission Slip caller identity), we now:

1. Resolve the Slack user with **GET `users.lookupByEmail`** (Bearer `access_token`).
2. Paginate **POST `conversations.members`** until the resolved user appears (or the member list is exhausted).
3. If they are not a member, return an **`AuthError`** with a message that points to re-authorizing as the correct Slack user or using the right DM id.
4. If **`UserEmail`** is empty, we skip this path so reading your own DMs (token owner) stays a single `conversations.history` / `conversations.replies` call as before.

The same guard runs for **`slack.read_thread`** on D-channels with email, matching `TestReadThread_DMUsesAccessTokenForReplies`.

## Test plan

- [ ] `go test ./connectors/slack/...` (full `go test ./...` in CI)
- Local agent environment could not run `go test` (toolchain vs `go.mod`); relying on GitHub Actions for the compile + test pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c079412-e361-4d18-811a-b5fba4b47b56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c079412-e361-4d18-811a-b5fba4b47b56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

