### PR TITLE
test: verify new CI pipeline with docs-only change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Permission Slip
 
 [![CI](https://github.com/supersuit-tech/permission-slip/actions/workflows/ci.yml/badge.svg)](https://github.com/supersuit-tech/permission-slip/actions/workflows/ci.yml)
+
 **Approve what [Openclaw](https://openclaw.org) does before it does it.**
 
 Permission Slip is an open-source approval layer for [Openclaw](https://openclaw.org). Every action Openclaw wants to take — sending emails, merging PRs, booking flights — goes through you first. Nothing happens without your say-so.


### PR DESCRIPTION
## Summary

Trivial README change (one blank line) to validate the new CI pipeline merged in #1224.

## What this PR tests

- The `changes` job (paths-filter) correctly detects that no backend / frontend / build / mobile paths were touched.
- All `*-work` jobs (`Backend Tests (worker)`, `Frontend Tests (worker)`, `Build (worker)`, `Mobile Tests & Typecheck (worker)`) get skipped.
- The aggregator jobs (`Backend Tests`, `Frontend Tests`, `Build`, `Mobile Tests & Typecheck`) **still emit ✅** via the always-run wrapper — this is the critical check, since these are the names branch protection requires.
- CodeQL does **not** run on this PR (it now only runs on `push: main` + weekly + manual).
- Total CI wall time should be roughly **20–30 seconds** instead of the ~4 min baseline.

## Expected result

PR mergeable, all required checks green, finished in well under a minute. If any required check stays pending or fails, the aggregator pattern needs more work.

Not meant to be merged on its own — feel free to close after verifying timings, or merge if you want the doc tweak.

---
_Generated by [Claude Code](https://claude.ai/code/session_015kBKjV7JtcU1yUTFZnamJo)_