### PR TITLE
chore: add SQLite db and journal files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,12 @@ storybook-static/
 
 # Custom connectors config (user-specific, not checked in)
 custom-connectors.json
+*.db
+
+# SQLite WAL journal files
+*-wal
+*-shm
+*-journal
+*.db-wal
+*.db-shm
+*.db-journal


### PR DESCRIPTION
Adds SQLite-specific files to gitignore:
- `*.db` - SQLite database files
- `*.db-wal`, `*.db-shm`, `*.db-journal` - SQLite WAL/shm/journal files
- `*-wal`, `-shm`, `-journal` - named WAL/shm/journal variants