### PR TITLE
feat(slack): add client.counts action for per-channel unread state

### DIFF
--- a/connectors/slack/client_counts.go
+++ b/connectors/slack/client_counts.go
@@ -1,0 +1,91 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// clientCountsResponse is the response from the undocumented client.counts endpoint.
+// This endpoint is used by the Slack web client to get per-channel and per-DM unread
+// state. It is undocumented and may change without notice.
+type clientCountsResponse struct {
+	slackResponse
+	Channels []clientCountChannel `json:"channels"`
+	Mpims    []clientCountChannel `json:"mpims"`
+	Ims      []clientCountChannel `json:"ims"`
+	Threads  clientCountThreads   `json:"threads"`
+}
+
+type clientCountChannel struct {
+	ID            string  `json:"id"`
+	HasUnreads    bool    `json:"has_unreads"`
+	MentionCount  int     `json:"mention_count"`
+	Latest        string  `json:"latest"`
+}
+
+type clientCountThreads struct {
+	HasUnreads   bool `json:"has_unreads"`
+	MentionCount int  `json:"mention_count"`
+}
+
+// clientCountsAction implements slack.client_counts.
+type clientCountsAction struct {
+	conn *SlackConnector
+}
+
+type clientCountsParams struct{}
+
+func (p *clientCountsParams) validate() error { return nil }
+
+type channelUnreadEntry struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelType string `json:"channel_type"`
+	HasUnreads  bool   `json:"has_unreads"`
+	MentionCount int   `json:"mention_count"`
+	LatestTS    string `json:"latest_ts,omitempty"`
+}
+
+type clientCountsResult struct {
+	Channels    []channelUnreadEntry `json:"channels"`
+	MPIMs       []channelUnreadEntry `json:"mpims"`
+	IMs         []channelUnreadEntry `json:"ims"`
+	ThreadsUnread bool               `json:"threads_unread"`
+}
+
+func (a *clientCountsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params clientCountsParams
+	if err := parseAndValidate(req.Parameters, &params); err != nil {
+		return nil, err
+	}
+
+	var resp clientCountsResponse
+	// client.counts is a GET endpoint — no parameters needed.
+	if err := a.conn.doGet(ctx, "client.counts", req.Credentials, nil, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, resp.asError()
+	}
+
+	entries := func(channels []clientCountChannel, channelType string) []channelUnreadEntry {
+		var entries []channelUnreadEntry
+		for _, ch := range channels {
+			entries = append(entries, channelUnreadEntry{
+				ChannelID:    ch.ID,
+				ChannelType:  channelType,
+				HasUnreads:   ch.HasUnreads,
+				MentionCount: ch.MentionCount,
+				LatestTS:     ch.Latest,
+			})
+		}
+		return entries
+	}
+
+	return connectors.JSONResult(clientCountsResult{
+		Channels:     entries(resp.Channels, "public_channel"),
+		MPIMs:        entries(resp.Mpims, "mpim"),
+		IMs:          entries(resp.Ims, "im"),
+		ThreadsUnread: resp.Threads.HasUnreads,
+	})
+}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -797,6 +797,17 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
+				ActionType:      "slack.client_counts",
+				Name:            "Get Unread Counts",
+				Description:     "Get unread state for all channels, DMs, and group DMs via Slack's undocumented client.counts endpoint. Returns has_unreads, mention_count, and latest timestamp per conversation. This is the only way to get per-channel unread state — conversations.info only provides it for DMs. WARNING: This endpoint is undocumented and may change or break without notice.",
+				RiskLevel:       "low",
+				DisplayTemplate: "Get Slack unread counts",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {}
+				}`)),
+			},
+			{
 				ActionType:      "slack.mark_read",
 				Name:            "Mark Read",
 				Description:     "Set the read cursor for a conversation (conversations.mark). Requires channel_id and ts — pass the Slack message timestamp of the last message you showed the user (no default).",

--- a/connectors/slack/param_validate.go
+++ b/connectors/slack/param_validate.go
@@ -43,6 +43,7 @@ var paramValidators = map[string]connectors.ParamValidatorFunc{
 	"slack.rename_channel":        makeParamValidator[renameChannelParams](),
 	"slack.unpin_message":         makeParamValidator[unpinMessageParams](),
 	"slack.list_unread":           makeParamValidator[listUnreadParams](),
+	"slack.client_counts":         makeParamValidator[clientCountsParams](),
 	"slack.mark_read":             makeParamValidator[markReadParams](),
 }
 

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -125,6 +125,7 @@ func (c *SlackConnector) Actions() map[string]connectors.Action {
 		"slack.pin_message":           &pinMessageAction{conn: c},
 		"slack.unpin_message":         &unpinMessageAction{conn: c},
 		"slack.list_unread":           &listUnreadAction{conn: c},
+		"slack.client_counts":          &clientCountsAction{conn: c},
 		"slack.mark_read":             &markReadAction{conn: c},
 	}
 }

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -47,6 +47,7 @@ func TestSlackConnector_Actions(t *testing.T) {
 		"slack.pin_message",
 		"slack.unpin_message",
 		"slack.list_unread",
+		"slack.client_counts",
 		"slack.mark_read",
 	}
 	for _, name := range expected {
@@ -115,9 +116,9 @@ func TestSlackConnector_Manifest(t *testing.T) {
 	if m.Name != "Slack" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Slack")
 	}
-	if len(m.Actions) != 24 {
-		t.Fatalf("Manifest().Actions has %d items, want 24", len(m.Actions))
-	}
+	if len(m.Actions) != 25 {
+			t.Fatalf("Manifest().Actions has %d items, want 25", len(m.Actions))
+		}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
 		actionTypes[a.ActionType] = true


### PR DESCRIPTION
## Summary

Adds a new `slack.client_counts` action that calls Slack's undocumented `client.counts` endpoint — the **only** way to get per-channel unread state.

### Problem

- `conversations.info` → `unread_count_display` is **DM-only** per Slack's own docs
- For channels (public/private), `unread_count_display` is absent → `list_unread` returns null for channel unreads
- `client.counts` is what the Slack web client uses internally to get `has_unreads` per channel

### Implementation

- New `client_counts.go` with `clientCountsAction`
- GET `https://slack.com/api/client.counts` (no parameters needed)
- Returns `has_unreads`, `mention_count`, `latest_ts` for each channel, mpim, and im
- ⚠️ **WARNING** in action description: undocumented endpoint, may break without notice

### Scopes

**No new OAuth scopes required.** Works with the existing user token scopes.

### Testing

Needs testing with real token — local dev DB doesn't have production OAuth tokens. Must test via `app.permissionslip.dev` after merge.

### Files Changed

- `connectors/slack/client_counts.go` (new)
- `connectors/slack/manifest.go` (register action)
- `connectors/slack/slack.go` (wire action)
- `connectors/slack/param_validate.go` (add validator)
- `connectors/slack/slack_test.go` (update expected counts)