### PR TITLE
Disable Dependabot version updates to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,27 @@
 version: 2
+# Version updates are disabled (open-pull-requests-limit: 0) to keep noise down.
+# Security updates are unaffected — they're controlled at the repo level
+# (Settings → Code security → Dependabot security updates) and continue to flow
+# through regardless of this file. To re-enable version updates for an
+# ecosystem, raise its open-pull-requests-limit (default is 5).
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/mobile"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     ignore:
       # react-native's version is dictated by the Expo SDK we're on.
       # Bump it via an Expo SDK upgrade, not directly.
@@ -24,13 +32,16 @@ updates:
     directory: "/cli"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

- Sets `open-pull-requests-limit: 0` on every ecosystem in `.github/dependabot.yml` (gomod, npm × 3, docker, github-actions) to stop routine version-update PRs.
- Security updates are unaffected — they're toggled at the repo level (Settings → Code security → Dependabot security updates) and continue to flow regardless of this file.
- Leaves the ecosystem blocks and the `react-native` ignore rule in place so version updates can be re-enabled later by raising the limit.

## Follow-up (manual, not in this PR)

- Confirm "Dependabot security updates" is **on** in repo Settings → Code security so security PRs still arrive.
- Optionally trim personal notification noise under GitHub → Notifications → Dependabot alerts.

## Test plan

- [ ] Verify no new Dependabot version-update PRs are opened after merge (next weekly run).
- [ ] Confirm an existing or new security advisory still produces a Dependabot security PR.

https://claude.ai/code/session_01NUokvHx5G2szvn1ayD4Kj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUokvHx5G2szvn1ayD4Kj2)_