### PR TITLE
Speed up CI: parallel build job and slimmer install path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: cd frontend && npm ci
+        run: cd frontend && npm ci --ignore-scripts
 
-      - name: Generate API client
-        run: make generate-frontend
-
-      - name: Verify bundled OpenAPI spec is up-to-date
+      - name: Bundle OpenAPI spec and verify it is committed
         run: |
           make bundle
           if ! git diff --exit-code spec/openapi/openapi.bundle.yaml; then
@@ -68,13 +65,20 @@ jobs:
             exit 1
           fi
 
+      - name: Generate frontend API client
+        run: make generate-frontend-from-bundle
+
       - name: Run frontend tests
         run: make test-frontend
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [backend, frontend]
+    # Runs in parallel with backend and frontend so wall time is max(job), not sum.
+    env:
+      # Vite inlines these at build time; CI only needs deterministic placeholders.
+      VITE_SUPABASE_URL: https://ci-placeholder.local
+      VITE_SUPABASE_PUBLISHABLE_KEY: ci-placeholder
 
     steps:
       - uses: actions/checkout@v6
@@ -89,11 +93,24 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Install dependencies
-        run: make install
+      - name: Ensure frontend/dist exists for go:embed
+        run: mkdir -p frontend/dist && touch frontend/dist/.gitkeep
 
-      - name: Build
-        run: make build
+      - name: Install build dependencies
+        run: make install-build-deps
+
+      - name: Bundle OpenAPI spec and generate frontend API types
+        run: make bundle generate-frontend-from-bundle
+
+      - name: Verify bundled OpenAPI spec is up-to-date
+        run: |
+          if ! git diff --exit-code spec/openapi/openapi.bundle.yaml; then
+            echo "::error::spec/openapi/openapi.bundle.yaml is out of date. Run 'make bundle' and commit the result."
+            exit 1
+          fi
+
+      - name: Build server (frontend + Go)
+        run: make build-ci
 
   notify-failure:
     name: Notify on Failure

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-.PHONY: dev dev-backend dev-frontend build run install setup \
+.PHONY: dev dev-backend dev-frontend build build-ci run install install-build-deps setup \
        test test-backend test-frontend test-integration typecheck \
        mobile-install mobile-start mobile-test mobile-typecheck \
        mobile-build-dev mobile-build-preview mobile-build-prod \
        mobile-build-dev-ios mobile-build-dev-android \
        mobile-build-preview-ios mobile-build-preview-android \
        mobile-submit mobile-update \
-       generate-frontend generate-mobile \
+       generate generate-frontend generate-mobile \
+       generate-frontend-from-bundle generate-mobile-from-bundle \
        migrate-up migrate-down migrate-create db-setup seed \
-       bundle generate generate-vapid-keys install-connectors \
+       bundle generate-vapid-keys install-connectors \
        audit audit-backend audit-frontend audit-mobile \
        docker-build deploy \
        cli cli-install cli-build cli-test
@@ -17,6 +18,13 @@ install:
 	cd frontend && npm install
 	cd mobile && npm install
 	cd cli && npm install
+	go mod download
+
+# Minimal install for server production build (CI): frontend + Go only.
+# Uses npm ci --ignore-scripts to skip postinstall (openapi-typescript); run
+# make bundle && make generate-frontend-from-bundle before frontend build.
+install-build-deps:
+	cd frontend && npm ci --ignore-scripts
 	go mod download
 
 # Full setup: install deps + generate API client
@@ -42,13 +50,17 @@ dev-frontend:
 bundle:
 	npx @redocly/cli@2.19.1 bundle spec/openapi/openapi.yaml -o spec/openapi/openapi.bundle.yaml
 
-# Generate typed API clients from the bundled OpenAPI spec
-generate: generate-frontend generate-mobile
+# Generate typed API clients from the bundled OpenAPI spec (bundles once).
+generate: bundle generate-frontend-from-bundle generate-mobile-from-bundle
 
-generate-frontend: bundle
+generate-frontend: bundle generate-frontend-from-bundle
+
+generate-frontend-from-bundle:
 	cd frontend && npm run generate:api
 
-generate-mobile: bundle
+generate-mobile: bundle generate-mobile-from-bundle
+
+generate-mobile-from-bundle:
 	cd mobile && npm run generate:api
 
 # Type-check frontend (generates API client first, then runs tsc --noEmit)
@@ -59,6 +71,13 @@ typecheck: generate-frontend
 # Embeds the git SHA as the Sentry release version via -ldflags.
 GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 build: generate
+	cd frontend && npm run build
+	touch frontend/dist/.gitkeep
+	go build -ldflags "-X main.version=$(GIT_SHA)" -o bin/server .
+
+# CI / slim server build: expects bundle + generate-frontend-from-bundle already
+# (see install-build-deps). Does not install mobile or CLI npm dependencies.
+build-ci:
 	cd frontend && npm run build
 	touch frontend/dist/.gitkeep
 	go build -ldflags "-X main.version=$(GIT_SHA)" -o bin/server .


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the main CI wall-clock and duplicate-work items from #1048 (Phases 1–3).

- **Shorter critical path:** The `build` job no longer `needs` backend and frontend; it runs in parallel with both so total time is closer to `max(backend, frontend, build)` instead of `max(backend, frontend) + build`.
- **Leaner build job:** Replaced `make install` with `make install-build-deps`, which only runs `npm ci --ignore-scripts` in `frontend/` plus `go mod download` (no mobile or CLI npm installs).
- **Single bundle per `make generate`:** `generate` now runs `bundle` once, then `generate-frontend-from-bundle` and `generate-mobile-from-bundle`, avoiding duplicate Redocly work when generating both clients.
- **Frontend job:** Uses `npm ci --ignore-scripts`, runs `make bundle` once (with the same committed-spec guard), then `generate-frontend-from-bundle`, avoiding duplicate `openapi-typescript` from postinstall + explicit generate.
- **Deterministic Vite build in CI:** Sets placeholder `VITE_SUPABASE_*` env vars on the build job so the production frontend build can complete without secrets.

Follow-up work from the issue (artifacts between jobs, path filters, optional Go sharding) can land in separate PRs once this is merged and re-measured.

## Test plan

- [x] `cd frontend && npm ci --ignore-scripts`, then `make bundle generate-frontend-from-bundle && make test-frontend` (passed locally).
- [ ] Full GitHub Actions run on this PR (backend `go test`, build job with Go version from `go.mod`).

Refs #1048
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39dcd6c8-7448-43d3-9c8f-a4f51b53f23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39dcd6c8-7448-43d3-9c8f-a4f51b53f23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

