### PR TITLE
Add reset-password CLI command and deploy script

### DIFF
--- a/cmd/reset-password/main.go
+++ b/cmd/reset-password/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/auth"
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+const minPasswordLen = 8
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: reset-password <email> <new-password>")
+		os.Exit(1)
+	}
+
+	dbPath := os.Getenv("DATABASE_PATH")
+	if dbPath == "" {
+		log.Fatal("DATABASE_PATH is required")
+	}
+
+	email := strings.ToLower(strings.TrimSpace(os.Args[1]))
+	password := os.Args[2]
+	if len(password) < minPasswordLen {
+		log.Fatalf("password must be at least %d characters", minPasswordLen)
+	}
+
+	ctx := context.Background()
+	pool, err := db.Connect(ctx, dbPath)
+	if err != nil {
+		log.Fatalf("connect database: %v", err)
+	}
+	defer pool.Close()
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		log.Fatalf("hash password: %v", err)
+	}
+
+	found, err := db.UpdatePasswordHash(ctx, pool, email, hash)
+	if err != nil {
+		log.Fatalf("update password: %v", err)
+	}
+	if !found {
+		log.Fatalf("no user found with email %s", email)
+	}
+
+	fmt.Printf("password updated for %s\n", email)
+}

--- a/db/users_auth.go
+++ b/db/users_auth.go
@@ -104,6 +104,19 @@ func RevokeAuthSession(ctx context.Context, d DBTX, sessionID string, revokedAt 
 	return err
 }
 
+// UpdatePasswordHash replaces the stored password hash for the user with the given email.
+// Returns true if a row was updated, false if no user with that email exists.
+func UpdatePasswordHash(ctx context.Context, d DBTX, email, passwordHash string) (bool, error) {
+	result, err := d.Exec(ctx,
+		`UPDATE users SET password_hash = $1 WHERE lower(email) = lower($2)`,
+		passwordHash, email,
+	)
+	if err != nil {
+		return false, err
+	}
+	return RowsAffected(result) > 0, nil
+}
+
 // RevokeAuthSessionByRefreshHash revokes the session matching the given refresh token hash.
 func RevokeAuthSessionByRefreshHash(ctx context.Context, d DBTX, refreshTokenHash string, revokedAt time.Time) error {
 	_, err := d.Exec(ctx,

--- a/deploy/reset-password
+++ b/deploy/reset-password
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Reset a user's password directly in the SQLite database.
+# The running service does not need to be stopped — SQLite WAL handles concurrency.
+#
+# Usage:
+#   DATABASE_PATH=/var/lib/permission-slip/app.db deploy/reset-password <email> <new-password>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: DATABASE_PATH=<path> deploy/reset-password <email> <new-password>" >&2
+    exit 1
+fi
+
+if [[ -z "${DATABASE_PATH:-}" ]]; then
+    echo "error: DATABASE_PATH environment variable is required" >&2
+    exit 1
+fi
+
+go run ./cmd/reset-password "$1" "$2"


### PR DESCRIPTION
## Summary

- Adds `cmd/reset-password` — a CLI tool that looks up a user by email and replaces their password hash using the same Argon2id parameters as sign-up
- Adds `db.UpdatePasswordHash` to `db/users_auth.go` as the underlying DB function
- Adds `deploy/reset-password` — a convenience shell script wrapper for use on the server

## Usage

No service restart needed — SQLite WAL mode handles concurrent writes safely.

```bash
DATABASE_PATH=/var/lib/permission-slip/app.db deploy/reset-password user@example.com newpassword
```

Or directly:

```bash
DATABASE_PATH=/var/lib/permission-slip/app.db go run ./cmd/reset-password user@example.com newpassword
```

The command errors out (non-zero exit) if the email isn't found, the password is under 8 characters, or the DB can't be opened.

## Test plan

- [ ] Run `deploy/reset-password test@example.com newpassword123` with a valid `DATABASE_PATH` pointing at a dev DB — confirm "password updated for test@example.com" output
- [ ] Confirm the new password works to log in via the app
- [ ] Run with an unknown email — confirm non-zero exit and clear error message
- [ ] Run with a password shorter than 8 chars — confirm rejection before any DB write
- [ ] CI passes

> **Note:** Backend tests were not run locally — the sandbox cannot run `go test` due to a Go 1.25 toolchain constraint (see CLAUDE.md). CI will cover the full test suite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RezQCPADHKiFboebJhDqSt)_