### PR TITLE
Fix copy button silently failing over HTTP (non-secure context)

### DIFF
--- a/frontend/src/components/CopyableCode.tsx
+++ b/frontend/src/components/CopyableCode.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { copyToClipboard } from "@/lib/clipboard";
 
 interface CopyableCodeProps {
   code: string;
@@ -19,7 +20,7 @@ export function CopyableCode({ code, className }: CopyableCodeProps) {
 
   function handleCopy(e: React.MouseEvent) {
     e.stopPropagation();
-    navigator.clipboard.writeText(code).then(
+    copyToClipboard(code).then(
       () => {
         setCopied(true);
         toast.success("Confirmation code copied");

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,27 @@
+/**
+ * Copies text to clipboard with a fallback for non-secure contexts (HTTP).
+ * navigator.clipboard is undefined on HTTP origins, so we fall back to the
+ * legacy execCommand approach.
+ */
+export function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text);
+  }
+
+  return new Promise((resolve, reject) => {
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}

--- a/frontend/src/pages/dashboard/InstructionsBlock.tsx
+++ b/frontend/src/pages/dashboard/InstructionsBlock.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { Copy, Check } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
 
 interface InstructionsBlockProps {
   instructions: string;
@@ -33,28 +34,9 @@ export function InstructionsBlock({
       timerRef.current = setTimeout(() => setCopied(false), 2000);
     };
 
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(instructions).then(onSuccess, () =>
-        toast.error("Failed to copy to clipboard"),
-      );
-      return;
-    }
-
-    // Fallback for non-secure contexts (HTTP), e.g. local network access
-    try {
-      const textarea = document.createElement("textarea");
-      textarea.value = instructions;
-      textarea.style.position = "fixed";
-      textarea.style.opacity = "0";
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textarea);
-      onSuccess();
-    } catch {
-      toast.error("Failed to copy to clipboard");
-    }
+    copyToClipboard(instructions).then(onSuccess, () =>
+      toast.error("Failed to copy to clipboard"),
+    );
   }
 
   return (

--- a/frontend/src/pages/dashboard/InstructionsBlock.tsx
+++ b/frontend/src/pages/dashboard/InstructionsBlock.tsx
@@ -26,15 +26,35 @@ export function InstructionsBlock({
   }, []);
 
   function handleCopy() {
-    navigator.clipboard.writeText(instructions).then(
-      () => {
-        setCopied(true);
-        toast.success("Instructions copied to clipboard");
-        if (timerRef.current) clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => setCopied(false), 2000);
-      },
-      () => toast.error("Failed to copy to clipboard"),
-    );
+    const onSuccess = () => {
+      setCopied(true);
+      toast.success("Instructions copied to clipboard");
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    };
+
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(instructions).then(onSuccess, () =>
+        toast.error("Failed to copy to clipboard"),
+      );
+      return;
+    }
+
+    // Fallback for non-secure contexts (HTTP), e.g. local network access
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = instructions;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      onSuccess();
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

- `navigator.clipboard` is `undefined` on HTTP origins (e.g. `http://192.168.1.123:8080`), causing a synchronous `TypeError` that bypassed the `.then()` rejection handler — the button silently did nothing
- Added a `document.execCommand('copy')` fallback in `InstructionsBlock.tsx` so the button works in both secure (HTTPS) and non-secure (HTTP) contexts

## Test plan

- [ ] Access the app over HTTP on a local network, open the Connect Openclaw dialog, and confirm the Copy Command button copies the text
- [ ] Access the app over HTTPS and confirm the copy button still works via the `navigator.clipboard` path
- [ ] Confirm the failure toast appears if both paths fail

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQGMHXrkQTnXi5JXJ7udCa)_