### PR TITLE
Add APPROVAL_REQUEST_TTL env var to control approval expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,6 +188,11 @@ VAULT_SECRET_KEY=your-vault-secret-key-from-openssl-rand
 # and should match the SQL interval in `purge_expired_audit_events()`.
 # AUDIT_RETENTION_DAYS=90
 
+# Default TTL applied to new approval requests when the agent does not pass an
+# `expires_in` override. Accepts Go duration syntax (e.g., "10m", "1h").
+# Clamped to [1m, 24h]; invalid or out-of-bounds values fall back to 10m.
+# APPROVAL_REQUEST_TTL=10m
+
 # Custom connectors — override the directory where external connectors are
 # installed and loaded from. Defaults to ~/.permission_slip/connectors/.
 # On platforms like Heroku, set this to a path inside the app slug (e.g. /app/connectors)

--- a/db/agent_approvals.go
+++ b/db/agent_approvals.go
@@ -5,11 +5,46 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"time"
 )
 
-// DefaultApprovalTTL is the default time-to-live for a new approval request.
-const DefaultApprovalTTL = 10 * time.Minute
+// DefaultApprovalTTL is the default time-to-live for a new approval request
+// when the agent does not supply an `expires_in` override. It is a var rather
+// than a const so it can be reassigned at process startup from the
+// APPROVAL_REQUEST_TTL env var via ApprovalTTLFromEnv.
+var DefaultApprovalTTL = 10 * time.Minute
+
+// ApprovalTTLFromEnv reads APPROVAL_REQUEST_TTL and returns a duration clamped
+// to [1m, 24h]. Unset, unparseable, or out-of-bounds values fall back to 10m
+// and emit a warning via the supplied logger.
+func ApprovalTTLFromEnv(logger *slog.Logger) time.Duration {
+	const def = 10 * time.Minute
+	const minTTL = time.Minute
+	const maxTTL = 24 * time.Hour
+
+	v := os.Getenv("APPROVAL_REQUEST_TTL")
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("invalid APPROVAL_REQUEST_TTL, using default 10m",
+				"value", v, "error", err)
+		}
+		return def
+	}
+	if d < minTTL || d > maxTTL {
+		if logger != nil {
+			logger.Warn("APPROVAL_REQUEST_TTL out of bounds, using default 10m",
+				"value", v, "min", minTTL.String(), "max", maxTTL.String())
+		}
+		return def
+	}
+	return d
+}
 
 // InsertApprovalParams holds the parameters for creating a new approval.
 type InsertApprovalParams struct {

--- a/db/agent_approvals_test.go
+++ b/db/agent_approvals_test.go
@@ -1,0 +1,46 @@
+package db_test
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+func TestApprovalTTLFromEnv(t *testing.T) {
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"Unset", "", 10 * time.Minute},
+		{"ValidMinutes", "30m", 30 * time.Minute},
+		{"ValidHours", "2h", 2 * time.Hour},
+		{"AtMin", "1m", time.Minute},
+		{"AtMax", "24h", 24 * time.Hour},
+		{"Invalid", "junk", 10 * time.Minute},
+		{"BelowMin", "30s", 10 * time.Minute},
+		{"AboveMax", "25h", 10 * time.Minute},
+		{"Negative", "-5m", 10 * time.Minute},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("APPROVAL_REQUEST_TTL", tc.env)
+			if got := db.ApprovalTTLFromEnv(silent); got != tc.want {
+				t.Errorf("env=%q: got %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApprovalTTLFromEnv_NilLoggerSafe(t *testing.T) {
+	t.Setenv("APPROVAL_REQUEST_TTL", "junk")
+	if got := db.ApprovalTTLFromEnv(nil); got != 10*time.Minute {
+		t.Errorf("nil logger: got %v, want 10m", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -110,6 +110,9 @@ func main() {
 		port = "8080"
 	}
 
+	// Apply APPROVAL_REQUEST_TTL override (defaults to 10m, clamped to [1m, 24h]).
+	db.DefaultApprovalTTL = db.ApprovalTTLFromEnv(logger)
+
 	// Configure dependencies
 	var deps api.Deps
 	deps.Logger = logger


### PR DESCRIPTION
## Summary

- Adds `APPROVAL_REQUEST_TTL` env var (Go duration string, default `10m`, clamped to `[1m, 24h]`) to override the hardcoded approval request expiration default.
- Converts `db.DefaultApprovalTTL` from `const` to `var` so it can be reassigned at startup.
- Wired into `main.go` immediately after logger init; warnings on invalid values flow through the structured logger.
- Per-request `expires_in` agent override (60–86400s) is unchanged — the env var only affects the fallback when an agent does not pass `expires_in`.

## Files changed

- `db/agent_approvals.go` — `const` → `var DefaultApprovalTTL`; new `ApprovalTTLFromEnv(logger)` helper.
- `db/agent_approvals_test.go` — new unit tests covering unset / valid / invalid / out-of-bounds inputs and nil-logger safety.
- `main.go` — one-line wiring: `db.DefaultApprovalTTL = db.ApprovalTTLFromEnv(logger)`.
- `.env.example` — append-only doc next to other duration-style vars.

## Test plan

- [x] `gofmt` clean on changed files.
- [x] Parse-check (`gofmt -e`) passes.
- [ ] Backend tests via CI — `go test ./db/... -run TestApprovalTTLFromEnv` cannot run in the sandbox (Go 1.25 transitive dep blocks local `go test`); relying on CI for the full suite per CLAUDE.md.
- [ ] Manual: unset `APPROVAL_REQUEST_TTL` → approval `expires_at = created_at + 10m`.
- [ ] Manual: set `APPROVAL_REQUEST_TTL=30m` → approval `expires_at = created_at + 30m`.
- [ ] Manual: set `APPROVAL_REQUEST_TTL=junk` → warning logged, default 10m applied.
- [ ] Manual: `expires_in: 300` request with `APPROVAL_REQUEST_TTL=30m` → per-request 5m wins.

Closes #1256

https://claude.ai/code/session_01NemUPJmiDKCSagEMFFaZqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NemUPJmiDKCSagEMFFaZqZ)_