### PR TITLE
ci: path-filter audit jobs on PRs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,8 +10,33 @@ on:
     - cron: "0 9 * * 1"
 
 jobs:
-  audit-frontend:
-    name: NPM Audit
+  # Detect which package manifests changed. Non-PR triggers (push to main,
+  # weekly schedule, manual) always run the full audit regardless.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/package.json'
+              - 'frontend/package-lock.json'
+              - '.github/workflows/audit.yml'
+            backend:
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/audit.yml'
+
+  audit-frontend-work:
+    name: NPM Audit (worker)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,8 +54,10 @@ jobs:
       - name: Run npm audit
         run: cd frontend && npm audit --audit-level=high
 
-  audit-backend:
-    name: Go Vulnerability Check
+  audit-backend-work:
+    name: Go Vulnerability Check (worker)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -50,3 +77,38 @@ jobs:
 
       - name: Run govulncheck
         run: govulncheck ./...
+
+  # Aggregator jobs emit the check-run names branch protection expects.
+  # Each always runs and passes when the worker either succeeded or was
+  # skipped. Keep `name:` in sync with required-check names.
+  audit-frontend:
+    name: NPM Audit
+    needs: audit-frontend-work
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate
+        env:
+          RESULT: ${{ needs.audit-frontend-work.result }}
+        run: |
+          echo "Worker result: $RESULT"
+          case "$RESULT" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac
+
+  audit-backend:
+    name: Go Vulnerability Check
+    needs: audit-backend-work
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate
+        env:
+          RESULT: ${{ needs.audit-backend-work.result }}
+        run: |
+          echo "Worker result: $RESULT"
+          case "$RESULT" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary

After #1224 landed, the audit workflow became the dominant wall-time on docs-only PRs (~22-27s for `NPM Audit` and `Go Vulnerability Check`). This PR applies the same paths-filter + aggregator pattern to `audit.yml` so the heavy work only runs when relevant manifests change.

## Changes

- `changes` job runs `dorny/paths-filter@v3` against `frontend/package*.json`, `go.mod`, `go.sum`, and the workflow file itself.
- `audit-frontend-work` and `audit-backend-work` are gated on those filters for PR events. **Push to main, the weekly cron, and `workflow_dispatch` always run the full audit** — `github.event_name != 'pull_request' || needs.changes.outputs.X == 'true'`.
- `audit-frontend` (`NPM Audit`) and `audit-backend` (`Go Vulnerability Check`) are tiny always-run aggregators that emit the existing required-check names — no branch-protection changes needed.

## Expected behavior

| PR touches | NPM Audit (work) | Go Vuln (work) | Required checks |
|---|---|---|---|
| docs/markdown only | ⏭️ skipped | ⏭️ skipped | both ✅ via aggregator |
| `frontend/package-lock.json` | ✅ runs | ⏭️ skipped | both ✅ |
| `go.mod` / `go.sum` | ⏭️ skipped | ✅ runs | both ✅ |
| weekly schedule | ✅ runs | ✅ runs | normal |

## Test plan

- [ ] PR's own checks: NPM Audit and Go Vulnerability Check workers should be skipped, aggregators should ✅
- [ ] Wall time on this PR should drop into the ~10-15s range (just the `changes` job + 2 aggregators in parallel)
- [ ] Next merge to main: weekly schedule run still does real audit work
- [ ] A future PR that bumps `frontend/package-lock.json` should run the real NPM Audit worker

---
_Generated by [Claude Code](https://claude.ai/code/session_015kBKjV7JtcU1yUTFZnamJo)_