### PR TITLE
Connectors: manifest-driven credential field schemas (closes #1109)

### DIFF
--- a/api/connectors.go
+++ b/api/connectors.go
@@ -37,12 +37,22 @@ type connectorActionResponse struct {
 	Preview               any     `json:"preview,omitempty"`
 }
 
+type credentialFieldResponse struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Placeholder string `json:"placeholder,omitempty"`
+	Secret      bool   `json:"secret"`
+	Required    bool   `json:"required"`
+	HelpText    string `json:"help_text,omitempty"`
+}
+
 type requiredCredentialResponse struct {
-	Service         string   `json:"service"`
-	AuthType        string   `json:"auth_type"`
-	InstructionsURL *string  `json:"instructions_url,omitempty"`
-	OAuthProvider   *string  `json:"oauth_provider,omitempty"`
-	OAuthScopes     []string `json:"oauth_scopes,omitempty"`
+	Service         string                    `json:"service"`
+	AuthType        string                    `json:"auth_type"`
+	InstructionsURL *string                   `json:"instructions_url,omitempty"`
+	OAuthProvider   *string                   `json:"oauth_provider,omitempty"`
+	OAuthScopes     []string                  `json:"oauth_scopes,omitempty"`
+	Fields          []credentialFieldResponse `json:"fields,omitempty"`
 }
 
 type connectorDetailResponse struct {
@@ -154,13 +164,20 @@ func toConnectorDetailResponse(ctx context.Context, c db.ConnectorDetail) connec
 
 	creds := make([]requiredCredentialResponse, len(c.RequiredCredentials))
 	for i, rc := range c.RequiredCredentials {
-		creds[i] = requiredCredentialResponse{
+		resp := requiredCredentialResponse{
 			Service:         rc.Service,
 			AuthType:        rc.AuthType,
 			InstructionsURL: rc.InstructionsURL,
 			OAuthProvider:   rc.OAuthProvider,
 			OAuthScopes:     rc.OAuthScopes,
 		}
+		for _, f := range rc.CredentialFields {
+			resp.Fields = append(resp.Fields, credentialFieldResponse{
+				Key: f.Key, Label: f.Label, Placeholder: f.Placeholder,
+				Secret: f.Secret, Required: f.Required, HelpText: f.HelpText,
+			})
+		}
+		creds[i] = resp
 	}
 
 	return connectorDetailResponse{

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -152,7 +152,7 @@ func handleStoreCredential(deps *Deps) http.HandlerFunc {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pickErr.Error()))
 			return
 		}
-		credJSON, err = json.Marshal(credStrings)
+		credJSON, err := json.Marshal(credStrings)
 		if err != nil {
 			log.Printf("[%s] StoreCredential: marshal credentials: %v", TraceID(r.Context()), err)
 			CaptureError(r.Context(), err)

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"regexp"
@@ -115,15 +116,6 @@ func handleStoreCredential(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		// Serialize the credentials object — never log the raw value.
-		credJSON, err := json.Marshal(req.Credentials)
-		if err != nil {
-			log.Printf("[%s] StoreCredential: marshal credentials: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to store credential"))
-			return
-		}
-
 		// Begin a transaction so limit check + vault insert + credential row
 		// insert are atomic. The advisory lock prevents TOCTOU races where
 		// concurrent requests could both pass the limit check.
@@ -145,6 +137,26 @@ func handleStoreCredential(deps *Deps) http.HandlerFunc {
 			return
 		}
 		if checkCredentialLimit(r.Context(), w, r, tx, profile.ID) {
+			return
+		}
+
+		candidates, err := db.GetRequiredCredentialsByService(r.Context(), tx, req.Service)
+		if err != nil {
+			log.Printf("[%s] StoreCredential: list required credentials: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to store credential"))
+			return
+		}
+		credStrings, pickErr := resolveAndValidateCredentialPayload(req.Service, candidates, req.Credentials)
+		if pickErr != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pickErr.Error()))
+			return
+		}
+		credJSON, err = json.Marshal(credStrings)
+		if err != nil {
+			log.Printf("[%s] StoreCredential: marshal credentials: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to store credential"))
 			return
 		}
 
@@ -273,3 +285,61 @@ func toCredentialSummary(c db.Credential) credentialSummary {
 	}
 }
 
+// resolveAndValidateCredentialPayload picks the matching connector credential row
+// for a service and validates keys/values. Returns string map for vault storage.
+func resolveAndValidateCredentialPayload(service string, candidates []db.RequiredCredential, submitted map[string]any) (map[string]string, error) {
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("unknown service %q — no connector declares this credential", service)
+	}
+	var matches []db.RequiredCredential
+	for _, c := range candidates {
+		if c.AuthType == "oauth2" {
+			continue
+		}
+		matches = append(matches, c)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("service %q only supports OAuth — use the OAuth flow instead of storing static credentials", service)
+	}
+	if len(matches) == 1 {
+		if err := db.ValidateStaticCredentialKeys(matches[0], submitted); err != nil {
+			return nil, err
+		}
+		return credentialMapStrings(submitted)
+	}
+	// Multiple connectors share this service name — disambiguate by field schema.
+	var picked *db.RequiredCredential
+	for i := range matches {
+		if err := db.ValidateStaticCredentialKeys(matches[i], submitted); err != nil {
+			continue
+		}
+		if picked != nil && !sameCredentialSchema(*picked, matches[i]) {
+			return nil, fmt.Errorf("ambiguous credential schema for service %q — contact support", service)
+		}
+		cp := matches[i]
+		picked = &cp
+	}
+	if picked == nil {
+		return nil, fmt.Errorf("credentials do not match any registered connector for service %q", service)
+	}
+	return credentialMapStrings(submitted)
+}
+
+func sameCredentialSchema(a, b db.RequiredCredential) bool {
+	if a.AuthType != b.AuthType {
+		return false
+	}
+	return db.CredentialFieldSpecsMatch(a.CredentialFields, b.CredentialFields)
+}
+
+func credentialMapStrings(m map[string]any) (map[string]string, error) {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("credential key %q must be a string", k)
+		}
+		out[k] = s
+	}
+	return out, nil
+}

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -287,10 +287,11 @@ func toCredentialSummary(c db.Credential) credentialSummary {
 
 // resolveAndValidateCredentialPayload picks the matching connector credential row
 // for a service and validates keys/values. Returns string map for vault storage.
+//
+// When no connector row exists for the service, or only OAuth rows exist, there is
+// no static field schema to enforce — accept any string-valued map (legacy behavior
+// for settings UI, ad-hoc services, and bot-token style credentials).
 func resolveAndValidateCredentialPayload(service string, candidates []db.RequiredCredential, submitted map[string]any) (map[string]string, error) {
-	if len(candidates) == 0 {
-		return nil, fmt.Errorf("unknown service %q — no connector declares this credential", service)
-	}
 	var matches []db.RequiredCredential
 	for _, c := range candidates {
 		if c.AuthType == "oauth2" {
@@ -299,7 +300,7 @@ func resolveAndValidateCredentialPayload(service string, candidates []db.Require
 		matches = append(matches, c)
 	}
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("service %q only supports OAuth — use the OAuth flow instead of storing static credentials", service)
+		return credentialMapStrings(submitted)
 	}
 	if len(matches) == 1 {
 		if err := db.ValidateStaticCredentialKeys(matches[0], submitted); err != nil {

--- a/api/credentials_test.go
+++ b/api/credentials_test.go
@@ -239,7 +239,7 @@ func TestStoreCredential_MissingService(t *testing.T) {
 	}
 }
 
-func TestStoreCredential_UnknownService(t *testing.T) {
+func TestStoreCredential_UnknownService_LegacyPermissive(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
@@ -248,13 +248,14 @@ func TestStoreCredential_UnknownService(t *testing.T) {
 	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
+	// No connector_required_credentials row: store still succeeds (settings / arbitrary services).
 	body := `{"service": "not_registered_anywhere", "credentials": {"api_key": "x"}}`
 	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/api/credentials_test.go
+++ b/api/credentials_test.go
@@ -160,6 +160,7 @@ func TestStoreCredential_Success(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	mockVault := vault.NewMockVaultStore()
 	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}
@@ -199,6 +200,7 @@ func TestStoreCredential_WithoutLabel(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "stripe", "stripe", "api_key", nil)
 
 	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -234,6 +236,66 @@ func TestStoreCredential_MissingService(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestStoreCredential_UnknownService(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service": "not_registered_anywhere", "credentials": {"api_key": "x"}}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestStoreCredential_ExtraKeyRejected(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service": "github", "credentials": {"api_key": "ghp_x", "org": "nope"}}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestStoreCredential_MultiFieldCustom(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	fields := []byte(`[{"key":"a","label":"A","secret":true,"required":true},{"key":"b","label":"B","secret":false,"required":true}]`)
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "twofield", "twofield", "custom", fields)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service": "twofield", "credentials": {"a": "secretval", "b": "plain"}}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -280,6 +342,7 @@ func TestStoreCredential_DuplicateConflict(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -317,7 +380,7 @@ func TestStoreCredential_RequiresAuth(t *testing.T) {
 	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	r := httptest.NewRequest(http.MethodPost, "/credentials", strings.NewReader(`{"service": "x", "credentials": {"k": "v"}}`))
+	r := httptest.NewRequest(http.MethodPost, "/credentials", strings.NewReader(`{"service": "x", "credentials": {"api_key": "v"}}`))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
@@ -337,7 +400,7 @@ func TestStoreCredential_ServiceTooLong(t *testing.T) {
 	router := NewRouter(deps)
 
 	longService := "a" + strings.Repeat("b", 128) // 129 chars
-	body := fmt.Sprintf(`{"service": %q, "credentials": {"k": "v"}}`, longService)
+	body := fmt.Sprintf(`{"service": %q, "credentials": {"api_key": "v"}}`, longService)
 	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
@@ -354,6 +417,7 @@ func TestDeleteCredential_Success(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	// Store a credential via the API so the vault also gets a secret.
 	mockVault := vault.NewMockVaultStore()
@@ -420,6 +484,7 @@ func TestDeleteCredential_OtherUserSeesNotFound(t *testing.T) {
 	uid2 := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid1, "u_"+uid1[:8])
 	testhelper.InsertUser(t, tx, uid2, "u_"+uid2[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	// Store credential for uid1.
 	mockVault := vault.NewMockVaultStore()
@@ -472,6 +537,7 @@ func TestDeleteCredential_VerifyActuallyDeleted(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	mockVault := vault.NewMockVaultStore()
 	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}
@@ -521,6 +587,7 @@ func TestStoreAndListCredentials(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -563,12 +630,13 @@ func TestStoreCredential_VaultSecretContainsSerializedCredentials(t *testing.T) 
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	mockVault := vault.NewMockVaultStore()
 	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
 
-	body := `{"service": "github", "credentials": {"api_key": "ghp_secret_value", "org": "myorg"}}`
+	body := `{"service": "github", "credentials": {"api_key": "ghp_secret_value"}}`
 	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
@@ -587,6 +655,7 @@ func TestStoreCredential_VaultErrorReturns500(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	deps := &Deps{DB: tx, Vault: &failingVaultStore{}, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -612,6 +681,7 @@ func TestStoreCredential_NilVaultReturns503(t *testing.T) {
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
 
 	deps := &Deps{DB: tx, Vault: nil, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)

--- a/api/plan_limits_test.go
+++ b/api/plan_limits_test.go
@@ -179,6 +179,10 @@ func TestStoreCredential_FreePlan_AtLimit_Returns403(t *testing.T) {
 		testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, fmt.Sprintf("service%d", i))
 	}
 
+	// POST /credentials validates against connector manifests when present; register
+	// the service used below so limit checks hit the vault path instead of 400.
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "planlim_nsvc", "newservice", "api_key", nil)
+
 	mockVault := vault.NewMockVaultStore()
 	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -219,6 +223,8 @@ func TestStoreCredential_FreePlan_UnderLimit_Succeeds(t *testing.T) {
 		testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, fmt.Sprintf("service%d", i))
 	}
 
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "planlim_nsvc2", "newservice", "api_key", nil)
+
 	mockVault := vault.NewMockVaultStore()
 	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -244,6 +250,8 @@ func TestStoreCredential_PaidPlan_NoLimit(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		testhelper.InsertCredential(t, tx, testhelper.GenerateID(t, "cred_"), uid, fmt.Sprintf("service%d", i))
 	}
+
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "planlim_nsvc3", "newservice", "api_key", nil)
 
 	mockVault := vault.NewMockVaultStore()
 	deps := &Deps{DB: tx, Vault: mockVault, SupabaseJWTSecret: testJWTSecret}

--- a/connectors/aws/README.md
+++ b/connectors/aws/README.md
@@ -12,6 +12,7 @@ The AWS connector integrates Permission Slip with the [AWS REST APIs](https://do
 |-----|----------|-------------|
 | `access_key_id` | Yes | AWS access key ID (starts with `AKIA` for long-term keys or `ASIA` for temporary credentials) |
 | `secret_access_key` | Yes | AWS secret access key paired with the access key ID |
+| `region` | Yes | Default AWS region (e.g. `us-east-1`) used when an action omits an explicit region |
 | `session_token` | No | Session token for temporary credentials (from STS AssumeRole, etc.) |
 
 The credential `auth_type` in the database is `custom`. Credentials are stored encrypted in Supabase Vault and decrypted only at execution time.

--- a/connectors/aws/aws.go
+++ b/connectors/aws/aws.go
@@ -5,11 +5,11 @@
 package aws
 
 import (
-	_ "embed"
 	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	_ "embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -54,6 +54,7 @@ func (c *AWSConnector) ID() string { return "aws" }
 
 // Manifest returns the connector's metadata manifest. Used by the server to
 // auto-seed DB rows on startup, replacing manual seed.go files.
+//
 //go:embed logo.svg
 var logoSVG string
 
@@ -295,6 +296,12 @@ func (c *AWSConnector) Manifest() *connectors.ConnectorManifest {
 				Service:         "aws",
 				AuthType:        "custom",
 				InstructionsURL: "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+				Fields: []connectors.ManifestCredentialField{
+					{Key: "access_key_id", Label: "Access Key ID", Placeholder: "AKIA...", Secret: ptrBool(false), Required: ptrBool(true)},
+					{Key: "secret_access_key", Label: "Secret Access Key", Placeholder: "Your secret key", Secret: ptrBool(true), Required: ptrBool(true)},
+					{Key: "region", Label: "Default region", Placeholder: "e.g. us-east-1", Secret: ptrBool(false), Required: ptrBool(true),
+						HelpText: "Used as the default when an action does not specify a region."},
+				},
 			},
 		},
 		Templates: []connectors.ManifestTemplate{
@@ -347,19 +354,19 @@ func (c *AWSConnector) Manifest() *connectors.ConnectorManifest {
 // Actions returns the registered action handlers keyed by action_type.
 func (c *AWSConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
-		"aws.describe_instances":   &describeInstancesAction{conn: c},
-		"aws.start_instance":       &startInstanceAction{conn: c},
-		"aws.stop_instance":        &stopInstanceAction{conn: c},
-		"aws.restart_instance":     &restartInstanceAction{conn: c},
-		"aws.get_metrics":          &getMetricsAction{conn: c},
-		"aws.list_s3_objects":      &listS3ObjectsAction{conn: c},
-		"aws.create_presigned_url": &createPresignedURLAction{conn: c},
+		"aws.describe_instances":     &describeInstancesAction{conn: c},
+		"aws.start_instance":         &startInstanceAction{conn: c},
+		"aws.stop_instance":          &stopInstanceAction{conn: c},
+		"aws.restart_instance":       &restartInstanceAction{conn: c},
+		"aws.get_metrics":            &getMetricsAction{conn: c},
+		"aws.list_s3_objects":        &listS3ObjectsAction{conn: c},
+		"aws.create_presigned_url":   &createPresignedURLAction{conn: c},
 		"aws.describe_rds_instances": &describeRDSInstancesAction{conn: c},
 	}
 }
 
 // ValidateCredentials checks that the provided credentials contain the
-// required AWS access key ID and secret access key.
+// required AWS access key ID, secret access key, and default region.
 func (c *AWSConnector) ValidateCredentials(_ context.Context, creds connectors.Credentials) error {
 	accessKey, ok := creds.Get("access_key_id")
 	if !ok || accessKey == "" {
@@ -368,6 +375,13 @@ func (c *AWSConnector) ValidateCredentials(_ context.Context, creds connectors.C
 	secretKey, ok := creds.Get("secret_access_key")
 	if !ok || secretKey == "" {
 		return &connectors.ValidationError{Message: "missing required credential: secret_access_key"}
+	}
+	region, ok := creds.Get("region")
+	if !ok || strings.TrimSpace(region) == "" {
+		return &connectors.ValidationError{Message: "missing required credential: region"}
+	}
+	if err := validateRegion(region); err != nil {
+		return err
 	}
 	return nil
 }
@@ -513,6 +527,8 @@ func deriveSigningKey(secret, datestamp, region, service string) []byte {
 	kService := hmacSHA256(kRegion, []byte(service))
 	return hmacSHA256(kService, []byte("aws4_request"))
 }
+
+func ptrBool(b bool) *bool { return &b }
 
 func buildCanonicalHeaders(req *http.Request) (canonicalHeaders, signedHeaders string) {
 	headers := make(map[string]string)

--- a/connectors/aws/aws_test.go
+++ b/connectors/aws/aws_test.go
@@ -64,6 +64,11 @@ func TestAWSConnector_ValidateCredentials(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "missing region",
+			creds:   connectors.NewCredentials(map[string]string{"access_key_id": "AKID", "secret_access_key": "secret"}),
+			wantErr: true,
+		},
+		{
 			name:    "empty access_key_id",
 			creds:   connectors.NewCredentials(map[string]string{"access_key_id": "", "secret_access_key": "secret"}),
 			wantErr: true,

--- a/connectors/aws/helpers_test.go
+++ b/connectors/aws/helpers_test.go
@@ -11,6 +11,7 @@ func validCreds() connectors.Credentials {
 	return connectors.NewCredentials(map[string]string{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"region":            "us-east-1",
 	})
 }
 

--- a/connectors/coinbaseagentkit/manifest.go
+++ b/connectors/coinbaseagentkit/manifest.go
@@ -31,6 +31,12 @@ func (c *CoinbaseAgentKitConnector) Manifest() *connectors.ConnectorManifest {
 				Service:         "coinbase_agentkit",
 				AuthType:        "api_key",
 				InstructionsURL: "https://portal.cdp.coinbase.com/access/api",
+				Fields: []connectors.ManifestCredentialField{
+					{Key: "api_key_id", Label: "API Key ID", Placeholder: "From CDP Portal → API Keys", Secret: ptrFalse()},
+					{Key: "api_key_secret", Label: "API Key Secret", Placeholder: "PEM EC private key or Ed25519 secret from portal"},
+					{Key: "wallet_secret", Label: "Wallet Secret", Placeholder: "Base64 PKCS#8 wallet secret from Wallet API product",
+						HelpText: "Create keys at https://portal.cdp.coinbase.com/ . The wallet secret is required for signing and sending transactions."},
+				},
 			},
 		},
 		Templates: []connectors.ManifestTemplate{
@@ -61,11 +67,11 @@ func (c *CoinbaseAgentKitConnector) Manifest() *connectors.ConnectorManifest {
 
 func createEvmAccountManifest() connectors.ManifestAction {
 	return connectors.ManifestAction{
-		ActionType:        "coinbase_agentkit.create_evm_account",
-		Name:              "Create EVM account",
-		Description:       "Create a new CDP-managed EVM wallet (MPC-secured). Optionally assign a unique name (2–36 alphanumeric characters and hyphens) for later lookup.",
-		RiskLevel:         "low",
-		DisplayTemplate:   "Create CDP EVM wallet {{name}}",
+		ActionType:      "coinbase_agentkit.create_evm_account",
+		Name:            "Create EVM account",
+		Description:     "Create a new CDP-managed EVM wallet (MPC-secured). Optionally assign a unique name (2–36 alphanumeric characters and hyphens) for later lookup.",
+		RiskLevel:       "low",
+		DisplayTemplate: "Create CDP EVM wallet {{name}}",
 		ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 			"type": "object",
 			"additionalProperties": false,
@@ -85,11 +91,11 @@ func createEvmAccountManifest() connectors.ManifestAction {
 
 func listEvmAccountsManifest() connectors.ManifestAction {
 	return connectors.ManifestAction{
-		ActionType:        "coinbase_agentkit.list_evm_accounts",
-		Name:              "List EVM accounts",
-		Description:       "List CDP EVM accounts in the project with optional pagination.",
-		RiskLevel:         "low",
-		DisplayTemplate:   "List CDP EVM accounts",
+		ActionType:      "coinbase_agentkit.list_evm_accounts",
+		Name:            "List EVM accounts",
+		Description:     "List CDP EVM accounts in the project with optional pagination.",
+		RiskLevel:       "low",
+		DisplayTemplate: "List CDP EVM accounts",
 		ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 			"type": "object",
 			"additionalProperties": false,
@@ -155,11 +161,11 @@ func sendCryptoManifest() connectors.ManifestAction {
 
 func requestTestnetFundsManifest() connectors.ManifestAction {
 	return connectors.ManifestAction{
-		ActionType:        "coinbase_agentkit.request_testnet_funds",
-		Name:              "Request testnet funds (faucet)",
-		Description:       "Request test tokens from the CDP faucet for development (subject to CDP limits).",
-		RiskLevel:         "medium",
-		DisplayTemplate:   "Faucet {{token}} on {{network}} → {{address}}",
+		ActionType:      "coinbase_agentkit.request_testnet_funds",
+		Name:            "Request testnet funds (faucet)",
+		Description:     "Request test tokens from the CDP faucet for development (subject to CDP limits).",
+		RiskLevel:       "medium",
+		DisplayTemplate: "Faucet {{token}} on {{network}} → {{address}}",
 		ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 			"type": "object",
 			"required": ["address", "network", "token"],
@@ -184,11 +190,11 @@ func requestTestnetFundsManifest() connectors.ManifestAction {
 
 func listTokenBalancesManifest() connectors.ManifestAction {
 	return connectors.ManifestAction{
-		ActionType:        "coinbase_agentkit.list_token_balances",
-		Name:              "List token balances",
-		Description:       "List token balances for an address on Base, Base Sepolia, or Ethereum mainnet (CDP data API).",
-		RiskLevel:         "low",
-		DisplayTemplate:   "Token balances for {{address}} on {{network}}",
+		ActionType:      "coinbase_agentkit.list_token_balances",
+		Name:            "List token balances",
+		Description:     "List token balances for an address on Base, Base Sepolia, or Ethereum mainnet (CDP data API).",
+		RiskLevel:       "low",
+		DisplayTemplate: "Token balances for {{address}} on {{network}}",
 		ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 			"type": "object",
 			"required": ["address", "network"],
@@ -216,11 +222,11 @@ func listTokenBalancesManifest() connectors.ManifestAction {
 
 func getSwapPriceManifest() connectors.ManifestAction {
 	return connectors.ManifestAction{
-		ActionType:        "coinbase_agentkit.get_swap_price",
-		Name:              "Get swap price quote",
-		Description:       "Read-only price quote for a token swap via CDP (no transaction). from_amount is in atomic units of from_token. Use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native per EIP-7528.",
-		RiskLevel:         "low",
-		DisplayTemplate:   "Swap quote on {{network}}: {{from_amount}} ({{from_token}} → {{to_token}})",
+		ActionType:      "coinbase_agentkit.get_swap_price",
+		Name:            "Get swap price quote",
+		Description:     "Read-only price quote for a token swap via CDP (no transaction). from_amount is in atomic units of from_token. Use 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE for native per EIP-7528.",
+		RiskLevel:       "low",
+		DisplayTemplate: "Swap quote on {{network}}: {{from_amount}} ({{from_token}} → {{to_token}})",
 		ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 			"type": "object",
 			"required": ["network", "from_token", "to_token", "from_amount", "taker"],
@@ -292,4 +298,9 @@ func swapTokensManifest() connectors.ManifestAction {
 			}
 		}`)),
 	}
+}
+
+func ptrFalse() *bool {
+	b := false
+	return &b
 }

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -55,13 +55,26 @@ type ActionPreview struct {
 	Fields map[string]string `json:"fields"`
 }
 
+// ManifestCredentialField describes one key/value field stored for a static
+// credential (auth_type api_key or custom). Omitted or empty Fields on the
+// parent credential implies a single default field (api_key → "API Key").
+type ManifestCredentialField struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Placeholder string `json:"placeholder,omitempty"`
+	Secret      *bool  `json:"secret,omitempty"`   // default true
+	Required    *bool  `json:"required,omitempty"` // default true
+	HelpText    string `json:"help_text,omitempty"`
+}
+
 // ManifestCredential describes a credential requirement for an external connector.
 type ManifestCredential struct {
-	Service         string   `json:"service"`
-	AuthType        string   `json:"auth_type"`
-	InstructionsURL string   `json:"instructions_url,omitempty"`
-	OAuthProvider   string   `json:"oauth_provider,omitempty"`
-	OAuthScopes     []string `json:"oauth_scopes,omitempty"`
+	Service         string                    `json:"service"`
+	AuthType        string                    `json:"auth_type"`
+	InstructionsURL string                    `json:"instructions_url,omitempty"`
+	OAuthProvider   string                    `json:"oauth_provider,omitempty"`
+	OAuthScopes     []string                  `json:"oauth_scopes,omitempty"`
+	Fields          []ManifestCredentialField `json:"fields,omitempty"`
 }
 
 // ManifestOAuthProvider describes an OAuth 2.0 provider declared by an external
@@ -379,6 +392,24 @@ func (m *ConnectorManifest) Validate() error {
 				return err
 			}
 		}
+		if len(c.Fields) > 0 {
+			if c.AuthType != "api_key" && c.AuthType != "custom" {
+				return fmt.Errorf("manifest validation: required_credentials[%d].fields is only allowed when auth_type is api_key or custom", i)
+			}
+			seenKeys := make(map[string]bool, len(c.Fields))
+			for j, f := range c.Fields {
+				if f.Key == "" {
+					return fmt.Errorf("manifest validation: required_credentials[%d].fields[%d].key is required", i, j)
+				}
+				if seenKeys[f.Key] {
+					return fmt.Errorf("manifest validation: required_credentials[%d].fields has duplicate key %q", i, f.Key)
+				}
+				seenKeys[f.Key] = true
+				if f.Label == "" {
+					return fmt.Errorf("manifest validation: required_credentials[%d].fields[%d].label is required", i, j)
+				}
+			}
+		}
 	}
 
 	// Collect all known OAuth provider IDs: built-in + declared in this manifest.
@@ -668,12 +699,44 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 		})
 	}
 	for _, c := range m.RequiredCredentials {
+		var fieldsJSON []byte
+		if len(c.Fields) > 0 {
+			type fieldRow struct {
+				Key         string `json:"key"`
+				Label       string `json:"label"`
+				Placeholder string `json:"placeholder,omitempty"`
+				Secret      bool   `json:"secret"`
+				Required    bool   `json:"required"`
+				HelpText    string `json:"help_text,omitempty"`
+			}
+			rows := make([]fieldRow, 0, len(c.Fields))
+			for _, f := range c.Fields {
+				sec := true
+				if f.Secret != nil {
+					sec = *f.Secret
+				}
+				req := true
+				if f.Required != nil {
+					req = *f.Required
+				}
+				rows = append(rows, fieldRow{
+					Key: f.Key, Label: f.Label, Placeholder: f.Placeholder,
+					Secret: sec, Required: req, HelpText: f.HelpText,
+				})
+			}
+			var err error
+			fieldsJSON, err = json.Marshal(rows)
+			if err != nil {
+				log.Printf("warning: failed to marshal credential fields for %s/%s: %v", c.Service, c.AuthType, err)
+			}
+		}
 		out.Credentials = append(out.Credentials, db.ExternalConnectorCredential{
 			Service:         c.Service,
 			AuthType:        c.AuthType,
 			InstructionsURL: c.InstructionsURL,
 			OAuthProvider:   c.OAuthProvider,
 			OAuthScopes:     c.OAuthScopes,
+			FieldsJSON:      fieldsJSON,
 		})
 	}
 	for _, tpl := range m.Templates {

--- a/connectors/manifest_test.go
+++ b/connectors/manifest_test.go
@@ -105,6 +105,10 @@ func TestParseManifest_ValidationErrors(t *testing.T) {
 		{"missing auth_type", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s"}]}`},
 		{"invalid auth_type", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"magic"}]}`},
 		{"oauth2 missing oauth_provider", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"oauth2"}]}`},
+		{"fields on oauth2", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"oauth_providers":[{"id":"p","authorize_url":"https://a.example/oauth","token_url":"https://a.example/token"}],"required_credentials":[{"service":"s","auth_type":"oauth2","oauth_provider":"p","fields":[{"key":"k","label":"L"}]}]}`},
+		{"fields duplicate key", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"custom","fields":[{"key":"a","label":"A"},{"key":"a","label":"B"}]}]}`},
+		{"fields empty key", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"api_key","fields":[{"key":"","label":"L"}]}]}`},
+		{"fields empty label", `{"id":"x","name":"X","actions":[{"action_type":"x.a","name":"A"}],"required_credentials":[{"service":"s","auth_type":"api_key","fields":[{"key":"k","label":""}]}]}`},
 		{"invalid JSON", `{not json`},
 	}
 

--- a/connectors/mysql/mysql.go
+++ b/connectors/mysql/mysql.go
@@ -14,9 +14,9 @@
 package mysql
 
 import (
-	_ "embed"
 	"context"
 	"database/sql"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -70,6 +70,7 @@ func (c *MySQLConnector) ID() string { return "mysql" }
 
 // Manifest returns the connector's metadata manifest. Used by the server to
 // auto-seed DB rows on startup.
+//
 //go:embed logo.svg
 var logoSVG string
 
@@ -207,7 +208,18 @@ func (c *MySQLConnector) Manifest() *connectors.ConnectorManifest {
 			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
-			{Service: "mysql", AuthType: "custom", InstructionsURL: "https://github.com/go-sql-driver/mysql#dsn-data-source-name"},
+			{
+				Service:         "mysql",
+				AuthType:        "custom",
+				InstructionsURL: "https://github.com/go-sql-driver/mysql#dsn-data-source-name",
+				Fields: []connectors.ManifestCredentialField{
+					{
+						Key:         "connection_string",
+						Label:       "Connection String",
+						Placeholder: "mysql://user:password@host:port/dbname",
+					},
+				},
+			},
 		},
 		Templates: []connectors.ManifestTemplate{
 			{

--- a/connectors/postgres/postgres.go
+++ b/connectors/postgres/postgres.go
@@ -10,9 +10,9 @@
 package postgres
 
 import (
-	_ "embed"
 	"context"
 	"database/sql"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -202,6 +202,13 @@ func (c *PostgresConnector) Manifest() *connectors.ConnectorManifest {
 				Service:         "postgres",
 				AuthType:        "custom",
 				InstructionsURL: "https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING",
+				Fields: []connectors.ManifestCredentialField{
+					{
+						Key:         "connection_string",
+						Label:       "Connection String",
+						Placeholder: "postgresql://user:password@host:port/dbname",
+					},
+				},
 			},
 		},
 		Templates: []connectors.ManifestTemplate{

--- a/connectors/redis/redis.go
+++ b/connectors/redis/redis.go
@@ -4,8 +4,8 @@
 package redis
 
 import (
-	_ "embed"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -186,7 +186,18 @@ func (c *RedisConnector) Manifest() *connectors.ConnectorManifest {
 			},
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
-			{Service: "redis", AuthType: "custom", InstructionsURL: "https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/"},
+			{
+				Service:         "redis",
+				AuthType:        "custom",
+				InstructionsURL: "https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/",
+				Fields: []connectors.ManifestCredentialField{
+					{
+						Key:         "url",
+						Label:       "Redis URL",
+						Placeholder: "redis://user:password@host:port/0",
+					},
+				},
+			},
 		},
 		Templates: []connectors.ManifestTemplate{
 			{

--- a/connectors/snowflake/snowflake.go
+++ b/connectors/snowflake/snowflake.go
@@ -81,6 +81,13 @@ func (c *SnowflakeConnector) Manifest() *connectors.ConnectorManifest {
 				Service:         "snowflake",
 				AuthType:        "custom",
 				InstructionsURL: "https://docs.snowflake.com/en/developer-guide/go/go-driver",
+				Fields: []connectors.ManifestCredentialField{
+					{
+						Key:         "connection_string",
+						Label:       "Connection String",
+						Placeholder: "user:password@account/database/schema",
+					},
+				},
 			},
 		},
 		Templates: []connectors.ManifestTemplate{

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -43,13 +44,24 @@ type ConnectorAction struct {
 	Preview               []byte // raw JSONB — structured preview layout config
 }
 
+// CredentialFieldSpec is one field in a static (api_key/custom) credential schema.
+type CredentialFieldSpec struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Placeholder string `json:"placeholder,omitempty"`
+	Secret      bool   `json:"secret"`
+	Required    bool   `json:"required"`
+	HelpText    string `json:"help_text,omitempty"`
+}
+
 // RequiredCredential represents a row from the connector_required_credentials table.
 type RequiredCredential struct {
-	Service         string
-	AuthType        string
-	InstructionsURL *string
-	OAuthProvider   *string
-	OAuthScopes     []string
+	Service          string
+	AuthType         string
+	InstructionsURL  *string
+	OAuthProvider    *string
+	OAuthScopes      []string
+	CredentialFields []CredentialFieldSpec // from credential_fields JSONB; empty means UI default single api_key field
 }
 
 // ListConnectors returns all connectors with their action types and required credential services.
@@ -121,7 +133,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	// Fetch required credentials.
 	credRows, err := db.Query(ctx,
-		`SELECT service, auth_type, instructions_url, oauth_provider, oauth_scopes
+		`SELECT service, auth_type, instructions_url, oauth_provider, oauth_scopes, COALESCE(credential_fields, '[]'::jsonb)
 		 FROM connector_required_credentials
 		 WHERE connector_id = $1
 		 ORDER BY service`,
@@ -134,12 +146,50 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	for credRows.Next() {
 		var rc RequiredCredential
-		if err := credRows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
+		var fieldsRaw []byte
+		if err := credRows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &fieldsRaw); err != nil {
 			return nil, err
+		}
+		if len(fieldsRaw) > 0 && string(fieldsRaw) != "[]" && string(fieldsRaw) != "null" {
+			if err := json.Unmarshal(fieldsRaw, &rc.CredentialFields); err != nil {
+				return nil, fmt.Errorf("unmarshal credential_fields for %s/%s: %w", rc.Service, rc.AuthType, err)
+			}
 		}
 		cd.RequiredCredentials = append(cd.RequiredCredentials, rc)
 	}
 	return &cd, credRows.Err()
+}
+
+// GetRequiredCredentialsByService returns all connector_required_credentials rows
+// matching the given service name (may be multiple connectors if they share a
+// service string — callers should handle ambiguity).
+func GetRequiredCredentialsByService(ctx context.Context, db DBTX, service string) ([]RequiredCredential, error) {
+	rows, err := db.Query(ctx, `
+		SELECT service, auth_type, instructions_url, oauth_provider, oauth_scopes, COALESCE(credential_fields, '[]'::jsonb)
+		FROM connector_required_credentials
+		WHERE service = $1`,
+		service,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []RequiredCredential
+	for rows.Next() {
+		var rc RequiredCredential
+		var fieldsRaw []byte
+		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &fieldsRaw); err != nil {
+			return nil, err
+		}
+		if len(fieldsRaw) > 0 && string(fieldsRaw) != "[]" && string(fieldsRaw) != "null" {
+			if err := json.Unmarshal(fieldsRaw, &rc.CredentialFields); err != nil {
+				return nil, fmt.Errorf("unmarshal credential_fields for service %q: %w", service, err)
+			}
+		}
+		out = append(out, rc)
+	}
+	return out, rows.Err()
 }
 
 // GetRequiredServicesByActionType returns the list of static credential services
@@ -278,6 +328,7 @@ type ExternalConnectorCredential struct {
 	InstructionsURL string
 	OAuthProvider   string
 	OAuthScopes     []string
+	FieldsJSON      []byte // JSON array of CredentialFieldSpec; nil/empty → store as []
 }
 
 // ExternalConnectorTemplate describes a configuration template from a connector manifest.
@@ -365,14 +416,19 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 	credKeys := make([]serviceAuthKey, 0, len(m.Credentials))
 	for _, c := range m.Credentials {
 		credKeys = append(credKeys, serviceAuthKey{c.Service, c.AuthType})
+		fieldsVal := c.FieldsJSON
+		if len(fieldsVal) == 0 {
+			fieldsVal = []byte("[]")
+		}
 		_, err := tx.Exec(ctx, `
-			INSERT INTO connector_required_credentials (connector_id, service, auth_type, instructions_url, oauth_provider, oauth_scopes)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO connector_required_credentials (connector_id, service, auth_type, instructions_url, oauth_provider, oauth_scopes, credential_fields)
+			VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
 			ON CONFLICT (connector_id, service, auth_type) DO UPDATE SET
 				instructions_url = EXCLUDED.instructions_url,
 				oauth_provider = EXCLUDED.oauth_provider,
-				oauth_scopes = EXCLUDED.oauth_scopes`,
-			m.ID, c.Service, c.AuthType, nilIfEmpty(c.InstructionsURL), nilIfEmpty(c.OAuthProvider), c.OAuthScopes)
+				oauth_scopes = EXCLUDED.oauth_scopes,
+				credential_fields = EXCLUDED.credential_fields`,
+			m.ID, c.Service, c.AuthType, nilIfEmpty(c.InstructionsURL), nilIfEmpty(c.OAuthProvider), c.OAuthScopes, fieldsVal)
 		if err != nil {
 			return err
 		}

--- a/db/connectors_test.go
+++ b/db/connectors_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip/db"
@@ -24,7 +25,7 @@ func TestConnectorsSchema(t *testing.T) {
 	t.Run("connector_required_credentials", func(t *testing.T) {
 		testhelper.RequireColumns(t, tx, "connector_required_credentials", []string{
 			"connector_id", "service", "auth_type", "instructions_url",
-			"oauth_provider", "oauth_scopes",
+			"oauth_provider", "oauth_scopes", "credential_fields",
 		})
 	})
 	t.Run("oauth_connections", func(t *testing.T) {
@@ -637,6 +638,53 @@ func TestUpsertConnectorFromManifest_NoTemplates(t *testing.T) {
 	}
 	if len(templates) != 0 {
 		t.Errorf("expected 0 templates after removal, got %d", len(templates))
+	}
+}
+
+func TestUpsertConnectorFromManifest_CredentialFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tx := testhelper.SetupTestDB(t)
+
+	fields := []db.CredentialFieldSpec{
+		{Key: "a", Label: "A", Placeholder: "pa", Secret: true, Required: true},
+		{Key: "b", Label: "B", Secret: false, Required: false},
+	}
+	fieldsJSON, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := db.ExternalConnectorManifest{
+		ID:   "ext-fields",
+		Name: "Fields Test",
+		Actions: []db.ExternalConnectorAction{
+			{ActionType: "ext-fields.ping", Name: "Ping"},
+		},
+		Credentials: []db.ExternalConnectorCredential{
+			{Service: "ext-fields", AuthType: "custom", FieldsJSON: fieldsJSON},
+		},
+	}
+	if err := db.UpsertConnectorFromManifest(ctx, tx, m); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	detail, err := db.GetConnectorByID(ctx, tx, "ext-fields")
+	if err != nil {
+		t.Fatalf("GetConnectorByID: %v", err)
+	}
+	if detail == nil || len(detail.RequiredCredentials) != 1 {
+		t.Fatalf("detail: %+v", detail)
+	}
+	got := detail.RequiredCredentials[0].CredentialFields
+	if len(got) != 2 {
+		t.Fatalf("len(fields) = %d, want 2", len(got))
+	}
+	if got[0].Key != "a" || !got[0].Secret || got[0].Placeholder != "pa" {
+		t.Errorf("field[0] = %+v", got[0])
+	}
+	if got[1].Key != "b" || got[1].Secret || got[1].Required {
+		t.Errorf("field[1] = %+v", got[1])
 	}
 }
 

--- a/db/credential_field_validation.go
+++ b/db/credential_field_validation.go
@@ -1,0 +1,136 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateStaticCredentialKeys checks submitted credential keys against the
+// declared schema for api_key, custom, or basic auth. Returns a non-nil error
+// with a user-facing message when validation fails.
+func ValidateStaticCredentialKeys(rc RequiredCredential, submitted map[string]any) error {
+	switch rc.AuthType {
+	case "oauth2":
+		return fmt.Errorf("service %q uses OAuth — use the OAuth flow instead of storing static credentials", rc.Service)
+	case "basic":
+		return validateBasicCredentialKeys(submitted)
+	case "api_key", "custom":
+		return validateManifestCredentialKeys(rc, submitted)
+	default:
+		return fmt.Errorf("unsupported auth_type %q for service %q", rc.AuthType, rc.Service)
+	}
+}
+
+func validateBasicCredentialKeys(submitted map[string]any) error {
+	if _, ok := submitted["username"]; !ok {
+		return fmt.Errorf("missing required credential key: username")
+	}
+	if _, ok := submitted["password"]; !ok {
+		return fmt.Errorf("missing required credential key: password")
+	}
+	for k := range submitted {
+		if k != "username" && k != "password" {
+			return fmt.Errorf("unexpected credential key %q (only username and password are allowed)", k)
+		}
+	}
+	u, okU := stringFromAny(submitted["username"])
+	p, okP := stringFromAny(submitted["password"])
+	if !okU || !okP {
+		return fmt.Errorf("username and password must be strings")
+	}
+	if strings.TrimSpace(u) == "" {
+		return fmt.Errorf("username cannot be empty")
+	}
+	if strings.TrimSpace(p) == "" {
+		return fmt.Errorf("password cannot be empty")
+	}
+	return nil
+}
+
+func validateManifestCredentialKeys(rc RequiredCredential, submitted map[string]any) error {
+	fields := rc.CredentialFields
+	if len(fields) == 0 {
+		if rc.AuthType == "api_key" {
+			if _, ok := submitted["api_key"]; !ok {
+				return fmt.Errorf("missing required credential key: api_key")
+			}
+			for k := range submitted {
+				if k != "api_key" {
+					return fmt.Errorf("unexpected credential key %q (only api_key is allowed for this connector)", k)
+				}
+			}
+			v, ok := stringFromAny(submitted["api_key"])
+			if !ok {
+				return fmt.Errorf("api_key must be a string")
+			}
+			if strings.TrimSpace(v) == "" {
+				return fmt.Errorf("api_key cannot be empty")
+			}
+			return nil
+		}
+		// custom with no manifest fields — cannot validate server-side.
+		return nil
+	}
+
+	allowed := make(map[string]CredentialFieldSpec, len(fields))
+	for _, f := range fields {
+		allowed[f.Key] = f
+	}
+	for k := range submitted {
+		if _, ok := allowed[k]; !ok {
+			return fmt.Errorf("unexpected credential key %q", k)
+		}
+	}
+	for _, f := range fields {
+		if !f.Required {
+			continue
+		}
+		raw, ok := submitted[f.Key]
+		if !ok {
+			return fmt.Errorf("missing required credential key: %s", f.Key)
+		}
+		v, ok := stringFromAny(raw)
+		if !ok {
+			return fmt.Errorf("credential key %q must be a string", f.Key)
+		}
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("%s cannot be empty", f.Key)
+		}
+	}
+	// Optional fields: if present, must be non-empty strings (reject garbage types).
+	for k, raw := range submitted {
+		spec := allowed[k]
+		if spec.Required {
+			continue
+		}
+		v, ok := stringFromAny(raw)
+		if !ok {
+			return fmt.Errorf("credential key %q must be a string", k)
+		}
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("%s cannot be empty when provided", k)
+		}
+	}
+	return nil
+}
+
+func stringFromAny(v any) (string, bool) {
+	s, ok := v.(string)
+	return s, ok
+}
+
+// CredentialFieldSpecsMatch returns true if two non-empty field slices are
+// identical (same keys, labels, secret, required, placeholder, help_text order).
+func CredentialFieldSpecsMatch(a, b []CredentialFieldSpec) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Key != b[i].Key || a[i].Label != b[i].Label ||
+			a[i].Secret != b[i].Secret || a[i].Required != b[i].Required ||
+			a[i].Placeholder != b[i].Placeholder || a[i].HelpText != b[i].HelpText {
+			return false
+		}
+	}
+	return true
+}

--- a/db/credential_field_validation_test.go
+++ b/db/credential_field_validation_test.go
@@ -1,0 +1,57 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+func TestValidateStaticCredentialKeys_apiKeyDefault(t *testing.T) {
+	t.Parallel()
+	rc := db.RequiredCredential{Service: "x", AuthType: "api_key"}
+	err := db.ValidateStaticCredentialKeys(rc, map[string]any{"api_key": "secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ValidateStaticCredentialKeys(rc, map[string]any{"api_key": "x", "extra": "y"}); err == nil {
+		t.Fatal("expected error for extra key")
+	}
+}
+
+func TestValidateStaticCredentialKeys_customManifest(t *testing.T) {
+	t.Parallel()
+	rc := db.RequiredCredential{
+		Service:  "aws",
+		AuthType: "custom",
+		CredentialFields: []db.CredentialFieldSpec{
+			{Key: "access_key_id", Label: "Access Key ID", Secret: false, Required: true},
+			{Key: "secret_access_key", Label: "Secret", Secret: true, Required: true},
+			{Key: "region", Label: "Region", Secret: false, Required: true},
+		},
+	}
+	err := db.ValidateStaticCredentialKeys(rc, map[string]any{
+		"access_key_id":     "AKIAEXAMPLE",
+		"secret_access_key": "s",
+		"region":            "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ValidateStaticCredentialKeys(rc, map[string]any{
+		"access_key_id": "AKIAEXAMPLE",
+	}); err == nil {
+		t.Fatal("expected error for missing keys")
+	}
+}
+
+func TestValidateStaticCredentialKeys_basic(t *testing.T) {
+	t.Parallel()
+	rc := db.RequiredCredential{Service: "t", AuthType: "basic"}
+	err := db.ValidateStaticCredentialKeys(rc, map[string]any{
+		"username": "u",
+		"password": "p",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/db/migrations/20260426032749_add_connector_required_credentials_fields.sql
+++ b/db/migrations/20260426032749_add_connector_required_credentials_fields.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE connector_required_credentials
+    ADD COLUMN IF NOT EXISTS credential_fields JSONB NOT NULL DEFAULT '[]'::jsonb;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE connector_required_credentials
+    DROP COLUMN IF EXISTS credential_fields;
+-- +goose StatementEnd

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -297,20 +297,26 @@ func ListExpiringOAuthConnections(ctx context.Context, db DBTX, horizon time.Dur
 // This function is retained for backward compatibility.
 func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType string) (*RequiredCredential, error) {
 	var rc RequiredCredential
+	var fieldsRaw []byte
 	err := db.QueryRow(ctx, `
-		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes, COALESCE(crc.credential_fields, '[]'::jsonb)
 		FROM connector_actions ca
 		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
 		WHERE ca.action_type = $1
 		ORDER BY CASE WHEN crc.auth_type = 'oauth2' THEN 0 ELSE 1 END, crc.service
 		LIMIT 1`,
 		actionType,
-	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes)
+	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &fieldsRaw)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
+	}
+	if len(fieldsRaw) > 0 && string(fieldsRaw) != "[]" && string(fieldsRaw) != "null" {
+		if err := json.Unmarshal(fieldsRaw, &rc.CredentialFields); err != nil {
+			return nil, fmt.Errorf("unmarshal credential_fields: %w", err)
+		}
 	}
 	return &rc, nil
 }
@@ -323,7 +329,7 @@ func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType 
 // fall back to static credentials when the user hasn't connected via OAuth.
 func GetRequiredCredentialsByActionType(ctx context.Context, db DBTX, actionType string) ([]RequiredCredential, error) {
 	rows, err := db.Query(ctx, `
-		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes, COALESCE(crc.credential_fields, '[]'::jsonb)
 		FROM connector_actions ca
 		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
 		WHERE ca.action_type = $1
@@ -338,8 +344,14 @@ func GetRequiredCredentialsByActionType(ctx context.Context, db DBTX, actionType
 	var creds []RequiredCredential
 	for rows.Next() {
 		var rc RequiredCredential
-		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
+		var fieldsRaw []byte
+		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &fieldsRaw); err != nil {
 			return nil, err
+		}
+		if len(fieldsRaw) > 0 && string(fieldsRaw) != "[]" && string(fieldsRaw) != "null" {
+			if err := json.Unmarshal(fieldsRaw, &rc.CredentialFields); err != nil {
+				return nil, fmt.Errorf("unmarshal credential_fields: %w", err)
+			}
 		}
 		creds = append(creds, rc)
 	}

--- a/db/testhelper/fixtures_connectors.go
+++ b/db/testhelper/fixtures_connectors.go
@@ -68,3 +68,22 @@ func InsertConnectorRequiredCredential(t *testing.T, d db.DBTX, connectorID, ser
 		`INSERT INTO connector_required_credentials (connector_id, service, auth_type) VALUES ($1, $2, $3)`,
 		connectorID, service, authType)
 }
+
+// InsertConnectorWithStaticCredential registers a minimal connector (one ping action)
+// and a required static credential row for POST /v1/credentials validation tests.
+// When fieldsJSON is non-nil, it is stored as credential_fields (JSONB); otherwise
+// the column defaults to [].
+func InsertConnectorWithStaticCredential(t *testing.T, d db.DBTX, connectorID, service, authType string, fieldsJSON []byte) {
+	t.Helper()
+	InsertConnector(t, d, connectorID)
+	InsertConnectorAction(t, d, connectorID, connectorID+".ping", "Ping")
+	if len(fieldsJSON) == 0 {
+		mustExec(t, d,
+			`INSERT INTO connector_required_credentials (connector_id, service, auth_type) VALUES ($1, $2, $3)`,
+			connectorID, service, authType)
+		return
+	}
+	mustExec(t, d,
+		`INSERT INTO connector_required_credentials (connector_id, service, auth_type, credential_fields) VALUES ($1, $2, $3, $4::jsonb)`,
+		connectorID, service, authType, fieldsJSON)
+}

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,7 @@ import { Label } from "@/components/ui/label";
 import { useStoreCredential } from "@/hooks/useStoreCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import validation from "@/lib/validation";
+import { resolveStaticCredentialFields } from "./credentialFields";
 
 interface AddCredentialDialogProps {
   open: boolean;
@@ -44,23 +45,43 @@ export function AddCredentialDialog({
 }: AddCredentialDialogProps) {
   const { storeCredential, isLoading } = useStoreCredential();
   const [label, setLabel] = useState("");
-  const [apiKey, setApiKey] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [cdpApiKeyID, setCdpApiKeyID] = useState("");
-  const [cdpApiKeySecret, setCdpApiKeySecret] = useState("");
-  const [cdpWalletSecret, setCdpWalletSecret] = useState("");
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
 
-  const isCoinbaseAgentKit = credential.service === "coinbase_agentkit";
+  const staticFields = useMemo(
+    () =>
+      resolveStaticCredentialFields(credential, {
+        credentialKey,
+        fieldLabel,
+        fieldPlaceholder,
+      }),
+    [credential, credentialKey, fieldLabel, fieldPlaceholder],
+  );
+
+  const staticFieldSig = useMemo(
+    () => staticFields.map((f) => f.key).join("\x1e"),
+    [staticFields],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const next: Record<string, string> = {};
+    for (const f of staticFields) {
+      next[f.key] = "";
+    }
+    setFieldValues(next);
+  }, [open, staticFieldSig, staticFields]);
 
   function resetForm() {
     setLabel("");
-    setApiKey("");
     setUsername("");
     setPassword("");
-    setCdpApiKeyID("");
-    setCdpApiKeySecret("");
-    setCdpWalletSecret("");
+    const cleared: Record<string, string> = {};
+    for (const f of staticFields) {
+      cleared[f.key] = "";
+    }
+    setFieldValues(cleared);
   }
 
   function handleOpenChange(nextOpen: boolean) {
@@ -94,57 +115,9 @@ export function AddCredentialDialog({
     }
   }
 
-  // Service-specific credential field overrides. Connectors with auth_type
-  // "custom" don't fit the default "API Key" mold — until we extend the
-  // connector manifest with per-field schemas, hardcode the known cases here.
-  const SERVICE_FIELD_OVERRIDES: Record<
-    string,
-    { key: string; label: string; placeholder: string }
-  > = {
-    postgres: {
-      key: "connection_string",
-      label: "Connection String",
-      placeholder: "postgresql://user:password@host:port/dbname",
-    },
-    mysql: {
-      key: "connection_string",
-      label: "Connection String",
-      placeholder: "mysql://user:password@host:port/dbname",
-    },
-    snowflake: {
-      key: "connection_string",
-      label: "Connection String",
-      placeholder: "user:password@account/database/schema",
-    },
-    redis: {
-      key: "url",
-      label: "Redis URL",
-      placeholder: "redis://user:password@host:port/0",
-    },
-  };
-  const override = SERVICE_FIELD_OVERRIDES[credential.service];
-  const resolvedKey = credentialKey ?? override?.key ?? "api_key";
-  const resolvedFieldLabel = fieldLabel ?? override?.label ?? "API Key";
-  const resolvedPlaceholder =
-    fieldPlaceholder ?? override?.placeholder ?? "Enter API key or token";
   const resolvedTitle = title ?? "Add Credential";
 
   function buildCredentials(): Record<string, string> | null {
-    if (isCoinbaseAgentKit) {
-      if (
-        !cdpApiKeyID.trim() ||
-        !cdpApiKeySecret.trim() ||
-        !cdpWalletSecret.trim()
-      ) {
-        toast.error("API Key ID, API Key Secret, and Wallet Secret are required");
-        return null;
-      }
-      return {
-        api_key_id: cdpApiKeyID.trim(),
-        api_key_secret: cdpApiKeySecret.trim(),
-        wallet_secret: cdpWalletSecret.trim(),
-      };
-    }
     if (credential.auth_type === "basic") {
       if (!username.trim() || !password.trim()) {
         toast.error("Username and password are required");
@@ -152,11 +125,23 @@ export function AddCredentialDialog({
       }
       return { username: username.trim(), password: password.trim() };
     }
-    if (!apiKey.trim()) {
-      toast.error(`${resolvedFieldLabel} is required`);
+    const out: Record<string, string> = {};
+    for (const f of staticFields) {
+      const v = (fieldValues[f.key] ?? "").trim();
+      if (f.required && !v) {
+        toast.error(`${f.label} is required`);
+        return null;
+      }
+      if (!f.required && !v) {
+        continue;
+      }
+      out[f.key] = v;
+    }
+    if (Object.keys(out).length === 0) {
+      toast.error("At least one credential value is required");
       return null;
     }
-    return { [resolvedKey]: apiKey.trim() };
+    return out;
   }
 
   const isBasic = credential.auth_type === "basic";
@@ -184,61 +169,7 @@ export function AddCredentialDialog({
                 disabled={isLoading}
               />
             </div>
-            {isCoinbaseAgentKit ? (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor="cdp-api-key-id">API Key ID</Label>
-                  <Input
-                    id="cdp-api-key-id"
-                    placeholder="From CDP Portal → API Keys"
-                    value={cdpApiKeyID}
-                    onChange={(e) => setCdpApiKeyID(e.target.value)}
-                    disabled={isLoading}
-                    required
-                    autoComplete="off"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="cdp-api-key-secret">API Key Secret</Label>
-                  <Input
-                    id="cdp-api-key-secret"
-                    type="password"
-                    placeholder="PEM EC private key or Ed25519 secret from portal"
-                    value={cdpApiKeySecret}
-                    onChange={(e) => setCdpApiKeySecret(e.target.value)}
-                    disabled={isLoading}
-                    required
-                    autoComplete="off"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="cdp-wallet-secret">Wallet Secret</Label>
-                  <Input
-                    id="cdp-wallet-secret"
-                    type="password"
-                    placeholder="Base64 PKCS#8 wallet secret from Wallet API product"
-                    value={cdpWalletSecret}
-                    onChange={(e) => setCdpWalletSecret(e.target.value)}
-                    disabled={isLoading}
-                    required
-                    autoComplete="off"
-                  />
-                </div>
-                <p className="text-muted-foreground text-xs">
-                  Create keys at{" "}
-                  <a
-                    href="https://portal.cdp.coinbase.com/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline"
-                  >
-                    portal.cdp.coinbase.com
-                  </a>
-                  . The wallet secret is required for signing and sending
-                  transactions.
-                </p>
-              </>
-            ) : isBasic ? (
+            {isBasic ? (
               <>
                 <div className="space-y-2">
                   <Label htmlFor="cred-username">Username</Label>
@@ -267,19 +198,29 @@ export function AddCredentialDialog({
                 </div>
               </>
             ) : (
-              <div className="space-y-2">
-                <Label htmlFor="cred-api-key">{resolvedFieldLabel}</Label>
-                <Input
-                  id="cred-api-key"
-                  type="password"
-                  placeholder={resolvedPlaceholder}
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  disabled={isLoading}
-                  required
-                  autoComplete="off"
-                />
-              </div>
+              staticFields.map((f) => (
+                <div key={f.key} className="space-y-2">
+                  <Label htmlFor={`cred-field-${f.key}`}>{f.label}</Label>
+                  <Input
+                    id={`cred-field-${f.key}`}
+                    type={f.secret ? "password" : "text"}
+                    placeholder={f.placeholder || undefined}
+                    value={fieldValues[f.key] ?? ""}
+                    onChange={(e) =>
+                      setFieldValues((prev) => ({
+                        ...prev,
+                        [f.key]: e.target.value,
+                      }))
+                    }
+                    disabled={isLoading}
+                    required={f.required}
+                    autoComplete="off"
+                  />
+                  {f.helpText ? (
+                    <p className="text-muted-foreground text-xs">{f.helpText}</p>
+                  ) : null}
+                </div>
+              ))
             )}
           </div>
           <DialogFooter>

--- a/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/SetupConnectorCredentialsDialog.tsx
@@ -34,6 +34,7 @@ import { isSaas } from "@/lib/saas";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
 import { AddCredentialDialog } from "./AddCredentialDialog";
+import { staticCredentialButtonLabel } from "./credentialFields";
 
 interface SetupConnectorCredentialsDialogProps {
   open: boolean;
@@ -457,16 +458,7 @@ function StaticOnlyContent({
           onClick={() => onConnect(cred)}
         >
           <KeyRound className="size-4" />
-          Add{" "}
-          {cred.auth_type === "basic"
-            ? "credentials"
-            : cred.service === "coinbase_agentkit"
-              ? "CDP credentials"
-              : ["postgres", "mysql", "snowflake"].includes(cred.service)
-                ? "connection string"
-                : cred.service === "redis"
-                  ? "Redis URL"
-                  : "API key"}
+          Add {staticCredentialButtonLabel(cred)}
         </Button>
       ))}
     </div>

--- a/frontend/src/pages/agents/connectors/credentialFields.test.ts
+++ b/frontend/src/pages/agents/connectors/credentialFields.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import {
+  resolveStaticCredentialFields,
+  staticCredentialButtonLabel,
+} from "./credentialFields";
+
+function cred(partial: Partial<RequiredCredential>): RequiredCredential {
+  return {
+    service: "test",
+    auth_type: "api_key",
+    ...partial,
+  } as RequiredCredential;
+}
+
+describe("resolveStaticCredentialFields", () => {
+  it("defaults api_key with no fields to single API Key field", () => {
+    const fields = resolveStaticCredentialFields(cred({ fields: undefined }));
+    expect(fields).toHaveLength(1);
+    expect(fields[0]?.key).toBe("api_key");
+    expect(fields[0]?.label).toBe("API Key");
+    expect(fields[0]?.secret).toBe(true);
+  });
+
+  it("renders manifest fields for custom auth", () => {
+    const fields = resolveStaticCredentialFields(
+      cred({
+        auth_type: "custom",
+        fields: [
+          {
+            key: "connection_string",
+            label: "Connection String",
+            placeholder: "postgres://",
+            secret: true,
+            required: true,
+          },
+        ],
+      }),
+    );
+    expect(fields).toHaveLength(1);
+    expect(fields[0]?.key).toBe("connection_string");
+  });
+
+  it("returns empty for basic (handled separately in dialog)", () => {
+    expect(resolveStaticCredentialFields(cred({ auth_type: "basic" }))).toEqual([]);
+  });
+});
+
+describe("staticCredentialButtonLabel", () => {
+  it("uses first field label for single-field custom creds", () => {
+    const label = staticCredentialButtonLabel(
+      cred({
+        auth_type: "custom",
+        fields: [
+          {
+            key: "url",
+            label: "Redis URL",
+            secret: true,
+            required: true,
+          },
+        ],
+      }),
+    );
+    expect(label).toBe("redis url");
+  });
+
+  it("uses credentials for multi-field", () => {
+    const label = staticCredentialButtonLabel(
+      cred({
+        auth_type: "api_key",
+        fields: [
+          { key: "a", label: "A", secret: true, required: true },
+          { key: "b", label: "B", secret: true, required: true },
+        ],
+      }),
+    );
+    expect(label).toBe("credentials");
+  });
+});

--- a/frontend/src/pages/agents/connectors/credentialFields.ts
+++ b/frontend/src/pages/agents/connectors/credentialFields.ts
@@ -1,0 +1,80 @@
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+
+/** One static credential field from the connector manifest (GET /connectors/:id). */
+export type ResolvedCredentialField = {
+  key: string;
+  label: string;
+  placeholder: string;
+  secret: boolean;
+  required: boolean;
+  helpText: string;
+};
+
+function normalizeField(
+  f: NonNullable<RequiredCredential["fields"]>[number],
+): ResolvedCredentialField {
+  return {
+    key: f.key,
+    label: f.label,
+    placeholder: f.placeholder ?? "",
+    secret: f.secret,
+    required: f.required,
+    helpText: f.help_text ?? "",
+  };
+}
+
+/**
+ * Fields to render for AddCredentialDialog (api_key / custom only).
+ * Empty array means use basic-auth UI; caller handles oauth elsewhere.
+ */
+export function resolveStaticCredentialFields(
+  credential: RequiredCredential,
+  opts?: {
+    credentialKey?: string;
+    fieldLabel?: string;
+    fieldPlaceholder?: string;
+  },
+): ResolvedCredentialField[] {
+  if (
+    credential.auth_type === "basic" ||
+    credential.auth_type === "oauth2"
+  ) {
+    return [];
+  }
+  const raw = credential.fields;
+  if (raw && raw.length > 0) {
+    return raw.map(normalizeField);
+  }
+  const key = opts?.credentialKey ?? "api_key";
+  const label = opts?.fieldLabel ?? "API Key";
+  const placeholder =
+    opts?.fieldPlaceholder ?? "Enter API key or token";
+  return [
+    {
+      key,
+      label,
+      placeholder,
+      secret: true,
+      required: true,
+      helpText: "",
+    },
+  ];
+}
+
+/** Label for the primary CTA when adding a static credential. */
+export function staticCredentialButtonLabel(credential: RequiredCredential): string {
+  if (credential.auth_type === "basic") {
+    return "credentials";
+  }
+  if (credential.auth_type === "oauth2") {
+    return "account";
+  }
+  const fields = credential.fields;
+  if (fields && fields.length > 1) {
+    return "credentials";
+  }
+  if (fields && fields.length === 1) {
+    return fields[0]?.label.toLowerCase() ?? "credential";
+  }
+  return "API key";
+}

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -383,6 +383,33 @@ ConnectorAction:
         - "repo"
         - "title"
 
+CredentialFieldSpec:
+  type: object
+  required:
+    - key
+    - label
+    - secret
+    - required
+  properties:
+    key:
+      type: string
+      description: Storage key sent to the credential vault with POST /v1/credentials.
+    label:
+      type: string
+      description: Human-readable label for the input.
+    placeholder:
+      type: string
+      description: Optional input placeholder.
+    secret:
+      type: boolean
+      description: When true, render as a password field; when false, as plain text.
+    required:
+      type: boolean
+      description: When true, the field must be present and non-empty.
+    help_text:
+      type: string
+      description: Optional helper text shown under the input.
+
 RequiredCredential:
   type: object
   required:
@@ -436,6 +463,14 @@ RequiredCredential:
         OAuth scopes required by this connector. Only present when `auth_type` is `oauth2`.
       example:
         - "https://www.googleapis.com/auth/gmail.send"
+
+    fields:
+      type: array
+      items:
+        $ref: '../schemas/connectors.yaml#/CredentialFieldSpec'
+      description: |
+        Per-field schema for static credentials (`api_key` or `custom`). When omitted or empty,
+        `api_key` auth behaves as a single field with key `api_key` and label "API Key".
 
   example:
     service: "github"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -8478,6 +8478,13 @@ components:
             OAuth scopes required by this connector. Only present when `auth_type` is `oauth2`.
           example:
             - https://www.googleapis.com/auth/gmail.send
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/CredentialFieldSpec'
+          description: |
+            Per-field schema for static credentials (`api_key` or `custom`). When omitted or empty,
+            `api_key` auth behaves as a single field with key `api_key` and label "API Key".
       example:
         service: github
         auth_type: api_key
@@ -12119,6 +12126,32 @@ components:
             timestamp: '1770816000'
             expected_window: 300 seconds
           trace_id: trace_xyz789
+    CredentialFieldSpec:
+      type: object
+      required:
+        - key
+        - label
+        - secret
+        - required
+      properties:
+        key:
+          type: string
+          description: Storage key sent to the credential vault with POST /v1/credentials.
+        label:
+          type: string
+          description: Human-readable label for the input.
+        placeholder:
+          type: string
+          description: Optional input placeholder.
+        secret:
+          type: boolean
+          description: When true, render as a password field; when false, as plain text.
+        required:
+          type: boolean
+          description: When true, the field must be present and non-empty.
+        help_text:
+          type: string
+          description: Optional helper text shown under the input.
     ApproverInfo:
       type: object
       description: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #1109](https://github.com/supersuit-tech/permission-slip/issues/1109): connector manifests declare static credential `fields`; the value is stored in Postgres, returned on connector detail, and enforced on `POST /v1/credentials`. The agents UI renders fields from the API instead of `SERVICE_FIELD_OVERRIDES` / service-specific branches.

## Key changes

- **Manifest:** `ManifestCredentialField` + validation (unique keys, non-empty key/label; `fields` only for `api_key` / `custom`).
- **DB:** `credential_fields` JSONB on `connector_required_credentials`; `UpsertConnectorFromManifest`, `GetConnectorByID`, OAuth lookup queries round-trip it; `GetRequiredCredentialsByService` for credential POST validation.
- **API:** Connector detail includes `fields`; credential store validates keys (extra keys rejected; required keys and non-empty strings enforced; `basic` fixed to username/password; default `api_key` when no manifest fields).
- **Built-in connectors:** `fields` added for postgres, mysql, snowflake, redis, aws, coinbase_agentkit. **AWS:** default `region` is now a stored credential (manifest + `ValidateCredentials`); README updated.
- **Frontend:** Generic multi-field dialog + `credentialFields` helper + Vitest; `StaticOnlyContent` uses synthesized button label.

## Test plan

- [ ] CI: `make test-backend`, `make test-frontend`, migration integrity.
- [ ] Local: `make migrate-up`, restart API, `GET /v1/connectors/aws` shows three fields; add AWS credential via UI; run an AWS action.
- [ ] Regenerate ignored clients if needed: `make bundle && make generate` (repo ignores `frontend/src/api/schema.d.ts` / mobile schema — CI should run generate per workflow).

Closes #1109
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f3a6cc3-ca3a-4cf4-9682-10e54dcf7fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f3a6cc3-ca3a-4cf4-9682-10e54dcf7fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

