### PR TITLE
mobile: add Developer Mode toggle with in-app request log overlay

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -25,6 +25,8 @@ import {
   hasConfiguredApiBase,
   loadCustomHostConfig,
 } from "./src/lib/customHostConfig";
+import { loadDevModeConfig } from "./src/lib/devModeConfig";
+import DevLogsOverlay from "./src/devlogs/DevLogsOverlay";
 import ServerUrlSetupScreen from "./src/screens/ServerUrlSetupScreen";
 import { ServerSetupContext } from "./src/lib/serverSetupContext";
 
@@ -167,7 +169,9 @@ export default function App() {
   const [hostHydrated, setHostHydrated] = useState(false);
   const [serverSetupBump, setServerSetupBump] = useState(0);
   useEffect(() => {
-    loadCustomHostConfig().finally(() => setHostHydrated(true));
+    Promise.all([loadCustomHostConfig(), loadDevModeConfig()]).finally(() =>
+      setHostHydrated(true),
+    );
   }, []);
 
   // Subscribe to AppState changes so React Query knows when the app is focused.
@@ -256,6 +260,7 @@ export default function App() {
               onOpenServerSetup={openServerSetup}
             />
             <StatusBar style="auto" />
+            <DevLogsOverlay />
           </ActiveAuthProvider>
         </ServerSetupContext.Provider>
       </SafeAreaProvider>

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -5,6 +5,7 @@ import {
   getCustomHost,
   PLACEHOLDER_API_BASE,
 } from "../lib/customHostConfig";
+import { loggingMiddleware } from "../devlogs/loggingMiddleware";
 
 /**
  * Returns the default API base URL for the mobile app.
@@ -136,6 +137,9 @@ const client = useMockApi
 if (!useMockApi) {
   client.use(customHostMiddleware);
   client.use(jsonSafeMiddleware);
+  // Logging is installed last so it sees the final URL after rewrites and the
+  // final Response after jsonSafeMiddleware normalizes non-JSON errors.
+  client.use(loggingMiddleware);
 }
 
 export default client;

--- a/mobile/src/devlogs/DevLogsOverlay.tsx
+++ b/mobile/src/devlogs/DevLogsOverlay.tsx
@@ -1,0 +1,296 @@
+import { useMemo, useState, useSyncExternalStore } from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import {
+  isDevModeEnabled,
+  subscribeDevMode,
+} from "../lib/devModeConfig";
+import {
+  clearDevLogs,
+  useDevLogs,
+  type DevLogEntry,
+} from "./devLogsStore";
+
+/**
+ * Fixed bottom overlay that lists every API request/response captured by
+ * {@link loggingMiddleware}. Visible only while the Developer Mode toggle
+ * in Settings is on; mounted unconditionally in App.tsx so flipping the
+ * toggle takes effect without a remount.
+ */
+export default function DevLogsOverlay() {
+  const enabled = useSyncExternalStore(
+    subscribeDevMode,
+    isDevModeEnabled,
+    isDevModeEnabled,
+  );
+  const entries = useDevLogs();
+  const [expanded, setExpanded] = useState(true);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+
+  const focused = useMemo(
+    () => entries.find((e) => e.id === focusedId) ?? null,
+    [entries, focusedId],
+  );
+
+  if (!enabled) return null;
+
+  return (
+    <View
+      style={[styles.container, expanded ? styles.expanded : styles.collapsed]}
+      pointerEvents="box-none"
+    >
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => setExpanded((v) => !v)}
+          accessibilityRole="button"
+          accessibilityLabel={expanded ? "Collapse dev logs" : "Expand dev logs"}
+          style={styles.headerButton}
+        >
+          <Text style={styles.headerTitle}>
+            Dev logs ({entries.length}) {expanded ? "▾" : "▴"}
+          </Text>
+        </Pressable>
+        {expanded && entries.length > 0 ? (
+          <Pressable
+            onPress={() => {
+              clearDevLogs();
+              setFocusedId(null);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Clear dev logs"
+            style={styles.headerButton}
+          >
+            <Text style={styles.clearText}>Clear</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {expanded ? (
+        focused ? (
+          <DetailView
+            entry={focused}
+            onClose={() => setFocusedId(null)}
+          />
+        ) : (
+          <EntryList entries={entries} onSelect={setFocusedId} />
+        )
+      ) : null}
+    </View>
+  );
+}
+
+function EntryList({
+  entries,
+  onSelect,
+}: {
+  entries: DevLogEntry[];
+  onSelect: (id: string) => void;
+}) {
+  if (entries.length === 0) {
+    return (
+      <View style={styles.emptyState}>
+        <Text style={styles.emptyText}>
+          No requests yet. Trigger an action to see logs here.
+        </Text>
+      </View>
+    );
+  }
+  // Newest first.
+  const ordered = [...entries].reverse();
+  return (
+    <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+      {ordered.map((entry) => (
+        <TouchableOpacity
+          key={entry.id}
+          onPress={() => onSelect(entry.id)}
+          style={styles.row}
+          accessibilityRole="button"
+          accessibilityLabel={`Show details for ${entry.method} ${entry.url}`}
+        >
+          <Text style={styles.rowText} numberOfLines={1}>
+            <Text style={[styles.status, statusStyle(entry)]}>
+              {entry.status ?? "ERR"}
+            </Text>{" "}
+            <Text style={styles.method}>{entry.method}</Text>{" "}
+            {shortPath(entry.url)}{" "}
+            <Text style={styles.duration}>{entry.durationMs}ms</Text>
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </ScrollView>
+  );
+}
+
+function DetailView({
+  entry,
+  onClose,
+}: {
+  entry: DevLogEntry;
+  onClose: () => void;
+}) {
+  return (
+    <View style={styles.detail}>
+      <View style={styles.detailHeader}>
+        <Text style={styles.detailTitle} numberOfLines={2}>
+          <Text style={[styles.status, statusStyle(entry)]}>
+            {entry.status ?? "ERR"}
+          </Text>{" "}
+          {entry.method} {entry.url}
+        </Text>
+        <Pressable
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close detail"
+          style={styles.headerButton}
+        >
+          <Text style={styles.clearText}>Back</Text>
+        </Pressable>
+      </View>
+      <Text style={styles.detailMeta}>
+        {entry.durationMs}ms · {new Date(entry.startedAt).toLocaleTimeString()}
+      </Text>
+      <ScrollView style={styles.detailBody}>
+        <Text style={styles.bodyText} selectable>
+          {entry.body || "(empty body)"}
+        </Text>
+      </ScrollView>
+    </View>
+  );
+}
+
+function shortPath(url: string): string {
+  // Strip protocol+host for readability; keep query string.
+  const match = url.match(/^[a-z]+:\/\/[^/]+(\/.*)$/i);
+  return match?.[1] ?? url;
+}
+
+function statusStyle(entry: DevLogEntry) {
+  if (entry.isError) return styles.statusError;
+  if (entry.status != null && entry.status >= 300) return styles.statusWarn;
+  return styles.statusOk;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(17, 17, 17, 0.94)",
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    borderTopWidth: 1,
+    borderColor: "rgba(255,255,255,0.15)",
+  },
+  collapsed: {
+    paddingBottom: 8,
+  },
+  expanded: {
+    maxHeight: "45%",
+    paddingBottom: 12,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  headerButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  headerTitle: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: 0.3,
+  },
+  clearText: {
+    color: "#9cc4ff",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  list: {
+    flexGrow: 0,
+  },
+  listContent: {
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+  },
+  emptyState: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  emptyText: {
+    color: "rgba(255,255,255,0.6)",
+    fontSize: 12,
+  },
+  row: {
+    paddingVertical: 4,
+  },
+  rowText: {
+    color: "#fff",
+    fontFamily: "Menlo",
+    fontSize: 11,
+  },
+  status: {
+    fontWeight: "700",
+  },
+  statusOk: {
+    color: "#7ee787",
+  },
+  statusWarn: {
+    color: "#f0b000",
+  },
+  statusError: {
+    color: "#ff7b72",
+  },
+  method: {
+    color: "#9cc4ff",
+    fontWeight: "600",
+  },
+  duration: {
+    color: "rgba(255,255,255,0.5)",
+  },
+  detail: {
+    paddingHorizontal: 12,
+    paddingBottom: 12,
+  },
+  detailHeader: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  detailTitle: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
+    flexShrink: 1,
+  },
+  detailMeta: {
+    color: "rgba(255,255,255,0.5)",
+    fontSize: 11,
+    marginTop: 4,
+    marginBottom: 6,
+  },
+  detailBody: {
+    maxHeight: 200,
+    backgroundColor: "rgba(0,0,0,0.35)",
+    borderRadius: 6,
+    padding: 8,
+  },
+  bodyText: {
+    color: "#e6edf3",
+    fontFamily: "Menlo",
+    fontSize: 11,
+    lineHeight: 15,
+  },
+});

--- a/mobile/src/devlogs/__tests__/devLogsStore.test.ts
+++ b/mobile/src/devlogs/__tests__/devLogsStore.test.ts
@@ -1,0 +1,66 @@
+import {
+  __getDevLogsForTests,
+  __resetDevLogsForTests,
+  appendDevLog,
+  clearDevLogs,
+  nextDevLogId,
+  type DevLogEntry,
+} from "../devLogsStore";
+
+function makeEntry(overrides: Partial<DevLogEntry> = {}): DevLogEntry {
+  return {
+    id: nextDevLogId(),
+    method: "GET",
+    url: "https://example.com/api/v1/x",
+    status: 200,
+    durationMs: 12,
+    startedAt: Date.now(),
+    body: "{}",
+    isError: false,
+    ...overrides,
+  };
+}
+
+describe("devLogsStore", () => {
+  beforeEach(() => {
+    __resetDevLogsForTests();
+  });
+
+  it("evicts oldest entries when exceeding the 50-entry cap", () => {
+    for (let i = 0; i < 80; i += 1) {
+      appendDevLog(makeEntry({ url: `https://x/api/v1/r-${i}` }));
+    }
+    const snapshot = __getDevLogsForTests();
+    expect(snapshot).toHaveLength(50);
+    // Oldest 30 should be gone; the newest must include r-79.
+    expect(snapshot[snapshot.length - 1]?.url).toBe(
+      "https://x/api/v1/r-79",
+    );
+    expect(snapshot[0]?.url).toBe("https://x/api/v1/r-30");
+  });
+
+  it("truncates oversized bodies with a marker", () => {
+    appendDevLog(makeEntry({ body: "x".repeat(10_000) }));
+    const [entry] = __getDevLogsForTests();
+    expect(entry).toBeDefined();
+    expect(entry!.body.length).toBeLessThan(5_000);
+    expect(entry!.body.endsWith("…(truncated)")).toBe(true);
+  });
+
+  it("clearDevLogs empties the buffer", () => {
+    appendDevLog(makeEntry());
+    appendDevLog(makeEntry());
+    expect(__getDevLogsForTests()).toHaveLength(2);
+    clearDevLogs();
+    expect(__getDevLogsForTests()).toHaveLength(0);
+  });
+
+  it("nextDevLogId returns unique values", () => {
+    const ids = new Set([
+      nextDevLogId(),
+      nextDevLogId(),
+      nextDevLogId(),
+    ]);
+    expect(ids.size).toBe(3);
+  });
+});

--- a/mobile/src/devlogs/__tests__/loggingMiddleware.test.ts
+++ b/mobile/src/devlogs/__tests__/loggingMiddleware.test.ts
@@ -1,0 +1,122 @@
+jest.mock("expo-secure-store", () => {
+  const store = new Map<string, string>();
+  return {
+    getItemAsync: jest.fn((key: string) =>
+      Promise.resolve(store.get(key) ?? null),
+    ),
+    setItemAsync: jest.fn((key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    deleteItemAsync: jest.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+  };
+});
+
+import { setDevModeEnabled } from "../../lib/devModeConfig";
+import { loggingMiddleware } from "../loggingMiddleware";
+import {
+  __getDevLogsForTests,
+  __resetDevLogsForTests,
+} from "../devLogsStore";
+
+async function runRequest(
+  request: Request,
+  response: Response,
+  id = "req-1",
+): Promise<void> {
+  const ctx = {
+    request,
+    schemaPath: "",
+    params: {},
+    id,
+    options: {} as never,
+  } as never;
+  await loggingMiddleware.onRequest!(ctx);
+  await loggingMiddleware.onResponse!({ ...(ctx as object), response } as never);
+}
+
+async function runRequestError(
+  request: Request,
+  error: unknown,
+  id = "req-err",
+): Promise<void> {
+  const ctx = {
+    request,
+    schemaPath: "",
+    params: {},
+    id,
+    options: {} as never,
+  } as never;
+  await loggingMiddleware.onRequest!(ctx);
+  await loggingMiddleware.onError!({ ...(ctx as object), error } as never);
+}
+
+describe("loggingMiddleware", () => {
+  beforeEach(async () => {
+    __resetDevLogsForTests();
+    await setDevModeEnabled(false);
+  });
+
+  it("captures nothing when dev mode is off", async () => {
+    await runRequest(
+      new Request("https://x/api/v1/profile", { method: "GET" }),
+      new Response("{}", { status: 200 }),
+    );
+    expect(__getDevLogsForTests()).toHaveLength(0);
+  });
+
+  it("captures method, url, status, and body when dev mode is on", async () => {
+    await setDevModeEnabled(true);
+    await runRequest(
+      new Request("https://my-host/api/v1/profile/notification-preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ preferences: [] }),
+      }),
+      new Response(
+        JSON.stringify({ error: { code: "invalid_request", message: "x" } }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const entries = __getDevLogsForTests();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0]!;
+    expect(entry.method).toBe("PUT");
+    expect(entry.url).toBe(
+      "https://my-host/api/v1/profile/notification-preferences",
+    );
+    expect(entry.status).toBe(400);
+    expect(entry.isError).toBe(true);
+    expect(entry.body).toContain("invalid_request");
+  });
+
+  it("does not drain the body for the downstream caller", async () => {
+    await setDevModeEnabled(true);
+    const original = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    await runRequest(
+      new Request("https://x/api/v1/profile", { method: "GET" }),
+      original,
+    );
+    // Downstream caller must still be able to read the body.
+    await expect(original.text()).resolves.toBe(JSON.stringify({ ok: true }));
+  });
+
+  it("captures transport errors via onError", async () => {
+    await setDevModeEnabled(true);
+    await runRequestError(
+      new Request("https://x/api/v1/profile", { method: "GET" }),
+      new Error("Network request failed"),
+    );
+    const entries = __getDevLogsForTests();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.status).toBeNull();
+    expect(entries[0]!.isError).toBe(true);
+    expect(entries[0]!.body).toBe("Network request failed");
+  });
+});

--- a/mobile/src/devlogs/devLogsStore.ts
+++ b/mobile/src/devlogs/devLogsStore.ts
@@ -1,0 +1,79 @@
+import { useSyncExternalStore } from "react";
+
+/** A single request/response entry captured by the logging middleware. */
+export type DevLogEntry = {
+  id: string;
+  method: string;
+  url: string;
+  /** Status code on completion, or null while the request is in-flight or threw before reaching the server. */
+  status: number | null;
+  /** Duration in ms from request start to response (or error). */
+  durationMs: number;
+  startedAt: number;
+  /** Truncated response body (or error message on transport failure). */
+  body: string;
+  /** True when the entry represents a transport-level failure rather than an HTTP response. */
+  isError: boolean;
+};
+
+const MAX_ENTRIES = 50;
+const MAX_BODY_CHARS = 4096;
+
+let entries: DevLogEntry[] = [];
+const listeners = new Set<() => void>();
+let counter = 0;
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+/** Append a finalized log entry, evicting the oldest when over capacity. */
+export function appendDevLog(entry: DevLogEntry): void {
+  const truncated =
+    entry.body.length > MAX_BODY_CHARS
+      ? entry.body.slice(0, MAX_BODY_CHARS) + "\n…(truncated)"
+      : entry.body;
+  const next: DevLogEntry[] = [...entries, { ...entry, body: truncated }];
+  if (next.length > MAX_ENTRIES) next.splice(0, next.length - MAX_ENTRIES);
+  entries = next;
+  notify();
+}
+
+/** Drop all captured entries; used by the overlay's Clear button. */
+export function clearDevLogs(): void {
+  if (entries.length === 0) return;
+  entries = [];
+  notify();
+}
+
+/** Monotonic-ish id for new entries (millisecond + counter, in-memory only). */
+export function nextDevLogId(): string {
+  counter += 1;
+  return `${Date.now()}-${counter}`;
+}
+
+function getSnapshot(): DevLogEntry[] {
+  return entries;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** React hook that re-renders when new entries are appended. */
+export function useDevLogs(): DevLogEntry[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Test-only helper to reset module state between tests. */
+export function __resetDevLogsForTests(): void {
+  entries = [];
+  listeners.clear();
+  counter = 0;
+}
+
+/** Test-only snapshot accessor; production code reads via {@link useDevLogs}. */
+export function __getDevLogsForTests(): DevLogEntry[] {
+  return entries;
+}

--- a/mobile/src/devlogs/loggingMiddleware.ts
+++ b/mobile/src/devlogs/loggingMiddleware.ts
@@ -1,0 +1,77 @@
+import type { Middleware } from "openapi-fetch";
+import { isDevModeEnabled } from "../lib/devModeConfig";
+import { appendDevLog, nextDevLogId, type DevLogEntry } from "./devLogsStore";
+
+type PendingMeta = {
+  id: string;
+  method: string;
+  url: string;
+  startedAt: number;
+};
+
+/**
+ * Per-request metadata, keyed by the openapi-fetch request id. Populated in
+ * onRequest and consumed in onResponse so we can compute the duration and
+ * carry the original (pre-rewrite) URL through to the log entry.
+ */
+const pending = new Map<string, PendingMeta>();
+
+/**
+ * Captures method + URL + status + response body for every API call into the
+ * in-memory dev log store. Reads {@link isDevModeEnabled} on every call so the
+ * user can flip the toggle without restarting the app — when disabled the
+ * middleware short-circuits with negligible overhead.
+ */
+export const loggingMiddleware: Middleware = {
+  async onRequest({ request, id }) {
+    if (!isDevModeEnabled()) return request;
+    pending.set(id, {
+      id: nextDevLogId(),
+      method: request.method,
+      url: request.url,
+      startedAt: Date.now(),
+    });
+    return request;
+  },
+  async onResponse({ response, id }) {
+    const meta = pending.get(id);
+    if (!meta) return response;
+    pending.delete(id);
+
+    // Clone to avoid draining the body the caller still needs to read.
+    let body = "";
+    try {
+      body = await response.clone().text();
+    } catch {
+      body = "(body unavailable)";
+    }
+    const entry: DevLogEntry = {
+      id: meta.id,
+      method: meta.method,
+      url: meta.url,
+      status: response.status,
+      durationMs: Date.now() - meta.startedAt,
+      startedAt: meta.startedAt,
+      body,
+      isError: response.status >= 400,
+    };
+    appendDevLog(entry);
+    return response;
+  },
+  async onError({ error, id }) {
+    const meta = pending.get(id);
+    if (!meta) return;
+    pending.delete(id);
+    const message = error instanceof Error ? error.message : String(error);
+    appendDevLog({
+      id: meta.id,
+      method: meta.method,
+      url: meta.url,
+      status: null,
+      durationMs: Date.now() - meta.startedAt,
+      startedAt: meta.startedAt,
+      body: message,
+      isError: true,
+    });
+  },
+};

--- a/mobile/src/lib/__tests__/devModeConfig.test.ts
+++ b/mobile/src/lib/__tests__/devModeConfig.test.ts
@@ -1,0 +1,65 @@
+jest.mock("expo-secure-store", () => {
+  const store = new Map<string, string>();
+  return {
+    getItemAsync: jest.fn((key: string) =>
+      Promise.resolve(store.get(key) ?? null),
+    ),
+    setItemAsync: jest.fn((key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    deleteItemAsync: jest.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+    __store: store,
+  };
+});
+
+import * as SecureStore from "expo-secure-store";
+import {
+  isDevModeEnabled,
+  loadDevModeConfig,
+  setDevModeEnabled,
+  subscribeDevMode,
+} from "../devModeConfig";
+
+const mockStore = (SecureStore as unknown as { __store: Map<string, string> })
+  .__store;
+
+describe("devModeConfig", () => {
+  beforeEach(async () => {
+    mockStore.clear();
+    await setDevModeEnabled(false);
+  });
+
+  it("defaults to disabled when nothing is stored", async () => {
+    mockStore.clear();
+    await loadDevModeConfig();
+    expect(isDevModeEnabled()).toBe(false);
+  });
+
+  it("loads the persisted true value on startup", async () => {
+    mockStore.set("developer_mode_enabled", "1");
+    await loadDevModeConfig();
+    expect(isDevModeEnabled()).toBe(true);
+  });
+
+  it("persists toggles and notifies subscribers", async () => {
+    let calls = 0;
+    const unsub = subscribeDevMode(() => {
+      calls += 1;
+    });
+
+    await setDevModeEnabled(true);
+    expect(isDevModeEnabled()).toBe(true);
+    expect(mockStore.get("developer_mode_enabled")).toBe("1");
+
+    await setDevModeEnabled(false);
+    expect(isDevModeEnabled()).toBe(false);
+    expect(mockStore.has("developer_mode_enabled")).toBe(false);
+
+    expect(calls).toBe(2);
+    unsub();
+  });
+});

--- a/mobile/src/lib/devModeConfig.ts
+++ b/mobile/src/lib/devModeConfig.ts
@@ -1,0 +1,38 @@
+import * as SecureStore from "expo-secure-store";
+
+const DEV_MODE_KEY = "developer_mode_enabled";
+
+let cachedEnabled = false;
+const listeners = new Set<() => void>();
+
+/**
+ * Hydrate the in-memory cache from SecureStore during app startup. Called
+ * once from App.tsx before any subtree that reads the toggle is mounted.
+ * Returns immediately when the stored value matches the current cache.
+ */
+export async function loadDevModeConfig(): Promise<void> {
+  const stored = await SecureStore.getItemAsync(DEV_MODE_KEY);
+  cachedEnabled = stored === "1";
+}
+
+/** Synchronous accessor used by middleware on every request. */
+export function isDevModeEnabled(): boolean {
+  return cachedEnabled;
+}
+
+/** Persist the new value and notify subscribers (toggle UI, overlay). */
+export async function setDevModeEnabled(enabled: boolean): Promise<void> {
+  cachedEnabled = enabled;
+  if (enabled) {
+    await SecureStore.setItemAsync(DEV_MODE_KEY, "1");
+  } else {
+    await SecureStore.deleteItemAsync(DEV_MODE_KEY);
+  }
+  for (const listener of listeners) listener();
+}
+
+/** Subscribe to dev-mode toggle changes (for useSyncExternalStore). */
+export function subscribeDevMode(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/mobile/src/screens/settings/DeveloperSettings.tsx
+++ b/mobile/src/screens/settings/DeveloperSettings.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { StyleSheet, Switch, Text, View } from "react-native";
+import {
+  isDevModeEnabled,
+  setDevModeEnabled,
+  subscribeDevMode,
+} from "../../lib/devModeConfig";
+import { colors } from "../../theme/colors";
+
+/**
+ * Settings section that exposes the Developer Mode toggle. When on, every
+ * API request the app makes is captured into an in-memory ring buffer and
+ * surfaced via {@link DevLogsOverlay} pinned to the bottom of the screen.
+ * Useful for diagnosing self-hosted server issues without server log access.
+ */
+export default function DeveloperSettings() {
+  const enabled = useSyncExternalStore(
+    subscribeDevMode,
+    isDevModeEnabled,
+    isDevModeEnabled,
+  );
+  const onToggle = useCallback(() => {
+    void setDevModeEnabled(!enabled);
+  }, [enabled]);
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Developer</Text>
+      <Text style={styles.sectionDescription}>
+        Show a live log of every API request and response at the bottom of
+        the screen. Useful for diagnosing connectivity or server errors.
+      </Text>
+      <View style={styles.card}>
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleLabel}>
+            <Text style={styles.toggleTitle}>Developer Mode</Text>
+            <Text style={styles.toggleDescription}>
+              Captures recent requests in memory only. Turn off to hide.
+            </Text>
+          </View>
+          <Switch
+            testID="developer-mode-toggle"
+            value={enabled}
+            onValueChange={onToggle}
+            trackColor={{ false: colors.gray300, true: colors.primary }}
+            accessibilityLabel="Developer Mode"
+            accessibilityRole="switch"
+            accessibilityState={{ checked: enabled }}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.gray500,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  sectionDescription: {
+    fontSize: 13,
+    color: colors.gray400,
+    marginBottom: 12,
+  },
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  toggleLabel: {
+    flex: 1,
+    marginRight: 12,
+  },
+  toggleTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.gray900,
+    marginBottom: 2,
+  },
+  toggleDescription: {
+    fontSize: 13,
+    color: colors.gray500,
+    lineHeight: 18,
+  },
+});

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -35,6 +35,7 @@ import Constants from "expo-constants";
 import { useDeleteAccount } from "../../hooks/useDeleteAccount";
 import { colors } from "../../theme/colors";
 import CustomServerSettings from "./CustomServerSettings";
+import DeveloperSettings from "./DeveloperSettings";
 
 const GIT_COMMIT_HASH: string =
   (Constants.expoConfig?.extra?.gitCommitHash as string) ?? "unknown";
@@ -296,6 +297,8 @@ export default function SettingsScreen(_props: Props) {
         </Text>
         <CustomServerSettings onSaved={signOut} />
       </View>
+
+      <DeveloperSettings />
 
       <View style={styles.buildInfo}>
         <Text style={styles.buildInfoText} testID="git-commit-hash">


### PR DESCRIPTION
## Summary

Adds a Settings → Developer Mode toggle. When on, every API request the app makes is captured into an in-memory ring buffer (last 50) and rendered in a fixed bottom overlay on every screen. Lets self-hosted users diagnose failing requests — like the notification preferences PUT that's been hard to root-cause — without needing server log access.

- `devModeConfig` persists the toggle to SecureStore; subscribers (overlay + Settings switch) stay in sync via a tiny event emitter.
- `devLogsStore` is a `useSyncExternalStore`-backed ring buffer. 50-entry cap, response bodies truncated at 4 KB with a `…(truncated)` marker.
- `loggingMiddleware` installs last in the openapi-fetch chain so it sees the final rewritten URL (after `customHostMiddleware`) and the normalized error body (after `jsonSafeMiddleware`). Short-circuits when dev mode is off so there is zero runtime cost for users who never flip it.
- `DevLogsOverlay` is a semi-transparent dark panel pinned to the bottom. Newest request first; tap a row to expand the full response body. Clear button drops the buffer. Mounted unconditionally in `App.tsx` but renders `null` until the toggle is on.

Production users who never enable Developer Mode see no behavior change.

## Test plan

- [x] `mobile/src/devlogs/__tests__/devLogsStore.test.ts` — cap eviction, body truncation, clear, unique ids.
- [x] `mobile/src/lib/__tests__/devModeConfig.test.ts` — defaults, hydration, persistence, subscriber notification.
- [x] `mobile/src/devlogs/__tests__/loggingMiddleware.test.ts` — captures nothing when off, captures method/URL/status/body when on, does not drain the response body for downstream callers, captures transport errors via `onError`.
- [x] Full mobile suite: 300/300 passing, `tsc --noEmit` clean.
- [ ] Manual: flip Developer Mode on, tap the notification toggle, confirm the failing PUT shows up in the overlay with the real server status + body.

https://claude.ai/code/session_01D5XzinkWWxgD8v1BXs1wrz

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5XzinkWWxgD8v1BXs1wrz)_