### PR TITLE
fix(frontend): gate Google closed-beta UX on SaaS mode

### DIFF
--- a/frontend/src/components/GoogleReauthBanner.tsx
+++ b/frontend/src/components/GoogleReauthBanner.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, LogIn, X } from "lucide-react";
 import { useAuth } from "@/auth/AuthContext";
 import { useOAuthConnections } from "@/hooks/useOAuthConnections";
 import { getOAuthAuthorizeUrl } from "@/lib/oauth";
+import { isSaas } from "@/lib/saas";
 import { Button } from "@/components/ui/button";
 import { GoogleBetaNoticeDialog } from "./GoogleBetaNoticeDialog";
 
@@ -26,9 +27,11 @@ export function GoogleReauthBanner() {
   const [pendingReconnect, setPendingReconnect] = useState<string | null>(null);
   const [dismissedTick, setDismissedTick] = useState(0);
 
-  const needsReauthGoogleConnections = connections.filter(
-    (c) => c.provider === "google" && c.status === "needs_reauth",
-  );
+  const needsReauthGoogleConnections = isSaas
+    ? connections.filter(
+        (c) => c.provider === "google" && c.status === "needs_reauth",
+      )
+    : [];
 
   // Re-read dismissal state each render (cheap). `dismissedTick` forces a
   // rerender after the user dismisses.
@@ -45,16 +48,25 @@ export function GoogleReauthBanner() {
 
   function handleReconnectClick(connectionId: string) {
     setPendingReconnect(connectionId);
-    setBetaNoticeOpen(true);
+    if (isSaas) {
+      setBetaNoticeOpen(true);
+      return;
+    }
+    handleContinueToGoogleFor(connectionId);
   }
 
-  function handleContinueToGoogle() {
-    if (!session?.access_token || !pendingReconnect) return;
+  function handleContinueToGoogleFor(connectionId: string) {
+    if (!session?.access_token) return;
     window.location.href = getOAuthAuthorizeUrl(
       "google",
       session.access_token,
-      { replaceId: pendingReconnect },
+      { replaceId: connectionId },
     );
+  }
+
+  function handleContinueToGoogle() {
+    if (!pendingReconnect) return;
+    handleContinueToGoogleFor(pendingReconnect);
   }
 
   function handleDismiss(connectionId: string) {

--- a/frontend/src/components/__tests__/GoogleReauthBanner.test.tsx
+++ b/frontend/src/components/__tests__/GoogleReauthBanner.test.tsx
@@ -6,6 +6,14 @@ import { createAuthWrapper } from "../../test-helpers";
 import { mockGet, resetClientMocks } from "../../api/__mocks__/client";
 import { GoogleReauthBanner } from "../GoogleReauthBanner";
 
+const saasMode = vi.hoisted(() => ({ isSaas: true }));
+
+vi.mock("@/lib/saas", () => ({
+  get isSaas() {
+    return saasMode.isSaas;
+  },
+}));
+
 vi.mock("../../lib/supabaseClient");
 vi.mock("../../api/client");
 
@@ -26,7 +34,25 @@ describe("GoogleReauthBanner", () => {
     vi.restoreAllMocks();
     resetClientMocks();
     sessionStorage.clear();
+    saasMode.isSaas = true;
     wrapper = createAuthWrapper(["/"]);
+  });
+
+  it("renders nothing for self-hosted when Google needs reauth", async () => {
+    saasMode.isSaas = false;
+    mockConnections([
+      {
+        id: "conn-1",
+        provider: "google",
+        scopes: ["openid"],
+        status: "needs_reauth",
+        connected_at: "2026-03-05T10:00:00Z",
+      },
+    ]);
+    const { container } = render(<GoogleReauthBanner />, { wrapper });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
   });
 
   it("renders nothing when there are no Google connections", async () => {

--- a/frontend/src/hooks/__tests__/useOAuthCallbackToast.test.tsx
+++ b/frontend/src/hooks/__tests__/useOAuthCallbackToast.test.tsx
@@ -1,0 +1,86 @@
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useOAuthCallbackToast } from "../useOAuthCallbackToast";
+
+const saasMode = vi.hoisted(() => ({ isSaas: true }));
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/lib/saas", () => ({
+  get isSaas() {
+    return saasMode.isSaas;
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    get success() {
+      return toastMocks.success;
+    },
+    get error() {
+      return toastMocks.error;
+    },
+  },
+}));
+
+function Harness() {
+  useOAuthCallbackToast();
+  return null;
+}
+
+function renderWithOauthUrl(search: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/${search}`]}>
+        <Harness />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("useOAuthCallbackToast", () => {
+  beforeEach(() => {
+    saasMode.isSaas = true;
+    toastMocks.success.mockClear();
+    toastMocks.error.mockClear();
+  });
+
+  it("does not add hosted-beta hint for Google access_denied when not SaaS", async () => {
+    saasMode.isSaas = false;
+    renderWithOauthUrl(
+      "?oauth_status=error&oauth_provider=google&oauth_error=access_denied",
+    );
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalled();
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to connect Google"),
+      { description: undefined },
+    );
+  });
+
+  it("adds hosted-beta hint for Google access_denied when SaaS", async () => {
+    saasMode.isSaas = true;
+    renderWithOauthUrl(
+      "?oauth_status=error&oauth_provider=google&oauth_error=access_denied",
+    );
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalled();
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to connect Google"),
+      {
+        description: expect.stringContaining("support@supersuit.tech"),
+      },
+    );
+  });
+});

--- a/frontend/src/hooks/useOAuthCallbackToast.ts
+++ b/frontend/src/hooks/useOAuthCallbackToast.ts
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { providerLabel } from "@/lib/labels";
+import { isSaas } from "@/lib/saas";
 
 /**
  * Global handler for OAuth callback query parameters. After the backend
@@ -44,6 +45,7 @@ export function useOAuthCallbackToast() {
       // user list. Surface the beta waitlist email so users know what to
       // do next.
       const isGoogleAccessDenied =
+        isSaas &&
         oauthProvider === "google" &&
         !!oauthError &&
         /access.?denied|admin.?policy|verification/i.test(oauthError);

--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -39,6 +39,7 @@ import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import type { OAuthConnection } from "@/hooks/useOAuthConnections";
 import { ManageCredentialsDialog } from "./ManageCredentialsDialog";
 import { GoogleBetaNoticeDialog } from "@/components/GoogleBetaNoticeDialog";
+import { isSaas } from "@/lib/saas";
 import type { InstanceCredentialBinding } from "@/hooks/useConnectorInstanceCredentialBindings";
 
 export interface ConnectorInstancesSectionProps {
@@ -393,7 +394,7 @@ export function ConnectorInstancesSection({
       setManageDialogOpen(true);
       return;
     }
-    if (connection.provider === "google") {
+    if (connection.provider === "google" && isSaas) {
       setGoogleNoticeState({
         providerId: connection.provider,
         replaceId: connection.id,
@@ -569,18 +570,20 @@ export function ConnectorInstancesSection({
         oauthError={oauthError}
       />
 
-      <GoogleBetaNoticeDialog
-        open={!!googleNoticeState}
-        mode="reconnect"
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setGoogleNoticeState(null);
-        }}
-        onContinue={() => {
-          const s = googleNoticeState;
-          setGoogleNoticeState(null);
-          if (s) performReauthRedirect(s.providerId, s.replaceId);
-        }}
-      />
+      {isSaas && (
+        <GoogleBetaNoticeDialog
+          open={!!googleNoticeState}
+          mode="reconnect"
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setGoogleNoticeState(null);
+          }}
+          onContinue={() => {
+            const s = googleNoticeState;
+            setGoogleNoticeState(null);
+            if (s) performReauthRedirect(s.providerId, s.replaceId);
+          }}
+        />
+      )}
     </Card>
   );
 }

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -40,6 +40,7 @@ import {
   GoogleBetaInlineNote,
   GoogleBetaNoticeDialog,
 } from "@/components/GoogleBetaNoticeDialog";
+import { isSaas } from "@/lib/saas";
 
 export interface ManageCredentialsDialogProps {
   open: boolean;
@@ -259,7 +260,7 @@ function OAuthCredentialRow({
       setShopDialogState({});
       return;
     }
-    if (providerId === "google") {
+    if (providerId === "google" && isSaas) {
       setGoogleNoticeState({ mode: "connect" });
       return;
     }
@@ -272,7 +273,7 @@ function OAuthCredentialRow({
       setShopDialogState({ replaceId: connectionId });
       return;
     }
-    if (providerId === "google") {
+    if (providerId === "google" && isSaas) {
       setGoogleNoticeState({ mode: "reconnect", replaceId: connectionId });
       return;
     }
@@ -397,7 +398,7 @@ function OAuthCredentialRow({
           </div>
         )}
 
-        {providerId === "google" && (
+        {providerId === "google" && isSaas && (
           <div className="mt-3">
             <GoogleBetaInlineNote />
           </div>
@@ -429,18 +430,20 @@ function OAuthCredentialRow({
         />
       )}
 
-      <GoogleBetaNoticeDialog
-        open={!!googleNoticeState}
-        mode={googleNoticeState?.mode ?? "connect"}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setGoogleNoticeState(null);
-        }}
-        onContinue={() => {
-          const replaceId = googleNoticeState?.replaceId;
-          setGoogleNoticeState(null);
-          performOAuthRedirect(replaceId);
-        }}
-      />
+      {isSaas && (
+        <GoogleBetaNoticeDialog
+          open={!!googleNoticeState}
+          mode={googleNoticeState?.mode ?? "connect"}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setGoogleNoticeState(null);
+          }}
+          onContinue={() => {
+            const replaceId = googleNoticeState?.replaceId;
+            setGoogleNoticeState(null);
+            performOAuthRedirect(replaceId);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -30,6 +30,7 @@ import {
   getOAuthAuthorizeUrl,
   SHOP_REQUIRED_PROVIDERS,
 } from "@/lib/oauth";
+import { isSaas } from "@/lib/saas";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
 import { AddCredentialDialog } from "./AddCredentialDialog";
@@ -148,7 +149,7 @@ export function SetupConnectorCredentialsDialog({
 
   function handleOAuthConnect() {
     if (!session?.access_token || !effectiveOAuthProvider) return;
-    if (effectiveOAuthProvider === "google") {
+    if (effectiveOAuthProvider === "google" && isSaas) {
       setGoogleNoticeOpen(true);
       return;
     }
@@ -215,7 +216,7 @@ export function SetupConnectorCredentialsDialog({
               onShopSubdomainChange={setShopSubdomain}
               onConnect={handleOAuthConnect}
               footer={
-                effectiveOAuthProvider === "google" ? (
+                effectiveOAuthProvider === "google" && isSaas ? (
                   <div className="w-full max-w-sm">
                     <GoogleBetaInlineNote />
                   </div>
@@ -288,15 +289,17 @@ export function SetupConnectorCredentialsDialog({
         />
       )}
 
-      <GoogleBetaNoticeDialog
-        open={googleNoticeOpen}
-        mode={needsReauth ? "reconnect" : "connect"}
-        onOpenChange={setGoogleNoticeOpen}
-        onContinue={() => {
-          setGoogleNoticeOpen(false);
-          performOAuthRedirect();
-        }}
-      />
+      {isSaas && (
+        <GoogleBetaNoticeDialog
+          open={googleNoticeOpen}
+          mode={needsReauth ? "reconnect" : "connect"}
+          onOpenChange={setGoogleNoticeOpen}
+          onContinue={() => {
+            setGoogleNoticeOpen(false);
+            performOAuthRedirect();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/settings/ConnectedAccountsSection.tsx
+++ b/frontend/src/pages/settings/ConnectedAccountsSection.tsx
@@ -35,6 +35,7 @@ import {
   GoogleBetaInlineNote,
   GoogleBetaNoticeDialog,
 } from "@/components/GoogleBetaNoticeDialog";
+import { isSaas } from "@/lib/saas";
 
 /**
  * Config for providers that need a per-instance subdomain before the OAuth
@@ -128,7 +129,7 @@ export function ConnectedAccountsSection() {
       setInstanceDialogState({ provider: providerId });
       return;
     }
-    if (providerId === "google") {
+    if (providerId === "google" && isSaas) {
       setGoogleNoticeState({ mode: "connect" });
       return;
     }
@@ -141,7 +142,7 @@ export function ConnectedAccountsSection() {
       setInstanceDialogState({ provider: providerId, replaceId: connectionId });
       return;
     }
-    if (providerId === "google") {
+    if (providerId === "google" && isSaas) {
       setGoogleNoticeState({ mode: "reconnect", replaceId: connectionId });
       return;
     }
@@ -299,12 +300,13 @@ export function ConnectedAccountsSection() {
 
             {/* Inline beta note shown whenever Google is offered as a
                 connection option, so users have context before clicking. */}
-            {(connections.some((c) => c.provider === "google") ||
-              configuredProviders.some((p) => p.id === "google")) && (
-              <div className="pt-2">
-                <GoogleBetaInlineNote />
-              </div>
-            )}
+            {isSaas &&
+              (connections.some((c) => c.provider === "google") ||
+                configuredProviders.some((p) => p.id === "google")) && (
+                <div className="pt-2">
+                  <GoogleBetaInlineNote />
+                </div>
+              )}
 
             {connections.length === 0 && configuredProviders.length === 0 && (
               <p className="text-muted-foreground py-4 text-center text-sm">
@@ -354,18 +356,20 @@ export function ConnectedAccountsSection() {
         />
       )}
 
-      <GoogleBetaNoticeDialog
-        open={!!googleNoticeState}
-        mode={googleNoticeState?.mode ?? "connect"}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setGoogleNoticeState(null);
-        }}
-        onContinue={() => {
-          const replaceId = googleNoticeState?.replaceId;
-          setGoogleNoticeState(null);
-          redirectToProvider("google", replaceId);
-        }}
-      />
+      {isSaas && (
+        <GoogleBetaNoticeDialog
+          open={!!googleNoticeState}
+          mode={googleNoticeState?.mode ?? "connect"}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setGoogleNoticeState(null);
+          }}
+          onContinue={() => {
+            const replaceId = googleNoticeState?.replaceId;
+            setGoogleNoticeState(null);
+            redirectToProvider("google", replaceId);
+          }}
+        />
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Google closed-beta interstitial, inline notes, app-wide reauth banner, and OAuth callback “email support” hint are meant for the hosted product. Self-hosted / personal deployments (`VITE_PERMISSION_SLIP_SAAS` not `true`) now skip that UX and go straight to Google OAuth where applicable.

## Changes

- Gate `GoogleBetaNoticeDialog`, `GoogleBetaInlineNote`, and `GoogleReauthBanner` behavior on `isSaas` from `@/lib/saas`.
- Google connect/reconnect handlers in settings and connector flows only open the beta dialog when `isSaas`; otherwise they redirect immediately.
- `useOAuthCallbackToast` only appends the beta waitlist description for Google access-denied-style errors when `isSaas`.

## Test plan

- [x] `npx vitest run src/components/__tests__/GoogleBetaNoticeDialog.test.tsx src/components/__tests__/GoogleReauthBanner.test.tsx src/hooks/__tests__/useOAuthCallbackToast.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (frontend)

## Notes

- Root `make build` failed in this environment at `generate-mobile-from-bundle` (`openapi-typescript` not on PATH under `mobile/`); frontend build and tests were run directly under `frontend/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6612ad6f-9118-4032-b5b7-d803a030f975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6612ad6f-9118-4032-b5b7-d803a030f975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

