### PR TITLE
fix(api): serialize panic recover tests that mutate package hook

### DIFF
--- a/api/recover_middleware_test.go
+++ b/api/recover_middleware_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestPanicRecoverMiddleware_ReturnsStructured500(t *testing.T) {
-	t.Parallel()
+	// Do not use t.Parallel: these tests swap the package-level panicCaptureError
+	// and would race with each other.
 
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("super-secret-panic-detail-do-not-leak")
@@ -55,7 +56,7 @@ func TestPanicRecoverMiddleware_ReturnsStructured500(t *testing.T) {
 }
 
 func TestPanicRecoverMiddleware_NoSecondWriteAfterImplicit200(t *testing.T) {
-	t.Parallel()
+	// See TestPanicRecoverMiddleware_ReturnsStructured500 — package-level hook.
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
@@ -86,7 +87,7 @@ func TestPanicRecoverMiddleware_NoSecondWriteAfterImplicit200(t *testing.T) {
 }
 
 func TestPanicRecoverMiddleware_NoSecondWriteAfterHeaders(t *testing.T) {
-	t.Parallel()
+	// See TestPanicRecoverMiddleware_ReturnsStructured500 — package-level hook.
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`TestPanicRecoverMiddleware_*` tests assigned the package-level `panicCaptureError` while using `t.Parallel()`, so concurrent tests could overwrite each other's stub. That produced flaky failures in `github.com/supersuit-tech/permission-slip/api` (e.g. "expected CaptureError to be invoked") on unrelated PRs.

Remove `t.Parallel()` from the three tests that swap the global hook. `TestPanicRecoverMiddleware_PassThrough` still uses `t.Parallel()` safely.

## Test plan
- [ ] CI `go test ./api/...` (full backend suite on merge)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-652c52e2-beeb-439e-8278-520d1e6fa584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-652c52e2-beeb-439e-8278-520d1e6fa584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

