### PR TITLE
Frontend: shared OTP digit lengths (Mailpit + inputs)

### DIFF
--- a/frontend/src/auth/OtpStep.tsx
+++ b/frontend/src/auth/OtpStep.tsx
@@ -8,7 +8,7 @@ import DevOnly from "../components/DevOnly";
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/FormError";
 import { OtpCodeInput } from "@/components/OtpCodeInput";
-import validation from "@/lib/validation";
+import { EMAIL_OTP_DIGIT_LENGTH } from "@/lib/otpDigitLengths";
 
 interface OtpStepProps {
   email: string;
@@ -29,7 +29,7 @@ export default function OtpStep({
   const [otpCode, setOtpCode] = useState("");
   const { error, isSubmitting, handleSubmit } = useFormSubmit();
   const resend = useResend({ onResend });
-  const emailOtpLen = validation.emailOtpCode.length;
+  const emailOtpLen = EMAIL_OTP_DIGIT_LENGTH;
 
   const handleAutoFill = async () => {
     // Dynamic import keeps dev-only Mailpit code out of the production bundle

--- a/frontend/src/auth/dev.ts
+++ b/frontend/src/auth/dev.ts
@@ -5,7 +5,13 @@
  *
  * Mailpit is proxied at /mailpit on the same origin (configured in both
  * vite.config.ts and dev-proxy.cjs → localhost:54324).
+ *
+ * OTP digit count comes from `@/lib/otpDigitLengths` (same source as
+ * OtpStep / OtpCodeInput) so the Mailpit regex stays in sync with
+ * `shared/validation.json` at build time.
  */
+
+import { EMAIL_OTP_DIGIT_LENGTH } from "@/lib/otpDigitLengths";
 
 /** Subset of the Mailpit v1 message-list response we rely on. */
 interface MailpitMessageSummary {
@@ -48,10 +54,9 @@ export async function fetchOtpFromMailpit(
 
     const fullMsg: MailpitMessage = await msgRes.json();
 
-    // Extract OTP code from the email body using the configured length.
-    const { default: validation } = await import("@/lib/validation");
-    const len = validation.emailOtpCode.length;
-    const match = fullMsg.Text?.match(new RegExp(`\\b(\\d{${len}})\\b`));
+    const match = fullMsg.Text?.match(
+      new RegExp(`\\b(\\d{${EMAIL_OTP_DIGIT_LENGTH}})\\b`),
+    );
     return match?.[1] ?? null;
   } catch {
     return null;

--- a/frontend/src/components/OtpCodeInput.tsx
+++ b/frontend/src/components/OtpCodeInput.tsx
@@ -1,6 +1,6 @@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import validation from "@/lib/validation";
+import { EMAIL_OTP_DIGIT_LENGTH, TOTP_DIGIT_LENGTH } from "@/lib/otpDigitLengths";
 
 interface OtpCodeInputProps {
   /** HTML id for the input element (also used for label association). */
@@ -37,9 +37,7 @@ export function OtpCodeInput({
   required,
 }: OtpCodeInputProps) {
   const maxLength =
-    variant === "email"
-      ? validation.emailOtpCode.length
-      : validation.totpCode.length;
+    variant === "email" ? EMAIL_OTP_DIGIT_LENGTH : TOTP_DIGIT_LENGTH;
   return (
     <div className="space-y-2">
       <Label htmlFor={id}>{label}</Label>

--- a/frontend/src/lib/__tests__/otpDigitLengths.test.ts
+++ b/frontend/src/lib/__tests__/otpDigitLengths.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import validation from "@/lib/validation";
+import {
+  EMAIL_OTP_DIGIT_LENGTH,
+  TOTP_DIGIT_LENGTH,
+} from "@/lib/otpDigitLengths";
+
+describe("otpDigitLengths", () => {
+  it("matches shared validation.json (email OTP and TOTP)", () => {
+    expect(EMAIL_OTP_DIGIT_LENGTH).toBe(validation.emailOtpCode.length);
+    expect(TOTP_DIGIT_LENGTH).toBe(validation.totpCode.length);
+  });
+});

--- a/frontend/src/lib/otpDigitLengths.ts
+++ b/frontend/src/lib/otpDigitLengths.ts
@@ -1,0 +1,9 @@
+/**
+ * OTP digit lengths for the web app, sourced from `shared/validation.json`
+ * via `@/lib/validation` so Mailpit dev auto-fill, inputs, and submit gating
+ * all use the same build-time values.
+ */
+import validation from "@/lib/validation";
+
+export const EMAIL_OTP_DIGIT_LENGTH = validation.emailOtpCode.length;
+export const TOTP_DIGIT_LENGTH = validation.totpCode.length;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `frontend/src/lib/otpDigitLengths.ts` exporting `EMAIL_OTP_DIGIT_LENGTH` and `TOTP_DIGIT_LENGTH` from the same `shared/validation.json` path as `@/lib/validation`. `dev.ts` now imports that module statically so the Mailpit OTP regex stays aligned with the auth UI without a runtime `import("@/lib/validation")`.

## Test plan

- `cd frontend && npx vitest run src/lib/__tests__/otpDigitLengths.test.ts src/auth/__tests__/OtpStep.test.tsx`

Manual dev check (optional): change `emailOtpCode.length` in `shared/validation.json`, rebuild, confirm Mailpit auto-fill still extracts the right-length code and Verify enables at the same length.

Closes #1108
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51dfbfbb-7f97-40ac-af4a-887f12c26b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51dfbfbb-7f97-40ac-af4a-887f12c26b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

