### PR TITLE
Add chiedoclaude to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Require @chiedo's approval for infrastructure, dependency, and CI files
-Dockerfile @chiedo
-go.mod @chiedo
-go.sum @chiedo
-Makefile @chiedo
-.github/workflows/ @chiedo
+Dockerfile @chiedo @chiedoclaude
+go.mod @chiedo @chiedoclaude
+go.sum @chiedo @chiedoclaude
+Makefile @chiedo @chiedoclaude
+.github/workflows/ @chiedo @chiedoclaude


### PR DESCRIPTION
## Summary

Add @chiedoclaude as an additional codeowner for all infrastructure, dependency, and CI files that @chiedo currently manages:

- Dockerfile
- go.mod
- go.sum
- Makefile
- .github/workflows/

## Test plan

- [x] CODEOWNERS file updated to include @chiedoclaude alongside @chiedo for all relevant paths
- [x] Changes pushed to designated branch