### PR TITLE
fix(slack): use GET instead of POST for search.messages

### DIFF
--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -2,16 +2,17 @@ package slack
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
 // searchMessagesAction implements connectors.Action for slack.search_messages.
-// It searches messages across channels via POST /search.messages.
+// It searches messages across Slack channels via GET /search.messages.
 //
 // This Slack endpoint requires a user token (xoxp-) with the legacy
-// search:read scope. The newer granular search:read.{public,private,im,mpim,files}
-// scopes only satisfy the Real-time Search API (assistant.search.context);
+// search:read scope. Uses GET (doGet) because search.messages does not
+// accept JSON body parameters — only query string args.
 // calling search.messages with only those scopes fails with invalid_arguments.
 type searchMessagesAction struct {
 	conn *SlackConnector
@@ -104,21 +105,25 @@ func (a *searchMessagesAction) Execute(ctx context.Context, req connectors.Actio
 		return nil, err
 	}
 
-	body := searchMessagesRequest{
-		Query: params.Query,
-		Count: params.Count,
-		Page:  params.Page,
-		Sort:  params.Sort,
+	count := params.Count
+	if count == 0 {
+		count = 20
 	}
-	if body.Count == 0 {
-		body.Count = 20
+	page := params.Page
+	if page == 0 {
+		page = 1
 	}
-	if body.Page == 0 {
-		body.Page = 1
+	paramsMap := map[string]string{
+		"query": params.Query,
+		"count": strconv.Itoa(count),
+		"page":  strconv.Itoa(page),
+	}
+	if params.Sort != "" {
+		paramsMap["sort"] = params.Sort
 	}
 
 	var resp searchMessagesResponse
-	if err := a.conn.doPost(ctx, "search.messages", req.Credentials, body, &resp); err != nil {
+	if err := a.conn.doGet(ctx, "search.messages", req.Credentials, paramsMap, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/search_messages_test.go
+++ b/connectors/slack/search_messages_test.go
@@ -20,19 +20,16 @@ func TestSearchMessages_Success(t *testing.T) {
 			return
 		}
 
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
 		}
 
-		var body searchMessagesRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
+		query := r.URL.Query()
+		if query.Get("query") != "deploy in:#engineering" {
+			t.Errorf("expected query 'deploy in:#engineering', got %q", query.Get("query"))
 		}
-		if body.Query != "deploy in:#engineering" {
-			t.Errorf("expected query 'deploy in:#engineering', got %q", body.Query)
-		}
-		if body.Count != 20 {
-			t.Errorf("expected count 20, got %d", body.Count)
+		if query.Get("count") != "20" {
+			t.Errorf("expected count 20, got %q", query.Get("count"))
 		}
 
 		json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
search.messages is a read-only GET endpoint that does not accept JSON body parameters. When called with POST + JSON body, Slack ignores the body params and returns 'No query passed' (or invalid_arguments), which the backend surfaces as HTTP 502 Bad Gateway.

This matches the fix in commit b958bcbd for conversations.info and users.info, which had the same issue.

**Files changed:**
- `connectors/slack/search_messages.go`: Switch from `doPost` (JSON body) to `doGet` (query string params)
- `connectors/slack/search_messages_test.go`: Updated test to expect GET and read query params from URL