### PR TITLE
Slack: surface silent scope gap that made list_channels types=im empty

### DIFF
--- a/connectors/slack/channel_membership.go
+++ b/connectors/slack/channel_membership.go
@@ -310,3 +310,33 @@ func filterPrivateTypes(types string) string {
 	}
 	return strings.Join(private, ",")
 }
+
+// requiredPrivateTypeScopes returns the user-token OAuth scopes required to
+// enumerate the caller's own conversations for the given comma-separated types.
+// Slack's users.conversations silently returns an empty channel list (with
+// ok=true, no error) when the token lacks the scope for a requested type,
+// instead of returning missing_scope — so we have to verify scopes up front
+// to distinguish "user has no DMs" from "token can't see DMs". See #1033.
+func requiredPrivateTypeScopes(types string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, raw := range strings.Split(types, ",") {
+		t := strings.TrimSpace(raw)
+		var scope string
+		switch t {
+		case "im":
+			scope = "im:read"
+		case "mpim":
+			scope = "mpim:read"
+		case "private_channel":
+			scope = "groups:read"
+		default:
+			continue
+		}
+		if !seen[scope] {
+			seen[scope] = true
+			out = append(out, scope)
+		}
+	}
+	return out
+}

--- a/connectors/slack/helpers_test.go
+++ b/connectors/slack/helpers_test.go
@@ -1,10 +1,40 @@
 package slack
 
-import "github.com/supersuit-tech/permission-slip/connectors"
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
 
 // validCreds returns a Credentials value with a valid user OAuth token for tests.
 func validCreds() connectors.Credentials {
 	return connectors.NewCredentials(map[string]string{
 		"access_token": "xoxp-test-token-123",
+	})
+}
+
+// testFullSlackScopes is a comma-separated list of user-token scopes that
+// satisfies every scope check in this package. Tests that don't care about
+// scope validation pass this to writeAuthTestResponse so the scope probe
+// (see #1033) doesn't false-positive and block their code path.
+const testFullSlackScopes = "channels:read,channels:history,groups:read,groups:history,im:read,im:history,mpim:read,mpim:history,users:read,users:read.email"
+
+// writeAuthTestResponse writes a minimal auth.test response with the given
+// comma-separated X-OAuth-Scopes header. Tests mock /auth.test with this
+// helper so the scope probe added for #1033 sees the expected granted
+// scopes and proceeds to the code path under test.
+func writeAuthTestResponse(w http.ResponseWriter, scopes string) {
+	if scopes != "" {
+		w.Header().Set("X-OAuth-Scopes", scopes)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":      true,
+		"url":     "https://example.slack.com/",
+		"team":    "Example",
+		"user":    "caller",
+		"team_id": "T_TEST",
+		"user_id": "U_CALLER",
 	})
 }

--- a/connectors/slack/list_channels_dm_merge_test.go
+++ b/connectors/slack/list_channels_dm_merge_test.go
@@ -13,6 +13,12 @@ func TestListChannels_MergesHumanDMNotVisibleToBot(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.lookupByEmail":

--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -43,6 +43,22 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 				}
 			}
 			privateTypes := filterPrivateTypes(types)
+			// Verify the user token actually has the scopes needed to enumerate
+			// the requested private types. Slack's users.conversations silently
+			// returns {"ok":true,"channels":[]} when the token lacks im:read /
+			// mpim:read / groups:read instead of returning missing_scope, so we
+			// have to probe scopes up front to surface that failure mode (#1033).
+			if required := requiredPrivateTypeScopes(privateTypes); len(required) > 0 {
+				granted, err := c.probeGrantedScopes(ctx, creds)
+				if err != nil {
+					return nil, fmt.Errorf("verifying Slack OAuth scopes: %w", err)
+				}
+				if missing := missingScopes(granted, required...); len(missing) > 0 {
+					return nil, &connectors.AuthError{
+						Message: fmt.Sprintf("Slack token is missing OAuth scope(s) %s required to list %s — re-authorize the Slack connection to grant them", strings.Join(missing, ", "), privateTypes),
+					}
+				}
+			}
 			userPrivateChs, err := c.getUserPrivateConversations(ctx, creds, privateTypes)
 			if err != nil {
 				return nil, fmt.Errorf("fetching user channel memberships: %w", err)

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
@@ -109,6 +110,12 @@ func TestListChannels_DefaultTypes(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
@@ -195,6 +202,12 @@ func TestListChannels_IMChannels(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
@@ -481,6 +494,12 @@ func TestListChannels_IMFiltersStrayPublicChannels(t *testing.T) {
 	// im:read scope it silently falls back instead of erroring). The merged
 	// result must still honor the requested types and exclude public channels.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
@@ -589,6 +608,12 @@ func TestListChannels_IMReturnsUserDMsWhenConversationsListEmpty(t *testing.T) {
 	// empty, even though the caller has DMs. The fix is to omit `user` on
 	// user-token calls so Slack returns the token owner's conversations.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
@@ -655,5 +680,175 @@ func TestListChannels_IMReturnsUserDMsWhenConversationsListEmpty(t *testing.T) {
 	}
 	if data.Channels[0].User != "U_PETER" {
 		t.Errorf("expected user U_PETER, got %q", data.Channels[0].User)
+	}
+}
+
+// TestListChannels_IMReturnsClearErrorWhenScopeMissing is the regression for
+// issue #1033. When the user token lacks im:read, Slack's users.conversations
+// silently returns {"ok":true,"channels":[]} instead of a missing_scope error,
+// and conversations.list falls back to public channels that get filtered out —
+// so the user saw an empty result with no hint that re-authorization was
+// needed. The scope probe must surface this as an AuthError naming im:read.
+func TestListChannels_IMReturnsClearErrorWhenScopeMissing(t *testing.T) {
+	t.Parallel()
+
+	var authTestHit, usersConversationsHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/auth.test":
+			authTestHit = true
+			// Token missing im:read — mirrors the real-world failure where
+			// the OAuth install didn't grant the scope but the token is
+			// otherwise valid.
+			writeAuthTestResponse(w, "users:read,users:read.email,channels:read,mpim:read")
+		case "/users.conversations":
+			usersConversationsHit = true
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected AuthError when im:read is missing, got nil")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "im:read") {
+		t.Errorf("expected error to name the missing scope im:read, got %q", err.Error())
+	}
+	if !authTestHit {
+		t.Error("expected auth.test probe to be called")
+	}
+	if usersConversationsHit {
+		t.Error("users.conversations must not be called after scope check fails")
+	}
+}
+
+// TestListChannels_IMSucceedsWhenScopesPresent is the positive counterpart to
+// TestListChannels_IMReturnsClearErrorWhenScopeMissing: when X-OAuth-Scopes
+// includes im:read and users:read.email, the scope probe must pass and the
+// merge must return the DM. Regression guard against the new check blocking
+// the happy path.
+func TestListChannels_IMSucceedsWhenScopesPresent(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			writeAuthTestResponse(w, "im:read,mpim:read,groups:read,users:read,users:read.email,channels:read")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "D_PETER", "user": "U_PETER", "is_private": true},
+				},
+			})
+		case "/conversations.list":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "channels": []any{}})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var data listChannelsResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(data.Channels) != 1 || data.Channels[0].ID != "D_PETER" {
+		t.Fatalf("expected D_PETER in result, got %+v", data.Channels)
+	}
+}
+
+// TestListChannels_IMScopeCheckIgnoresMissingHeader guards against false
+// positives: when X-OAuth-Scopes is absent (e.g. a test stub or a Slack
+// response variant), we must not block the call — missingScopes returns
+// nil in that case and the merge proceeds normally.
+func TestListChannels_IMScopeCheckIgnoresMissingHeader(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth.test":
+			// No X-OAuth-Scopes header — pass "" to writeAuthTestResponse.
+			writeAuthTestResponse(w, "")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]string{"id": "U_CALLER"},
+			})
+		case "/users.conversations":
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "D_PETER", "user": "U_PETER", "is_private": true},
+				},
+			})
+		case "/conversations.list":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true, "channels": []any{}})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listChannelsAction{conn: conn}
+	params, _ := json.Marshal(listChannelsParams{Types: "im"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_channels",
+		Parameters:  params,
+		Credentials: validCreds(),
+		UserEmail:   "user@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error when X-OAuth-Scopes is absent: %v", err)
 	}
 }

--- a/connectors/slack/list_unread.go
+++ b/connectors/slack/list_unread.go
@@ -2,6 +2,8 @@ package slack
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
@@ -57,6 +59,23 @@ func (a *listUnreadAction) Execute(ctx context.Context, req connectors.ActionReq
 	}
 
 	types := "public_channel,private_channel,mpim,im"
+
+	// Verify the user token has the scopes needed to enumerate private
+	// conversations. Slack's users.conversations silently returns an empty
+	// channel list when the token lacks im:read / mpim:read / groups:read
+	// instead of returning missing_scope — same failure mode as #1033.
+	privateTypes := filterPrivateTypes(types)
+	if required := requiredPrivateTypeScopes(privateTypes); len(required) > 0 {
+		granted, scopeErr := a.conn.probeGrantedScopes(ctx, req.Credentials)
+		if scopeErr != nil {
+			return nil, fmt.Errorf("verifying Slack OAuth scopes: %w", scopeErr)
+		}
+		if missing := missingScopes(granted, required...); len(missing) > 0 {
+			return nil, &connectors.AuthError{
+				Message: fmt.Sprintf("Slack token is missing OAuth scope(s) %s required to list unread conversations — re-authorize the Slack connection to grant them", strings.Join(missing, ", ")),
+			}
+		}
+	}
 	var entries []unreadChannelEntry
 	cursor := ""
 	for page := 0; page < maxUserConversationPages; page++ {

--- a/connectors/slack/list_unread_test.go
+++ b/connectors/slack/list_unread_test.go
@@ -34,6 +34,10 @@ func TestListUnread_NoUnreads(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.lookupByEmail":
@@ -95,6 +99,10 @@ func TestListUnread_MixedTypes_WithPreview(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.lookupByEmail":
@@ -216,6 +224,10 @@ func TestListUnread_EmptyChannelList(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.lookupByEmail":
@@ -251,6 +263,10 @@ func TestListUnread_MissingLatestOmitsPreview(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.lookupByEmail":
@@ -302,6 +318,10 @@ func TestListUnread_RateLimitOnInfo(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
 		switch r.URL.Path {
 		case "/users.lookupByEmail":
 			w.Header().Set("Content-Type", "application/json")
@@ -344,6 +364,10 @@ func TestListUnread_PaginatesUsersConversations(t *testing.T) {
 
 	page := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth.test" {
+			writeAuthTestResponse(w, testFullSlackScopes)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.lookupByEmail":
@@ -405,5 +429,54 @@ func TestListUnread_PaginatesUsersConversations(t *testing.T) {
 	_ = json.Unmarshal(res.Data, &out)
 	if len(out.UnreadChannels) != 1 || out.UnreadChannels[0].ChannelID != "C2" {
 		t.Fatalf("expected single unread on C2, got %+v", out.UnreadChannels)
+	}
+}
+
+// TestListUnread_ReturnsClearErrorWhenScopeMissing mirrors the list_channels
+// scope-probe regression (#1033) for list_unread, which uses the same
+// users.conversations call pattern and the same silent-empty failure mode
+// when im:read / mpim:read are missing.
+func TestListUnread_ReturnsClearErrorWhenScopeMissing(t *testing.T) {
+	t.Parallel()
+
+	var usersConversationsHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/users.lookupByEmail":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U1"},
+			})
+		case "/auth.test":
+			writeAuthTestResponse(w, "users:read,users:read.email,channels:read")
+		case "/users.conversations":
+			usersConversationsHit = true
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &listUnreadAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.list_unread",
+		Parameters:  []byte(`{}`),
+		Credentials: validCreds(),
+		UserEmail:   "a@b.com",
+	})
+	if err == nil {
+		t.Fatal("expected AuthError for missing scopes, got nil")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "im:read") {
+		t.Errorf("expected error to name missing im:read scope, got %q", err.Error())
+	}
+	if usersConversationsHit {
+		t.Error("users.conversations must not be called after scope check fails")
 	}
 }

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -108,7 +108,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "string",
 							"default": "public_channel,private_channel,mpim,im",
 							"enum": ["public_channel", "private_channel", "mpim", "im"],
-							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types when a user email is available; falls back to public_channel only when no email is set. im/mpim/private_channel results are filtered to the authorizing user; user-token merge fills in human-only DMs when configured.",
+							"description": "Comma-separated channel types: public_channel, private_channel, mpim, im. Defaults to all types when a user email is available; falls back to public_channel only when no email is set. im/mpim/private_channel results are filtered to the authorizing user; requires user-scope OAuth grants im:read (DMs), mpim:read (group DMs), groups:read (private channels), and users:read.email on the Slack connection.",
 							"x-ui": {"label": "Channel types", "widget": "multi-select", "help_text": "public_channel, private_channel, mpim (group DMs), im (direct messages)"}
 						},
 						"limit": {

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -159,6 +159,40 @@ func (r slackResponse) asError() error {
 	return mapSlackError(r.Error)
 }
 
+// grantedScopes parses Slack's X-OAuth-Scopes response header into a set.
+// Slack returns granted scopes as a comma-separated list on every API
+// response, so any endpoint (e.g. auth.test) can be used as a probe.
+// Returns nil when the header is absent.
+func grantedScopes(h http.Header) map[string]bool {
+	raw := h.Get("X-OAuth-Scopes")
+	if raw == "" {
+		return nil
+	}
+	scopes := make(map[string]bool)
+	for _, s := range strings.Split(raw, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			scopes[s] = true
+		}
+	}
+	return scopes
+}
+
+// missingScopes returns the subset of required scopes not present in granted.
+// Returns nil when granted is nil (header was absent) so callers don't
+// produce false positives against non-Slack test servers or mocks.
+func missingScopes(granted map[string]bool, required ...string) []string {
+	if granted == nil {
+		return nil
+	}
+	var missing []string
+	for _, s := range required {
+		if !granted[s] {
+			missing = append(missing, s)
+		}
+	}
+	return missing
+}
+
 // validatable is implemented by action param structs to validate their fields.
 type validatable interface {
 	validate() error
@@ -268,24 +302,51 @@ func (c *SlackConnector) getToken(creds connectors.Credentials) (string, error) 
 	return "", &connectors.ValidationError{Message: "credential is missing: access_token"}
 }
 
+// probeGrantedScopes calls auth.test and returns the scopes granted to the
+// current user token, parsed from the X-OAuth-Scopes response header. auth.test
+// works with any valid token so it's a safe probe. Used to detect silent scope
+// gaps before calling endpoints (like users.conversations) that return empty
+// results instead of missing_scope errors. See #1033.
+func (c *SlackConnector) probeGrantedScopes(ctx context.Context, creds connectors.Credentials) (map[string]bool, error) {
+	var resp slackResponse
+	header, err := c.doPostWithHeaders(ctx, "auth.test", creds, struct{}{}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, resp.asError()
+	}
+	return grantedScopes(header), nil
+}
+
 // doPost is the shared request lifecycle for all Slack actions. It marshals
 // body as JSON, sends a POST to the given Slack API method with auth headers,
 // handles rate limiting and timeouts, and unmarshals the response into dest.
 // Callers are responsible for checking the Slack-level ok/error fields in dest.
 func (c *SlackConnector) doPost(ctx context.Context, method string, creds connectors.Credentials, body any, dest any) error {
+	_, err := c.doPostWithHeaders(ctx, method, creds, body, dest)
+	return err
+}
+
+// doPostWithHeaders is doPost that also returns the response headers. Used by
+// callers that need to inspect X-OAuth-Scopes (granted token scopes) to detect
+// silent scope gaps — Slack returns {"ok":true, "channels":[]} from endpoints
+// like users.conversations when the token lacks im:read / mpim:read instead of
+// a missing_scope error. See issue #1033.
+func (c *SlackConnector) doPostWithHeaders(ctx context.Context, method string, creds connectors.Credentials, body any, dest any) (http.Header, error) {
 	token, err := c.getToken(creds)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	payload, err := json.Marshal(body)
 	if err != nil {
-		return fmt.Errorf("marshaling request body: %w", err)
+		return nil, fmt.Errorf("marshaling request body: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/"+method, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
@@ -293,35 +354,35 @@ func (c *SlackConnector) doPost(ctx context.Context, method string, creds connec
 	resp, err := c.client.Do(req)
 	if err != nil {
 		if connectors.IsTimeout(err) {
-			return &connectors.TimeoutError{Message: fmt.Sprintf("Slack API request timed out: %v", err)}
+			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Slack API request timed out: %v", err)}
 		}
 		if errors.Is(err, context.Canceled) {
-			return &connectors.CanceledError{Message: "Slack API request canceled"}
+			return nil, &connectors.CanceledError{Message: "Slack API request canceled"}
 		}
-		return &connectors.ExternalError{Message: fmt.Sprintf("Slack API request failed: %v", err)}
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Slack API request failed: %v", err)}
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
-		return &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+		return resp.Header, &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
 	}
 
 	// Handle HTTP-level errors before attempting JSON unmarshal.
 	// Slack normally returns 200 with {"ok": false} for app-level errors,
 	// but can return non-200 for rate limits, auth failures, and server errors.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return checkHTTPStatus(resp.StatusCode, resp.Header, respBody)
+		return resp.Header, checkHTTPStatus(resp.StatusCode, resp.Header, respBody)
 	}
 
 	if err := json.Unmarshal(respBody, dest); err != nil {
-		return &connectors.ExternalError{
+		return resp.Header, &connectors.ExternalError{
 			StatusCode: resp.StatusCode,
 			Message:    "failed to decode Slack API response",
 		}
 	}
 
-	return nil
+	return resp.Header, nil
 }
 
 // Post and Get expose the Slack Web API request lifecycle for helpers in

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -402,3 +402,68 @@ func TestValidateMessageTS(t *testing.T) {
 		})
 	}
 }
+
+func TestGrantedScopes(t *testing.T) {
+	t.Parallel()
+
+	h := http.Header{}
+	if got := grantedScopes(h); got != nil {
+		t.Errorf("missing header should return nil, got %v", got)
+	}
+
+	h.Set("X-OAuth-Scopes", "im:read, users:read.email ,channels:read,")
+	got := grantedScopes(h)
+	for _, want := range []string{"im:read", "users:read.email", "channels:read"} {
+		if !got[want] {
+			t.Errorf("expected scope %q in %v", want, got)
+		}
+	}
+	if got[""] {
+		t.Error("empty scope entries must not be kept")
+	}
+}
+
+func TestMissingScopes(t *testing.T) {
+	t.Parallel()
+
+	if got := missingScopes(nil, "im:read"); got != nil {
+		t.Errorf("nil granted header must return nil (no false positives), got %v", got)
+	}
+	granted := map[string]bool{"im:read": true, "users:read.email": true}
+	if got := missingScopes(granted, "im:read"); len(got) != 0 {
+		t.Errorf("expected no missing, got %v", got)
+	}
+	got := missingScopes(granted, "im:read", "mpim:read", "groups:read")
+	if len(got) != 2 || got[0] != "mpim:read" || got[1] != "groups:read" {
+		t.Errorf("expected [mpim:read groups:read], got %v", got)
+	}
+}
+
+func TestRequiredPrivateTypeScopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		types string
+		want  []string
+	}{
+		{"", nil},
+		{"public_channel", nil},
+		{"im", []string{"im:read"}},
+		{"mpim", []string{"mpim:read"}},
+		{"private_channel", []string{"groups:read"}},
+		{"im,mpim,private_channel", []string{"im:read", "mpim:read", "groups:read"}},
+		{"im, im ,im", []string{"im:read"}}, // dedupe
+	}
+	for _, tt := range tests {
+		got := requiredPrivateTypeScopes(tt.types)
+		if len(got) != len(tt.want) {
+			t.Errorf("requiredPrivateTypeScopes(%q) = %v, want %v", tt.types, got, tt.want)
+			continue
+		}
+		for i, s := range tt.want {
+			if got[i] != s {
+				t.Errorf("requiredPrivateTypeScopes(%q)[%d] = %q, want %q", tt.types, i, got[i], s)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Third patch for `slack.list_channels types=im` returning empty. #1029 and #1032 fixed two real bugs but the reporter is still getting `{"channels":[]}` in two workspaces. Re-reading the flow in `list_channels_merged.go` uncovered a third failure mode that neither earlier patch could see.

### Why the two prior fixes aren't enough

When the user-token is missing `im:read` / `mpim:read`, Slack's `users.conversations` silently returns `{"ok":true,"channels":[]}` — not `missing_scope`. `conversations.list` then falls back to public channels, which #1029 correctly filters out when `types=im`. Net result: empty array, no error, no hint that the user should re-authorize. The reporter's workspace-wide effect (both Innovation Hub and Supersuit) strongly implies an install-time scope gap rather than "no DMs".

Cross-reference: `connectors/slack/list_channels_merged.go:36-56` is the path where we successfully resolve `slackUserID` and then silently accept an empty DM list.

### Fix

Probe the granted scopes via `auth.test` before calling `users.conversations`. Slack includes the token's actual scopes in the `X-OAuth-Scopes` response header on every API call. If the token is missing the scope required for any requested private type, return a typed `AuthError` that names the missing scopes so the user knows to re-authorize.

- New private helpers in `connectors/slack/slack.go`:
  - `doPostWithHeaders` — variant of `doPost` that exposes response headers. `doPost` now delegates to it.
  - `grantedScopes(http.Header)` — parses `X-OAuth-Scopes`.
  - `missingScopes(granted, required...)` — returns any required scopes not in granted. Returns `nil` when granted is nil (header absent) so non-Slack test stubs don't produce false positives.
  - `probeGrantedScopes(ctx, creds)` — single `auth.test` call returning the granted-scope set.
- New `requiredPrivateTypeScopes(types)` helper in `channel_membership.go`: `im`→`im:read`, `mpim`→`mpim:read`, `private_channel`→`groups:read`.
- `listChannelsMerged` (in `list_channels_merged.go`) probes scopes after the email lookup succeeds but before `getUserPrivateConversations`. Only fires when private types are requested and `userEmail` is present — no overhead for public-only or no-email calls.
- `list_unread.go` has the same silent-empty failure mode (same helper call). Applied the same guard.
- Updated the `slack.list_channels` `types` parameter description in `manifest.go` to name the required user scopes (`im:read`, `mpim:read`, `groups:read`, `users:read.email`) so the dependency is documented in UI-facing copy.

### Test plan

- [ ] CI: `go test ./connectors/slack/...` — sandbox can't run Go tests (Go 1.24.7 vs. `cloud.google.com/go/bigquery` 1.25+ per CLAUDE.md "Sandbox limitations"), relying on CI for backend verification. `gofmt -e` passes on every changed file.
- [ ] New regression tests:
  - `TestListChannels_IMReturnsClearErrorWhenScopeMissing` — reproduces the reported scenario (lookup succeeds, `auth.test` returns scopes without `im:read`) and asserts a clear `AuthError` naming the missing scope.
  - `TestListChannels_IMSucceedsWhenScopesPresent` — positive regression guard so the new check doesn't block the happy path.
  - `TestListChannels_IMScopeCheckIgnoresMissingHeader` — no false positives when `X-OAuth-Scopes` is absent (test stubs, Slack response variants).
  - `TestListUnread_ReturnsClearErrorWhenScopeMissing` — mirror for list_unread.
  - Unit tests for `grantedScopes`, `missingScopes`, `requiredPrivateTypeScopes` in `slack_test.go`.
- [ ] Existing tests that reach the DM merge path updated to mock `/auth.test` via a shared `writeAuthTestResponse` helper (in `helpers_test.go`) so the new scope probe sees full scopes and the tests exercise the code path they originally targeted.
- [ ] Post-merge manual repro against reporter's workspace:
  ```
  npx tsx src/index.ts request \
    --action slack.list_channels \
    --params '{"types":"im","connector_instance":"617eab67-bfa7-4f51-a26a-96e4b89ef455"}' \
    --agent-id 3 --pretty
  ```
  Expected outcome: either (a) an `AuthError` naming the missing scope(s) — reporter re-authorizes the Slack connection, DMs appear on the next run; or (b) if all required scopes are already granted, the check passes silently and the DM list is returned (eliminating the missing-scope hypothesis and pointing to a different root cause).
- [ ] Confirm `slack.list_unread` still works for users with full scopes.

Closes #1033