### PR TITLE
Allow access from any network IP without hardcoding a specific address

### DIFF
--- a/api/registration_invites.go
+++ b/api/registration_invites.go
@@ -156,9 +156,17 @@ func handleCreateRegistrationInvite(deps *Deps) http.HandlerFunc {
 			CreatedAt:  invite.CreatedAt,
 		}
 
-		if deps.BaseURL != "" {
-			resp.InviteURL = buildInviteURL(deps.BaseURL, inviteCode)
+		// Fall back to the request's own origin when BASE_URL is not configured,
+		// so invite links work correctly on any network the server is reachable from.
+		baseURL := deps.BaseURL
+		if baseURL == "" {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			baseURL = scheme + "://" + r.Host
 		}
+		resp.InviteURL = buildInviteURL(baseURL, inviteCode)
 
 		RespondJSON(w, http.StatusCreated, resp)
 	}

--- a/api/registration_invites_test.go
+++ b/api/registration_invites_test.go
@@ -79,9 +79,13 @@ func TestCreateRegistrationInvite_Success(t *testing.T) {
 		t.Errorf("expires_at not ~15 minutes after created_at: created=%v, expires=%v", resp.CreatedAt, resp.ExpiresAt)
 	}
 
-	// No BaseURL configured, so invite_url should be empty
-	if resp.InviteURL != "" {
-		t.Errorf("expected empty invite_url when BaseURL not configured, got %q", resp.InviteURL)
+	// No BaseURL configured — server falls back to the request's own origin.
+	// httptest.NewRequest uses "example.com" as the default host.
+	if !strings.HasPrefix(resp.InviteURL, "http://example.com/invite/PS-") {
+		t.Errorf("expected invite_url derived from request host, got %q", resp.InviteURL)
+	}
+	if !strings.Contains(resp.InviteURL, resp.InviteCode) {
+		t.Errorf("invite_url %q does not contain invite_code %q", resp.InviteURL, resp.InviteCode)
 	}
 }
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -94,7 +94,7 @@ Works out of the box on macOS and most Linux desktops, but **may not be reachabl
 hostname   # prints e.g. "raspberrypi" → reachable as "raspberrypi.local"
 ```
 
-Use whichever address you choose consistently in the `BASE_URL` and `ALLOWED_ORIGINS` below — changing it later requires restarting the service.
+Use whichever address you choose in `BASE_URL` below. `ALLOWED_ORIGINS` does not need to be set — the server automatically allows requests from whatever address the browser used to reach it, so it works on all your networks without configuration.
 
 ---
 
@@ -111,11 +111,28 @@ SECRET_ENCRYPTION_KEY=replace-me
 JWT_SIGNING_SECRET=replace-me
 INVITE_HMAC_KEY=replace-me
 
-# Public URL of this server (used for OAuth callbacks and invite links)
-# Use your Pi's local IP address (e.g. http://192.168.1.100:8080) — see above.
-# Hostnames like raspberrypi.local may not be reachable from all devices.
-BASE_URL=http://192.168.1.100:8080
-ALLOWED_ORIGINS=http://192.168.1.100:8080
+# Public URL of this server — used for OAuth connector callback URLs and
+# as a fallback base for invite links.
+#
+# If you use OAuth connectors (Google, Slack, etc.), set this to the address
+# you'll register as the redirect URI with each provider. If you access the
+# server from multiple networks (e.g. LAN + Tailscale), register all of them
+# as redirect URIs in your OAuth app and pick any one here — or use a stable
+# hostname (e.g. Tailscale MagicDNS) that works across networks.
+#
+# If you don't use OAuth connectors, you can leave BASE_URL unset — invite
+# links will automatically use the address the request came in on.
+#
+# Examples:
+#   BASE_URL=http://192.168.1.100:8080    # LAN IP
+#   BASE_URL=http://raspberrypi.local:8080 # mDNS (macOS/Linux clients only)
+#   BASE_URL=http://mypi.tailnet.ts.net:8080 # Tailscale MagicDNS
+BASE_URL=
+
+# ALLOWED_ORIGINS — leave unset. The server automatically allows requests from
+# whatever address the browser used to reach it (same-origin mode), so it works
+# on all your networks without listing specific IPs here.
+ALLOWED_ORIGINS=
 EOF
 
 # Replace the placeholders with real secrets
@@ -236,7 +253,7 @@ cloudflared tunnel route dns permission-slip permissions.yourdomain.com
 cloudflared tunnel run --url http://localhost:8080 permission-slip
 ```
 
-After setting up a tunnel, update `BASE_URL` and `ALLOWED_ORIGINS` in your `.env` to your public URL and restart Permission Slip.
+After setting up a tunnel, update `BASE_URL` in your `.env` to your public URL and restart Permission Slip. `ALLOWED_ORIGINS` does not need to be set.
 
 > **Strongly recommended:** Once your Pi is reachable from the internet, set a gateway secret so a leaked hostname alone isn't enough to reach the app. See [Lock Down with a Gateway Secret](#lock-down-the-tunnel-with-a-gateway-secret).
 
@@ -247,7 +264,7 @@ curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up
 ```
 
-Access via your Tailscale IP or MagicDNS hostname. No config changes needed since it's a private network.
+Access via your Tailscale IP or MagicDNS hostname. No CORS config changes needed — the server allows requests from any address automatically. If you use OAuth connectors and want them to work over Tailscale, add your Tailscale address as an additional redirect URI in each OAuth app. Set `BASE_URL` to your Tailscale MagicDNS hostname (e.g. `http://mypi.tailnet.ts.net:8080`) if you primarily access via Tailscale.
 
 ### Lock Down the Tunnel with a Gateway Secret
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -94,10 +94,10 @@ Most routers let you bind a fixed IP to the Pi's MAC address — look for "DHCP 
 Set it directly on the Pi so it doesn't rely on the router. The method depends on your OS:
 
 ```bash
-cat /etc/os-release | grep VERSION_CODENAME   # check: bookworm (2023+) or bullseye/older
+cat /etc/os-release | grep VERSION_CODENAME   # bookworm/trixie → NetworkManager; bullseye/older → dhcpcd
 ```
 
-*Bookworm (Raspberry Pi OS 12, 2023+) — NetworkManager:*
+*Bookworm (Raspberry Pi OS 12, 2023+) or Trixie (Raspberry Pi OS 13) — NetworkManager:*
 ```bash
 nmcli connection show   # find your WiFi connection name (often "preconfigured")
 sudo nmcli connection modify "preconfigured" \

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -81,11 +81,44 @@ make build
 You need to know how other devices on your network will reach the Pi. **Use the local IP address — it's the most reliable option.**
 
 **Option 1 — Local IP address (recommended, e.g. `192.168.1.100`)**
-Always works regardless of OS or mDNS support on client devices. The risk is that DHCP can reassign the address after a reboot. To prevent that, set a **static DHCP lease** for the Pi's MAC address in your router's admin UI — most routers call this "DHCP reservation" or "address binding".
+Always works regardless of OS or mDNS support on client devices. The risk is that DHCP can reassign the address after a reboot. Fix that with either approach below — pick one.
 
 ```bash
 hostname -I | awk '{print $1}'   # prints the Pi's current IP
 ```
+
+**Option 1a — Static DHCP lease (set it at the router)**
+Most routers let you bind a fixed IP to the Pi's MAC address — look for "DHCP reservation" or "address binding" in your router's admin UI. Nothing to configure on the Pi itself.
+
+**Option 1b — Static IP on the Pi**
+Set it directly on the Pi so it doesn't rely on the router. The method depends on your OS:
+
+```bash
+cat /etc/os-release | grep VERSION_CODENAME   # check: bookworm (2023+) or bullseye/older
+```
+
+*Bookworm (Raspberry Pi OS 12, 2023+) — NetworkManager:*
+```bash
+nmcli connection show   # find your WiFi connection name (often "preconfigured")
+sudo nmcli connection modify "preconfigured" \
+  ipv4.method manual \
+  ipv4.addresses 192.168.1.100/24 \
+  ipv4.gateway 192.168.1.1 \
+  ipv4.dns "8.8.8.8"
+sudo nmcli connection up "preconfigured"
+```
+
+*Bullseye (Raspberry Pi OS 11) and earlier — dhcpcd:*
+```bash
+echo "
+interface wlan0
+static ip_address=192.168.1.100/24
+static routers=192.168.1.1
+static domain_name_servers=8.8.8.8" | sudo tee -a /etc/dhcpcd.conf
+sudo systemctl restart dhcpcd
+```
+
+Replace `192.168.1.100` with your chosen address and `192.168.1.1` with your router's IP (usually ends in `.1`). Verify with `hostname -I` after restarting.
 
 **Option 2 — mDNS hostname (e.g. `raspberrypi.local`)**
 Works out of the box on macOS and most Linux desktops, but **may not be reachable from other devices on your network** — Android and some Windows configurations don't support mDNS without extra software ([Bonjour](https://support.apple.com/kb/DL999) or iTunes). Prefer the IP address unless you know all clients on your network support mDNS.


### PR DESCRIPTION
## Summary

- **CORS already worked for any IP** via same-origin mode (the server derives the expected origin from the `Host` header). The docs were incorrectly telling users to lock it to one IP via `ALLOWED_ORIGINS`, which actually broke multi-network access.
- **Invite links now fall back to the request's own origin** when `BASE_URL` is unset, so they generate a correct URL regardless of which network the request arrives on.
- **Updated self-hosted deployment docs** to leave `ALLOWED_ORIGINS` unset, clarify that `BASE_URL` is only required for OAuth connectors, and explain the multi-network approach (register multiple redirect URIs with each OAuth provider).

## Test plan

- [ ] `TestCreateRegistrationInvite_Success` — updated to assert invite URL is derived from request host (`http://example.com/invite/PS-...`) instead of asserting empty
- [ ] `TestCreateRegistrationInvite_WithBaseURL` — unchanged; still asserts configured `BASE_URL` is used when set
- [ ] `TestBuildInviteURL` — unchanged; pure unit test for URL construction helper
- [ ] Frontend tests unaffected (no frontend changes)

https://claude.ai/code/session_01KRPzgvBG5nZwJrtUhtU2Uk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRPzgvBG5nZwJrtUhtU2Uk)_