### PR TITLE
fix(auth): surface swallowed login errors to console + Sentry

### DIFF
--- a/frontend/src/auth/useFormSubmit.ts
+++ b/frontend/src/auth/useFormSubmit.ts
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from "react";
+import * as Sentry from "@sentry/react";
 import type { AuthError } from "@supabase/supabase-js";
 import { safeErrorMessage } from "./errors";
 
@@ -28,7 +29,9 @@ export function useFormSubmit(): UseFormSubmitResult {
       if (error) {
         setError(safeErrorMessage(error));
       }
-    } catch {
+    } catch (err) {
+      console.error("[auth] form submit threw:", err);
+      Sentry.captureException(err);
       setError("Something went wrong. Please try again.");
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## Summary

The catch block in `useFormSubmit` was throwing away the underlying exception silently and only showing the generic "Something went wrong. Please try again." string to the user. That made it painful to diagnose anything that throws inside the Supabase SDK call — network errors, edge 403s (`x-deny-reason: host_not_allowed`), unexpected response bodies, etc. — because we had to bisect deploys instead of just reading the browser console.

This adds two lines: `console.error` for local/dev debugging and `Sentry.captureException` so production failures surface in Sentry. The user-facing message is unchanged.

### Motivation

Login on `app.permissionslip.dev` was failing today with the generic message. The actual cause turned out to be a Supabase platform-side `403 host_not_allowed` from Supabase's [May 15 Auth Service update](https://status.supabase.com/history) — none of our code regressed. The diagnostic took longer than it should have because the catch block hid the real error; this PR makes the next occurrence a 5-second triage instead.

### Changes

- `frontend/src/auth/useFormSubmit.ts`: import `@sentry/react`, bind the caught error to `err`, log it via `console.error` and `Sentry.captureException`.

## Test plan

- [x] `npx vitest run src/auth/` — 84 / 84 passing (the existing "shows generic error for unknown errors" test still passes; it exercises the `safeErrorMessage` return-value path, not the throw path, so `console.error` is not triggered)
- [x] `npx tsc -b` — clean
- [ ] CI green on this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01RHTCtX64EdpMC2vk6QzUNb)_