### PR TITLE
fix(slack): restore legacy search:read scope for search.messages (fix 502s)

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -519,7 +519,7 @@ Lists workspace users visible to the bot, with cursor-based pagination.
 
 ### `slack.search_messages`
 
-Searches messages across Slack channels. **Requires a user token** (`xoxp-`) with the granular `search:read.*` scopes (`search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`) — bot tokens (`xoxb-`) do not support this endpoint. Slack returns only content visible to that user; results are not post-filtered in Permission Slip.
+Searches messages across Slack channels. **Requires a user token** (`xoxp-`) with the legacy `search:read` scope — bot tokens (`xoxb-`) do not support this endpoint. The granular `search:read.{public,private,im,mpim,files}` scopes only satisfy the newer Real-time Search API (`assistant.search.context`); they do **not** satisfy `search.messages`, which rejects tokens that only carry the granular scopes with `invalid_arguments`. Slack returns only content visible to that user; results are not post-filtered in Permission Slip.
 
 **Risk level:** low
 
@@ -555,7 +555,7 @@ Searches messages across Slack channels. **Requires a user token** (`xoxp-`) wit
 
 **Slack API:** `POST /search.messages` ([docs](https://api.slack.com/methods/search.messages))
 
-**Required scopes:** `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files` (user token only)
+**Required scopes:** `search:read` (user token only; legacy monolithic scope — granular `search:read.*` scopes do not satisfy this endpoint)
 
 > **Note:** This action will return a `missing_scope` error when invoked with a bot token. To use it, the OAuth flow must persist the user's access token (the `authed_user.access_token` field from Slack's OAuth v2 response).
 
@@ -718,11 +718,7 @@ When connecting via OAuth, scopes are requested automatically. If you're creatin
 
 | Scope | Purpose |
 |-------|---------|
-| `search:read.public` | Search public channel messages |
-| `search:read.private` | Search private channel messages |
-| `search:read.im` | Search DM messages |
-| `search:read.mpim` | Search group DM messages |
-| `search:read.files` | Search shared files |
+| `search:read` | Search workspace messages via `search.messages` (legacy scope; still required — the granular `search:read.*` scopes only work with the Real-time Search API, not `search.messages`) |
 
 ## Testing
 

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -533,7 +533,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:      "slack.search_messages",
 				Name:            "Search Messages",
-				Description:     "Search messages across Slack channels (requires granular search:read.* scopes)",
+				Description:     "Search messages across Slack channels (requires the legacy search:read user scope)",
 				RiskLevel:       "low",
 				DisplayTemplate: "Search {{channel_name}} for {{query}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -9,9 +9,10 @@ import (
 // searchMessagesAction implements connectors.Action for slack.search_messages.
 // It searches messages across channels via POST /search.messages.
 //
-// This Slack endpoint requires a user token (xoxp-) with the granular
-// search:read.* scopes (public/private/im/mpim/files). The legacy monolithic
-// search:read scope is no longer sufficient and causes invalid_arguments.
+// This Slack endpoint requires a user token (xoxp-) with the legacy
+// search:read scope. The newer granular search:read.{public,private,im,mpim,files}
+// scopes only satisfy the Real-time Search API (assistant.search.context);
+// calling search.messages with only those scopes fails with invalid_arguments.
 type searchMessagesAction struct {
 	conn *SlackConnector
 }

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -39,9 +39,12 @@ const (
 // authorization URL (no bot "scope" param). The resulting user token (xoxp-)
 // is stored as the connection's primary access_token.
 //
-// Search uses the granular search:read.* scopes. The legacy monolithic
-// search:read scope is no longer sufficient for search.messages — the API
-// rejects it with invalid_arguments at runtime.
+// Search uses the legacy monolithic search:read scope. The granular
+// search:read.{public,private,im,mpim,files} scopes only satisfy the new
+// Real-time Search API (assistant.search.context) introduced in Feb 2026.
+// They do NOT satisfy search.messages, which still requires search:read.
+// See https://docs.slack.dev/reference/methods/search.messages and
+// https://docs.slack.dev/apis/web-api/real-time-search-api/.
 var OAuthScopes = []string{
 	"channels:history",
 	"channels:read",
@@ -61,11 +64,7 @@ var OAuthScopes = []string{
 	"mpim:write",
 	"reactions:read",
 	"reactions:write",
-	"search:read.public",
-	"search:read.private",
-	"search:read.im",
-	"search:read.mpim",
-	"search:read.files",
+	"search:read",
 	"users:read",
 	"users:read.email",
 	"pins:read",
@@ -405,6 +404,12 @@ func mapSlackError(slackErr string) error {
 		return &connectors.AuthError{Message: "Slack token is missing a required OAuth scope — re-authorize the Slack connection at https://api.slack.com/apps"}
 	case "not_allowed_token_type":
 		return &connectors.AuthError{Message: "Slack rejected this request for the token type in use — reconnect Slack"}
+	case "invalid_arguments", "invalid_arg_name":
+		// search.messages returns invalid_arguments when the user token is
+		// missing the legacy search:read scope (the granular search:read.*
+		// scopes only work with assistant.search.context). Surface that as a
+		// re-auth hint so operators aren't left chasing phantom 502s.
+		return &connectors.AuthError{Message: "Slack rejected the request arguments — if this is search_messages, your token likely lacks the legacy \"search:read\" user scope; re-authorize the Slack connection"}
 
 	// Rate limiting
 	case "ratelimited":

--- a/connectors/slack/user_token_test.go
+++ b/connectors/slack/user_token_test.go
@@ -80,11 +80,7 @@ func TestOAuthScopes_IncludesRequiredUserScopes(t *testing.T) {
 		"mpim:write":           {},
 		"reactions:read":       {},
 		"reactions:write":      {},
-		"search:read.public":   {},
-		"search:read.private":  {},
-		"search:read.im":       {},
-		"search:read.mpim":     {},
-		"search:read.files":    {},
+		"search:read":          {},
 		"users:read":           {},
 		"users:read.email":     {},
 	}

--- a/db/migrations/20260422131317_slack_legacy_search_read_scope_reauth.sql
+++ b/db/migrations/20260422131317_slack_legacy_search_read_scope_reauth.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+
+-- Revert of 20260422001318_slack_granular_search_scopes_reauth.sql.
+--
+-- That migration assumed the granular search:read.{public,private,im,mpim,files}
+-- scopes satisfied Slack's search.messages endpoint. They do not: those scopes
+-- only work with the newer Real-time Search API (assistant.search.context).
+-- search.messages still requires the legacy monolithic search:read scope, and
+-- tokens that only carry the granular scopes are rejected with
+-- invalid_arguments — surfacing as 502 upstream_error for slack.search_messages
+-- on every affected instance.
+--
+-- The connector now requests the legacy search:read user scope (and no longer
+-- requests the granular search:read.* scopes). Force re-authorization for any
+-- Slack connection whose stored scopes do not already include search:read so
+-- users pick up a working token.
+UPDATE oauth_connections
+SET status = 'needs_reauth', updated_at = now()
+WHERE provider = 'slack'
+  AND status = 'active'
+  AND NOT ('search:read' = ANY (scopes));
+
+-- +goose Down
+
+-- Not reversible: we cannot distinguish rows flipped by this migration from
+-- those already in needs_reauth for other reasons.

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -553,7 +553,7 @@ Under **Scopes**, add **Bot Token Scopes** and **User Token Scopes** to match wh
 
 **User Token Scopes** (required for search actions that only work with user tokens)
 
-- `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`
+- `search:read` — legacy monolithic scope, still the only one that satisfies `search.messages`. The granular `search:read.public/.private/.im/.mpim/.files` scopes only work with the newer `assistant.search.context` endpoint.
 
 ### 4. Configure environment
 
@@ -868,7 +868,7 @@ If using `OAUTH_REDIRECT_BASE_URL`, the callback URL is `{OAUTH_REDIRECT_BASE_UR
 
 - **`missing_scope`** — The Slack app is missing bot or user scopes listed in [Slack OAuth Setup](#slack-oauth-setup). Add them under **OAuth & Permissions**, then have the user **Re-authorize** so Slack issues new tokens.
 - **`invalid_auth` / `token_revoked`** — The workspace uninstalled the app or tokens were rotated. **Re-authorize** from the connector settings.
-- **Search actions fail but messaging works** — Search uses a user token (`xoxp-`). Ensure **User Token Scopes** (especially `search:read.*`) are configured in the Slack app and the user completed consent for user scopes.
+- **Search actions fail but messaging works** — Search uses a user token (`xoxp-`). Ensure the **`search:read`** user token scope is configured in the Slack app and the user completed consent for user scopes. Granular `search:read.*` scopes alone are **not** enough: `search.messages` rejects them with `invalid_arguments`.
 
 ### "Failed to initiate OAuth flow" error
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Revert the user-scope change from #1032: `search.messages` still requires the legacy monolithic `search:read` scope. The granular `search:read.{public,private,im,mpim,files}` scopes only satisfy the new Real-time Search API (`assistant.search.context`) introduced in Feb 2026 — they do **not** satisfy `search.messages`, which rejects those tokens with `invalid_arguments` (mapped to `ExternalError` → HTTP 502 `upstream_error`). This is the 502 reported across all three Slack instances for `search_messages`.
- Add an `invalid_arguments` / `invalid_arg_name` case to `mapSlackError` that returns an `AuthError` with a re-auth hint, so this misdiagnosis is self-evident next time instead of a silent 502.
- Add migration `20260422131317_slack_legacy_search_read_scope_reauth.sql` that flips any Slack connection whose stored scopes don't include `search:read` back to `needs_reauth`. This is symmetric to — and effectively supersedes — `20260422001318_slack_granular_search_scopes_reauth.sql`.

## Related Issue

N/A (hotfix surfaced in user reports today after #1032 / #1044 deployed).

## Why the granular scopes don't work here

Current Slack docs:

- [`search.messages`](https://docs.slack.dev/reference/methods/search.messages) — user token scope: `search:read` (legacy).
- [Real-time Search API](https://docs.slack.dev/apis/web-api/real-time-search-api/) — uses `assistant.search.context`, which is the only endpoint that accepts the granular `search:read.*` scopes.

Our connector calls `POST /search.messages`, so a token that only carries the granular scopes gets `invalid_arguments`. After #1032's migration flipped every Slack connection to `needs_reauth`, users reconnected and got exactly that: tokens with the granular scopes but not the legacy `search:read`. Search broke for everyone.

## Rollout

1. Merge this PR.
2. On deploy, migration `20260422131317` flips all affected Slack connections to `needs_reauth`.
3. Users re-authorize → new tokens carry `search:read` → `search.messages` works again.

## Test Plan

### Developer

- [x] Updated `TestOAuthScopes_IncludesRequiredUserScopes` to expect `search:read`.
- [x] `gofmt -l connectors/slack/ docs/` clean.
- [ ] `make test-backend` — **not run locally** (sandbox Go 1.24.7 vs `cloud.google.com/go/bigquery` requiring Go ≥ 1.25). CI will execute the full suite.

### Manual Testing

- [ ] After deploy, verify a Slack connection is flipped to `needs_reauth`.
- [ ] Re-authorize the Slack connector; confirm the consent screen now shows `search:read` under user scopes.
- [ ] Trigger `slack.search_messages` and confirm it returns 200 with results instead of 502.
- [ ] Trigger a `search_messages` call against a connection that still has only the granular scopes (pre-reauth) and confirm the error is now a typed `AuthError` with the re-auth hint rather than a silent 502.

## Notes for Reviewers

- I'd normally dedupe or edit the previous migration rather than ship a second one that undoes it, but migrations are append-only and the earlier one may already have been applied in staging/prod. This new migration intentionally covers both "granular only" and "no search scopes at all" stored-scope states by predicating on `search:read` membership rather than on the presence/absence of the granular scopes.
- Left the `invalid_arg_name` alias in `mapSlackError` because Slack sometimes returns that instead for the same family of failures; happy to split that out if you'd rather keep the map narrow.
- Did not touch `search_messages.go`'s logic, `resolve_resource_details.go`, or any test servers — this is purely scopes + error-mapping + docs + a migration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83cae698-4b77-4a92-b984-91e5b8761d58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83cae698-4b77-4a92-b984-91e5b8761d58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

