### PR TITLE
docs: clarify shell exports are temporary setup-only variables

### DIFF
--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -71,6 +71,8 @@ This is the only step where you make a choice: **pick the hostname you'll use fo
 export PS_HOSTNAME=permissions.yourdomain.com   # ← change this
 ```
 
+> These shell variables are **only needed during setup** — they get written into config files and aren't referenced again. No need to add them to `.bashrc`.
+
 Install `cloudflared` (use `cloudflared-linux-amd64` on x86 servers):
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a callout note after the `export PS_HOSTNAME=...` line clarifying that the shell variables used throughout Step 2 are only needed during setup — they get written into config files and don't need to be persisted to `.bashrc`

## Test plan

- [ ] Read through Step 2 and confirm the note is clear and correctly placed

---
_Generated by [Claude Code](https://claude.ai/code/session_015G2TCJmHB4hZuTkTD7nThM)_