### PR TITLE
chore(deps): ignore react-native major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     directory: "/mobile"
     schedule:
       interval: "weekly"
+    ignore:
+      # react-native's version is dictated by the Expo SDK we're on.
+      # Bump it via an Expo SDK upgrade, not directly.
+      - dependency-name: "react-native"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/cli"


### PR DESCRIPTION
## Summary

Adds a Dependabot ignore rule for major-version bumps of `react-native` in `/mobile`. RN's version is effectively pinned by the Expo SDK we use — bumping it directly fails (Expo packages pin to a specific RN minor, jest-expo's preset breaks, etc.). The right path for a major RN upgrade is an Expo SDK upgrade, which carries the matching RN.

This stops Dependabot from re-opening the kind of PR we just hit on #1138. Patch and minor bumps are still surfaced.

Closes #1138

## Test plan

- [x] `dependabot.yml` is YAML-valid and follows the existing structure
- [ ] After merge, Dependabot won't re-create a `react-native` major-bump PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwYQbasNUQAxBX9UfjRYCP)_