### PR TITLE
fix: include --agent-id in dashboard verify instructions

### DIFF
--- a/frontend/src/pages/dashboard/agentInstructions.ts
+++ b/frontend/src/pages/dashboard/agentInstructions.ts
@@ -32,9 +32,11 @@ export function generateVerificationInstructions(
   confirmationCode: string,
   origin: string,
 ): string {
-  return `npx @permission-slip/cli verify --code ${shellQuote(confirmationCode)} --server ${shellQuote(origin)}
-
-Your agent ID is: ${agentId}`;
+  // Pass --agent-id explicitly so the command works without relying on a
+  // saved registration in ~/.permission-slip/registrations.json. Without
+  // this, verify silently fails locally (never reaches the server) on any
+  // machine that didn't run `register` against this exact --server URL.
+  return `npx @permission-slip/cli verify --agent-id ${agentId} --code ${shellQuote(confirmationCode)} --server ${shellQuote(origin)}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The CLI's `verify` command (`cli/src/commands/verify.ts:42-50`) requires either `--agent-id` *or* a matching saved registration in `~/.permission-slip/registrations.json` for the exact `--server` URL. When neither is available it throws locally and **never makes the HTTP call**:

```ts
const reg = findRegistration(server);
if (!reg) {
  throw new Error(`No registration found for ${server}. ...`);
}
```

The dashboard's "Complete Agent Registration" dialog (`ReviewPendingAgentDialog`) renders a verify command via `generateVerificationInstructions`. That command was missing `--agent-id` — the agent ID was shown only as informational footer text ("Your agent ID is: N"). When the user copy-pasted the command on a machine that did not have a matching saved registration (different host, cleared `~/.permission-slip/`, trailing-slash mismatch, etc.), the CLI errored out silently and the dashboard stayed stuck on "pending" because no verify request ever reached the server.

This is the symptom that was reported: CLI appears to succeed (or the user dismisses the error), agent stays pending, server logs show no `/verify` request.

## Fix

Pass `--agent-id ${agentId}` directly in the generated command. The dashboard already has the value, so the instructions are now self-contained and don't depend on local CLI state.

```
- npx @permission-slip/cli verify --code 'XXX' --server 'https://...'
-
- Your agent ID is: 1
+ npx @permission-slip/cli verify --agent-id 1 --code 'XXX' --server 'https://...'
```

## Why the previous "stub fix" missed this

Earlier investigation claimed `api/agents.go` was a stub and added a `/verify` endpoint. That was incorrect — `POST /agents/{agent_id}/verify` already exists at `api/registration.go:73` and the underlying `db.VerifyAgentConfirmationCode` works correctly (verified by SELECT + UPDATE flow against a fresh sqlite3 instance using the on-branch schema). The real failure was upstream of the network call.

## Test plan

- [x] `npm test` (frontend) — all 895 tests in 99 files pass
- [x] Manual SQL trace of the `VerifyAgentConfirmationCode` path against the SQLite schema confirms the persist step works
- [ ] After deploy: copy the verify command from the dashboard on a machine with **no** prior `permission-slip register` state, confirm it now hits the server and the agent transitions to `registered`

Backend Go tests were not run locally (sandbox is on Go 1.24.7; `cloud.google.com/go/bigquery` transitively requires Go 1.25). No backend files changed in this PR, so risk is limited to the frontend — but CI should still run the full suite before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Z1sShRg5gbCczoEL3Wygo)_