### PR TITLE
fix(api): stabilize agent standing approval pagination test

### DIFF
--- a/api/agent_standing_approvals_test.go
+++ b/api/agent_standing_approvals_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
 )
@@ -343,9 +344,13 @@ func TestAgentListStandingApprovals_Pagination(t *testing.T) {
 	}
 	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
 
-	// Create 3 standing approvals.
+	// Create 3 standing approvals with distinct created_at values so cursor
+	// pagination stays stable (tight InsertStandingApproval loops can share the
+	// same SQLite strftime('now') tick, breaking (created_at, id) keyset logic).
+	base := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Second)
 	for i := 0; i < 3; i++ {
-		testhelper.InsertStandingApproval(t, tx, testhelper.GenerateID(t, "sa_"), agentID, uid)
+		testhelper.InsertStandingApprovalWithCreatedAt(t, tx, testhelper.GenerateID(t, "sa_"), agentID, uid,
+			base.Add(time.Duration(i)*time.Second))
 	}
 
 	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`TestAgentListStandingApprovals_Pagination` was flaky on main: three `InsertStandingApproval` calls in a tight loop often share the same SQLite `created_at`, which breaks keyset pagination on `(created_at, standing_approval_id)` so page 2 could return two rows instead of one.

## Changes
- Insert the three fixtures with `InsertStandingApprovalWithCreatedAt` and timestamps spaced by one second (same pattern as `TestListStandingApprovals_Pagination`).

## Test plan
- [ ] `go test ./api/... -run TestAgentListStandingApprovals_Pagination -count=10` (local)
- [ ] CI Backend Tests job green



Shell
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff6aa9cf-ccd8-4eb0-acc8-36fccd7ecf59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff6aa9cf-ccd8-4eb0-acc8-36fccd7ecf59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

