### PR TITLE
Fix CI: Slack context test compile, Actions v6, resilient notify webhook

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/permission_slip_test?sslmode=disable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -77,13 +77,13 @@ jobs:
     needs: [backend, frontend]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -143,4 +143,5 @@ jobs:
             '{message: $msg, secret: $secret}')
           curl -s -f -X POST "$NOTIFY_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
+            -d "$PAYLOAD" \
+            || { echo "::warning::Webhook notification request failed"; true; }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -13,9 +13,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/regenerate-api-types.yml
+++ b/.github/workflows/regenerate-api-types.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/connectors/slack/context/fetch_test.go
+++ b/connectors/slack/context/fetch_test.go
@@ -67,7 +67,7 @@ func TestFetchThread_Truncation(t *testing.T) {
 	var list []slackMessage
 	list = append(list, slackMessage{User: "U1", Text: "parent", TS: "10.0"})
 	for i := 1; i <= 25; i++ {
-		list = append(list, slackMessage{User: "U1", Text: fmt.Sprintf("r%d", i), TS: fmt.Sprintf("10.%06d", i)})
+		list = append(list, slackMessage{User: "U1", Text: slackNullableText(fmt.Sprintf("r%d", i)), TS: fmt.Sprintf("10.%06d", i)})
 	}
 	api.postHandlers["conversations.replies"] = func(body json.RawMessage) (any, error) {
 		return messagesResponse{slackResponse: slackResponse{OK: true}, Messages: list}, nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fix the backend compile failure in `connectors/slack/context/fetch_test.go` by casting dynamic reply text to `slackNullableText`, matching the `slackMessage` struct after `Text` became a distinct type.
- Bump `actions/checkout`, `actions/setup-node`, and `actions/setup-go` to **v6** in CI and related workflows so composite actions run on the Node 24 runtime and GitHub’s Node 20 deprecation warnings go away.
- Treat a failed optional webhook `curl` in the **Notify on Failure** job as a warning instead of failing the job (avoids masking the real CI failure with exit code 6 when the webhook is down or returns an error).

## Test plan

- [ ] Confirm GitHub Actions **CI** workflow is green (backend tests, frontend tests, build).
- [ ] Confirm **Dependency Audit** workflow still parses (same action bumps applied there for consistency).

Note: Full `go test` was not run in this agent environment; relying on CI for the Go test pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a00db1c-37f4-41ba-aaf8-c91dd5f1cc5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a00db1c-37f4-41ba-aaf8-c91dd5f1cc5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

