### PR TITLE
Document slack.list_unread Slack API limits; add response notes

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -180,7 +180,7 @@ Reads recent messages from a Slack channel, DM, or group DM using `conversations
 
 To answer “do I have unread Slack messages?” or load only unread content, use this flow (no extra OAuth scopes beyond the connector’s user token):
 
-1. Call **`slack.list_unread`** — returns conversations where `unread_count` &gt; 0, with `last_read_ts` and a short `latest_message_preview` when Slack provides `latest`.
+1. Call **`slack.list_unread`** — returns conversations where Slack’s `conversations.info` reports `unread_count` &gt; 0 (in practice **DMs and group DMs**; public/private channels are omitted because Slack does not surface unread counts there), plus a fixed **`notes`** field on every response describing the limitation and per-channel workarounds. Each row includes `last_read_ts` and a short `latest_message_preview` when Slack provides `latest`.
 2. For a given conversation, call **`slack.read_channel_messages`** with **`oldest` = `last_read_ts`** from that row (Slack accepts the same timestamp format as in `list_unread`). That limits history to messages after the user’s read cursor instead of guessing from “recent” history alone.
 3. Optionally **`slack.mark_read`** with **`channel_id`** and an explicit **`ts`** — the Slack message timestamp of the last message you surfaced to the user. **`ts` is required** (there is no default) so the agent cannot clear unreads it never showed.
 
@@ -188,7 +188,9 @@ To answer “do I have unread Slack messages?” or load only unread content, us
 
 ### `slack.list_unread`
 
-Lists conversations where the authorizing user has unread messages. Uses `users.conversations` to enumerate conversations, then `conversations.info` per channel for `last_read`, `unread_count_display`, and `latest`.
+Lists conversations where Slack reports an unread count via `conversations.info` (`unread_count_display` &gt; 0). **Slack only fills those fields for IMs and MPIMs**; public and private channels are not included even when the user has unread messages in the client. Every JSON response includes **`notes`** with the same limitation text, the impracticality of scanning all channels, and that comparing `last_read` to the latest message for **specific** channels via `read_channel_messages` is the supported workaround (manual “mark as unread” in Slack may not move `last_read`).
+
+Uses `users.conversations` to enumerate conversations, then `conversations.info` per channel for `last_read`, `unread_count_display`, and `latest`.
 
 **Slack API:** `POST /users.conversations`, `GET /conversations.info`
 

--- a/connectors/slack/list_unread.go
+++ b/connectors/slack/list_unread.go
@@ -7,6 +7,10 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
+// listUnreadResponseNotes is returned on every slack.list_unread response so
+// agents and API clients learn Slack platform limits without relying on UI copy alone.
+const listUnreadResponseNotes = "Slack only populates unread_count on conversations.info for DMs (im) and group DMs (mpim). Public and private channels never appear here even when the user has unreads. For a specific channel, use slack.read_channel_messages (conversations.history) and compare the latest message ts to conversations.info last_read for that channel; scanning all channels that way is not feasible (many API calls, rate limits). If the user marks messages as unread in the Slack client, last_read may not reflect that, so this read-cursor check can miss those cases."
+
 // listUnreadAction implements slack.list_unread.
 type listUnreadAction struct {
 	conn *SlackConnector
@@ -32,6 +36,7 @@ type unreadChannelEntry struct {
 }
 
 type listUnreadResult struct {
+	Notes          string               `json:"notes"`
 	UnreadChannels []unreadChannelEntry `json:"unread_channels"`
 }
 
@@ -166,7 +171,10 @@ func (a *listUnreadAction) Execute(ctx context.Context, req connectors.ActionReq
 		})
 	}
 
-	return connectors.JSONResult(listUnreadResult{UnreadChannels: entries})
+	return connectors.JSONResult(listUnreadResult{
+		Notes:          listUnreadResponseNotes,
+		UnreadChannels: entries,
+	})
 }
 
 func channelDisplayNameFromListEntry(ch listChannelEntry) string {

--- a/connectors/slack/list_unread_test.go
+++ b/connectors/slack/list_unread_test.go
@@ -40,6 +40,9 @@ func TestListUnread_NoEmail_Succeeds(t *testing.T) {
 	if err := json.Unmarshal(res.Data, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+	if out.Notes != listUnreadResponseNotes {
+		t.Fatalf("notes mismatch")
+	}
 	if len(out.UnreadChannels) != 0 {
 		t.Fatalf("expected no unreads, got %+v", out.UnreadChannels)
 	}
@@ -96,6 +99,9 @@ func TestListUnread_NoUnreads(t *testing.T) {
 	if err := json.Unmarshal(res.Data, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+	if out.Notes != listUnreadResponseNotes {
+		t.Fatalf("notes mismatch")
+	}
 	if len(out.UnreadChannels) != 0 {
 		t.Fatalf("expected no unreads, got %+v", out.UnreadChannels)
 	}
@@ -120,16 +126,17 @@ func TestListUnread_MixedTypes_WithPreview(t *testing.T) {
 			ch := r.URL.Query().Get("channel")
 			switch ch {
 			case "Cpub":
+				// Slack does not surface unread_count_display for public channels; still listed in users.conversations.
 				json.NewEncoder(w).Encode(map[string]any{
 					"ok": true,
 					"channel": map[string]any{
 						"id":                   "Cpub",
 						"name":                 "announce",
 						"is_private":           false,
-						"unread_count_display": 2,
+						"unread_count_display": 0,
 						"last_read":            "100.0",
 						"latest": map[string]any{
-							"text": strings.Repeat("a", 250),
+							"text": "would not be treated as unread",
 							"user": "U9",
 							"ts":   "200.0",
 						},
@@ -145,7 +152,7 @@ func TestListUnread_MixedTypes_WithPreview(t *testing.T) {
 						"unread_count_display": 1,
 						"last_read":            "1.0",
 						"latest": map[string]any{
-							"text": "dm hello",
+							"text": strings.Repeat("a", 250),
 							"user": "U222",
 							"ts":   "2.0",
 						},
@@ -192,27 +199,30 @@ func TestListUnread_MixedTypes_WithPreview(t *testing.T) {
 	if err := json.Unmarshal(res.Data, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(out.UnreadChannels) != 3 {
-		t.Fatalf("expected 3 unreads, got %d", len(out.UnreadChannels))
+	if out.Notes != listUnreadResponseNotes {
+		t.Fatalf("notes mismatch")
 	}
-	// Find Cpub and check truncation
-	var pub *unreadChannelEntry
+	if len(out.UnreadChannels) != 2 {
+		t.Fatalf("expected 2 unreads (DM + mpim; public channel omitted by Slack), got %d", len(out.UnreadChannels))
+	}
+	// Find Ddm and check truncation on preview text
+	var dm *unreadChannelEntry
 	for i := range out.UnreadChannels {
-		if out.UnreadChannels[i].ChannelID == "Cpub" {
-			pub = &out.UnreadChannels[i]
+		if out.UnreadChannels[i].ChannelID == "Ddm" {
+			dm = &out.UnreadChannels[i]
 			break
 		}
 	}
-	if pub == nil {
-		t.Fatal("missing Cpub entry")
+	if dm == nil {
+		t.Fatal("missing Ddm entry")
 	}
-	if pub.ChannelType != "public_channel" {
-		t.Errorf("Cpub type: got %q", pub.ChannelType)
+	if dm.ChannelType != "direct_message" {
+		t.Errorf("Ddm type: got %q", dm.ChannelType)
 	}
-	if pub.LatestMessagePreview == nil {
+	if dm.LatestMessagePreview == nil {
 		t.Fatal("missing preview")
 	}
-	if got := len([]rune(pub.LatestMessagePreview.Text)); got != 201 { // 200 runes + ellipsis
+	if got := len([]rune(dm.LatestMessagePreview.Text)); got != 201 { // 200 runes + ellipsis
 		t.Errorf("expected truncated text length 201 runes, got %d", got)
 	}
 }
@@ -245,6 +255,9 @@ func TestListUnread_EmptyChannelList(t *testing.T) {
 	}
 	var out listUnreadResult
 	_ = json.Unmarshal(res.Data, &out)
+	if out.Notes != listUnreadResponseNotes {
+		t.Fatalf("notes mismatch")
+	}
 	if len(out.UnreadChannels) != 0 {
 		t.Fatalf("expected empty, got %d", len(out.UnreadChannels))
 	}
@@ -291,6 +304,9 @@ func TestListUnread_MissingLatestOmitsPreview(t *testing.T) {
 	}
 	var out listUnreadResult
 	_ = json.Unmarshal(res.Data, &out)
+	if out.Notes != listUnreadResponseNotes {
+		t.Fatalf("notes mismatch")
+	}
 	if len(out.UnreadChannels) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(out.UnreadChannels))
 	}
@@ -400,6 +416,9 @@ func TestListUnread_PaginatesUsersConversations(t *testing.T) {
 	}
 	var out listUnreadResult
 	_ = json.Unmarshal(res.Data, &out)
+	if out.Notes != listUnreadResponseNotes {
+		t.Fatalf("notes mismatch")
+	}
 	if len(out.UnreadChannels) != 1 || out.UnreadChannels[0].ChannelID != "C2" {
 		t.Fatalf("expected single unread on C2, got %+v", out.UnreadChannels)
 	}

--- a/connectors/slack/manifest.go
+++ b/connectors/slack/manifest.go
@@ -788,7 +788,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:      "slack.list_unread",
 				Name:            "List Unread",
-				Description:     "List Slack conversations where the authorizing user has unread messages (users.conversations + conversations.info per channel). Use slack.read_channel_messages with oldest = last_read_ts from an entry to load only unread messages; optionally clear read state with slack.mark_read using the ts of the last message you surfaced (required parameter).",
+				Description:     "List Slack conversations where Slack exposes an unread count (typically DMs and group DMs only). Slack does not populate unread_count on conversations.info for public/private channels, so those never appear here even when the user has unreads — this is a Slack API limitation, not a Permission Slip bug. The action response includes a notes field explaining limits and how to approximate unreads per channel via read_channel_messages vs last_read. Use slack.read_channel_messages with oldest = last_read_ts from an entry to load only unread messages; optionally clear read state with slack.mark_read using the ts of the last message you surfaced (required parameter). Manual \"mark as unread\" in Slack clients may not update last_read.",
 				RiskLevel:       "low",
 				DisplayTemplate: "List unread Slack conversations",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
@@ -1047,7 +1047,7 @@ func (c *SlackConnector) Manifest() *connectors.ConnectorManifest {
 				ID:               "tpl_slack_list_unread",
 				ActionType:       "slack.list_unread",
 				Name:             "List unread conversations",
-				Description:      "Agent can list conversations with unread messages for the authorizing user.",
+				Description:      "Agent can list conversations where Slack reports unreads (DMs and group DMs; not public/private channels — see response notes).",
 				Parameters:       json.RawMessage(`{}`),
 				StandingApproval: neverExpire,
 			},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [GitHub issue #1064](https://github.com/supersuit-tech/permission-slip/issues/1064): `slack.list_unread` now returns a fixed `notes` string on every successful response so agents and API clients see Slack platform limits (DM/mpim-only unread counts from `conversations.info`), why public/private channels never appear, the per-channel workaround (`read_channel_messages` vs `last_read`), and caveats (many channels = rate limits; client "mark as unread" may not update `last_read`).

Also updates the Slack connector manifest action/template descriptions and the Slack README to match.

## Test plan

- [ ] `go test ./connectors/slack/...` (not run in this environment: local `go` is older than `go.mod`; syntax verified with `gofmt -e` on changed files)
- [ ] CI `go test` on the PR branch

Closes #1064
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41bd2ba6-11c3-431d-8ef2-e686edf50569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41bd2ba6-11c3-431d-8ef2-e686edf50569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

