### PR TITLE
docs: remove cert.pem after Cloudflare tunnel setup

### DIFF
--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -110,7 +110,12 @@ cloudflared tunnel route dns permission-slip $PS_HOSTNAME
 # Install and start the cloudflared service
 sudo cloudflared service install
 sudo systemctl enable --now cloudflared
+
+# Remove the broad account credentials — the tunnel only needs its own JSON credentials file
+rm ~/.cloudflared/cert.pem
 ```
+
+> **Why delete `cert.pem`?** `cloudflared tunnel login` creates `~/.cloudflared/cert.pem`, which grants broad access to manage your Cloudflare account. Once the tunnel is created and its credentials file is copied to `/etc/cloudflared/`, the running service only needs that tunnel-scoped JSON file. Deleting `cert.pem` limits the machine's access to this tunnel only.
 
 Your tunnel is now running. Once Permission Slip is up (next steps), it'll be reachable at `https://$PS_HOSTNAME`.
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -115,7 +115,7 @@ sudo systemctl enable --now cloudflared
 rm ~/.cloudflared/cert.pem
 ```
 
-> **Why delete `cert.pem`?** `cloudflared tunnel login` creates `~/.cloudflared/cert.pem`, which grants broad access to manage your Cloudflare account. Once the tunnel is created and its credentials file is copied to `/etc/cloudflared/`, the running service only needs that tunnel-scoped JSON file. Deleting `cert.pem` limits the machine's access to this tunnel only.
+> **Why delete `cert.pem`?** `cloudflared tunnel login` creates `~/.cloudflared/cert.pem`, scoped to the domain you selected. It grants management-level access to that zone — enough to create/delete DNS records and manage tunnels. Once the tunnel is created and its credentials file is copied to `/etc/cloudflared/`, the running service only needs that tunnel-scoped JSON file, which can do nothing except maintain this specific tunnel's connection. Deleting `cert.pem` removes the unnecessary zone management access.
 
 Your tunnel is now running. Once Permission Slip is up (next steps), it'll be reachable at `https://$PS_HOSTNAME`.
 


### PR DESCRIPTION
## Summary

- Adds a `rm ~/.cloudflared/cert.pem` step at the end of the Cloudflare tunnel setup in the self-hosted deployment guide
- Includes a callout explaining why: `cert.pem` grants broad Cloudflare account access and is no longer needed once the tunnel-scoped credentials JSON is in place

## Test plan

- [ ] Read through Step 2 of the self-hosted guide and confirm the new step and callout are clear and correctly placed

---
_Generated by [Claude Code](https://claude.ai/code/session_015G2TCJmHB4hZuTkTD7nThM)_