### PR TITLE
mobile: accept the base server URL and add /api automatically

### DIFF
--- a/mobile/src/lib/__tests__/customHostConfig.test.ts
+++ b/mobile/src/lib/__tests__/customHostConfig.test.ts
@@ -1,0 +1,114 @@
+jest.mock("expo-secure-store", () => {
+  const store = new Map<string, string>();
+  return {
+    getItemAsync: jest.fn((key: string) =>
+      Promise.resolve(store.get(key) ?? null),
+    ),
+    setItemAsync: jest.fn((key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    deleteItemAsync: jest.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+    __store: store,
+  };
+});
+
+import * as SecureStore from "expo-secure-store";
+import {
+  getCustomHost,
+  loadCustomHostConfig,
+  normalizeApiBase,
+  setCustomHostConfig,
+} from "../customHostConfig";
+
+const store = (SecureStore as unknown as { __store: Map<string, string> }).__store;
+
+describe("normalizeApiBase", () => {
+  it("appends /api when the URL is just the origin", () => {
+    expect(normalizeApiBase("https://permission-slip.example.com")).toBe(
+      "https://permission-slip.example.com/api",
+    );
+  });
+
+  it("strips a trailing slash before appending /api", () => {
+    expect(normalizeApiBase("https://permission-slip.example.com/")).toBe(
+      "https://permission-slip.example.com/api",
+    );
+  });
+
+  it("leaves a URL that already ends in /api alone", () => {
+    expect(normalizeApiBase("https://permission-slip.example.com/api")).toBe(
+      "https://permission-slip.example.com/api",
+    );
+  });
+
+  it("strips a trailing slash after /api", () => {
+    expect(normalizeApiBase("https://permission-slip.example.com/api/")).toBe(
+      "https://permission-slip.example.com/api",
+    );
+  });
+
+  it("strips a trailing /v1 segment", () => {
+    expect(normalizeApiBase("https://permission-slip.example.com/api/v1")).toBe(
+      "https://permission-slip.example.com/api",
+    );
+  });
+
+  it("preserves a custom path and still ensures /api is appended", () => {
+    expect(normalizeApiBase("https://example.com/mounted-at")).toBe(
+      "https://example.com/mounted-at/api",
+    );
+  });
+
+  it("returns null for empty, whitespace, or null input", () => {
+    expect(normalizeApiBase(null)).toBeNull();
+    expect(normalizeApiBase(undefined)).toBeNull();
+    expect(normalizeApiBase("")).toBeNull();
+    expect(normalizeApiBase("   ")).toBeNull();
+  });
+
+  it("is idempotent", () => {
+    const once = normalizeApiBase("https://permission-slip.example.com");
+    const twice = normalizeApiBase(once);
+    expect(twice).toBe(once);
+  });
+});
+
+describe("setCustomHostConfig", () => {
+  beforeEach(() => {
+    store.clear();
+    jest.clearAllMocks();
+  });
+
+  it("normalizes the URL before persisting", async () => {
+    await setCustomHostConfig("https://permission-slip.example.com", null);
+    expect(store.get("custom_host_url")).toBe(
+      "https://permission-slip.example.com/api",
+    );
+    expect(getCustomHost()).toBe("https://permission-slip.example.com/api");
+  });
+
+  it("deletes the stored host when given an empty value", async () => {
+    await setCustomHostConfig("https://permission-slip.example.com", null);
+    await setCustomHostConfig("", null);
+    expect(store.has("custom_host_url")).toBe(false);
+    expect(getCustomHost()).toBeNull();
+  });
+});
+
+describe("loadCustomHostConfig", () => {
+  beforeEach(() => {
+    store.clear();
+    jest.clearAllMocks();
+  });
+
+  it("normalizes legacy un-normalized values on read", async () => {
+    // Simulate a value saved by an older app version (no /api suffix).
+    store.set("custom_host_url", "https://permission-slip.example.com");
+    await loadCustomHostConfig();
+    expect(getCustomHost()).toBe("https://permission-slip.example.com/api");
+  });
+});

--- a/mobile/src/lib/customHostConfig.ts
+++ b/mobile/src/lib/customHostConfig.ts
@@ -11,6 +11,40 @@ const GATEWAY_SECRET_KEY = "gateway_secret";
 export const PLACEHOLDER_API_BASE = "https://__permission_slip_no_host__.invalid/api";
 
 /**
+ * Canonicalize a user-entered server URL into the form the app needs to talk
+ * to the backend. Users enter the base origin of their deployment (the same
+ * URL they use in the web app, e.g. https://permission-slip.example.com);
+ * the backend mounts the API at `/api`, so we append it automatically when
+ * it's missing. Without this, a user who types only the origin gets HTML
+ * 404s from their reverse proxy on every auth request and the app surfaces
+ * a confusing "Something went wrong" error.
+ *
+ * Behavior:
+ *   - Strips surrounding whitespace, trailing slashes, and a trailing `/v1`
+ *     (which spec paths already include).
+ *   - Returns `null` for empty input so callers can distinguish "not set".
+ *   - Idempotent: a URL already ending in `/api` is left alone, so we never
+ *     produce `…/api/api`.
+ *   - Conservative on custom paths: any non-empty path that doesn't already
+ *     end in `/api` gets `/api` appended, including `https://host.tld/foo`
+ *     → `https://host.tld/foo/api`. Operators with non-standard mounts can
+ *     still enter the full path explicitly.
+ */
+export function normalizeApiBase(input: string | null | undefined): string | null {
+  if (input == null) return null;
+  let url = input.trim();
+  if (!url) return null;
+  url = url.replace(/\/+$/, "");
+  url = url.replace(/\/v1$/, "");
+  url = url.replace(/\/+$/, "");
+  if (!url) return null;
+  if (!/\/api$/.test(url)) {
+    url = `${url}/api`;
+  }
+  return url;
+}
+
+/**
  * In-memory cache so middleware reads are synchronous and fast.
  * Call loadCustomHostConfig() at app startup to hydrate from SecureStore.
  */
@@ -27,7 +61,11 @@ let cachedSecret: string | null = null;
  * from firing before the cache is populated.
  */
 export async function loadCustomHostConfig(): Promise<void> {
-  cachedHost = (await SecureStore.getItemAsync(CUSTOM_HOST_KEY)) ?? null;
+  const storedHost = (await SecureStore.getItemAsync(CUSTOM_HOST_KEY)) ?? null;
+  // Normalize on read so existing saves from older app versions (which
+  // required the user to type `/api` themselves) start working even before
+  // the user re-enters their URL.
+  cachedHost = normalizeApiBase(storedHost);
   cachedSecret = (await SecureStore.getItemAsync(GATEWAY_SECRET_KEY)) ?? null;
 }
 
@@ -66,9 +104,10 @@ export async function setCustomHostConfig(
   host: string | null,
   secret: string | null,
 ): Promise<void> {
-  if (host && host.trim().length > 0) {
-    await SecureStore.setItemAsync(CUSTOM_HOST_KEY, host.trim());
-    cachedHost = host.trim();
+  const normalized = normalizeApiBase(host);
+  if (normalized) {
+    await SecureStore.setItemAsync(CUSTOM_HOST_KEY, normalized);
+    cachedHost = normalized;
   } else {
     await SecureStore.deleteItemAsync(CUSTOM_HOST_KEY);
     cachedHost = null;

--- a/mobile/src/screens/ServerUrlSetupScreen.tsx
+++ b/mobile/src/screens/ServerUrlSetupScreen.tsx
@@ -65,7 +65,7 @@ export default function ServerUrlSetupScreen({
   const handleSave = useCallback(async () => {
     const trimmedHost = hostUrl.trim();
     if (!trimmedHost) {
-      Alert.alert("Missing URL", "Enter your Permission Slip server URL (e.g. https://your-pi:8080/api).");
+      Alert.alert("Missing URL", "Enter your Permission Slip server URL (e.g. https://permission-slip.example.com).");
       return;
     }
     try {
@@ -136,14 +136,14 @@ export default function ServerUrlSetupScreen({
         <Text style={styles.subtitle}>
           {isChangeMode
             ? "Update the URL the app talks to. Saving signs you out so the new server takes effect."
-            : "Permission Slip is self-hosted. Enter the API base URL for your instance (the same URL you use in the web app, usually ending in /api)."}
+            : "Permission Slip is self-hosted. Enter the URL of your deployment — the same one you use in the web app."}
         </Text>
 
         <Text style={styles.label}>Server URL</Text>
         <TextInput
           testID="server-url-setup-input"
           style={styles.input}
-          placeholder="https://your-server.example.com/api"
+          placeholder="https://permission-slip.example.com"
           placeholderTextColor={colors.gray400}
           value={hostUrl}
           onChangeText={setHostUrl}

--- a/mobile/src/screens/settings/CustomServerSettings.tsx
+++ b/mobile/src/screens/settings/CustomServerSettings.tsx
@@ -152,7 +152,7 @@ export default function CustomServerSettings({ onSaved }: Props) {
           <TextInput
             testID="custom-host-input"
             style={styles.input}
-            placeholder="https://your-server.example.com/api"
+            placeholder="https://permission-slip.example.com"
             placeholderTextColor={colors.gray400}
             value={hostUrl}
             onChangeText={setHostUrl}


### PR DESCRIPTION
## Summary

Follow-up to #1246. Users were expected to type the trailing `/api` themselves when entering their server URL — an internal routing detail that should not have been part of the UX. Saving the origin alone (e.g. `https://permission-slip.example.com`) sent auth requests to the SPA handler, which returned HTML and surfaced a confusing "Something went wrong" error on login.

## Changes

- **`mobile/src/lib/customHostConfig.ts`** — new `normalizeApiBase()` helper that trims, strips trailing slashes and trailing `/v1`, appends `/api` when missing, is idempotent (never produces `…/api/api`), and returns `null` for empty/whitespace input.
- Apply normalization on **save** (`setCustomHostConfig`) so future writes are canonical, and on **load** (`loadCustomHostConfig`) so users who saved a URL with an older app version (no `/api`) are auto-fixed on their next cold start without re-entering anything.
- Update copy and placeholders in `ServerUrlSetupScreen` and `CustomServerSettings` to show the origin example (`https://permission-slip.example.com`) rather than the `/api`-suffixed form.

## Test plan

- [x] `npm test` — 280 tests pass (10 new for `normalizeApiBase`, `setCustomHostConfig`, and `loadCustomHostConfig` round-tripping legacy values).
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: existing install with a stale saved URL → cold-launch the app after OTA → login works without changing the URL.
- [ ] Manual: first-launch flow → type origin only → login works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZamq39wXkzQCwtA3Ck3T)_