### PR TITLE
feat: add auth_option_group for mutually exclusive connector auth paths

### DIFF
--- a/api/connectors.go
+++ b/api/connectors.go
@@ -43,6 +43,7 @@ type requiredCredentialResponse struct {
 	InstructionsURL *string  `json:"instructions_url,omitempty"`
 	OAuthProvider   *string  `json:"oauth_provider,omitempty"`
 	OAuthScopes     []string `json:"oauth_scopes,omitempty"`
+	AuthOptionGroup *string  `json:"auth_option_group,omitempty"`
 }
 
 type connectorDetailResponse struct {
@@ -160,6 +161,7 @@ func toConnectorDetailResponse(ctx context.Context, c db.ConnectorDetail) connec
 			InstructionsURL: rc.InstructionsURL,
 			OAuthProvider:   rc.OAuthProvider,
 			OAuthScopes:     rc.OAuthScopes,
+			AuthOptionGroup: rc.AuthOptionGroup,
 		}
 	}
 

--- a/connectors/github/manifest.go
+++ b/connectors/github/manifest.go
@@ -1337,15 +1337,17 @@ func (c *GitHubConnector) Manifest() *connectors.ConnectorManifest {
 		},
 		RequiredCredentials: []connectors.ManifestCredential{
 			{
-				Service:       "github",
-				AuthType:      "oauth2",
-				OAuthProvider: "github",
-				OAuthScopes:   []string{"repo"},
+				Service:         "github",
+				AuthType:        "oauth2",
+				OAuthProvider:   "github",
+				OAuthScopes:     []string{"repo"},
+				AuthOptionGroup: "github_auth",
 			},
 			{
 				Service:         "github_pat",
 				AuthType:        "api_key",
 				InstructionsURL: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+				AuthOptionGroup: "github_auth",
 			},
 		},
 		Templates: []connectors.ManifestTemplate{

--- a/connectors/manifest.go
+++ b/connectors/manifest.go
@@ -62,6 +62,10 @@ type ManifestCredential struct {
 	InstructionsURL string   `json:"instructions_url,omitempty"`
 	OAuthProvider   string   `json:"oauth_provider,omitempty"`
 	OAuthScopes     []string `json:"oauth_scopes,omitempty"`
+	// AuthOptionGroup marks credentials that are mutually exclusive alternatives.
+	// All credentials sharing the same non-empty group name are treated as "pick
+	// one" options. Leave empty for credentials that are individually required.
+	AuthOptionGroup string `json:"auth_option_group,omitempty"`
 }
 
 // ManifestOAuthProvider describes an OAuth 2.0 provider declared by an external
@@ -342,7 +346,17 @@ func (m *ConnectorManifest) Validate() error {
 	// declare the same service with different auth types (e.g. oauth2 + api_key).
 	type serviceAuth struct{ service, authType string }
 	seen := make(map[serviceAuth]bool, len(m.RequiredCredentials))
+	// Pre-count group memberships to validate that each group has ≥2 members.
+	groupCount := make(map[string]int)
+	for _, c := range m.RequiredCredentials {
+		if c.AuthOptionGroup != "" {
+			groupCount[c.AuthOptionGroup]++
+		}
+	}
 	for i, c := range m.RequiredCredentials {
+		if c.AuthOptionGroup != "" && groupCount[c.AuthOptionGroup] < 2 {
+			return fmt.Errorf("manifest validation: required_credentials[%d].auth_option_group %q must contain at least two credentials", i, c.AuthOptionGroup)
+		}
 		if c.Service == "" {
 			return fmt.Errorf("manifest validation: required_credentials[%d].service is required", i)
 		}
@@ -674,6 +688,7 @@ func (m *ConnectorManifest) ToDBManifest() db.ExternalConnectorManifest {
 			InstructionsURL: c.InstructionsURL,
 			OAuthProvider:   c.OAuthProvider,
 			OAuthScopes:     c.OAuthScopes,
+			AuthOptionGroup: c.AuthOptionGroup,
 		})
 	}
 	for _, tpl := range m.Templates {

--- a/db/connectors.go
+++ b/db/connectors.go
@@ -50,6 +50,7 @@ type RequiredCredential struct {
 	InstructionsURL *string
 	OAuthProvider   *string
 	OAuthScopes     []string
+	AuthOptionGroup *string
 }
 
 // ListConnectors returns all connectors with their action types and required credential services.
@@ -121,7 +122,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	// Fetch required credentials.
 	credRows, err := db.Query(ctx,
-		`SELECT service, auth_type, instructions_url, oauth_provider, oauth_scopes
+		`SELECT service, auth_type, instructions_url, oauth_provider, oauth_scopes, auth_option_group
 		 FROM connector_required_credentials
 		 WHERE connector_id = $1
 		 ORDER BY service`,
@@ -134,7 +135,7 @@ func GetConnectorByID(ctx context.Context, db DBTX, connectorID string) (*Connec
 
 	for credRows.Next() {
 		var rc RequiredCredential
-		if err := credRows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
+		if err := credRows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &rc.AuthOptionGroup); err != nil {
 			return nil, err
 		}
 		cd.RequiredCredentials = append(cd.RequiredCredentials, rc)
@@ -278,6 +279,7 @@ type ExternalConnectorCredential struct {
 	InstructionsURL string
 	OAuthProvider   string
 	OAuthScopes     []string
+	AuthOptionGroup string
 }
 
 // ExternalConnectorTemplate describes a configuration template from a connector manifest.
@@ -366,13 +368,14 @@ func UpsertConnectorFromManifest(ctx context.Context, d DBTX, m ExternalConnecto
 	for _, c := range m.Credentials {
 		credKeys = append(credKeys, serviceAuthKey{c.Service, c.AuthType})
 		_, err := tx.Exec(ctx, `
-			INSERT INTO connector_required_credentials (connector_id, service, auth_type, instructions_url, oauth_provider, oauth_scopes)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO connector_required_credentials (connector_id, service, auth_type, instructions_url, oauth_provider, oauth_scopes, auth_option_group)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (connector_id, service, auth_type) DO UPDATE SET
 				instructions_url = EXCLUDED.instructions_url,
 				oauth_provider = EXCLUDED.oauth_provider,
-				oauth_scopes = EXCLUDED.oauth_scopes`,
-			m.ID, c.Service, c.AuthType, nilIfEmpty(c.InstructionsURL), nilIfEmpty(c.OAuthProvider), c.OAuthScopes)
+				oauth_scopes = EXCLUDED.oauth_scopes,
+				auth_option_group = EXCLUDED.auth_option_group`,
+			m.ID, c.Service, c.AuthType, nilIfEmpty(c.InstructionsURL), nilIfEmpty(c.OAuthProvider), c.OAuthScopes, nilIfEmpty(c.AuthOptionGroup))
 		if err != nil {
 			return err
 		}

--- a/db/migrations/20260426034443_add_auth_option_group_to_required_credentials.sql
+++ b/db/migrations/20260426034443_add_auth_option_group_to_required_credentials.sql
@@ -1,0 +1,88 @@
+-- +goose Up
+
+-- Add auth_option_group to connector_required_credentials.
+-- Credentials sharing the same non-null group are mutually exclusive
+-- alternatives (e.g. "connect via OAuth OR PAT"). The user picks one;
+-- the agent_connector_credentials binding satisfies whichever they chose.
+ALTER TABLE connector_required_credentials
+    ADD COLUMN auth_option_group text CHECK (char_length(auth_option_group) <= 255);
+
+-- Update the mixed-auth trigger to allow mixing oauth2 and non-oauth2
+-- within the same auth_option_group. Rows in the same group are
+-- alternatives, so the "one binding per agent+connector" invariant holds.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION check_no_mixed_auth_types()
+RETURNS trigger AS $$
+DECLARE
+    new_is_oauth boolean;
+    has_conflict boolean;
+BEGIN
+    new_is_oauth := (NEW.auth_type = 'oauth2');
+
+    SELECT EXISTS (
+        SELECT 1 FROM connector_required_credentials
+        WHERE connector_id = NEW.connector_id
+          AND (auth_type = 'oauth2') <> new_is_oauth
+          -- Rows in the same non-null auth_option_group are alternatives, not a conflict.
+          AND NOT (
+              NEW.auth_option_group IS NOT NULL
+              AND auth_option_group IS NOT DISTINCT FROM NEW.auth_option_group
+          )
+          -- Exclude the row being updated (UPDATE path).
+          AND NOT (
+              connector_id = NEW.connector_id
+              AND service = NEW.service
+              AND auth_type = CASE WHEN TG_OP = 'UPDATE' THEN OLD.auth_type
+                                   ELSE NEW.auth_type END
+          )
+    ) INTO has_conflict;
+
+    IF has_conflict THEN
+        RAISE EXCEPTION
+            'connector % cannot mix oauth2 and non-oauth2 auth types outside of an auth_option_group',
+            NEW.connector_id
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+ALTER TABLE connector_required_credentials
+    DROP COLUMN IF EXISTS auth_option_group;
+
+-- Restore the original trigger (no auth_option_group awareness).
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION check_no_mixed_auth_types()
+RETURNS trigger AS $$
+DECLARE
+    new_is_oauth boolean;
+    has_conflict boolean;
+BEGIN
+    new_is_oauth := (NEW.auth_type = 'oauth2');
+
+    SELECT EXISTS (
+        SELECT 1 FROM connector_required_credentials
+        WHERE connector_id = NEW.connector_id
+          AND (auth_type = 'oauth2') <> new_is_oauth
+          AND NOT (
+              connector_id = NEW.connector_id
+              AND service = NEW.service
+              AND auth_type = CASE WHEN TG_OP = 'UPDATE' THEN OLD.auth_type
+                                   ELSE NEW.auth_type END
+          )
+    ) INTO has_conflict;
+
+    IF has_conflict THEN
+        RAISE EXCEPTION
+            'connector % cannot mix oauth2 and non-oauth2 auth types',
+            NEW.connector_id
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/db/oauth_connections.go
+++ b/db/oauth_connections.go
@@ -298,14 +298,14 @@ func ListExpiringOAuthConnections(ctx context.Context, db DBTX, horizon time.Dur
 func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType string) (*RequiredCredential, error) {
 	var rc RequiredCredential
 	err := db.QueryRow(ctx, `
-		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes, crc.auth_option_group
 		FROM connector_actions ca
 		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
 		WHERE ca.action_type = $1
 		ORDER BY CASE WHEN crc.auth_type = 'oauth2' THEN 0 ELSE 1 END, crc.service
 		LIMIT 1`,
 		actionType,
-	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes)
+	).Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &rc.AuthOptionGroup)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -323,7 +323,7 @@ func GetRequiredCredentialByActionType(ctx context.Context, db DBTX, actionType 
 // fall back to static credentials when the user hasn't connected via OAuth.
 func GetRequiredCredentialsByActionType(ctx context.Context, db DBTX, actionType string) ([]RequiredCredential, error) {
 	rows, err := db.Query(ctx, `
-		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes
+		SELECT crc.service, crc.auth_type, crc.instructions_url, crc.oauth_provider, crc.oauth_scopes, crc.auth_option_group
 		FROM connector_actions ca
 		JOIN connector_required_credentials crc ON crc.connector_id = ca.connector_id
 		WHERE ca.action_type = $1
@@ -338,7 +338,7 @@ func GetRequiredCredentialsByActionType(ctx context.Context, db DBTX, actionType
 	var creds []RequiredCredential
 	for rows.Next() {
 		var rc RequiredCredential
-		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes); err != nil {
+		if err := rows.Scan(&rc.Service, &rc.AuthType, &rc.InstructionsURL, &rc.OAuthProvider, &rc.OAuthScopes, &rc.AuthOptionGroup); err != nil {
 			return nil, err
 		}
 		creds = append(creds, rc)

--- a/spec/openapi/components/schemas/connectors.yaml
+++ b/spec/openapi/components/schemas/connectors.yaml
@@ -437,6 +437,17 @@ RequiredCredential:
       example:
         - "https://www.googleapis.com/auth/gmail.send"
 
+    auth_option_group:
+      type: string
+      maxLength: 255
+      description: |
+        Groups credentials that are mutually exclusive alternatives. All credentials
+        sharing the same non-null group name are "pick one" options — the user satisfies
+        the connector's requirement by providing any one of them. Credentials without
+        this field are individually required. Only present when the connector declares
+        alternative auth paths (e.g. OAuth or PAT).
+      example: "github_auth"
+
   example:
     service: "github"
     auth_type: "api_key"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -8478,6 +8478,16 @@ components:
             OAuth scopes required by this connector. Only present when `auth_type` is `oauth2`.
           example:
             - https://www.googleapis.com/auth/gmail.send
+        auth_option_group:
+          type: string
+          maxLength: 255
+          description: |
+            Groups credentials that are mutually exclusive alternatives. All credentials
+            sharing the same non-null group name are "pick one" options — the user satisfies
+            the connector's requirement by providing any one of them. Credentials without
+            this field are individually required. Only present when the connector declares
+            alternative auth paths (e.g. OAuth or PAT).
+          example: github_auth
       example:
         service: github
         auth_type: api_key


### PR DESCRIPTION
## Summary

- Introduces `auth_option_group` on `connector_required_credentials` to express "pick one of these" credential alternatives (e.g. OAuth or PAT) within a single connector
- Updates the `check_no_mixed_auth_types` trigger to allow mixed auth types when all conflicting rows share the same non-null group — the existing "one binding per agent+connector" invariant still holds
- Tags both GitHub credentials with `AuthOptionGroup: "github_auth"`, fixing the seed failure that caused GitHub to not appear in the dashboard
- Exposes `auth_option_group` through the API and OpenAPI spec; frontend already renders the "OAuth or API key" description when both are present

## Test plan

- [ ] `supabase db reset` (or `make seed`) completes without error and GitHub connector appears in the dashboard
- [ ] Assigning an OAuth connection to the GitHub connector works
- [ ] Assigning a PAT credential to the GitHub connector works
- [ ] A connector with a single credential in a group (< 2 members) is rejected at manifest parse time
- [ ] A connector mixing oauth2 + api_key without a group still fails the trigger
- [ ] Frontend tests pass (`make test-frontend`) ✅ 1089/1089

> Note: backend `go test` cannot run locally due to a Go 1.25 toolchain constraint in the sandbox. CI covers the full test suite.

Closes #1110

https://claude.ai/code/session_01RomC25e5NRv4dniHYTqHyF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RomC25e5NRv4dniHYTqHyF)_