### PR TITLE
feat(oauth): surface Google closed-beta status in-app

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -8,6 +8,7 @@ import { Footer } from "./Footer";
 import { UserMenu } from "./UserMenu";
 import { PendingAgentBanners } from "./PendingAgentBanners";
 import { BetaBanner } from "./BetaBanner";
+import { GoogleReauthBanner } from "./GoogleReauthBanner";
 
 interface NavItem {
   label: string;
@@ -83,6 +84,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         </div>
       </nav>
       <main className="mx-auto max-w-[1200px]">
+        <GoogleReauthBanner />
         <PendingAgentBanners />
         {children}
       </main>

--- a/frontend/src/components/GoogleBetaNoticeDialog.tsx
+++ b/frontend/src/components/GoogleBetaNoticeDialog.tsx
@@ -1,0 +1,163 @@
+import { AlertTriangle, Clock, Mail, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Shown before the user is redirected to Google's OAuth consent screen while
+ * Permission Slip is in closed beta. Explains three things users need to know:
+ *
+ *  1. The app is not yet Google-verified, so Google shows a scary "unverified"
+ *     warning — users must click "Advanced" → "Go to Permission Slip (unsafe)"
+ *     to proceed.
+ *  2. During beta, Google treats them as a test user. We can only add test
+ *     users by email address, so they must have emailed support to be added.
+ *  3. Google refresh tokens expire every ~7 days while the app is unverified,
+ *     so they'll periodically need to reconnect.
+ */
+
+export const BETA_SUPPORT_EMAIL = "support@supersuit.tech";
+
+interface GoogleBetaNoticeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onContinue: () => void;
+  mode?: "connect" | "reconnect";
+}
+
+export function GoogleBetaNoticeDialog({
+  open,
+  onOpenChange,
+  onContinue,
+  mode = "connect",
+}: GoogleBetaNoticeDialogProps) {
+  const actionLabel = mode === "reconnect" ? "Continue to reconnect" : "Continue to Google";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Before you connect Google</DialogTitle>
+          <DialogDescription>
+            Permission Slip is in closed beta. Please read this before continuing —
+            Google&apos;s flow will look a little different than a fully-verified app.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2 text-sm">
+          <NoticeItem
+            icon={<Mail className="size-5 text-amber-600 dark:text-amber-400" />}
+            title="Your Google account must be added to the beta"
+          >
+            <p>
+              Google only lets unverified apps connect accounts that have been
+              individually added to the allowlist. If you haven&apos;t already
+              done so, please email{" "}
+              <a
+                href={`mailto:${BETA_SUPPORT_EMAIL}?subject=${encodeURIComponent(
+                  "Permission Slip beta — Google account access",
+                )}`}
+                className="font-medium underline underline-offset-2"
+              >
+                {BETA_SUPPORT_EMAIL}
+              </a>{" "}
+              with the Google account you plan to use. Without this, the
+              connection will fail with an &quot;access blocked&quot; error.
+            </p>
+          </NoticeItem>
+
+          <NoticeItem
+            icon={
+              <ShieldAlert className="size-5 text-amber-600 dark:text-amber-400" />
+            }
+            title={'Google will say "Google hasn\'t verified this app"'}
+          >
+            <p>
+              This is expected during beta. To proceed, click{" "}
+              <span className="font-medium">Advanced</span> on the warning
+              screen, then{" "}
+              <span className="font-medium">
+                &quot;Go to Permission Slip (unsafe)&quot;
+              </span>
+              . Your data is not at additional risk — Google simply hasn&apos;t
+              finished reviewing our OAuth scopes yet.
+            </p>
+          </NoticeItem>
+
+          <NoticeItem
+            icon={<Clock className="size-5 text-amber-600 dark:text-amber-400" />}
+            title="You'll need to reconnect every ~7 days"
+          >
+            <p>
+              Google expires refresh tokens for unverified apps after 7 days.
+              Permission Slip will let you know when your Google connection
+              needs to be re-authorized — a banner will appear at the top of
+              the app. This goes away once we complete Google verification.
+            </p>
+          </NoticeItem>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onContinue}>{actionLabel}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function NoticeItem({
+  icon,
+  title,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex gap-3 rounded-lg border border-amber-200 bg-amber-50/60 p-3 dark:border-amber-900/40 dark:bg-amber-950/30">
+      <div aria-hidden="true" className="mt-0.5 shrink-0">
+        {icon}
+      </div>
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{title}</p>
+        <div className="text-muted-foreground leading-relaxed">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/** Re-export for call sites that want to display the warning icon alongside
+ *  a "Beta" inline note without opening the full dialog. */
+export function GoogleBetaInlineNote({ className = "" }: { className?: string }) {
+  return (
+    <p
+      className={`text-muted-foreground flex items-start gap-1.5 text-xs ${className}`.trim()}
+    >
+      <AlertTriangle
+        aria-hidden="true"
+        className="mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+      />
+      <span>
+        Google is in closed beta. Your account must be allowlisted — email{" "}
+        <a
+          href={`mailto:${BETA_SUPPORT_EMAIL}`}
+          className="underline underline-offset-2"
+        >
+          {BETA_SUPPORT_EMAIL}
+        </a>{" "}
+        to join. You&apos;ll see an &quot;unverified app&quot; warning from
+        Google and will need to reconnect every ~7 days.
+      </span>
+    </p>
+  );
+}

--- a/frontend/src/components/GoogleReauthBanner.tsx
+++ b/frontend/src/components/GoogleReauthBanner.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertTriangle, LogIn, X } from "lucide-react";
+import { useAuth } from "@/auth/AuthContext";
+import { useOAuthConnections } from "@/hooks/useOAuthConnections";
+import { getOAuthAuthorizeUrl } from "@/lib/oauth";
+import { Button } from "@/components/ui/button";
+import { GoogleBetaNoticeDialog } from "./GoogleBetaNoticeDialog";
+
+const DISMISS_KEY_PREFIX = "google-reauth-banner-dismissed:";
+
+/**
+ * App-wide banner that appears when any of the user's Google OAuth connections
+ * are in the `needs_reauth` state. Shown prominently in AppLayout because
+ * Google refresh tokens for unverified apps expire after 7 days during beta,
+ * and a silently-broken Google connection is a common support complaint.
+ *
+ * Dismissal is per-connection-ID and stored in sessionStorage, so the banner
+ * reappears if the connection still needs reauth in a new session but doesn't
+ * pester the user who's deliberately ignoring it right now.
+ */
+export function GoogleReauthBanner() {
+  const { session } = useAuth();
+  const { connections } = useOAuthConnections();
+  const [betaNoticeOpen, setBetaNoticeOpen] = useState(false);
+  const [pendingReconnect, setPendingReconnect] = useState<string | null>(null);
+  const [dismissedTick, setDismissedTick] = useState(0);
+
+  const needsReauthGoogleConnections = connections.filter(
+    (c) => c.provider === "google" && c.status === "needs_reauth",
+  );
+
+  // Re-read dismissal state each render (cheap). `dismissedTick` forces a
+  // rerender after the user dismisses.
+  void dismissedTick;
+  const visibleConnections = needsReauthGoogleConnections.filter(
+    (c) =>
+      typeof sessionStorage === "undefined" ||
+      !sessionStorage.getItem(`${DISMISS_KEY_PREFIX}${c.id}`),
+  );
+
+  if (visibleConnections.length === 0) {
+    return null;
+  }
+
+  function handleReconnectClick(connectionId: string) {
+    setPendingReconnect(connectionId);
+    setBetaNoticeOpen(true);
+  }
+
+  function handleContinueToGoogle() {
+    if (!session?.access_token || !pendingReconnect) return;
+    window.location.href = getOAuthAuthorizeUrl(
+      "google",
+      session.access_token,
+      { replaceId: pendingReconnect },
+    );
+  }
+
+  function handleDismiss(connectionId: string) {
+    if (typeof sessionStorage !== "undefined") {
+      sessionStorage.setItem(`${DISMISS_KEY_PREFIX}${connectionId}`, "1");
+    }
+    setDismissedTick((n) => n + 1);
+  }
+
+  const hasMultiple = visibleConnections.length > 1;
+  const first = visibleConnections[0]!;
+
+  return (
+    <div className="mb-4 space-y-2" role="status">
+      <div className="flex flex-col gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm sm:flex-row sm:items-center sm:justify-between dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200">
+        <div className="flex min-w-0 items-start gap-3">
+          <AlertTriangle className="mt-0.5 size-5 shrink-0" aria-hidden="true" />
+          <div className="min-w-0 space-y-0.5">
+            <p className="font-medium">
+              {hasMultiple
+                ? `${visibleConnections.length} Google connections need to be reconnected`
+                : "Your Google connection needs to be reconnected"}
+            </p>
+            <p className="text-xs opacity-90">
+              While Permission Slip is in closed beta, Google expires refresh
+              tokens every ~7 days. Agents that depend on Google will fail until
+              you reconnect.{" "}
+              <Link to="/settings" className="underline underline-offset-2">
+                Manage all connections
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {!hasMultiple && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="border-amber-400 bg-white/70 hover:bg-white dark:border-amber-700 dark:bg-amber-950/40"
+              onClick={() => handleReconnectClick(first.id)}
+            >
+              <LogIn className="size-4" />
+              Reconnect Google
+            </Button>
+          )}
+          {hasMultiple && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="border-amber-400 bg-white/70 hover:bg-white dark:border-amber-700 dark:bg-amber-950/40"
+              asChild
+            >
+              <Link to="/settings">
+                <LogIn className="size-4" />
+                Go to Settings
+              </Link>
+            </Button>
+          )}
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="Dismiss until next session"
+            onClick={() => {
+              // Dismiss all currently-visible banners with one click.
+              visibleConnections.forEach((c) => handleDismiss(c.id));
+            }}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <GoogleBetaNoticeDialog
+        open={betaNoticeOpen}
+        onOpenChange={(nextOpen) => {
+          setBetaNoticeOpen(nextOpen);
+          if (!nextOpen) setPendingReconnect(null);
+        }}
+        onContinue={handleContinueToGoogle}
+        mode="reconnect"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/GoogleBetaNoticeDialog.test.tsx
+++ b/frontend/src/components/__tests__/GoogleBetaNoticeDialog.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import {
+  BETA_SUPPORT_EMAIL,
+  GoogleBetaInlineNote,
+  GoogleBetaNoticeDialog,
+} from "../GoogleBetaNoticeDialog";
+
+describe("GoogleBetaNoticeDialog", () => {
+  it("renders the three key warnings when open", () => {
+    render(
+      <GoogleBetaNoticeDialog
+        open
+        onOpenChange={() => {}}
+        onContinue={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("Your Google account must be added to the beta"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Google will say "Google hasn't verified this app"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/You'll need to reconnect every ~7 days/),
+    ).toBeInTheDocument();
+  });
+
+  it("includes a mailto: link to support", () => {
+    render(
+      <GoogleBetaNoticeDialog
+        open
+        onOpenChange={() => {}}
+        onContinue={() => {}}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: BETA_SUPPORT_EMAIL });
+    expect(link.getAttribute("href")).toMatch(
+      new RegExp(`^mailto:${BETA_SUPPORT_EMAIL}`),
+    );
+  });
+
+  it("invokes onContinue when the continue button is clicked", async () => {
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+    render(
+      <GoogleBetaNoticeDialog
+        open
+        onOpenChange={() => {}}
+        onContinue={onContinue}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /continue to google/i }),
+    );
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels the button differently in reconnect mode", () => {
+    render(
+      <GoogleBetaNoticeDialog
+        open
+        mode="reconnect"
+        onOpenChange={() => {}}
+        onContinue={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /continue to reconnect/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onOpenChange(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <GoogleBetaNoticeDialog
+        open
+        onOpenChange={onOpenChange}
+        onContinue={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("GoogleBetaInlineNote", () => {
+  it("renders the beta support email", () => {
+    render(<GoogleBetaInlineNote />);
+    const link = screen.getByRole("link", { name: BETA_SUPPORT_EMAIL });
+    expect(link.getAttribute("href")).toBe(`mailto:${BETA_SUPPORT_EMAIL}`);
+  });
+});

--- a/frontend/src/components/__tests__/GoogleReauthBanner.test.tsx
+++ b/frontend/src/components/__tests__/GoogleReauthBanner.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../test-helpers";
+import { mockGet, resetClientMocks } from "../../api/__mocks__/client";
+import { GoogleReauthBanner } from "../GoogleReauthBanner";
+
+vi.mock("../../lib/supabaseClient");
+vi.mock("../../api/client");
+
+function mockConnections(connections: unknown[]) {
+  setupAuthMocks({ authenticated: true });
+  mockGet.mockImplementation((url: string) => {
+    if (url === "/v1/oauth/connections") {
+      return Promise.resolve({ data: { connections } });
+    }
+    return Promise.resolve({ data: null });
+  });
+}
+
+describe("GoogleReauthBanner", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    sessionStorage.clear();
+    wrapper = createAuthWrapper(["/"]);
+  });
+
+  it("renders nothing when there are no Google connections", async () => {
+    mockConnections([]);
+    const { container } = render(<GoogleReauthBanner />, { wrapper });
+    // Wait one tick to let the query settle.
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders nothing when Google connection is active", async () => {
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "google",
+        scopes: ["openid"],
+        status: "active",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    const { container } = render(<GoogleReauthBanner />, { wrapper });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("does not render for non-google connection needing reauth", async () => {
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "microsoft",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    const { container } = render(<GoogleReauthBanner />, { wrapper });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders the reconnect banner when a google connection needs reauth", async () => {
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "google",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    render(<GoogleReauthBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your Google connection needs to be reconnected"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: /reconnect google/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a plural title when multiple google connections need reauth", async () => {
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "google",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+      {
+        id: "conn-2",
+        provider: "google",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    render(<GoogleReauthBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("2 Google connections need to be reconnected"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("opens the beta notice dialog when the reconnect button is clicked", async () => {
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "google",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    const user = userEvent.setup();
+    render(<GoogleReauthBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /reconnect google/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /reconnect google/i }),
+    );
+
+    expect(
+      screen.getByText("Your Google account must be added to the beta"),
+    ).toBeInTheDocument();
+  });
+
+  it("can be dismissed per session", async () => {
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "google",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    const user = userEvent.setup();
+    render(<GoogleReauthBanner />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your Google connection needs to be reconnected"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /dismiss until next session/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Your Google connection needs to be reconnected"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/hooks/useOAuthCallbackToast.ts
+++ b/frontend/src/hooks/useOAuthCallbackToast.ts
@@ -39,7 +39,19 @@ export function useOAuthCallbackToast() {
       const detail = oauthError
         ? `Failed to connect ${label}: ${oauthError}`
         : `Failed to connect ${label}. Please try again.`;
-      toast.error(detail);
+      // While Permission Slip is in closed beta, the most common Google
+      // failure is "access_denied" from an account that isn't on the test
+      // user list. Surface the beta waitlist email so users know what to
+      // do next.
+      const isGoogleAccessDenied =
+        oauthProvider === "google" &&
+        !!oauthError &&
+        /access.?denied|admin.?policy|verification/i.test(oauthError);
+      toast.error(detail, {
+        description: isGoogleAccessDenied
+          ? "Google blocked the sign-in. If you haven't already, email support@supersuit.tech to be added to the Permission Slip beta."
+          : undefined,
+      });
     }
 
     // Remove OAuth params without a full navigation.

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -38,6 +38,7 @@ import { useAutoAssignOAuthCredential } from "@/hooks/useAutoAssignOAuthCredenti
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import type { OAuthConnection } from "@/hooks/useOAuthConnections";
 import { ManageCredentialsDialog } from "./ManageCredentialsDialog";
+import { GoogleBetaNoticeDialog } from "@/components/GoogleBetaNoticeDialog";
 import type { InstanceCredentialBinding } from "@/hooks/useConnectorInstanceCredentialBindings";
 
 export interface ConnectorInstancesSectionProps {
@@ -67,6 +68,10 @@ export function ConnectorInstancesSection({
     [connectorId, requiredCredentials],
   );
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
+  const [googleNoticeState, setGoogleNoticeState] = useState<{
+    providerId: string;
+    replaceId: string;
+  } | null>(null);
   const { session } = useAuth();
 
   useAutoAssignOAuthCredential(agentId, connectorId);
@@ -368,6 +373,18 @@ export function ConnectorInstancesSection({
     return `Added ${new Date(row.credential.created_at).toLocaleDateString()}`;
   }
 
+  function performReauthRedirect(providerId: string, replaceId: string) {
+    if (!session?.access_token) return;
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      {
+        scopes: oauthScopesByProvider.get(providerId),
+        replaceId,
+      },
+    );
+  }
+
   function handleReauthorize(connection: OAuthConnection) {
     if (!session?.access_token) return;
     // Shop-required providers (e.g. shopify) prompt for a shop subdomain —
@@ -376,14 +393,14 @@ export function ConnectorInstancesSection({
       setManageDialogOpen(true);
       return;
     }
-    window.location.href = getOAuthAuthorizeUrl(
-      connection.provider,
-      session.access_token,
-      {
-        scopes: oauthScopesByProvider.get(connection.provider),
+    if (connection.provider === "google") {
+      setGoogleNoticeState({
+        providerId: connection.provider,
         replaceId: connection.id,
-      },
-    );
+      });
+      return;
+    }
+    performReauthRedirect(connection.provider, connection.id);
   }
 
   return (
@@ -550,6 +567,19 @@ export function ConnectorInstancesSection({
         anyLoading={anyLoading}
         error={credsError}
         oauthError={oauthError}
+      />
+
+      <GoogleBetaNoticeDialog
+        open={!!googleNoticeState}
+        mode="reconnect"
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setGoogleNoticeState(null);
+        }}
+        onContinue={() => {
+          const s = googleNoticeState;
+          setGoogleNoticeState(null);
+          if (s) performReauthRedirect(s.providerId, s.replaceId);
+        }}
       />
     </Card>
   );

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -36,6 +36,10 @@ import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
+import {
+  GoogleBetaInlineNote,
+  GoogleBetaNoticeDialog,
+} from "@/components/GoogleBetaNoticeDialog";
 
 export interface ManageCredentialsDialogProps {
   open: boolean;
@@ -218,6 +222,10 @@ function OAuthCredentialRow({
     id: string;
     displayName?: string;
   } | null>(null);
+  const [googleNoticeState, setGoogleNoticeState] = useState<{
+    mode: "connect" | "reconnect";
+    replaceId?: string;
+  } | null>(null);
 
   const providerId = requiredCredential.oauth_provider ?? "";
   const providerConnections = connections.filter(
@@ -233,17 +241,29 @@ function OAuthCredentialRow({
   const hasAnyConnection = providerConnections.length > 0;
   const isConnected = activeConnections.length > 0;
 
+  function performOAuthRedirect(replaceId?: string) {
+    if (!session?.access_token || !providerId) return;
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      {
+        scopes: requiredCredential.oauth_scopes,
+        ...(replaceId ? { replaceId } : {}),
+      },
+    );
+  }
+
   function handleConnect() {
     if (!session?.access_token || !providerId) return;
     if (SHOP_REQUIRED_PROVIDERS.has(providerId)) {
       setShopDialogState({});
       return;
     }
-    window.location.href = getOAuthAuthorizeUrl(
-      providerId,
-      session.access_token,
-      { scopes: requiredCredential.oauth_scopes },
-    );
+    if (providerId === "google") {
+      setGoogleNoticeState({ mode: "connect" });
+      return;
+    }
+    performOAuthRedirect();
   }
 
   function handleReconnect(connectionId: string) {
@@ -252,11 +272,11 @@ function OAuthCredentialRow({
       setShopDialogState({ replaceId: connectionId });
       return;
     }
-    window.location.href = getOAuthAuthorizeUrl(
-      providerId,
-      session.access_token,
-      { scopes: requiredCredential.oauth_scopes, replaceId: connectionId },
-    );
+    if (providerId === "google") {
+      setGoogleNoticeState({ mode: "reconnect", replaceId: connectionId });
+      return;
+    }
+    performOAuthRedirect(connectionId);
   }
 
   return (
@@ -377,6 +397,12 @@ function OAuthCredentialRow({
           </div>
         )}
 
+        {providerId === "google" && (
+          <div className="mt-3">
+            <GoogleBetaInlineNote />
+          </div>
+        )}
+
       </div>
 
       {SHOP_REQUIRED_PROVIDERS.has(providerId) && shopDialogState && (
@@ -402,6 +428,19 @@ function OAuthCredentialRow({
           displayName={disconnectTarget.displayName}
         />
       )}
+
+      <GoogleBetaNoticeDialog
+        open={!!googleNoticeState}
+        mode={googleNoticeState?.mode ?? "connect"}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setGoogleNoticeState(null);
+        }}
+        onContinue={() => {
+          const replaceId = googleNoticeState?.replaceId;
+          setGoogleNoticeState(null);
+          performOAuthRedirect(replaceId);
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -17,6 +17,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ConnectorLogo } from "@/components/ConnectorLogo";
+import {
+  GoogleBetaInlineNote,
+  GoogleBetaNoticeDialog,
+} from "@/components/GoogleBetaNoticeDialog";
 import { useAuth } from "@/auth/AuthContext";
 import { useConnectorDetail } from "@/hooks/useConnectorDetail";
 import { useOAuthProviders } from "@/hooks/useOAuthProviders";
@@ -73,6 +77,7 @@ export function SetupConnectorCredentialsDialog({
     useState(false);
   const [addCredentialTarget, setAddCredentialTarget] =
     useState<RequiredCredential | null>(null);
+  const [googleNoticeOpen, setGoogleNoticeOpen] = useState(false);
   const { tryAssign } = useTryAutoAssign(agentId, connectorId);
 
   const isLoading = detailLoading || providersLoading || connectionsLoading;
@@ -118,7 +123,7 @@ export function SetupConnectorCredentialsDialog({
     effectiveOAuthProvider != null &&
     SHOP_REQUIRED_PROVIDERS.has(effectiveOAuthProvider);
 
-  function handleOAuthConnect() {
+  function performOAuthRedirect() {
     if (!session?.access_token || !effectiveOAuthProvider) return;
 
     if (needsShopDomain) {
@@ -139,6 +144,15 @@ export function SetupConnectorCredentialsDialog({
       session.access_token,
       oauthCredential?.oauth_scopes,
     );
+  }
+
+  function handleOAuthConnect() {
+    if (!session?.access_token || !effectiveOAuthProvider) return;
+    if (effectiveOAuthProvider === "google") {
+      setGoogleNoticeOpen(true);
+      return;
+    }
+    performOAuthRedirect();
   }
 
   function handleUseApiKey(credential: RequiredCredential) {
@@ -200,6 +214,13 @@ export function SetupConnectorCredentialsDialog({
               shopSubdomain={shopSubdomain}
               onShopSubdomainChange={setShopSubdomain}
               onConnect={handleOAuthConnect}
+              footer={
+                effectiveOAuthProvider === "google" ? (
+                  <div className="w-full max-w-sm">
+                    <GoogleBetaInlineNote />
+                  </div>
+                ) : null
+              }
             />
           ) : hasOAuth && !hasOAuthCredentials ? (
             <OAuthUnavailableContent
@@ -266,6 +287,16 @@ export function SetupConnectorCredentialsDialog({
           }}
         />
       )}
+
+      <GoogleBetaNoticeDialog
+        open={googleNoticeOpen}
+        mode={needsReauth ? "reconnect" : "connect"}
+        onOpenChange={setGoogleNoticeOpen}
+        onContinue={() => {
+          setGoogleNoticeOpen(false);
+          performOAuthRedirect();
+        }}
+      />
     </>
   );
 }
@@ -342,12 +373,14 @@ function OAuthSetupContent({
   shopSubdomain,
   onShopSubdomainChange,
   onConnect,
+  footer,
 }: {
   providerName: string;
   needsShopDomain: boolean;
   shopSubdomain: string;
   onShopSubdomainChange: (value: string) => void;
   onConnect: () => void;
+  footer?: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col items-center gap-4 py-6 text-center">
@@ -379,6 +412,7 @@ function OAuthSetupContent({
         Connect with {providerName}
       </Button>
 
+      {footer}
     </div>
   );
 }

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -31,6 +31,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { DisconnectOAuthDialog } from "@/pages/agents/connectors/DisconnectOAuthDialog";
+import {
+  GoogleBetaInlineNote,
+  GoogleBetaNoticeDialog,
+} from "@/components/GoogleBetaNoticeDialog";
 
 /**
  * Config for providers that need a per-instance subdomain before the OAuth
@@ -104,16 +108,31 @@ export function ConnectedAccountsSection() {
     displayName?: string;
   } | null>(null);
 
+  const [googleNoticeState, setGoogleNoticeState] = useState<{
+    mode: "connect" | "reconnect";
+    replaceId?: string;
+  } | null>(null);
+
+  function redirectToProvider(providerId: string, replaceId?: string) {
+    if (!session?.access_token) return;
+    window.location.href = getOAuthAuthorizeUrl(
+      providerId,
+      session.access_token,
+      replaceId ? { replaceId } : undefined,
+    );
+  }
+
   function handleConnect(providerId: string) {
     if (!session?.access_token) return;
     if (providerId in INSTANCE_SUBDOMAIN_PROVIDERS) {
       setInstanceDialogState({ provider: providerId });
       return;
     }
-    window.location.href = getOAuthAuthorizeUrl(
-      providerId,
-      session.access_token,
-    );
+    if (providerId === "google") {
+      setGoogleNoticeState({ mode: "connect" });
+      return;
+    }
+    redirectToProvider(providerId);
   }
 
   function handleReconnect(connectionId: string, providerId: string) {
@@ -122,11 +141,11 @@ export function ConnectedAccountsSection() {
       setInstanceDialogState({ provider: providerId, replaceId: connectionId });
       return;
     }
-    window.location.href = getOAuthAuthorizeUrl(
-      providerId,
-      session.access_token,
-      { replaceId: connectionId },
-    );
+    if (providerId === "google") {
+      setGoogleNoticeState({ mode: "reconnect", replaceId: connectionId });
+      return;
+    }
+    redirectToProvider(providerId, connectionId);
   }
 
   // Providers that are ready to connect (have credentials configured)
@@ -278,6 +297,15 @@ export function ConnectedAccountsSection() {
               </div>
             )}
 
+            {/* Inline beta note shown whenever Google is offered as a
+                connection option, so users have context before clicking. */}
+            {(connections.some((c) => c.provider === "google") ||
+              configuredProviders.some((p) => p.id === "google")) && (
+              <div className="pt-2">
+                <GoogleBetaInlineNote />
+              </div>
+            )}
+
             {connections.length === 0 && configuredProviders.length === 0 && (
               <p className="text-muted-foreground py-4 text-center text-sm">
                 No OAuth providers are configured yet. Set up client credentials
@@ -325,6 +353,19 @@ export function ConnectedAccountsSection() {
           displayName={disconnectTarget.displayName}
         />
       )}
+
+      <GoogleBetaNoticeDialog
+        open={!!googleNoticeState}
+        mode={googleNoticeState?.mode ?? "connect"}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setGoogleNoticeState(null);
+        }}
+        onContinue={() => {
+          const replaceId = googleNoticeState?.replaceId;
+          setGoogleNoticeState(null);
+          redirectToProvider("google", replaceId);
+        }}
+      />
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

While Permission Slip is in closed beta with Google (OAuth verification withdrawn), users face three Google-specific friction points that the UI previously didn't address. This PR surfaces those issues inside the app so beta users can't miss them.

### What the UI now tells the user

1. **Their Google account must be allowlisted.** A dialog shown before any Google OAuth redirect explains this and links to `mailto:support@supersuit.tech` to request beta access.
2. **Google's "unverified app" warning is expected.** The dialog walks users through how to click `Advanced → Go to Permission Slip (unsafe)` so they don't bail at the scary screen.
3. **Refresh tokens expire every ~7 days.** Covered in the same dialog; additionally, an app-wide banner (`GoogleReauthBanner`) appears in `AppLayout` the moment any Google connection enters `needs_reauth` state, with one-click reconnect.

### Changes

- **`GoogleBetaNoticeDialog`** — interstitial dialog wired into all four places that initiate Google OAuth:
  - `ConnectedAccountsSection.tsx` (Settings → Connected Accounts)
  - `SetupConnectorCredentialsDialog.tsx` (post-enable setup flow)
  - `ManageCredentialsDialog.tsx` (per-connector credentials manager)
  - `ConnectorInstancesSection.tsx` (reauthorize from agent connector page)
- **`GoogleBetaInlineNote`** — compact note rendered inline anywhere Google is offered as a connection option, so users have context before they click.
- **`GoogleReauthBanner`** — app-wide amber banner shown in `AppLayout` when any Google connection is `needs_reauth`. Dismissable per-session. Triggers the beta dialog on reconnect.
- **`useOAuthCallbackToast`** — when Google's callback returns `access_denied` / `admin_policy_enforced` / a verification error, the toast now hints at the beta waitlist email.

### Not changed

- OAuth scopes — kept as-is pending the verification strategy decision (CASA vs. narrower scopes vs. continued Testing mode).
- Backend refresh/reauth logic — already correctly transitions revoked/expired Google connections to `needs_reauth`; this PR is purely a UX layer on top.
- Mobile — the mobile app doesn't initiate OAuth flows; no changes needed.

## Test plan

- [x] `npx vitest run src/components/__tests__/GoogleBetaNoticeDialog.test.tsx src/components/__tests__/GoogleReauthBanner.test.tsx` — 13/13 pass
- [x] `npx vitest run` (full frontend suite) — 1083/1083 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Manual: click "Connect Google" from each of the four entrypoints and confirm the dialog appears with all three warnings
- [ ] Manual: simulate `needs_reauth` on a Google connection and confirm the app-wide banner appears and reconnect flows back through the dialog
- [ ] Manual: trigger a Google OAuth failure with `oauth_error=access_denied` and confirm the toast shows the beta-waitlist hint

https://claude.ai/code/session_01T389RvQNwi26terKbF5PYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01T389RvQNwi26terKbF5PYM)_