### PR TITLE
fix(slack): handle null message text from Slack API

### DIFF
--- a/connectors/slack/context/fetch_helpers.go
+++ b/connectors/slack/context/fetch_helpers.go
@@ -24,7 +24,7 @@ type RecentMessagesOpts struct {
 }
 
 func messageToContextMessage(ctx context.Context, api SlackAPI, creds connectors.Credentials, teamDomain, channelID string, msg slackMessage, mcache *MentionCache) (ContextMessage, error) {
-	text := msg.Text
+	text := msg.Text.String()
 	resolved, err := ResolveMentions(ctx, text, api, creds, mcache)
 	if err != nil {
 		return ContextMessage{}, err

--- a/connectors/slack/context/nullable_slack_text.go
+++ b/connectors/slack/context/nullable_slack_text.go
@@ -1,0 +1,25 @@
+package context
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// slackNullableText unmarshals JSON null as empty string. Slack sometimes
+// returns "text": null on messages that use only blocks/attachments.
+type slackNullableText string
+
+func (t *slackNullableText) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*t = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*t = slackNullableText(s)
+	return nil
+}
+
+func (t slackNullableText) String() string { return string(t) }

--- a/connectors/slack/context/nullable_slack_text_test.go
+++ b/connectors/slack/context/nullable_slack_text_test.go
@@ -1,0 +1,17 @@
+package context
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSlackNullableText_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	var got slackNullableText
+	if err := json.Unmarshal([]byte(`null`), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.String() != "" {
+		t.Errorf("null → %q, want empty", got.String())
+	}
+}

--- a/connectors/slack/context/slack_api.go
+++ b/connectors/slack/context/slack_api.go
@@ -13,13 +13,13 @@ type paginationMeta struct {
 
 // slackMessage is the subset of a Slack message object used for context.
 type slackMessage struct {
-	Type     string      `json:"type"`
-	User     string      `json:"user,omitempty"`
-	BotID    string      `json:"bot_id,omitempty"`
-	Text     string      `json:"text"`
-	TS       string      `json:"ts"`
-	ThreadTS string      `json:"thread_ts,omitempty"`
-	Files    []slackFile `json:"files,omitempty"`
+	Type     string            `json:"type"`
+	User     string            `json:"user,omitempty"`
+	BotID    string            `json:"bot_id,omitempty"`
+	Text     slackNullableText `json:"text"`
+	TS       string            `json:"ts"`
+	ThreadTS string            `json:"thread_ts,omitempty"`
+	Files    []slackFile       `json:"files,omitempty"`
 }
 
 type slackFile struct {

--- a/connectors/slack/events.go
+++ b/connectors/slack/events.go
@@ -38,13 +38,13 @@ type slackEventEnvelope struct {
 
 // slackInnerEvent is the inner event structure within an event_callback.
 type slackInnerEvent struct {
-	Type        string `json:"type"`
-	ChannelType string `json:"channel_type"` // "im", "mpim", "channel", "group"
-	Channel     string `json:"channel"`
-	User        string `json:"user"`
-	Text        string `json:"text"`
-	TS          string `json:"ts"`
-	BotID       string `json:"bot_id,omitempty"`
+	Type        string            `json:"type"`
+	ChannelType string            `json:"channel_type"` // "im", "mpim", "channel", "group"
+	Channel     string            `json:"channel"`
+	User        string            `json:"user"`
+	Text        slackNullableText `json:"text"`
+	TS          string            `json:"ts"`
+	BotID       string            `json:"bot_id,omitempty"`
 }
 
 // IMMessagePayload is the typed payload for message.im events.
@@ -92,7 +92,7 @@ func (c *SlackConnector) VerifyAndParseEvent(payload []byte, headers http.Header
 		p := IMMessagePayload{
 			User:      inner.User,
 			Channel:   inner.Channel,
-			Text:      inner.Text,
+			Text:      inner.Text.String(),
 			Timestamp: inner.TS,
 		}
 		var marshalErr error

--- a/connectors/slack/events_test.go
+++ b/connectors/slack/events_test.go
@@ -109,6 +109,42 @@ func TestVerifyAndParseEvent_MessageIM(t *testing.T) {
 	}
 }
 
+func TestVerifyAndParseEvent_MessageIM_NullText(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	payload := []byte(`{
+		"type": "event_callback",
+		"team_id": "T01234",
+		"api_app_id": "A01234",
+		"event": {
+			"type": "message",
+			"channel_type": "im",
+			"channel": "D01234",
+			"user": "U01234",
+			"text": null,
+			"ts": "1710000000.123456"
+		},
+		"event_id": "EvNullText",
+		"event_time": 1710000000
+	}`)
+	headers := signPayload(t, payload, testSigningSecret)
+
+	envelope, err := conn.VerifyAndParseEvent(payload, headers, testSigningSecret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envelope.Event == nil || envelope.Event.EventType != "message.im" {
+		t.Fatalf("event: %#v", envelope.Event)
+	}
+	var msg IMMessagePayload
+	if err := json.Unmarshal(envelope.Event.Payload, &msg); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if msg.Text != "" {
+		t.Errorf("expected empty text for null, got %q", msg.Text)
+	}
+}
+
 func TestVerifyAndParseEvent_NonIMMessage(t *testing.T) {
 	conn := New()
 	payload := []byte(`{

--- a/connectors/slack/list_unread.go
+++ b/connectors/slack/list_unread.go
@@ -71,7 +71,7 @@ func (a *listUnreadAction) Execute(ctx context.Context, req connectors.ActionReq
 			var previewPtr *latestMessagePreview
 			if info.Latest != nil {
 				p := latestMessagePreview{
-					Text: truncatePreviewText(info.Latest.Text),
+					Text: truncatePreviewText(info.Latest.Text.String()),
 					User: info.Latest.User,
 					TS:   info.Latest.TS,
 				}

--- a/connectors/slack/messages.go
+++ b/connectors/slack/messages.go
@@ -3,13 +3,13 @@ package slack
 // slackMessage is the Slack API representation of a single message.
 // Used by both conversations.history and conversations.replies responses.
 type slackMessage struct {
-	Type       string `json:"type"`
-	User       string `json:"user,omitempty"`
-	BotID      string `json:"bot_id,omitempty"`
-	Text       string `json:"text"`
-	TS         string `json:"ts"`
-	ThreadTS   string `json:"thread_ts,omitempty"`
-	ReplyCount int    `json:"reply_count,omitempty"`
+	Type       string            `json:"type"`
+	User       string            `json:"user,omitempty"`
+	BotID      string            `json:"bot_id,omitempty"`
+	Text       slackNullableText `json:"text"`
+	TS         string            `json:"ts"`
+	ThreadTS   string            `json:"thread_ts,omitempty"`
+	ReplyCount int               `json:"reply_count,omitempty"`
 }
 
 // messagesResponse is the shared Slack API response shape for endpoints
@@ -50,7 +50,7 @@ func toMessagesResult(resp *messagesResponse) messagesResult {
 		result.Messages = append(result.Messages, messageSummary{
 			User:       msg.User,
 			BotID:      msg.BotID,
-			Text:       msg.Text,
+			Text:       msg.Text.String(),
 			TS:         msg.TS,
 			ThreadTS:   msg.ThreadTS,
 			ReplyCount: msg.ReplyCount,

--- a/connectors/slack/nullable_slack_text.go
+++ b/connectors/slack/nullable_slack_text.go
@@ -1,0 +1,26 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// slackNullableText unmarshals JSON null as empty string. Slack sometimes
+// returns "text": null on messages that use only blocks/attachments or when
+// the text field is absent in the serialized form the API returns.
+type slackNullableText string
+
+func (t *slackNullableText) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*t = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*t = slackNullableText(s)
+	return nil
+}
+
+func (t slackNullableText) String() string { return string(t) }

--- a/connectors/slack/nullable_slack_text_test.go
+++ b/connectors/slack/nullable_slack_text_test.go
@@ -1,0 +1,122 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestSlackNullableText_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		raw  string
+		want string
+	}{
+		{`null`, ""},
+		{`""`, ""},
+		{`"hello"`, "hello"},
+	} {
+		var got slackNullableText
+		if err := json.Unmarshal([]byte(tc.raw), &got); err != nil {
+			t.Fatalf("Unmarshal(%q): %v", tc.raw, err)
+		}
+		if got.String() != tc.want {
+			t.Errorf("Unmarshal(%q) = %q, want %q", tc.raw, got.String(), tc.want)
+		}
+	}
+}
+
+func TestReadChannelMessages_NullMessageText(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/conversations.history" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"ok": true,
+			"messages": [
+				{"type":"message","user":"U1","text":null,"ts":"1.1"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &readChannelMessagesAction{conn: conn}
+	params, _ := json.Marshal(readChannelMessagesParams{Channel: "C01234567"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.read_channel_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var data messagesResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(data.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(data.Messages))
+	}
+	if data.Messages[0].Text != "" {
+		t.Errorf("expected empty text for null slack text, got %q", data.Messages[0].Text)
+	}
+}
+
+func TestSearchMessages_NullMatchText(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/search.messages" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"ok": true,
+			"messages": {
+				"matches": [
+					{
+						"channel": {"id": "C001", "name": "general"},
+						"user": "U001",
+						"text": null,
+						"ts": "1234567890.123456"
+					}
+				],
+				"paging": {"count": 20, "total": 1, "page": 1, "pages": 1}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	conn := newForTest(srv.Client(), srv.URL)
+	action := &searchMessagesAction{conn: conn}
+	params, _ := json.Marshal(searchMessagesParams{Query: "blocks only"})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "slack.search_messages",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var data searchMessagesResult
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(data.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(data.Matches))
+	}
+	if data.Matches[0].Text != "" {
+		t.Errorf("expected empty text, got %q", data.Matches[0].Text)
+	}
+}

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -62,11 +62,11 @@ type searchMatch struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"channel"`
-	User      string `json:"user"`
-	Username  string `json:"username"`
-	Text      string `json:"text"`
-	TS        string `json:"ts"`
-	Permalink string `json:"permalink"`
+	User      string            `json:"user"`
+	Username  string            `json:"username"`
+	Text      slackNullableText `json:"text"`
+	TS        string            `json:"ts"`
+	Permalink string            `json:"permalink"`
 }
 
 type searchMessagePaging struct {
@@ -133,7 +133,7 @@ func (a *searchMessagesAction) Execute(ctx context.Context, req connectors.Actio
 			ChannelName: m.Channel.Name,
 			User:        m.User,
 			Username:    m.Username,
-			Text:        m.Text,
+			Text:        m.Text.String(),
 			TS:          m.TS,
 			Permalink:   m.Permalink,
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slack sometimes returns `"text": null` on messages (for example blocks-only or attachment-heavy payloads). Our connector unmarshaled `text` into a plain `string`, which makes `encoding/json` fail on `null` and bubbles up as `failed to decode Slack API response` → HTTP 502 (`upstream_error`) for `slack.read_channel_messages`, `slack.search_messages`, and related paths.

This change introduces a small `slackNullableText` type that unmarshals JSON `null` as an empty string, and wires it through:

- `slackMessage` (conversations.history / conversations.replies)
- `searchMatch` (search.messages)
- Slack Events API inner `message` events
- The `connectors/slack/context` copy of `slackMessage` (approval context fetches)

## Sentry

`sentry-cli` was installed locally, but this environment has no `SENTRY_AUTH_TOKEN`, so the issue could not be fetched via CLI. The stack/symptom matches JSON decode failures on Slack responses where `text` is null—consistent with 502s on search and DM read while `list_channels` still works.

## Test plan

- [x] Added unit tests: `TestReadChannelMessages_NullMessageText`, `TestSearchMessages_NullMatchText`, `TestVerifyAndParseEvent_MessageIM_NullText`, plus `TestSlackNullableText_UnmarshalJSON` in root and context packages.
- [ ] `go test ./connectors/slack/...` — not run in this agent sandbox (Go toolchain vs `go.mod`); CI should execute the full suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3eaef94-f84a-415e-a691-fdc19ad3fc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3eaef94-f84a-415e-a691-fdc19ad3fc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

