### PR TITLE
fix(slack): use GET for search.messages and conversations.members

### DIFF
--- a/connectors/slack/dm_read_guard.go
+++ b/connectors/slack/dm_read_guard.go
@@ -69,12 +69,6 @@ func (c *SlackConnector) lookupSlackUserIDByEmail(ctx context.Context, creds con
 	return resp.User.ID, nil
 }
 
-type conversationsMembersRequest struct {
-	Channel string `json:"channel"`
-	Limit   int    `json:"limit,omitempty"`
-	Cursor  string `json:"cursor,omitempty"`
-}
-
 type conversationsMembersResponse struct {
 	slackResponse
 	Members []string        `json:"members,omitempty"`
@@ -86,13 +80,15 @@ const maxConversationMemberPages = 50
 func (c *SlackConnector) slackUserIsConversationMember(ctx context.Context, creds connectors.Credentials, channelID, slackUserID string) (bool, error) {
 	cursor := ""
 	for page := 0; page < maxConversationMemberPages; page++ {
-		body := conversationsMembersRequest{
-			Channel: channelID,
-			Limit:   200,
-			Cursor:  cursor,
+		params := map[string]string{
+			"channel": channelID,
+			"limit":   "200",
+		}
+		if cursor != "" {
+			params["cursor"] = cursor
 		}
 		var resp conversationsMembersResponse
-		if err := c.doPost(ctx, "conversations.members", creds, body, &resp); err != nil {
+		if err := c.doGet(ctx, "conversations.members", creds, params, &resp); err != nil {
 			return false, err
 		}
 		if !resp.OK {


### PR DESCRIPTION
Two Slack endpoints are GET-only but were being called with POST + JSON body, causing HTTP 502 Bad Gateway.

## Changes

1. **`search.messages`** (`connectors/slack/search_messages.go`)
   - Switched from `doPost` (JSON body) to `doGet` (query string params)
   - Slack ignores JSON body for this read endpoint → always returned `invalid_arguments`
   - Confirmed with direct API test: POST → error, GET → works

2. **`conversations.members`** (`connectors/slack/dm_read_guard.go`)
   - Switched `slackUserIsConversationMember` from `doPost` to `doGet`
   - This is called by the DM guard when reading channel history for DM channels
   - Without this fix, `read_channel_messages` always 502s for DMs

Both are read-only GET endpoints. The write-style endpoints (chat.postMessage, reactions.add, etc.) correctly use POST.

## Tests
All existing tests pass. `search_messages_test.go` updated to expect GET.