### PR TITLE
mobile: sign out on server URL change (no restart required)

### DIFF
--- a/mobile/src/screens/settings/CustomServerSettings.tsx
+++ b/mobile/src/screens/settings/CustomServerSettings.tsx
@@ -5,7 +5,8 @@
  * When enabled, all API calls are routed to the custom host URL and the
  * gateway secret is sent as the X-Gateway-Secret header on every request.
  *
- * Changes take effect on app restart.
+ * Saving signs the user out so the new server takes effect immediately
+ * without requiring a manual app restart.
  */
 import { useCallback, useEffect, useState } from "react";
 import {
@@ -28,7 +29,11 @@ import {
   setCustomHostConfig,
 } from "../../lib/customHostConfig";
 
-export default function CustomServerSettings() {
+interface Props {
+  onSaved?: () => void;
+}
+
+export default function CustomServerSettings({ onSaved }: Props) {
   const [enabled, setEnabled] = useState(false);
   const [hostUrl, setHostUrl] = useState("");
   const [secret, setSecret] = useState("");
@@ -57,7 +62,8 @@ export default function CustomServerSettings() {
             setSecret("");
             Alert.alert(
               "Custom server cleared",
-              "Set EXPO_PUBLIC_API_BASE_URL for this build, or enter your server URL again when the app prompts you.",
+              "You'll be signed out so the change takes effect.",
+              [{ text: "OK", onPress: () => onSaved?.() }],
             );
           })
           .catch(() => {
@@ -94,8 +100,9 @@ export default function CustomServerSettings() {
     try {
       await setCustomHostConfig(trimmedHost, secret.trim() || null);
       Alert.alert(
-        "Saved",
-        "Custom server settings saved. Restart the app for changes to take effect.",
+        "Server updated",
+        "You'll be signed out so the new server takes effect.",
+        [{ text: "OK", onPress: () => onSaved?.() }],
       );
     } catch {
       Alert.alert("Error", "Failed to save custom server settings.");
@@ -119,8 +126,8 @@ export default function CustomServerSettings() {
           <View style={styles.toggleLabel}>
             <Text style={styles.toggleTitle}>Custom Server</Text>
             <Text style={styles.toggleDescription}>
-              Point this app at your self-hosted Permission Slip API (saved on
-              device; restart the app after changing).
+              Point this app at your self-hosted Permission Slip API. Changes
+              sign you out and take effect immediately.
             </Text>
           </View>
           <Switch
@@ -186,7 +193,7 @@ export default function CustomServerSettings() {
           </TouchableOpacity>
 
           <Text style={styles.hint}>
-            Changes take effect on app restart.
+            Saving will sign you out so the new server takes effect immediately.
           </Text>
         </View>
       ) : null}

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -272,7 +272,7 @@ export default function SettingsScreen(_props: Props) {
         <Text style={styles.sectionDescription}>
           Connect to a self-hosted Permission Slip instance.
         </Text>
-        <CustomServerSettings />
+        <CustomServerSettings onSaved={signOut} />
       </View>
 
       <View style={styles.buildInfo}>


### PR DESCRIPTION
## Summary

- Changing the server URL in Settings now signs the user out automatically once they confirm the alert, so the new server takes effect without a manual app restart
- Clearing the custom server also signs out, which causes `App.tsx` to fall back to `ServerUrlSetupScreen` if no `EXPO_PUBLIC_API_BASE_URL` is configured
- Removes all "restart the app" messaging and replaces it with "you'll be signed out" copy

## How it works

`CustomServerSettings` gets an `onSaved?: () => void` prop. `SettingsScreen` passes `signOut` as that callback. After the user taps OK on the confirmation alert, `signOut()` fires → `authStatus` flips to `unauthenticated` → `App.tsx` re-renders → either the login screen or `ServerUrlSetupScreen` appears depending on whether a URL is configured.

The `App.tsx` sign-out handler already clears the React Query cache, so no stale data from the old server leaks through.

## Test plan

- [ ] Change server URL in Settings → confirmation alert says "You'll be signed out" → tap OK → app goes to login screen
- [ ] Clear custom server (toggle off) → same flow → if no `EXPO_PUBLIC_API_BASE_URL`, app shows server setup screen
- [ ] Log back in → requests go to the new server URL
- [ ] TypeScript: `npx tsc --noEmit` passes
- [ ] Tests: `cd mobile && npm test -- --ci` passes (13 tests)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3Pz2hkCuf3QWmE7ohKeki)_