### PR TITLE
ci: auto-merge Dependabot PRs when CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (skip major version bumps)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml`, which enables GitHub's native auto-merge on Dependabot PRs so they merge automatically once required status checks pass.

- Runs only when the PR author is `dependabot[bot]`.
- Uses `dependabot/fetch-metadata@v2` to detect the update type.
- **Skips major version bumps** (`version-update:semver-major`) so they're reviewed by a human.
- Merge method: **squash**.
- Token: `GITHUB_TOKEN` with `contents: write` + `pull-requests: write` — no PAT needed.

## Required repo settings (out of band)

For this workflow to actually do anything useful, the following must be configured in repo settings — the workflow alone is not enough:

1. **Settings → General → Pull Requests → "Allow auto-merge"** must be enabled. Without it, `gh pr merge --auto` errors and Dependabot PRs will not auto-merge.
2. **Settings → Branches → branch protection on `main`** must require status checks (CI / Mobile CI / Dependency Audit). Without required checks, "auto-merge when checks pass" effectively merges immediately, which is not what we want.
3. Dependabot must be able to run the existing CI workflows. The current `ci.yml`, `audit.yml`, and `mobile-ci.yml` don't read any secrets on `pull_request` runs, so they should work as-is.

## Test plan

- [ ] Confirm "Allow auto-merge" is enabled in repo settings.
- [ ] Confirm `main` branch protection requires CI / Mobile CI / Dependency Audit status checks.
- [ ] After merge, watch the next Dependabot PR: workflow should run, set the PR to auto-merge, and the PR should merge itself once all required checks go green.
- [ ] Open a Dependabot major-version-bump PR (or simulate one) and confirm it is **not** auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177i1KqSz858fEhVE7uCB4R)_