### PR TITLE
fix(cli): show human-readable names for OAuth connector instances

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -1085,6 +1085,10 @@ func instanceFromExtraData(extraData json.RawMessage) string {
 // login or Microsoft displayName), falls back to "email". When "team_name"
 // is present (Slack), appends " @ <workspace>" to help distinguish
 // connections to different workspaces. Returns "" if no identifier is found.
+//
+// The SQL mirror of this logic lives in db.connectorInstanceDisplayNameSQL and
+// powers the CLI capabilities endpoint. Keep the two in sync: any change to the
+// priority order or to the set of recognized keys must be applied in both places.
 func displayNameFromExtraData(extraData json.RawMessage) string {
 	if len(extraData) == 0 {
 		return ""

--- a/db/agent_connector_instances.go
+++ b/db/agent_connector_instances.go
@@ -11,7 +11,9 @@ import (
 )
 
 // AgentConnectorInstance is a row in agent_connectors (one instance of a connector type for an agent).
-// DisplayName is derived from the bound credential (API key label or OAuth workspace name in extra_data).
+// DisplayName is derived from the bound credential: the static API key label, or for OAuth
+// connections the identifier in extra_data (display_name / email, optionally suffixed with
+// " @ <team_name>" for Slack). See connectorInstanceDisplayNameSQL for the exact priority.
 type AgentConnectorInstance struct {
 	ConnectorInstanceID string
 	AgentID             int64
@@ -21,6 +23,32 @@ type AgentConnectorInstance struct {
 	IsDefault           bool
 	EnabledAt           time.Time
 }
+
+// connectorInstanceDisplayNameSQL is the shared SQL expression that derives a human-readable
+// display name for a connector instance. It must stay in sync with the Go helper
+// api.displayNameFromExtraData: priority is cr.label → "<display_name> @ <team_name>" →
+// "<email> @ <team_name>" → display_name → email → team_name → "".
+//
+// Callers must alias LEFT JOINs on credentials as cr and oauth_connections as oc.
+const connectorInstanceDisplayNameSQL = `COALESCE(
+    cr.label,
+    CASE
+        WHEN NULLIF(oc.extra_data->>'display_name', '') IS NOT NULL
+             AND NULLIF(oc.extra_data->>'team_name', '') IS NOT NULL
+            THEN (oc.extra_data->>'display_name') || ' @ ' || (oc.extra_data->>'team_name')
+        WHEN NULLIF(oc.extra_data->>'email', '') IS NOT NULL
+             AND NULLIF(oc.extra_data->>'team_name', '') IS NOT NULL
+            THEN (oc.extra_data->>'email') || ' @ ' || (oc.extra_data->>'team_name')
+        WHEN NULLIF(oc.extra_data->>'display_name', '') IS NOT NULL
+            THEN oc.extra_data->>'display_name'
+        WHEN NULLIF(oc.extra_data->>'email', '') IS NOT NULL
+            THEN oc.extra_data->>'email'
+        WHEN NULLIF(oc.extra_data->>'team_name', '') IS NOT NULL
+            THEN oc.extra_data->>'team_name'
+        ELSE ''
+    END,
+    ''
+)`
 
 // AgentConnectorInstanceError is a domain error for connector instance operations.
 type AgentConnectorInstanceError struct {
@@ -40,10 +68,10 @@ const (
 )
 
 // agentConnectorInstanceSelect is the standard SELECT for an agent_connectors row with display name
-// from the assigned credential (static API key label or OAuth extra_data name).
+// from the assigned credential (static API key label or OAuth extra_data identifier).
 const agentConnectorInstanceSelect = `
 	SELECT ac.connector_instance_id, ac.agent_id, ac.connector_id, ac.approver_id,
-	       COALESCE(cr.label, oc.extra_data->>'name', '') AS display_name,
+	       ` + connectorInstanceDisplayNameSQL + ` AS display_name,
 	       ac.is_default, ac.enabled_at
 	FROM agent_connectors ac
 	LEFT JOIN agent_connector_credentials acc
@@ -317,7 +345,7 @@ func ResolveAgentConnectorInstance(ctx context.Context, db DBTX, agentID int64, 
 
 	rows, err := db.Query(ctx, agentConnectorInstanceSelect+`
 		WHERE ac.agent_id = $1 AND ac.approver_id = $2 AND ac.connector_id = $3
-		  AND COALESCE(cr.label, oc.extra_data->>'name', '') = $4
+		  AND `+connectorInstanceDisplayNameSQL+` = $4
 		ORDER BY ac.connector_instance_id ASC`,
 		agentID, approverID, connectorID, sel,
 	)

--- a/db/agent_connector_instances_test.go
+++ b/db/agent_connector_instances_test.go
@@ -160,10 +160,10 @@ func TestResolveAgentConnectorInstance_AmbiguousDisplay(t *testing.T) {
 		t.Fatalf("default: %v", defInst)
 	}
 
-	// Two OAuth connections with the same extra_data->>'name' (credentials cannot duplicate label per user+service).
+	// Two OAuth connections with the same extra_data display_name (credentials cannot duplicate label per user+service).
 	oauth1 := testhelper.GenerateID(t, "oauth_")
 	oauth2 := testhelper.GenerateID(t, "oauth_")
-	sharedName, _ := json.Marshal(map[string]string{"name": "SharedOAuthName"})
+	sharedName, _ := json.Marshal(map[string]string{"display_name": "SharedOAuthName"})
 	testhelper.InsertOAuthConnectionFull(t, tx, oauth1, uid, "test_oauth", testhelper.OAuthConnectionOpts{
 		Scopes:    []string{},
 		ExtraData: sharedName,

--- a/db/capabilities.go
+++ b/db/capabilities.go
@@ -146,9 +146,11 @@ func GetAgentCapabilities(ctx context.Context, db DBTX, agentID int64, approverI
 	}
 
 	// 1b. Per-instance credential readiness (one row per agent_connectors instance).
+	// Display name uses the shared connectorInstanceDisplayNameSQL fragment so the CLI
+	// capabilities output matches the UI's Settings → Credentials page.
 	instRows, err := db.Query(ctx, `
 		SELECT ac.connector_id, ac.connector_instance_id::text,
-		       COALESCE(cr.label, oc.extra_data->>'name', ''),
+		       `+connectorInstanceDisplayNameSQL+`,
 		       NOT EXISTS (
 		           SELECT 1 FROM connector_required_credentials crc
 		           WHERE crc.connector_id = ac.connector_id

--- a/db/capabilities_test.go
+++ b/db/capabilities_test.go
@@ -631,3 +631,151 @@ func TestConnectorRequiredCredentials_MixedAuthTypeRejectedOnUpdate(t *testing.T
 		t.Fatal("expected error when updating auth_type to create mixed auth types, got nil")
 	}
 }
+
+// TestGetAgentCapabilities_ConnectorInstanceDisplayName exercises each shape of
+// oauth_connections.extra_data the soft enrichers produce, and asserts that the
+// display string matches api.displayNameFromExtraData. This guards the CLI
+// `capabilities` output against the "display is empty for every OAuth instance"
+// regression where the SQL looked up a key that no enricher ever writes.
+func TestGetAgentCapabilities_ConnectorInstanceDisplayName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		provider  string
+		extraData map[string]string
+		want      string
+	}{
+		{
+			name:      "slack_team_name_only",
+			provider:  "slack",
+			extraData: map[string]string{"team_name": "stauntonhub"},
+			want:      "stauntonhub",
+		},
+		{
+			name:      "slack_oidc_email_and_team",
+			provider:  "slack",
+			extraData: map[string]string{"email": "alice@example.com", "team_name": "innovation hub"},
+			want:      "alice@example.com @ innovation hub",
+		},
+		{
+			name:      "slack_display_name_and_team",
+			provider:  "slack",
+			extraData: map[string]string{"display_name": "Alice Example", "team_name": "supersuit-tech"},
+			want:      "Alice Example @ supersuit-tech",
+		},
+		{
+			name:      "google_email_only",
+			provider:  "google",
+			extraData: map[string]string{"email": "alice@example.com", "display_name": "Alice Example"},
+			want:      "Alice Example",
+		},
+		{
+			name:      "github_login",
+			provider:  "github",
+			extraData: map[string]string{"display_name": "octocat", "email": "oct@example.com"},
+			want:      "octocat",
+		},
+		{
+			name:      "microsoft_display_name_preferred",
+			provider:  "microsoft",
+			extraData: map[string]string{"display_name": "Alice Example", "email": "alice@contoso.com"},
+			want:      "Alice Example",
+		},
+		{
+			name:      "email_fallback_when_no_display_name",
+			provider:  "google",
+			extraData: map[string]string{"email": "alice@example.com"},
+			want:      "alice@example.com",
+		},
+		{
+			name:      "empty_when_nothing_recognizable",
+			provider:  "google",
+			extraData: map[string]string{},
+			want:      "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tx := testhelper.SetupTestDB(t)
+
+			uid := testhelper.GenerateUID(t)
+			agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+			connID := testhelper.GenerateID(t, "conn_")
+			testhelper.InsertConnector(t, tx, connID)
+			testhelper.InsertConnectorRequiredCredentialOAuth(t, tx, connID, "svc", tc.provider, []string{"scope"})
+
+			extra, err := json.Marshal(tc.extraData)
+			if err != nil {
+				t.Fatalf("marshal extra: %v", err)
+			}
+			ocID := testhelper.GenerateID(t, "oc_")
+			testhelper.InsertOAuthConnectionFull(t, tx, ocID, uid, tc.provider, testhelper.OAuthConnectionOpts{
+				Scopes:    []string{"scope"},
+				ExtraData: extra,
+			})
+
+			testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+			testhelper.InsertAgentConnectorCredentialOAuth(t, tx, testhelper.GenerateID(t, "acc_"), agentID, uid, connID, ocID)
+
+			caps, err := db.GetAgentCapabilities(t.Context(), tx, agentID, uid)
+			if err != nil {
+				t.Fatalf("GetAgentCapabilities: %v", err)
+			}
+			if len(caps.ConnectorInstances) != 1 {
+				t.Fatalf("expected 1 instance, got %d", len(caps.ConnectorInstances))
+			}
+			if got := caps.ConnectorInstances[0].DisplayName; got != tc.want {
+				t.Errorf("DisplayName: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestListAgentConnectorInstances_OAuthDisplayName mirrors the capabilities
+// display-name test on the ListAgentConnectorInstances code path, which uses
+// the same SQL fragment via agentConnectorInstanceSelect.
+func TestListAgentConnectorInstances_OAuthDisplayName(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	connID := testhelper.GenerateID(t, "conn_")
+	testhelper.InsertConnector(t, tx, connID)
+	testhelper.InsertAgentConnector(t, tx, agentID, uid, connID)
+
+	defInst, err := db.GetDefaultAgentConnectorInstance(t.Context(), tx, agentID, uid, connID)
+	if err != nil || defInst == nil {
+		t.Fatalf("default: err=%v inst=%v", err, defInst)
+	}
+
+	extra, _ := json.Marshal(map[string]string{"display_name": "octocat", "email": "oct@example.com"})
+	ocID := testhelper.GenerateID(t, "oc_")
+	testhelper.InsertOAuthConnectionFull(t, tx, ocID, uid, "github", testhelper.OAuthConnectionOpts{
+		Scopes:    []string{},
+		ExtraData: extra,
+	})
+	_, err = db.UpsertAgentConnectorCredentialByInstance(t.Context(), tx, db.UpsertAgentConnectorCredentialByInstanceParams{
+		ID: testhelper.GenerateID(t, "acc_"), AgentID: agentID, ConnectorID: connID,
+		ConnectorInstanceID: defInst.ConnectorInstanceID, ApproverID: uid, OAuthConnectionID: &ocID,
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	instances, err := db.ListAgentConnectorInstances(t.Context(), tx, agentID, uid, connID)
+	if err != nil {
+		t.Fatalf("ListAgentConnectorInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+	if got := instances[0].DisplayName; got != "octocat" {
+		t.Errorf("DisplayName: got %q, want %q", got, "octocat")
+	}
+}


### PR DESCRIPTION
## Summary

- The CLI `capabilities` endpoint was rendering `display=""` for every OAuth-backed connector instance, so users only saw opaque UUIDs while the UI (Settings → Credentials) showed friendly names like "innovation hub", "supersuit-tech", or a Google email. Root cause: three SQL queries in `db/` read `oc.extra_data->>'name'`, but no enricher ever writes that key — Google/Microsoft/GitHub/Slack OIDC soft enrichers write `display_name` and `email`, and `extractSlackTeamName` writes `team_name`.
- Extracted the display-name derivation into a shared SQL fragment `connectorInstanceDisplayNameSQL` that mirrors the existing `displayNameFromExtraData` Go helper: prefers `display_name`, falls back to `email`, optionally suffixes with ` @ <team_name>` for Slack. Reused from `agentConnectorInstanceSelect`, `ResolveAgentConnectorInstance`'s selector-match, and the `GetAgentCapabilities` instance subquery so all three paths stay in sync.
- The issue suggested calling Slack `auth.test` at CLI-read time. That's unnecessary — `team_name` is already captured at OAuth install time and persisted in `oauth_connections.extra_data`. No live API call, cache, or backfill required.

## Test plan

- [x] New table-driven test `TestGetAgentCapabilities_ConnectorInstanceDisplayName` covering each provider shape: Slack team-only, Slack email + team composite, Slack display_name + team composite, Google email, GitHub login, Microsoft displayName, email fallback, and empty extra_data.
- [x] New `TestListAgentConnectorInstances_OAuthDisplayName` covering the same fragment on the Resolve/List code path.
- [x] Fixed `TestResolveAgentConnectorInstance_AmbiguousDisplay` seed — it was using `extra_data = {"name": ...}`, which production never writes; swapped for `display_name`.
- [x] `gofmt` clean on all changed files.
- [ ] Backend tests (`make test-backend`) — not run locally; the sandbox blocks Go module resolution (Go 1.24.7 vs. bigquery's Go 1.25 requirement, documented in CLAUDE.md). Relying on CI.
- [ ] Manual end-to-end on a dev instance: connect Slack → confirm `permission-slip capabilities --pretty` shows `"display": "innovation hub"` (or `"alice@example.com @ innovation hub"`) instead of `""`.

Closes #1056

https://claude.ai/code/session_01KcyWCVGtyZTcB82fEyPbCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcyWCVGtyZTcB82fEyPbCP)_