### PR TITLE
Add Slack client_counts to manifest templates

### DIFF
--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -1070,6 +1070,14 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				Parameters:       json.RawMessage(`{"channel_id":"*","ts":"*"}`),
 				StandingApproval: neverExpire,
 			},
+			{
+				ID:               "tpl_slack_client_counts",
+				ActionType:       "slack.client_counts",
+				Name:             "Get unread counts",
+				Description:      "Agent can read per-conversation unread state via Slack client.counts (undocumented; may change without notice).",
+				Parameters:       json.RawMessage(`{}`),
+				StandingApproval: neverExpire,
+			},
 		},
 	}
 }

--- a/connectors/slack/slack_test.go
+++ b/connectors/slack/slack_test.go
@@ -117,8 +117,8 @@ func TestSlackConnector_Manifest(t *testing.T) {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Slack")
 	}
 	if len(m.Actions) != 25 {
-			t.Fatalf("Manifest().Actions has %d items, want 25", len(m.Actions))
-		}
+		t.Fatalf("Manifest().Actions has %d items, want 25", len(m.Actions))
+	}
 	actionTypes := make(map[string]bool)
 	for _, a := range m.Actions {
 		actionTypes[a.ActionType] = true
@@ -132,7 +132,7 @@ func TestSlackConnector_Manifest(t *testing.T) {
 		"slack.list_users", "slack.search_messages",
 		"slack.archive_channel", "slack.rename_channel", "slack.remove_from_channel",
 		"slack.get_user_profile", "slack.pin_message", "slack.unpin_message",
-		"slack.list_unread", "slack.mark_read",
+		"slack.list_unread", "slack.client_counts", "slack.mark_read",
 	} {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The Slack connector already exposed `slack.list_unread` as manifest template `tpl_slack_list_unread`, but `slack.client_counts` had no corresponding `ManifestTemplate`, so it never appeared in the action configuration template list (including the Recommended Templates UI).

This change adds `tpl_slack_client_counts` with the same shape as list unread: empty `{}` parameters and `standing_approval` so it matches other read-style Slack templates.

## Test plan
- [ ] CI: `go test ./connectors/slack/...` (full backend suite not run locally in this environment due to Go module graph constraints).
- [ ] After deploy/seed: confirm `/v1/action-config-templates?connector_id=slack` includes both `tpl_slack_list_unread` and `tpl_slack_client_counts` when those actions are enabled for the agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2033b431-757c-4c41-9df6-bb393bc4410f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2033b431-757c-4c41-9df6-bb393bc4410f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

