### PR TITLE
mobile: let users change or reset server URL when stuck pre-auth

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   AppState,
@@ -21,10 +21,13 @@ import { useBiometricAuth } from "./src/hooks/useBiometricAuth";
 import { BiometricLockScreen } from "./src/screens/BiometricLockScreen";
 import { colors } from "./src/theme/colors";
 import {
+  getCustomHost,
+  getGatewaySecret,
   hasConfiguredApiBase,
   loadCustomHostConfig,
 } from "./src/lib/customHostConfig";
 import ServerUrlSetupScreen from "./src/screens/ServerUrlSetupScreen";
+import { ServerSetupContext } from "./src/lib/serverSetupContext";
 
 const useMockAuth = __DEV__ && process.env.EXPO_PUBLIC_MOCK_AUTH === "true";
 const ActiveAuthProvider = useMockAuth ? MockAuthProvider : AuthProvider;
@@ -49,7 +52,13 @@ const queryClient = new QueryClient({
 
 const LOADING_TIMEOUT_MS = 10_000;
 
-function AppContent({ onRetry }: { onRetry: () => void }) {
+function AppContent({
+  onRetry,
+  onOpenServerSetup,
+}: {
+  onRetry: () => void;
+  onOpenServerSetup: () => void;
+}) {
   const { authStatus, session } = useAuth();
   const qc = useQueryClient();
   const [timedOut, setTimedOut] = useState(false);
@@ -119,6 +128,15 @@ function AppContent({ onRetry }: { onRetry: () => void }) {
             >
               <Text style={styles.retryText}>Retry</Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              testID="loading-change-server"
+              accessibilityLabel="Change server URL"
+              accessibilityRole="button"
+              style={styles.secondaryButton}
+              onPress={onOpenServerSetup}
+            >
+              <Text style={styles.secondaryButtonText}>Change server URL</Text>
+            </TouchableOpacity>
           </>
         ) : (
           <ActivityIndicator size="large" color={colors.gray900} />
@@ -149,7 +167,7 @@ export default function App() {
   // requests after cold start would bypass the custom host and gateway
   // secret, causing surprising 403s against a gateway-locked server.
   const [hostHydrated, setHostHydrated] = useState(false);
-  const [, setServerSetupBump] = useState(0);
+  const [serverSetupBump, setServerSetupBump] = useState(0);
   useEffect(() => {
     loadCustomHostConfig().finally(() => setHostHydrated(true));
   }, []);
@@ -165,6 +183,19 @@ export default function App() {
   const [authKey, setAuthKey] = useState(0);
   const handleRetry = useCallback(() => setAuthKey((k) => k + 1), []);
 
+  // Overlay state for the in-app "Change server URL" affordance. Reachable
+  // from the Connection issue screen and the Login screen so a user stuck
+  // against a dead/unreachable host can fix it without reinstalling. (On
+  // iOS, expo-secure-store uses Keychain, which persists across uninstalls,
+  // so even a fresh install does not always reset the saved URL.)
+  const [serverSetupOpen, setServerSetupOpen] = useState(false);
+  const openServerSetup = useCallback(() => setServerSetupOpen(true), []);
+  const closeServerSetup = useCallback(() => setServerSetupOpen(false), []);
+  const serverSetupContextValue = useMemo(
+    () => ({ openServerSetup }),
+    [openServerSetup],
+  );
+
   if (!hostHydrated) {
     return (
       <SafeAreaProvider>
@@ -176,6 +207,8 @@ export default function App() {
     );
   }
 
+  // First-launch setup: no env URL and no saved host. Render the setup
+  // screen unconditionally; it owns the entire UI until a host is saved.
   if (!useMockAuth && !hasConfiguredApiBase()) {
     return (
       <SafeAreaProvider>
@@ -189,13 +222,45 @@ export default function App() {
     );
   }
 
+  // "Change server URL" overlay. Pre-fills the current saved values so the
+  // user can see and edit them. Saving re-mounts AuthProvider so the next
+  // request goes to the new host with a fresh bootstrap; Cancel just
+  // dismisses without touching anything.
+  if (serverSetupOpen) {
+    return (
+      <SafeAreaProvider>
+        <ServerUrlSetupScreen
+          initialHostUrl={getCustomHost() ?? ""}
+          initialSecret={getGatewaySecret() ?? ""}
+          onCancel={closeServerSetup}
+          onComplete={() => {
+            closeServerSetup();
+            setServerSetupBump((n) => n + 1);
+            setAuthKey((k) => k + 1);
+          }}
+        />
+        <StatusBar style="auto" />
+      </SafeAreaProvider>
+    );
+  }
+
+  // serverSetupBump is read here so changes to the saved host trigger a
+  // re-render of the tree below — useful when the user saves a new URL or
+  // resets, since the new value must be picked up immediately.
+  void serverSetupBump;
+
   return (
     <QueryClientProvider client={queryClient}>
       <SafeAreaProvider>
-        <ActiveAuthProvider key={authKey}>
-          <AppContent onRetry={handleRetry} />
-          <StatusBar style="auto" />
-        </ActiveAuthProvider>
+        <ServerSetupContext.Provider value={serverSetupContextValue}>
+          <ActiveAuthProvider key={authKey}>
+            <AppContent
+              onRetry={handleRetry}
+              onOpenServerSetup={openServerSetup}
+            />
+            <StatusBar style="auto" />
+          </ActiveAuthProvider>
+        </ServerSetupContext.Provider>
       </SafeAreaProvider>
     </QueryClientProvider>
   );
@@ -232,6 +297,19 @@ const styles = StyleSheet.create({
   retryText: {
     color: colors.white,
     fontSize: 16,
+    fontWeight: "600",
+  },
+  secondaryButton: {
+    marginTop: 12,
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+  },
+  secondaryButtonText: {
+    color: colors.gray900,
+    fontSize: 15,
     fontWeight: "600",
   },
 });

--- a/mobile/src/auth/errors.ts
+++ b/mobile/src/auth/errors.ts
@@ -8,6 +8,8 @@ const SAFE_ERROR_MESSAGES: Record<string, string> = {
   request_failed: "Something went wrong. Please try again.",
   logout_failed: "Sign out failed. Please try again.",
   invalid_response: "Something went wrong. Please try again.",
+  network_unreachable:
+    "Couldn't reach the server. Check the server URL and your connection.",
 };
 
 export function safeErrorMessage(error: AuthError): string {

--- a/mobile/src/lib/__tests__/authApi.test.ts
+++ b/mobile/src/lib/__tests__/authApi.test.ts
@@ -1,0 +1,85 @@
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../customHostConfig", () => ({
+  getCustomHost: () => "https://stub.example/api",
+  getGatewaySecret: () => null,
+  PLACEHOLDER_API_BASE: "https://__permission_slip_no_host__.invalid/api",
+}));
+
+import { postAuth } from "../authApi";
+
+describe("postAuth", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it("returns a structured network_unreachable error when fetch rejects with a network failure", async () => {
+    global.fetch = jest.fn(() => Promise.reject(new TypeError("Network request failed"))) as unknown as typeof fetch;
+
+    const { data, error } = await postAuth("refresh", { refresh_token: "abc" });
+
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error?.code).toBe("network_unreachable");
+    expect(error?.status).toBe(0);
+    expect(error?.message).toMatch(/unable to reach/i);
+  });
+
+  it("aborts the fetch after the timeout and returns network_unreachable", async () => {
+    jest.useFakeTimers();
+
+    const fetchMock = jest.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            const err = new Error("Aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = postAuth("refresh", { refresh_token: "abc" });
+    // Run all timers (including the 8s timeout) so the fetch is aborted.
+    await jest.runAllTimersAsync();
+    const { data, error } = await promise;
+
+    expect(data).toBeNull();
+    expect(error?.code).toBe("network_unreachable");
+    expect(error?.message).toMatch(/server did not respond|unable to reach/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns success when fetch resolves with a valid token payload", async () => {
+    const body = {
+      access_token: "access-1",
+      refresh_token: "refresh-1",
+      expires_at: "2030-01-01T00:00:00.000Z",
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const { data, error } = await postAuth("login", {
+      email: "a@b.co",
+      password: "pw",
+    });
+
+    expect(error).toBeNull();
+    expect(data?.access_token).toBe("access-1");
+    expect(data?.refresh_token).toBe("refresh-1");
+  });
+});

--- a/mobile/src/lib/authApi.ts
+++ b/mobile/src/lib/authApi.ts
@@ -28,6 +28,13 @@ export type AuthTokenResponse = {
   expires_at: string;
 };
 
+/**
+ * Network timeout for auth requests. Set well below the 10s App-level loading
+ * guard in App.tsx so an unreachable server fails fast and surfaces a
+ * "connection issue" error instead of hanging until the higher-level fallback.
+ */
+const AUTH_REQUEST_TIMEOUT_MS = 8_000;
+
 function parseJsonSafe(text: string): unknown {
   try {
     return JSON.parse(text) as unknown;
@@ -49,11 +56,34 @@ export async function postAuth(
     headers["X-Gateway-Secret"] = secret;
   }
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), AUTH_REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    // AbortError (timeout) or TypeError (DNS/connection failure) — both
+    // indicate the configured server URL is unreachable. Surface a
+    // structured error so callers can show "Connection issue" UI and offer
+    // a "Change server URL" affordance without hanging on the network.
+    const aborted =
+      err instanceof Error &&
+      (err.name === "AbortError" || /aborted/i.test(err.message));
+    const message = aborted
+      ? "Server did not respond. Check the server URL and try again."
+      : "Unable to reach the server. Check the server URL and try again.";
+    return {
+      data: null,
+      error: createAuthError("network_unreachable", message, 0),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
 
   if (path === "logout") {
     if (res.status === 204) {

--- a/mobile/src/lib/serverSetupContext.tsx
+++ b/mobile/src/lib/serverSetupContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Lets any unauthenticated screen (login, connection-error retry) open the
+ * server URL setup overlay from App.tsx. Without this, a user stuck pointing
+ * at a dead server would have no way to fix it short of reinstalling — and
+ * on iOS, expo-secure-store uses Keychain, which persists across uninstalls,
+ * so even reinstalling does not always reset the saved URL.
+ */
+type ServerSetupContextValue = {
+  openServerSetup: () => void;
+};
+
+export const ServerSetupContext = createContext<ServerSetupContextValue>({
+  openServerSetup: () => {},
+});
+
+export function useServerSetup(): ServerSetupContextValue {
+  return useContext(ServerSetupContext);
+}

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -15,11 +15,13 @@ import { useFormSubmit } from "../auth/useFormSubmit";
 import { authStyles } from "../auth/styles";
 import { colors } from "../theme/colors";
 import validation from "../lib/validation";
+import { useServerSetup } from "../lib/serverSetupContext";
 
 type Mode = "login" | "signup";
 
 export default function LoginScreen() {
   const { signInWithPassword, signUpWithPassword } = useAuth();
+  const { openServerSetup } = useServerSetup();
   const [mode, setMode] = useState<Mode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -167,6 +169,17 @@ export default function LoginScreen() {
         >
           <Text style={authStyles.primaryButtonText}>{submitLabel}</Text>
         </TouchableOpacity>
+
+        <TouchableOpacity
+          testID="login-change-server"
+          accessibilityLabel="Change server URL"
+          accessibilityRole="button"
+          style={localStyles.changeServer}
+          onPress={openServerSetup}
+          disabled={isSubmitting}
+        >
+          <Text style={localStyles.changeServerText}>Change server URL</Text>
+        </TouchableOpacity>
       </Pressable>
     </KeyboardAvoidingView>
   );
@@ -202,5 +215,16 @@ const localStyles = StyleSheet.create({
     marginTop: 6,
     fontSize: 12,
     color: colors.gray500,
+  },
+  changeServer: {
+    marginTop: 20,
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  changeServerText: {
+    color: colors.gray500,
+    fontSize: 14,
+    fontWeight: "500",
+    textDecorationLine: "underline",
   },
 });

--- a/mobile/src/screens/ServerUrlSetupScreen.tsx
+++ b/mobile/src/screens/ServerUrlSetupScreen.tsx
@@ -12,21 +12,55 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { colors } from "../theme/colors";
-import { setCustomHostConfig } from "../lib/customHostConfig";
+import {
+  clearCustomHostConfig,
+  setCustomHostConfig,
+} from "../lib/customHostConfig";
+import { clearStoredRefreshToken } from "../lib/authStorage";
 
 type Props = {
   onComplete: () => void;
+  /**
+   * Initial value for the server URL field. Pre-fill with the currently
+   * saved host when this screen is used to *change* the URL (vs. first
+   * launch), so the user can see and edit what's there.
+   */
+  initialHostUrl?: string;
+  /** Initial value for the gateway secret field. */
+  initialSecret?: string;
+  /**
+   * When provided, a Cancel button is shown that calls this callback.
+   * Used when the screen is opened as an overlay (e.g. from the
+   * connection-error retry screen or the login screen), so the user can
+   * back out without changing anything.
+   */
+  onCancel?: () => void;
 };
 
 /**
- * First-launch screen when neither EXPO_PUBLIC_API_BASE_URL nor a saved
- * custom server URL is present. Self-hosted Permission Slip has no default host.
+ * Server URL setup. Shown:
+ *   - On first launch when neither EXPO_PUBLIC_API_BASE_URL nor a saved
+ *     custom host exists (App.tsx gates rendering on this).
+ *   - As an overlay from unauthenticated screens (Connection issue, Login)
+ *     so a user pointing at a dead server can fix it without reinstalling.
+ *
+ * Self-hosted Permission Slip has no default host, so this is the only
+ * way to configure connectivity from the device.
  */
-export default function ServerUrlSetupScreen({ onComplete }: Props) {
+export default function ServerUrlSetupScreen({
+  onComplete,
+  initialHostUrl = "",
+  initialSecret = "",
+  onCancel,
+}: Props) {
   const insets = useSafeAreaInsets();
-  const [hostUrl, setHostUrl] = useState("");
-  const [secret, setSecret] = useState("");
+  const [hostUrl, setHostUrl] = useState(initialHostUrl);
+  const [secret, setSecret] = useState(initialSecret);
   const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  const isChangeMode = onCancel != null;
+  const busy = saving || resetting;
 
   const handleSave = useCallback(async () => {
     const trimmedHost = hostUrl.trim();
@@ -48,6 +82,10 @@ export default function ServerUrlSetupScreen({ onComplete }: Props) {
     setSaving(true);
     try {
       await setCustomHostConfig(trimmedHost, secret.trim() || null);
+      // Always drop any cached refresh token when the server URL is saved
+      // from this screen — tokens issued by the old host won't work against
+      // the new one. Safe to call even when no token is stored.
+      await clearStoredRefreshToken();
       onComplete();
     } catch {
       Alert.alert("Error", "Could not save server URL. Please try again.");
@@ -56,16 +94,49 @@ export default function ServerUrlSetupScreen({ onComplete }: Props) {
     }
   }, [hostUrl, secret, onComplete]);
 
+  const handleReset = useCallback(() => {
+    Alert.alert(
+      "Reset connection?",
+      "This clears the saved server URL, gateway secret, and signed-in session on this device. You'll need to enter the server URL again.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reset",
+          style: "destructive",
+          onPress: () => {
+            setResetting(true);
+            void (async () => {
+              try {
+                await clearCustomHostConfig();
+                await clearStoredRefreshToken();
+                setHostUrl("");
+                setSecret("");
+                onComplete();
+              } catch {
+                Alert.alert("Error", "Could not reset connection. Please try again.");
+              } finally {
+                setResetting(false);
+              }
+            })();
+          },
+        },
+      ],
+    );
+  }, [onComplete]);
+
   return (
     <KeyboardAvoidingView
       style={[styles.root, { paddingTop: insets.top + 24, paddingBottom: insets.bottom + 24 }]}
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <View style={styles.inner}>
-        <Text style={styles.title}>Connect to your server</Text>
+        <Text style={styles.title}>
+          {isChangeMode ? "Change server URL" : "Connect to your server"}
+        </Text>
         <Text style={styles.subtitle}>
-          Permission Slip is self-hosted. Enter the API base URL for your instance
-          (the same URL you use in the web app, usually ending in /api).
+          {isChangeMode
+            ? "Update the URL the app talks to. Saving signs you out so the new server takes effect."
+            : "Permission Slip is self-hosted. Enter the API base URL for your instance (the same URL you use in the web app, usually ending in /api)."}
         </Text>
 
         <Text style={styles.label}>Server URL</Text>
@@ -80,6 +151,7 @@ export default function ServerUrlSetupScreen({ onComplete }: Props) {
           autoCorrect={false}
           keyboardType="url"
           textContentType="URL"
+          editable={!busy}
         />
 
         <Text style={[styles.label, styles.labelSpaced]}>Gateway secret</Text>
@@ -93,22 +165,51 @@ export default function ServerUrlSetupScreen({ onComplete }: Props) {
           autoCapitalize="none"
           autoCorrect={false}
           secureTextEntry
+          editable={!busy}
         />
 
         <TouchableOpacity
           testID="server-url-setup-continue"
-          style={[styles.button, saving && styles.buttonDisabled]}
+          style={[styles.button, busy && styles.buttonDisabled]}
           onPress={() => {
             void handleSave();
           }}
-          disabled={saving}
+          disabled={busy}
           accessibilityRole="button"
-          accessibilityLabel="Continue with this server URL"
+          accessibilityLabel={isChangeMode ? "Save server URL" : "Continue with this server URL"}
         >
           {saving ? (
             <ActivityIndicator size="small" color={colors.white} />
           ) : (
-            <Text style={styles.buttonText}>Continue</Text>
+            <Text style={styles.buttonText}>{isChangeMode ? "Save" : "Continue"}</Text>
+          )}
+        </TouchableOpacity>
+
+        {isChangeMode ? (
+          <TouchableOpacity
+            testID="server-url-setup-cancel"
+            style={[styles.secondaryButton, busy && styles.buttonDisabled]}
+            onPress={onCancel}
+            disabled={busy}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel"
+          >
+            <Text style={styles.secondaryButtonText}>Cancel</Text>
+          </TouchableOpacity>
+        ) : null}
+
+        <TouchableOpacity
+          testID="server-url-setup-reset"
+          style={[styles.resetButton, busy && styles.buttonDisabled]}
+          onPress={handleReset}
+          disabled={busy}
+          accessibilityRole="button"
+          accessibilityLabel="Reset saved connection"
+        >
+          {resetting ? (
+            <ActivityIndicator size="small" color={colors.gray700} />
+          ) : (
+            <Text style={styles.resetButtonText}>Reset saved connection</Text>
           )}
         </TouchableOpacity>
       </View>
@@ -171,5 +272,30 @@ const styles = StyleSheet.create({
     color: colors.white,
     fontSize: 16,
     fontWeight: "600",
+  },
+  secondaryButton: {
+    marginTop: 12,
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    backgroundColor: colors.white,
+  },
+  secondaryButtonText: {
+    color: colors.gray900,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  resetButton: {
+    marginTop: 16,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  resetButtonText: {
+    color: colors.gray500,
+    fontSize: 14,
+    fontWeight: "500",
+    textDecorationLine: "underline",
   },
 });

--- a/mobile/src/screens/__tests__/LoginScreen.test.tsx
+++ b/mobile/src/screens/__tests__/LoginScreen.test.tsx
@@ -3,6 +3,7 @@ import { create, act, type ReactTestRenderer } from "react-test-renderer";
 
 const mockSignInWithPassword = jest.fn();
 const mockSignUpWithPassword = jest.fn();
+const mockOpenServerSetup = jest.fn();
 
 jest.mock("../../auth/AuthContext", () => ({
   useAuth: () => ({
@@ -12,6 +13,10 @@ jest.mock("../../auth/AuthContext", () => ({
     user: null,
     authStatus: "unauthenticated" as const,
   }),
+}));
+
+jest.mock("../../lib/serverSetupContext", () => ({
+  useServerSetup: () => ({ openServerSetup: mockOpenServerSetup }),
 }));
 
 import LoginScreen from "../LoginScreen";
@@ -79,5 +84,18 @@ describe("LoginScreen", () => {
     });
 
     expect(mockSignUpWithPassword).toHaveBeenCalledWith("new@b.co", "password12345");
+  });
+
+  it("opens the server setup overlay when the Change server URL link is tapped", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(createElement(LoginScreen));
+    });
+
+    await act(async () => {
+      findByTestId(renderer!, "login-change-server").props.onPress();
+    });
+
+    expect(mockOpenServerSetup).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/screens/__tests__/ServerUrlSetupScreen.test.tsx
+++ b/mobile/src/screens/__tests__/ServerUrlSetupScreen.test.tsx
@@ -1,0 +1,152 @@
+import { createElement } from "react";
+import { Alert } from "react-native";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+
+const mockSetCustomHostConfig = jest.fn((..._args: unknown[]) => Promise.resolve());
+const mockClearCustomHostConfig = jest.fn(() => Promise.resolve());
+const mockClearStoredRefreshToken = jest.fn(() => Promise.resolve());
+
+jest.mock("../../lib/customHostConfig", () => ({
+  setCustomHostConfig: (host: string | null, secret: string | null) =>
+    mockSetCustomHostConfig(host, secret),
+  clearCustomHostConfig: () => mockClearCustomHostConfig(),
+}));
+
+jest.mock("../../lib/authStorage", () => ({
+  clearStoredRefreshToken: () => mockClearStoredRefreshToken(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import ServerUrlSetupScreen from "../ServerUrlSetupScreen";
+
+function findByTestId(renderer: ReactTestRenderer, testID: string) {
+  return renderer.root.findByProps({ testID });
+}
+
+describe("ServerUrlSetupScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("saves the host URL and clears the stored refresh token", async () => {
+    const onComplete = jest.fn();
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ServerUrlSetupScreen, { onComplete }),
+      );
+    });
+
+    await act(async () => {
+      findByTestId(renderer!, "server-url-setup-input").props.onChangeText(
+        "https://my-pi.example.com:8080/api",
+      );
+    });
+    await act(async () => {
+      findByTestId(renderer!, "server-url-setup-secret").props.onChangeText(
+        "shh",
+      );
+    });
+    await act(async () => {
+      await findByTestId(renderer!, "server-url-setup-continue").props.onPress();
+    });
+
+    expect(mockSetCustomHostConfig).toHaveBeenCalledWith(
+      "https://my-pi.example.com:8080/api",
+      "shh",
+    );
+    expect(mockClearStoredRefreshToken).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects URLs that do not parse", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const onComplete = jest.fn();
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ServerUrlSetupScreen, { onComplete }),
+      );
+    });
+
+    await act(async () => {
+      findByTestId(renderer!, "server-url-setup-input").props.onChangeText(
+        "not a url",
+      );
+    });
+    await act(async () => {
+      await findByTestId(renderer!, "server-url-setup-continue").props.onPress();
+    });
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(mockSetCustomHostConfig).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  it("shows a Cancel button only when onCancel is provided", async () => {
+    const onComplete = jest.fn();
+    const onCancel = jest.fn();
+
+    let withCancel: ReactTestRenderer;
+    await act(async () => {
+      withCancel = create(
+        createElement(ServerUrlSetupScreen, { onComplete, onCancel }),
+      );
+    });
+    const cancelButton = withCancel!.root.findByProps({
+      testID: "server-url-setup-cancel",
+    });
+    await act(async () => {
+      cancelButton.props.onPress();
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    let withoutCancel: ReactTestRenderer;
+    await act(async () => {
+      withoutCancel = create(
+        createElement(ServerUrlSetupScreen, { onComplete }),
+      );
+    });
+    expect(() =>
+      withoutCancel!.root.findByProps({ testID: "server-url-setup-cancel" }),
+    ).toThrow();
+  });
+
+  it("clears all saved connection state when Reset is confirmed", async () => {
+    const onComplete = jest.fn();
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_t, _m, buttons) => {
+        // Simulate the user tapping "Reset" in the confirmation dialog.
+        const reset = buttons?.find((b) => b.text === "Reset");
+        reset?.onPress?.();
+      });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ServerUrlSetupScreen, {
+          onComplete,
+          initialHostUrl: "https://old.example/api",
+          initialSecret: "old-secret",
+          onCancel: () => {},
+        }),
+      );
+    });
+
+    await act(async () => {
+      await findByTestId(renderer!, "server-url-setup-reset").props.onPress();
+    });
+
+    expect(mockClearCustomHostConfig).toHaveBeenCalledTimes(1);
+    expect(mockClearStoredRefreshToken).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    alertSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Users whose saved server URL becomes unreachable (server down, network change, stale host) were stuck on the "Connection issue" screen with no way to recover short of a device reset — iOS Keychain (used by `expo-secure-store`) persists across app uninstalls, so even reinstalling did not clear the saved host. This PR makes the unauthenticated UI resilient to a dead server:

- **Fast-fail networking.** `postAuth` now wraps `fetch` in an `AbortController` with an 8s timeout. On timeout or DNS/network failure it returns a structured `network_unreachable` error instead of hanging until the App-level 10s loading guard.
- **"Change server URL" reachable from anywhere pre-auth.** New `ServerSetupContext` lets the Connection issue retry screen and the Login screen pop a server-URL overlay. Overlay pre-fills the currently saved host + gateway secret so the user can see/edit them.
- **"Reset saved connection"** button (with confirmation alert) inside the overlay clears the saved host, gateway secret, and stored refresh token — useful when the saved config is too broken to fix by editing.
- Saving from the overlay always drops any cached refresh token, since tokens issued by the old host won't work against the new one (matches the behavior of `CustomServerSettings` in #1244).

## Files changed

- `mobile/src/lib/authApi.ts` — AbortController timeout + structured network error.
- `mobile/src/auth/errors.ts` — Safe message for `network_unreachable`.
- `mobile/src/lib/serverSetupContext.tsx` (new) — React context exposing `openServerSetup()`.
- `mobile/src/screens/ServerUrlSetupScreen.tsx` — Reusable for first-launch and "change" modes; added Cancel + Reset.
- `mobile/App.tsx` — Manages overlay state, adds "Change server URL" button to the Connection issue screen, wraps tree in `ServerSetupContext.Provider`, remounts `AuthProvider` after save.
- `mobile/src/screens/LoginScreen.tsx` — "Change server URL" link under Sign in.
- Tests for `postAuth` (timeout, network failure, happy path), `ServerUrlSetupScreen` (save, invalid URL, cancel gating, reset), and `LoginScreen` (new button).

## Test plan

- [x] `npm test` in `mobile/` — 269 tests pass
- [x] `npx tsc --noEmit` in `mobile/` — clean
- [ ] Manual: OTA build, install on device with stale saved host. Confirm the Connection issue screen shows a "Change server URL" button after the 10s timeout (or sooner now that `postAuth` fails fast).
- [ ] Manual: tap "Change server URL" → overlay opens pre-filled → edit URL → Save → app reconnects to the new host.
- [ ] Manual: from the overlay, tap "Reset saved connection" → confirm in the alert → app returns to the first-launch `ServerUrlSetupScreen`.
- [ ] Manual: from the Login screen (saved host reachable but no session), tap "Change server URL" → overlay opens → Cancel returns to Login unchanged.

https://claude.ai/code/session_018VaMs94JMNoqMcBBicmqF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZamq39wXkzQCwtA3Ck3T)_