### PR TITLE
Add auto-approve checkbox on approval screens (web + mobile)

### DIFF
--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -833,6 +833,38 @@ func TestCreateStandingApproval_ConstraintsEmptyObject(t *testing.T) {
 	}
 }
 
+func TestCreateStandingApproval_ParameterlessActionNullOrEmptyConstraints(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	actionType := "google.list_calendars"
+	testhelper.InsertConnector(t, tx, "google")
+	testhelper.InsertConnectorAction(t, tx, "google", actionType, actionType)
+	acID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfigFull(t, tx, acID, agentID, uid, "google", actionType, testhelper.ActionConfigOpts{
+		Parameters: []byte("{}"),
+	})
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	for _, constraints := range []string{"null", "{}"} {
+		t.Run("constraints="+constraints, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"agent_id": %d, "action_type": %q, "constraints": %s, "source_action_configuration_id": %q, "expires_at": null}`,
+				agentID, actionType, constraints, acID,
+			)
+			r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+			if w.Code != http.StatusCreated {
+				t.Fatalf("expected 201 for parameterless action, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestCreateStandingApproval_ConstraintsAllWildcard(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -1,9 +1,11 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { Loader2, Clock, AlertTriangle, CheckCircle, XCircle, ShieldCheck, Check } from "lucide-react";
+import { Loader2, Clock, AlertTriangle, CheckCircle, XCircle, Check } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -17,8 +19,9 @@ import type { ApproveResult } from "@/hooks/useApproveApproval";
 import { useDenyApproval } from "@/hooks/useDenyApproval";
 import { useActionSchema } from "@/hooks/useActionSchema";
 import type { ApprovalSummary } from "@/hooks/useApprovals";
-import { useAgents } from "@/hooks/useAgents";
 import { useStandingApprovals } from "@/hooks/useStandingApprovals";
+import { useCreateStandingApproval } from "@/hooks/useCreateStandingApproval";
+import { useActionConfigs } from "@/hooks/useActionConfigs";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
 import { ActionPreviewCard } from "@/components/previews/ActionPreviewCard";
 import {
@@ -28,7 +31,6 @@ import {
 } from "@/components/previews/EmailThreadPreview";
 import { SlackContextPreview } from "@/components/previews/SlackContextPreview";
 import type { components } from "@/api/schema";
-import { CreateStandingApprovalDialog } from "./CreateStandingApprovalDialog";
 import {
   useCountdown,
   formatCountdown,
@@ -36,6 +38,7 @@ import {
   RiskBadge,
 } from "./approval-components";
 import { formatConnectorDisplayName } from "./approvalConnectorLabel";
+import { buildCreateStandingApprovalFromApproval } from "./standingApprovalFromApproval";
 
 /** Auto-close delay (ms) after a successful approval. */
 const SUCCESS_AUTO_CLOSE_MS = 3_000;
@@ -101,20 +104,6 @@ function ExecutionStatusBanner({ result }: { result: ApproveResult }) {
   );
 }
 
-/**
- * Derive initial constraints from an approval's action parameters.
- * Each parameter becomes a "fixed" constraint by default.
- */
-function deriveConstraintsFromParams(
-  parameters: Record<string, unknown>,
-): Record<string, unknown> {
-  const constraints: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(parameters)) {
-    constraints[key] = value ?? "";
-  }
-  return constraints;
-}
-
 export function ReviewApprovalDialog({
   approval,
   agentDisplayName,
@@ -122,14 +111,14 @@ export function ReviewApprovalDialog({
   onOpenChange,
 }: ReviewApprovalDialogProps) {
   const [approveResult, setApproveResult] = useState<ApproveResult | null>(null);
-  const [standingDialogOpen, setStandingDialogOpen] = useState(false);
   const [standingApprovalCreated, setStandingApprovalCreated] = useState(false);
-  const [autoCloseBlocked, setAutoCloseBlocked] = useState(false);
-  const [pendingAction, setPendingAction] = useState<"approve" | "alwaysAllow" | null>(null);
+  const [autoApproveFuture, setAutoApproveFuture] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"approve" | null>(null);
   const [paramsOpen, setParamsOpen] = useState(false);
   const isApproved = approveResult !== null;
   const { approveApproval } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
+  const { createStandingApproval } = useCreateStandingApproval();
   const { schema, actionName, displayTemplate, preview, connectorName, connectorLogoSvg, isLoading: schemaLoading } =
     useActionSchema(approval.action.type);
   const connectorInstanceDisplayStr =
@@ -150,9 +139,8 @@ export function ReviewApprovalDialog({
   const isExpired = remaining <= 0;
   const isBusy = pendingAction !== null || isDenying;
 
-  // Data for "Always Allow This"
-  const { agents } = useAgents();
   const { standingApprovals, isLoading: standingApprovalsLoading } = useStandingApprovals();
+  const { configs, isFetched: configsFetched } = useActionConfigs(approval.agent_id);
   const params = approval.action.parameters as Record<string, unknown>;
   const hasParams = Object.keys(params).length > 0;
   const hasExistingStandingApproval = useMemo(
@@ -164,7 +152,15 @@ export function ReviewApprovalDialog({
       ),
     [standingApprovals, approval.agent_id, approval.action.type],
   );
-  const showAlwaysAllow = hasParams && !standingApprovalsLoading && !hasExistingStandingApproval;
+  const matchingActionConfig = useMemo(
+    () =>
+      configs.find(
+        (c) => c.status === "active" && c.action_type === approval.action.type,
+      ) ?? null,
+    [configs, approval.action.type],
+  );
+  const showAutoApproveCheckbox =
+    !standingApprovalsLoading && !hasExistingStandingApproval;
 
   const emailThread = useMemo(
     () => parseEmailThreadFromDetails(approval.context.details),
@@ -179,26 +175,54 @@ export function ReviewApprovalDialog({
     [approval.context.details],
   );
 
-  // Auto-close dialog after successful approval (never while the nested standing-approval
-  // wizard is open — a render with isApproved true before autoCloseBlocked flips true
-  // would otherwise start the timer and unmount the child dialog).
   useEffect(() => {
-    if (!isApproved || autoCloseBlocked || standingDialogOpen) return;
+    if (!isApproved) return;
     const timer = setTimeout(() => onOpenChange(false), SUCCESS_AUTO_CLOSE_MS);
     return () => clearTimeout(timer);
-  }, [isApproved, autoCloseBlocked, standingDialogOpen, onOpenChange]);
+  }, [isApproved, onOpenChange]);
 
   const handleApprove = useCallback(async () => {
     setPendingAction("approve");
     try {
       const result = await approveApproval(approval.approval_id);
       setApproveResult(result);
+
+      if (autoApproveFuture && result.execution_status !== "error") {
+        if (!configsFetched || !matchingActionConfig) {
+          toast.error(
+            "Request approved, but no action configuration was found to enable auto-approval.",
+          );
+        } else {
+          try {
+            await createStandingApproval(
+              buildCreateStandingApprovalFromApproval(
+                approval,
+                matchingActionConfig.id,
+              ),
+            );
+            setStandingApprovalCreated(true);
+          } catch (err) {
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : "Request approved, but failed to create auto-approval rule.",
+            );
+          }
+        }
+      }
     } catch {
       toast.error("Failed to approve request. Please try again.");
     } finally {
       setPendingAction(null);
     }
-  }, [approveApproval, approval.approval_id]);
+  }, [
+    approveApproval,
+    approval,
+    autoApproveFuture,
+    configsFetched,
+    matchingActionConfig,
+    createStandingApproval,
+  ]);
 
   const handleDeny = useCallback(async () => {
     try {
@@ -210,40 +234,11 @@ export function ReviewApprovalDialog({
     }
   }, [denyApproval, approval.approval_id, onOpenChange]);
 
-  const handleAlwaysAllow = useCallback(async () => {
-    setPendingAction("alwaysAllow");
-    setAutoCloseBlocked(true);
-    try {
-      const result = await approveApproval(approval.approval_id);
-      setApproveResult(result);
-      if (result.execution_status === "error") {
-        setAutoCloseBlocked(false);
-      } else {
-        setStandingDialogOpen(true);
-      }
-    } catch {
-      setAutoCloseBlocked(false);
-      toast.error("Failed to approve request. Please try again.");
-    } finally {
-      setPendingAction(null);
-    }
-  }, [approveApproval, approval.approval_id]);
-
-  function handleStandingDialogChange(nextOpen: boolean) {
-    setStandingDialogOpen(nextOpen);
-    // Unblock parent auto-close whenever the nested wizard closes (cancel or success).
-    // Do not gate on standingApprovalCreated — that state updates after this handler runs,
-    // so a closure check would always see the pre-create value.
-    if (!nextOpen) {
-      setAutoCloseBlocked(false);
-    }
-  }
-
   function handleClose(nextOpen: boolean) {
     if (!nextOpen) {
       setApproveResult(null);
       setStandingApprovalCreated(false);
-      setAutoCloseBlocked(false);
+      setAutoApproveFuture(false);
       setPendingAction(null);
     }
     onOpenChange(nextOpen);
@@ -294,9 +289,9 @@ export function ReviewApprovalDialog({
             <ExecutionStatusBanner result={approveResult} />
             {standingApprovalCreated && (
               <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-950/30">
-                <ShieldCheck className="size-4 shrink-0 text-green-600 dark:text-green-400" aria-hidden="true" />
+                <CheckCircle className="size-4 shrink-0 text-green-600 dark:text-green-400" aria-hidden="true" />
                 <p className="text-sm text-green-800 dark:text-green-300">
-                  Standing approval created. Future matching requests will be auto-approved.
+                  Future matching requests will be auto-approved.
                 </p>
               </div>
             )}
@@ -448,6 +443,27 @@ export function ReviewApprovalDialog({
 
             {/* Action buttons — stacked full-width matching mockup */}
             <div className="space-y-2 pt-2">
+              {showAutoApproveCheckbox && (
+                <div className="flex items-start gap-3 rounded-lg border p-3">
+                  <Checkbox
+                    id="auto-approve-future"
+                    checked={autoApproveFuture}
+                    onCheckedChange={(checked) =>
+                      setAutoApproveFuture(checked === true)
+                    }
+                    disabled={isBusy || isExpired}
+                    aria-describedby="auto-approve-future-label"
+                  />
+                  <Label
+                    id="auto-approve-future-label"
+                    htmlFor="auto-approve-future"
+                    className="cursor-pointer text-sm font-normal leading-snug"
+                  >
+                    Auto-approve all future requests like this
+                  </Label>
+                </div>
+              )}
+
               <Button
                 size="lg"
                 className="w-full bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700"
@@ -479,42 +495,10 @@ export function ReviewApprovalDialog({
                   "Deny"
                 )}
               </Button>
-
-              {showAlwaysAllow && (
-                <button
-                  className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors disabled:opacity-50"
-                  disabled={isBusy || isExpired}
-                  onClick={handleAlwaysAllow}
-                  aria-label={pendingAction === "alwaysAllow" ? "Approving and creating rule…" : undefined}
-                  type="button"
-                >
-                  {pendingAction === "alwaysAllow" ? (
-                    <Loader2 className="size-3 animate-spin" />
-                  ) : (
-                    <>
-                      <ShieldCheck className="size-3" />
-                      Always allow this action
-                    </>
-                  )}
-                </button>
-              )}
             </div>
           </div>
         )}
       </DialogContent>
-
-      {/* Standing approval creation dialog — only mounted when needed */}
-      {standingDialogOpen && (
-        <CreateStandingApprovalDialog
-          agents={agents}
-          open={standingDialogOpen}
-          onOpenChange={handleStandingDialogChange}
-          onCreated={() => setStandingApprovalCreated(true)}
-          initialAgentId={approval.agent_id}
-          initialActionType={approval.action.type}
-          initialConstraints={deriveConstraintsFromParams(params)}
-        />
-      )}
     </Dialog>
   );
 }

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -42,8 +42,19 @@ const mockAgents = [
   },
 ];
 
+const mockActionConfig = {
+  id: "ac_config1",
+  agent_id: 1,
+  connector_id: "email",
+  action_type: "email.send",
+  status: "active" as const,
+  name: "Send email",
+  parameters: {},
+};
+
 function setupMocks({
   standingApprovals = [] as Array<{ agent_id: number; action_type: string }>,
+  actionConfigs = [mockActionConfig],
 } = {}) {
   setupAuthMocks({ authenticated: true });
   mockGet.mockImplementation((url: string) => {
@@ -54,9 +65,8 @@ function setupMocks({
       return Promise.resolve({ data: { data: standingApprovals } });
     }
     if (url === "/v1/action-configurations") {
-      return Promise.resolve({ data: { data: [] } });
+      return Promise.resolve({ data: { data: actionConfigs } });
     }
-    // Connector/schema lookups
     if (url.startsWith("/v1/connectors/")) {
       return Promise.resolve({ data: { id: "email", name: "Email", actions: [] } });
     }
@@ -64,7 +74,20 @@ function setupMocks({
   });
 }
 
-describe("ReviewApprovalDialog — Always Allow This", () => {
+function mockApproveSuccess() {
+  mockPost.mockResolvedValueOnce({
+    data: {
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      confirmation_code: "ABC12-3DEFG",
+      execution_status: "success",
+      execution_result: null,
+    },
+  });
+}
+
+describe("ReviewApprovalDialog — auto-approve future requests", () => {
   let wrapper: ReturnType<typeof createAuthWrapper>;
 
   beforeEach(() => {
@@ -73,13 +96,11 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     wrapper = createAuthWrapper();
   });
 
-  it("shows 'Always Allow' button on the approval screen when action has parameters", async () => {
+  it("shows checkbox when no matching standing approval exists", async () => {
     setupMocks();
-    const approval = makeApproval();
-
     render(
       <ReviewApprovalDialog
-        approval={approval}
+        approval={makeApproval()}
         agentDisplayName="Test Bot"
         open={true}
         onOpenChange={vi.fn()}
@@ -87,18 +108,25 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    // "Always Allow" button should be visible alongside Approve/Deny
     await waitFor(() => {
-      expect(screen.getByText("Always allow this action")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Auto-approve all future requests like this"),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText("Approve")).toBeInTheDocument();
-    expect(screen.getByText("Deny")).toBeInTheDocument();
   });
 
-  it("does NOT show 'Always Allow' when action has no parameters", () => {
-    setupMocks();
+  it("shows checkbox for parameterless actions", async () => {
+    setupMocks({
+      actionConfigs: [
+        {
+          ...mockActionConfig,
+          id: "ac_list",
+          action_type: "google.list_calendars",
+        },
+      ],
+    });
     const approval = makeApproval({
-      action: { type: "system.noop", version: "1", parameters: {} },
+      action: { type: "google.list_calendars", version: "1", parameters: {} },
     });
 
     render(
@@ -111,20 +139,22 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Auto-approve all future requests like this"),
+      ).toBeInTheDocument();
+    });
     expect(screen.queryByText("Always allow this action")).not.toBeInTheDocument();
   });
 
-  it("does NOT show 'Always Allow' when a standing approval already exists for agent+action", async () => {
+  it("hides checkbox when a standing approval already exists for agent+action", async () => {
     setupMocks({
-      standingApprovals: [
-        { agent_id: 1, action_type: "email.send" },
-      ],
+      standingApprovals: [{ agent_id: 1, action_type: "email.send" }],
     });
-    const approval = makeApproval();
 
     render(
       <ReviewApprovalDialog
-        approval={approval}
+        approval={makeApproval()}
         agentDisplayName="Test Bot"
         open={true}
         onOpenChange={vi.fn()}
@@ -132,130 +162,31 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
       { wrapper },
     );
 
-    // Wait for standing approvals to load, then verify button is absent
     await waitFor(() => {
-      // Standing approvals have loaded (no loading state)
       expect(screen.getByText("Approve")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Always allow this action")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Auto-approve all future requests like this"),
+    ).not.toBeInTheDocument();
   });
 
-  it("approves request and opens CreateStandingApprovalDialog when 'Always Allow' is clicked", async () => {
+  it("ticking checkbox + Approve calls approve then createStandingApproval with pinned params", async () => {
     setupMocks();
-    const approval = makeApproval();
-
+    mockApproveSuccess();
     mockPost.mockResolvedValueOnce({
       data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC12-3DEFG",
-        execution_status: "success",
-        execution_result: null,
+        standing_approval_id: "sa_new",
+        agent_id: 1,
+        action_type: "email.send",
+        status: "active",
       },
     });
 
     const user = userEvent.setup();
     render(
       <ReviewApprovalDialog
-        approval={approval}
-        agentDisplayName="Test Bot"
-        open={true}
-        onOpenChange={vi.fn()}
-      />,
-      { wrapper },
-    );
-
-    await settleAuthHydration();
-
-    // Click "Always Allow" from the pre-approval screen
-    await waitFor(() => {
-      expect(screen.getByText("Always allow this action")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("Always allow this action"));
-
-    // The CreateStandingApprovalDialog should open (skipping to constraints step)
-    await waitFor(() => {
-      expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
-    });
-
-    // Should show step 1 of 2 (constraints), not step 1 of 4
-    expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
-  });
-
-  it(
-    "does NOT call onOpenChange(false) while the standing-approval wizard is open",
-    async () => {
-      setupMocks();
-      const approval = makeApproval();
-      const onOpenChange = vi.fn();
-
-      mockPost.mockResolvedValueOnce({
-        data: {
-          approval_id: approval.approval_id,
-          status: "approved",
-          approved_at: new Date().toISOString(),
-          confirmation_code: "ABC12-3DEFG",
-          execution_status: "success",
-          execution_result: null,
-        },
-      });
-
-      const user = userEvent.setup();
-
-      render(
-        <ReviewApprovalDialog
-          approval={approval}
-          agentDisplayName="Test Bot"
-          open={true}
-          onOpenChange={onOpenChange}
-        />,
-        { wrapper },
-      );
-
-      await settleAuthHydration();
-
-      await waitFor(() => {
-        expect(screen.getByText("Always allow this action")).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByText("Always allow this action"));
-
-      await waitFor(() => {
-        expect(screen.getByText(/Step 1 of 2/)).toBeInTheDocument();
-      });
-
-      // Parent auto-close is SUCCESS_AUTO_CLOSE_MS (3000); if a regression schedules it
-      // while the wizard is open, this would fire too early. Real timers avoid RTL waitFor
-      // hanging under vi.useFakeTimers().
-      await new Promise((r) => setTimeout(r, 3_100));
-
-      expect(onOpenChange).not.toHaveBeenCalledWith(false);
-    },
-    10_000,
-  );
-
-  it("does NOT open standing approval wizard when execution fails after 'Always Allow'", async () => {
-    setupMocks();
-    const approval = makeApproval();
-
-    mockPost.mockResolvedValueOnce({
-      data: {
-        approval_id: approval.approval_id,
-        status: "approved",
-        approved_at: new Date().toISOString(),
-        confirmation_code: "ABC12-3DEFG",
-        execution_status: "error",
-        execution_result: { execution_error: "Connection failed" },
-      },
-    });
-
-    const user = userEvent.setup();
-    render(
-      <ReviewApprovalDialog
-        approval={approval}
+        approval={makeApproval()}
         agentDisplayName="Test Bot"
         open={true}
         onOpenChange={vi.fn()}
@@ -266,16 +197,77 @@ describe("ReviewApprovalDialog — Always Allow This", () => {
     await settleAuthHydration();
 
     await waitFor(() => {
-      expect(screen.getByText("Always allow this action")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Auto-approve all future requests like this"),
+      ).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Always allow this action"));
+    await user.click(
+      screen.getByLabelText("Auto-approve all future requests like this"),
+    );
+    await user.click(screen.getByText("Approve"));
 
-    // Should show execution failure, NOT the standing approval wizard
     await waitFor(() => {
-      expect(screen.getByText("Execution Failed")).toBeInTheDocument();
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText(/Step 1 of 2/)).not.toBeInTheDocument();
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    const createCall = mockPost.mock.calls.find(
+      (call) => call[0] === "/v1/standing-approvals/create",
+    );
+    expect(createCall).toBeDefined();
+    expect(createCall?.[1]?.body).toMatchObject({
+      agent_id: 1,
+      action_type: "email.send",
+      action_version: "1",
+      constraints: {
+        recipient: "user@example.com",
+        subject: "Hello",
+      },
+      source_action_configuration_id: "ac_config1",
+      expires_at: null,
+    });
+
+    expect(
+      screen.getByText("Future matching requests will be auto-approved."),
+    ).toBeInTheDocument();
+  });
+
+  it("standing approval failure does not block approve from succeeding", async () => {
+    setupMocks();
+    mockApproveSuccess();
+    mockPost.mockRejectedValueOnce(new Error("Standing approval failed"));
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={makeApproval()}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await settleAuthHydration();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Auto-approve all future requests like this"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByLabelText("Auto-approve all future requests like this"),
+    );
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Future matching requests will be auto-approved."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/dashboard/standingApprovalFromApproval.ts
+++ b/frontend/src/pages/dashboard/standingApprovalFromApproval.ts
@@ -1,0 +1,50 @@
+import type { components } from "@/api/schema";
+import type { ApprovalSummary } from "@/hooks/useApprovals";
+
+type CreateStandingApprovalRequest =
+  components["schemas"]["CreateStandingApprovalRequest"];
+
+/**
+ * Derive initial constraints from an approval's action parameters.
+ * Each parameter becomes a fixed constraint pinned to its exact value.
+ */
+export function deriveConstraintsFromParams(
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const constraints: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(parameters)) {
+    constraints[key] = value ?? "";
+  }
+  return constraints;
+}
+
+/** With source_action_configuration_id, `{}` means match-all (backend stores NULL constraints). */
+export function standingApprovalConstraintsForCreate(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const entries = Object.entries(params);
+  if (entries.length === 0) {
+    return {};
+  }
+  return deriveConstraintsFromParams(params);
+}
+
+export function buildCreateStandingApprovalFromApproval(
+  approval: ApprovalSummary,
+  sourceActionConfigurationId: string,
+): CreateStandingApprovalRequest {
+  const params = approval.action.parameters as Record<string, unknown>;
+  const version =
+    typeof approval.action.version === "string" && approval.action.version !== ""
+      ? approval.action.version
+      : "1";
+
+  return {
+    agent_id: approval.agent_id,
+    action_type: approval.action.type,
+    action_version: version,
+    constraints: standingApprovalConstraintsForCreate(params),
+    source_action_configuration_id: sourceActionConfigurationId,
+    expires_at: null,
+  };
+}

--- a/mobile/src/hooks/useActionConfigs.ts
+++ b/mobile/src/hooks/useActionConfigs.ts
@@ -1,0 +1,43 @@
+/**
+ * React Query hook for listing action configurations for an agent.
+ */
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import type { components } from "../api/schema";
+
+export type ActionConfiguration = components["schemas"]["ActionConfiguration"];
+
+export function useActionConfigs(agentId: number) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+
+  const tokenRef = useRef(accessToken);
+  tokenRef.current = accessToken;
+
+  const query = useQuery({
+    queryKey: ["action-configs", agentId],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Not authenticated");
+      const { data, error } = await client.GET("/v1/action-configurations", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { query: { agent_id: agentId } },
+      });
+      if (error) throw new Error("Failed to load action configurations");
+      return data;
+    },
+    enabled: !!accessToken && agentId > 0,
+  });
+
+  return {
+    configs: query.data?.data ?? [],
+    isLoading: query.isLoading,
+    isFetched: query.isFetched,
+    error: query.isError
+      ? "Unable to load action configurations. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/mobile/src/hooks/useCreateStandingApproval.ts
+++ b/mobile/src/hooks/useCreateStandingApproval.ts
@@ -1,0 +1,48 @@
+/**
+ * React Query mutation hook for creating a standing approval.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+
+type CreateStandingApprovalRequest =
+  components["schemas"]["CreateStandingApprovalRequest"];
+
+export function useCreateStandingApproval() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (req: CreateStandingApprovalRequest) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST(
+        "/v1/standing-approvals/create",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          body: req,
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to create standing approval"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
+      queryClient.invalidateQueries({ queryKey: ["action-configs"] });
+    },
+  });
+
+  return {
+    createStandingApproval: (req: CreateStandingApprovalRequest) =>
+      mutation.mutateAsync(req),
+    isPending: mutation.isPending,
+  };
+}

--- a/mobile/src/hooks/useStandingApprovals.ts
+++ b/mobile/src/hooks/useStandingApprovals.ts
@@ -1,0 +1,43 @@
+/**
+ * React Query hook for listing active standing approvals for the current user.
+ */
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import type { components } from "../api/schema";
+
+export type StandingApproval = components["schemas"]["StandingApproval"];
+
+export function useStandingApprovals() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  tokenRef.current = accessToken;
+
+  const query = useQuery({
+    queryKey: ["standing-approvals", userId ?? ""],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Not authenticated");
+      const { data, error } = await client.GET("/v1/standing-approvals", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { query: { status: "active" } },
+      });
+      if (error) throw new Error("Failed to load standing approvals");
+      return data;
+    },
+    enabled: !!accessToken,
+  });
+
+  return {
+    standingApprovals: query.data?.data ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load standing approvals. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/mobile/src/screens/approvals/ApprovalActions.tsx
+++ b/mobile/src/screens/approvals/ApprovalActions.tsx
@@ -6,7 +6,14 @@
  * notification for deny.
  */
 import { useCallback } from "react";
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import * as Haptics from "expo-haptics";
 import { colors } from "../../theme/colors";
 
@@ -16,6 +23,10 @@ interface ApprovalActionsProps {
   isApproving: boolean;
   isDenying: boolean;
   disabled: boolean;
+  /** When false, the auto-approve checkbox row is hidden. */
+  showAutoApproveCheckbox?: boolean;
+  autoApproveFuture?: boolean;
+  onAutoApproveFutureChange?: (value: boolean) => void;
 }
 
 export function ApprovalActions({
@@ -24,6 +35,9 @@ export function ApprovalActions({
   isApproving,
   isDenying,
   disabled,
+  showAutoApproveCheckbox = false,
+  autoApproveFuture = false,
+  onAutoApproveFutureChange,
 }: ApprovalActionsProps) {
   const isBusy = isApproving || isDenying;
 
@@ -37,8 +51,43 @@ export function ApprovalActions({
     onDeny();
   }, [onDeny]);
 
+  const handleToggleAutoApprove = useCallback(() => {
+    onAutoApproveFutureChange?.(!autoApproveFuture);
+  }, [autoApproveFuture, onAutoApproveFutureChange]);
+
   return (
-    <View style={styles.container}>
+    <View style={styles.wrapper}>
+      {showAutoApproveCheckbox && (
+        <Pressable
+          style={styles.checkboxRow}
+          onPress={handleToggleAutoApprove}
+          disabled={disabled || isBusy}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: autoApproveFuture, disabled: disabled || isBusy }}
+          accessibilityLabel="Auto-approve all future requests like this"
+          testID="auto-approve-checkbox"
+        >
+          <View
+            style={[
+              styles.checkboxBox,
+              autoApproveFuture && styles.checkboxBoxChecked,
+              (disabled || isBusy) && styles.checkboxBoxDisabled,
+            ]}
+          >
+            {autoApproveFuture && <Text style={styles.checkboxMark}>✓</Text>}
+          </View>
+          <Text
+            style={[
+              styles.checkboxLabel,
+              (disabled || isBusy) && styles.checkboxLabelDisabled,
+            ]}
+          >
+            Auto-approve all future requests like this
+          </Text>
+        </Pressable>
+      )}
+
+      <View style={styles.container}>
       <TouchableOpacity
         style={[styles.denyButton, (disabled || isBusy) && styles.buttonDisabled]}
         onPress={handleDeny}
@@ -72,16 +121,59 @@ export function ApprovalActions({
           </Text>
         )}
       </TouchableOpacity>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  wrapper: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    gap: 12,
+  },
+  checkboxRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingVertical: 4,
+  },
+  checkboxBox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 2,
+    borderColor: colors.gray400,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 1,
+  },
+  checkboxBoxChecked: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primary,
+  },
+  checkboxBoxDisabled: {
+    opacity: 0.5,
+  },
+  checkboxMark: {
+    color: colors.white,
+    fontSize: 14,
+    fontWeight: "700",
+    lineHeight: 16,
+  },
+  checkboxLabel: {
+    flex: 1,
+    fontSize: 14,
+    color: colors.gray900,
+    lineHeight: 20,
+  },
+  checkboxLabelDisabled: {
+    color: colors.gray400,
+  },
   container: {
     flexDirection: "row",
     gap: 12,
-    paddingHorizontal: 20,
-    paddingVertical: 16,
+    paddingBottom: 16,
   },
   denyButton: {
     flex: 1,

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -24,6 +24,10 @@ import {
 } from "../../hooks/useAgents";
 import { useApproveApproval } from "../../hooks/useApproveApproval";
 import { useDenyApproval } from "../../hooks/useDenyApproval";
+import { useStandingApprovals } from "../../hooks/useStandingApprovals";
+import { useCreateStandingApproval } from "../../hooks/useCreateStandingApproval";
+import { useActionConfigs } from "../../hooks/useActionConfigs";
+import { buildCreateStandingApprovalFromApproval } from "./standingApprovalFromApproval";
 import { colors } from "../../theme/colors";
 import {
   humanizeActionType,
@@ -58,6 +62,8 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const [isApproved, setIsApproved] = useState(false);
   const [isDenied, setIsDenied] = useState(false);
   const [resolvedAt, setResolvedAt] = useState<string | null>(null);
+  const [autoApproveFuture, setAutoApproveFuture] = useState(false);
+  const [standingApprovalCreated, setStandingApprovalCreated] = useState(false);
 
   const {
     approveApproval,
@@ -67,6 +73,12 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
     denyApproval,
     isPending: isDenying,
   } = useDenyApproval();
+  const { standingApprovals, isLoading: standingApprovalsLoading } =
+    useStandingApprovals();
+  const { createStandingApproval } = useCreateStandingApproval();
+  const { configs, isFetched: configsFetched } = useActionConfigs(
+    approval.agent_id,
+  );
 
   const agent = useMemo(
     () => agents.find((a: AgentSummary) => a.agent_id === approval.agent_id),
@@ -104,6 +116,25 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const isPending = approval.status === "pending" && !isApproved && !isDenied;
   const expired = checkExpired(approval.status, approval.expires_at);
   const canAct = isPending && !expired;
+
+  const hasExistingStandingApproval = useMemo(
+    () =>
+      standingApprovals.some(
+        (sa) =>
+          sa.agent_id === approval.agent_id &&
+          sa.action_type === approval.action.type,
+      ),
+    [standingApprovals, approval.agent_id, approval.action.type],
+  );
+  const matchingActionConfig = useMemo(
+    () =>
+      configs.find(
+        (c) => c.status === "active" && c.action_type === approval.action.type,
+      ) ?? null,
+    [configs, approval.action.type],
+  );
+  const showAutoApproveCheckbox =
+    !standingApprovalsLoading && !hasExistingStandingApproval;
 
   const summary = buildActionSummary(approval.action.type, parameters, undefined, approval.resource_details as Record<string, unknown> | undefined);
   const actionName = humanizeActionType(approval.action.type);
@@ -161,13 +192,45 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
       setResolvedAt(new Date().toISOString());
       setIsApproved(true);
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+
+      if (autoApproveFuture) {
+        if (!configsFetched || !matchingActionConfig) {
+          Alert.alert(
+            "Auto-approval not set up",
+            "Request approved, but no action configuration was found to enable auto-approval.",
+          );
+        } else {
+          try {
+            await createStandingApproval(
+              buildCreateStandingApprovalFromApproval(
+                approval,
+                matchingActionConfig.id,
+              ),
+            );
+            setStandingApprovalCreated(true);
+          } catch (err) {
+            const message =
+              err instanceof Error
+                ? err.message
+                : "Failed to create auto-approval rule.";
+            Alert.alert("Auto-approval failed", message);
+          }
+        }
+      }
     } catch (err) {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
       const message =
         err instanceof Error ? err.message : "Failed to approve request";
       Alert.alert("Approval Failed", message);
     }
-  }, [approveApproval, approval.approval_id]);
+  }, [
+    approveApproval,
+    approval,
+    autoApproveFuture,
+    configsFetched,
+    matchingActionConfig,
+    createStandingApproval,
+  ]);
 
   const handleDeny = useCallback(() => {
     Alert.alert(
@@ -213,6 +276,17 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
               <StatusPill status="approved" />
               <Text style={styles.confirmationText}>Request Approved</Text>
             </View>
+            {standingApprovalCreated && (
+              <View
+                style={styles.standingApprovalBanner}
+                accessibilityRole="text"
+                testID="standing-approval-success"
+              >
+                <Text style={styles.standingApprovalBannerText}>
+                  Future matching requests will be auto-approved.
+                </Text>
+              </View>
+            )}
             <TouchableOpacity
               style={styles.doneButton}
               onPress={handleDone}
@@ -357,6 +431,9 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
             isApproving={isApproving}
             isDenying={isDenying}
             disabled={expired}
+            showAutoApproveCheckbox={showAutoApproveCheckbox}
+            autoApproveFuture={autoApproveFuture}
+            onAutoApproveFutureChange={setAutoApproveFuture}
           />
         </View>
       )}
@@ -401,6 +478,19 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "700",
     color: colors.gray900,
+  },
+  standingApprovalBanner: {
+    marginTop: 12,
+    backgroundColor: "#ECFDF5",
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: "#A7F3D0",
+  },
+  standingApprovalBannerText: {
+    fontSize: 14,
+    color: "#047857",
+    fontWeight: "500",
   },
   // --- Sections ---
   sectionMajor: {

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -24,9 +24,15 @@ import {
 } from "../../hooks/useAgents";
 import { useApproveApproval } from "../../hooks/useApproveApproval";
 import { useDenyApproval } from "../../hooks/useDenyApproval";
-import { useStandingApprovals } from "../../hooks/useStandingApprovals";
+import {
+  useStandingApprovals,
+  type StandingApproval,
+} from "../../hooks/useStandingApprovals";
 import { useCreateStandingApproval } from "../../hooks/useCreateStandingApproval";
-import { useActionConfigs } from "../../hooks/useActionConfigs";
+import {
+  useActionConfigs,
+  type ActionConfiguration,
+} from "../../hooks/useActionConfigs";
 import { buildCreateStandingApprovalFromApproval } from "./standingApprovalFromApproval";
 import { colors } from "../../theme/colors";
 import {
@@ -120,7 +126,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const hasExistingStandingApproval = useMemo(
     () =>
       standingApprovals.some(
-        (sa) =>
+        (sa: StandingApproval) =>
           sa.agent_id === approval.agent_id &&
           sa.action_type === approval.action.type,
       ),
@@ -129,7 +135,8 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const matchingActionConfig = useMemo(
     () =>
       configs.find(
-        (c) => c.status === "active" && c.action_type === approval.action.type,
+        (c: ActionConfiguration) =>
+          c.status === "active" && c.action_type === approval.action.type,
       ) ?? null,
     [configs, approval.action.type],
   );

--- a/mobile/src/screens/approvals/__tests__/ApprovalActions.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalActions.test.tsx
@@ -1,0 +1,63 @@
+import React, { createElement } from "react";
+import { create, act, type ReactTestRenderer } from "react-test-renderer";
+import { ApprovalActions } from "../ApprovalActions";
+
+function renderActions(
+  overrides: Partial<React.ComponentProps<typeof ApprovalActions>> = {},
+) {
+  const props = {
+    onApprove: jest.fn(),
+    onDeny: jest.fn(),
+    isApproving: false,
+    isDenying: false,
+    disabled: false,
+    ...overrides,
+  };
+  return create(createElement(ApprovalActions, props));
+}
+
+function hasTestId(renderer: ReactTestRenderer, testID: string) {
+  return renderer.root.findAll((node) => node.props.testID === testID).length > 0;
+}
+
+describe("ApprovalActions — auto-approve checkbox", () => {
+  let renderer: ReactTestRenderer;
+
+  afterEach(async () => {
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
+  it("shows checkbox when showAutoApproveCheckbox is true", async () => {
+    await act(async () => {
+      renderer = renderActions({ showAutoApproveCheckbox: true });
+    });
+    expect(hasTestId(renderer, "auto-approve-checkbox")).toBe(true);
+  });
+
+  it("hides checkbox when showAutoApproveCheckbox is false", async () => {
+    await act(async () => {
+      renderer = renderActions({ showAutoApproveCheckbox: false });
+    });
+    expect(hasTestId(renderer, "auto-approve-checkbox")).toBe(false);
+  });
+
+  it("calls onAutoApproveFutureChange when checkbox is pressed", async () => {
+    const onAutoApproveFutureChange = jest.fn();
+    await act(async () => {
+      renderer = renderActions({
+        showAutoApproveCheckbox: true,
+        autoApproveFuture: false,
+        onAutoApproveFutureChange,
+      });
+    });
+
+    const checkbox = renderer.root.findByProps({ testID: "auto-approve-checkbox" });
+    await act(async () => {
+      checkbox.props.onPress();
+    });
+
+    expect(onAutoApproveFutureChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
@@ -8,6 +8,7 @@ import { makeApproval, MOCK_AGENTS, mockGetAgentDisplayName } from "../testFixtu
 
 const mockApproveApproval = jest.fn();
 const mockDenyApproval = jest.fn();
+const mockCreateStandingApproval = jest.fn();
 
 jest.mock("../../../hooks/useApproveApproval", () => ({
   useApproveApproval: () => ({
@@ -24,6 +25,38 @@ jest.mock("../../../hooks/useDenyApproval", () => ({
     isPending: false,
     error: null,
     reset: jest.fn(),
+  }),
+}));
+
+jest.mock("../../../hooks/useStandingApprovals", () => ({
+  useStandingApprovals: () => ({
+    standingApprovals: [],
+    isLoading: false,
+  }),
+}));
+
+jest.mock("../../../hooks/useCreateStandingApproval", () => ({
+  useCreateStandingApproval: () => ({
+    createStandingApproval: mockCreateStandingApproval,
+    isPending: false,
+  }),
+}));
+
+jest.mock("../../../hooks/useActionConfigs", () => ({
+  useActionConfigs: () => ({
+    configs: [
+      {
+        id: "ac_config1",
+        agent_id: 42,
+        connector_id: "email",
+        action_type: "email.send",
+        status: "active",
+        name: "Send",
+        parameters: {},
+      },
+    ],
+    isLoading: false,
+    isFetched: true,
   }),
 }));
 
@@ -459,6 +492,54 @@ describe("ApprovalDetailScreen", () => {
     });
 
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it("shows auto-approve checkbox for pending approvals", async () => {
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+    expect(hasTestId(renderer, "auto-approve-checkbox")).toBe(true);
+  });
+
+  it("creates standing approval when checkbox is ticked and approve succeeds", async () => {
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+    });
+    mockCreateStandingApproval.mockResolvedValueOnce({
+      standing_approval_id: "sa_new",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const checkbox = findFirstByTestId(renderer, "auto-approve-checkbox");
+    await act(async () => {
+      checkbox?.props.onPress();
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockCreateStandingApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_id: 42,
+        action_type: "email.send",
+        source_action_configuration_id: "ac_config1",
+        expires_at: null,
+      }),
+    );
+    expect(hasTestId(renderer, "standing-approval-success")).toBe(true);
   });
 
   it("hides action buttons after successful approval", async () => {

--- a/mobile/src/screens/approvals/standingApprovalFromApproval.ts
+++ b/mobile/src/screens/approvals/standingApprovalFromApproval.ts
@@ -1,0 +1,45 @@
+import type { components } from "../../api/schema";
+import type { ApprovalSummary } from "../../hooks/useApprovals";
+
+type CreateStandingApprovalRequest =
+  components["schemas"]["CreateStandingApprovalRequest"];
+
+function deriveConstraintsFromParams(
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const constraints: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(parameters)) {
+    constraints[key] = value ?? "";
+  }
+  return constraints;
+}
+
+/** With source_action_configuration_id, `{}` means match-all (backend stores NULL constraints). */
+function standingApprovalConstraintsForCreate(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  if (Object.keys(params).length === 0) {
+    return {};
+  }
+  return deriveConstraintsFromParams(params);
+}
+
+export function buildCreateStandingApprovalFromApproval(
+  approval: ApprovalSummary,
+  sourceActionConfigurationId: string,
+): CreateStandingApprovalRequest {
+  const params = approval.action.parameters as Record<string, unknown>;
+  const version =
+    typeof approval.action.version === "string" && approval.action.version !== ""
+      ? approval.action.version
+      : "1";
+
+  return {
+    agent_id: approval.agent_id,
+    action_type: approval.action.type,
+    action_version: version,
+    constraints: standingApprovalConstraintsForCreate(params),
+    source_action_configuration_id: sourceActionConfigurationId,
+    expires_at: null,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add an **"Auto-approve all future requests like this"** checkbox to the web approval dialog and mobile approval screen, shown whenever no standing approval already exists for the same agent + action type (including parameterless actions).
- On Approve with the checkbox ticked, create a standing approval with pinned parameter constraints (or `{}` for parameterless actions), `expires_at: null`, and the matching action configuration; approval still succeeds if standing-approval creation fails.
- Remove the web **Always allow this action** wizard entry point from `ReviewApprovalDialog`; `CreateStandingApprovalDialog` remains for editing rules elsewhere.

Closes #1261

## Test plan

### Claude Code
- [x] `npx vitest run frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx`
- [x] `npm test -- --ci` for mobile approval tests (`ApprovalActions`, `ApprovalDetailScreen`)
- [x] `npm run build` in `frontend/`
- [ ] Backend: `TestCreateStandingApproval_ParameterlessActionNullOrEmptyConstraints` (CI only — Go tests not runnable in this sandbox)

### OpenClaw
- [ ] Manually approve a request on web with the checkbox and confirm future matching requests auto-approve
- [ ] Repeat on mobile
- [ ] Confirm checkbox is hidden when a standing approval already exists
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b10b8783-6938-4386-96ef-69f235c8132c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b10b8783-6938-4386-96ef-69f235c8132c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

