### PR TITLE
chore(slack): follow-ups for GET search.messages / conversations.members (#1053)

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -553,7 +553,7 @@ Searches messages across Slack channels. **Requires a user token** (`xoxp-`) wit
 }
 ```
 
-**Slack API:** `POST /search.messages` ([docs](https://api.slack.com/methods/search.messages))
+**Slack API:** `GET /search.messages` ([docs](https://api.slack.com/methods/search.messages))
 
 **Required scopes:** `search:read` (user token only; legacy monolithic scope — granular `search:read.*` scopes do not satisfy this endpoint)
 

--- a/connectors/slack/chat_user_token_test.go
+++ b/connectors/slack/chat_user_token_test.go
@@ -276,6 +276,9 @@ func TestReadChannelMessages_DMUsesAccessTokenForMembersAndHistory(t *testing.T)
 				"user": map[string]any{"id": "U_ALICE"},
 			})
 		case "/conversations.members":
+			if r.Method != http.MethodGet {
+				t.Errorf("conversations.members: expected GET, got %s", r.Method)
+			}
 			membersAuth = r.Header.Get("Authorization")
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok":      true,
@@ -376,6 +379,9 @@ func TestReadThread_DMUsesAccessTokenForReplies(t *testing.T) {
 				"user": map[string]any{"id": "U_ALICE"},
 			})
 		case "/conversations.members":
+			if r.Method != http.MethodGet {
+				t.Errorf("conversations.members: expected GET, got %s", r.Method)
+			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok":      true,
 				"members": []string{"U_ALICE", "U_BOB"},

--- a/connectors/slack/search_messages.go
+++ b/connectors/slack/search_messages.go
@@ -43,14 +43,6 @@ func (p *searchMessagesParams) validate() error {
 	return nil
 }
 
-// searchMessagesRequest is the Slack API request body for search.messages.
-type searchMessagesRequest struct {
-	Query string `json:"query"`
-	Count int    `json:"count,omitempty"`
-	Page  int    `json:"page,omitempty"`
-	Sort  string `json:"sort,omitempty"`
-}
-
 type searchMessagesResponse struct {
 	slackResponse
 	Messages struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the cleanup from #1053 after the Slack GET fixes merged.

## Summary

- Removed the unused `searchMessagesRequest` type from `search_messages.go` (the action uses query params via `doGet` only).
- Updated `connectors/slack/README.md` to document `GET /search.messages` instead of POST.
- In `chat_user_token_test.go`, assert `http.MethodGet` for `/conversations.members` in both DM read tests that stub that endpoint.

## Test plan

- [ ] `go test ./connectors/slack/...` (CI)
- Local sandbox Go is older than `go.mod`; backend tests were not run here — rely on CI for `make test-backend`.

Closes #1053
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19ac3971-03b2-402f-ac8c-0b8764edafec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19ac3971-03b2-402f-ac8c-0b8764edafec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

