### PR TITLE
revert: downgrade typescript to 5.9.3 to unblock Fly.io deploys

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "openapi-typescript": "^7.13.0",
         "storybook": "^10.3.5",
         "tailwindcss": "^4.1.18",
-        "typescript": "^6.0.3",
+        "typescript": "^5.9.3",
         "vite": "^8.0.13",
         "vitest": "^4.1.5"
       }
@@ -8163,9 +8163,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "openapi-typescript": "^7.13.0",
     "storybook": "^10.3.5",
     "tailwindcss": "^4.1.18",
-    "typescript": "^6.0.3",
+    "typescript": "^5.9.3",
     "vite": "^8.0.13",
     "vitest": "^4.1.5"
   }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary

Fly.io deploys have been failing since 2026-05-03 (40 failed `Deploy` workflow runs, 0 successes). Root cause is PR #1129 which bumped `typescript` 5.9.3 → 6.0.3.

The Docker build runs `npm ci` inside `node:26-alpine` (npm 11), which strictly enforces peer dependencies. `openapi-typescript@7.13.0` declares `peerDependencies: typescript@"^5.x"`, so the resolution fails with `ERESOLVE`:

```
npm error While resolving: openapi-typescript@7.13.0
npm error Found: typescript@6.0.3
npm error Conflicting peer dependency: typescript@5.9.3
```

CI passed because it runs on `node:22` (npm 10), which is lenient about peer conflicts — hiding the regression until Docker build time.

## Changes

- `frontend/package.json`: `typescript` `^6.0.3` → `^5.9.3`
- `frontend/package-lock.json`: regenerated
- `frontend/tsconfig.json`: remove `"ignoreDeprecations": "6.0"` (TS 6 only; invalid in TS 5)

## Test plan

- [x] `npm ci` succeeds with new lockfile (the failing step in Docker)
- [x] `make test-frontend` — 1094/1094 tests pass
- [x] `npm run build` — Vite + tsc compiles cleanly
- [ ] Post-merge: `Deploy to Fly.io` succeeds on the resulting `main` push

## Follow-ups

- Consider aligning the Dockerfile's Node version with CI's (`node:22-alpine`) to catch this class of mismatch in CI before deploy.
- The `dependabot-auto-merge.yml` rule (added in #1166) already skips major bumps, so this revert won't get re-merged automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkhF9Rua8xiV8ixwowcZb6)_