### PR TITLE
fix: unblock local dev first-run

### DIFF
--- a/cli/src/auth/keys.ts
+++ b/cli/src/auth/keys.ts
@@ -50,6 +50,11 @@ export function readPublicKey(): string {
 
 /**
  * Loads the private key from disk as a Node KeyObject.
+ *
+ * Supports both PKCS8 PEM (`-----BEGIN PRIVATE KEY-----`, what Node natively
+ * understands) and the OpenSSH native format (`-----BEGIN OPENSSH PRIVATE KEY-----`,
+ * what `ssh-keygen` produces by default). For OpenSSH keys, the 32-byte ed25519
+ * seed is extracted manually and converted to a JWK before construction.
  */
 export function loadPrivateKey(): crypto.KeyObject {
   if (!fs.existsSync(PRIVATE_KEY_FILE)) {
@@ -57,8 +62,82 @@ export function loadPrivateKey(): crypto.KeyObject {
       `Private key not found at ${PRIVATE_KEY_FILE}. Run 'permission-slip register' to generate one.`,
     );
   }
-  const pem = fs.readFileSync(PRIVATE_KEY_FILE);
-  return crypto.createPrivateKey({ key: pem, format: "pem" });
+  const raw = fs.readFileSync(PRIVATE_KEY_FILE, "utf-8");
+  if (raw.includes("BEGIN OPENSSH PRIVATE KEY")) {
+    return loadOpenSSHPrivateKey(raw);
+  }
+  return crypto.createPrivateKey({ key: raw, format: "pem" });
+}
+
+/**
+ * Parses an unencrypted OpenSSH-format ed25519 private key and returns it as a
+ * Node KeyObject. Format reference: PROTOCOL.key in the OpenSSH source.
+ */
+function loadOpenSSHPrivateKey(pem: string): crypto.KeyObject {
+  const b64 = pem
+    .replace(/-----BEGIN OPENSSH PRIVATE KEY-----/, "")
+    .replace(/-----END OPENSSH PRIVATE KEY-----/, "")
+    .replace(/\s+/g, "");
+  const buf = Buffer.from(b64, "base64");
+
+  // Magic: "openssh-key-v1\0"
+  const magic = "openssh-key-v1\0";
+  if (buf.slice(0, magic.length).toString("binary") !== magic) {
+    throw new Error("Not a valid OpenSSH private key (bad magic)");
+  }
+  let off = magic.length;
+
+  const readString = (): Buffer => {
+    const len = buf.readUInt32BE(off);
+    off += 4;
+    const out = buf.slice(off, off + len);
+    off += len;
+    return out;
+  };
+
+  const cipher = readString().toString();
+  if (cipher !== "none") {
+    throw new Error(
+      `Encrypted OpenSSH keys are not supported (cipher: ${cipher}). Decrypt the key with 'ssh-keygen -p -P <pw> -N "" -f <key>' first.`,
+    );
+  }
+  readString(); // kdfname
+  readString(); // kdfoptions
+  const numKeys = buf.readUInt32BE(off);
+  off += 4;
+  if (numKeys !== 1) {
+    throw new Error(`Expected exactly 1 key in OpenSSH file, got ${numKeys}`);
+  }
+  readString(); // public key blob (we don't need it; derive from private)
+  const privateBlob = readString();
+
+  // Parse the private key blob.
+  let pOff = 8; // skip check1+check2
+  const readPrivString = (): Buffer => {
+    const len = privateBlob.readUInt32BE(pOff);
+    pOff += 4;
+    const out = privateBlob.slice(pOff, pOff + len);
+    pOff += len;
+    return out;
+  };
+  const keyType = readPrivString().toString();
+  if (keyType !== "ssh-ed25519") {
+    throw new Error(`Unsupported key type: ${keyType} (only ssh-ed25519)`);
+  }
+  readPrivString(); // public key (32 bytes)
+  const privKey = readPrivString(); // 64 bytes: 32-byte seed + 32-byte public
+  if (privKey.length !== 64) {
+    throw new Error(`Unexpected ed25519 private key length: ${privKey.length}`);
+  }
+  const seed = privKey.slice(0, 32);
+  const pub = privKey.slice(32, 64);
+
+  const b64url = (b: Buffer) =>
+    b.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return crypto.createPrivateKey({
+    key: { kty: "OKP", crv: "Ed25519", d: b64url(seed), x: b64url(pub) },
+    format: "jwk",
+  });
 }
 
 /**

--- a/frontend/src/auth/dev.ts
+++ b/frontend/src/auth/dev.ts
@@ -48,8 +48,10 @@ export async function fetchOtpFromMailpit(
 
     const fullMsg: MailpitMessage = await msgRes.json();
 
-    // Extract 6-digit OTP code from the email body
-    const match = fullMsg.Text?.match(/\b(\d{6})\b/);
+    // Extract OTP code from the email body using the configured length.
+    const { default: validation } = await import("@/lib/validation");
+    const len = validation.emailOtpCode.length;
+    const match = fullMsg.Text?.match(new RegExp(`\\b(\\d{${len}})\\b`));
     return match?.[1] ?? null;
   } catch {
     return null;

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -94,9 +94,39 @@ export function AddCredentialDialog({
     }
   }
 
-  const resolvedKey = credentialKey ?? "api_key";
-  const resolvedFieldLabel = fieldLabel ?? "API Key";
-  const resolvedPlaceholder = fieldPlaceholder ?? "Enter API key or token";
+  // Service-specific credential field overrides. Connectors with auth_type
+  // "custom" don't fit the default "API Key" mold — until we extend the
+  // connector manifest with per-field schemas, hardcode the known cases here.
+  const SERVICE_FIELD_OVERRIDES: Record<
+    string,
+    { key: string; label: string; placeholder: string }
+  > = {
+    postgres: {
+      key: "connection_string",
+      label: "Connection String",
+      placeholder: "postgresql://user:password@host:port/dbname",
+    },
+    mysql: {
+      key: "connection_string",
+      label: "Connection String",
+      placeholder: "mysql://user:password@host:port/dbname",
+    },
+    snowflake: {
+      key: "connection_string",
+      label: "Connection String",
+      placeholder: "user:password@account/database/schema",
+    },
+    redis: {
+      key: "url",
+      label: "Redis URL",
+      placeholder: "redis://user:password@host:port/0",
+    },
+  };
+  const override = SERVICE_FIELD_OVERRIDES[credential.service];
+  const resolvedKey = credentialKey ?? override?.key ?? "api_key";
+  const resolvedFieldLabel = fieldLabel ?? override?.label ?? "API Key";
+  const resolvedPlaceholder =
+    fieldPlaceholder ?? override?.placeholder ?? "Enter API key or token";
   const resolvedTitle = title ?? "Add Credential";
 
   function buildCredentials(): Record<string, string> | null {

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -462,7 +462,11 @@ function StaticOnlyContent({
             ? "credentials"
             : cred.service === "coinbase_agentkit"
               ? "CDP credentials"
-              : "API key"}
+              : ["postgres", "mysql", "snowflake"].includes(cred.service)
+                ? "connection string"
+                : cred.service === "redis"
+                  ? "Redis URL"
+                  : "API key"}
         </Button>
       ))}
     </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
   server: {
     fs: {
       allow: [
+        // Frontend project root (Vite's default — must be explicit when fs.allow is set).
+        path.resolve(__dirname),
         // Allow Vite dev server to read config/ from repo root.
         path.resolve(__dirname, "../config"),
       ],

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -206,7 +206,7 @@ secure_password_change = false
 # Set low for local dev to avoid rate-limit friction. Production uses hosted Supabase defaults.
 max_frequency = "1s"
 # Number of characters used in the email OTP.
-otp_length = 6
+otp_length = 8
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 


### PR DESCRIPTION
## Summary

Walking a fresh checkout through the local dev quickstart in `docs/development.md` hits several blockers before the first agent can register and run an action. This PR fixes the ones that have a clear correct answer; one related blocker (the GitHub connector seed) is intentionally left for a deliberate decision (see **Known issue not fixed here** below).

Each fix below is independent and small; happy to split if a reviewer prefers.

### Fixes

- **`cli/src/auth/keys.ts`** — Parse OpenSSH-format ed25519 private keys (the format `ssh-keygen` produces by default). The previous comment claimed Node's `crypto.createPrivateKey` accepts both PKCS8 and OpenSSH PEM — it does not, and `permission-slip register` failed with `error:1E08010C:DECODER routines::unsupported`. The fix manually parses the OpenSSH private-key blob to extract the 32-byte ed25519 seed + public key, then constructs the `KeyObject` from a JWK. PKCS8 PEM keys (the existing `writeOpenSSHPrivateKey` fallback path) still load via the same code path as before. Existing `cli/tests/keys.test.ts` continues to pass.

- **`supabase/config.toml`** — Bump `auth.email.otp_length` from `6` to `8`. The frontend's `OtpStep` and the backend's `shared/validation.go` both enforce `emailOtpCode.length = 8` from `shared/validation.json` — Supabase shipping 6-digit codes meant the OTP sign-in screen's Verify button stayed disabled forever and `emailOtpCode.length` was effectively unenforced.

- **`frontend/src/auth/dev.ts`** — ⚠️ **Workaround, flagged for follow-up.** The "Dev: Auto-fill code from Mailpit" button extracted the OTP with a regex hardcoded to `\d{6}`. Once `validation.json` says `length: 8`, that regex returns nothing and auto-fill silently fails. We patched the regex to read the length from `validation.json`. Without this, the local dev sign-in flow is impossible to auto-complete; with it, anyone who later changes `emailOtpCode.length` is fine. The cleaner long-term fix is probably to source OTP length from a single shared place at build time so this regex doesn't need a runtime dynamic-import.

- **`frontend/vite.config.ts`** — Re-add the frontend project root to `server.fs.allow`. Commit 2952d417 (`Narrow free plan type and tighten Vite fs.allow scope`) reduced the allow-list from `..` to `../config` only. Setting `fs.allow` *replaces* Vite's defaults (which include the project root), so `frontend/index.html` and `src/main.tsx` were no longer servable in dev — the Vite log spammed `outside of Vite serving allow list` for every request. The fix preserves the security intent: the new entries are `__dirname` (frontend root) + `../config` only, so Go source / migrations / `.env` outside `frontend/` stay denied.

- **`frontend/src/pages/agents/connectors/AddCredentialDialog.tsx`** + **`SetupConnectorCredentialsDialog.tsx`** — Per-service field overrides for connectors with `auth_type: "custom"`. Every custom-auth connector previously rendered a single field labeled **"API Key"** stored under the key `api_key`. PostgreSQL credentials silently went into the wrong slot (`api_key` instead of `connection_string`); the connector's `Validate` later failed with `missing required credential: connection_string`. This PR adds a small lookup table for `postgres`/`mysql`/`snowflake` (all want `connection_string`) and `redis` (wants `url`) so the dialog labels and stores them correctly. **This is a stopgap** — the proper fix is to extend `connectors.ManifestCredential` with field schemas (key + label + placeholder) and have the dialog render generically. Filing a follow-up issue would unstick the next custom-auth connector someone adds.

### Known issue not fixed here

The GitHub connector's manifest declares both an OAuth2 (`github`) and an API-key (`github_pat`) credential. Migration `20260324120723_prevent_mixed_auth_type_connectors.sql` installs a trigger that rejects any connector with both, so the seed transaction fails and GitHub never gets a `connector_required_credentials` row — making the connector invisible in the dashboard. The fix is a product/architecture call (drop PAT support, split into two connectors, or make the seeder tolerant of the trigger), so I left it alone here. Workaround during testing: temporarily delete the `github_pat` block from the manifest.

## Test plan

- [x] `cd cli && npm run build` clean
- [x] `cd cli && npm test -- keys.test` (7/7 pass — covers OpenSSH key path)
- [x] `cd frontend && npx tsc --noEmit` clean
- [x] `cd frontend && npx vitest run src/auth/__tests__/OtpStep.test.tsx` (12/12 pass)
- [ ] Backend (`go test ./...`): not run locally — these changes don't touch Go, but CI should confirm
- [ ] Manual: fresh `supabase db reset` → sign up via Mailpit → "Dev: Auto-fill code from Mailpit" populates 8-digit code → submit succeeds
- [ ] Manual: build CLI → `register --invite-code` succeeds with no `DECODER` error → `verify --code` succeeds
- [ ] Manual: connect PostgreSQL → dialog labels the field "Connection String" → execute a `postgres.query` end-to-end