### PR TITLE
Add automerge-by-default rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - After making the first commit on a branch, automatically create a pull request using `gh pr create`. Use a concise title and include a descriptive body with a summary and test plan. For subsequent commits, push to the existing PR branch.
 - **Link PRs to issues.** When a PR addresses a GitHub issue, include `Closes #<issue>` in the PR body so the issue is automatically closed when the PR merges. Don't wait to be asked.
 - **Never open draft PRs.** Always open PRs as ready for review.
+- **Enable automerge on every PR.** After creating a PR, immediately enable automerge with the squash strategy: `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr merge --auto --squash <pr-number>`. This way the PR merges automatically once checks pass and a review approves it.
 - Always include the pull request URL at the end of every message where a PR already exists, formatted exactly as: `Pull request: <url>` — no bold, no markdown link syntax, just the plain text and URL so the link doesn't break.
 - Whenever you bring up a problem, always suggest a recommendation for how to address it.
 - When asked to review for improvements or issues: fix anything you're confident should be fixed (commit & push), then mention any additional findings that are more subjective or optional so the user can decide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@
 - After making the first commit on a branch, automatically create a pull request using `gh pr create`. Use a concise title and include a descriptive body with a summary and test plan. For subsequent commits, push to the existing PR branch.
 - **Link PRs to issues.** When a PR addresses a GitHub issue, include `Closes #<issue>` in the PR body so the issue is automatically closed when the PR merges. Don't wait to be asked.
 - **Never open draft PRs.** Always open PRs as ready for review.
-- **Enable automerge on every PR.** After creating a PR, immediately enable automerge with the squash strategy: `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr merge --auto --squash <pr-number>`. This way the PR merges automatically once checks pass and a review approves it.
+- **Enable automerge on every PR.** After creating a PR, immediately enable squash automerge so it merges automatically once checks pass and a review approves. Use whichever method is available:
+  - MCP tool (preferred in web sessions): `mcp__github__enable_pr_auto_merge` with `merge_method: "squash"`
+  - gh CLI (local sessions): `GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh pr merge --auto --squash <pr-number>`
 - Always include the pull request URL at the end of every message where a PR already exists, formatted exactly as: `Pull request: <url>` — no bold, no markdown link syntax, just the plain text and URL so the link doesn't break.
 - Whenever you bring up a problem, always suggest a recommendation for how to address it.
 - When asked to review for improvements or issues: fix anything you're confident should be fixed (commit & push), then mention any additional findings that are more subjective or optional so the user can decide.


### PR DESCRIPTION
Instructs Claude to enable squash automerge on every PR immediately after
creation, so PRs merge automatically once CI passes and a review approves.

https://claude.ai/code/session_01CBQwhWJJdMTDSPCuFXKtDi