### PR TITLE
fix(frontend): do not auto-delete default connector instance as orphan

### DIFF
--- a/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorInstancesSection.tsx
@@ -217,6 +217,10 @@ export function ConnectorInstancesSection({
     if (!bindingByInstance) return [];
     const out: string[] = [];
     for (const inst of instances) {
+      // Never auto-delete the default instance: it can briefly have no binding
+      // (e.g. race with refetch) or legitimately be unassigned while still the
+      // default row — the API rejects DELETE on default (Sentry: PERMISSION-SLIP-REACT-2).
+      if (inst.is_default) continue;
       const b = bindingByInstance.get(inst.connector_instance_id);
       if (!bindingRowKey(b ?? undefined)) out.push(inst.connector_instance_id);
     }

--- a/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx
@@ -356,6 +356,97 @@ describe("ConnectorInstancesSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not auto-delete the default instance when its credential binding is empty", async () => {
+    mockStandardGets(false);
+    const emptyBinding = new Map<string, InstanceCredentialBinding | null>();
+    emptyBinding.set(defaultInstance.connector_instance_id, {
+      agent_id: 42,
+      connector_id: "slack",
+      credential_id: null,
+      oauth_connection_id: null,
+    });
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue({
+      data: emptyBinding,
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      status: "success" as const,
+    });
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Slack OAuth — Acme/)).toBeInTheDocument();
+    });
+    await waitFor(
+      () => {
+        const instDeletes = mockDelete.mock.calls.filter(
+          (c) =>
+            c[0] ===
+            "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+        );
+        expect(instDeletes.length).toBe(0);
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  it("auto-deletes a non-default instance with no credential binding (orphan cleanup)", async () => {
+    mockStandardGets(true);
+    const m = new Map<string, InstanceCredentialBinding | null>();
+    m.set(defaultInstance.connector_instance_id, oauthBinding("oconn_1"));
+    m.set(secondInstance.connector_instance_id, {
+      agent_id: 42,
+      connector_id: "slack",
+      credential_id: null,
+      oauth_connection_id: null,
+    });
+    mockUseConnectorInstanceCredentialBindings.mockReturnValue({
+      data: m,
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+      status: "success" as const,
+    });
+    renderWithProviders(
+      <ConnectorInstancesSection
+        agentId={42}
+        connectorId="slack"
+        requiredCredentials={[
+          {
+            service: "slack",
+            auth_type: "oauth2",
+            oauth_provider: "slack",
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Slack OAuth — Sales/)).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      const instDeletes = mockDelete.mock.calls.filter(
+        (c) =>
+          c[0] ===
+          "/v1/agents/{agent_id}/connectors/{connector_id}/instances/{instance_id}",
+      );
+      expect(instDeletes.length).toBeGreaterThan(0);
+      expect(instDeletes[0]?.[1]?.params?.path?.instance_id).toBe(
+        secondInstance.connector_instance_id,
+      );
+    });
+  });
+
   it("re-authorize button navigates to the OAuth authorize URL with replace param", async () => {
     mockStandardGets(true, { secondNeedsReauth: true });
     mockUseConnectorInstanceCredentialBindings.mockReturnValue(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [Sentry issue PERMISSION-SLIP-REACT-2](https://supersuit-technologies.sentry.io/issues/7441657083/): **"Cannot delete the default connector instance"** from `useDeleteAgentConnectorInstance` on `/agents/:agentId/connectors/:connectorId`.

The connector instances UI auto-deletes rows it considers "orphans" (instance exists but no credential binding). The **default** instance can temporarily have an empty binding (e.g. refetch race) or legitimately be unassigned while still marked default; the API correctly rejects `DELETE` on the default instance. We now **exclude `is_default` instances** from that automatic orphan cleanup.

## Test plan

- `cd frontend && npx vitest run src/pages/agents/connectors/__tests__/ConnectorInstancesSection.test.tsx`
- `cd frontend && npm run build`

Note: root `make build` failed here because `mobile` lacks `openapi-typescript` in PATH; frontend build succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7906501b-ff2a-4b86-ad66-e938fa1ef841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7906501b-ff2a-4b86-ad66-e938fa1ef841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

