### PR TITLE
docs: trim self-hosted guide and add Google + Slack OAuth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Permission Slip is an open-source approval layer for [Openclaw](https://openclaw
 
 Permission Slip is **self-hosted**: you run the server on your own machine or network.
 
-- **[Self-hosted deployment guide](docs/deployment-self-hosted.md)** — Raspberry Pi (recommended), bare metal, Docker, Fly.io
+- **[Self-hosted deployment guide](docs/deployment-self-hosted.md)** — Raspberry Pi (recommended) or any Linux machine, with Google + Slack OAuth setup
 - **[iPhone app](https://apps.apple.com/us/app/permission-slip/id6761718603)** — approve requests on the go; enter your server URL on first launch
 - **[CLI](cli/README.md)** — talks to your server; set `PS_SERVER` or pass `--server`
 
@@ -113,7 +113,7 @@ Tested a connector? [Open an issue](https://github.com/supersuit-tech/permission
 ## Documentation
 
 **Setup & deployment**
-- [Self-Hosted Deployment](docs/deployment-self-hosted.md) — Raspberry Pi, bare metal, Docker, Fly.io
+- [Self-Hosted Deployment](docs/deployment-self-hosted.md) — Raspberry Pi or any Linux machine, with Google + Slack OAuth setup
 - [Developer guide](docs/development.md) — local dev servers, builds, testing, tech stack
 
 **Architecture & protocol**

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -77,8 +77,8 @@ npx @permission-slip/cli register --invite-code <code>
 
 > **Can't connect?** Also make sure the machine running the CLI and your
 > Permission Slip server are on the same network. See the
-> [Self-Hosted Deployment Guide](deployment-self-hosted.md) troubleshooting
-> section for more.
+> [Self-Hosted Deployment Guide](deployment-self-hosted.md) for setup
+> details.
 
 ## Manual Quick Start (raw HTTP)
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -186,237 +186,78 @@ curl https://$PS_HOSTNAME/api/health            # through the tunnel
 
 ---
 
-## Step 5: Create Your Account
+## Step 5: Connect Google
 
-```bash
-DATABASE_PATH=~/permission-slip/data/app.db \
-  go run ./cmd/create-user you@example.com 'your-password'
-```
+Permission Slip's Google connector handles Gmail and Calendar actions. To enable it, register an OAuth client in Google Cloud:
 
-Open `https://$PS_HOSTNAME` in your browser and log in.
+1. In the [Google Cloud Console](https://console.cloud.google.com/), create or pick a project.
+2. Under **APIs & Services > Library**, enable the **Gmail API** and **Google Calendar API**.
+3. Under **APIs & Services > OAuth consent screen**, choose **External** (or **Internal** for Google Workspace). Fill in:
+   - App name: `Permission Slip`
+   - User support email: your email
+   - Authorized domain: your `$PS_HOSTNAME` domain
 
----
-
-## Notifications (Optional)
-
-The base setup works without notifications — you can poll the web UI or use the iPhone app. When you're ready:
-
-### Web Push (no account needed)
-
-```bash
-cd ~/permission-slip
-go run ./cmd/generate-vapid-keys
-```
-
-Add the output (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) to `.env` and restart.
-
-### Email (SMTP)
-
-```bash
-NOTIFICATION_EMAIL_PROVIDER=smtp
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USERNAME=you@gmail.com
-SMTP_PASSWORD=your-app-password
-NOTIFICATION_EMAIL_FROM=you@gmail.com
-```
-
-### SMS (Amazon SNS)
-
-1. Create an AWS account and an IAM user with `sns:Publish` permission:
-   ```json
-   {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sns:Publish","Resource":"*"}]}
+   Add these scopes:
+   - `openid`
+   - `https://www.googleapis.com/auth/userinfo.email`
+   - `https://www.googleapis.com/auth/gmail.send`
+   - `https://www.googleapis.com/auth/gmail.readonly`
+   - `https://www.googleapis.com/auth/calendar.events`
+4. Under **APIs & Services > Credentials**, click **Create Credentials > OAuth 2.0 Client ID**. Application type: **Web application**. Add the authorized redirect URI:
    ```
-2. Exit the [SMS Sandbox](https://docs.aws.amazon.com/sns/latest/dg/sns-sms-sandbox.html) in the SNS console.
-3. Set the environment variables:
-
-| Variable | Description |
-|---|---|
-| `AWS_REGION` | AWS region (e.g. `us-east-1`) — **required** |
-| `AWS_ACCESS_KEY_ID` | AWS access key (optional with IAM roles) |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key (optional with IAM roles) |
-| `SNS_SMS_SENDER_ID` | Optional alphanumeric sender ID |
-| `SNS_SMS_ORIGINATION_NUMBER` | Origination number in E.164 format (required for US) |
-
----
-
-## Hardening (Optional)
-
-Your tunnel is public — anyone with the hostname can reach the login page. Two ways to add a gate in front:
-
-### Cloudflare Access (recommended)
-
-Put a Cloudflare Access policy in front of your tunnel hostname. Users authenticate with email, Google, GitHub, etc. before reaching Permission Slip. Works with both the web UI and the mobile app. Configure it in the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/).
-
-### Gateway Secret
-
-For mobile-only deployments, set `GATEWAY_SECRET` so the server rejects any request without a matching `X-Gateway-Secret` header:
-
-```bash
-echo "GATEWAY_SECRET=$(openssl rand -hex 32)" >> ~/permission-slip/.env
-sudo systemctl restart permission-slip
-```
-
-Configure the **mobile app**: Settings → Server → enable Custom Server → paste the secret into the gateway secret field.
-
-> **Note:** Browsers can't inject custom headers, so the web UI won't work with `GATEWAY_SECRET` set. Use Cloudflare Access if you need browser access.
+   https://$PS_HOSTNAME/api/v1/oauth/google/callback
+   ```
+5. Copy the Client ID and Client Secret into `~/permission-slip/.env`:
+   ```bash
+   GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+   GOOGLE_CLIENT_SECRET=your-client-secret
+   ```
+6. Restart Permission Slip:
+   ```bash
+   sudo systemctl restart permission-slip
+   ```
 
 ---
 
-## Updating
+## Step 6: Connect Slack
 
-```bash
-cd ~/permission-slip
-git pull origin main
-make build
-sudo systemctl restart permission-slip
-```
+Slack uses [OAuth 2.0 with the V2 flow](https://api.slack.com/authentication/oauth-v2): bot scopes produce a bot token (`xoxb-`), and user scopes produce a user token (`xoxp-`) used for APIs that only accept user tokens (e.g. `search.messages`).
 
-Database migrations run automatically on startup.
+1. At [api.slack.com/apps](https://api.slack.com/apps), click **Create New App > From scratch**. Name it `Permission Slip` and pick a development workspace.
+2. Open **OAuth & Permissions**. Under **Redirect URLs**, add:
+   ```
+   https://$PS_HOSTNAME/api/v1/oauth/slack/callback
+   ```
+3. Still under **OAuth & Permissions**, scroll to **Scopes** and add:
 
----
+   **Bot Token Scopes**
+   - `channels:history`, `channels:join`, `channels:manage`, `channels:read`
+   - `chat:write`
+   - `files:write`
+   - `groups:history`, `groups:read`
+   - `im:history`, `im:read`, `im:write`
+   - `mpim:history`, `mpim:read`, `mpim:write`
+   - `reactions:write`
+   - `users:read`, `users:read.email`
 
-## Alternative Deployments
+   **User Token Scopes**
+   - `search:read` — required for `search.messages` (the granular `search:read.*` scopes only work with the newer `assistant.search.context` endpoint).
+4. Under **Basic Information > App Credentials**, copy the **Client ID** and **Client Secret** into `~/permission-slip/.env`:
+   ```bash
+   SLACK_CLIENT_ID=your-slack-client-id
+   SLACK_CLIENT_SECRET=your-slack-client-secret
+   ```
+5. Restart Permission Slip:
+   ```bash
+   sudo systemctl restart permission-slip
+   ```
 
-### Fly.io
-
-Fly handles TLS itself, so you can skip Cloudflare Tunnel:
-
-```bash
-fly launch
-fly secrets set \
-  DATABASE_PATH=/data/app.db \
-  SECRET_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
-  JWT_SIGNING_SECRET="$(openssl rand -base64 32)" \
-  INVITE_HMAC_KEY="$(openssl rand -hex 32)" \
-  BASE_URL="https://your-app.fly.dev" \
-  ALLOWED_ORIGINS="https://your-app.fly.dev"
-fly deploy
-```
-
-See the dedicated [Fly.io deployment guide](deployment.md) for full details.
-
-### Tailscale (personal/VPN-only)
-
-If you only need to reach Permission Slip from your own devices, skip Cloudflare Tunnel and use Tailscale instead:
-
-```bash
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up
-```
-
-Set `BASE_URL` to your MagicDNS hostname (e.g. `http://mypi.tailnet.ts.net:8080`). No public hostname, no TLS — the Tailscale network is your security boundary.
-
-### Railway / Render / Other PaaS
-
-1. Connect your repo
-2. Set the required environment variables in the platform dashboard
-3. Point the health check at `GET /api/health` on port 8080
+When a user connects Slack from Permission Slip, they'll complete Slack's OAuth consent and install the app to their workspace.
 
 ---
 
-## Scaling
+## Other Connectors
 
-Permission Slip is stateless (all state is in the database):
+Permission Slip ships with 15+ more OAuth providers — Atlassian (Jira), Datadog, Dropbox, Figma, GitHub, HubSpot, Linear, Meta (Facebook/Instagram), Microsoft, Notion, PagerDuty, Square, PayPal, Stripe, and X (Twitter). See the [OAuth setup guide](oauth-setup.md) for per-provider instructions.
 
-- **SQLite (default):** Single instance only.
-- **PostgreSQL:** Run as many copies as needed behind a load balancer. Set `DATABASE_URL` instead of `DATABASE_PATH`.
-- **VAPID keys:** When running multiple instances, set keys explicitly so all instances share the same pair.
-
----
-
-## Secret Rotation
-
-| Secret | Effect of rotation |
-|--------|-------------------|
-| `JWT_SIGNING_SECRET` | Invalidates all active sessions — users must log in again |
-| `SECRET_ENCRYPTION_KEY` | Requires re-encrypting all stored credentials — do not rotate without a migration plan |
-| `INVITE_HMAC_KEY` | Invalidates pending invite links (accepted invites unaffected) |
-| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | Invalidates all push subscriptions — users must re-subscribe |
-| `GATEWAY_SECRET` | Every client must be updated simultaneously — no overlap window |
-
-Recommended cadence: every 90 days for `JWT_SIGNING_SECRET` and `INVITE_HMAC_KEY`.
-
----
-
-## Troubleshooting
-
-**"required configuration value(s) missing" on startup**
-Check that `DATABASE_PATH`, `JWT_SIGNING_SECRET`, and `SECRET_ENCRYPTION_KEY` are all set.
-
-**`https://$PS_HOSTNAME` returns 502 or 1033**
-The tunnel is up but Permission Slip isn't. Check `sudo systemctl status permission-slip` and `journalctl -u permission-slip -n 50`.
-
-**`https://$PS_HOSTNAME` returns 1016 ("Origin DNS error")**
-The DNS record hasn't propagated yet, or `cloudflared tunnel route dns` wasn't run. Re-run it and wait a minute.
-
-**`cloudflared` won't start**
-Check `sudo systemctl status cloudflared`. Common cause: credentials file path in `/etc/cloudflared/config.yml` doesn't match the file you copied. Run `ls /etc/cloudflared/` to verify.
-
-**Health check fails on localhost**
-Common causes: missing env vars, bad `DATABASE_PATH`, or the `data/` directory isn't writable.
-
-**Out of memory during build**
-On a 4GB Pi, add swap:
-```bash
-sudo dphys-swapfile swapoff
-sudo sed -i 's/CONF_SWAPSIZE=.*/CONF_SWAPSIZE=2048/' /etc/dphys-swapfile
-sudo dphys-swapfile setup && sudo dphys-swapfile swapon
-```
-
-**VAPID error on startup**
-If any VAPID variable is set, all three (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) must be present.
-
-**Migrations fail**
-The `data/` directory must be writable by the user running the server.
-
----
-
-## Environment Variable Reference
-
-| Variable | Required | Description |
-|---|---|---|
-| `DATABASE_PATH` | Yes | SQLite file path (e.g. `/var/lib/permission-slip/app.db`) |
-| `SECRET_ENCRYPTION_KEY` | Yes | AES-256-GCM master key — 32 bytes, base64-encoded. `openssl rand -base64 32` |
-| `JWT_SIGNING_SECRET` | Yes | HS256 signing key for session tokens — 32+ bytes. `openssl rand -base64 32` |
-| `INVITE_HMAC_KEY` | Recommended | HMAC key for invite code signing. `openssl rand -hex 32` |
-| `BASE_URL` | Recommended | Public deployment URL (for OAuth callbacks and invite links) |
-| `ALLOWED_ORIGINS` | — | Comma-separated CORS origins. Leave unset for same-origin mode. |
-| `PORT` | No | Listen port (default: `8080`) |
-| `MODE` | No | Set to `development` to relax config validation |
-| `TRUSTED_PROXY_HEADER` | No | Client IP header from reverse proxy (default: `X-Forwarded-For`) |
-| `SHUTDOWN_TIMEOUT` | No | Graceful shutdown timeout (default: `30s`) |
-| `OAUTH_STATE_SECRET` | No | HMAC key for OAuth CSRF state tokens (falls back to `JWT_SIGNING_SECRET`) |
-| `GATEWAY_SECRET` | No | Shared secret for private deployments. Rejects requests without `X-Gateway-Secret` header. |
-| `VAPID_PUBLIC_KEY` | For Web Push | VAPID public key |
-| `VAPID_PRIVATE_KEY` | For Web Push | VAPID private key |
-| `VAPID_SUBJECT` | For Web Push | VAPID contact (`mailto:` or `https://`) |
-| `NOTIFICATION_EMAIL_PROVIDER` | For email | `twilio-sendgrid` or `smtp` |
-| `SENDGRID_API_KEY` | For SendGrid | SendGrid API key |
-| `NOTIFICATION_EMAIL_FROM` | For email | Sender email address |
-| `SMTP_HOST` | For SMTP | SMTP server hostname |
-| `SMTP_PORT` | For SMTP | SMTP port (default: `587`) |
-| `SMTP_USERNAME` | For SMTP | SMTP username |
-| `SMTP_PASSWORD` | For SMTP | SMTP password |
-| `AWS_REGION` | For SMS | AWS region for SNS (e.g. `us-east-1`) |
-| `AWS_ACCESS_KEY_ID` | For SMS | AWS access key (optional with IAM roles) |
-| `AWS_SECRET_ACCESS_KEY` | For SMS | AWS secret key (optional with IAM roles) |
-| `SNS_SMS_SENDER_ID` | No | Alphanumeric SMS sender ID |
-| `SNS_SMS_ORIGINATION_NUMBER` | No | Origination phone number (E.164 format) |
-| `SMS_NOTIFICATIONS_HIDDEN` | No | Set to `true` to hide SMS from notification preferences UI |
-| `SENTRY_DSN` | No | Backend error tracking (Sentry) |
-| `SENTRY_CSP_ENDPOINT` | No | CSP violation reporting endpoint |
-| `VITE_SENTRY_DSN` | No (build) | Frontend error tracking (Sentry) |
-| `SENTRY_AUTH_TOKEN` | No (build) | Sentry source map upload token |
-| `SENTRY_ORG` | No (build) | Sentry org slug |
-| `SENTRY_PROJECT` | No (build) | Sentry project slug |
-| `VITE_POSTHOG_KEY` | No (build) | PostHog project API key |
-| `VITE_POSTHOG_HOST` | No (build) | PostHog API host (default: `us.i.posthog.com`) |
-| `BILLING_ENABLED` | No | Enable billing (`true`/`false`, default: `false`) |
-| `STRIPE_SECRET_KEY` | For billing | Stripe API secret key |
-| `STRIPE_PUBLISHABLE_KEY` | For billing | Stripe publishable key |
-| `STRIPE_WEBHOOK_SECRET` | For billing | Stripe webhook signing secret |
-| `STRIPE_PRICE_ID_REQUEST` | For billing | Metered Stripe Price ID |
-| `VITE_STRIPE_PUBLISHABLE_KEY` | For billing (build) | Stripe publishable key (frontend) |
-| `CONNECTORS_DIR` | No | Custom connector directory |
-| `CUSTOM_CONNECTORS_JSON` | No | Inline connector JSON config |
+To build your own connector for a service Permission Slip doesn't yet support, see [custom connectors](custom-connectors.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,7 @@ make dev-backend   # Go API server → http://localhost:8080
 make dev-frontend  # Vite + HMR   → http://localhost:5173
 ```
 
-For the full walkthrough including PostgreSQL setup and test database configuration, see the [self-hosted deployment guide](deployment-self-hosted.md).
+For the production deployment walkthrough, see the [self-hosted deployment guide](deployment-self-hosted.md).
 
 ---
 
@@ -66,7 +66,7 @@ The server serves both the API and frontend on a single port (default 8080). The
 | `INVITE_HMAC_KEY` | Recommended | HMAC key for invite codes — `openssl rand -hex 32` |
 | `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` | For Web Push | Generate with `make generate-vapid-keys` |
 
-Bootstrap the first user on a new database with `go run ./cmd/create-user user@example.com 'password'` (see repository README). For the full environment variable reference, Dockerfile, Fly.io setup, and hardening checklist, see [Self-hosted deployment](deployment-self-hosted.md).
+Bootstrap the first user on a new database with `go run ./cmd/create-user user@example.com 'password'` (see repository README). For the full production deployment walkthrough, see [Self-hosted deployment](deployment-self-hosted.md).
 
 ---
 


### PR DESCRIPTION
Replace Step 5 onward with concise Google and Slack OAuth setup steps,
plus a pointer to oauth-setup.md and custom-connectors.md for the rest.
Fix dangling cross-references in development.md, agents.md, and README.

https://claude.ai/code/session_01WdAFwu3Frti5MGb6v4FU74