### PR TITLE
chore(deps): consolidated dependabot bumps (Stripe v6, storybook-themes)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "openapi-typescript": "^7.13.0",
         "storybook": "^10.3.5",
         "tailwindcss": "^4.1.18",
-        "typescript": "^6.0.3",
+        "typescript": "^5.6.3",
         "vite": "^6.0.0",
         "vitest": "^4.1.5"
       }
@@ -8247,9 +8247,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,8 +19,8 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@sentry/react": "^10.51.0",
-        "@stripe/react-stripe-js": "^5.6.1",
-        "@stripe/stripe-js": "^8.9.0",
+        "@stripe/react-stripe-js": "^6.3.0",
+        "@stripe/stripe-js": "^9.3.1",
         "@supabase/supabase-js": "^2.95.3",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@sentry/vite-plugin": "^3.6.1",
         "@storybook/addon-docs": "^10.3.6",
-        "@storybook/addon-themes": "^10.3.5",
+        "@storybook/addon-themes": "^10.3.6",
         "@storybook/react": "^10.3.5",
         "@storybook/react-vite": "^10.3.5",
         "@tailwindcss/vite": "^4.1.18",
@@ -57,7 +57,7 @@
         "openapi-typescript": "^7.13.0",
         "storybook": "^10.3.5",
         "tailwindcss": "^4.1.18",
-        "typescript": "^5.6.3",
+        "typescript": "^6.0.3",
         "vite": "^6.0.0",
         "vitest": "^4.1.5"
       }
@@ -3375,9 +3375,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-themes": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.3.5.tgz",
-      "integrity": "sha512-Mv+C7GuZ0MhGRx5C+rv8sCEjgYsDTLBvq68101V0s8Vwh3gKd6W9cbS31HoOeLAiIMiPPZ8C1iWudA3Oumdtlw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.3.6.tgz",
+      "integrity": "sha512-/6lPU36+nDQzoDJqwy5BrAO0zFHOHDXn6hy/aq2aKF/RTS54+KrA0fdv0sxTssaBo5tjqZ4jKs60hB0iRWKkFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3388,7 +3388,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5"
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/builder-vite": {
@@ -3559,23 +3559,23 @@
       }
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-5.6.1.tgz",
-      "integrity": "sha512-5xBrjkGmFvKvpMod6VvpOaFaa67eRbmieKeFTePZyOr/sUXzm7A3YY91l330pS0usUst5PxTZDUZHWfOc0v1GA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.3.0.tgz",
+      "integrity": "sha512-N1FTRNCMKySElDz1lAsf/m6Oy5vcl6LRVXcW29t0Y3U3HYOAqCBlk6nuDsR2x7SAuaXkVCjnpCqrNbA/7l74jg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": ">=8.0.0 <9.0.0",
+        "@stripe/stripe-js": ">=9.3.1 <10.0.0",
         "react": ">=16.8.0 <20.0.0",
         "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.11.0.tgz",
-      "integrity": "sha512-3fVF4z3efsgwgyj64nFK+6F4/vMw0mUXD2TBbOfftJtKVNx4JNv3CSfe1fY4DCtCk0JFp8/YPNcRkzgV0HJ8cg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.3.1.tgz",
+      "integrity": "sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"
@@ -8247,9 +8247,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,8 +27,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@sentry/react": "^10.51.0",
-    "@stripe/react-stripe-js": "^5.6.1",
-    "@stripe/stripe-js": "^8.9.0",
+    "@stripe/react-stripe-js": "^6.3.0",
+    "@stripe/stripe-js": "^9.3.1",
     "@supabase/supabase-js": "^2.95.3",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@sentry/vite-plugin": "^3.6.1",
     "@storybook/addon-docs": "^10.3.6",
-    "@storybook/addon-themes": "^10.3.5",
+    "@storybook/addon-themes": "^10.3.6",
     "@storybook/react": "^10.3.5",
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "^4.1.18",
@@ -65,7 +65,7 @@
     "openapi-typescript": "^7.13.0",
     "storybook": "^10.3.5",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.6.3",
+    "typescript": "^6.0.3",
     "vite": "^6.0.0",
     "vitest": "^4.1.5"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "openapi-typescript": "^7.13.0",
     "storybook": "^10.3.5",
     "tailwindcss": "^4.1.18",
-    "typescript": "^6.0.3",
+    "typescript": "^5.6.3",
     "vite": "^6.0.0",
     "vitest": "^4.1.5"
   }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@config/*": ["../config/*"]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@config/*": ["../config/*"]


### PR DESCRIPTION
## Summary

Combines two of the four open dependabot PRs into a single change so they can be closed at once. The other two are intentionally deferred — see below.

### Bumped

- **`@stripe/react-stripe-js`** `^5.6.1` → `^6.3.0` — closes #1130
- **`@stripe/stripe-js`** `^8.9.0` → `^9.3.1` — required peer dep of `react-stripe-js@6` (this is the only piece dependabot didn't include in its PR; `npm install` failed without it)
- **`@storybook/addon-themes`** `^10.3.5` → `^10.3.6` — closes #1117

Stripe `v6` only deprecates `useCheckout`; the only consumer in this repo (`frontend/src/pages/settings/AddCardDialog.tsx`) uses `Elements`, `CardElement`, `useStripe`, `useElements` — none of which changed.

### Deferred

- **typescript 5.6.3 → 6.0.3 (#1129)** — Tried; CI's `npm ci --ignore-scripts` is strict about peer deps and the TS 6 ecosystem hasn't caught up yet. `openapi-typescript@7.13.0` (latest) still pins `typescript: ^5.x`, and the storybook react-vite tooling chain (`react-docgen-typescript`, `@joshwooding/vite-plugin-react-docgen-typescript`) does too. Reverted in 1e4f299. Recommendation: leave #1129 open; dependabot will recreate it once openapi-typescript and the storybook chain ship TS 6 support.
- **react-native 0.83.2 → 0.85.2 (#1118)** — Expo SDK 55 is paired with React Native 0.83.x (`expo/bundledNativeModules.json` pins `react-native: 0.83.6`). RN 0.85 also moved its Jest preset out of the `react-native` package, and `jest-expo@55` still requires the old path — the mobile test suite errors on boot under RN 0.85. This bump should ride with an Expo SDK upgrade in its own PR. Recommendation: close #1118 manually; dependabot will recreate it once SDK 55 is upgraded.

## Test plan

- [x] `cd frontend && npm ci --ignore-scripts` — strict resolution succeeds
- [x] `cd frontend && npm audit --audit-level=high` — 0 vulnerabilities
- [x] `cd frontend && npm run build` — `tsc -b && vite build` both succeed
- [x] `cd frontend && npm test` — 115 test files, 1094 tests passing
- [x] `cd mobile && npm test -- --ci` — 30 suites, 288 tests passing (unchanged, no mobile deps modified)
- [ ] CI green on push

Closes #1117
Closes #1130

https://claude.ai/code/session_01RFYSdsi9KbHS1PjRKaJv8s