### PR TITLE
Show build commit hash in web footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,13 @@ ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
 
+# Build stamp: .git isn't copied into this stage, so the host must pass the
+# commit SHA + ISO timestamp as build args (Makefile docker-build/deploy do).
+ARG GIT_COMMIT_HASH
+ARG GIT_COMMIT_TIMESTAMP
+ENV VITE_GIT_COMMIT_HASH=$GIT_COMMIT_HASH
+ENV VITE_GIT_COMMIT_TIMESTAMP=$GIT_COMMIT_TIMESTAMP
+
 # Copy shared validation config (imported by frontend/src/lib/validation.ts)
 COPY shared/ /app/shared/
 

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ typecheck: generate-frontend
 # Build for production (generates API client first, then compiles)
 # Embeds the git SHA as the Sentry release version via -ldflags.
 GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GIT_COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_COMMIT_TIMESTAMP := $(shell git log -1 --format=%cI HEAD 2>/dev/null || echo "unknown")
 build: generate
 	cd frontend && npm run build
 	touch frontend/dist/.gitkeep
@@ -96,6 +98,8 @@ docker-build:
 	docker build \
 		--build-arg VITE_SUPABASE_URL=$${VITE_SUPABASE_URL} \
 		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY} \
+		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) \
+		--build-arg GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP) \
 		-t permission-slip .
 
 # Deploy to Fly.io. Reads Supabase build args from the environment.
@@ -104,7 +108,9 @@ docker-build:
 deploy:
 	fly deploy \
 		--build-arg VITE_SUPABASE_URL=$${VITE_SUPABASE_URL} \
-		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY}
+		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY} \
+		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) \
+		--build-arg GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP)
 
 # ---------- Testing ----------
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -7,14 +7,36 @@ interface FooterProps {
 
 const linkClass = "hover:text-foreground transition-colors";
 
+const GIT_COMMIT_HASH = import.meta.env.VITE_GIT_COMMIT_HASH ?? "unknown";
+const GIT_COMMIT_TIMESTAMP =
+  import.meta.env.VITE_GIT_COMMIT_TIMESTAMP ?? "unknown";
+
+function formatCommitTimestamp(iso: string): string {
+  if (iso === "unknown") return "";
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function buildLabel(): string {
+  const sha = GIT_COMMIT_HASH.slice(0, 7);
+  const ts = formatCommitTimestamp(GIT_COMMIT_TIMESTAMP);
+  return ts ? `Build ${sha} · ${ts}` : `Build ${sha}`;
+}
+
 /** Shared site footer for auth and marketing-style layouts. */
 export function Footer({ className }: FooterProps) {
   return (
     <footer className={cn("text-xs text-muted-foreground", className)}>
-      <div className="flex flex-wrap gap-x-4 gap-y-2">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         <Link to="/support" className={linkClass}>
           Support
         </Link>
+        <span data-testid="git-commit-hash">{buildLabel()}</span>
       </div>
     </footer>
   );

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -12,6 +12,10 @@ interface ImportMetaEnv {
   readonly VITE_REACT_DEVTOOLS?: string;
   /** Sentry DSN for error tracking. Omit to disable Sentry. */
   readonly VITE_SENTRY_DSN?: string;
+  /** Git commit SHA stamped at build time (full hash). */
+  readonly VITE_GIT_COMMIT_HASH?: string;
+  /** Git commit timestamp stamped at build time (ISO-8601). */
+  readonly VITE_GIT_COMMIT_TIMESTAMP?: string;
 }
 
 interface ImportMeta {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,22 @@
+import { execSync } from "child_process";
 import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
+
+// Build stamp: prefer env vars (Docker build args pass these in), fall back
+// to local git. Mirrors mobile/app.config.ts so web and mobile use the same
+// Build "<sha>" identifier.
+function readGit(cmd: string): string {
+  try {
+    return execSync(cmd, { encoding: "utf-8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+process.env.VITE_GIT_COMMIT_HASH ||= readGit("git rev-parse HEAD");
+process.env.VITE_GIT_COMMIT_TIMESTAMP ||= readGit("git log -1 --format=%cI HEAD");
 
 // Source maps are only generated when all Sentry upload vars are present.
 // This prevents .map files from being left in dist/ and accidentally served


### PR DESCRIPTION
## Summary

- Adds a `Build <7char-sha> · <date>` line to the web footer, next to the Support link, mirroring the existing mobile Settings build stamp.
- Reads the commit SHA + ISO timestamp at Vite build time, falling back to `VITE_GIT_COMMIT_HASH` / `VITE_GIT_COMMIT_TIMESTAMP` env vars (set from Docker build args, since `.git` isn't copied into the frontend Docker stage).
- `make docker-build` and `make deploy` now pass the git info automatically — no extra flags needed when redeploying.

Motivates this came from PR #1262 — on a self-hosted deploy, there was no way to confirm whether the web bundle actually included the latest feature without diffing the JS. The footer now answers that at a glance.

## Test plan

- [x] `npx tsc --noEmit` clean in `frontend/`
- [x] `npm run build` succeeds; current commit SHA `90abb2c…` confirmed inlined into the JS bundle
- [x] `npx vitest run` — all 894 existing tests pass
- [x] `make -n docker-build` dry-run shows both `--build-arg GIT_COMMIT_HASH=…` and `--build-arg GIT_COMMIT_TIMESTAMP=…` plumbed through
- [ ] Deploy and visually confirm footer shows the expected build stamp on every page

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wif4Qz87WGjPX21ivxCpow)_