### PR TITLE
fix(slack): use GET for search.messages, conversations.members, conversations.list, and users.list

### DIFF
--- a/connectors/slack/list_channels_merged.go
+++ b/connectors/slack/list_channels_merged.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
@@ -34,18 +35,21 @@ func (c *SlackConnector) listChannelsMerged(ctx context.Context, creds connector
 		userPrivateMerge = userPrivateChs
 	}
 
-	body := listChannelsRequest{
-		Types:           types,
-		Limit:           params.Limit,
-		Cursor:          params.Cursor,
-		ExcludeArchived: excludeArchived,
+	limit := params.Limit
+	if limit == 0 {
+		limit = 100
 	}
-	if body.Limit == 0 {
-		body.Limit = 100
+	paramsMap := map[string]string{
+		"types":             types,
+		"limit":             strconv.Itoa(limit),
+		"exclude_archived":  strconv.FormatBool(excludeArchived),
+	}
+	if params.Cursor != "" {
+		paramsMap["cursor"] = params.Cursor
 	}
 
 	var resp listChannelsResponse
-	if err := c.doPost(ctx, "conversations.list", creds, body, &resp); err != nil {
+	if err := c.doGet(ctx, "conversations.list", creds, paramsMap, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/list_channels_test.go
+++ b/connectors/slack/list_channels_test.go
@@ -13,25 +13,22 @@ func TestListChannels_Success(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
 		}
 		if r.URL.Path != "/conversations.list" {
 			t.Errorf("expected path /conversations.list, got %s", r.URL.Path)
 		}
 
-		var body listChannelsRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
+		query := r.URL.Query()
+		if query.Get("types") != "public_channel" {
+			t.Errorf("expected types 'public_channel', got %q", query.Get("types"))
 		}
-		if body.Types != "public_channel" {
-			t.Errorf("expected types 'public_channel', got %q", body.Types)
+		if query.Get("limit") != "100" {
+			t.Errorf("expected limit 100, got %q", query.Get("limit"))
 		}
-		if body.Limit != 100 {
-			t.Errorf("expected limit 100, got %d", body.Limit)
-		}
-		if !body.ExcludeArchived {
-			t.Error("expected exclude_archived to be true")
+		if query.Get("exclude_archived") != "true" {
+			t.Errorf("expected exclude_archived 'true', got %q", query.Get("exclude_archived"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -134,12 +131,12 @@ func TestListChannels_DefaultTypes(t *testing.T) {
 				},
 			})
 		case "/conversations.list":
-			var body listChannelsRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode: %v", err)
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
 			}
-			if body.Types != "public_channel,private_channel,mpim,im" {
-				t.Errorf("expected default types 'public_channel,private_channel,mpim,im', got %q", body.Types)
+			query := r.URL.Query()
+			if query.Get("types") != "public_channel,private_channel,mpim,im" {
+				t.Errorf("expected default types 'public_channel,private_channel,mpim,im', got %q", query.Get("types"))
 			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,
@@ -205,12 +202,12 @@ func TestListChannels_IMChannels(t *testing.T) {
 				"channels": []map[string]any{},
 			})
 		case "/conversations.list":
-			var body listChannelsRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode: %v", err)
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
 			}
-			if body.Types != "im" {
-				t.Errorf("expected types 'im', got %q", body.Types)
+			query := r.URL.Query()
+			if query.Get("types") != "im" {
+				t.Errorf("expected types 'im', got %q", query.Get("types"))
 			}
 			// IM channels have no name — they have a user field instead.
 			json.NewEncoder(w).Encode(map[string]any{
@@ -283,15 +280,15 @@ func TestListChannels_WithPagination(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body listChannelsRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if body.Cursor != "dGVhbTpDMDI=" {
-			t.Errorf("expected cursor 'dGVhbTpDMDI=', got %q", body.Cursor)
+		query := r.URL.Query()
+		if query.Get("cursor") != "dGVhbTpDMDI=" {
+			t.Errorf("expected cursor 'dGVhbTpDMDI=', got %q", query.Get("cursor"))
 		}
-		if body.Limit != 10 {
-			t.Errorf("expected limit 10, got %d", body.Limit)
+		if query.Get("limit") != "10" {
+			t.Errorf("expected limit 10, got %q", query.Get("limit"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -422,12 +419,12 @@ func TestListChannels_DefaultWithoutEmail(t *testing.T) {
 				"channels": []map[string]any{},
 			})
 		case "/conversations.list":
-			var body listChannelsRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode: %v", err)
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
 			}
-			if body.Types != "public_channel,private_channel,mpim,im" {
-				t.Errorf("expected default types on conversations.list, got %q", body.Types)
+			query := r.URL.Query()
+			if query.Get("types") != "public_channel,private_channel,mpim,im" {
+				t.Errorf("expected default types on conversations.list, got %q", query.Get("types"))
 			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"ok": true,

--- a/connectors/slack/list_users.go
+++ b/connectors/slack/list_users.go
@@ -2,12 +2,13 @@ package slack
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
 // listUsersAction implements connectors.Action for slack.list_users.
-// It lists workspace users via POST /users.list.
+// It lists workspace users via GET /users.list.
 type listUsersAction struct {
 	conn *SlackConnector
 }
@@ -73,16 +74,19 @@ func (a *listUsersAction) Execute(ctx context.Context, req connectors.ActionRequ
 		return nil, err
 	}
 
-	body := listUsersRequest{
-		Limit:  params.Limit,
-		Cursor: params.Cursor,
+	limit := params.Limit
+	if limit == 0 {
+		limit = 100
 	}
-	if body.Limit == 0 {
-		body.Limit = 100
+	paramsMap := map[string]string{
+		"limit": strconv.Itoa(limit),
+	}
+	if params.Cursor != "" {
+		paramsMap["cursor"] = params.Cursor
 	}
 
 	var resp listUsersResponse
-	if err := a.conn.doPost(ctx, "users.list", req.Credentials, body, &resp); err != nil {
+	if err := a.conn.doGet(ctx, "users.list", req.Credentials, paramsMap, &resp); err != nil {
 		return nil, err
 	}
 

--- a/connectors/slack/list_users_test.go
+++ b/connectors/slack/list_users_test.go
@@ -13,19 +13,16 @@ func TestListUsers_Success(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
 		}
 		if r.URL.Path != "/users.list" {
 			t.Errorf("expected path /users.list, got %s", r.URL.Path)
 		}
 
-		var body listUsersRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-		if body.Limit != 100 {
-			t.Errorf("expected limit 100, got %d", body.Limit)
+		query := r.URL.Query()
+		if query.Get("limit") != "100" {
+			t.Errorf("expected limit 100, got %q", query.Get("limit"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -106,15 +103,12 @@ func TestListUsers_WithPagination(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body listUsersRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
+		query := r.URL.Query()
+		if query.Get("cursor") != "dXNlcjpVMDAy" {
+			t.Errorf("expected cursor 'dXNlcjpVMDAy', got %q", query.Get("cursor"))
 		}
-		if body.Cursor != "dXNlcjpVMDAy" {
-			t.Errorf("expected cursor 'dXNlcjpVMDAy', got %q", body.Cursor)
-		}
-		if body.Limit != 50 {
-			t.Errorf("expected limit 50, got %d", body.Limit)
+		if query.Get("limit") != "50" {
+			t.Errorf("expected limit 50, got %q", query.Get("limit"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/connectors/slack/user_lister.go
+++ b/connectors/slack/user_lister.go
@@ -23,13 +23,13 @@ func (c *SlackConnector) ListUsers(ctx context.Context, creds connectors.Credent
 	seen := make(map[string]bool)
 	cursor := ""
 	for page := 0; page < slackUserListMaxPages; page++ {
-		body := listUsersRequest{
-			Limit:  200,
-			Cursor: cursor,
+		paramsMap := map[string]string{"limit": "200"}
+		if cursor != "" {
+			paramsMap["cursor"] = cursor
 		}
 
 		var resp listUsersResponse
-		if err := c.doPost(ctx, "users.list", creds, body, &resp); err != nil {
+		if err := c.doGet(ctx, "users.list", creds, paramsMap, &resp); err != nil {
 			return nil, err
 		}
 		if !resp.OK {


### PR DESCRIPTION
Four Slack endpoints are GET-only but were being called with POST + JSON body, causing various failures.

## Changes

1. **\** — switched from \ to \
   - Search queries were ignored → always returned 502
   
2. **\** — switched from \ to \
   - DM guard always failed → \ 502s for DMs

3. **\** — switched from \ to \
   - Only returned public channels, IMs/DMs invisible → \ returns empty

4. **\** — switched from \ to \
   - JSON body limit ignored → always returned full user list regardless of limit
   - Pagination cursor also passed as query param correctly

## Root cause
Slack's read-only endpoints read URL query parameters, not JSON body. Write-style endpoints (chat.postMessage, reactions.add, etc.) correctly use POST.

## Note
\ was also found to ignore limit with POST, but is kept as POST because it requires specific behavior for private channel discovery that GET doesn't support. Tests updated accordingly.