### PR TITLE
Add deploy/server and deploy/restart scripts

### DIFF
--- a/deploy/restart
+++ b/deploy/restart
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "==> Building..."
+make build
+
+echo ""
+echo "==> Restarting service..."
+sudo systemctl restart permission-slip
+
+echo ""
+sudo systemctl status permission-slip

--- a/deploy/server
+++ b/deploy/server
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "==> Building..."
+make build
+
+echo ""
+echo "==> Starting service..."
+sudo systemctl daemon-reload
+sudo systemctl enable --now permission-slip
+
+echo ""
+sudo systemctl status permission-slip


### PR DESCRIPTION
deploy/server builds the binary and starts the systemd service for the
first time (daemon-reload + enable --now).

deploy/restart rebuilds the binary and restarts the running service,
intended for use after a git pull.

https://claude.ai/code/session_017zkEFGqBeBshSroxHx88De